### PR TITLE
Pause SecOps generator when demo is not running.

### DIFF
--- a/crates/adapters/src/transport/kafka/input.rs
+++ b/crates/adapters/src/transport/kafka/input.rs
@@ -272,7 +272,7 @@ impl KafkaInputEndpointInner {
         // Context object to intercept rebalancing events and errors.
         let context = KafkaInputContext::new();
 
-        eprintln!("Creating Kafka consumer");
+        debug!("Creating Kafka consumer");
         // Create Kafka consumer.
         let kafka_consumer = BaseConsumer::from_config_and_context(&client_config, context)?;
 

--- a/demo/project_demo00-SecOps/run.py
+++ b/demo/project_demo00-SecOps/run.py
@@ -53,7 +53,7 @@ def make_config(project):
         name="secops_pipeline_sources",
         stream="PIPELINE_SOURCES",
         config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_pipeline_sources"], "auto.offset.reset": "earliest"}
+            {"topics": ["secops_pipeline_sources"], "auto.offset.reset": "earliest", "group.id": "secops_pipeline_sources"}
         ),
         format=JsonInputFormatConfig(update_format = "insert_delete"),
     )

--- a/demo/project_demo00-SecOps/simulator/Cargo.toml
+++ b/demo/project_demo00-SecOps/simulator/Cargo.toml
@@ -16,3 +16,5 @@ csv = "1.2.2"
 rand = "0.8.5"
 mockd = { version = "0.4.1", features = ["datetime"] }
 circular-queue = "0.2.6"
+log="0.4.20"
+env_logger="0.10.0"


### PR DESCRIPTION
The SecOps generator used to run continuously whether the demo was running or not.  This created a small but non-trivial I/O and CPU load on the system.

The fix is to only run the generator when the pipeline is running and is close to exhausting all previously generated messages.  We achieve this but monitoring the consumer group offset.  When the offset is more than 1000 messages behind the producer, the generator stops.

This requires the producer to know consumer group id, so we use a fixed group id for one of the topics in the demo.