### PR TITLE
rolling_aggregate: enforce unsigned timestamps.

### DIFF
--- a/crates/dbsp/src/operator/time_series/mod.rs
+++ b/crates/dbsp/src/operator/time_series/mod.rs
@@ -10,3 +10,4 @@ pub use partitioned::{
     PartitionedIndexedZSet,
 };
 pub use range::{Range, RelOffset, RelRange};
+pub use radix_tree::UPrimInt;

--- a/crates/dbsp/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -1,4 +1,4 @@
-use super::{radix_tree_update, Prefix, RadixTreeCursor, TreeNode};
+use super::{radix_tree_update, Prefix, RadixTreeCursor, TreeNode, UPrimInt};
 use crate::{
     algebra::{HasOne, HasZero, Semigroup, ZRingValue},
     circuit::{
@@ -16,7 +16,6 @@ use crate::{
     trace::{cursor::CursorEmpty, Builder, Cursor, Spine},
     Circuit, DBData, DBWeight, OrdIndexedZSet, RootCircuit, Stream,
 };
-use num::PrimInt;
 use size_of::SizeOf;
 use std::{
     borrow::Cow,
@@ -63,7 +62,7 @@ pub trait PartitionedRadixTreeCursor<PK, TS, A, R>:
     fn format_tree<W>(&mut self, writer: &mut W) -> Result<(), fmt::Error>
     where
         PK: Debug,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         A: DBData,
         R: HasZero,
         W: Write,
@@ -83,7 +82,7 @@ pub trait PartitionedRadixTreeCursor<PK, TS, A, R>:
     fn validate<S>(&mut self, contents: &BTreeMap<PK, BTreeMap<TS, A>>)
     where
         PK: Ord,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         R: DBWeight + ZRingValue,
         A: DBData,
         S: Semigroup<A>,
@@ -121,7 +120,7 @@ where
     ) -> OrdPartitionedRadixTreeStream<Z::Key, TS, Agg::Accumulator, isize>
     where
         Z: PartitionedIndexedZSet<TS, V> + SizeOf,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
         Agg: Aggregator<V, (), Z::R>,
         Agg::Accumulator: Default,
@@ -142,7 +141,7 @@ where
     ) -> Stream<RootCircuit, O>
     where
         Z: PartitionedIndexedZSet<TS, V> + SizeOf,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
         Agg: Aggregator<V, (), Z::R>,
         Agg::Accumulator: Default,
@@ -250,7 +249,7 @@ impl<TS, V, Z, IT, OT, Agg, O> TernaryOperator<Z, IT, OT, O>
     for PartitionedRadixTreeAggregate<TS, V, Z, IT, OT, Agg, O>
 where
     Z: PartitionedBatchReader<TS, V> + Clone,
-    TS: DBData + PrimInt,
+    TS: DBData + UPrimInt,
     V: DBData,
     IT: PartitionedBatchReader<TS, V, Key = Z::Key, R = Z::R> + Clone,
     OT: PartitionedRadixTreeReader<TS, Agg::Accumulator, Key = Z::Key, R = O::R> + Clone,
@@ -372,14 +371,13 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::{super::test::test_aggregate_range, PartitionCursor, PartitionedRadixTreeCursor};
+    use super::{super::test::test_aggregate_range, PartitionCursor, PartitionedRadixTreeCursor, UPrimInt};
     use crate::{
         algebra::{DefaultSemigroup, HasZero, Semigroup},
         operator::Fold,
         trace::BatchReader,
         CollectionHandle, DBData, RootCircuit,
     };
-    use num::PrimInt;
     use std::{
         collections::{btree_map::Entry, BTreeMap},
         sync::{Arc, Mutex},
@@ -393,7 +391,7 @@ mod test {
     ) where
         C: PartitionedRadixTreeCursor<PK, TS, A, R>,
         PK: DBData,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         A: DBData,
         R: DBData + HasZero,
         S: Semigroup<A>,

--- a/crates/dbsp/src/operator/time_series/radix_tree/tree_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/radix_tree/tree_aggregate.rs
@@ -1,4 +1,4 @@
-use super::{radix_tree_update, Prefix, TreeNode};
+use super::{radix_tree_update, Prefix, TreeNode, UPrimInt};
 use crate::{
     algebra::{HasOne, IndexedZSet, ZRingValue},
     circuit::{
@@ -13,7 +13,6 @@ use crate::{
     trace::{Batch, BatchReader, Builder, Spine},
     Circuit, NumEntries, OrdIndexedZSet, Stream,
 };
-use num::PrimInt;
 use size_of::SizeOf;
 use std::{borrow::Cow, cmp::Ordering, marker::PhantomData, ops::Neg};
 
@@ -60,7 +59,7 @@ where
     ) -> Stream<C, OrdRadixTree<Z::Key, Agg::Accumulator, isize>>
     where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
-        Z::Key: PrimInt,
+        Z::Key: UPrimInt,
         Agg: Aggregator<Z::Val, (), Z::R>,
         Agg::Accumulator: Default,
     {
@@ -73,7 +72,7 @@ where
     pub fn tree_aggregate_generic<Agg, O>(&self, aggregator: Agg) -> Stream<C, O>
     where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
-        Z::Key: PrimInt,
+        Z::Key: UPrimInt,
         Agg: Aggregator<Z::Val, (), Z::R>,
         Agg::Accumulator: Default,
         O: RadixTreeBatch<Z::Key, Agg::Accumulator>,
@@ -170,7 +169,7 @@ where
 impl<Z, IT, OT, Agg, O> TernaryOperator<Z, IT, OT, O> for RadixTreeAggregate<Z, IT, OT, Agg, O>
 where
     Z: IndexedZSet,
-    Z::Key: PrimInt,
+    Z::Key: UPrimInt,
     IT: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + Clone,
     OT: RadixTreeReader<Z::Key, Agg::Accumulator, R = O::R> + Clone,
     Agg: Aggregator<Z::Val, (), Z::R>,

--- a/crates/dbsp/src/operator/time_series/radix_tree/updater.rs
+++ b/crates/dbsp/src/operator/time_series/radix_tree/updater.rs
@@ -1,10 +1,9 @@
-use super::{ChildPtr, Prefix, RadixTreeCursor, TreeNode, RADIX_BITS};
+use super::{ChildPtr, Prefix, RadixTreeCursor, TreeNode, RADIX_BITS, UPrimInt};
 use crate::{
     algebra::{HasZero, MonoidValue, Semigroup},
     operator::Aggregator,
     trace::{cursor::CursorGroup, Cursor},
 };
-use num::PrimInt;
 use std::{fmt::Debug, marker::PhantomData, mem::size_of};
 
 /// Describes incremental update to a radix tree node.
@@ -91,7 +90,7 @@ where
 
 impl<'a, TS, A, R, S, TC> TreeUpdater<'a, TS, A, R, S, TC>
 where
-    TS: PrimInt + Debug,
+    TS: UPrimInt + Debug,
     A: Clone + Default + Debug,
     S: Semigroup<A>,
     TC: RadixTreeCursor<TS, A, R>,
@@ -371,7 +370,7 @@ pub(super) fn radix_tree_update<'a, TS, V, R, Agg, UC, IC, TC, OR>(
     aggregator: &Agg,
     output_updates: &'a mut Vec<TreeNodeUpdate<TS, Agg::Accumulator>>,
 ) where
-    TS: PrimInt + Debug,
+    TS: UPrimInt + Debug,
     R: MonoidValue,
     Agg: Aggregator<V, (), R>,
     Agg::Accumulator: Clone + Default + Eq + Debug,

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -9,7 +9,7 @@ use crate::{
             radix_tree::{PartitionedRadixTreeReader, RadixTreeCursor},
             range::{Range, RangeCursor, Ranges, RelRange},
             OrdPartitionedIndexedZSet, PartitionCursor, PartitionedBatchReader,
-            PartitionedIndexedZSet, RelOffset,
+            PartitionedIndexedZSet, RelOffset, UPrimInt,
         },
         trace::{TraceBound, TraceBounds, TraceFeedback},
         Aggregator, FilterMap,
@@ -17,7 +17,7 @@ use crate::{
     trace::{Builder, Cursor, Spine},
     Circuit, DBData, DBWeight, RootCircuit, Stream,
 };
-use num::{Bounded, PrimInt};
+use num::Bounded;
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 
 // TODO: `Default` trait bounds in this module are due to an implementation
@@ -165,7 +165,7 @@ where
         PF: Fn(&B::Val) -> (PK, V) + Clone + 'static,
         Agg: Aggregator<V, (), B::R>,
         Agg::Accumulator: Default,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
     {
         self.circuit()
@@ -240,7 +240,7 @@ impl<B> Stream<RootCircuit, B> {
         B::R: ZRingValue,
         Agg: Aggregator<V, (), B::R>,
         Agg::Accumulator: Default,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
     {
         self.partitioned_rolling_aggregate_generic::<TS, V, Agg, _>(aggregator, range)
@@ -259,7 +259,7 @@ impl<B> Stream<RootCircuit, B> {
         Agg: Aggregator<V, (), B::R>,
         Agg::Accumulator: Default,
         O: PartitionedIndexedZSet<TS, Option<Agg::Output>, Key = B::Key, R = B::R>,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
     {
         // ```
@@ -295,7 +295,7 @@ impl<B> Stream<RootCircuit, B> {
         Agg: Aggregator<V, (), B::R>,
         Agg::Accumulator: Default,
         O: PartitionedIndexedZSet<TS, Option<Agg::Output>, Key = B::Key, R = B::R>,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
     {
         let circuit = self.circuit();
@@ -348,7 +348,7 @@ impl<B> Stream<RootCircuit, B> {
         A: DBData + MulByRef<B::R, Output = A> + GroupValue + Default,
         F: Fn(&V) -> A + Clone + 'static,
         OF: Fn(A) -> O + Clone + 'static,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
         O: DBData,
     {
@@ -370,7 +370,7 @@ impl<B> Stream<RootCircuit, B> {
         A: DBData + MulByRef<B::R, Output = A> + GroupValue + Default,
         F: Fn(&V) -> A + Clone + 'static,
         OF: Fn(A) -> O + Clone + 'static,
-        TS: DBData + PrimInt,
+        TS: DBData + UPrimInt,
         V: DBData,
         O: DBData,
         Out: PartitionedIndexedZSet<TS, Option<O>, Key = B::Key, R = B::R>,
@@ -408,7 +408,7 @@ impl<TS, V, Agg> PartitionedRollingAggregate<TS, V, Agg> {
     fn affected_ranges<R, C>(&self, delta_cursor: &mut C) -> Ranges<TS>
     where
         C: Cursor<TS, V, (), R>,
-        TS: PrimInt,
+        TS: UPrimInt,
     {
         let mut affected_ranges = Ranges::new();
         let mut delta_ranges = Ranges::new();
@@ -446,7 +446,7 @@ where
 impl<TS, V, Agg, B, T, RT, OT, O> QuaternaryOperator<B, T, RT, OT, O>
     for PartitionedRollingAggregate<TS, V, Agg>
 where
-    TS: DBData + PrimInt,
+    TS: DBData + UPrimInt,
     V: DBData,
     Agg: Aggregator<V, (), B::R>,
     B: PartitionedBatchReader<TS, V> + Clone,


### PR DESCRIPTION
Rolling aggregates are built on top of radix trees, which rely on bit pattern manipulation, which currently assumes unsigned timestamps. However, this requirement is not enforced in any way and the operator simply produces incorrect results when used with signed timestamps.

This commit adds the `Unsigned` trait bound to enforce unsigned timestamps at compile time.

Addresses #179.