### PR TITLE
Reduce log level for some errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "indicatif",
  "itertools",
+ "log",
  "mimalloc-rust-sys",
  "num",
  "once_cell",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -39,7 +39,7 @@ actix-web = { version = "4.3", default-features = false, features = ["cookies", 
 actix-web-static-files = "4.0.0"
 static-files = "0.2.3"
 mime = "0.3.16"
-log = "0.4.17"
+log = "0.4.20"
 size-of = { version = "0.1.2", features = ["time-std"], optional = true }
 futures = { version = "0.3.28" }
 futures-util = { version = "0.3.28" }

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -58,6 +58,7 @@ size-of = { version = "0.1.5", features = ["hashbrown", "time-std", "xxhash-xxh3
 tarpc = { version = "0.33.0", features = ["full"] }
 futures = "0.3"
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread"] }
+log = "0.4.20"
 
 [dev-dependencies]
 csv = "1.2.2"

--- a/crates/dbsp/src/algebra/present.rs
+++ b/crates/dbsp/src/algebra/present.rs
@@ -3,7 +3,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 use size_of::SizeOf;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use super::{F64, F32};
+use super::{F32, F64};
 
 /// A zero-sized weight that indicates a value is present
 #[derive(

--- a/crates/dbsp/src/error.rs
+++ b/crates/dbsp/src/error.rs
@@ -1,5 +1,6 @@
 use crate::{RuntimeError, SchedulerError};
 use anyhow::Error as AnyError;
+use log::Level;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     borrow::Cow,
@@ -10,6 +11,9 @@ use std::{
 
 pub trait DetailedError: StdError + Serialize {
     fn error_code(&self) -> Cow<'static, str>;
+    fn log_level(&self) -> Level {
+        Level::Error
+    }
 }
 
 #[derive(Debug)]

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -961,7 +961,7 @@
 //!     Ok(())
 //! }
 //! ```
-//! 
+//!
 //! The whole program is in `tutorial6.rs`.  If we run it, it prints both per-month
 //! vaccination numbers and 3-month moving averages:
 //!

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -22,7 +22,7 @@ static-files = "0.2.3"
 actix-cors = "0.6.4"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 tokio = { version = "1.25.0", features = ["rt-multi-thread", "fs", "macros", "process", "io-util", "io-std", "signal"] }
-log = "0.4.17"
+log = "0.4.20"
 env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.103"

--- a/crates/pipeline_manager/src/db/error.rs
+++ b/crates/pipeline_manager/src/db/error.rs
@@ -6,6 +6,7 @@ use actix_web::{
 use dbsp_adapters::DetailedError;
 use dbsp_adapters::ErrorResponse;
 use deadpool_postgres::PoolError;
+use log::Level;
 use refinery::Error as RefineryError;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{backtrace::Backtrace, borrow::Cow, error::Error as StdError, fmt, fmt::Display};
@@ -431,6 +432,16 @@ impl DetailedError for DBError {
             Self::RevisionNotChanged => Cow::from("RevisionNotChanged"),
             Self::TablesNotInSchema { .. } => Cow::from("TablesNotInSchema"),
             Self::ViewsNotInSchema { .. } => Cow::from("ViewsNotInSchema"),
+        }
+    }
+
+    fn log_level(&self) -> Level {
+        match self {
+            Self::UnknownProgram { .. } => Level::Info,
+            Self::UnknownPipeline { .. } => Level::Info,
+            Self::UnknownConnector { .. } => Level::Info,
+            Self::UnknownName { .. } => Level::Info,
+            _ => Level::Error,
         }
     }
 }

--- a/crates/pipeline_manager/src/error.rs
+++ b/crates/pipeline_manager/src/error.rs
@@ -23,6 +23,7 @@ use actix_web::{
     body::BoxBody, http::StatusCode, HttpResponse, HttpResponseBuilder, ResponseError,
 };
 use dbsp_adapters::{DetailedError, ErrorResponse};
+use log::Level;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     backtrace::Backtrace,
@@ -210,6 +211,14 @@ impl DetailedError for ManagerError {
             Self::IoError { .. } => Cow::from("ManagerIoError"),
             Self::InvalidProgramSchema { .. } => Cow::from("InvalidProgramSchema"),
             Self::RustCompilerError { .. } => Cow::from("RustCompilerError"),
+        }
+    }
+
+    fn log_level(&self) -> Level {
+        match self {
+            Self::DBError { db_error } => db_error.log_level(),
+            Self::RunnerError { runner_error } => runner_error.log_level(),
+            _ => Level::Error,
         }
     }
 }


### PR DESCRIPTION
Some of the things we report as HTTP errors are benign events that are part of the normal operation.  One example is retrieving a program by name to check if it exists.  Another one is probing pipeline status to determine whether it's finished initializing.

Logging such errors at the ERROR log level is confusing to the user. This commit makes error log level configurable by extending the `DetaileError` trait, which all our errors implment, with the `log_level()` method.  It return `Level::Error`, by default, but can be customized.  For now I reduced the log level of some obvious candidates to Info.  Going forward, we now have a way to fine tune this behavior.