### PR TITLE
Minor changes to `dataflow-jit`.

### DIFF
--- a/crates/dataflow-jit/src/codegen/json/mod.rs
+++ b/crates/dataflow-jit/src/codegen/json/mod.rs
@@ -3,7 +3,7 @@ mod serialize;
 mod tests;
 
 pub use deserialize::{call_deserialize_fn, DeserializeJsonFn, DeserializeResult, JsonDeserConfig};
-pub use serialize::{JsonSerConfig, SerializeJsonFn};
+pub use serialize::{JsonSerConfig, SerializeFn};
 
 // The index of a column within a row
 // TODO: Newtyping for column indices within the layout interfaces

--- a/crates/dataflow-jit/src/codegen/json/serialize.rs
+++ b/crates/dataflow-jit/src/codegen/json/serialize.rs
@@ -13,7 +13,7 @@ use cranelift_module::{FuncId, Module};
 use serde::Deserialize;
 use std::{mem::align_of, ops::Not};
 
-pub type SerializeJsonFn = unsafe extern "C" fn(*const u8, &mut String);
+pub type SerializeFn = unsafe extern "C" fn(*const u8, &mut String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct JsonSerConfig {

--- a/crates/dataflow-jit/src/codegen/json/tests.rs
+++ b/crates/dataflow-jit/src/codegen/json/tests.rs
@@ -3,7 +3,7 @@
 use crate::{
     codegen::{
         json::{
-            call_deserialize_fn, DeserializeJsonFn, JsonDeserConfig, JsonSerConfig, SerializeJsonFn,
+            call_deserialize_fn, DeserializeJsonFn, JsonDeserConfig, JsonSerConfig, SerializeFn,
         },
         Codegen, CodegenConfig,
     },
@@ -84,7 +84,7 @@ fn deserialize_json_smoke() {
         let (deserialize_json, serialize_json) = unsafe {
             (
                 transmute::<_, DeserializeJsonFn>(jit.get_finalized_function(deserialize_json)),
-                transmute::<_, SerializeJsonFn>(jit.get_finalized_function(serialize_json)),
+                transmute::<_, SerializeFn>(jit.get_finalized_function(serialize_json)),
             )
         };
 


### PR DESCRIPTION
These changes help with the JIT integration with `adapters`:

- rename `SerializeJsonFn` -> `SerializeFn` - I expect all serialization functions to have the same signature
- `DbspCircuit::json_ser_function()` method to retrieve a pointer to JSON serialization function by layout id.
- Made the `DbspCircuit::outputs` field `pub`.