### PR TITLE
docker: set redpanda memory using --memory instead of docker limits

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -525,13 +525,11 @@ build-demo-container:
 test-docker-compose:
     FROM earthly/dind:alpine
     COPY deploy/docker-compose.yml .
-    # Remove resource limits from Redpanda because that does not work from docker-in-docker
-    RUN apk add --no-cache python3 py3-pip && pip3 install yq && cat docker-compose.yml | yq 'del(.services.redpanda.deploy)' -y > docker-compose-no-resources.yml
     WITH DOCKER --pull postgres \
                 --pull docker.redpanda.com/vectorized/redpanda:v23.2.3 \
                 --load ghcr.io/feldera/pipeline-manager=+build-pipeline-manager-container \
                 --load ghcr.io/feldera/demo-container=+build-demo-container
-        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--prepare-args 200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose-no-resources.yml --profile demo up --force-recreate --exit-code-from demo
+        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--prepare-args 200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo
     END
 
 # Fetches the test binary from test-manager, and produces a container image out of it

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
       - --smp 1
       # The amount of memory to make available to Redpanda.
-      - --memory 1G
+      - --memory 2G
       # Mode dev-container uses well-known configuration properties for development in containers.
       - --mode dev-container
       # enable logs for debugging.
@@ -62,10 +62,6 @@ services:
       - 18082:18082
       - 19092:19092
       - 19644:9644
-    deploy:
-      resources:
-        limits:
-          memory: 3GB
 
   demo:
     profiles: ["demo"]


### PR DESCRIPTION
This reverts the earlier fix for https://github.com/feldera/feldera/issues/496, and instead, uses the Redpanda sizing guidelines of setting at least 2GB per core via the --memory argument. It was previously at 1GB per core. I can confirm using `docker stats` that the redpanda container does not use more than 2GB during the SecOps demo.