### PR TITLE
cargo: Set resolver version 2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["crates/*", "sql-to-dbsp-compiler/lib/*"]
 exclude = ["sql-to-dbsp-compiler/temp"]
+resolver = "2"
 
     [workspace.metadata.release]
     release = false


### PR DESCRIPTION
This avoids the following warning given by Rust 1.72:

warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest