### PR TITLE
dbsp: Slight simplification in `eval_strict_owned` for `StrictUnaryOp…

### DIFF
--- a/crates/dbsp/src/operator/trace.rs
+++ b/crates/dbsp/src/operator/trace.rs
@@ -698,8 +698,8 @@ where
         self.trace = Some(i);
 
         self.dirty[0] = dirty;
-        for d in self.dirty[1..].iter_mut() {
-            *d = *d || dirty;
+        if dirty {
+            self.dirty.fill(true);
         }
     }
 


### PR DESCRIPTION
…erator`.

It's not necessary to individually "or" each element of `dirty`, since we're either setting them all to `true` or not modifying them.