### PR TITLE
dbsp: Release `dbsp` 0.2.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbsp"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Continuous streaming analytics engine"


### PR DESCRIPTION
This release mainly includes some additional documentation.  It is a major version bump because it removes `merging` from the public interface for `dbsp::trace::Spine`.