### PR TITLE
Enable verbose for earthly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,4 @@ jobs:
         run: earthly --version
 
       - name: Run CI
-        run: earthly -P --ci +all-tests
+        run: earthly --verbose -P --ci +all-tests


### PR DESCRIPTION
This will print some statistics for individual task build times so we can find & optimize the worst offenders.