### PR TITLE
SQL: print SQL in error messages, not internal compiler data structures

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -88,7 +88,7 @@ public class ToRustVisitor extends CircuitVisitor {
     }
 
     void generateOperator(DBSPOperator operator) {
-        String str = operator.getNode().toString();
+        String str = operator.getNode().toInternalString();
         this.writeComments(str);
         operator.accept(this);
         this.builder.newline();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/UnimplementedException.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/UnimplementedException.java
@@ -60,8 +60,7 @@ public class UnimplementedException extends BaseCompilerException {
     }
 
     public UnimplementedException(CalciteObject object) {
-        this(object.getClass().getSimpleName() + ":" + object,
-                null, object);
+        this(object.toString(), null, object);
     }
 
     public UnimplementedException(String message, IDBSPNode node) {
@@ -70,7 +69,7 @@ public class UnimplementedException extends BaseCompilerException {
     }
 
     public UnimplementedException(String message, CalciteObject node) {
-        this(message + " " + node.getClass().getSimpleName() + ":" + node,
+        this(message + " " + node,
                 null, node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteObject.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteObject.java
@@ -1,8 +1,10 @@
 package org.dbsp.sqlCompiler.compiler.frontend;
 
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -78,9 +80,31 @@ public class CalciteObject {
     public String toString() {
         if (this.operator != null)
             return this.operator.toString();
-        else if (this.relNode != null)
+        else if (this.relNode != null) {
+            try {
+                RelToSqlConverter converter =
+                        new RelToSqlConverter(SqlDialect.DatabaseProduct.UNKNOWN.getDialect());
+                SqlNode node = converter.visitRoot(this.relNode).asStatement();
+                return node.toString();
+            } catch (Exception ex) {
+                // Sometimes Calcite crashes when converting rel to SQL
+                return this.relNode.toString();
+            }
+        } else if (this.sqlNode != null)
+            return this.sqlNode.toString();
+        else if (this.relType != null)
+            return this.relType.toString();
+        else if (this.rexNode != null)
+            return this.rexNode.toString();
+        return "";
+    }
+
+    public String toInternalString() {
+        if (this.operator != null)
+            return this.operator.toString();
+        else if (this.relNode != null) {
             return this.relNode.toString();
-        else if (this.sqlNode != null)
+        } else if (this.sqlNode != null)
             return this.sqlNode.toString();
         else if (this.relType != null)
             return this.relType.toString();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -917,8 +917,11 @@ public class CalciteToDBSPCompiler extends RelVisitor
                     !sortType.is(DBSPTypeDate.class))
                 throw new UnimplementedException("OVER currently requires an integer type for ordering "
                         + "and cannot handle " + sortType, node);
-            if (sortType.mayBeNull)
-                throw new UnimplementedException("OVER currently does not support sorting on nullable column ", node);
+            if (sortType.mayBeNull) {
+                RelDataTypeField relDataTypeField = inputNode.getRowType().getFieldList().get(orderColumnIndex);
+                throw new UnimplementedException("OVER currently does not support sorting on nullable column " +
+                        Utilities.singleQuote(relDataTypeField.getName()) + ":", node);
+            }
 
             // Create window description
             DBSPExpression lb = this.compileWindowBound(group.lowerBound, sortType, eComp);


### PR DESCRIPTION
Still not perfect, but hopefully an improvement.

Previous error message:
```
error: Not yet implemented: OVER currently does not support sorting on nullable column  CalciteObject:rel#74:LogicalWindow.(input=LogicalProject#72,window#0=window(partition {0} order by [1] range between $3 PRECEDING and CURRENT ROW aggs [COUNT($2), $SUM0($2)]))
```

New error message:
```
error: Not yet implemented: OVER currently does not support sorting on nullable column 'FULFILLMENT_DATE': SELECT `PART_ORDER`.`CUSTOMER`, `FULFILLMENT`.`FULFILLMENT_DATE`, DATEDIFF(DAY, `PART_ORDER`.`TARGET_DATE`, `FULFILLMENT`.`FULFILLMENT_DATE`) AS `$2`, 90 * INTERVAL '1' DAY AS `$3`, COUNT(DATEDIFF(DAY, `PART_ORDER`.`TARGET_DATE`, `FULFILLMENT`.`FULFILLMENT_DATE`)) OVER (PARTITION BY `PART_ORDER`.`CUSTOMER` ORDER BY `FULFILLMENT`.`FULFILLMENT_DATE` RANGE BETWEEN 90 * INTERVAL '1' DAY PRECEDING AND CURRENT ROW) AS `w0$o0`, COALESCE(SUM(DATEDIFF(DAY, `PART_ORDER`.`TARGET_DATE`, `FULFILLMENT`.`FULFILLMENT_DATE`)) OVER (PARTITION BY `PART_ORDER`.`CUSTOMER` ORDER BY `FULFILLMENT`.`FULFILLMENT_DATE` RANGE BETWEEN 90 * INTERVAL '1' DAY PRECEDING AND CURRENT ROW), 0) AS `w0$o1`
FROM `schema`.`PART_ORDER`
INNER JOIN `schema`.`FULFILLMENT` ON `PART_ORDER`.`ID` = `FULFILLMENT`.`PART_ORDER`
```