### PR TITLE
Release management (fixes #529)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+checksum = "7417b1484e3641a8791af3c3123cdc083ac60a0d262a2f281b6125d58917caf4"
 dependencies = [
  "num-traits",
  "rand",

--- a/Earthfile
+++ b/Earthfile
@@ -557,6 +557,7 @@ integration-test-container:
     # Check that the binary does indeed run integration tests
     RUN ./test_binary integration_test --list | grep integration_test
     ENV TEST_DBSP_URL=http://pipeline-manager:8080
+    ENV RUST_BACKTRACE=1
     ENTRYPOINT ["./test_binary", "integration_test::"]
     SAVE IMAGE itest:latest
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -3,7 +3,7 @@
 set -ex
 
 #
-# To use this function, make sure you have maven installed, and run `cargo install cargo-edit` first
+# Run `cargo install cargo-edit` once before you use this function
 #
 # When pushing commits created by this script, don't forget to use the --follow-tags argument to `git push`
 #
@@ -14,31 +14,22 @@ release() {
     fi
 
     if [ $1 = "major" ]; then
-        cargo set-version --bump major
+        cargo set-version --bump major -p pipeline-manager
     fi
 
     if [ $1 = "minor" ]; then
-        cargo set-version --bump minor
+        cargo set-version --bump minor -p pipeline-manager
     fi
 
     if [ $1 = "patch" ]; then
-        cargo set-version --bump patch
+        cargo set-version --bump patch -p pipeline-manager
     fi
 
     version=`cargo run --bin=api-server -- -V | awk '{print $NF}'`
 
-    cd ../sql-to-dbsp-compiler/SQL-compiler
-
-    mvn versions:set -DnewVersion=$version
-
     # Commit the new version
     git commit -am "release: bump project version to $version" -s
     git tag -a v$version -m "v$version"
-
-    # Start next development cycle. Bump the SQL compiler to a
-    # SNAPSHOT release for the next patch version.
-    mvn release:update-versions --batch-mode
-    git commit -am "release: start post-$version release cycle" -s
 }
 
 release "$@"

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -13,17 +13,15 @@ release() {
         exit 1
     fi
 
-    if [ $1 = "major" ]; then
-        cargo set-version --bump major -p pipeline-manager
+    if ! (cargo set-version --version) >/dev/null 2>&1; then
+        echo >&2 "$0: cargo-edit not installed, please run 'cargo install cargo-edit'"
+        exit 1
     fi
 
-    if [ $1 = "minor" ]; then
-        cargo set-version --bump minor -p pipeline-manager
-    fi
-
-    if [ $1 = "patch" ]; then
-        cargo set-version --bump patch -p pipeline-manager
-    fi
+    case $1 in
+        major|minor|patch) cargo set-version --bump $1 -p pipeline-manager ;;
+        *) echo >&2 "Argument must be 'major' or 'minor' or 'patch'"; exit 1 ;;
+    esac
 
     version=`cargo run --bin=api-server -- -V | awk '{print $NF}'`
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+#
+# To use this function, make sure you have maven installed, and run `cargo install cargo-edit` first
+#
+# When pushing commits created by this script, don't forget to use the --follow-tags argument to `git push`
+#
+release() {
+    if [ $# -ne 1 ]; then 
+        echo "Illegal number of parameters. Usage: ./bump-versions.sh major|minor|patch"
+        exit 1
+    fi
+
+    if [ $1 = "major" ]; then
+        cargo set-version --bump major
+    fi
+
+    if [ $1 = "minor" ]; then
+        cargo set-version --bump minor
+    fi
+
+    if [ $1 = "patch" ]; then
+        cargo set-version --bump patch
+    fi
+
+    version=`cargo run --bin=api-server -- -V | awk '{print $NF}'`
+
+    cd ../sql-to-dbsp-compiler/SQL-compiler
+
+    mvn versions:set -DnewVersion=$version
+
+    # Commit the new version
+    git commit -am "release: bump project version to $version" -s
+    git tag -a v$version -m "v$version"
+
+    # Start next development cycle. Bump the SQL compiler to a
+    # SNAPSHOT release for the next patch version.
+    mvn release:update-versions --batch-mode
+    git commit -am "release: start post-$version release cycle" -s
+}
+
+release "$@"


### PR DESCRIPTION
Adds a script to bump versions and create release commits. Usage looks like this.

```
./bump-versions.sh major|minor|patch
```

It currently:
* bumps versions for all rust packages in the project workspace
* lines up the SQL compiler's version (in pom.xml) to the updated rust package versions. 
* It then creates a release commit with the tag "v$version" 
* It then bumps the SQL compiler to a SNAPSHOT release for the following patch version, and creates a "start post-v$version release cycle" commit.

The `clap` library we use for the rust binaries CLI already intrinsically adds a "-V" argument to display the package versions for the binaries.

This fixes #529 except for separating release from main documentation. We'll need the docusaurus experts to help sort that out.

You can see example commits here where we update the project from version 0.1.0 to 0.2.0: https://github.com/feldera/dbsp/tree/release-example

The 2nd commit takes the SQL compiler to 0.2.1-SNAPSHOT.

This is the output the script shows:

```
scripts git:(releases) ✗ ./bump-versions.sh minor
+ release minor
+ '[' 1 -ne 1 ']'
+ '[' minor = major ']'
+ '[' minor = minor ']'
+ cargo set-version --bump minor
   Upgrading dataflow-jit from 0.1.0 to 0.2.0
   Upgrading dbsp from 0.1.0 to 0.2.0
   Upgrading dbsp_adapters from 0.1.0 to 0.2.0
   Upgrading dbsp_nexmark from 0.1.0 to 0.2.0
   Upgrading hashing from 0.1.0 to 0.2.0
   Upgrading pipeline-manager from 0.1.0 to 0.2.0
   Upgrading readers from 0.1.0 to 0.2.0
   Upgrading sqllib from 0.1.0 to 0.2.0
   Upgrading sqlvalue from 0.1.0 to 0.2.0
   Upgrading tuple from 0.1.0 to 0.2.0
   Upgrading webui-tester from 0.1.0 to 0.2.0
+ '[' minor = patch ']'
++ cargo run --bin=api-server -- -V
++ awk '{print $NF}'
   Compiling dbsp_adapters v0.2.0 (/Users/lalith/code/dbsp/crates/adapters)
   Compiling pipeline-manager v0.2.0 (/Users/lalith/code/dbsp/crates/pipeline_manager)
    Finished dev [unoptimized + debuginfo] target(s) in 5.45s
     Running `/Users/lalith/code/dbsp/target/debug/api-server -V`
+ version=0.2.0
+ cd ../sql-to-dbsp-compiler/SQL-compiler
+ mvn versions:set -DnewVersion=0.2.0
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< org.example:SQL-compiler >----------------------
[INFO] Building SQL-compiler 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- versions:2.16.0:set (default-cli) @ SQL-compiler ---
[INFO] Searching for local aggregator root...
[INFO] Local aggregation root: /Users/lalith/code/dbsp/sql-to-dbsp-compiler/SQL-compiler
[INFO] Processing change of org.example:SQL-compiler:1.0-SNAPSHOT -> 0.2.0
[INFO] Processing org.example:SQL-compiler
[INFO]     Updating project org.example:SQL-compiler
[INFO]         from version 1.0-SNAPSHOT to 0.2.0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.494 s
[INFO] Finished at: 2023-08-22T16:33:44-07:00
[INFO] ------------------------------------------------------------------------
+ git commit -am 'release: bump project version to 0.2.0' -s
[releases 3470ad6b] release: bump project version to 0.2.0
 13 files changed, 24 insertions(+), 24 deletions(-)
+ git tag -a v0.2.0 -m v0.2.0
+ mvn release:update-versions --batch-mode
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< org.example:SQL-compiler >----------------------
[INFO] Building SQL-compiler 0.2.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- release:3.0.1:update-versions (default-cli) @ SQL-compiler ---
[INFO] starting updateVersions goal, composed of 4 phases: check-poms-updateversions, create-backup-poms, map-development-versions, rewrite-pom-versions
[INFO] 1/4 updateVersions:check-poms-updateversions
[INFO] 2/4 updateVersions:create-backup-poms
[INFO] Creating pom.xml backup with .releaseBackup suffix
[INFO] 3/4 updateVersions:map-development-versions
[INFO] 4/4 updateVersions:rewrite-pom-versions
[INFO] Transforming pom.xml SQL-compiler 'SQL-compiler'...
[INFO] Cleaning up after release...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.458 s
[INFO] Finished at: 2023-08-22T16:33:45-07:00
[INFO] ------------------------------------------------------------------------
+ git commit -am 'release: start post-0.2.0 release cycle' -s
[releases f9b91101] release: start post-0.2.0 release cycle
 1 file changed, 2 insertions(+), 4 deletions(-)
```