### PR TITLE
Remove localhost assumptions in the code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags 1.3.2",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +568,12 @@ name = "ascii_table"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75054ce561491263d7b80dc2f6f6c6f8cdfd0c7a7c17c5cf3b8117829fa72ae1"
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "async-attributes"
@@ -3179,6 +3208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,6 +4390,7 @@ name = "pipeline-manager"
 version = "0.1.1"
 dependencies = [
  "actix-cors",
+ "actix-files",
  "actix-http",
  "actix-web",
  "actix-web-httpauth",

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -114,7 +114,7 @@ struct Args {
     metadata_file: Option<String>,
 
     /// TCP bind address
-    #[arg(short, long, default_value = "127.0.0.1")]
+    #[arg(short, long, default_value = "0.0.0.0")]
     bind_address: String,
 
     /// Run the server on this port if it is available. If the port is in

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -17,6 +17,7 @@ development = ["pg-client-config"]
 dbsp_adapters = { path = "../adapters" }
 actix-web = "4.3"
 actix-web-static-files = "4.0.0"
+actix-files = "0.6.2"
 awc = {version = "3.1.0", features = ["openssl"] } # Needed for auth workflows
 static-files = "0.2.3"
 actix-cors = "0.6.4"

--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -27,6 +27,10 @@ fn default_db_connection_string() -> String {
     "".to_string()
 }
 
+fn default_binary_ref_port() -> u16 {
+    9090
+}
+
 /// Pipeline manager configuration read from a YAML config file or from command
 /// line arguments.
 #[derive(Parser, Deserialize, Debug, Clone)]
@@ -195,6 +199,17 @@ pub struct CompilerConfig {
     #[serde(skip)]
     #[arg(long)]
     pub precompile: bool,
+
+    /// The hostname to use in a URL for making compiled binaries available
+    /// for runners. This will typically be a DNS name for the host running
+    /// this compiler service.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub binary_ref_host: String,
+
+    /// The port to use in a URL for making compiled binaries available
+    /// for runners.
+    #[arg(long, default_value_t = default_binary_ref_port())]
+    pub binary_ref_port: u16,
 }
 
 impl CompilerConfig {
@@ -365,6 +380,12 @@ pub struct LocalRunnerConfig {
     #[serde(default = "default_working_directory")]
     #[arg(long, default_value_t = default_working_directory())]
     pub runner_working_directory: String,
+
+    /// The hostname or IP address over which pipelines created by
+    /// this local runner will be reachable
+    #[serde(default = "default_server_address")]
+    #[arg(long, default_value_t = default_server_address())]
+    pub pipeline_host: String,
 }
 
 impl LocalRunnerConfig {
@@ -396,6 +417,17 @@ impl LocalRunnerConfig {
         Path::new(&self.runner_working_directory)
             .join("pipelines")
             .join(format!("pipeline{pipeline_id}"))
+    }
+
+    /// Location to write the fetched pipeline binary to.
+    pub(crate) fn binary_file_path(
+        &self,
+        pipeline_id: PipelineId,
+        program: ProgramId,
+        version: Version,
+    ) -> PathBuf {
+        self.pipeline_dir(pipeline_id)
+            .join(format!("program_{program}_v{version}"))
     }
 
     /// Location to write the pipeline config file.

--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -70,11 +70,14 @@ async fn initialize_local_pipeline_manager_instance() -> TempDir {
         dbsp_override_path: Some("../../".to_owned()),
         debug: false,
         precompile: true,
+        binary_ref_host: "127.0.0.1".to_string(),
+        binary_ref_port: 9090,
     }
     .canonicalize()
     .unwrap();
     let local_runner_config = LocalRunnerConfig {
         runner_working_directory: workdir.to_owned(),
+        pipeline_host: "127.0.0.1".to_owned(),
     }
     .canonicalize()
     .unwrap();

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -186,7 +186,7 @@ impl PipelineAutomaton {
                                 None,
                             )
                             .await;
-                            pipeline.set_location(port.to_string());
+                            pipeline.set_location(format!("127.0.0.1:{port}"));
                             pipeline.set_created();
                             self.update_pipeline_runtime_state(&pipeline).await?;
                             poll_timeout = Self::INITIALIZATION_POLL_PERIOD;

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -386,9 +386,9 @@ impl RunnerApi {
         pipeline_id: PipelineId,
         method: Method,
         endpoint: &str,
-        port: &str,
+        location: &str,
     ) -> Result<HttpResponse, ManagerError> {
-        let response = Self::pipeline_http_request(pipeline_id, method, endpoint, port).await?;
+        let response = Self::pipeline_http_request(pipeline_id, method, endpoint, location).await?;
         let status = response.status();
 
         let mut response_builder = HttpResponse::build(status);
@@ -418,11 +418,11 @@ impl RunnerApi {
         pipeline_id: PipelineId,
         method: Method,
         endpoint: &str,
-        port: &str,
+        location: &str,
     ) -> Result<reqwest::Response, RunnerError> {
         let client = reqwest::Client::new();
         client
-            .request(method, &format!("http://localhost:{port}/{endpoint}",))
+            .request(method, &format!("http://{location}/{endpoint}",))
             .send()
             .await
             .map_err(|e| RunnerError::HttpForwardError {
@@ -452,11 +452,11 @@ impl RunnerApi {
             }
             _ => {}
         }
-        let port = pipeline_state.location;
+        let location = pipeline_state.location;
 
         // TODO: it might be better to have ?name={}, otherwise we have to
         // restrict name format
-        let url = format!("http://localhost:{port}/{endpoint}?{}", req.query_string());
+        let url = format!("http://{location}/{endpoint}?{}", req.query_string());
 
         let client = awc::Client::new();
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -37,7 +37,7 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=pipeline-manager --no-default-features
 COPY . .
-RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --no-default-features
+RUN /root/.cargo/bin/cargo build --release --package=pipeline-manager --no-default-features
 
 # Java build can be performed in parallel
 FROM base as javabuild
@@ -47,7 +47,7 @@ COPY sql-to-dbsp-compiler /sql/sql-to-dbsp-compiler
 RUN cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -DskipTests package
 
 # Minimal image for running the pipeline manager
-FROM base as release
+from base as release
 ENV PATH="$PATH:/root/.cargo/bin"
 # Pipeline manager binary
 COPY --from=builder /app/target/release/pipeline-manager pipeline-manager
@@ -69,6 +69,40 @@ COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql
 RUN ./pipeline-manager --bind-address=0.0.0.0 --api-server-working-directory=/working-dir --compiler-working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor --precompile
 ENV BANNER_ADDR localhost
 ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir", "--compiler-working-directory=/working-dir", "--runner-working-directory=/working-dir", "--sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler", "--dbsp-override-path=/database-stream-processor"]
+
+# Standalone api-server
+FROM ubuntu:22.04 as api-server
+COPY --from=builder /app/target/release/api-server api-server
+ENV BANNER_ADDR localhost
+ENTRYPOINT ["./api-server", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir"]
+
+# Standalone compiler-server
+FROM base as compiler-server
+ENV PATH="$PATH:/root/.cargo/bin"
+COPY --from=builder /app/target/release/compiler-server compiler-server
+# SQL compiler uber jar
+RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
+# The crates needed for the SQL compiler
+COPY crates/dbsp database-stream-processor/crates/dbsp
+COPY crates/adapters database-stream-processor/crates/adapters
+COPY crates/dataflow-jit database-stream-processor/crates/dataflow-jit
+COPY README.md database-stream-processor/README.md
+RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+
+# Copy over the rust code and sql-to-dbsp script
+COPY sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
+COPY sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
+COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+# Run the precompile phase to speed up Rust compilations during deployment
+RUN ./compiler-server --compiler-working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor --precompile
+ENTRYPOINT ["./compiler-server", "--compiler-working-directory=/working-dir", "--sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler", "--dbsp-override-path=/database-stream-processor"]
+
+# Standalone local-runner
+FROM ubuntu:22.04 as local-runner
+COPY --from=builder /app/target/release/local-runner local-runner
+ENTRYPOINT ["./local-runner", "--runner-working-directory=/working-dir"] 
+
 
 ##### The stages below are used to build the demo container
 
@@ -118,6 +152,7 @@ RUN apt update && apt install pkg-config \
    # cleanup packages we don't need anymore
    && apt remove python3-pip unzip pkg-config -y && apt autoremove -y
 CMD bash
+
 
 # By default, only build the release version
 FROM release


### PR DESCRIPTION
This PR allows the api-server, compiler-server and local-runner to run as separate processes without any local filesystem to coordinate over. It adds a web endpoint to the compiler service to serve binaries, which the local runners now make use of. This is done by using the binary-ref table, where location URLs can now also be http/https links pointing to the compiler service's endpoint.

I have not removed fileref support for backward compatibility (we can keep it around for a while).