### PR TITLE
Debezium MySQL demo

### DIFF
--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -110,7 +110,7 @@ impl<'a> UpdateFormat for InsDelUpdate<&'a RawValue> {
     }
 }
 
-impl<'de> UpdateFormat for DebeziumUpdate<'de> {
+impl<'a> UpdateFormat for DebeziumUpdate<&'a RawValue> {
     fn error() -> &'static str {
         "error deserializing JSON string as a Debezium CDC event"
     }
@@ -391,7 +391,7 @@ impl JsonParser {
                     self.apply_update::<InsDelUpdate<_>>(update, &mut errors)
                 }
                 JsonUpdateFormat::Debezium => {
-                    self.apply_update::<DebeziumUpdate>(update, &mut errors)
+                    self.apply_update::<DebeziumUpdate<_>>(update, &mut errors)
                 }
                 JsonUpdateFormat::Weighted => {
                     self.apply_update::<WeightedUpdate<_>>(update, &mut errors)

--- a/crates/adapters/src/format/json/mod.rs
+++ b/crates/adapters/src/format/json/mod.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue;
 
 mod input;
 mod output;
@@ -71,6 +70,8 @@ pub enum DebeziumOp {
     Delete,
     #[serde(rename = "u")]
     Update,
+    #[serde(rename = "r")]
+    Read,
 }
 
 /// Debezium CDC source specification describes the origin of the record,
@@ -85,24 +86,20 @@ pub struct DebeziumSource {
 ///
 /// Only the `payload` field is currently supported; other fields are ignored.
 #[derive(Debug, Deserialize)]
-pub struct DebeziumUpdate<'a> {
-    #[serde(borrow)]
-    payload: DebeziumPayload<'a>,
+pub struct DebeziumUpdate<T> {
+    payload: DebeziumPayload<T>,
 }
 
 /// Schema of the `payload` field of a Debezium data change event.
 #[derive(Debug, Deserialize)]
-pub struct DebeziumPayload<'a> {
-    #[allow(dead_code)]
-    source: Option<DebeziumSource>,
+pub struct DebeziumPayload<T> {
+    // source: Option<DebeziumSource>,
     #[allow(dead_code)]
     op: DebeziumOp,
     /// When present and not `null`, this field specifies a record to be deleted from the table.
-    #[serde(borrow)]
-    before: Option<&'a RawValue>,
+    before: Option<T>,
     /// When present and not `null`, this field specifies a record to be inserted to the table.
-    #[serde(borrow)]
-    after: Option<&'a RawValue>,
+    after: Option<T>,
 }
 
 /// A data change event in the insert/delete format.

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -3,56 +3,62 @@ import argparse
 from dbsp import DBSPConnection
 
 
-def execute(dbsp_url, actions, name, code_file, make_pipeline_fn, prepare_fn=None, verify_fn=None):
+def execute(
+    dbsp_url,
+    actions,
+    name,
+    code_file,
+    make_pipeline_fn,
+    prepare_fn=None,
+    verify_fn=None,
+):
     dbsp = DBSPConnection(dbsp_url + "/v0")
     sql_code = open(code_file, "r").read()
-    program = dbsp.create_or_replace_program(
-        name=name, sql_code=sql_code)
+    program = dbsp.create_or_replace_program(name=name, sql_code=sql_code)
     pipeline = make_pipeline_fn(program)
 
-    if 'compile' in actions:
+    if "compile" in actions:
         program.compile()
         print("Project compiled")
         status = program.status()
         print("Project status: " + status)
 
-    if prepare_fn and 'prepare' in actions:
+    if prepare_fn and "prepare" in actions:
         print("Preparing...")
         prepare_fn()
 
-    if 'run' in actions:
-        try:
-            pipeline.run()
-            print("Pipeline status: " + str(pipeline.descriptor().status))
-            #print("Pipeline stats: " + str(pipeline.stats()))
-        finally:
-            pipeline.delete()
-            print("Pipeline removed")
+    if "run" in actions:
+        pipeline.run()
+        print("Pipeline started")
 
-    if verify_fn and 'verify' in actions:
+    if verify_fn and "verify" in actions:
         verify_fn()
 
 
 def run_demo(name, code_file, make_pipeline_fn, prepare_fn=None, verify_fn=None):
     parser = argparse.ArgumentParser(
-        description='What do you want to do with the demo.')
-    parser.add_argument('--dbsp_url', required=True)
-    parser.add_argument('--actions', nargs='*', default=['create'])
-    parser.add_argument('--prepare-args', nargs='*', default=None)
+        description="What do you want to do with the demo."
+    )
+    parser.add_argument("--dbsp_url", required=True)
+    parser.add_argument("--actions", nargs="*", default=["create"])
+    parser.add_argument("--prepare-args", nargs="*", default=None)
     args = parser.parse_args()
 
     # Add hard-coded dependencies
     dbsp_url = args.dbsp_url
     actions = set(args.actions)
-    if 'create' in actions:
-        actions.add('compile')
-    if 'run' in actions:
-        actions.add('create')
-        actions.add('compile')
-    if 'verify' in actions:
-        actions.add('compile')
-        actions.add('create')
-        actions.add('run')
-    prepare = prepare_fn if args.prepare_args == None else lambda: prepare_fn(args.prepare_args)
-    execute(dbsp_url, actions, name, code_file,
-            make_pipeline_fn, prepare, verify_fn)
+    if "create" in actions:
+        actions.add("compile")
+    if "run" in actions:
+        actions.add("create")
+        actions.add("compile")
+    if "verify" in actions:
+        actions.add("compile")
+        actions.add("create")
+        actions.add("run")
+    prepare = (
+        prepare_fn
+        if args.prepare_args == None
+        else lambda: prepare_fn(args.prepare_args)
+    )
+    execute(dbsp_url, actions, name, code_file, make_pipeline_fn, prepare, verify_fn)

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -4,11 +4,13 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="${THIS_DIR}/../"
 SERVER_DIR="${ROOT}/crates/pipeline_manager/"
 
-export REDPANDA_BROKERS=localhost:9092
+# docker kill redpanda
+# docker rm redpanda
+# docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v23.2.3 || { echo 'Failed to start RedPanda container' ; exit 1; }
 
-docker kill redpanda
-docker rm redpanda
-docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v23.2.3 || { echo 'Failed to start RedPanda container' ; exit 1; }
+docker compose -f deploy/docker-compose.yml -f deploy/docker-compose-debezium.yml up redpanda connect mysql -d --force-recreate -V
+
+export REDPANDA_BROKERS=localhost:19092
 
 # Kill the entire process group (including processes spawned by prepare_demo_data.sh) on shutdown.
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT

--- a/demo/project_demo05-DebeziumMySQL/project.sql
+++ b/demo/project_demo05-DebeziumMySQL/project.sql
@@ -1,0 +1,39 @@
+-- SQL program from the Debezium MySQL tutorial used to demo Feldera
+-- Debezium integration.
+
+CREATE TABLE customers (
+  id int NOT NULL PRIMARY KEY,
+  first_name varchar(255) NOT NULL,
+  last_name varchar(255) NOT NULL,
+  email varchar(255) NOT NULL
+);
+
+CREATE TABLE addresses (
+  id int NOT NULL PRIMARY KEY,
+  customer_id int NOT NULL,
+  street varchar(255) NOT NULL,
+  city varchar(255) NOT NULL,
+  state varchar(255) NOT NULL,
+  zip varchar(255) NOT NULL,
+  type varchar(32) NOT NULL
+);
+
+CREATE TABLE orders (
+  order_number int NOT NULL PRIMARY KEY,
+  order_date date NOT NULL,
+  purchaser int NOT NULL,
+  quantity int NOT NULL,
+  product_id int NOT NULL
+);
+
+CREATE TABLE products (
+  id int NOT NULL PRIMARY KEY,
+  name varchar(255) NOT NULL,
+  description varchar(512),
+  weight float
+);
+
+CREATE TABLE products_on_hand (
+  product_id int NOT NULL PRIMARY KEY,
+  quantity int NOT NULL
+);

--- a/demo/project_demo05-DebeziumMySQL/run.py
+++ b/demo/project_demo05-DebeziumMySQL/run.py
@@ -1,0 +1,184 @@
+import os
+import sys
+import time
+import requests
+
+from dbsp import DBSPPipelineConfig
+from dbsp import JsonInputFormatConfig, JsonOutputFormatConfig
+from dbsp import KafkaInputConfig
+from dbsp import KafkaOutputConfig
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".."))
+from demo import *
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+
+
+def prepare(args=[]):
+    connect_server = os.getenv("KAFKA_CONNECT_SERVER", "http://localhost:8083")
+
+    print("Delete old connector")
+    # Delete previous connector instance if any.
+    # Note: this won't delete any existing Kafka topics created
+    # by the connector.
+    requests.delete(f"{connect_server}/connectors/inventory-connector")
+
+    print("Create connector")
+    # Create connector.  The new connector will continue working with
+    # existing Kafka topics created by the previous connectors instance
+    # if the exist.
+    config = {
+        "name": "inventory-connector",
+        "config": {
+            "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+            "tasks.max": "1",
+            "database.hostname": "mysql",
+            "database.port": "3306",
+            "database.user": "debezium",
+            "database.password": "dbz",
+            "database.server.id": "184054",
+            "database.server.name": "dbserver1",
+            "database.include.list": "inventory",
+            "database.history.kafka.bootstrap.servers": "redpanda:9092",
+            "topic.prefix": "inventory",
+            "schema.history.internal.kafka.topic": "schema-changes.inventory.internal",
+            "schema.history.internal.kafka.bootstrap.servers": "redpanda:9092",
+            "include.schema.changes": "true",
+        },
+    }
+    response = requests.post(
+        f"{connect_server}/connectors", json=config
+    ).raise_for_status()
+
+    print("Checking connector status")
+    start_time = time.time()
+    while True:
+        response = requests.get(
+            f"{connect_server}/connectors/inventory-connector/status"
+        )
+        print(f"response: {response}")
+        if response.ok:
+            status = response.json()
+            print(f"status: {status}")
+            if status["connector"]["state"] != "RUNNING":
+                raise Exception(f"Unexpected connector state: {status}")
+            if len(status["tasks"]) == 0:
+                print("Waiting for connector task")
+                time.sleep(1)
+                continue
+            if status["tasks"][0]["state"] != "RUNNING":
+                raise Exception(f"Unexpected task state: {status}")
+            break
+        else:
+            if time.time() - start_time >= 5:
+                raise Exception("Timeout waiting for connector creation")
+                break
+            print("Waiting for connector creation")
+            time.sleep(1)
+
+    # Connector is up, but this doesn't guarantee that it has created all 5 topics.
+    print("Waiting for the connector to create Kafka topics")
+    start_time = time.time()
+    while True:
+        response = requests.get(
+            f"{connect_server}/connectors/inventory-connector/topics"
+        )
+        if not response.ok:
+            raise Exception(f"Error retrieving topic list from connector: {response}")
+        else:
+            status = response.json()
+            print(f"topics: {status}")
+            topics = status["inventory-connector"]["topics"]
+            if all(
+                element in topics
+                for element in [
+                    "inventory.inventory.orders",
+                    "inventory.inventory.addresses",
+                    "inventory.inventory.customers",
+                    "inventory.inventory.products",
+                    "inventory.inventory.products_on_hand",
+                ]
+            ):
+                break
+
+            if time.time() - start_time >= 10:
+                raise Exception("Timeout waiting for topic creation")
+                break
+            print("Waiting for topics")
+            time.sleep(1)
+
+
+def make_config(project):
+    config = DBSPPipelineConfig(project, 8, "Debezium MySQL Pipeline")
+
+    config.add_kafka_input(
+        name="addresses",
+        stream="ADDRESSES",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["inventory.inventory.addresses"],
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="debezium"),
+    )
+
+    config.add_kafka_input(
+        name="customers",
+        stream="CUSTOMERS",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["inventory.inventory.customers"],
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="debezium"),
+    )
+
+    config.add_kafka_input(
+        name="orders",
+        stream="ORDERS",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["inventory.inventory.orders"],
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="debezium"),
+    )
+
+    config.add_kafka_input(
+        name="products",
+        stream="PRODUCTS",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["inventory.inventory.products"],
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="debezium"),
+    )
+
+    config.add_kafka_input(
+        name="products_on_hand",
+        stream="PRODUCTS_ON_HAND",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["inventory.inventory.products_on_hand"],
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="debezium"),
+    )
+
+    config.save()
+    return config
+
+
+if __name__ == "__main__":
+    run_demo(
+        "Debezium MySQL Demo",
+        os.path.join(SCRIPT_DIR, "project.sql"),
+        make_config,
+        prepare,
+    )

--- a/deploy/docker-compose-debezium.yml
+++ b/deploy/docker-compose-debezium.yml
@@ -1,0 +1,56 @@
+# Additional services needed to test/demo Debezium integration
+
+services:
+  # Kafka connect.
+  # TODO: add a healthcheck to this container.
+  connect:
+    image: debezium/connect:2.3
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    ports:
+      - "8083:8083"
+    environment:
+      BOOTSTRAP_SERVERS: "redpanda:9092"
+      GROUP_ID: "1"
+      CONFIG_STORAGE_TOPIC: "inventory.configs"
+      OFFSET_STORAGE_TOPIC: "inventory.offset"
+      STATUS_STORAGE_TOPIC: "inventory.status"
+
+  # MySQL container with a toy database used in the Debezium
+  # MySQL tutorial (based on MySQL 8.0).
+  mysql:
+    image: debezium/example-mysql:2.3
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: debezium
+      MYSQL_USER: mysqluser
+      MYSQL_PASSWORD: mysqlpw
+    healthcheck:
+      test: ["CMD", "mysqladmin" , "-u", "$$MYSQL_USER",  "-p$$MYSQL_PASSWORD" ,"ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 20s
+      # MySQL can be _very_ slow to start.
+      retries: 40
+
+  # Feldera demo container that creates a Debezium MySQL connector to
+  # sync the MySQL database with Feldera.
+  debezium-demo:
+    depends_on:
+      pipeline-manager:
+        condition: service_healthy
+      connect:
+        condition: service_started
+      mysql:
+        condition: service_healthy
+    image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.1.3}
+    environment:
+      RUST_BACKTRACE: "1"
+      REDPANDA_BROKERS: "redpanda:9092"
+      RUST_LOG: "info"
+      KAFKA_CONNECT_SERVER: "http://connect:8083"
+    command:
+      - bash
+      - -c
+      - "sleep 5 && cd demo/project_demo05-DebeziumMySQL/ && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile run"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -62,6 +62,12 @@ services:
       - 18082:18082
       - 19092:19092
       - 19644:9644
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
   demo:
     profiles: ["demo"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
 
   redpanda:
-    profiles: ["demo"]
+    profiles: ["demo", "debezium"]
     command:
       - redpanda
       - start

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,6 +28,13 @@ services:
     command:
       - --db-connection-string=postgresql://postgres:postgres@db:5432
       - --use-auth=${USE_AUTH:-false}
+    healthcheck:
+      # TODO: add `/status` endpoint.
+      test: ["CMD-SHELL", "curl --fail --request GET --url http://localhost:8080/v0/pipelines"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 
   redpanda:
     profiles: ["demo"]
@@ -73,7 +80,7 @@ services:
     profiles: ["demo"]
     depends_on:
       pipeline-manager:
-        condition: service_started
+        condition: service_healthy
     image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.1.3}
     environment:
       - RUST_BACKTRACE=1


### PR DESCRIPTION
This commit adds a new demo program that ingests data into Feldera
from a MySQL database using Debezium.

We configure the following services:

- Redpanda
- Kafka Connect with Debezium connector using the RedPanda service as
  its internal state store.
- MySQL container with a simple database from the Debezium MySQL tutorial

and create a Debezium connector that streams updates to the database to
RedPanda topics (one topic per table).  All of this setup is done outside
of Feldera.  Inside Feldera, we create a SQL program that mirrors the MySQL
program and build a pipeline with one Kafka connector per topic.
Connectors are configured to parse the Debezium JSON format (I
implemented support for it earlier and only had to fix it up slightly).

With this setup we are able to ingest the contents of all tables except the
one table that has a field of type `DATE` (see below).

I added a minimal test of the above config to CI.  It only starts the
demo, but doesn't look at the outputs or do anything interesting with
it.  I didn't want to spend too much time on this until we have an
end-to-end architecture.

TODOs:

- Parsing Debezium-generated JSON.  The format is generally
  straightforward and we already mostly support it.  However Debezium
  has a very unfortunate way to encode temporal types.  Not only they
  use numbers instead of strings (that wouldn't be too bad), but the
  semantics of the number depends on (1) the exact column type, (2) connector
  config, and (3) source database (i.e., MySQL, Postgres, etc.).  The encoding
  of decimals is also tricky.

- Replace the Debezium tutorial container with our own MySQL container
  configured the way we expect Feldera users to configure their MySQL
  instances for Debezium.

- UI for creating Feldera Debezium connectors (as explained above, it's
  just a special case of a Kafka + JSON connector).

- We probably want to look into Avro support.

Addresses #681