### PR TITLE
Fix #94

### DIFF
--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -1567,7 +1567,7 @@ impl<'a> CodegenCtx<'a> {
     fn binary_op(&mut self, expr_id: ExprId, binop: &BinaryOp, builder: &mut FunctionBuilder<'_>) {
         let (lhs, rhs) = (self.exprs[&binop.lhs()], self.exprs[&binop.rhs()]);
         let (lhs_ty, rhs_ty) = (self.expr_types[&binop.lhs()], self.expr_types[&binop.rhs()]);
-        debug_assert_eq!(builder.value_type(lhs), builder.value_type(rhs),);
+        debug_assert_eq!(builder.value_type(lhs), builder.value_type(rhs));
         debug_assert_eq!(lhs_ty, rhs_ty);
 
         let mut value_ty = lhs_ty;

--- a/crates/dataflow-jit/src/dataflow/tests.rs
+++ b/crates/dataflow-jit/src/dataflow/tests.rs
@@ -243,7 +243,10 @@ fn bfs() {
             StreamKind::Set,
         );
 
-        let joined_plus_roots = subgraph.add_node(Sum::new(vec![nodes_join_edges, roots]));
+        let joined_plus_roots = subgraph.add_node(Sum::new(
+            vec![nodes_join_edges, roots],
+            StreamLayout::Set(u64x2),
+        ));
         let joined_plus_roots = subgraph.index_with(joined_plus_roots, u64x1, u64x1, {
             let mut func = FunctionBuilder::new(subgraph.layout_cache().clone());
             let input = func.add_input(u64x2);
@@ -279,7 +282,7 @@ fn bfs() {
                 func.build()
             },
         );
-        let min_set_distinct = subgraph.distinct(min_set);
+        let min_set_distinct = subgraph.distinct(min_set, StreamLayout::Set(u64x2));
         subgraph.connect_feedback(min_set_distinct, nodes);
         subgraph.export(min_set_distinct, StreamLayout::Set(u64x2))
     });
@@ -340,7 +343,10 @@ fn bfs() {
         },
     );
 
-    let distances = graph.add_node(Sum::new(vec![distances, unreachable_nodes]));
+    let distances = graph.add_node(Sum::new(
+        vec![distances, unreachable_nodes],
+        StreamLayout::Set(u64x2),
+    ));
     let sink = graph.sink(distances);
 
     let (dataflow, jit_handle, layout_cache) =

--- a/crates/dataflow-jit/src/ir/exprs/mod.rs
+++ b/crates/dataflow-jit/src/ir/exprs/mod.rs
@@ -6,13 +6,14 @@ mod constant;
 mod select;
 mod unary;
 
+pub use crate::ir::ExprId;
 pub use binary::{BinaryOp, BinaryOpKind};
 pub use call::{ArgType, Call};
 pub use constant::Constant;
 pub use select::Select;
 pub use unary::{UnaryOp, UnaryOpKind};
 
-use crate::ir::{exprs::visit::MapLayouts, ColumnType, ExprId, LayoutId};
+use crate::ir::{exprs::visit::MapLayouts, ColumnType, LayoutId};
 use derive_more::From;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/dataflow-jit/src/ir/graph.rs
+++ b/crates/dataflow-jit/src/ir/graph.rs
@@ -146,8 +146,8 @@ pub trait GraphExt {
         self.add_node(Map::new(input, map_fn, input_layout, output_layout))
     }
 
-    fn distinct(&mut self, input: NodeId) -> NodeId {
-        self.add_node(Distinct::new(input))
+    fn distinct(&mut self, input: NodeId, layout: StreamLayout) -> NodeId {
+        self.add_node(Distinct::new(input, layout))
     }
 
     fn index_with(
@@ -160,12 +160,12 @@ pub trait GraphExt {
         self.add_node(IndexWith::new(input, index_fn, key_layout, value_layout))
     }
 
-    fn differentiate(&mut self, input: NodeId) -> NodeId {
-        self.add_node(Differentiate::new(input))
+    fn differentiate(&mut self, input: NodeId, layout: StreamLayout) -> NodeId {
+        self.add_node(Differentiate::new(input, layout))
     }
 
-    fn integrate(&mut self, input: NodeId) -> NodeId {
-        self.add_node(Integrate::new(input))
+    fn integrate(&mut self, input: NodeId, layout: StreamLayout) -> NodeId {
+        self.add_node(Integrate::new(input, layout))
     }
 
     fn join_core(
@@ -718,13 +718,19 @@ mod tests {
         // ```
         // let stream7883: Stream<_, OrdZSet<Tuple1<Option<i32>>, Weight>> = stream7130.differentiate();
         // ```
-        let stream7883 = graph.add_node(Differentiate::new(stream7130));
+        let stream7883 = graph.add_node(Differentiate::new(
+            stream7130,
+            StreamLayout::Set(nullable_i32),
+        ));
 
         // ```
         // let stream7887: Stream<_, OrdZSet<Tuple1<Option<i32>>, Weight>> =
         //     stream7883.sum([&stream7879, &stream7866]);
         // ```
-        let stream7887 = graph.add_node(Sum::new(vec![stream7883, stream7879, stream7866]));
+        let stream7887 = graph.add_node(Sum::new(
+            vec![stream7883, stream7879, stream7866],
+            StreamLayout::Set(nullable_i32),
+        ));
 
         // ```
         // let stream7892: Stream<_, OrdIndexedZSet<(), Tuple6<i32, F64, bool, String, Option<i32>, Option<F64>>, Weight>> =

--- a/crates/dataflow-jit/src/ir/nodes/differentiate.rs
+++ b/crates/dataflow-jit/src/ir/nodes/differentiate.rs
@@ -10,15 +10,20 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Differentiate {
     input: NodeId,
+    layout: StreamLayout,
 }
 
 impl Differentiate {
-    pub fn new(input: NodeId) -> Self {
-        Self { input }
+    pub const fn new(input: NodeId, layout: StreamLayout) -> Self {
+        Self { input, layout }
     }
 
-    pub fn input(&self) -> NodeId {
+    pub const fn input(&self) -> NodeId {
         self.input
+    }
+
+    pub const fn layout(&self) -> StreamLayout {
+        self.layout
     }
 }
 
@@ -37,38 +42,46 @@ impl DataflowNode for Differentiate {
         map(&mut self.input);
     }
 
-    fn output_stream(&self, inputs: &[StreamLayout]) -> Option<StreamLayout> {
-        Some(match inputs[0] {
-            StreamLayout::Set(value) => StreamLayout::Set(value),
-            StreamLayout::Map(key, value) => StreamLayout::Map(key, value),
-        })
+    fn output_stream(&self, _inputs: &[StreamLayout]) -> Option<StreamLayout> {
+        Some(self.layout)
     }
 
-    fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {}
+    fn validate(&self, inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0], self.layout);
+    }
 
     fn optimize(&mut self, _layout_cache: &RowLayoutCache) {}
 
-    fn map_layouts<F>(&self, _map: &mut F)
+    fn map_layouts<F>(&self, map: &mut F)
     where
         F: FnMut(LayoutId),
     {
+        self.layout.map_layouts(map);
     }
 
-    fn remap_layouts(&mut self, _mappings: &BTreeMap<LayoutId, LayoutId>) {}
+    fn remap_layouts(&mut self, mappings: &BTreeMap<LayoutId, LayoutId>) {
+        self.layout.remap_layouts(mappings);
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct Integrate {
     input: NodeId,
+    layout: StreamLayout,
 }
 
 impl Integrate {
-    pub fn new(input: NodeId) -> Self {
-        Self { input }
+    pub const fn new(input: NodeId, layout: StreamLayout) -> Self {
+        Self { input, layout }
     }
 
-    pub fn input(&self) -> NodeId {
+    pub const fn input(&self) -> NodeId {
         self.input
+    }
+
+    pub const fn layout(&self) -> StreamLayout {
+        self.layout
     }
 }
 
@@ -87,22 +100,25 @@ impl DataflowNode for Integrate {
         map(&mut self.input);
     }
 
-    fn output_stream(&self, inputs: &[StreamLayout]) -> Option<StreamLayout> {
-        Some(match inputs[0] {
-            StreamLayout::Set(value) => StreamLayout::Set(value),
-            StreamLayout::Map(key, value) => StreamLayout::Map(key, value),
-        })
+    fn output_stream(&self, _inputs: &[StreamLayout]) -> Option<StreamLayout> {
+        Some(self.layout)
     }
 
-    fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {}
+    fn validate(&self, inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0], self.layout);
+    }
 
     fn optimize(&mut self, _layout_cache: &RowLayoutCache) {}
 
-    fn map_layouts<F>(&self, _map: &mut F)
+    fn map_layouts<F>(&self, map: &mut F)
     where
         F: FnMut(LayoutId),
     {
+        self.layout.map_layouts(map);
     }
 
-    fn remap_layouts(&mut self, _mappings: &BTreeMap<LayoutId, LayoutId>) {}
+    fn remap_layouts(&mut self, mappings: &BTreeMap<LayoutId, LayoutId>) {
+        self.layout.remap_layouts(mappings);
+    }
 }

--- a/crates/dataflow-jit/src/ir/nodes/index.rs
+++ b/crates/dataflow-jit/src/ir/nodes/index.rs
@@ -48,6 +48,10 @@ impl IndexWith {
     pub const fn value_layout(&self) -> LayoutId {
         self.value_layout
     }
+
+    pub const fn output_layout(&self) -> StreamLayout {
+        StreamLayout::Map(self.key_layout, self.value_layout)
+    }
 }
 
 impl DataflowNode for IndexWith {
@@ -66,7 +70,7 @@ impl DataflowNode for IndexWith {
     }
 
     fn output_stream(&self, _inputs: &[StreamLayout]) -> Option<StreamLayout> {
-        Some(StreamLayout::Map(self.key_layout, self.value_layout))
+        Some(self.output_layout())
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {

--- a/crates/dataflow-jit/src/ir/nodes/io.rs
+++ b/crates/dataflow-jit/src/ir/nodes/io.rs
@@ -201,6 +201,10 @@ impl SourceMap {
     pub const fn value(&self) -> LayoutId {
         self.value_layout
     }
+
+    pub const fn output_layout(&self) -> StreamLayout {
+        StreamLayout::Map(self.key_layout, self.value_layout)
+    }
 }
 
 impl DataflowNode for SourceMap {
@@ -217,7 +221,7 @@ impl DataflowNode for SourceMap {
     }
 
     fn output_stream(&self, _inputs: &[StreamLayout]) -> Option<StreamLayout> {
-        Some(StreamLayout::Map(self.key_layout, self.value_layout))
+        Some(self.output_layout())
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {}

--- a/crates/dataflow-jit/src/ir/nodes/join.rs
+++ b/crates/dataflow-jit/src/ir/nodes/join.rs
@@ -58,6 +58,13 @@ impl JoinCore {
         self.value_layout
     }
 
+    pub const fn output_layout(&self) -> StreamLayout {
+        match self.output_kind {
+            StreamKind::Set => StreamLayout::Set(self.key_layout),
+            StreamKind::Map => StreamLayout::Map(self.key_layout, self.value_layout),
+        }
+    }
+
     pub(crate) fn result_kind(&self) -> StreamKind {
         self.output_kind
     }
@@ -81,10 +88,7 @@ impl DataflowNode for JoinCore {
     }
 
     fn output_stream(&self, _inputs: &[StreamLayout]) -> Option<StreamLayout> {
-        Some(match self.output_kind {
-            StreamKind::Set => StreamLayout::Set(self.key_layout),
-            StreamKind::Map => StreamLayout::Map(self.key_layout, self.value_layout),
-        })
+        Some(self.output_layout())
     }
 
     fn validate(&self, _inputs: &[StreamLayout], layout_cache: &RowLayoutCache) {

--- a/crates/dataflow-jit/src/ir/optimize/dedup.rs
+++ b/crates/dataflow-jit/src/ir/optimize/dedup.rs
@@ -103,8 +103,8 @@ mod tests {
         );
 
         let source = graph.source(u32);
-        let distinct2 = graph.distinct(source);
-        let distinct3 = graph.distinct(source);
+        let distinct2 = graph.distinct(source, StreamLayout::Set(u32));
+        let distinct3 = graph.distinct(source, StreamLayout::Set(u32));
         let sink1 = graph.sink(distinct2);
         let sink2 = graph.sink(distinct3);
 

--- a/crates/dataflow-jit/src/ir/optimize/distinct.rs
+++ b/crates/dataflow-jit/src/ir/optimize/distinct.rs
@@ -243,7 +243,7 @@ impl Subgraph {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ir::{ColumnType, Constant, Graph, GraphExt, RowLayoutBuilder},
+        ir::{nodes::StreamLayout, ColumnType, Constant, Graph, GraphExt, RowLayoutBuilder},
         utils,
     };
 
@@ -260,7 +260,7 @@ mod tests {
         );
 
         let source = graph.source(u32);
-        let distinct_1 = graph.distinct(source);
+        let distinct_1 = graph.distinct(source, StreamLayout::Set(u32));
         let filtered = graph.filter(distinct_1, {
             let mut builder = graph.function_builder().with_return_type(ColumnType::Bool);
             let input = builder.add_input(u32);
@@ -271,7 +271,7 @@ mod tests {
             builder.ret(less_than);
             builder.build()
         });
-        let distinct_2 = graph.distinct(filtered);
+        let distinct_2 = graph.distinct(filtered, StreamLayout::Set(u32));
         let sink = graph.sink(distinct_2);
 
         graph.optimize();


### PR DESCRIPTION
Implements validation for all node types, changes `Differentiate`, `Integrate`, `Sum` and `Distinct` to all have a `layout: StreamLayout` field within them (this causes changes to the JSON format @mihaibudiu)