### PR TITLE
Add more public types to pipeline-manager to make it usable as a library

### DIFF
--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -435,11 +435,6 @@ impl LocalRunnerConfig {
         self.pipeline_dir(pipeline_id).join("config.yaml")
     }
 
-    /// Location to write the pipeline metadata file.
-    pub(crate) fn metadata_file_path(&self, pipeline_id: PipelineId) -> PathBuf {
-        self.pipeline_dir(pipeline_id).join("metadata.json")
-    }
-
     /// Location for pipeline port file
     pub(crate) fn port_file_path(&self, pipeline_id: PipelineId) -> PathBuf {
         self.pipeline_dir(pipeline_id)

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -508,7 +508,7 @@ impl From<PipelineStatus> for &'static str {
 /// A pipeline revision is a versioned, immutable configuration struct that
 /// contains all information necessary to run a pipeline.
 #[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
-pub(crate) struct PipelineRevision {
+pub struct PipelineRevision {
     /// The revision number, starts at 1, increases every time the pipeline is
     /// comitted.
     pub(crate) revision: Revision,

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -31,10 +31,7 @@ const RETRY_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(2
 /// also be checking object versions and only issue notifications for version changes, and discard
 /// notifications about older versions. In the absence of such a check, there is a potential race +
 /// redundnacy between sync() calls and receiving notifications from the registered LISTEN calls
-pub(crate) async fn listen(
-    conn: Arc<tokio::sync::Mutex<ProjectDB>>,
-    tx: UnboundedSender<DbNotification>,
-) {
+pub async fn listen(conn: Arc<tokio::sync::Mutex<ProjectDB>>, tx: UnboundedSender<DbNotification>) {
     loop {
         let (client, mut connection) = conn
             .lock()
@@ -190,13 +187,13 @@ fn parse_notification(channel: &str, payload: &str) -> Result<DbNotification, No
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum DbNotification {
+pub enum DbNotification {
     Program(Operation, TenantId, ProgramId),
     Pipeline(Operation, TenantId, PipelineId),
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum Operation {
+pub enum Operation {
     Add,
     Delete,
     Update,

--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -311,7 +311,10 @@ impl TestConfig {
             let val: Value = resp.json().await.unwrap();
 
             let status = val["status"].clone();
-            if status != json!("CompilingSql") && status != json!("CompilingRust") && status != json!("Pending") {
+            if status != json!("CompilingSql")
+                && status != json!("CompilingRust")
+                && status != json!("Pending")
+            {
                 if status == json!("Success") {
                     break;
                 } else {
@@ -882,7 +885,8 @@ async fn parse_datetime() {
     assert!(req.status().is_success());
 
     let quantiles = config.quantiles_json(&id, "T1").await;
-    assert_eq!(quantiles, "[{\"insert\":{\"D\":\"2024-02-25\",\"T\":\"11:12:33.483221092\",\"TS\":\"2024-02-25 12:12:33\"}},{\"insert\":{\"D\":\"2021-05-20\",\"T\":\"13:22:00\",\"TS\":\"2021-05-20 12:12:33\"}}]");
+    assert_eq!(quantiles.parse::<Value>().unwrap(), 
+               "[{\"insert\":{\"D\":\"2024-02-25\",\"T\":\"11:12:33.483221092\",\"TS\":\"2024-02-25 12:12:33\"}},{\"insert\":{\"D\":\"2021-05-20\",\"T\":\"13:22:00\",\"TS\":\"2021-05-20 12:12:33\"}}]".parse::<Value>().unwrap());
 
     // Shutdown the pipeline
     let resp = config
@@ -920,14 +924,18 @@ async fn quoted_columns() {
                 "/v0/pipelines/{}/ingress/T1?format=json&update_format=raw",
                 id
             ),
-            r#"{"c1": 10, "C2": true, "😁❤": "foo", "αβγ": true, "δθ": false}"#
-                .to_string(),
+            r#"{"c1": 10, "C2": true, "😁❤": "foo", "αβγ": true, "δθ": false}"#.to_string(),
         )
         .await;
     assert!(req.status().is_success());
 
     let quantiles = config.quantiles_json(&id, "T1").await;
-    assert_eq!(quantiles, "[{\"insert\":{\"C2\":true,\"c1\":10,\"ΔΘ\":false,\"αβγ\":true,\"😁❤\":\"foo\"}}]");
+    assert_eq!(
+        quantiles.parse::<Value>().unwrap(),
+        "[{\"insert\":{\"C2\":true,\"c1\":10,\"ΔΘ\":false,\"αβγ\":true,\"😁❤\":\"foo\"}}]"
+            .parse::<Value>()
+            .unwrap()
+    );
 
     // Shutdown the pipeline
     let resp = config

--- a/crates/pipeline_manager/src/lib.rs
+++ b/crates/pipeline_manager/src/lib.rs
@@ -1,5 +1,4 @@
 mod auth;
-mod db_notifier;
 mod error;
 #[cfg(test)]
 #[cfg(feature = "integration-test")]
@@ -9,6 +8,8 @@ pub mod api;
 pub mod compiler;
 pub mod config;
 pub mod db;
+pub mod db_notifier;
 pub mod local_runner;
 pub mod logging;
+pub mod pipeline_automata;
 pub mod runner;

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -2,610 +2,54 @@ use crate::db::{ProgramId, Version};
 /// A local runner that watches for pipeline objects in the API
 /// and instantiates them locally as processes.
 use crate::db_notifier::{DbNotification, Operation};
-use crate::runner::RunnerApi;
+use crate::pipeline_automata::{fetch_binary_ref, PipelineAutomaton};
+use crate::pipeline_automata::{PipelineExecutionDesc, PipelineExecutor};
 use crate::{
     api::ManagerError,
-    auth::TenantId,
     config::LocalRunnerConfig,
-    db::{
-        storage::Storage, DBError, PipelineId, PipelineRevision, PipelineRuntimeState,
-        PipelineStatus, ProjectDB,
-    },
+    db::{storage::Storage, PipelineId, PipelineRevision, ProjectDB},
     runner::RunnerError,
 };
-use actix_web::http::{Method, StatusCode};
-use chrono::{DateTime, Utc};
-use dbsp_adapters::ErrorResponse;
-use log::{error, info, trace};
-use serde::Deserialize;
-use serde_json::Value as JsonValue;
+use async_trait::async_trait;
+use dbsp_adapters::PipelineConfig;
+use log::trace;
 use std::{
     collections::BTreeMap,
     process::Stdio,
     process::{Child, Command},
     sync::Arc,
 };
-use tokio::io::AsyncWriteExt;
+use tokio::sync::Notify;
 use tokio::{
     fs,
     fs::{create_dir_all, remove_dir_all},
     spawn,
     sync::Mutex,
-    time::Duration,
 };
-use tokio::{sync::Notify, time::timeout};
 
 /// A handle to the pipeline process that kills the pipeline
 /// on `drop`.
-struct PipelineHandle {
-    pipeline_process: Child,
-}
-
-impl Drop for PipelineHandle {
-    fn drop(&mut self) {
-        let _ = self.pipeline_process.kill();
-    }
-}
-
-/// Pipeline automaton monitors the runtime state of a single pipeline
-/// and continually reconciles desired and actual state.
-///
-/// The automaton runs as a separate tokio task.
-struct PipelineAutomaton {
+pub struct ProcessRunner {
     pipeline_id: PipelineId,
-    tenant_id: TenantId,
-    pipeline_process: Option<PipelineHandle>,
+    pipeline_process: Option<Child>,
     config: Arc<LocalRunnerConfig>,
     db: Arc<Mutex<ProjectDB>>,
-    notifier: Arc<Notify>,
 }
 
-impl PipelineAutomaton {
-    /// The frequency of polling the pipeline during normal operation
-    /// when we don't normally expect its state to change.
-    const DEFAULT_PIPELINE_POLL_PERIOD: Duration = Duration::from_millis(10_000);
-
-    /// Max time to wait for the pipeline process to initialize its
-    /// HTTP server.
-    const PROVISIONING_TIMEOUT: Duration = Duration::from_millis(10_000);
-
-    /// How often to check for the pipeline port file during the
-    /// provisioning phase.
-    const PROVISIONING_POLL_PERIOD: Duration = Duration::from_millis(300);
-
-    /// Max time to wait for the pipeline to initialize all connectors.
-    const INITIALIZATION_TIMEOUT: Duration = Duration::from_millis(20_000);
-
-    /// How often to poll for the pipeline initialization status.
-    const INITIALIZATION_POLL_PERIOD: Duration = Duration::from_millis(300);
-
-    /// Max time to wait for the pipeline process to exit.
-    // TODO: It seems that Actix often takes a while to shutdown.  This
-    // is something to investigate.
-    const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(10_000);
-
-    /// How often to poll for the pipeline process to exit.
-    const SHUTDOWN_POLL_PERIOD: Duration = Duration::from_millis(300);
-
-    fn new(
-        pipeline_id: PipelineId,
-        tenant_id: TenantId,
-        config: &Arc<LocalRunnerConfig>,
-        db: Arc<Mutex<ProjectDB>>,
-        notifier: Arc<Notify>,
-    ) -> Self {
-        Self {
-            pipeline_id,
-            tenant_id,
-            pipeline_process: None,
-            config: config.clone(),
-            db,
-            notifier,
-        }
+impl Drop for ProcessRunner {
+    fn drop(&mut self) {
+        let _ = self.pipeline_process.as_mut().map(|p| p.kill());
     }
+}
 
-    /// Runs until the pipeline is deleted or an unexpected error occurs.
-    async fn run(self) -> Result<(), ManagerError> {
-        let pipeline_id = self.pipeline_id;
+#[async_trait]
+impl PipelineExecutor for ProcessRunner {
+    async fn start(&mut self, ped: PipelineExecutionDesc) -> Result<(), ManagerError> {
+        let pipeline_id = ped.pipeline_id;
+        let program_id = ped.program_id;
+        let version = ped.version;
 
-        self.do_run().await.map_err(|e| {
-            error!(
-                "Pipeline automaton '{}' terminated with error: '{e}'",
-                pipeline_id
-            );
-            e
-        })
-    }
-
-    async fn do_run(mut self) -> Result<(), ManagerError> {
-        let mut poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
-
-        loop {
-            // Wait until the timeout expires or we get notified that
-            // the desired state of the pipelime has changed.
-            let _ = timeout(poll_timeout, self.notifier.notified()).await;
-            poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
-
-            // TODO: use transactional API when ready to avoid races with a parallel
-            // `/deploy /shutdown` sequence.
-
-            // txn = db.transaction();
-            let db = self.db.lock().await;
-            let result = db
-                .get_pipeline_runtime_state(self.tenant_id, self.pipeline_id)
-                .await;
-            if let Err(e) = result {
-                match e {
-                    DBError::UnknownPipeline { pipeline_id } => {
-                        // Pipeline deletions should not lead to errors in the logs.
-                        info!("Pipeline {pipeline_id} does not exist. Shutting down pipeline automaton.");
-                        return Ok(());
-                    }
-                    _ => return Err(e.into()),
-                }
-            }
-            let mut pipeline = result.unwrap();
-
-            // Handle deployment request.
-            if pipeline.current_status == PipelineStatus::Shutdown
-                && pipeline.desired_status != PipelineStatus::Shutdown
-            {
-                self.update_pipeline_status(&mut pipeline, PipelineStatus::Provisioning, None)
-                    .await;
-                let revision = db
-                    .get_last_committed_pipeline_revision(self.tenant_id, self.pipeline_id)
-                    .await?;
-                db.update_pipeline_runtime_state(self.tenant_id, self.pipeline_id, &pipeline)
-                    .await?;
-                // txn.commit();
-                drop(db);
-
-                match self.start(revision).await {
-                    Ok(child) => {
-                        self.pipeline_process = Some(child);
-                    }
-                    Err(e) => {
-                        self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                    }
-                }
-                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
-                continue;
-            } else {
-                // txn.commit();
-                drop(db);
-            }
-
-            match (pipeline.current_status, pipeline.desired_status) {
-                // We're waiting for the pipeline's HTTP server to come online.
-                // Poll its port file.  On success, go to `Initializing` state.
-                (PipelineStatus::Provisioning, PipelineStatus::Running)
-                | (PipelineStatus::Provisioning, PipelineStatus::Paused) => {
-                    match self.read_pipeline_port_file().await {
-                        Ok(Some(port)) => {
-                            self.update_pipeline_status(
-                                &mut pipeline,
-                                PipelineStatus::Initializing,
-                                None,
-                            )
-                            .await;
-                            let host = &self.config.pipeline_host;
-                            pipeline.set_location(format!("{host}:{port}"));
-                            pipeline.set_created();
-                            self.update_pipeline_runtime_state(&pipeline).await?;
-                            poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
-                        }
-                        Ok(None) => {
-                            if Self::timeout_expired(
-                                pipeline.status_since,
-                                Self::PROVISIONING_TIMEOUT,
-                            ) {
-                                self.force_kill_pipeline(
-                                    &mut pipeline,
-                                    Some(RunnerError::PipelineProvisioningTimeout {
-                                        pipeline_id: self.pipeline_id,
-                                        timeout: Self::PROVISIONING_TIMEOUT,
-                                    }),
-                                )
-                                .await?;
-                            } else {
-                                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
-                            }
-                        }
-                        Err(e) => {
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                    }
-                }
-                // User cancels the pipeline while it's still provisioning.
-                (PipelineStatus::Provisioning, PipelineStatus::Shutdown) => {
-                    self.force_kill_pipeline(&mut pipeline, <Option<RunnerError>>::None)
-                        .await?;
-                }
-                // We're waiting for the pipeline to initialize.
-                // Poll the pipeline's status.  Kill the pipeline on timeout or error.
-                // On success, go to the `PAUSED` state.
-                (PipelineStatus::Initializing, PipelineStatus::Running)
-                | (PipelineStatus::Initializing, PipelineStatus::Paused) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "stats",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Paused,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                            } else if status == StatusCode::SERVICE_UNAVAILABLE {
-                                if Self::timeout_expired(
-                                    pipeline.status_since,
-                                    Self::INITIALIZATION_TIMEOUT,
-                                ) {
-                                    self.force_kill_pipeline(
-                                        &mut pipeline,
-                                        Some(RunnerError::PipelineInitializationTimeout {
-                                            pipeline_id: self.pipeline_id,
-                                            timeout: Self::INITIALIZATION_TIMEOUT,
-                                        }),
-                                    )
-                                    .await?;
-                                } else {
-                                    poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
-                                }
-                            } else {
-                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // User cancels the pipeline while it is still initalizing.
-                (PipelineStatus::Initializing, PipelineStatus::Shutdown) => {
-                    self.force_kill_pipeline(&mut pipeline, <Option<RunnerError>>::None)
-                        .await?;
-                }
-                // Unpause the pipeline.
-                (PipelineStatus::Paused, PipelineStatus::Running) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "start",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Running,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                            } else {
-                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // Pause the pipeline.
-                (PipelineStatus::Running, PipelineStatus::Paused) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "pause",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Paused,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                            } else {
-                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // Shutdown request.  Forward to the pipeline; on success go to the `ShuttingDown`
-                // state.
-                (PipelineStatus::Running, PipelineStatus::Shutdown)
-                | (PipelineStatus::Paused, PipelineStatus::Shutdown) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "shutdown",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::ShuttingDown,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                                poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
-                            } else {
-                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // Graceful shutdown in progress.  Wait for the pipeline process to self-terminate.
-                // Force-kill the pipeline after a timeout.
-                (PipelineStatus::ShuttingDown, _) => {
-                    if self
-                        .pipeline_process
-                        .as_mut()
-                        .map(|p| p.pipeline_process.try_wait().is_ok())
-                        .unwrap_or(true)
-                    {
-                        self.pipeline_process = None;
-                        self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, None)
-                            .await;
-                        self.update_pipeline_runtime_state(&pipeline).await?;
-                    } else if Self::timeout_expired(pipeline.status_since, Self::SHUTDOWN_TIMEOUT) {
-                        self.force_kill_pipeline(
-                            &mut pipeline,
-                            Some(RunnerError::PipelineShutdownTimeout {
-                                pipeline_id: self.pipeline_id,
-                                timeout: Self::SHUTDOWN_TIMEOUT,
-                            }),
-                        )
-                        .await?;
-                    } else {
-                        poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
-                    }
-                }
-                // Steady-state operation.  Periodically poll the pipeline.
-                (PipelineStatus::Running, _) | (PipelineStatus::Paused, _) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "stats",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            // Cannot reach the pipeline.
-                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if !status.is_success() {
-                                // Pipeline responds with an error, meaning that the pipeline
-                                // HTTP server is still running, but the pipeline itself failed --
-                                // save it out of its misery.
-                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            } else {
-                                let global_metrics = if let Some(metrics) =
-                                    body.get("global_metrics")
-                                {
-                                    metrics
-                                } else {
-                                    Err(RunnerError::HttpForwardError {
-                                        pipeline_id: self.pipeline_id,
-                                        error: format!("Pipeline status descriptor doesn't contain 'global_metrics' field: '{body}'")
-                                    })?
-                                };
-                                let state = if let Some(state) = global_metrics.get("state") {
-                                    state
-                                } else {
-                                    Err(RunnerError::HttpForwardError {
-                                        pipeline_id: self.pipeline_id,
-                                        error: format!("Pipeline status descriptor doesn't contain 'global_metrics.state' field: '{body}'")
-                                    })?
-                                };
-                                let state = if let Some(state) = state.as_str() {
-                                    state
-                                } else {
-                                    Err(RunnerError::HttpForwardError {
-                                        pipeline_id: self.pipeline_id,
-                                        error: format!("Pipeline status descriptor contains invalid 'global_metrics.state' field: '{body}'")
-                                    })?
-                                };
-
-                                if state == "Paused"
-                                    && pipeline.current_status != PipelineStatus::Paused
-                                {
-                                    self.update_pipeline_status(
-                                        &mut pipeline,
-                                        PipelineStatus::Paused,
-                                        None,
-                                    )
-                                    .await;
-                                    self.update_pipeline_runtime_state(&pipeline).await?;
-                                } else if state == "Running"
-                                    && pipeline.current_status != PipelineStatus::Running
-                                {
-                                    self.update_pipeline_status(
-                                        &mut pipeline,
-                                        PipelineStatus::Running,
-                                        None,
-                                    )
-                                    .await;
-                                    self.update_pipeline_runtime_state(&pipeline).await?;
-                                } else if state != "Paused" && state != "Running" {
-                                    self.force_kill_pipeline(&mut pipeline, Some(RunnerError::HttpForwardError {
-                                        pipeline_id: self.pipeline_id,
-                                        error: format!("Pipeline reported unexpected status '{state}', expected 'Paused' or 'Running'")
-                                    })).await?;
-                                }
-                            }
-                        }
-                    }
-                }
-                // User acknowledges pipeline failure by invoking the `/shutdown` endpoint.
-                // Move to the `Shutdown` state so that the pipeline can be started again.
-                (PipelineStatus::Failed, PipelineStatus::Shutdown) => {
-                    let error = pipeline.error.clone();
-                    self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, error)
-                        .await;
-                    self.update_pipeline_runtime_state(&pipeline).await?;
-                }
-                (PipelineStatus::Failed | PipelineStatus::Shutdown, _) => {}
-                _ => {
-                    error!(
-                        "Unexpected current/desired pipeline status combination {:?}/{:?}",
-                        pipeline.current_status, pipeline.desired_status
-                    )
-                }
-            }
-        }
-    }
-
-    async fn update_pipeline_status(
-        &self,
-        pipeline: &mut PipelineRuntimeState,
-        status: PipelineStatus,
-        error: Option<ErrorResponse>,
-    ) {
-        pipeline.set_current_status(status, error.clone());
-        if status == PipelineStatus::Shutdown {
-            match remove_dir_all(self.config.pipeline_dir(self.pipeline_id)).await {
-                Ok(_) => (),
-                Err(e) => {
-                    log::warn!(
-                        "Failed to delete pipeline directory for pipeline {}: {}",
-                        self.pipeline_id,
-                        e
-                    );
-                }
-            }
-        }
-    }
-
-    async fn update_pipeline_runtime_state(
-        &self,
-        state: &PipelineRuntimeState,
-    ) -> Result<(), DBError> {
-        self.db
-            .lock()
-            .await
-            .update_pipeline_runtime_state(self.tenant_id, self.pipeline_id, state)
-            .await
-    }
-
-    // We store timestamps in the DB and retrieve them as Utc times;
-    // hence we cannot use the normal `Instant::elapsed` API for timeouts.
-    fn timeout_expired(since: DateTime<Utc>, timeout: Duration) -> bool {
-        Utc::now().timestamp_millis() - since.timestamp_millis() > timeout.as_millis() as i64
-    }
-
-    /// Force-kill the pipeline process, set its error description.
-    ///
-    /// If the desired state of the pipeline is `Paused` or `Running`,
-    /// places pipeline in the `Failed` state to avoid instant automatic
-    /// restart.  Otherwise (the desired state was `Shutdown`), set the
-    /// state of the pipeline to `Shutdown`.
-    async fn force_kill_pipeline<E>(
-        &mut self,
-        pipeline: &mut PipelineRuntimeState,
-        error: Option<E>,
-    ) -> Result<(), DBError>
-    where
-        ErrorResponse: for<'a> From<&'a E>,
-    {
-        self.pipeline_process = None;
-
-        if pipeline.desired_status == PipelineStatus::Shutdown {
-            self.update_pipeline_status(
-                pipeline,
-                PipelineStatus::Shutdown,
-                error.map(|e| ErrorResponse::from(&e)),
-            )
-            .await;
-        } else {
-            self.update_pipeline_status(
-                pipeline,
-                PipelineStatus::Failed,
-                error.map(|e| ErrorResponse::from(&e)),
-            )
-            .await;
-        }
-        self.update_pipeline_runtime_state(pipeline).await
-    }
-
-    /// Same as `force_kill_pipeline`, but deserializes `ErrorResponse` from
-    /// a JSON error returned by the pipeline.
-    async fn force_kill_pipeline_on_error(
-        &mut self,
-        pipeline: &mut PipelineRuntimeState,
-        status: StatusCode,
-        error: &JsonValue,
-    ) -> Result<(), DBError> {
-        self.pipeline_process = None;
-        let error = Self::error_response_from_json(self.pipeline_id, status, error);
-
-        if pipeline.desired_status == PipelineStatus::Shutdown {
-            self.update_pipeline_status(pipeline, PipelineStatus::Shutdown, Some(error))
-                .await;
-        } else {
-            self.update_pipeline_status(pipeline, PipelineStatus::Failed, Some(error))
-                .await;
-        }
-        self.update_pipeline_runtime_state(pipeline).await
-    }
-
-    async fn read_pipeline_port_file(&self) -> Result<Option<u16>, ManagerError> {
-        let port_file_path = self.config.port_file_path(self.pipeline_id);
-
-        match fs::read_to_string(port_file_path).await {
-            Ok(port) => {
-                let parse = port.trim().parse::<u16>();
-                match parse {
-                    Ok(port) => Ok(Some(port)),
-                    Err(e) => Err(ManagerError::from(RunnerError::PortFileParseError {
-                        pipeline_id: self.pipeline_id,
-                        error: e.to_string(),
-                    })),
-                }
-            }
-            Err(_) => Ok(None),
-        }
-    }
-
-    /// Start the pipeline process.
-    async fn start(&self, pr: PipelineRevision) -> Result<PipelineHandle, ManagerError> {
-        let pipeline_id = pr.pipeline.pipeline_id;
-        let program_id = pr.pipeline.program_id.unwrap();
-        let version = pr.program.version;
-
-        log::debug!("Pipeline config is '{:?}'", pr.config);
+        log::debug!("Pipeline config is '{:?}'", ped.config);
 
         // Create pipeline directory (delete old directory if exists); write metadata
         // and config files to it.
@@ -619,7 +63,7 @@ impl PipelineAutomaton {
             )
         })?;
         let config_file_path = self.config.config_file_path(pipeline_id);
-        let expanded_config = serde_yaml::to_string(&pr.config).unwrap();
+        let expanded_config = serde_yaml::to_string(&ped.config).unwrap();
         fs::write(&config_file_path, &expanded_config)
             .await
             .map_err(|e| {
@@ -628,33 +72,10 @@ impl PipelineAutomaton {
                     e,
                 )
             })?;
-        let metadata_file_path = self.config.metadata_file_path(pipeline_id);
-        fs::write(&metadata_file_path, serde_json::to_string(&pr).unwrap())
-            .await
-            .map_err(|e| {
-                ManagerError::io_error(
-                    format!("writing metadata file '{}'", metadata_file_path.display()),
-                    e,
-                )
-            })?;
 
-        // Locate project executable.
-        let executable_ref = self
-            .db
-            .lock()
-            .await
-            .get_compiled_binary_ref(program_id, pr.program.version)
-            .await?;
-        if executable_ref.is_none() {
-            return Err(RunnerError::BinaryFetchError {
-                pipeline_id,
-                error: format!("Did not receieve a compiled binary URL for {pipeline_id}"),
-            }
-            .into());
-        }
         let fetched_executable = fetch_binary_ref(
             &self.config,
-            &executable_ref.unwrap(),
+            &ped.binary_ref,
             pipeline_id,
             program_id,
             version,
@@ -667,31 +88,55 @@ impl PipelineAutomaton {
             .current_dir(self.config.pipeline_dir(pipeline_id))
             .arg("--config-file")
             .arg(&config_file_path)
-            .arg("--metadata-file")
-            .arg(&metadata_file_path)
             .stdin(Stdio::null())
             .spawn()
             .map_err(|e| RunnerError::PipelineStartupError {
                 pipeline_id,
                 error: e.to_string(),
             })?;
-
-        Ok(PipelineHandle { pipeline_process })
+        self.pipeline_process = Some(pipeline_process);
+        Ok(())
     }
 
-    /// Parse `ErrorResponse` from JSON. On error, builds an `ErrorResponse`
-    /// with the originaln JSON content.
-    fn error_response_from_json(
-        pipeline_id: PipelineId,
-        status: StatusCode,
-        json: &JsonValue,
-    ) -> ErrorResponse {
-        ErrorResponse::deserialize(json).unwrap_or_else(|_| {
-            ErrorResponse::from(&RunnerError::HttpForwardError {
-                pipeline_id,
-                error: format!("Pipeline returned HTTP status {status}, response body:{json:#}"),
-            })
-        })
+    async fn get_location(&mut self) -> Result<Option<String>, ManagerError> {
+        let port_file_path = self.config.port_file_path(self.pipeline_id);
+        let host = &self.config.pipeline_host;
+
+        match fs::read_to_string(port_file_path).await {
+            Ok(port) => {
+                let parse = port.trim().parse::<u16>();
+                match parse {
+                    Ok(port) => Ok(Some(format!("{host}:{port}"))),
+                    Err(e) => Err(ManagerError::from(RunnerError::PortFileParseError {
+                        pipeline_id: self.pipeline_id,
+                        error: e.to_string(),
+                    })),
+                }
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn check_if_shutdown(&mut self) -> bool {
+        self.pipeline_process
+            .as_mut()
+            .map(|p| p.try_wait().is_ok())
+            .unwrap_or(true)
+    }
+
+    async fn shutdown(&mut self) -> Result<(), ManagerError> {
+        self.pipeline_process = None;
+        match remove_dir_all(self.config.pipeline_dir(self.pipeline_id)).await {
+            Ok(_) => (),
+            Err(e) => {
+                log::warn!(
+                    "Failed to delete pipeline directory for pipeline {}: {}",
+                    self.pipeline_id,
+                    e
+                );
+            }
+        }
+        Ok(())
     }
 }
 
@@ -735,13 +180,19 @@ async fn reconcile(
                         .entry(pipeline_id)
                         .or_insert_with(|| {
                             let notifier = Arc::new(Notify::new());
+                            let pipeline_handle = ProcessRunner {
+                                pipeline_id,
+                                pipeline_process: None,
+                                config: config.clone(),
+                                db: db.clone(),
+                            };
                             spawn(
                                 PipelineAutomaton::new(
                                     pipeline_id,
                                     tenant_id,
-                                    &config,
                                     db.clone(),
                                     notifier.clone(),
+                                    pipeline_handle,
                                 )
                                 .run(),
                             );
@@ -758,109 +209,4 @@ async fn reconcile(
             };
         }
     }
-}
-
-pub async fn fetch_binary_ref(
-    config: &LocalRunnerConfig,
-    binary_ref: &str,
-    pipeline_id: PipelineId,
-    program_id: ProgramId,
-    version: Version,
-) -> Result<String, ManagerError> {
-    let parsed =
-        url::Url::parse(binary_ref).expect("Can only be invoked with valid URLs created by us");
-    match parsed.scheme() {
-        // A file scheme assumes the binary is available locally where
-        // the runner is located.
-        "file" => {
-            let exists = fs::try_exists(parsed.path()).await;
-            match exists {
-                Ok(true) => Ok(parsed.path().to_string()),
-                Ok(false) => Err(RunnerError::BinaryFetchError {
-                    pipeline_id,
-                    error: format!(
-                        "Binary required by pipeline {pipeline_id} does not exist at URL {}",
-                        parsed.path()
-                    ),
-                }.into()),
-                Err(e) => Err(RunnerError::BinaryFetchError {
-                    pipeline_id,
-                    error: format!(
-                        "Accessing URL {} for binary required by pipeline {pipeline_id} returned an error: {}",
-                        parsed.path(),
-                        e
-                    ),
-                }.into()),
-            }
-        }
-        // Access a file over HTTP/HTTPS
-        // TODO: implement retries
-        "http" | "https" => {
-            let resp = reqwest::get(binary_ref).await;
-            match resp {
-                Ok(resp) => {
-                    let resp = resp.bytes().await.expect("Binary reference should be accessible as bytes");
-                    let resp_ref = resp.as_ref();
-                    let path = config.binary_file_path(pipeline_id, program_id, version);
-                    let mut file = tokio::fs::File::options()
-                        .create(true)
-                        .write(true)
-                        .read(true)
-                        .mode(0o760)
-                        .open(path.clone())
-                        .await
-                        .map_err(|e| {
-                            ManagerError::io_error(
-                                format!("File creation failed ({:?}) while saving {pipeline_id} binary fetched from '{}'", path, parsed.path()),
-                                e,
-                            )
-                        })?;
-                    file.write_all(resp_ref).await.map_err(|e| {
-                        ManagerError::io_error(
-                            format!("File write failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
-                            e,
-                        )
-                    })?;
-                    file.flush().await.map_err(|e| {
-                        ManagerError::io_error(
-                            format!("File flush() failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
-                            e,
-                        )
-                    })?;
-                    Ok(path.into_os_string().into_string().expect("Path should be valid Unicode"))
-                }
-                Err(e) => {
-                    Err(RunnerError::BinaryFetchError {
-                        pipeline_id,
-                        error: format!(
-                            "Fetching URL {} for binary required by pipeline {pipeline_id} returned an error: {}",
-                            parsed.path(), e
-                       ),
-                    }.into())
-                }
-            }
-        }
-        _ => todo!("Unsupported URL scheme for binary ref"),
-    }
-}
-
-/// Send HTTP request to pipeline and parse response as a JSON object.
-async fn pipeline_http_request_json_response(
-    pipeline_id: PipelineId,
-    method: Method,
-    endpoint: &str,
-    port: &str,
-) -> Result<(StatusCode, JsonValue), RunnerError> {
-    let response = RunnerApi::pipeline_http_request(pipeline_id, method, endpoint, port).await?;
-    let status = response.status();
-
-    let value = response
-        .json::<JsonValue>()
-        .await
-        .map_err(|e| RunnerError::HttpForwardError {
-            pipeline_id,
-            error: e.to_string(),
-        })?;
-
-    Ok((status, value))
 }

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -1,4 +1,3 @@
-use crate::db::{ProgramId, Version};
 /// A local runner that watches for pipeline objects in the API
 /// and instantiates them locally as processes.
 use crate::db_notifier::{DbNotification, Operation};
@@ -7,11 +6,10 @@ use crate::pipeline_automata::{PipelineExecutionDesc, PipelineExecutor};
 use crate::{
     api::ManagerError,
     config::LocalRunnerConfig,
-    db::{storage::Storage, PipelineId, PipelineRevision, ProjectDB},
+    db::{PipelineId, ProjectDB},
     runner::RunnerError,
 };
 use async_trait::async_trait;
-use dbsp_adapters::PipelineConfig;
 use log::trace;
 use std::{
     collections::BTreeMap,
@@ -33,7 +31,6 @@ pub struct ProcessRunner {
     pipeline_id: PipelineId,
     pipeline_process: Option<Child>,
     config: Arc<LocalRunnerConfig>,
-    db: Arc<Mutex<ProjectDB>>,
 }
 
 impl Drop for ProcessRunner {
@@ -184,7 +181,6 @@ async fn reconcile(
                                 pipeline_id,
                                 pipeline_process: None,
                                 config: config.clone(),
-                                db: db.clone(),
                             };
                             spawn(
                                 PipelineAutomaton::new(

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -1,0 +1,715 @@
+//! This module contains helpers to build pipeline runners.
+use crate::db::{ProgramId, Version};
+use crate::runner::RunnerApi;
+use crate::{
+    api::ManagerError,
+    auth::TenantId,
+    config::LocalRunnerConfig,
+    db::{
+        storage::Storage, DBError, PipelineId, PipelineRevision, PipelineRuntimeState,
+        PipelineStatus, ProjectDB,
+    },
+    runner::RunnerError,
+};
+use actix_web::http::{Method, StatusCode};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use dbsp_adapters::{ErrorResponse, PipelineConfig};
+use log::{error, info};
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tokio::{
+    fs,
+    sync::Mutex,
+    time::Duration,
+};
+use tokio::{sync::Notify, time::timeout};
+
+/// Trait to be implemented by any pipeline runner. The PipelineAutomaton
+/// invokes these methods per pipeline.
+#[async_trait]
+pub trait PipelineExecutor {
+    async fn start(&mut self, ped: PipelineExecutionDesc) -> Result<(), ManagerError>;
+
+    async fn get_location(&mut self) -> Result<Option<String>, ManagerError>;
+
+    async fn check_if_shutdown(&mut self) -> bool;
+
+    async fn shutdown(&mut self) -> Result<(), ManagerError>;
+}
+
+
+/// Pipeline automaton monitors the runtime state of a single pipeline
+/// and continually reconciles desired and actual state.
+///
+/// The automaton runs as a separate tokio task.
+pub struct PipelineAutomaton<T>
+where T: PipelineExecutor {
+    pipeline_id: PipelineId,
+    tenant_id: TenantId,
+    pipeline_handle: T,
+    db: Arc<Mutex<ProjectDB>>,
+    notifier: Arc<Notify>,
+}
+
+/// A description of a pipeline to execute
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct PipelineExecutionDesc {
+    pub pipeline_id: PipelineId,
+    pub pipeline_name: String,
+    pub program_id: ProgramId,
+    pub version: Version,
+    pub config: PipelineConfig,
+    pub binary_ref: String
+}
+
+fn to_execution_desc(pr: PipelineRevision, binary_ref: String) -> PipelineExecutionDesc {
+    PipelineExecutionDesc {
+        pipeline_id: pr.pipeline.pipeline_id,
+        pipeline_name: pr.pipeline.name,
+        program_id: pr.program.program_id,
+        version: pr.program.version,
+        config: pr.config,
+        binary_ref: binary_ref.clone()
+    }
+}
+
+impl <T: PipelineExecutor> PipelineAutomaton<T> {
+    /// The frequency of polling the pipeline during normal operation
+    /// when we don't normally expect its state to change.
+    const DEFAULT_PIPELINE_POLL_PERIOD: Duration = Duration::from_millis(10_000);
+
+    /// Max time to wait for the pipeline process to initialize its
+    /// HTTP server.
+    const PROVISIONING_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+    /// How often to check for the pipeline port file during the
+    /// provisioning phase.
+    const PROVISIONING_POLL_PERIOD: Duration = Duration::from_millis(300);
+
+    /// Max time to wait for the pipeline to initialize all connectors.
+    const INITIALIZATION_TIMEOUT: Duration = Duration::from_millis(20_000);
+
+    /// How often to poll for the pipeline initialization status.
+    const INITIALIZATION_POLL_PERIOD: Duration = Duration::from_millis(300);
+
+    /// Max time to wait for the pipeline process to exit.
+    // TODO: It seems that Actix often takes a while to shutdown.  This
+    // is something to investigate.
+    const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+    /// How often to poll for the pipeline process to exit.
+    const SHUTDOWN_POLL_PERIOD: Duration = Duration::from_millis(300);
+
+    /// Create a new PipelineAutomaton for a given pipeline
+    pub fn new(
+        pipeline_id: PipelineId,
+        tenant_id: TenantId,
+        db: Arc<Mutex<ProjectDB>>,
+        notifier: Arc<Notify>,
+        pipeline_handle: T,
+    ) -> Self {
+        Self {
+            pipeline_id,
+            tenant_id,
+            pipeline_handle,
+            db,
+            notifier,
+        }
+    }
+
+    /// Runs until the pipeline is deleted or an unexpected error occurs.
+    pub async fn run(self) -> Result<(), ManagerError> {
+        let pipeline_id = self.pipeline_id;
+
+        self.do_run().await.map_err(|e| {
+            error!(
+                "Pipeline automaton '{}' terminated with error: '{e}'",
+                pipeline_id
+            );
+            e
+        })
+    }
+
+    async fn do_run(mut self) -> Result<(), ManagerError> {
+        let mut poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
+
+        loop {
+            // Wait until the timeout expires or we get notified that
+            // the desired state of the pipelime has changed.
+            let _ = timeout(poll_timeout, self.notifier.notified()).await;
+            poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
+
+            // TODO: use transactional API when ready to avoid races with a parallel
+            // `/deploy /shutdown` sequence.
+
+            // txn = db.transaction();
+            let db = self.db.lock().await;
+            let result = db
+                .get_pipeline_runtime_state(self.tenant_id, self.pipeline_id)
+                .await;
+            if let Err(e) = result {
+                match e {
+                    DBError::UnknownPipeline { pipeline_id } => {
+                        // Pipeline deletions should not lead to errors in the logs.
+                        info!("Pipeline {pipeline_id} does not exist. Shutting down pipeline automaton.");
+                        return Ok(());
+                    }
+                    _ => return Err(e.into()),
+                }
+            }
+            let mut pipeline = result.unwrap();
+
+            // Handle deployment request.
+            if pipeline.current_status == PipelineStatus::Shutdown
+                && pipeline.desired_status != PipelineStatus::Shutdown
+            {
+                let revision = db
+                    .get_last_committed_pipeline_revision(self.tenant_id, self.pipeline_id)
+                    .await?;
+                db.update_pipeline_runtime_state(self.tenant_id, self.pipeline_id, &pipeline)
+                    .await?;
+                // txn.commit();
+                // Locate project executable.
+                let executable_ref = db
+                    .get_compiled_binary_ref(revision.program.program_id, revision.program.version)
+                    .await?;
+                let pipeline_id = self.pipeline_id;
+                if executable_ref.is_none() {
+                    return Err(RunnerError::BinaryFetchError {
+                        pipeline_id,
+                        error: format!("Did not receieve a compiled binary URL for {pipeline_id}"),
+                    }
+                    .into());
+                }
+                drop(db);
+                let execution_desc = to_execution_desc(revision, executable_ref.unwrap());
+
+                match self.pipeline_handle.start(execution_desc).await {
+                   Ok(_) => {
+                        info!("Pipeline {} started (Tenant {})", self.pipeline_id, self.tenant_id);
+                        self.update_pipeline_status(&mut pipeline, PipelineStatus::Provisioning, None).await;
+                    }
+                    Err(e) => {
+                        self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                    }
+                }
+                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
+                continue;
+            } else {
+                // txn.commit();
+                drop(db);
+            }
+
+            match (pipeline.current_status, pipeline.desired_status) {
+                // We're waiting for the pipeline's HTTP server to come online.
+                // Poll its port file.  On success, go to `Initializing` state.
+                (PipelineStatus::Provisioning, PipelineStatus::Running)
+                | (PipelineStatus::Provisioning, PipelineStatus::Paused) => {
+                    match self.pipeline_handle.get_location().await {
+                        Ok(Some(location)) => {
+                            self.update_pipeline_status(
+                                &mut pipeline,
+                                PipelineStatus::Initializing,
+                                None,
+                            )
+                            .await;
+                            pipeline.set_location(location);
+                            pipeline.set_created();
+                            self.update_pipeline_runtime_state(&pipeline).await?;
+                            poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
+                        }
+                        Ok(None) => {
+                            if Self::timeout_expired(
+                                pipeline.status_since,
+                                Self::PROVISIONING_TIMEOUT,
+                            ) {
+                                self.force_kill_pipeline(
+                                    &mut pipeline,
+                                    Some(RunnerError::PipelineProvisioningTimeout {
+                                        pipeline_id: self.pipeline_id,
+                                        timeout: Self::PROVISIONING_TIMEOUT,
+                                    }),
+                                )
+                                .await?;
+                            } else {
+                                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
+                            }
+                        }
+                        Err(e) => {
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                    }
+                }
+                // User cancels the pipeline while it's still provisioning.
+                (PipelineStatus::Provisioning, PipelineStatus::Shutdown) => {
+                    self.force_kill_pipeline(&mut pipeline, <Option<RunnerError>>::None)
+                        .await?;
+                }
+                // We're waiting for the pipeline to initialize.
+                // Poll the pipeline's status.  Kill the pipeline on timeout or error.
+                // On success, go to the `PAUSED` state.
+                (PipelineStatus::Initializing, PipelineStatus::Running)
+                | (PipelineStatus::Initializing, PipelineStatus::Paused) => {
+                    match pipeline_http_request_json_response(
+                        self.pipeline_id,
+                        Method::GET,
+                        "stats",
+                        &pipeline.location,
+                    )
+                    .await
+                    {
+                        Err(e) => {
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                        Ok((status, body)) => {
+                            if status.is_success() {
+                                self.update_pipeline_status(
+                                    &mut pipeline,
+                                    PipelineStatus::Paused,
+                                    None,
+                                )
+                                .await;
+                                self.update_pipeline_runtime_state(&pipeline).await?;
+                            } else if status == StatusCode::SERVICE_UNAVAILABLE {
+                                if Self::timeout_expired(
+                                    pipeline.status_since,
+                                    Self::INITIALIZATION_TIMEOUT,
+                                ) {
+                                    self.force_kill_pipeline(
+                                        &mut pipeline,
+                                        Some(RunnerError::PipelineInitializationTimeout {
+                                            pipeline_id: self.pipeline_id,
+                                            timeout: Self::INITIALIZATION_TIMEOUT,
+                                        }),
+                                    )
+                                    .await?;
+                                } else {
+                                    poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
+                                }
+                            } else {
+                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
+                                    .await?;
+                            }
+                        }
+                    }
+                }
+                // User cancels the pipeline while it is still initalizing.
+                (PipelineStatus::Initializing, PipelineStatus::Shutdown) => {
+                    self.force_kill_pipeline(&mut pipeline, <Option<RunnerError>>::None)
+                        .await?;
+                }
+                // Unpause the pipeline.
+                (PipelineStatus::Paused, PipelineStatus::Running) => {
+                    match pipeline_http_request_json_response(
+                        self.pipeline_id,
+                        Method::GET,
+                        "start",
+                        &pipeline.location,
+                    )
+                    .await
+                    {
+                        Err(e) => {
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                        Ok((status, body)) => {
+                            if status.is_success() {
+                                self.update_pipeline_status(
+                                    &mut pipeline,
+                                    PipelineStatus::Running,
+                                    None,
+                                )
+                                .await;
+                                self.update_pipeline_runtime_state(&pipeline).await?;
+                            } else {
+                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
+                                    .await?;
+                            }
+                        }
+                    }
+                }
+                // Pause the pipeline.
+                (PipelineStatus::Running, PipelineStatus::Paused) => {
+                    match pipeline_http_request_json_response(
+                        self.pipeline_id,
+                        Method::GET,
+                        "pause",
+                        &pipeline.location,
+                    )
+                    .await
+                    {
+                        Err(e) => {
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                        Ok((status, body)) => {
+                            if status.is_success() {
+                                self.update_pipeline_status(
+                                    &mut pipeline,
+                                    PipelineStatus::Paused,
+                                    None,
+                                )
+                                .await;
+                                self.update_pipeline_runtime_state(&pipeline).await?;
+                            } else {
+                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
+                                    .await?;
+                            }
+                        }
+                    }
+                }
+                // Shutdown request.  Forward to the pipeline; on success go to the `ShuttingDown`
+                // state.
+                (PipelineStatus::Running, PipelineStatus::Shutdown)
+                | (PipelineStatus::Paused, PipelineStatus::Shutdown) => {
+                    match pipeline_http_request_json_response(
+                        self.pipeline_id,
+                        Method::GET,
+                        "shutdown",
+                        &pipeline.location,
+                    )
+                    .await
+                    {
+                        Err(e) => {
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                        Ok((status, body)) => {
+                            if status.is_success() {
+                                self.update_pipeline_status(
+                                    &mut pipeline,
+                                    PipelineStatus::ShuttingDown,
+                                    None,
+                                )
+                                .await;
+                                self.update_pipeline_runtime_state(&pipeline).await?;
+                                poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
+                            } else {
+                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
+                                    .await?;
+                            }
+                        }
+                    }
+                }
+                // Graceful shutdown in progress.  Wait for the pipeline process to self-terminate.
+                // Force-kill the pipeline after a timeout.
+                (PipelineStatus::ShuttingDown, _) => {
+                    if self.pipeline_handle.check_if_shutdown().await
+                    {
+                        let _ = self.pipeline_handle.shutdown().await;
+                        self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, None)
+                            .await;
+                        self.update_pipeline_runtime_state(&pipeline).await?;
+                    } else if Self::timeout_expired(pipeline.status_since, Self::SHUTDOWN_TIMEOUT) {
+                        self.force_kill_pipeline(
+                            &mut pipeline,
+                            Some(RunnerError::PipelineShutdownTimeout {
+                                pipeline_id: self.pipeline_id,
+                                timeout: Self::SHUTDOWN_TIMEOUT,
+                            }),
+                        )
+                        .await?;
+                    } else {
+                        poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
+                    }
+                }
+                // Steady-state operation.  Periodically poll the pipeline.
+                (PipelineStatus::Running, _) | (PipelineStatus::Paused, _) => {
+                    match pipeline_http_request_json_response(
+                        self.pipeline_id,
+                        Method::GET,
+                        "stats",
+                        &pipeline.location,
+                    )
+                    .await
+                    {
+                        Err(e) => {
+                            // Cannot reach the pipeline.
+                            self.force_kill_pipeline(&mut pipeline, Some(e)).await?;
+                        }
+                        Ok((status, body)) => {
+                            if !status.is_success() {
+                                // Pipeline responds with an error, meaning that the pipeline
+                                // HTTP server is still running, but the pipeline itself failed --
+                                // save it out of its misery.
+                                self.force_kill_pipeline_on_error(&mut pipeline, status, &body)
+                                    .await?;
+                            } else {
+                                let global_metrics = if let Some(metrics) =
+                                    body.get("global_metrics")
+                                {
+                                    metrics
+                                } else {
+                                    Err(RunnerError::HttpForwardError {
+                                        pipeline_id: self.pipeline_id,
+                                        error: format!("Pipeline status descriptor doesn't contain 'global_metrics' field: '{body}'")
+                                    })?
+                                };
+                                let state = if let Some(state) = global_metrics.get("state") {
+                                    state
+                                } else {
+                                    Err(RunnerError::HttpForwardError {
+                                        pipeline_id: self.pipeline_id,
+                                        error: format!("Pipeline status descriptor doesn't contain 'global_metrics.state' field: '{body}'")
+                                    })?
+                                };
+                                let state = if let Some(state) = state.as_str() {
+                                    state
+                                } else {
+                                    Err(RunnerError::HttpForwardError {
+                                        pipeline_id: self.pipeline_id,
+                                        error: format!("Pipeline status descriptor contains invalid 'global_metrics.state' field: '{body}'")
+                                    })?
+                                };
+
+                                if state == "Paused"
+                                    && pipeline.current_status != PipelineStatus::Paused
+                                {
+                                    self.update_pipeline_status(
+                                        &mut pipeline,
+                                        PipelineStatus::Paused,
+                                        None,
+                                    )
+                                    .await;
+                                    self.update_pipeline_runtime_state(&pipeline).await?;
+                                } else if state == "Running"
+                                    && pipeline.current_status != PipelineStatus::Running
+                                {
+                                    self.update_pipeline_status(
+                                        &mut pipeline,
+                                        PipelineStatus::Running,
+                                        None,
+                                    )
+                                    .await;
+                                    self.update_pipeline_runtime_state(&pipeline).await?;
+                                } else if state != "Paused" && state != "Running" {
+                                    self.force_kill_pipeline(&mut pipeline, Some(RunnerError::HttpForwardError {
+                                        pipeline_id: self.pipeline_id,
+                                        error: format!("Pipeline reported unexpected status '{state}', expected 'Paused' or 'Running'")
+                                    })).await?;
+                                }
+                            }
+                        }
+                    }
+                }
+                // User acknowledges pipeline failure by invoking the `/shutdown` endpoint.
+                // Move to the `Shutdown` state so that the pipeline can be started again.
+                (PipelineStatus::Failed, PipelineStatus::Shutdown) => {
+                    let error = pipeline.error.clone();
+                    self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, error)
+                        .await;
+                    self.update_pipeline_runtime_state(&pipeline).await?;
+                }
+                (PipelineStatus::Failed | PipelineStatus::Shutdown, _) => {}
+                _ => {
+                    error!(
+                        "Unexpected current/desired pipeline status combination {:?}/{:?}",
+                        pipeline.current_status, pipeline.desired_status
+                    )
+                }
+            }
+        }
+    }
+
+    async fn update_pipeline_status(
+        &self,
+        pipeline: &mut PipelineRuntimeState,
+        status: PipelineStatus,
+        error: Option<ErrorResponse>,
+    ) {
+        pipeline.set_current_status(status, error);
+    }
+
+    async fn update_pipeline_runtime_state(
+        &self,
+        state: &PipelineRuntimeState,
+    ) -> Result<(), DBError> {
+        self.db
+            .lock()
+            .await
+            .update_pipeline_runtime_state(self.tenant_id, self.pipeline_id, state)
+            .await
+    }
+
+    // We store timestamps in the DB and retrieve them as Utc times;
+    // hence we cannot use the normal `Instant::elapsed` API for timeouts.
+    fn timeout_expired(since: DateTime<Utc>, timeout: Duration) -> bool {
+        Utc::now().timestamp_millis() - since.timestamp_millis() > timeout.as_millis() as i64
+    }
+
+    /// Force-kill the pipeline process, set its error description.
+    ///
+    /// If the desired state of the pipeline is `Paused` or `Running`,
+    /// places pipeline in the `Failed` state to avoid instant automatic
+    /// restart.  Otherwise (the desired state was `Shutdown`), set the
+    /// state of the pipeline to `Shutdown`.
+    async fn force_kill_pipeline<E>(
+        &mut self,
+        pipeline: &mut PipelineRuntimeState,
+        error: Option<E>,
+    ) -> Result<(), DBError>
+    where
+        ErrorResponse: for<'a> From<&'a E>,
+    {
+        let _ = self.pipeline_handle.shutdown().await;
+
+        if pipeline.desired_status == PipelineStatus::Shutdown {
+            self.update_pipeline_status(
+                pipeline,
+                PipelineStatus::Shutdown,
+                error.map(|e| ErrorResponse::from(&e)),
+            )
+            .await;
+        } else {
+            self.update_pipeline_status(
+                pipeline,
+                PipelineStatus::Failed,
+                error.map(|e| ErrorResponse::from(&e)),
+            )
+            .await;
+        }
+        self.update_pipeline_runtime_state(pipeline).await
+    }
+
+    /// Same as `force_kill_pipeline`, but deserializes `ErrorResponse` from
+    /// a JSON error returned by the pipeline.
+    async fn force_kill_pipeline_on_error(
+        &mut self,
+        pipeline: &mut PipelineRuntimeState,
+        status: StatusCode,
+        error: &JsonValue,
+    ) -> Result<(), DBError> {
+        let _ = self.pipeline_handle.shutdown().await;
+        let error = Self::error_response_from_json(self.pipeline_id, status, error);
+
+        if pipeline.desired_status == PipelineStatus::Shutdown {
+            self.update_pipeline_status(pipeline, PipelineStatus::Shutdown, Some(error))
+                .await;
+        } else {
+            self.update_pipeline_status(pipeline, PipelineStatus::Failed, Some(error))
+                .await;
+        }
+        self.update_pipeline_runtime_state(pipeline).await
+    }
+
+
+    /// Parse `ErrorResponse` from JSON. On error, builds an `ErrorResponse`
+    /// with the originaln JSON content.
+    fn error_response_from_json(
+        pipeline_id: PipelineId,
+        status: StatusCode,
+        json: &JsonValue,
+    ) -> ErrorResponse {
+        ErrorResponse::deserialize(json).unwrap_or_else(|_| {
+            ErrorResponse::from(&RunnerError::HttpForwardError {
+                pipeline_id,
+                error: format!("Pipeline returned HTTP status {status}, response body:{json:#}"),
+            })
+        })
+    }
+}
+
+pub async fn fetch_binary_ref(
+    config: &LocalRunnerConfig,
+    binary_ref: &str,
+    pipeline_id: PipelineId,
+    program_id: ProgramId,
+    version: Version,
+) -> Result<String, ManagerError> {
+    let parsed =
+        url::Url::parse(binary_ref).expect("Can only be invoked with valid URLs created by us");
+    match parsed.scheme() {
+        // A file scheme assumes the binary is available locally where
+        // the runner is located.
+        "file" => {
+            let exists = fs::try_exists(parsed.path()).await;
+            match exists {
+                Ok(true) => Ok(parsed.path().to_string()),
+                Ok(false) => Err(RunnerError::BinaryFetchError {
+                    pipeline_id,
+                    error: format!(
+                        "Binary required by pipeline {pipeline_id} does not exist at URL {}",
+                        parsed.path()
+                    ),
+                }.into()),
+                Err(e) => Err(RunnerError::BinaryFetchError {
+                    pipeline_id,
+                    error: format!(
+                        "Accessing URL {} for binary required by pipeline {pipeline_id} returned an error: {}",
+                        parsed.path(),
+                        e
+                    ),
+                }.into()),
+            }
+        }
+        // Access a file over HTTP/HTTPS
+        // TODO: implement retries
+        "http" | "https" => {
+            let resp = reqwest::get(binary_ref).await;
+            match resp {
+                Ok(resp) => {
+                    let resp = resp.bytes().await.expect("Binary reference should be accessible as bytes");
+                    let resp_ref = resp.as_ref();
+                    let path = config.binary_file_path(pipeline_id, program_id, version);
+                    let mut file = tokio::fs::File::options()
+                        .create(true)
+                        .write(true)
+                        .read(true)
+                        .mode(0o760)
+                        .open(path.clone())
+                        .await
+                        .map_err(|e| 
+                            ManagerError::io_error(
+                                format!("File creation failed ({:?}) while saving {pipeline_id} binary fetched from '{}'", path, parsed.path()),
+                                e,
+                            )
+                        )?;
+                    file.write_all(resp_ref).await.map_err(|e| 
+                            ManagerError::io_error(
+                                format!("File write failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
+                                e,
+                            )
+                        )?;
+                    file.flush().await.map_err(|e| 
+                            ManagerError::io_error(
+                                format!("File flush() failed ({:?}) while saving binary file for {pipeline_id} fetched from '{}'", path, parsed.path()),
+                                e,
+                            )
+                        )?;
+                    Ok(path.into_os_string().into_string().expect("Path should be valid Unicode"))
+                }
+                Err(e) => {
+                    Err(RunnerError::BinaryFetchError {
+                        pipeline_id,
+                        error: format!(
+                            "Fetching URL {} for binary required by pipeline {pipeline_id} returned an error: {}",
+                            parsed.path(), e
+                       ),
+                    }.into())
+                }
+            }
+        }
+        _ => todo!("Unsupported URL scheme for binary ref"),
+    }
+}
+
+/// Send HTTP request to pipeline and parse response as a JSON object.
+async fn pipeline_http_request_json_response(
+    pipeline_id: PipelineId,
+    method: Method,
+    endpoint: &str,
+    port: &str,
+) -> Result<(StatusCode, JsonValue), RunnerError> {
+    let response = RunnerApi::pipeline_http_request(pipeline_id, method, endpoint, port).await?;
+    let status = response.status();
+
+    let value = response
+        .json::<JsonValue>()
+        .await
+        .map_err(|e| RunnerError::HttpForwardError {
+            pipeline_id,
+            error: e.to_string(),
+        })?;
+
+    Ok((status, value))
+}

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -77,7 +77,7 @@ fn to_execution_desc(pr: PipelineRevision, binary_ref: String) -> PipelineExecut
         program_id: pr.program.program_id,
         version: pr.program.version,
         config: pr.config,
-        binary_ref: binary_ref.clone()
+        binary_ref
     }
 }
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,7 +19,6 @@ RUN apt update --fix-missing && apt install \
   # To add the nodesource debian repository
   ca-certificates gnupg
 
-
 # Set UTF-8 locale. Needed for the Rust compiler to handle Unicode column names.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
   locale-gen

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -91,6 +91,7 @@ ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--api-server-workin
 FROM ubuntu:22.04 as api-server
 COPY --from=builder /app/target/release/api-server api-server
 ENV BANNER_ADDR localhost
+RUN apt update && apt install libsasl2-dev -y
 ENTRYPOINT ["./api-server", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir"]
 
 # Standalone compiler-server
@@ -106,7 +107,6 @@ COPY crates/adapters database-stream-processor/crates/adapters
 COPY crates/dataflow-jit database-stream-processor/crates/dataflow-jit
 COPY README.md database-stream-processor/README.md
 RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
-
 # Copy over the rust code and sql-to-dbsp script
 COPY sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
 COPY sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
@@ -117,6 +117,7 @@ ENTRYPOINT ["./compiler-server", "--compiler-working-directory=/working-dir", "-
 
 # Standalone local-runner
 FROM ubuntu:22.04 as local-runner
+RUN apt update && apt install libsasl2-dev -y
 COPY --from=builder /app/target/release/local-runner local-runner
 ENTRYPOINT ["./local-runner", "--runner-working-directory=/working-dir"]
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -48,10 +48,10 @@ COPY . .
 # web-console build tools:
 # - nodejs
 RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR=20
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-RUN apt update --fix-missing && apt install nodejs
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt update --fix-missing && apt install nodejs -y
 # - yarn
 RUN npm install --global yarn openapi-typescript-codegen
 RUN /root/.cargo/bin/cargo build --release --package=pipeline-manager --no-default-features


### PR DESCRIPTION
* Splits out the pipeline-automaton out of the local runner code so that it can be reused.
* Exposes some existing types and adds a new async-trait to write different runners.
* Makes the local runner no longer prepare and use metadata.json when bringing up pipelines, as it is unused on the pipeline side.
* Fixes some unrelated regressions.