### PR TITLE
Ingest data via HTTP in paused state.

### DIFF
--- a/crates/pipeline_manager/src/api.rs
+++ b/crates/pipeline_manager/src/api.rs
@@ -1764,6 +1764,7 @@ pub struct PipelineIdOrNameQuery {
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier."),
         ("table_name" = String, Path, description = "SQL table name."),
+        ("force" = bool, Query, description = "When `true`, push data to the pipeline even if the pipeline is paused. The default value is `false`"),
         ("format" = String, Query, description = "Input data format, e.g., 'csv' or 'json'."),
         ("array" = Option<bool>, Query, description = "Set to `true` if updates in this stream are packaged into JSON arrays (used in conjunction with `format=json`). The default values is `false`."),
         ("update_format" = Option<JsonUpdateFormat>, Query, description = "JSON data change event format (used in conjunction with `format=json`).  The default value is 'insert_delete'."),

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -652,7 +652,14 @@ impl PipelineAutomaton {
             }
             .into());
         }
-        let fetched_executable = fetch_binary_ref(&self.config, &executable_ref.unwrap(), pipeline_id, program_id, version).await?;
+        let fetched_executable = fetch_binary_ref(
+            &self.config,
+            &executable_ref.unwrap(),
+            pipeline_id,
+            program_id,
+            version,
+        )
+        .await?;
 
         // Run executable, set current directory to pipeline directory, pass metadata
         // file and config as arguments.
@@ -802,24 +809,24 @@ pub async fn fetch_binary_ref(
                         .mode(0o760)
                         .open(path.clone())
                         .await
-                        .map_err(|e| 
+                        .map_err(|e| {
                             ManagerError::io_error(
                                 format!("File creation failed ({:?}) while saving {pipeline_id} binary fetched from '{}'", path, parsed.path()),
                                 e,
                             )
-                        )?;
-                    file.write_all(resp_ref).await.map_err(|e| 
-                            ManagerError::io_error(
-                                format!("File write failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
-                                e,
-                            )
-                        )?;
-                    file.flush().await.map_err(|e| 
-                            ManagerError::io_error(
-                                format!("File flush() failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
-                                e,
-                            )
-                        )?;
+                        })?;
+                    file.write_all(resp_ref).await.map_err(|e| {
+                        ManagerError::io_error(
+                            format!("File write failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
+                            e,
+                        )
+                    })?;
+                    file.flush().await.map_err(|e| {
+                        ManagerError::io_error(
+                            format!("File flush() failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
+                            e,
+                        )
+                    })?;
                     Ok(path.into_os_string().into_string().expect("Path should be valid Unicode"))
                 }
                 Err(e) => {

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/http_input.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/http_input.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     pipeline_id: str,
     table_name: str,
     *,
+    force: bool,
     format_: str,
     array: Union[Unset, None, bool] = UNSET,
     update_format: Union[Unset, None, JsonUpdateFormat] = UNSET,
@@ -21,6 +22,8 @@ def _get_kwargs(
     pass
 
     params: Dict[str, Any] = {}
+    params["force"] = force
+
     params["format"] = format_
 
     params["array"] = array
@@ -83,6 +86,7 @@ def sync_detailed(
     table_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    force: bool,
     format_: str,
     array: Union[Unset, None, bool] = UNSET,
     update_format: Union[Unset, None, JsonUpdateFormat] = UNSET,
@@ -102,6 +106,7 @@ def sync_detailed(
     Args:
         pipeline_id (str):
         table_name (str):
+        force (bool):
         format_ (str):
         array (Union[Unset, None, bool]):
         update_format (Union[Unset, None, JsonUpdateFormat]): Supported JSON data change event
@@ -122,6 +127,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         pipeline_id=pipeline_id,
         table_name=table_name,
+        force=force,
         format_=format_,
         array=array,
         update_format=update_format,
@@ -139,6 +145,7 @@ def sync(
     table_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    force: bool,
     format_: str,
     array: Union[Unset, None, bool] = UNSET,
     update_format: Union[Unset, None, JsonUpdateFormat] = UNSET,
@@ -158,6 +165,7 @@ def sync(
     Args:
         pipeline_id (str):
         table_name (str):
+        force (bool):
         format_ (str):
         array (Union[Unset, None, bool]):
         update_format (Union[Unset, None, JsonUpdateFormat]): Supported JSON data change event
@@ -179,6 +187,7 @@ def sync(
         pipeline_id=pipeline_id,
         table_name=table_name,
         client=client,
+        force=force,
         format_=format_,
         array=array,
         update_format=update_format,
@@ -190,6 +199,7 @@ async def asyncio_detailed(
     table_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    force: bool,
     format_: str,
     array: Union[Unset, None, bool] = UNSET,
     update_format: Union[Unset, None, JsonUpdateFormat] = UNSET,
@@ -209,6 +219,7 @@ async def asyncio_detailed(
     Args:
         pipeline_id (str):
         table_name (str):
+        force (bool):
         format_ (str):
         array (Union[Unset, None, bool]):
         update_format (Union[Unset, None, JsonUpdateFormat]): Supported JSON data change event
@@ -229,6 +240,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         pipeline_id=pipeline_id,
         table_name=table_name,
+        force=force,
         format_=format_,
         array=array,
         update_format=update_format,
@@ -244,6 +256,7 @@ async def asyncio(
     table_name: str,
     *,
     client: Union[AuthenticatedClient, Client],
+    force: bool,
     format_: str,
     array: Union[Unset, None, bool] = UNSET,
     update_format: Union[Unset, None, JsonUpdateFormat] = UNSET,
@@ -263,6 +276,7 @@ async def asyncio(
     Args:
         pipeline_id (str):
         table_name (str):
+        force (bool):
         format_ (str):
         array (Union[Unset, None, bool]):
         update_format (Union[Unset, None, JsonUpdateFormat]): Supported JSON data change event
@@ -285,6 +299,7 @@ async def asyncio(
             pipeline_id=pipeline_id,
             table_name=table_name,
             client=client,
+            force=force,
             format_=format_,
             array=array,
             update_format=update_format,


### PR DESCRIPTION
Add `?force` flag to the `/ingress` endpoint, which forces the endpoint to push data to the pipeline even if it is in the paused state.  This is useful for debugging, including WebConsole-based debugging, where we want to pause the pipeline and play with some test inputs.

@Karakatiza666, this should address #612 , just make sure to pass `?flag=true` to all `/ingress` calls from the UI.