### PR TITLE
Use the same connection for query and prepare in Postgres.

### DIFF
--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -2480,12 +2480,7 @@ impl ProjectDB {
             )
             .await?;
 
-        let row = self
-            .pool
-            .get()
-            .await?
-            .query_one(&stmt, &[&program_id, &version])
-            .await?;
+        let row = conn.query_one(&stmt, &[&program_id, &version]).await?;
 
         Ok(row.get(0))
     }


### PR DESCRIPTION
Otherwise, this leads to errors like this in the log:

```
2023-09-15 19:07:23 INFO [manager] 2023-09-15 12:07:23.668 PDT [1224747] ERROR:  prepared statement "s19" does not exist
```