### PR TITLE
Durable input for fault tolerance

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -33,6 +33,9 @@
 //! of transmitted bytes and records and updating respective performance
 //! counters in the controller.
 
+use crate::transport::AtomicStep;
+use crate::transport::InputReader;
+use crate::transport::Step;
 use crate::DbspCircuitHandle;
 use crate::{
     catalog::SerBatch, Catalog, CircuitCatalog, Encoder, InputConsumer, InputEndpoint, InputFormat,
@@ -47,8 +50,10 @@ use crossbeam::{
 };
 use log::{debug, error, info};
 use pipeline_types::query::OutputQuery;
+use std::collections::HashMap;
+use std::sync::Condvar;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
@@ -276,6 +281,26 @@ impl Controller {
             .add_output_endpoint(endpoint_name, endpoint_config, endpoint)
     }
 
+    /// Reports whether the circuit is fault tolerant.  A circuit is fault
+    /// tolerant if it computes a deterministic function and all of its inputs
+    /// and outputs are durable.  This function assumes that the circuit is
+    /// deterministic.
+    pub fn is_fault_tolerant(&self) -> bool {
+        self.inner
+            .status
+            .input_status()
+            .values()
+            .all(|status| status.is_durable)
+            && self
+                .inner
+                .outputs
+                .read()
+                .unwrap()
+                .by_id
+                .values()
+                .all(|descr| descr.is_durable)
+    }
+
     /// Increment the nubmber of active API connections.
     ///
     /// API connections are created dynamically via the `ingress` and `egress`
@@ -416,6 +441,8 @@ impl Controller {
             Duration::from_micros(controller.status.global_config.max_buffering_delay_usecs);
         let min_batch_size_records = controller.status.global_config.min_batch_size_records;
 
+        let mut step = 0;
+
         loop {
             let dump_profile = controller
                 .dump_profile_request
@@ -458,6 +485,15 @@ impl Controller {
                             .map(|start| start.elapsed() >= max_buffering_delay)
                             .unwrap_or(false)
                     {
+                        // Request all of the inputs to commit this step, and
+                        // then wait for the commits to complete.
+                        for endpoint in controller.inputs.lock().unwrap().values() {
+                            endpoint.reader.commit(step);
+                        }
+                        while !controller.status.step_is_committed(step) {
+                            parker.park();
+                        }
+
                         start = None;
                         // Reset all counters of buffered records and bytes to 0.
                         controller.status.consume_buffered_inputs();
@@ -534,7 +570,7 @@ impl Controller {
                                         // been sent to the output endpoint, the endpoint will get
                                         // labeled with this
                                         // frontier.
-                                        endpoint.queue.push((batch, processed_records));
+                                        endpoint.queue.push((step, batch, processed_records));
                                         endpoint.snapshot_sent.store(true, Ordering::Release);
                                     }
                                 } else if delta_batch.is_some() {
@@ -548,7 +584,7 @@ impl Controller {
                                         delta_batch.as_ref().unwrap().clone()
                                     };
 
-                                    endpoint.queue.push((batch, processed_records));
+                                    endpoint.queue.push((step, batch, processed_records));
                                 }
 
                                 // Wake up the output thread.  We're not trying to be smart here and
@@ -557,6 +593,10 @@ impl Controller {
                                 endpoint.unparker.unpark();
                             }
                         }
+
+                        step += 1;
+                        controller.step.store(step, Ordering::Release);
+                        controller.unpark_backpressure();
                     } else if buffered_records > 0 {
                         // We have some buffered data, but less than `min_batch_size_records` --
                         // wait up to `max_buffering_delay` for more data to
@@ -581,76 +621,41 @@ impl Controller {
 
     /// Backpressure thread function.
     fn backpressure_thread(controller: Arc<ControllerInner>, parker: Parker) {
-        // `global_pause` flag is `true` when the entire controller is paused
-        // (the controller starts in a paused state and switches between
-        // paused and running states in responsed to `Controller::start()` and
-        // `Controller::pause()` methods).
-        let mut global_pause = true;
+        #[derive(Copy, Clone, PartialEq, Eq)]
+        enum EndpointState {
+            Pause,
+            Run(Step),
+        }
 
-        // Endpoints paused due to backpressure.
-        let mut paused_endpoints = HashSet::new();
+        let mut endpoint_states = HashMap::new();
 
         loop {
-            let inputs = controller.inputs.lock().unwrap();
-
-            match controller.state() {
-                PipelineState::Paused => {
-                    // Pause circuit if not yet paused.
-                    if !global_pause {
-                        for (epid, ep) in inputs.iter() {
-                            // Pause the endpoint unless it's already paused due to backpressure.
-                            if !paused_endpoints.contains(epid) {
-                                ep.endpoint.pause().unwrap_or_else(|e| {
-                                    controller.input_transport_error(
-                                        *epid,
-                                        &ep.endpoint_name,
-                                        true,
-                                        e,
-                                    )
-                                });
-                            }
-                        }
-                    }
-                    global_pause = true;
-                }
-                PipelineState::Running => {
-                    // Resume endpoints that have buffer space, pause endpoints with full buffers.
-                    for (epid, ep) in inputs.iter() {
-                        if controller.status.input_endpoint_full(epid) {
-                            // The endpoint is full and is not yet in the paused state -- pause it
-                            // now.
-                            if !global_pause && !paused_endpoints.contains(epid) {
-                                ep.endpoint.pause().unwrap_or_else(|e| {
-                                    controller.input_transport_error(
-                                        *epid,
-                                        &ep.endpoint_name,
-                                        true,
-                                        e,
-                                    )
-                                });
-                            }
-                            paused_endpoints.insert(*epid);
-                        } else {
-                            // The endpoint is paused when it should be running -- unpause it.
-                            if global_pause || paused_endpoints.contains(epid) {
-                                ep.endpoint.start().unwrap_or_else(|e| {
-                                    controller.input_transport_error(
-                                        *epid,
-                                        &ep.endpoint_name,
-                                        true,
-                                        e,
-                                    )
-                                });
-                            }
-                            paused_endpoints.remove(epid);
-                        }
-                    }
-                    global_pause = false;
-                }
+            let global_pause = match controller.state() {
+                PipelineState::Paused => true,
+                PipelineState::Running => false,
                 PipelineState::Terminated => return,
-            }
+            };
+            let step = controller.step.load(Ordering::Acquire);
+            info!("stepping to {step}");
 
-            drop(inputs);
+            for (epid, ep) in controller.inputs.lock().unwrap().iter() {
+                let current_state = endpoint_states.entry(*epid).or_insert(EndpointState::Pause);
+                let desired_state = if global_pause || controller.status.input_endpoint_full(epid) {
+                    EndpointState::Pause
+                } else {
+                    EndpointState::Run(step)
+                };
+                if *current_state != desired_state {
+                    let result = match desired_state {
+                        EndpointState::Pause => ep.reader.pause(),
+                        EndpointState::Run(step) => ep.reader.start(step),
+                    };
+                    if let Err(error) = result {
+                        controller.input_transport_error(*epid, &ep.endpoint_name, true, error);
+                    };
+                    *current_state = desired_state;
+                }
+            }
 
             parker.park();
         }
@@ -660,14 +665,14 @@ impl Controller {
 /// State tracked by the controller for each input endpoint.
 struct InputEndpointDescr {
     endpoint_name: String,
-    endpoint: Box<dyn InputEndpoint>,
+    reader: Box<dyn InputReader>,
 }
 
 impl InputEndpointDescr {
-    pub fn new(endpoint_name: &str, endpoint: Box<dyn InputEndpoint>) -> Self {
+    pub fn new(endpoint_name: &str, reader: Box<dyn InputReader>) -> Self {
         Self {
             endpoint_name: endpoint_name.to_owned(),
-            endpoint,
+            reader,
         }
     }
 }
@@ -677,7 +682,7 @@ impl InputEndpointDescr {
 /// that is equal to the number of input records fully processed by
 /// DBSP before emitting this batch of outputs.  The label increases
 /// monotonically over time.
-type BatchQueue = SegQueue<(Vec<Arc<dyn SerBatch>>, u64)>;
+type BatchQueue = SegQueue<(Step, Vec<Arc<dyn SerBatch>>, u64)>;
 
 /// State tracked by the controller for each output endpoint.
 struct OutputEndpointDescr {
@@ -703,6 +708,9 @@ struct OutputEndpointDescr {
 
     /// Unparker for the endpoint thread.
     unparker: Unparker,
+
+    /// Whether the output endpoint can discard duplicate output.
+    is_durable: bool,
 }
 
 impl OutputEndpointDescr {
@@ -711,6 +719,7 @@ impl OutputEndpointDescr {
         stream_name: &str,
         query: OutputQuery,
         unparker: Unparker,
+        is_durable: bool,
     ) -> Self {
         Self {
             endpoint_name: endpoint_name.to_string(),
@@ -720,6 +729,7 @@ impl OutputEndpointDescr {
             snapshot_sent: AtomicBool::new(false),
             disconnect_flag: Arc::new(AtomicBool::new(false)),
             unparker,
+            is_durable,
         }
     }
 }
@@ -803,6 +813,16 @@ struct ControllerInner {
     circuit_thread_unparker: Unparker,
     backpressure_thread_unparker: Unparker,
     error_cb: Box<dyn Fn(ControllerError) + Send + Sync>,
+    step: AtomicStep,
+
+    /// The lowest-numbered input step not known to have settled yet.
+    ///
+    /// This is updated lazily, only when we need to wait for a step to settle
+    /// in `wait_to_settle`.
+    unsettled_step: Mutex<Step>,
+
+    /// Condition that fires when `unsettled_step` increases.
+    step_settled: Condvar,
 }
 
 impl ControllerInner {
@@ -825,6 +845,9 @@ impl ControllerInner {
             circuit_thread_unparker,
             backpressure_thread_unparker,
             error_cb,
+            step: AtomicStep::new(0),
+            unsettled_step: Mutex::new(0),
+            step_settled: Condvar::new(),
         }
     }
 
@@ -854,7 +877,7 @@ impl ControllerInner {
         let mut inputs = self.inputs.lock().unwrap();
 
         if let Some(ep) = inputs.remove(endpoint_id) {
-            ep.endpoint.disconnect();
+            ep.reader.disconnect();
             self.status.remove_input(endpoint_id);
             self.unpark_circuit();
             self.unpark_backpressure();
@@ -865,7 +888,7 @@ impl ControllerInner {
         self: &Arc<Self>,
         endpoint_name: &str,
         endpoint_config: InputEndpointConfig,
-        mut endpoint: Box<dyn InputEndpoint>,
+        endpoint: Box<dyn InputEndpoint>,
     ) -> Result<EndpointId, ControllerError> {
         let mut inputs = self.inputs.lock().unwrap();
 
@@ -914,22 +937,23 @@ impl ControllerInner {
         ));
 
         // Initialize endpoint stats.
-        self.status
-            .add_input(&endpoint_id, endpoint_name, endpoint_config);
+        self.status.add_input(
+            &endpoint_id,
+            endpoint_name,
+            endpoint_config,
+            endpoint.is_durable(),
+        );
 
-        endpoint
-            .connect(probe)
+        let reader = endpoint
+            .open(probe, 0)
             .map_err(|e| ControllerError::input_transport_error(endpoint_name, true, e))?;
         if self.state() == PipelineState::Running {
-            endpoint
-                .start()
+            reader
+                .start(0)
                 .map_err(|e| ControllerError::input_transport_error(endpoint_name, true, e))?;
         }
 
-        inputs.insert(
-            endpoint_id,
-            InputEndpointDescr::new(endpoint_name, endpoint),
-        );
+        inputs.insert(endpoint_id, InputEndpointDescr::new(endpoint_name, reader));
 
         drop(inputs);
 
@@ -1006,7 +1030,7 @@ impl ControllerInner {
         self: &Arc<Self>,
         endpoint_name: &str,
         endpoint_config: &OutputEndpointConfig,
-        endpoint: Box<dyn OutputEndpoint>,
+        mut endpoint: Box<dyn OutputEndpoint>,
     ) -> Result<EndpointId, ControllerError> {
         let mut outputs = self.outputs.write().unwrap();
 
@@ -1042,6 +1066,7 @@ impl ControllerInner {
                 }
             }))
             .map_err(|e| ControllerError::output_transport_error(endpoint_name, true, e))?;
+        let is_durable = endpoint.is_durable();
 
         // Create probe.
         let probe = Box::new(OutputProbe::new(
@@ -1071,6 +1096,7 @@ impl ControllerInner {
             &endpoint_config.stream,
             endpoint_config.query,
             parker.unparker().clone(),
+            is_durable,
         );
         let queue = endpoint_descr.queue.clone();
         let disconnect_flag = endpoint_descr.disconnect_flag.clone();
@@ -1120,13 +1146,14 @@ impl ControllerInner {
             }
 
             // Dequeue the next output batch and push it to the encoder.
-            if let Some((data, processed_records)) = queue.pop() {
+            if let Some((step, data, processed_records)) = queue.pop() {
                 let num_records = data.iter().map(|b| b.len()).sum();
 
-                encoder.consumer().batch_start();
+                encoder.consumer().batch_start(step);
                 encoder
                     .encode(data.as_slice())
                     .unwrap_or_else(|e| controller.encode_error(endpoint_id, &endpoint_name, e));
+                controller.wait_to_settle(step);
                 encoder.consumer().batch_end();
 
                 // `num_records` output records have been transmitted --
@@ -1142,6 +1169,28 @@ impl ControllerInner {
                 // Queue is empty -- wait for the circuit thread to wake us up when
                 // more data is available.
                 parker.park();
+            }
+        }
+    }
+
+    /// Waits for input `step` to settle.
+    ///
+    /// An input step must settle before we can commit any of the output.
+    /// Otherwise, if there is a crash, we might have output for which we don't
+    /// know the corresponding input, which would break fault tolerance.
+    fn wait_to_settle(self: &Arc<Self>, step: Step) {
+        if !self.status.step_is_settled(step) {
+            let mut guard = self.unsettled_step.lock().unwrap();
+            loop {
+                let unsettled_step = self.status.unsettled_step().unwrap();
+                if unsettled_step > *guard {
+                    *guard = unsettled_step;
+                    self.step_settled.notify_all();
+                }
+                if unsettled_step < step {
+                    return;
+                }
+                guard = self.step_settled.wait(guard).unwrap();
             }
         }
     }
@@ -1164,7 +1213,7 @@ impl ControllerInner {
         let mut inputs = self.inputs.lock().unwrap();
 
         for ep in inputs.values() {
-            ep.endpoint.disconnect();
+            ep.reader.disconnect();
         }
         inputs.clear();
 
@@ -1333,6 +1382,16 @@ impl InputConsumer for InputProbe {
             self.backpressure_thread_unparker.clone(),
         ))
     }
+
+    fn start_step(&mut self, step: Step) {
+        self.controller.status.start_step(self.endpoint_id, step);
+        self.circuit_thread_unparker.unpark();
+    }
+
+    fn settled(&mut self, step: Step) {
+        self.controller.status.settled(self.endpoint_id, step);
+        self.circuit_thread_unparker.unpark();
+    }
 }
 
 /// An output probe inserted between the encoder and the output transport
@@ -1365,8 +1424,8 @@ impl OutputConsumer for OutputProbe {
         self.endpoint.max_buffer_size_bytes()
     }
 
-    fn batch_start(&mut self) {
-        self.endpoint.batch_start().unwrap_or_else(|e| {
+    fn batch_start(&mut self, step: Step) {
+        self.endpoint.batch_start(step).unwrap_or_else(|e| {
             self.controller
                 .output_transport_error(self.endpoint_id, &self.endpoint_name, false, e);
         })

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -155,7 +155,7 @@ impl Controller {
             let inner = inner.clone();
 
             // A channel to communicate circuit initialization status.
-            // The `citcuit_factory` closure must be invoked in the context of
+            // The `circuit_factory` closure must be invoked in the context of
             // the circuit thread, because the circuit handle it returns doesn't
             // implement `Send`.  So we need this channel to communicate circuit
             // initialization status back to this thread.

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -1,4 +1,6 @@
-use crate::{catalog::SerBatch, ControllerError, DeCollectionHandle, FieldParseError};
+use crate::{
+    catalog::SerBatch, transport::Step, ControllerError, DeCollectionHandle, FieldParseError,
+};
 use actix_web::HttpRequest;
 use anyhow::Result as AnyResult;
 use erased_serde::Serialize as ErasedSerialize;
@@ -468,7 +470,7 @@ pub trait OutputConsumer: Send {
     /// The encoder should not generate buffers exceeding this size.
     fn max_buffer_size_bytes(&self) -> usize;
 
-    fn batch_start(&mut self);
+    fn batch_start(&mut self, step: Step);
     fn push_buffer(&mut self, buffer: &[u8]);
     fn batch_end(&mut self);
 }

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -159,9 +159,6 @@ where
     let args = ServerArgs::try_parse().map_err(|e| ControllerError::cli_args_error(&e))?;
 
     run_server(args, circuit_factory).map_err(|e| {
-        // Write to stderror in case the error happened before logging
-        // has been enabled.
-        eprintln!("{e}");
         error!("{e}");
         e
     })

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -37,28 +37,59 @@ pub struct KafkaResources {
 // Checks `consumer` to make sure that all of the topics in `topics` are
 // accessible and have the specified number of partitions.
 fn check_topics<C: ClientContext>(consumer: &Client<C>, topics: &[(&str, i32)]) -> AnyResult<()> {
+    // Retrieve the list of all topics and then filter it.  If the broker is
+    // configured to automatically create topics, then asking for each of them
+    // individually will create them, which is no good for topics we want to
+    // delete.
+    let metadata = consumer.fetch_metadata(None, Duration::from_secs(1))?;
+
     for &(topic, partitions) in topics.iter() {
-        let m = consumer
-            .fetch_metadata(Some(topic), Duration::from_secs(1))
-            .map_err(|e| anyhow!("topic {topic}: {e}"))?;
-        let cur_partitions = m
+        let cur_partitions = metadata
             .topics()
-            .get(0)
-            .map(|topic| topic.partitions().len() as i32)
-            .unwrap_or_default();
+            .iter()
+            .find(|m| m.name() == topic)
+            .map(|mt| mt.partitions().len())
+            .unwrap_or(0) as i32;
         if cur_partitions != partitions {
-            bail!("{topic} only has {cur_partitions} partitions, waiting for {partitions}");
+            bail!("{topic} has {cur_partitions} partitions, waiting for {partitions}");
         }
-        consumer
-            .fetch_watermarks(topic, 0, Duration::from_secs(1))
-            .map_err(|e| anyhow!("topic {topic}: {e}"))?;
+        if partitions > 0 {
+            consumer
+                .fetch_watermarks(topic, 0, Duration::from_secs(1))
+                .map_err(|e| anyhow!("topic {topic}: {e}"))?;
+        }
     }
     Ok(())
+}
+
+fn wait_for_completion<C: ClientContext>(admin_client: &AdminClient<C>, topics: &[(&str, i32)]) {
+    let topic_names = topics
+        .iter()
+        .map(|(topic_name, _partitions)| &**topic_name)
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    let mut backoff = 100;
+    let mut n_retries = 0;
+    while let Err(err) = check_topics(admin_client.inner(), topics) {
+        info!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, retrying: {err}");
+        if start.elapsed() > MAX_TOPIC_PROBE_TIMEOUT {
+            panic!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, giving up after {}ms: {err}", MAX_TOPIC_PROBE_TIMEOUT.as_millis());
+        }
+        sleep(Duration::from_millis(backoff));
+        backoff = 1000.min(backoff * 2);
+        n_retries += 1;
+    }
+    if n_retries > 0 {
+        info!("KafkaResources::create_topics {topic_names:?}: success after {n_retries} tries");
+    }
 }
 
 /// An object that creates Kafka topics on startup and deletes them
 /// on drop.  Helps make sure that test runs don't leave garbage behind.
 impl KafkaResources {
+    /// `(topic, n_partitions)` creates a topic with `n_partitions` partitions.
+    /// If `n_partitions` is 0 then the topic is deleted instead.
     pub fn create_topics(topics: &[(&str, i32)]) -> Self {
         // Kafka does not handle topic deletion and creation consistently when
         // multiple operations are performed in parallel, so serialize calls to
@@ -74,40 +105,32 @@ impl KafkaResources {
             .set_log_level(RDKafkaLogLevel::Debug);
         let admin_client = AdminClient::from_config(&admin_config).unwrap();
 
-        let new_topics = topics
-            .iter()
-            .map(|(topic_name, partitions)| {
-                NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1))
-            })
-            .collect::<Vec<_>>();
-        let topic_names = topics
-            .iter()
-            .map(|(topic_name, _partitions)| &**topic_name)
-            .collect::<Vec<_>>();
-
         // Delete topics if they exist from previous failed runs that crashed before
         // cleaning up.  Otherwise, it may take a long time to re-join a
         // group whose members are dead, plus the old topics may contain
         // messages that will mess up our tests.
-        let _ = block_on(admin_client.delete_topics(&topic_names, &AdminOptions::new()));
+        //
+        // We wait for deletion to finish before creating topics, because Kafka
+        // doesn't seem to always do what we want if we tell it to re-create a
+        // topic before it's been fully deleted.
+        let delete_topics = topics
+            .iter()
+            .map(|(topic_name, _partitions)| &**topic_name)
+            .collect::<Vec<_>>();
+        let _ = block_on(admin_client.delete_topics(&delete_topics, &AdminOptions::new()));
+        let deleted_topics: Vec<_> = topics.iter().map(|(name, _)| (*name, 0)).collect();
+        wait_for_completion(&admin_client, &deleted_topics[..]);
 
+        // Now create the topics and wait for the creations to complete.
+        let new_topics = topics
+            .iter()
+            .filter_map(|(topic_name, partitions)| {
+                (*partitions > 0)
+                    .then(|| NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1)))
+            })
+            .collect::<Vec<_>>();
         block_on(admin_client.create_topics(&new_topics, &AdminOptions::new())).unwrap();
-
-        let start = Instant::now();
-        let mut backoff = 100;
-        let mut n_retries = 0;
-        while let Err(err) = check_topics(admin_client.inner(), topics) {
-            info!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, retrying: {err}");
-            if start.elapsed() > MAX_TOPIC_PROBE_TIMEOUT {
-                panic!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, giving up after {}ms: {err}", MAX_TOPIC_PROBE_TIMEOUT.as_millis());
-            }
-            sleep(Duration::from_millis(backoff));
-            backoff = 1000.min(backoff * 2);
-            n_retries += 1;
-        }
-        if n_retries > 0 {
-            info!("KafkaResources::create_topics {topic_names:?}: success after {n_retries} tries");
-        }
+        wait_for_completion(&admin_client, topics);
 
         Self {
             admin_client,

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -313,8 +313,16 @@ impl BufferConsumer {
     pub fn wait_for_output_unordered(&self, data: &[Vec<TestStruct>]) {
         let num_records: usize = data.iter().map(Vec::len).sum();
 
-        // println!("waiting for {num_records} records");
-        wait(|| self.len() == num_records, DEFAULT_TIMEOUT_MS).unwrap();
+        wait(
+            move || {
+                info!(
+                    "waiting for {num_records} records (received {})",
+                    self.len()
+                );
+                self.len() == num_records
+            },
+            DEFAULT_TIMEOUT_MS,
+        );
         //println!("{num_records} records received: {:?}",
         // received_data.lock().unwrap().iter().map(|r| r.id).collect::<Vec<_>>());
 

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -1,5 +1,6 @@
 use crate::{
-    controller::FormatConfig, DeCollectionHandle, InputConsumer, InputFormat, ParseError, Parser,
+    controller::FormatConfig, transport::Step, DeCollectionHandle, InputConsumer, InputFormat,
+    ParseError, Parser,
 };
 use anyhow::{anyhow, Error as AnyError};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -151,4 +152,8 @@ impl InputConsumer for MockInputConsumer {
     fn fork(&self) -> Box<dyn InputConsumer> {
         Box::new(self.clone())
     }
+
+    fn start_step(&mut self, _step: Step) {}
+
+    fn settled(&mut self, _step: Step) {}
 }

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -1,4 +1,4 @@
-use crate::OutputConsumer;
+use crate::{transport::Step, OutputConsumer};
 use std::sync::{Arc, Mutex};
 
 pub struct MockOutputConsumer {
@@ -30,7 +30,7 @@ impl OutputConsumer for MockOutputConsumer {
         self.max_buffer_size_bytes
     }
 
-    fn batch_start(&mut self) {}
+    fn batch_start(&mut self, _step: Step) {}
     fn push_buffer(&mut self, buffer: &[u8]) {
         self.data.lock().unwrap().extend_from_slice(buffer)
     }

--- a/crates/adapters/src/transport/durable_kafka/input.rs
+++ b/crates/adapters/src/transport/durable_kafka/input.rs
@@ -1,0 +1,1041 @@
+use super::{count_partitions_in_topic, Ctp, DataConsumerContext, ErrorHandler, POLL_TIMEOUT};
+use crate::transport::durable_kafka::check_fatal_errors;
+use crate::transport::{InputReader, Step};
+use crate::{InputConsumer, InputEndpoint, InputTransport};
+use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
+use crossbeam::sync::{Parker, Unparker};
+use futures::executor::block_on;
+use log::{debug, info, warn};
+use pipeline_types::transport::durable_kafka::KafkaDurableInputConfig;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
+use rdkafka::config::{FromClientConfig, FromClientConfigAndContext};
+use rdkafka::consumer::base_consumer::PartitionQueue;
+use rdkafka::consumer::{BaseConsumer, ConsumerContext};
+use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedProducer};
+use rdkafka::types::RDKafkaErrorCode;
+use rdkafka::{consumer::Consumer, producer::Producer, Message, Offset};
+use rdkafka::{ClientContext, TopicPartitionList};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_yaml::Value as YamlValue;
+use std::cmp::{max, Ordering};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::thread::sleep;
+use std::time::Duration;
+use std::{
+    borrow::Cow,
+    error::Error,
+    fmt::Result as FmtResult,
+    ops::Range,
+    sync::{Arc, Mutex},
+    thread::{Builder, JoinHandle},
+};
+
+use super::CommonConfig;
+
+/// [`InputTransport`] implementation that durably reads data from one or more
+/// Kafka topics.
+///
+/// This input transport is only available if the crate is configured with
+/// `with-kafka` feature.
+///
+/// The input transport factory gives this transport the name `durable_kafka`.
+pub struct KafkaDurableInputTransport;
+
+impl InputTransport for KafkaDurableInputTransport {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("durable_kafka")
+    }
+
+    /// Creates a new [`InputEndpoint`] for reading from Kafka topics,
+    /// interpreting `config` as a [`KafkaDurableInputConfig`].
+    ///
+    /// See [`InputTransport::new_endpoint()`] for more information.
+    fn new_endpoint(&self, config: &YamlValue) -> AnyResult<Box<dyn InputEndpoint>> {
+        let config = KafkaDurableInputConfig::deserialize(config)?;
+        let ep = Endpoint::new(config)?;
+        Ok(Box::new(ep))
+    }
+}
+
+/// Validated version of [`KafkaDurableInputConfig`], converted into a
+/// convenient form for internal use.
+#[derive(Clone)]
+struct Config {
+    /// Common with output configuration.
+    common: CommonConfig,
+
+    /// Topics to be read.
+    data_topics: Vec<String>,
+
+    /// The index topic suffix.
+    index_suffix: String,
+
+    /// Create index topics if they are missing?
+    create_missing_index: bool,
+
+    /// Maximum number of bytes in a step.
+    max_step_bytes: usize,
+
+    /// Maximum number of messages in a step.
+    max_step_messages: i64,
+}
+
+impl TryFrom<KafkaDurableInputConfig> for Config {
+    type Error = AnyError;
+
+    fn try_from(source: KafkaDurableInputConfig) -> Result<Self, Self::Error> {
+        let max_step_bytes = source.max_step_bytes.unwrap_or(u64::MAX).max(1);
+        let max_step_messages = source.max_step_messages.unwrap_or(u64::MAX).max(1);
+
+        let common = CommonConfig::try_from(&source.common)?;
+        let index_suffix = match source.index_suffix {
+            Some(ref s) => s.clone(),
+            None => "_input-index".into(),
+        };
+
+        if source.topics.is_empty() {
+            bail!("`data_topics` must name at least one data topic.");
+        }
+
+        Ok(Config {
+            common,
+            data_topics: source.topics.clone(),
+            index_suffix,
+            create_missing_index: source.create_missing_index.unwrap_or(true),
+            max_step_bytes: max_step_bytes.try_into().unwrap_or(usize::MAX),
+            max_step_messages: max_step_messages.try_into().unwrap_or(i64::MAX),
+        })
+    }
+}
+
+/// Durable Kafka input endpoint.
+struct Endpoint(Arc<Config>);
+
+impl Endpoint {
+    fn new(config: KafkaDurableInputConfig) -> AnyResult<Self> {
+        Ok(Self(Arc::new(config.try_into()?)))
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum OkAction {
+    Run(Step),
+    Pause,
+}
+
+/// Request made of the `WorkerThread`:
+///
+/// - `Ok(action)`: Run or pause.
+///
+/// - `Err(Exit)`: All done, please exit.
+///
+/// Representing an exit request as `Err` allows it to be implemented via `?`.
+type Action = Result<OkAction, Exit>;
+
+/// Error type to represent that the worker thread should exit.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct Exit;
+impl Display for Exit {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "Exit")
+    }
+}
+impl Error for Exit {}
+
+/// A reader for durable Kafka input.
+///
+/// Code outside this module accesses this as `dyn InputReader`.
+struct Reader {
+    action: Arc<Mutex<Action>>,
+    commit_step: Arc<Mutex<Option<Step>>>,
+    unparker: Unparker,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl Reader {
+    fn set_action(&self, new_action: Action) {
+        let mut action = self.action.lock().unwrap();
+        if *action != new_action {
+            *action = new_action;
+            self.unparker.unpark();
+        }
+    }
+}
+
+impl InputReader for Reader {
+    fn start(&self, step: Step) -> AnyResult<()> {
+        self.set_action(Ok(OkAction::Run(step)));
+        Ok(())
+    }
+
+    fn pause(&self) -> AnyResult<()> {
+        self.set_action(Ok(OkAction::Pause));
+        Ok(())
+    }
+
+    fn commit(&self, new_step: Step) {
+        let mut commit_step = self.commit_step.lock().unwrap();
+        match *commit_step {
+            Some(step) if new_step <= step => (),
+            _ => {
+                *commit_step = Some(new_step);
+                self.unparker.unpark();
+            }
+        }
+    }
+
+    fn disconnect(&self) {
+        self.set_action(Err(Exit));
+    }
+}
+
+impl Drop for Reader {
+    fn drop(&mut self) {
+        self.set_action(Err(Exit));
+        let _ = self.join_handle.take().unwrap().join();
+    }
+}
+
+impl Reader {
+    fn new(config: &Arc<Config>, start_step: Step, consumer: Box<dyn InputConsumer>) -> Self {
+        let parker = Parker::new();
+        let unparker = parker.unparker().clone();
+        let action = Arc::new(Mutex::new(Ok(OkAction::Pause)));
+        let commit_step = Arc::new(Mutex::new(None));
+        let join_handle = Some(WorkerThread::spawn(
+            &action,
+            &commit_step,
+            start_step,
+            parker,
+            config,
+            consumer,
+        ));
+        Reader {
+            action,
+            commit_step,
+            unparker,
+            join_handle,
+        }
+    }
+}
+
+struct PollerThread {
+    join_handle: Option<JoinHandle<()>>,
+    exit_request: Arc<AtomicBool>,
+}
+
+impl PollerThread {
+    fn new<C: ConsumerContext + 'static>(
+        consumer: &Arc<BaseConsumer<C>>,
+        receiver: &Arc<Mutex<Box<dyn InputConsumer>>>,
+    ) -> Self {
+        let exit_request = Arc::new(AtomicBool::new(false));
+        let join_handle = Some(
+            Builder::new()
+                .name("poller(durable_kafka)".into())
+                .spawn({
+                    let consumer = consumer.clone();
+                    let receiver = receiver.clone();
+                    let exit_request = exit_request.clone();
+                    move || Self::run(consumer, receiver, exit_request)
+                })
+                .unwrap(),
+        );
+        Self {
+            join_handle,
+            exit_request,
+        }
+    }
+
+    fn run<C: ConsumerContext>(
+        consumer: Arc<BaseConsumer<C>>,
+        receiver: Arc<Mutex<Box<dyn InputConsumer>>>,
+        exit_request: Arc<AtomicBool>,
+    ) {
+        while !exit_request.load(AtomicOrdering::Acquire) {
+            match consumer.poll(POLL_TIMEOUT).transpose() {
+                Ok(None) => (),
+                Ok(Some(_)) => {
+                    // All of the subscribed partitions should have be broken
+                    // off into `PartitionQueue`s.
+                    unreachable!()
+                }
+                Err(error) => {
+                    let fatal = error
+                        .rdkafka_error_code()
+                        .is_some_and(|code| code == RDKafkaErrorCode::Fatal);
+                    if !fatal {
+                        receiver.lock().unwrap().error(false, error.into())
+                    } else {
+                        // The client will detect this later.
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Drop for PollerThread {
+    fn drop(&mut self) {
+        self.exit_request.store(true, AtomicOrdering::Release);
+        let _ = self.join_handle.take().unwrap().join();
+    }
+}
+
+struct WorkerThread {
+    action: Arc<Mutex<Action>>,
+    commit_step: Arc<Mutex<Option<Step>>>,
+    start_step: Step,
+    parker: Parker,
+    config: Arc<Config>,
+    receiver: Arc<Mutex<Box<dyn InputConsumer>>>,
+}
+
+impl WorkerThread {
+    fn spawn(
+        action: &Arc<Mutex<Action>>,
+        commit_step: &Arc<Mutex<Option<Step>>>,
+        start_step: Step,
+        parker: Parker,
+        config: &Arc<Config>,
+        receiver: Box<dyn InputConsumer>,
+    ) -> JoinHandle<()> {
+        let receiver = Arc::new(Mutex::new(receiver));
+        let worker_thread = Self {
+            action: action.clone(),
+            commit_step: commit_step.clone(),
+            start_step,
+            parker,
+            config: config.clone(),
+            receiver: receiver.clone(),
+        };
+        Builder::new()
+            .name("worker(durable_Kafka)".into())
+            .spawn(move || {
+                if let Err(error) = worker_thread.run() {
+                    if error.downcast_ref::<Exit>().is_some() {
+                        // Normal termination because of a requested exit.
+                    } else {
+                        info!("Durable Kafka input endpoint failed due to: {error:#}");
+                        receiver.lock().unwrap().error(true, error);
+                    }
+                }
+            })
+            .unwrap()
+    }
+
+    /// Wait for `reader.start()` to be called.
+    fn wait_for_pipeline_start(&self, step: Step) -> AnyResult<()> {
+        loop {
+            if let OkAction::Run(up_to_step) = (*self.action.lock().unwrap())? {
+                if step <= up_to_step {
+                    return Ok(());
+                }
+            }
+            self.parker.park_timeout(POLL_TIMEOUT);
+        }
+    }
+
+    fn is_commit_requested(&self, step: Step) -> bool {
+        match *self.commit_step.lock().unwrap() {
+            Some(commit_step) => step <= commit_step,
+            None => false,
+        }
+    }
+
+    fn run(self) -> AnyResult<()> {
+        self.wait_for_pipeline_start(self.start_step)?;
+
+        // Read the index for each partition.
+        let mut topics = Vec::with_capacity(self.config.data_topics.len());
+        let index_suffix = &self.config.index_suffix;
+        let mut assignment = TopicPartitionList::new();
+        for data_topic in &self.config.data_topics {
+            let index_topic = format!("{data_topic}{index_suffix}");
+            let index = Index::new(data_topic, &self.config, |error| {
+                self.receiver.lock().unwrap().error(false, error)
+            })
+            .with_context(|| format!("Failed to read index topic {index_topic}"))?;
+            let positions = index.find_step(self.start_step).with_context(|| {
+                format!("Failed to find step {} in {index_topic}", self.start_step)
+            })?;
+            let index_partitions = index.into_partitions();
+
+            for (index, p) in positions.iter().enumerate() {
+                let index = index as i32;
+                assignment.add_partition_offset(
+                    data_topic,
+                    index,
+                    Offset::Offset(p.data_offset),
+                )?;
+                assignment.add_partition_offset(
+                    &index_topic,
+                    index,
+                    Offset::Offset(p.index_offset),
+                )?;
+            }
+            topics.push((data_topic, index_topic, positions, index_partitions));
+        }
+        let n_partitions = topics.iter().map(|x| x.2.len()).sum();
+
+        // Create a consumer.
+        let receiver_clone = self.receiver.clone();
+        let consumer = Arc::new(
+            BaseConsumer::from_config_and_context(
+                &self.config.common.data_consumer_config,
+                DataConsumerContext::new(move |error| {
+                    receiver_clone.lock().unwrap().error(false, error)
+                }),
+            )
+            .context("Failed to create consumer")?,
+        );
+
+        let error_cb = |error| self.receiver.lock().unwrap().error(false, error);
+        let consumer_eh = ErrorHandler::new(&error_cb, consumer.client());
+
+        consumer
+            .assign(&assignment)
+            .context("Failed to assign topics and partitions")?;
+
+        let mut partitions = Vec::with_capacity(n_partitions);
+        let mut data_queues = Vec::with_capacity(n_partitions);
+        for (data_topic, index_topic, positions, index_partitions) in topics.iter() {
+            for (index, p) in index_partitions.iter().enumerate() {
+                let index = index as i32;
+                let index_ctp = Ctp::new(&consumer, index_topic, index);
+                let index_queue = index_ctp.split_partition_queue()?;
+                let data_ctp = Ctp::new(&consumer, data_topic, index);
+                let mut data_queue = data_ctp.split_partition_queue()?;
+                let unparker = self.parker.unparker().clone();
+                data_queue.set_nonempty_callback(move || unparker.unpark());
+                data_queues.push(data_queue);
+                partitions.push(Partition {
+                    index,
+                    index_ctp,
+                    index_queue,
+                    data_ctp,
+                    next_offset: positions[index as usize].data_offset,
+                    start_offset: None,
+                    steps: p.steps.clone(),
+                });
+            }
+        }
+        let _poller_thread = PollerThread::new(&consumer, &self.receiver);
+
+        // Create a Kafka producer for adding to the index topic.
+        debug!("creating Kafka producer for index topics");
+        let expected_deliveries = Arc::new(Mutex::new(HashMap::new()));
+        let producer = ThreadedProducer::from_config_and_context(
+            &self.config.common.producer_config,
+            IndexProducerContext::new(&self.receiver, &expected_deliveries),
+        )
+        .context("creating Kafka producer for index topics failed")?;
+        let producer_eh = ErrorHandler::new(&error_cb, producer.client());
+
+        // Fetch the watermarks for the topic we're going to produce to, and
+        // then throw away the information because we don't care.  librdkafka
+        // needs this information, and it will fetch it for itself eventually,
+        // but it likes to wait 1 full second before asking for it and fetching
+        // it immediately avoids that delay.
+        for (_data_topic, index_topic, positions, _index_partitions) in topics.iter() {
+            for partition in 0..positions.len() {
+                let producer_ctp = Ctp::new(&producer, index_topic, partition as i32);
+                producer_eh
+                    .retry_errors(|| producer_ctp.fetch_watermarks(None), producer.client())
+                    .with_context(|| format!("Fetching watermark for {producer_ctp} failed"))?;
+            }
+        }
+
+        // Each loop iteration produces one step.
+        let mut next_partition = 0;
+        let mut saved_message = None;
+        for step in self.start_step.. {
+            self.receiver.lock().unwrap().start_step(step);
+            self.wait_for_pipeline_start(step)?;
+            check_fatal_errors(consumer.client()).context("Consumer reported fatal error")?;
+            check_fatal_errors(producer.client()).context("Producer reported fatal error")?;
+
+            // Get all of the messages already written to the step from any
+            // partitions that already have them.
+            let mut n_prewritten = 0;
+            for p in &mut partitions {
+                if step >= p.steps.end {
+                    continue;
+                }
+                n_prewritten += 1;
+
+                // Read the `IndexEntry` that tells us where to get the step's data.
+                let index_message = consumer_eh
+                    .read_partition_queue(&consumer, &p.index_queue)
+                    .with_context(|| format!("Failed to read {} partition queue", p.index_ctp))?;
+                let payload = index_message.payload().unwrap_or(&[]);
+                let index_entry: IndexEntry =
+                    serde_json::from_slice(payload).with_context(|| {
+                        format!(
+                            "Failed to parse index entry in message at offset {} in {}",
+                            index_message.offset(),
+                            p.index_ctp
+                        )
+                    })?;
+                if let Some(error) = {
+                    if index_entry.step != step {
+                        Some(format!("IndexEntry should be for step {step}"))
+                    } else if p.next_offset > index_entry.data_offsets.start {
+                        Some(format!("data offset less than {}", p.next_offset))
+                    } else {
+                        None
+                    }
+                } {
+                    bail!(
+                        "bad IndexEntry at {} offset {} ({error}): {index_entry:?}",
+                        p.index_ctp,
+                        index_message.offset()
+                    );
+                }
+
+                // Read the step's data.
+                while p.next_offset < index_entry.data_offsets.end {
+                    let data_message = consumer_eh
+                        .read_partition_queue(&consumer, &data_queues[p.index as usize])
+                        .with_context(|| {
+                            format!("Failed to read {} partition queue.", p.data_ctp)
+                        })?;
+                    if data_message.offset() < index_entry.data_offsets.start {
+                        continue;
+                    }
+                    if let Some(payload) = data_message.payload() {
+                        let _ = self.receiver.lock().unwrap().input_chunk(payload);
+                    }
+                    p.next_offset = data_message.offset() + 1;
+                }
+            }
+
+            if n_prewritten == 0 {
+                // Add messages to the step.
+                let mut lack_of_progress = 0;
+
+                let mut n_messages = 0;
+                let mut n_bytes = 0;
+                'assemble: while !self.is_commit_requested(step)
+                    && n_messages < self.config.max_step_messages
+                    && n_bytes < self.config.max_step_bytes
+                {
+                    let p = &mut partitions[next_partition];
+
+                    self.wait_for_pipeline_start(step)?;
+                    check_fatal_errors(consumer.client())
+                        .context("Consumer reported fatal error")?;
+                    check_fatal_errors(producer.client())
+                        .context("Producer reported fatal error")?;
+
+                    // If there's a saved message, take it, otherwise try to
+                    // fetch a message.  Because we resume where we left off,
+                    // any saved message is for `next_partition`.
+                    let data_message = if let Some(message) = saved_message.take() {
+                        Ok(Some(message))
+                    } else {
+                        data_queues[next_partition]
+                            .poll(Duration::ZERO)
+                            .transpose()
+                            .with_context(|| {
+                                format!("Failed to read {} partition queue.", p.data_ctp)
+                            })
+                    };
+
+                    match data_message? {
+                        Some(data_message)
+                            if n_messages == 0
+                                || n_bytes + data_message.payload_len()
+                                    <= self.config.max_step_bytes =>
+                        {
+                            // We got a message that fits within the byte
+                            // limit (or there are no messages in the current
+                            // step).
+
+                            if let Some(payload) = data_message.payload() {
+                                let _ = self.receiver.lock().unwrap().input_chunk(payload);
+                            }
+                            n_messages += 1;
+                            n_bytes += data_message.payload_len();
+
+                            p.start_offset.get_or_insert(data_message.offset());
+                            p.next_offset = data_message.offset() + 1;
+                            lack_of_progress = 0;
+                        }
+                        Some(data_message) => {
+                            // We got a message but it would overflow the byte
+                            // limit for the step.  Save it for the next step.
+                            //
+                            // We don't advance `next_partition` so that we'll
+                            // resume in the same place.
+                            saved_message = Some(data_message);
+                            break 'assemble;
+                        }
+                        None => lack_of_progress += 1,
+                    }
+
+                    next_partition += 1;
+                    if next_partition >= n_partitions {
+                        next_partition = 0;
+                    }
+
+                    if lack_of_progress >= n_partitions {
+                        // Wait for at least one of these to happen:
+                        //
+                        //   - A message to arrive in one of the data partitions.
+                        //
+                        //   - A commit request for this step.
+                        //
+                        //   - A request to exit.
+                        self.parker.park();
+                        lack_of_progress = 0;
+                    }
+                }
+            } else {
+                // At least some of the partitions for this step were written to
+                // the index in a previous run.  In the common case, all of the
+                // partitions were written; a partial write only happens on a
+                // crash.
+                //
+                // We have to keep the partitions that were written.  We could
+                // add to the other partitions, if any, but that would slightly
+                // complicate the loop above and there's little value in it.
+            }
+
+            // Commit the step.
+            if n_prewritten < n_partitions {
+                // Prepare to count deliveries so we can later report that the
+                // step has settled.
+                expected_deliveries
+                    .lock()
+                    .unwrap()
+                    .insert(step, n_partitions - n_prewritten);
+
+                // Write an index entry in each partition that doesn't already
+                // have one.
+                for p in &mut partitions {
+                    if step >= p.steps.end {
+                        let offsets = p.start_offset.unwrap_or(p.next_offset)..p.next_offset;
+                        p.start_offset = None;
+
+                        // The errors that writing to a partition produces are ones that we can
+                        // reasonably treat as fatal, whether Kafka considers them fatal or not.
+                        let producer_ctp = Ctp::new(&producer, p.index_ctp.topic, p.index);
+                        IndexEntry::new(step, offsets)
+                            .write(&producer_ctp)
+                            .with_context(|| {
+                                format!("Failed to write {producer_ctp} index entry.")
+                            })?;
+                    }
+                }
+            } else {
+                // This is a fully pre-existing step that has already settled.
+                self.receiver.lock().unwrap().settled(step);
+            }
+        }
+        unreachable!()
+    }
+}
+
+struct Partition<'a, F>
+where
+    F: Fn(AnyError) + Send + Sync,
+{
+    index: i32,
+    index_ctp: Ctp<'a, Arc<BaseConsumer<DataConsumerContext<F>>>, DataConsumerContext<F>>,
+    index_queue: PartitionQueue<DataConsumerContext<F>>,
+    data_ctp: Ctp<'a, Arc<BaseConsumer<DataConsumerContext<F>>>, DataConsumerContext<F>>,
+    next_offset: i64,
+    start_offset: Option<i64>,
+    steps: Range<Step>,
+}
+
+impl InputEndpoint for Endpoint {
+    fn steps(&self) -> AnyResult<Range<Step>> {
+        let mut steps = None;
+        for data_topic in &self.0.data_topics {
+            let Range {
+                start: new_start,
+                end: new_end,
+            } = Index::new(data_topic, &self.0, |error| warn!("{error:#}"))
+                .with_context(|| format!("Failed to read index for {data_topic}"))?
+                .steps();
+            steps = Some(steps.map_or(
+                new_start..new_end,
+                |Range {
+                     start: old_start,
+                     end: old_end,
+                 }| { max(old_start, new_start)..max(old_end, new_end) },
+            ));
+        }
+        Ok(steps.unwrap())
+    }
+
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        start_step: Step,
+    ) -> AnyResult<Box<dyn InputReader>> {
+        Ok(Box::new(Reader::new(&self.0, start_step, consumer)))
+    }
+
+    fn is_durable(&self) -> bool {
+        true
+    }
+
+    fn expire(&self, _step: Step) {}
+}
+
+struct IndexProducerContext {
+    consumer: Arc<Mutex<Box<dyn InputConsumer>>>,
+
+    /// Maps from a step number to the number of messages that remain to be
+    /// delivered before that step is considered settled.
+    expected_deliveries: Arc<Mutex<HashMap<Step, usize>>>,
+}
+
+impl IndexProducerContext {
+    fn new(
+        consumer: &Arc<Mutex<Box<dyn InputConsumer>>>,
+        expected_deliveries: &Arc<Mutex<HashMap<Step, usize>>>,
+    ) -> Self {
+        Self {
+            consumer: consumer.clone(),
+            expected_deliveries: expected_deliveries.clone(),
+        }
+    }
+}
+
+impl ClientContext for IndexProducerContext {
+    fn error(&self, error: KafkaError, reason: &str) {
+        let fatal = error
+            .rdkafka_error_code()
+            .is_some_and(|code| code == RDKafkaErrorCode::Fatal);
+        if !fatal {
+            self.consumer
+                .lock()
+                .unwrap()
+                .error(false, anyhow!(reason.to_string()));
+        } else {
+            // The caller will detect this later and bail out with it as its
+            // final action.
+        }
+    }
+}
+
+impl ProducerContext for IndexProducerContext {
+    type DeliveryOpaque = Box<Step>;
+    fn delivery(&self, delivery_result: &DeliveryResult, step: Self::DeliveryOpaque) {
+        match delivery_result {
+            Ok(_) => {
+                if let Entry::Occupied(mut o) =
+                    self.expected_deliveries.lock().unwrap().entry(*step)
+                {
+                    let count = o.get_mut();
+                    if *count > 1 {
+                        *count -= 1;
+                        return;
+                    } else {
+                        o.remove();
+                    }
+                } else {
+                    return;
+                }
+
+                // We do this after the above to avoid holding the lock on
+                // `expected_deliveries`.
+                self.consumer.lock().unwrap().settled(*step);
+            }
+            Err(_) => {
+                // If there's an error, we don't want to ever report that the
+                // step settled, and we don't want to leak an entry in
+                // `expected_deliveries` either.  This has both effects.
+                self.expected_deliveries.lock().unwrap().remove(&*step);
+            }
+        }
+    }
+}
+
+/// Type of the records stored in a index partition, to associate a DBSP step
+/// number with the corresponding range of event offsets in the data partition.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+struct IndexEntry {
+    step: Step,
+    #[serde(serialize_with = "serialize_range")]
+    data_offsets: Range<i64>,
+}
+
+impl IndexEntry {
+    // Create and return a new `IndexEntry`.
+    fn new(step: Step, data_offsets: Range<i64>) -> Self {
+        Self { step, data_offsets }
+    }
+
+    /// Reads and returns an `IndexEntry` from `ctp` at Kafka event offset
+    /// `offset`.
+    fn read<C: ClientContext + ConsumerContext>(
+        ctp: &Ctp<BaseConsumer<C>, C>,
+        offset: i64,
+    ) -> AnyResult<IndexEntry> {
+        Self::from_message(&ctp.read_at_offset(offset)?).with_context(|| {
+            format!("message at offset {offset} in {ctp} should be valid IndexEntry")
+        })
+    }
+
+    /// Writes this `IndexEntry` to `ctp`.
+    fn write<C: ClientContext + ProducerContext<DeliveryOpaque = Box<u64>>>(
+        &self,
+        ctp: &Ctp<ThreadedProducer<C>, C>,
+    ) -> KafkaResult<()> {
+        let json = serde_json::to_string(self).unwrap();
+        let key = self.step.to_string();
+        let record = BaseRecord::with_opaque_to(ctp.topic, Box::new(self.step))
+            .partition(ctp.partition)
+            .payload(&json)
+            .key(&key);
+        ctp.client.send(record).map_err(|(error, _record)| error)
+    }
+
+    fn from_message<M>(msg: &M) -> AnyResult<IndexEntry>
+    where
+        M: Message,
+    {
+        Ok(serde_json::from_slice(msg.payload().unwrap_or(&[]))?)
+    }
+}
+
+/// Serializes `r` as `[start, end]` rather than as `["start": start, "end":
+/// end]`.
+fn serialize_range<S: Serializer>(r: &Range<i64>, serializer: S) -> Result<S::Ok, S::Error> {
+    let mut tup = serializer.serialize_tuple(2)?;
+    tup.serialize_element(&r.start)?;
+    tup.serialize_element(&r.end)?;
+    tup.end()
+}
+
+#[cfg(test)]
+#[test]
+fn test_index_entry() {
+    let data = r#"
+{
+    "step": 123,
+    "data_offsets": [12, 23]
+}
+"#;
+    assert_eq!(
+        serde_json::from_str::<IndexEntry>(data).unwrap(),
+        IndexEntry::new(123, 12..23)
+    );
+}
+
+/// Index reader for durable Kafka input and output.
+///
+/// The key to repeatability for Kafka input and output is to ensure that events
+/// in the data topic are always divided into steps in the same way.  We do this
+/// by tracking the division into steps in a separate "index" topic that
+/// consists of [`IndexEntry`] events, each of which maps a range of Kafka
+/// events in the data topic to a step number.
+///
+/// `Index` provides an interface for reading the index topic.
+struct Index<E>
+where
+    E: Fn(AnyError) + Send + Sync + Clone,
+{
+    consumer: BaseConsumer<DataConsumerContext<E>>,
+    index_topic: String,
+
+    partitions: Vec<IndexPartition>,
+}
+
+struct IndexPartition {
+    /// The range of valid Kafka event offsets in the index topic.
+    watermarks: Range<i64>,
+
+    /// The range of valid step numbers.
+    steps: Range<Step>,
+
+    /// The Kafka event offset in the data topic at which the next step's data
+    /// will begin.  (The next step will be numbered `steps.end`.)
+    next_step_start: i64,
+}
+
+impl<E> Index<E>
+where
+    E: Fn(AnyError) + Send + Sync + Clone,
+{
+    fn create_topic(topic: &str, n_partitions: i32, config: &Config) -> AnyResult<()> {
+        let admin_client = AdminClient::from_config(&config.common.admin_config)?;
+        let new_topic = NewTopic::new(
+            topic,
+            n_partitions,
+            rdkafka::admin::TopicReplication::Fixed(-1),
+        );
+        block_on(admin_client.create_topics(&[new_topic], &AdminOptions::new()))?;
+        Ok(())
+    }
+
+    fn count_or_create_topic<C: ConsumerContext>(
+        consumer: &impl Consumer<C>,
+        config: &Config,
+        topic: &str,
+        n_partitions: i32,
+    ) -> AnyResult<usize> {
+        let mut creating = false;
+        loop {
+            match count_partitions_in_topic(consumer, topic) {
+                Ok(n) => return Ok(n),
+                Err(error) => {
+                    if let Some(kafka_error) = error.downcast_ref::<KafkaError>() {
+                        let code = kafka_error.rdkafka_error_code();
+                        if code == Some(RDKafkaErrorCode::UnknownTopicOrPartition)
+                            || (creating && code == Some(RDKafkaErrorCode::NotLeaderForPartition))
+                        {
+                            info!("Index topic {topic} does not yet exist, creating with {n_partitions} partitions");
+                            Self::create_topic(topic, n_partitions, config)?;
+                            creating = true;
+                            sleep(Duration::from_millis(100));
+                            continue;
+                        }
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    fn new(data_topic: &str, config: &Config, error_cb: E) -> AnyResult<Self> {
+        let index_topic = format!("{data_topic}{}", config.index_suffix);
+        let context = DataConsumerContext::new(error_cb.clone());
+        let consumer =
+            BaseConsumer::from_config_and_context(&config.common.seekable_consumer_config, context)
+                .context("Failed to open seekable consumer")?;
+
+        let n_partitions = consumer
+            .context()
+            .deferred_logging
+            .with_deferred_logging(|| count_partitions_in_topic(&consumer, data_topic))?;
+        let index_partitions = if config.create_missing_index {
+            Self::count_or_create_topic(&consumer, config, &index_topic, n_partitions as i32)?
+        } else {
+            count_partitions_in_topic(&consumer, &index_topic)?
+        };
+        if n_partitions != index_partitions {
+            bail!("{data_topic} and {index_topic} should have the same number of partitions, but {data_topic} has {n_partitions} and {index_topic} has {index_partitions}");
+        }
+        if n_partitions == 0 {
+            bail!("{data_topic} has 0 partitions but it should have at least 1");
+        }
+
+        let mut partitions = Vec::with_capacity(n_partitions);
+        for partition in 0..n_partitions as i32 {
+            let ctp = Ctp::new(&consumer, &index_topic, partition);
+
+            let watermarks = ctp
+                .fetch_watermarks(None)
+                .with_context(|| format!("Failed to fetch watermarks for {ctp}"))?;
+
+            let (steps, next_step_start) = if !watermarks.is_empty() {
+                let first = IndexEntry::read(&ctp, watermarks.start)?;
+                let Some(last) = ctp.read_last_message(&watermarks)? else {
+                    bail!("{ctp} was not previously empty but its last message cannot be read");
+                };
+                let last = IndexEntry::from_message(&last)?;
+                (first.step..(last.step + 1), last.data_offsets.end)
+            } else {
+                if watermarks.end > 0 {
+                    // The partition is empty, but it has nonzero watermarks:
+                    //
+                    // - If it once had some content, which is now all deleted or expired, we can't
+                    //   continue because we need to know about at least the most recent step.
+                    //
+                    // - Maybe it has always been empty of real content, but a producer once started
+                    //   a transaction and either aborted it or didn't write anything, and then the
+                    //   segment was compacted.  We could have a heuristic for that by checking for
+                    //   a relatively small `high` value, e.g. <1000.
+                    //
+                    // For now, just warn.
+                    warn!(
+                        "{ctp} is empty but it has nonzero high watermark {}",
+                        watermarks.end
+                    );
+                }
+                (0..0, 0)
+            };
+            debug!("index {ctp} has steps {steps:?} and watermarks {watermarks:?}");
+            partitions.push(IndexPartition {
+                watermarks,
+                steps,
+                next_step_start,
+            });
+        }
+        Ok(Self {
+            consumer,
+            index_topic,
+            partitions,
+        })
+    }
+
+    /// Searches the index topic for `step` and returns the step's position in
+    /// every partition.  If `step` is beyond the current end of a partition,
+    /// returns a position just past the end; if `step` is before the current
+    /// beginning of a partition, returns an error.
+    fn find_step(&self, step: Step) -> AnyResult<Vec<StepPosition>> {
+        let mut steps = Vec::with_capacity(self.partitions.len());
+        for (index, partition) in self.partitions.iter().enumerate() {
+            if step >= partition.steps.end {
+                steps.push(StepPosition {
+                    index_offset: partition.watermarks.end,
+                    data_offset: partition.next_step_start,
+                });
+            } else if step >= partition.steps.start {
+                let ctp = Ctp::new(&self.consumer, &self.index_topic, index as i32);
+                let mut events = partition.watermarks.clone();
+                loop {
+                    assert!(!events.is_empty());
+                    let offset = events.start + (events.end - events.start) / 2;
+                    let entry = IndexEntry::read(&ctp, offset)?;
+                    events = match step.cmp(&entry.step) {
+                        Ordering::Equal => {
+                            ctp.pause()?;
+                            steps.push(StepPosition {
+                                index_offset: offset,
+                                data_offset: entry.data_offsets.start,
+                            });
+                            break;
+                        }
+                        Ordering::Greater => offset + 1..events.end,
+                        Ordering::Less => events.start..offset,
+                    };
+                }
+            } else {
+                bail!("can't read step {} because it has already expired in partition {index} (the first unexpired step in that partition is {})",
+                step, partition.steps.start);
+            }
+        }
+        Ok(steps)
+    }
+
+    /// Returns the range of steps that at least partially exist.
+    fn steps(&self) -> Range<Step> {
+        let start = self.partitions.iter().map(|p| p.steps.start).max().unwrap();
+        let end = self.partitions.iter().map(|p| p.steps.end).max().unwrap();
+        start..end
+    }
+
+    fn into_partitions(self) -> Vec<IndexPartition> {
+        self.partitions
+    }
+}
+
+struct StepPosition {
+    /// The Kafka event offset of `step` in the index topic.
+    index_offset: i64,
+
+    /// The Kafka event offset of the first message in `step` in the data topic.
+    data_offset: i64,
+}

--- a/crates/adapters/src/transport/durable_kafka/mod.rs
+++ b/crates/adapters/src/transport/durable_kafka/mod.rs
@@ -1,0 +1,564 @@
+//! Durable Kafka input and output transport.
+//!
+//! For input from Kafka to be repeatable, we need to ensure that a given worker
+//! reads the same messages from the same partitions in a given step.  To do
+//! that, we store the mapping from steps to Kafka offsets in a separate Kafka
+//! topic, called the "index topic", which the durable input transport maintains
+//! automatically.
+//!
+//! For output to Kafka, we need to be able to discard duplicate output.  We do
+//! that by recording the step number as the key in each output message.  On
+//! initialization, we read the final step number and discard any output for
+//! duplicate steps.  We use Kafka transactions to avoid writing partial output
+//! for a step.
+mod input;
+mod output;
+
+use crate::transport::kafka::refine_kafka_error;
+use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
+use log::warn;
+use pipeline_types::transport::{
+    durable_kafka::CommonConfigSchema, kafka::default_redpanda_server,
+};
+use rdkafka::{
+    client::Client as KafkaClient,
+    config::RDKafkaLogLevel,
+    consumer::{base_consumer::PartitionQueue, BaseConsumer, Consumer, ConsumerContext},
+    error::{KafkaError, KafkaResult},
+    message::BorrowedMessage,
+    producer::{Producer, ProducerContext, ThreadedProducer},
+    types::RDKafkaErrorCode,
+    util::Timeout,
+    ClientConfig, ClientContext, Offset, TopicPartitionList,
+};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter, Result as FmtResult},
+    marker::PhantomData,
+    ops::Range,
+    sync::Arc,
+    time::Duration,
+};
+use uuid::Uuid;
+
+pub use input::KafkaDurableInputTransport;
+pub use output::KafkaDurableOutputTransport;
+
+use super::kafka::{rdkafka_loglevel_from, DeferredLogging};
+
+#[cfg(test)]
+pub mod test;
+
+const POLL_TIMEOUT: Duration = Duration::from_millis(1);
+
+/// Set `option` to `val`; return an error if `option` is set to a different
+/// value.
+fn enforce_option<'a>(
+    settings: &mut BTreeMap<&'a str, &'a str>,
+    option: &'a str,
+    val: &'a str,
+) -> AnyResult<()> {
+    if *settings.entry(option).or_insert(val) != val {
+        bail!("cannot override '{option}' option: the Kafka transport adapter sets this option to '{val}'");
+    }
+    Ok(())
+}
+
+/// Set `option` to `val`, if missing.
+fn set_option_if_missing<'a>(
+    settings: &mut BTreeMap<&'a str, &'a str>,
+    option: &'a str,
+    val: &'a str,
+) {
+    settings.entry(option).or_insert(val);
+}
+
+/// Returns a Kafka client configuration from `source.kafka_options` as
+/// overridden by `type_specific_options`.  The latter should be
+/// `&source.consumer_options` or `&source.producer_options` depending on
+/// the type of client to be configured.
+///
+/// `overrides` specifies key-value pairs to override. This function flags
+/// an error on if `source` and `type_specific_options` conflict with
+/// `overrides`.
+///
+/// `config_name` is used only in the returned error message, if any.
+fn kafka_config(
+    common: &CommonConfigSchema,
+    type_specific_options: &BTreeMap<String, String>,
+    overrides: &[(&str, &str)],
+    add_group_id: bool,
+    config_name: &str,
+) -> AnyResult<ClientConfig> {
+    let mut settings: BTreeMap<&str, &str> = common
+        .kafka_options
+        .iter()
+        .chain(type_specific_options.iter())
+        .map(|(o, v)| (o.as_str(), v.as_str()))
+        .collect();
+    for (option, val) in overrides {
+        enforce_option(&mut settings, option, val)
+            .with_context(|| format!("Failed to validate Kafka options for {config_name}"))?;
+    }
+
+    // Set a unique `group.id` to ensure that we don't conflict with any
+    // existing consumer group.  In experiments, Kafka won't create any
+    // consumer group on the backend unless we implicitly (with
+    // `enable.auto.commit`) or explicitly commit an offset.  We don't do
+    // that, so this doesn't waste space on the Kafka brokers.
+    let group_id = &Uuid::new_v4().to_string();
+    if add_group_id {
+        enforce_option(&mut settings, "group.id", group_id)
+            .with_context(|| format!("Failed to validate Kafka options for {config_name}"))?;
+    }
+
+    let default_redpanda_server = default_redpanda_server();
+    set_option_if_missing(&mut settings, "bootstrap.servers", &default_redpanda_server);
+
+    let mut config: ClientConfig = settings
+        .iter()
+        .map(|(&o, &v)| (String::from(o), String::from(v)))
+        .collect();
+    if let Some(log_level) = common.log_level {
+        config.set_log_level(rdkafka_loglevel_from(log_level));
+    }
+
+    Ok(config)
+}
+
+/// Validated version of [`KafkaDurableInputConfig`], converted into a
+/// convenient form for internal use.
+#[derive(Clone)]
+struct CommonConfig {
+    /// Kafka client configuration for reading `data_topic`.
+    data_consumer_config: ClientConfig,
+
+    /// Kafka client configuration for reading with multiple seeks.
+    seekable_consumer_config: ClientConfig,
+
+    /// Kafka client configuration for writing to the data and index topics.
+    producer_config: ClientConfig,
+
+    /// Kafka admin client configuration for adding new topics.
+    admin_config: ClientConfig,
+}
+
+impl TryFrom<&CommonConfigSchema> for CommonConfig {
+    type Error = AnyError;
+
+    fn try_from(source: &CommonConfigSchema) -> Result<Self, Self::Error> {
+        const CONSUMER_SETTINGS: &[(&str, &str)] = &[
+            ("enable.auto.commit", "false"),
+            ("enable.auto.offset.store", "false"),
+            ("auto.offset.reset", "earliest"),
+            ("isolation.level", "read_committed"),
+            ("fetch.wait.max.ms", "0"),
+            ("fetch.min.bytes", "1"),
+        ];
+        let mut seekable_consumer_config = kafka_config(
+            source,
+            &source.consumer_options,
+            CONSUMER_SETTINGS,
+            true,
+            "consumer",
+        )?;
+        let mut data_consumer_config = seekable_consumer_config.clone();
+        seekable_consumer_config.set("enable.partition.eof", "true");
+        data_consumer_config.set("fetch.wait.max.ms", "1000");
+
+        const PRODUCER_SETTINGS: &[(&str, &str)] = &[
+            ("acks", "all"),
+            ("enable.idempotence", "true"),
+            ("batch.size", "1"),
+            ("batch.num.messages", "1"),
+            ("retries", "5"),
+            ("socket.nagle.disable", "true"),
+            ("linger.ms", "0"),
+        ];
+        let mut producer_config = kafka_config(
+            source,
+            &source.producer_options,
+            PRODUCER_SETTINGS,
+            true,
+            "producer",
+        )?;
+        producer_config.remove("group.id");
+
+        let admin_config = kafka_config(source, &BTreeMap::new(), &[], false, "admin")?;
+
+        Ok(Self {
+            seekable_consumer_config,
+            data_consumer_config,
+            producer_config,
+            admin_config,
+        })
+    }
+}
+
+/// Provides access to the `KafkaClient` inside Kafka consumers and producers.
+trait AsKafkaClient<C: ClientContext> {
+    /// Returns this type's Kafka client.
+    fn as_kafka_client(&self) -> &KafkaClient<C>;
+}
+
+impl<C: ClientContext + ConsumerContext> AsKafkaClient<C> for BaseConsumer<C> {
+    fn as_kafka_client(&self) -> &KafkaClient<C> {
+        self.client()
+    }
+}
+
+impl<C: ClientContext + ConsumerContext> AsKafkaClient<C> for Arc<BaseConsumer<C>> {
+    fn as_kafka_client(&self) -> &KafkaClient<C> {
+        self.client()
+    }
+}
+
+impl<C: ClientContext + ProducerContext> AsKafkaClient<C> for ThreadedProducer<C> {
+    fn as_kafka_client(&self) -> &KafkaClient<C> {
+        self.client()
+    }
+}
+
+/// Client, topic, and partition.
+///
+/// [`rdkafka`] uses these three pieces together for a lot of calls, without
+/// providing a type to bind them together.  This helps.
+struct Ctp<'a, T, C>
+where
+    T: AsKafkaClient<C>,
+    C: ClientContext,
+{
+    client: &'a T,
+    topic: &'a str,
+    partition: i32,
+    _marker: PhantomData<C>,
+}
+
+impl<'a, T, C> Ctp<'a, T, C>
+where
+    T: AsKafkaClient<C>,
+    C: ClientContext,
+{
+    /// Returns a new `Ctp` for `client`, `topic`, and `partition`.
+    fn new(client: &'a T, topic: &'a str, partition: i32) -> Ctp<'a, T, C> {
+        Self {
+            client,
+            partition,
+            topic,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Fetches the watermarks for this client, topic, and particular, and
+    /// returns them as a `Range`.
+    fn fetch_watermarks<W>(&self, timeout: W) -> KafkaResult<Range<i64>>
+    where
+        W: Into<Timeout>,
+    {
+        self.client
+            .as_kafka_client()
+            .fetch_watermarks(self.topic, self.partition, timeout)
+            .map(|(low, high)| {
+                assert!(high >= low);
+                low..high
+            })
+    }
+
+    /// Returns a `TopicPartitionList` for this `Ctp`, with no offset.
+    fn as_topic_partition_list(&self) -> TopicPartitionList {
+        make_topic_partition_list([(self.topic, self.partition, Offset::Invalid)]).unwrap()
+    }
+}
+
+/// Consumer, topic, and partition.
+impl<'a, T: Consumer<C> + AsKafkaClient<C>, C: ClientContext + ConsumerContext> Ctp<'a, T, C> {
+    /// Assigns this consumer to read this topic and partition starting at
+    /// `offset`.
+    ///
+    /// For consuming a single partition, this has the effect of a Kafka seek
+    /// operation.  However, a seek operation only works after an assign
+    /// operation, and only if there was a poll operation in between, whereas
+    /// assign always works.
+    fn assign(&self, offset: i64) -> KafkaResult<()> {
+        let assignment =
+            make_topic_partition_list([(self.topic, self.partition, Offset::Offset(offset))])?;
+        self.client.assign(&assignment)
+    }
+
+    /// Pauses consuming this partition.
+    fn pause(&self) -> KafkaResult<()> {
+        self.client.pause(&self.as_topic_partition_list())
+    }
+
+    /// Resumes consuming this partition,
+    fn resume(&self) -> KafkaResult<()> {
+        self.client.resume(&self.as_topic_partition_list())
+    }
+
+    /// Resumes, evaluates `f`, pauses, and returns what `f`'s returned.  If any
+    /// of the operations fails, returns the error.
+    fn while_resumed<R>(&self, f: impl Fn() -> AnyResult<R>) -> AnyResult<R> {
+        self.resume()?;
+        match (f(), self.pause()) {
+            (Err(error), _) => Err(error),
+            (_, Err(error)) => Err(error.into()),
+            (result, _) => result,
+        }
+    }
+}
+
+impl<'a, C: ClientContext + ConsumerContext> Ctp<'a, BaseConsumer<C>, C> {
+    fn read(&self) -> KafkaResult<BorrowedMessage<'a>> {
+        self.client
+            .poll(None)
+            .expect("poll(None) should always return a message or an error")
+    }
+    fn read_at_offset(&self, offset: i64) -> AnyResult<BorrowedMessage<'a>> {
+        self.assign(offset)?;
+        self.while_resumed(|| self.read().map_err(|err| err.into()))
+    }
+
+    // Read the last message in the partition, which has the given `watermarks`.
+    // The consumer should have `enable.partition.eof` set to `true`.
+    //
+    // This is harder than it seems because the high watermark probably points
+    // to a Kafka "control record" that indicates the end of a transaction.  In
+    // fact, if transactions were aborted, there can be any number of these.  So
+    // we have to try reading earlier offsets too.  We step backward at an
+    // exponentially growing rate to allow Kafka to do some of the work for us.
+    fn read_last_message(&self, watermarks: &Range<i64>) -> AnyResult<Option<BorrowedMessage<'a>>> {
+        if watermarks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut offset = watermarks.end - 1;
+        let mut delta = 1;
+        loop {
+            self.assign(offset)?;
+
+            // Read messages until we get an error.  Retain the last message we
+            // read.
+            let last_message = self.while_resumed(|| {
+                let mut last_message = None;
+                loop {
+                    match self.read() {
+                        Ok(message) => last_message = Some(message),
+                        Err(KafkaError::PartitionEOF(p)) if p == self.partition => {
+                            break Ok(last_message)
+                        }
+                        Err(error) => break Err(error.into()),
+                    }
+                }
+            })?;
+
+            // Return the message if we got one.
+            if let Some(message) = last_message {
+                return Ok(Some(message));
+            }
+
+            // Step backward.
+            if offset == watermarks.start {
+                return Ok(None);
+            }
+            offset = offset.saturating_sub(delta).max(watermarks.start);
+            delta = delta.saturating_mul(2);
+        }
+    }
+}
+
+impl<'a, T, C> Display for Ctp<'a, T, C>
+where
+    T: AsKafkaClient<C>,
+    C: ClientContext,
+{
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "topic {} partition {}", self.topic, self.partition)
+    }
+}
+
+/// Returns the number of partitions in `topic`.  A topic that exists always has
+/// at least one partition.
+///
+/// This function doesn't retry failed calls because it is currently used
+/// only early on in endpoint initialization.  Limiting retries at
+/// initialization time is useful to make sure that the configuration is
+/// correct.
+fn count_partitions_in_topic<C: ConsumerContext>(
+    consumer: &impl Consumer<C>,
+    topic: &str,
+) -> AnyResult<usize> {
+    let metadata = consumer
+        .fetch_metadata(Some(topic), Duration::from_secs(10))
+        .with_context(|| format!("Failed to read metadata for topic {topic}"))?;
+    let Some(metadata_topic) = metadata.topics().get(0) else {
+        // Should not happen: if `topic` doesn't exist, the server should
+        // tell us that.
+        bail!("Kafka server returned no results for {topic}")
+    };
+    if let Some(error) = metadata_topic.error() {
+        Err(KafkaError::MetadataFetch(error.into()))
+            .with_context(|| format!("Error reading metadata for topic {topic}"))?;
+    }
+    if metadata_topic.partitions().is_empty() {
+        bail!("Kafka server reports {topic} has zero partitions but it should have at least one");
+    }
+    warn!(
+        "{topic} has {} partitions",
+        metadata_topic.partitions().len()
+    );
+    Ok(metadata_topic.partitions().len())
+}
+
+/// Returns a `TopicPartitionList` that contains `elements`.
+fn make_topic_partition_list<'a>(
+    elements: impl IntoIterator<Item = (&'a str, i32, Offset)>,
+) -> KafkaResult<TopicPartitionList> {
+    let mut list = TopicPartitionList::new();
+    for (topic, partition, offset) in elements {
+        list.add_partition_offset(topic, partition, offset)?;
+    }
+    Ok(list)
+}
+
+impl<'a, C: ClientContext + ConsumerContext> Ctp<'a, Arc<BaseConsumer<C>>, C> {
+    fn split_partition_queue(&self) -> AnyResult<PartitionQueue<C>> {
+        self.client
+            .split_partition_queue(self.topic, self.partition)
+            .ok_or_else(|| anyhow!("Failed to split {self} from consumer"))
+    }
+}
+
+fn check_fatal_errors<C: ClientContext>(client: &KafkaClient<C>) -> AnyResult<()> {
+    if let Some((_errcode, errstr)) = client.fatal_error() {
+        Err(AnyError::msg(errstr))
+    } else {
+        Ok(())
+    }
+}
+
+struct ErrorHandler<'a, E, C>
+where
+    E: Fn(AnyError),
+    C: ClientContext,
+{
+    error_cb: &'a E,
+    client: &'a KafkaClient<C>,
+}
+
+impl<'a, E, C> ErrorHandler<'a, E, C>
+where
+    E: Fn(AnyError),
+    C: ClientContext,
+{
+    fn new(error_cb: &'a E, client: &'a KafkaClient<C>) -> Self {
+        Self { error_cb, client }
+    }
+
+    /// Calls `f` until it returns success or a fatal error and returns the
+    /// result.  For non-fatal errors, refines the error with `client` and
+    /// reports it and calls `f` again.
+    fn retry_errors<T, F>(&self, f: F, client: &KafkaClient<C>) -> AnyResult<T>
+    where
+        F: Fn() -> KafkaResult<T>,
+    {
+        loop {
+            match f() {
+                Ok(result) => return Ok(result),
+                Err(error) => match refine_kafka_error(client, error) {
+                    (true, error) => return Err(error),
+                    (false, error) => (self.error_cb)(error),
+                },
+            }
+        }
+    }
+
+    /// Checks for errors.  Passes non-fatal errors to the error callback and
+    /// returns fatal ones.
+    fn check_errors(&self) -> AnyResult<()> {
+        check_fatal_errors(self.client)
+    }
+
+    /// Calls `consumer.poll`, as must be done periodically, and checks for
+    /// errors reported to consumer and producer contexts.
+    fn poll_consumer(&self, consumer: &BaseConsumer<C>) -> AnyResult<()>
+    where
+        C: ConsumerContext,
+    {
+        self.check_errors()?;
+
+        // Call `consumer.poll`.
+        match self.retry_errors(
+            || consumer.poll(Duration::ZERO).transpose(),
+            consumer.client(),
+        )? {
+            None => Ok(()),
+            Some(_message) => Err(anyhow!(
+                "Partition queues should be split off for all subscribed partitions"
+            )),
+        }
+    }
+
+    /// Reads a message from `consumer`, blocking if necessary.  Returns a
+    /// message or fatal error.
+    fn read_partition_queue(
+        &self,
+        consumer: &BaseConsumer<C>,
+        partition: &'a PartitionQueue<C>,
+    ) -> AnyResult<BorrowedMessage<'a>>
+    where
+        C: ConsumerContext,
+    {
+        loop {
+            self.poll_consumer(consumer)?;
+            if let Some(result) = self.retry_errors(
+                || partition.poll(POLL_TIMEOUT).transpose(),
+                consumer.client(),
+            )? {
+                return Ok(result);
+            }
+        }
+    }
+}
+
+struct DataConsumerContext<F>
+where
+    F: Fn(AnyError) + Send + Sync,
+{
+    error_cb: F,
+    deferred_logging: DeferredLogging,
+}
+
+impl<F> DataConsumerContext<F>
+where
+    F: Fn(AnyError) + Send + Sync,
+{
+    fn new(error_cb: F) -> Self {
+        Self {
+            error_cb,
+            deferred_logging: DeferredLogging::new(),
+        }
+    }
+}
+
+impl<F> ClientContext for DataConsumerContext<F>
+where
+    F: Fn(AnyError) + Send + Sync,
+{
+    fn error(&self, error: KafkaError, reason: &str) {
+        let fatal = error
+            .rdkafka_error_code()
+            .is_some_and(|code| code == RDKafkaErrorCode::Fatal);
+        if !fatal {
+            (self.error_cb)(anyhow!(reason.to_string()));
+        } else {
+            // The caller will detect this later and bail out with it as its
+            // final action.
+        }
+    }
+
+    fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        self.deferred_logging.log(level, fac, log_message);
+    }
+}
+
+impl<F> ConsumerContext for DataConsumerContext<F> where F: Fn(AnyError) + Send + Sync {}

--- a/crates/adapters/src/transport/durable_kafka/output.rs
+++ b/crates/adapters/src/transport/durable_kafka/output.rs
@@ -1,0 +1,400 @@
+use crate::{
+    transport::{kafka::DeferredLogging, Step},
+    AsyncErrorCallback, OutputEndpoint, OutputEndpointConfig, OutputTransport,
+};
+use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
+use log::{debug, info, warn};
+use pipeline_types::transport::durable_kafka::KafkaDurableOutputConfig;
+use rdkafka::{
+    config::FromClientConfigAndContext,
+    consumer::BaseConsumer,
+    error::KafkaError,
+    producer::{BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer},
+    types::RDKafkaErrorCode,
+    ClientConfig, ClientContext, Message,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    borrow::Cow,
+    cmp::max,
+    sync::{Condvar, Mutex, RwLock},
+    time::Duration,
+};
+
+use super::{count_partitions_in_topic, CommonConfig, Ctp, DataConsumerContext};
+
+const DEFAULT_MAX_MESSAGE_SIZE: usize = 1_000_000;
+
+/// Max metadata overhead added by Kafka to each message.  Useful payload size
+/// plus this overhead must not exceed `message.max.bytes`.
+// This value was established empirically.
+const MAX_MESSAGE_OVERHEAD: usize = 64;
+
+/// [`OutputTransport`] implementation that durably writes data to a Kafka
+/// topic.
+///
+/// This output transport is only available if the crate is configured with
+/// `with-kafka` feature.
+///
+/// The output transport factory gives this transport the name `durable_kafka`.
+pub struct KafkaDurableOutputTransport;
+
+impl OutputTransport for KafkaDurableOutputTransport {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("durable_kafka")
+    }
+
+    /// Creates a new [`OutputEndpoint`] fpor writing to a Kafka topic,
+    /// interpreting `config` as a [`KafkaDurableOutputConfig`].
+    ///
+    /// See [`OutputTransport::new_endpoint()`] for more information.
+    fn new_endpoint(&self, config: &OutputEndpointConfig) -> AnyResult<Box<dyn OutputEndpoint>> {
+        let config =
+            KafkaDurableOutputConfig::deserialize(&config.connector_config.transport.config)?;
+        let ep = KafkaOutputEndpoint::new(config)?;
+
+        Ok(Box::new(ep))
+    }
+}
+
+/// State of the `KafkaOutputEndpoint`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum State {
+    /// Just created.
+    New,
+
+    /// `connect` has been called.
+    Connected,
+
+    /// `batch_start_step()` has been called.  The next call to `push_buffer()`
+    /// will write at position `.0`.
+    BatchOpen(OutputPosition),
+
+    /// `batch_end` has been called for step `.0`.
+    BatchClosed(Step),
+}
+
+/// A position in the output partition.
+///
+/// This is stored as the Kafka message key.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct OutputPosition {
+    /// The step number.
+    step: Step,
+
+    /// An index within the step.  The first message output in a step has
+    /// substep 0, the second has substep 1, and so on.
+    ///
+    /// We don't have an a priori need to store the substep number in the Kafka
+    /// message key, but the substep number allows us to have a unique key for
+    /// every message.  That is valuable because Kafka can be configured to
+    /// deduplicate messages based on key and we do not want to lose data in
+    /// that case.
+    substep: u64,
+}
+
+impl OutputPosition {
+    fn from_message<M>(msg: &M) -> AnyResult<OutputPosition>
+    where
+        M: Message,
+    {
+        Ok(serde_json::from_slice(msg.key().unwrap_or(&[]))?)
+    }
+}
+
+struct KafkaOutputEndpoint {
+    kafka_producer: ThreadedProducer<DataProducerContext>,
+    topic: String,
+    next_partition: usize,
+    n_partitions: usize,
+    max_message_size: usize,
+    next_step: Step,
+    state: State,
+}
+
+impl KafkaOutputEndpoint {
+    fn new(config: KafkaDurableOutputConfig) -> AnyResult<Self> {
+        let mut common: CommonConfig = (&config.common).try_into()?;
+        common
+            .producer_config
+            .set("transactional.id", &config.topic);
+
+        let message_max_bytes = common
+            .producer_config
+            .get("message.max.bytes")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_MAX_MESSAGE_SIZE);
+        if message_max_bytes <= MAX_MESSAGE_OVERHEAD {
+            bail!("Invalid setting 'message.max.bytes={message_max_bytes}'. 'message.max.bytes' must be greater than {MAX_MESSAGE_OVERHEAD}");
+        }
+
+        let max_message_size = message_max_bytes - MAX_MESSAGE_OVERHEAD;
+        debug!("Configured max message size: {max_message_size} ('message.max.bytes={message_max_bytes}')");
+
+        // Initialize our producer.
+        //
+        // This makes first contact with the broker and gives up after a
+        // timeout.  After this, Kafka will retry indefinitely, but limiting the
+        // time for initialization is useful to make sure that the configuration
+        // is correct.
+        //
+        // Since we initialize transactions, this has the effect of achieving
+        // mutual exclusion with other instances of ourselves and any other
+        // producers cooperating with us by using the same `transactional.id`.
+        let context = DataProducerContext::new(config.max_inflight_messages);
+        let kafka_producer =
+            ThreadedProducer::from_config_and_context(&common.producer_config, context)?;
+        kafka_producer
+            .context()
+            .deferred_logging
+            .with_deferred_logging(|| {
+                kafka_producer
+                    .init_transactions(Duration::from_secs(config.initialization_timeout_secs))
+            })?;
+
+        // Read the number of partitions and the next step number.  We do this
+        // after initializing transactions to avoid a race.
+        let (n_partitions, next_step) =
+            Self::read_next_step(&config.topic, &common.seekable_consumer_config)?;
+
+        Ok(Self {
+            kafka_producer,
+            topic: config.topic.clone(),
+            n_partitions,
+            next_partition: 0,
+            max_message_size,
+            next_step,
+            state: State::New,
+        })
+    }
+
+    /// Reads the tail of `topic` using `seekable_consumer_config`. Returns the
+    /// number of partitions in `topic` and the step number for the next step to
+    /// be written.
+    fn read_next_step(
+        topic: &str,
+        seekable_consumer_config: &ClientConfig,
+    ) -> AnyResult<(usize, Step)> {
+        let context = DataConsumerContext::new(|error| warn!("{error}"));
+        let consumer = BaseConsumer::from_config_and_context(seekable_consumer_config, context)?;
+        let n_partitions = count_partitions_in_topic(&consumer, topic)?;
+        let mut next_step = 0;
+        for partition in 0..n_partitions {
+            let ctp = Ctp::new(&consumer, topic, partition as i32);
+            let watermarks = ctp.fetch_watermarks(None)?;
+            if !watermarks.is_empty() {
+                if let Some(msg) = ctp.read_last_message(&watermarks)? {
+                    let key = OutputPosition::from_message(&msg).with_context(|| {
+                        format!(
+                            "message at offset {} in {ctp} should have step and substep as key",
+                            msg.offset()
+                        )
+                    })?;
+                    next_step = max(next_step, key.step + 1);
+                }
+            } else if watermarks != (0..0) {
+                // The partition is empty, but it has nonzero watermarks:
+                //
+                // - If it once had some content, which is now all deleted or expired, we can't
+                //   continue because we need to know about at least the most recent step.
+                //
+                // - Maybe it has always been empty of real content, but a producer once started
+                //   a transaction and either aborted it or didn't write anything, and then the
+                //   segment was compacted.  We could have a heuristic for that by checking for
+                //   a relatively small `high` value, e.g. <1000.
+                //
+                // For now, just warn.
+                warn!(
+                    "{ctp} is empty but has nonzero high watermark {}",
+                    watermarks.end
+                );
+            };
+        }
+        Ok((n_partitions, next_step))
+    }
+}
+
+impl OutputEndpoint for KafkaOutputEndpoint {
+    fn connect(&mut self, async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
+        debug_assert_eq!(self.state, State::New);
+        self.state = State::Connected;
+
+        *self
+            .kafka_producer
+            .context()
+            .async_error_callback
+            .write()
+            .unwrap() = Some(async_error_callback);
+        Ok(())
+    }
+
+    fn max_buffer_size_bytes(&self) -> usize {
+        self.max_message_size
+    }
+
+    fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
+        let State::BatchOpen(OutputPosition { step, substep }) = self.state else {
+            unreachable!(
+                "state should be BatchOpen (not {:?}) in `push_buffer()`",
+                self.state
+            )
+        };
+        self.state = State::BatchOpen(OutputPosition {
+            step,
+            substep: substep + 1,
+        });
+
+        if step >= self.next_step {
+            let key = OutputPosition { step, substep };
+            let key = serde_json::to_string(&key).unwrap();
+            let record = BaseRecord::to(&self.topic)
+                .key(&key)
+                .partition(self.next_partition as i32)
+                .payload(buffer);
+            self.kafka_producer
+                .send(record)
+                .map_err(|(err, _record)| err)?;
+            self.kafka_producer.context().take_delivery_slot();
+
+            self.next_partition += 1;
+            if self.next_partition >= self.n_partitions {
+                self.next_partition = 0;
+            }
+        }
+        Ok(())
+    }
+
+    fn batch_end(&mut self) -> AnyResult<()> {
+        let State::BatchOpen(position) = self.state else {
+            unreachable!(
+                "state should be BatchOpen (not {:?}) in `batch_end()`",
+                self.state
+            )
+        };
+        self.state = State::BatchClosed(position.step);
+
+        if position.step >= self.next_step {
+            self.kafka_producer.commit_transaction(None)?;
+            self.next_step = position.step + 1;
+        }
+        Ok(())
+    }
+
+    fn batch_start(&mut self, step: Step) -> AnyResult<()> {
+        let first_step = match self.state {
+            State::New => unreachable!("connect() should be called first"),
+            State::Connected => true,
+            State::BatchClosed(closed_step) => {
+                if step <= closed_step {
+                    unreachable!(
+                        "step numbers should increase, not go from {closed_step} to {step}"
+                    );
+                };
+                false
+            }
+            State::BatchOpen(_) => {
+                unreachable!("batch_end() should be called before next batch_start_step()")
+            }
+        };
+
+        if step >= self.next_step {
+            if step > self.next_step {
+                warn!("skipping from step {} to {step}", self.next_step);
+            }
+            self.kafka_producer.begin_transaction()?;
+        } else if first_step {
+            info!(
+                "dropping steps {step}..{} that were already output in a previous run",
+                self.next_step
+            );
+        }
+        self.state = State::BatchOpen(OutputPosition { step, substep: 0 });
+        Ok(())
+    }
+
+    fn is_durable(&self) -> bool {
+        true
+    }
+}
+
+struct DataProducerContext {
+    /// Callback to notify the controller about delivery failure.
+    async_error_callback: RwLock<Option<AsyncErrorCallback>>,
+
+    /// Number of additional messages that may be in flight.  Decreases when we
+    /// send a message, increases when one is delivered.  When this reaches 0,
+    /// we wait for it to increase before sending another message.
+    delivery_slots: Mutex<u32>,
+
+    /// Notifies when `in_flight_limiter` has increased from zero to nonzero.
+    nonzero_condition: Condvar,
+
+    deferred_logging: DeferredLogging,
+}
+
+impl DataProducerContext {
+    /// Creates a new producer context that supports keeping up to
+    /// `max_inflight_messages` in flight at once.
+    fn new(max_inflight_messages: u32) -> Self {
+        Self {
+            async_error_callback: RwLock::new(None),
+            delivery_slots: Mutex::new(max_inflight_messages),
+            nonzero_condition: Condvar::new(),
+            deferred_logging: DeferredLogging::new(),
+        }
+    }
+
+    /// Waits as long as the number of in-flight messages is at its maximum, and
+    /// then takes one of those slots.
+    fn take_delivery_slot(&self) {
+        let mut delivery_slots = self
+            .nonzero_condition
+            .wait_while(self.delivery_slots.lock().unwrap(), |n| *n == 0)
+            .unwrap();
+        *delivery_slots -= 1;
+    }
+
+    /// Records that an in-flight message has been delivered (or delivery
+    /// failed).
+    fn free_delivery_slot(&self) {
+        let mut delivery_slots = self.delivery_slots.lock().unwrap();
+        if *delivery_slots == 0 {
+            self.nonzero_condition.notify_one();
+        }
+        *delivery_slots += 1;
+    }
+}
+
+impl ClientContext for DataProducerContext {
+    fn error(&self, error: KafkaError, reason: &str) {
+        if let Some(cb) = self.async_error_callback.read().unwrap().as_ref() {
+            let fatal = error
+                .rdkafka_error_code()
+                .is_some_and(|code| code == RDKafkaErrorCode::Fatal);
+            cb(fatal, anyhow!(reason.to_string()));
+        } else {
+            warn!("{error}");
+        }
+    }
+
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        self.deferred_logging.log(level, fac, log_message);
+    }
+}
+
+impl ProducerContext for DataProducerContext {
+    type DeliveryOpaque = ();
+
+    fn delivery(
+        &self,
+        delivery_result: &DeliveryResult<'_>,
+        _delivery_opaque: Self::DeliveryOpaque,
+    ) {
+        self.free_delivery_slot();
+        if let Err((error, _message)) = delivery_result {
+            if let Some(cb) = self.async_error_callback.read().unwrap().as_ref() {
+                cb(false, AnyError::new(error.clone()));
+            }
+        }
+    }
+}

--- a/crates/adapters/src/transport/durable_kafka/test.rs
+++ b/crates/adapters/src/transport/durable_kafka/test.rs
@@ -1,0 +1,777 @@
+use crate::{
+    test::{
+        generate_test_batches,
+        kafka::{BufferConsumer, KafkaResources, TestProducer},
+        mock_input_pipeline, test_circuit, wait, MockDeZSet, TestStruct, DEFAULT_TIMEOUT_MS,
+    },
+    transport::Step,
+    Controller, InputConsumer, InputTransport, OutputTransport, ParseError, PipelineConfig,
+};
+use anyhow::Error as AnyError;
+use crossbeam::sync::{Parker, Unparker};
+use env_logger::Env;
+use log::info;
+use proptest::prelude::*;
+use std::{
+    io::Write,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread::sleep,
+    time::{Duration, Instant},
+};
+use uuid::Uuid;
+
+/// Wait to receive all records in `data` in the same order.
+fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
+    let num_records: usize = data.iter().map(Vec::len).sum();
+
+    wait(
+        || zset.state().flushed.len() == num_records,
+        DEFAULT_TIMEOUT_MS,
+    );
+
+    for (i, val) in data.iter().flat_map(|data| data.iter()).enumerate() {
+        assert_eq!(&zset.state().flushed[i].0, val);
+    }
+}
+
+/// Wait to receive all records in `data` in some order.
+fn wait_for_output_unordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
+    let num_records: usize = data.iter().map(Vec::len).sum();
+
+    wait(
+        || zset.state().flushed.len() == num_records,
+        DEFAULT_TIMEOUT_MS,
+    );
+
+    let mut data_sorted = data
+        .iter()
+        .flat_map(|data| data.clone().into_iter())
+        .collect::<Vec<_>>();
+    data_sorted.sort();
+
+    let mut zset_sorted = zset
+        .state()
+        .flushed
+        .iter()
+        .map(|(val, polarity)| {
+            assert!(polarity);
+            val.clone()
+        })
+        .collect::<Vec<_>>();
+    zset_sorted.sort();
+
+    assert_eq!(zset_sorted, data_sorted);
+}
+
+fn init_test_logger() {
+    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("debug"))
+        .is_test(true)
+        .format(move |buf, record| {
+            let t = chrono::Utc::now();
+            let t = format!("{}", t.format("%Y-%m-%d %H:%M:%S%.6f"));
+            writeln!(
+                buf,
+                "{t} {} {}",
+                buf.default_styled_level(record.level()),
+                record.args()
+            )
+        })
+        .try_init();
+}
+
+#[test]
+fn test_kafka_output_errors() {
+    init_test_logger();
+
+    info!("test_kafka_output_errors: Test invalid Kafka broker address");
+
+    let config_str = r#"
+name: test
+workers: 4
+inputs:
+outputs:
+    test_output:
+        stream: test_output1
+        transport:
+            name: durable_kafka
+            config:
+                kafka_options:
+                    bootstrap.servers: localhost:11111
+                topic: durable_end_to_end_test_output_topic
+                max_inflight_messages: 0
+        format:
+            name: csv
+"#;
+
+    info!("test_kafka_output_errors: Creating circuit");
+
+    info!("test_kafka_output_errors: Starting controller");
+    let config: PipelineConfig = serde_yaml::from_str(config_str).unwrap();
+
+    match Controller::with_config(
+        |workers| Ok(test_circuit(workers)),
+        &config,
+        Box::new(|e| panic!("error: {e}")),
+    ) {
+        Ok(_) => panic!("expected an error"),
+        Err(e) => info!("test_kafka_output_errors: error: {e}"),
+    }
+}
+
+fn durable_kafka_end_to_end_test(
+    test_name: &str,
+    format: &str,
+    format_config: &str,
+    message_max_bytes: usize,
+    data: Vec<Vec<TestStruct>>,
+) {
+    init_test_logger();
+    let uuid = Uuid::new_v4();
+    let input_topic = format!("{test_name}_input_topic_{uuid}");
+    let input_index_topic = format!("{input_topic}_input-index");
+    let output_topic = format!("{test_name}_output_topic_{uuid}");
+
+    // Create topics.
+    let mut _kafka_resources = KafkaResources::create_topics(&[
+        (&input_topic, 1),
+        (&input_index_topic, 0),
+        (&output_topic, 1),
+    ]);
+
+    // Create controller.
+
+    let config_str = format!(
+        r#"
+name: test
+workers: 4
+inputs:
+    test_input1:
+        stream: test_input1
+        transport:
+            name: durable_kafka
+            config:
+                topics: ["{input_topic}"]
+                log_level: debug
+        format:
+            name: csv
+outputs:
+    test_output2:
+        stream: test_output1
+        transport:
+            name: durable_kafka
+            config:
+                topic: {output_topic}
+                max_inflight_messages: 0
+                message.max.bytes: "{message_max_bytes}"
+        format:
+            name: {format}
+            config:
+                {format_config}
+"#
+    );
+
+    info!("{test_name}: Creating circuit. Config {config_str}");
+
+    info!("{test_name}: Starting controller");
+    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+    let test_name_clone = test_name.to_string();
+
+    let controller = Controller::with_config(
+        |workers| Ok(test_circuit(workers)),
+        &config,
+        Box::new(move |e| if running_clone.load(Ordering::Acquire) {
+            panic!("{test_name_clone}: error: {e}")
+        } else {
+            info!("{test_name_clone}: error during shutdown (likely caused by Kafka topics being deleted): {e}")
+        }),
+    )
+        .unwrap();
+    assert!(controller.is_fault_tolerant());
+
+    let buffer_consumer = BufferConsumer::new(&output_topic, format, format_config);
+
+    info!("{test_name}: Sending inputs");
+    let producer = TestProducer::new();
+    producer.send_to_topic(&data, &input_topic);
+
+    info!("{test_name}: Starting controller");
+    // Start controller.
+    controller.start();
+
+    // Wait for output buffer to contain all of `data`.
+
+    info!("{test_name}: Waiting for output");
+    buffer_consumer.wait_for_output_unordered(&data);
+
+    drop(buffer_consumer);
+
+    controller.stop().unwrap();
+
+    // Endpoint threads might still be running (`controller.stop()` doesn't wait
+    // for them to terminate).  Once `KafkaResources` is dropped, these threads
+    // may start throwing errors due to deleted Kafka topics.  Make sure these
+    // errors don't cause panics.
+    running.store(false, Ordering::Release);
+}
+
+/// Test a topic that's empty and won't get any data.
+#[test]
+fn test_empty_input() {
+    init_test_logger();
+
+    let mut _kafka_resources =
+        KafkaResources::create_topics(&[("empty", 1), ("empty_input-index", 0)]);
+
+    let transport = <dyn InputTransport>::get_transport("durable_kafka").unwrap();
+
+    let config_str = r#"
+topics: [empty]
+log_level: debug
+"#
+    .to_string();
+
+    let endpoint = transport
+        .new_endpoint(&serde_yaml::from_str(&config_str).unwrap())
+        .unwrap();
+    assert!(endpoint.is_durable());
+
+    info!("checking initial steps");
+    assert_eq!(endpoint.steps().unwrap(), 0..0);
+
+    // Initially there are no steps.  Reading step 0 should block because
+    // nothing is writing data.
+    info!("trying to read read step 0 (should time out)");
+    let receiver = DummyInputReceiver::new();
+    let reader = endpoint.open(receiver.consumer(), 0).unwrap();
+    reader.start(Step::MAX).unwrap();
+    receiver.expect(vec![ConsumerCall::StartStep(0)]);
+
+    // Five times, try to commit
+    for step in 0..=4 {
+        info!("committing and reading step {step}",);
+        reader.commit(step);
+        receiver.wait_to_settle(step);
+        receiver.expect(vec![ConsumerCall::StartStep(step + 1)]);
+        receiver.wait_to_settle(step);
+        assert_eq!(endpoint.steps().unwrap(), 0..(step + 1));
+    }
+
+    // Try to read multiple steps beyond the last available.
+    let mut step = 4;
+    for n in 2..10 {
+        let commits = (step + 1)..=(step + n);
+        step = *commits.end();
+        info!("committing up to step {step}");
+        reader.commit(step);
+        for step in commits {
+            receiver.expect(vec![ConsumerCall::StartStep(step + 1)])
+        }
+        receiver.wait_to_settle(step);
+        assert_eq!(endpoint.steps().unwrap(), 0..(step + 1));
+    }
+    receiver.expect_eof();
+
+    // Now open the same endpoint again and all the steps should be immediately
+    // available.
+    let receiver2 = DummyInputReceiver::new();
+    let reader2 = endpoint.open(receiver2.consumer(), 0).unwrap();
+    reader2.start(step + 1).unwrap();
+    for step in 0..=step {
+        receiver2.expect(vec![ConsumerCall::StartStep(step)])
+    }
+    receiver2.wait_to_settle(step);
+    receiver2.expect(vec![ConsumerCall::StartStep(step + 1)]);
+    receiver2.expect_eof();
+}
+
+#[test]
+fn test_input() {
+    init_test_logger();
+
+    let topic = "durability";
+    let index_topic = &format!("{topic}_input-index");
+    let mut _kafka_resources = KafkaResources::create_topics(&[(topic, 1), (index_topic, 0)]);
+
+    let config_str = format!(
+        r#"
+topics: [{topic}]
+log_level: debug
+max_step_messages: 5
+"#
+    );
+
+    let transport = <dyn InputTransport>::get_transport("durable_kafka").unwrap();
+
+    let endpoint = transport
+        .new_endpoint(&serde_yaml::from_str(&config_str).unwrap())
+        .unwrap();
+    assert!(endpoint.is_durable());
+
+    info!("checking initial steps");
+    assert_eq!(endpoint.steps().unwrap(), 0..0);
+
+    info!("trying to read read step 0 (should time out)");
+    let receiver = DummyInputReceiver::new();
+    let reader = endpoint.open(receiver.consumer(), 0).unwrap();
+    reader.start(0).unwrap();
+    receiver.expect(vec![ConsumerCall::StartStep(0)]);
+
+    fn test(id: u32) -> TestStruct {
+        TestStruct {
+            id,
+            b: false,
+            i: None,
+            s: "".into(),
+        }
+    }
+
+    info!("now write some data");
+    let producer = TestProducer::new();
+    producer.send_to_topic(&[vec![test(0)]], topic);
+
+    info!("now we should get that data in step 0");
+    receiver.expect(vec![ConsumerCall::InputChunk("0,false,,\n".into())]);
+
+    info!("commit step 0");
+    reader.commit(0);
+    receiver.expect(vec![ConsumerCall::StartStep(1)]);
+    receiver.wait_to_settle(0);
+    assert_eq!(endpoint.steps().unwrap(), 0..1);
+
+    info!("we shouldn't get more data yet because we didn't ask for step 1 yet");
+    let producer = TestProducer::new();
+    producer.send_to_topic(&[vec![test(1), test(2)]], topic);
+    receiver.expect_eof();
+
+    info!("ask for more steps and we should get that data");
+    reader.start(10).unwrap();
+    receiver.expect(vec![ConsumerCall::InputChunk(
+        "1,false,,\n2,false,,\n".into(),
+    )]);
+
+    info!("commit step 1");
+    reader.commit(1);
+    receiver.expect(vec![ConsumerCall::StartStep(2)]);
+    receiver.wait_to_settle(1);
+    assert_eq!(endpoint.steps().unwrap(), 0..2);
+
+    info!("writing 4 messages (with max_step_messages=5) should not force a step");
+    for i in 3..=6 {
+        producer.send_to_topic(&[vec![test(i)]], topic);
+        receiver.expect(vec![ConsumerCall::InputChunk(format!("{i},false,,\n"))]);
+    }
+    receiver.expect_eof();
+
+    info!("writing a fifth message should force a step");
+    producer.send_to_topic(&[vec![test(7)]], topic);
+    receiver.expect(vec![ConsumerCall::InputChunk("7,false,,\n".into())]);
+    receiver.expect(vec![ConsumerCall::StartStep(3)]);
+    receiver.wait_to_settle(2);
+    assert_eq!(endpoint.steps().unwrap(), 0..3);
+
+    receiver.expect_eof();
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum ConsumerCall {
+    StartStep(Step),
+    InputFragment(String),
+    InputChunk(String),
+    Error(bool),
+    Eoi,
+}
+
+struct DummyInputReceiver {
+    inner: Arc<DummyInputReceiverInner>,
+    parker: Parker,
+}
+
+struct DummyInputReceiverInner {
+    unparker: Unparker,
+    calls: Mutex<Vec<ConsumerCall>>,
+    settled: Mutex<Option<Step>>,
+}
+
+impl DummyInputReceiver {
+    pub fn new() -> Self {
+        let parker = Parker::new();
+        let unparker = parker.unparker().clone();
+        Self {
+            inner: Arc::new(DummyInputReceiverInner {
+                unparker,
+                calls: Mutex::new(Vec::new()),
+                settled: Mutex::new(None),
+            }),
+            parker,
+        }
+    }
+
+    /// Wait some time for the input consumer to report that `settled` was
+    /// called.  However, we don't expect it to have been called, so we panic
+    /// with an error if it has.
+    ///
+    /// The waiting time here is arbitrary, since we expect that we could wait
+    /// forever.
+    #[track_caller]
+    pub fn expect_eof(&self) {
+        sleep(Duration::from_millis(100));
+
+        let actual: Vec<_> = self.inner.calls.lock().unwrap().drain(..).collect();
+        assert_eq!(Vec::<ConsumerCall>::new(), actual);
+    }
+
+    /// Wait until the input consumer receives `expected`. Panics if it receives
+    /// something else or if it doesn't receive it within a reasonable amount of
+    /// time.  It is not an error for the consumer receives more following
+    /// `expected`; any calls afterward is left for later calls to check.
+    #[track_caller]
+    pub fn expect(&self, expected: Vec<ConsumerCall>) {
+        let mut last_change = Instant::now();
+        let mut last_len = 0;
+        loop {
+            let mut current = self.inner.calls.lock().unwrap();
+            if current.len() >= expected.len()
+                || Instant::now().duration_since(last_change) > Duration::from_secs(10)
+            {
+                let len = current.len().min(expected.len());
+                let actual: Vec<_> = current.drain(0..len).collect();
+
+                // Without this, sometimes we get SIGSEGV in librdkafka.
+                drop(current);
+
+                assert_eq!(expected, actual);
+                return;
+            }
+            if current.len() != last_len {
+                last_len = current.len();
+                last_change = Instant::now();
+            }
+            drop(current);
+
+            self.parker.park_timeout(Duration::from_millis(100));
+        }
+    }
+
+    pub fn wait_to_settle(&self, step: Step) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            assert!(Instant::now() < deadline);
+            if let Some(settled) = *self.inner.settled.lock().unwrap() {
+                if settled >= step {
+                    return;
+                }
+            }
+            self.parker.park_deadline(deadline);
+        }
+    }
+
+    pub fn consumer(&self) -> Box<dyn InputConsumer> {
+        Box::new(DummyInputConsumer(self.inner.clone()))
+    }
+}
+
+struct DummyInputConsumer(Arc<DummyInputReceiverInner>);
+
+impl DummyInputConsumer {
+    fn called(&mut self, call: ConsumerCall) {
+        info!("{call:?}");
+        self.0.calls.lock().unwrap().push(call);
+        self.0.unparker.unpark();
+    }
+}
+
+impl InputConsumer for DummyInputConsumer {
+    fn start_step(&mut self, step: Step) {
+        self.called(ConsumerCall::StartStep(step));
+    }
+    fn input_fragment(&mut self, data: &[u8]) -> Vec<ParseError> {
+        self.called(ConsumerCall::InputFragment(
+            String::from_utf8(data.into()).unwrap(),
+        ));
+        vec![]
+    }
+    fn input_chunk(&mut self, data: &[u8]) -> Vec<ParseError> {
+        self.called(ConsumerCall::InputChunk(
+            String::from_utf8(data.into()).unwrap(),
+        ));
+        vec![]
+    }
+    fn error(&mut self, fatal: bool, error: AnyError) {
+        info!("error: {error}");
+        self.called(ConsumerCall::Error(fatal));
+    }
+    fn eoi(&mut self) -> Vec<ParseError> {
+        self.called(ConsumerCall::Eoi);
+        vec![]
+    }
+    fn fork(&self) -> Box<dyn InputConsumer> {
+        unreachable!()
+    }
+    fn settled(&mut self, step: Step) {
+        info!("step {step} settled");
+        let mut settled = self.0.settled.lock().unwrap();
+        if let Some(settled) = *settled {
+            assert_eq!(settled + 1, step);
+        }
+        *settled = Some(step);
+        self.0.unparker.unpark();
+    }
+}
+
+#[test]
+fn output_test() {
+    kafka_output_test(
+        "durable_kafka_end_to_end_csv_large",
+        "csv",
+        "",
+        1000000,
+        Vec::new(),
+    );
+}
+
+fn kafka_output_test(
+    test_name: &str,
+    _format: &str,
+    _format_config: &str,
+    _message_max_bytes: usize,
+    _data: Vec<Vec<TestStruct>>,
+) {
+    init_test_logger();
+    let output_topic = format!("durable_{test_name}_output_topic");
+
+    // Create topics.
+    let _kafka_resources = KafkaResources::create_topics(&[(&output_topic, 1)]);
+
+    let transport = <dyn OutputTransport>::get_transport("durable_kafka").unwrap();
+
+    let config_str = format!(
+        r#"
+stream: test_output1
+transport:
+    name: durable_kafka
+    config:
+        topic: {output_topic}
+format:
+    name: csv
+"#
+    );
+
+    let mut endpoint = transport
+        .new_endpoint(&serde_yaml::from_str(&config_str).unwrap())
+        .unwrap();
+    assert!(endpoint.is_durable());
+    endpoint
+        .connect(Box::new(|fatal, error| info!("({fatal:?}, {error:?})")))
+        .unwrap();
+    for step in 0..5 {
+        endpoint.batch_start(step).unwrap();
+        endpoint
+            .push_buffer(format!("string{step}").as_bytes())
+            .unwrap();
+        endpoint.batch_end().unwrap();
+    }
+}
+
+fn _test() {
+    let transport = <dyn OutputTransport>::get_transport("durable_kafka").unwrap();
+
+    let config_str = r#"
+stream: my_test_stream
+transport:
+    name: durable_kafka
+    config:
+        topic: my_topic
+format:
+    name: csv
+"#;
+
+    let mut endpoint = transport
+        .new_endpoint(&serde_yaml::from_str(&config_str).unwrap())
+        .unwrap();
+    assert!(endpoint.is_durable());
+    endpoint
+        .connect(Box::new(|fatal, error| info!("({fatal:?}, {error:?})")))
+        .unwrap();
+    for step in 0..5 {
+        endpoint.batch_start(step).unwrap();
+        endpoint
+            .push_buffer(format!("string{step}").as_bytes())
+            .unwrap();
+        endpoint.batch_end().unwrap();
+    }
+}
+
+fn test_durable_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str) {
+    init_test_logger();
+
+    let topic1 = &format!("durable_{topic1}");
+    let index_topic1 = &format!("{topic1}_input-index");
+    let topic2 = &format!("durable_{topic2}");
+    let index_topic2 = &format!("{topic2}_input-index");
+    let mut _kafka_resources = KafkaResources::create_topics(&[
+        (topic1, 1),
+        (index_topic1, 0),
+        (topic2, 2),
+        (index_topic2, 0),
+    ]);
+
+    info!("proptest_kafka_input: Test: Specify invalid Kafka broker address");
+
+    let config_str = format!(
+        r#"
+stream: test_input
+transport:
+    name: durable_kafka
+    config:
+        kafka_options:
+            bootstrap.servers: localhost:11111
+        topics: ["{topic1}", "{topic2}"]
+        log_level: debug
+format:
+    name: csv
+"#
+    );
+
+    let (reader, consumer, _input_handle) =
+        mock_input_pipeline::<TestStruct>(serde_yaml::from_str(&config_str).unwrap()).unwrap();
+    consumer.on_error(Some(Box::new(|_| {})));
+    reader.start(0).unwrap();
+    wait(|| consumer.state().endpoint_error.is_some(), 60000).unwrap();
+    info!(
+        "proptest_kafka_input: Error: {}",
+        consumer.state().endpoint_error.as_ref().unwrap()
+    );
+
+    info!("proptest_kafka_input: Test: Specify invalid Kafka topic name");
+
+    let config_str = r#"
+stream: test_input
+transport:
+    name: durable_kafka
+    config:
+        topics: ["this_topic_does_not_exist"]
+        log_level: debug
+format:
+    name: csv
+"#;
+
+    let (reader, consumer, _input_handle) =
+        mock_input_pipeline::<TestStruct>(serde_yaml::from_str(config_str).unwrap()).unwrap();
+    consumer.on_error(Some(Box::new(|_| {})));
+    reader.start(0).unwrap();
+    wait(|| consumer.state().endpoint_error.is_some(), 60000).unwrap();
+    info!(
+        "proptest_kafka_input: Error: {}",
+        consumer.state().endpoint_error.as_ref().unwrap()
+    );
+
+    let config_str = format!(
+        r#"
+stream: test_input
+transport:
+    name: durable_kafka
+    config:
+        topics: [{topic1}, {topic2}]
+        log_level: debug
+format:
+    name: csv
+"#
+    );
+
+    info!("proptest_kafka_input: Building input pipeline");
+
+    let (endpoint, _consumer, zset) =
+        mock_input_pipeline::<TestStruct>(serde_yaml::from_str(&config_str).unwrap()).unwrap();
+
+    endpoint.start(0).unwrap();
+
+    let producer = TestProducer::new();
+
+    info!("proptest_kafka_input: Test: Receive from a topic with a single partition");
+
+    // Send data to a topic with a single partition;
+    // Make sure all records arrive in the original order.
+    producer.send_to_topic(&data, topic1);
+
+    wait_for_output_ordered(&zset, &data);
+    zset.reset();
+
+    info!("proptest_kafka_input: Test: Receive from a topic with multiple partitions");
+
+    // Send data to a topic with multiple partitions.
+    // Make sure all records are delivered, but not necessarily in the original
+    // order.
+    producer.send_to_topic(&data, topic2);
+
+    wait_for_output_unordered(&zset, &data);
+    zset.reset();
+
+    info!("proptest_kafka_input: Test: pause/resume");
+    //println!("records before pause: {}", zset.state().flushed.len());
+
+    // Paused endpoint shouldn't receive any data.
+    endpoint.pause().unwrap();
+    sleep(Duration::from_millis(1000));
+
+    producer.send_to_topic(&data, topic1);
+    sleep(Duration::from_millis(1000));
+    assert_eq!(zset.state().flushed.len(), 0);
+
+    // Receive everything after unpause.
+    endpoint.start(0).unwrap();
+    wait_for_output_unordered(&zset, &data);
+
+    zset.reset();
+
+    info!("proptest_kafka_input: Test: Disconnect");
+    // Disconnected endpoint should not receive any data.
+    endpoint.disconnect();
+    sleep(Duration::from_millis(1000));
+
+    producer.send_to_topic(&data, topic1);
+    sleep(Duration::from_millis(1000));
+    assert_eq!(zset.state().flushed.len(), 0);
+}
+
+/// If Kafka tests are going to fail because the server is not running or
+/// not functioning properly, it's good to fail quickly without printing a
+/// thousand records as part of the failure.
+#[test]
+fn kafka_input_trivial() {
+    test_durable_kafka_input(Vec::new(), "trivial_test_topic1", "trivial_test_topic2");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2))]
+
+    #[test]
+    fn proptest_kafka_input(data in generate_test_batches(0, 100, 1000)) {
+        test_durable_kafka_input(data, "input_test_topic1", "input_test_topic2");
+    }
+
+    #[test]
+    fn proptest_kafka_end_to_end_csv_large(data in generate_test_batches(0, 30, 1000)) {
+        durable_kafka_end_to_end_test("proptest_kafka_end_to_end_csv_large", "csv", "", 1000000, data);
+    }
+
+    #[test]
+    fn proptest_kafka_end_to_end_csv_small(data in generate_test_batches(0, 30, 1000)) {
+        durable_kafka_end_to_end_test("proptest_kafka_end_to_end_csv_small", "csv", "", 1500, data);
+    }
+
+    #[test]
+    fn proptest_kafka_end_to_end_json_small(data in generate_test_batches(0, 30, 1000)) {
+        durable_kafka_end_to_end_test("proptest_kafka_end_to_end_json_small", "json", "", 2048, data);
+    }
+
+    #[test]
+    fn proptest_kafka_end_to_end_json_array_small(data in generate_test_batches(0, 30, 1000)) {
+        durable_kafka_end_to_end_test("proptest_kafka_end_to_end_json_array_small", "json", "array: true", 5000, data);
+    }
+}

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -253,7 +253,7 @@ impl HttpOutputEndpoint {
 }
 
 impl OutputEndpoint for HttpOutputEndpoint {
-    fn connect(&self, _async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
+    fn connect(&mut self, _async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
         // *self.inner.async_error_callback.write().unwrap() =
         // Some(async_error_callback);
         Ok(())
@@ -283,5 +283,9 @@ impl OutputEndpoint for HttpOutputEndpoint {
             *self.inner.sender.write().unwrap() = None;
         }
         Ok(())
+    }
+
+    fn is_durable(&self) -> bool {
+        false
     }
 }

--- a/crates/adapters/src/transport/kafka/input.rs
+++ b/crates/adapters/src/transport/kafka/input.rs
@@ -1,14 +1,12 @@
 use super::{refine_kafka_error, DeferredLogging};
-use crate::transport::secret_resolver::MaybeSecret;
 use crate::{
-    transport::kafka::rdkafka_loglevel_from, InputConsumer, InputEndpoint, InputTransport,
-    PipelineState,
+    transport::{kafka::rdkafka_loglevel_from, InputReader, Step},
+    InputConsumer, InputEndpoint, InputTransport, PipelineState,
 };
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use crossbeam::queue::ArrayQueue;
 use log::debug;
 use num_traits::FromPrimitive;
-use pipeline_types::secret_ref::MaybeSecretRef;
 use pipeline_types::transport::kafka::KafkaInputConfig;
 use rdkafka::config::RDKafkaLogLevel;
 use rdkafka::{
@@ -55,18 +53,24 @@ impl InputTransport for KafkaInputTransport {
     /// See [`InputTransport::new_endpoint()`] for more information.
     fn new_endpoint(&self, config: &YamlValue) -> AnyResult<Box<dyn InputEndpoint>> {
         let config = KafkaInputConfig::deserialize(config)?;
-        let ep = KafkaInputEndpoint::new(config)?;
-        Ok(Box::new(ep))
+        Ok(Box::new(KafkaInputEndpoint::new(config)?))
     }
 }
 
-struct KafkaInputEndpoint(Arc<KafkaInputEndpointInner>);
+struct KafkaInputEndpoint {
+    config: Arc<KafkaInputConfig>,
+}
 
 impl KafkaInputEndpoint {
-    fn new(config: KafkaInputConfig) -> AnyResult<Self> {
-        Ok(Self(KafkaInputEndpointInner::new(config)?))
+    fn new(mut config: KafkaInputConfig) -> AnyResult<KafkaInputEndpoint> {
+        config.validate()?;
+        Ok(KafkaInputEndpoint {
+            config: Arc::new(config),
+        })
     }
 }
+
+struct KafkaInputReader(Arc<KafkaInputReaderInner>);
 
 /// Client context used to intercept rebalancing events.
 ///
@@ -81,7 +85,7 @@ impl KafkaInputEndpoint {
 struct KafkaInputContext {
     // We keep a weak reference to the endpoint to avoid a reference cycle:
     // endpoint->BaseConsumer->context->endpoint.
-    endpoint: Mutex<Weak<KafkaInputEndpointInner>>,
+    endpoint: Mutex<Weak<KafkaInputReaderInner>>,
 
     deferred_logging: DeferredLogging,
 }
@@ -125,56 +129,14 @@ impl ConsumerContext for KafkaInputContext {
     }
 }
 
-struct KafkaInputEndpointInner {
-    config: KafkaInputConfig,
+struct KafkaInputReaderInner {
+    config: Arc<KafkaInputConfig>,
     state: AtomicU32,
     kafka_consumer: BaseConsumer<KafkaInputContext>,
     errors: ArrayQueue<(KafkaError, String)>,
 }
 
-impl KafkaInputEndpointInner {
-    fn new(mut config: KafkaInputConfig) -> AnyResult<Arc<Self>> {
-        // Create Kafka consumer configuration.
-        config.validate()?;
-        debug!("Starting Kafka input endpoint: {config:?}");
-
-        let mut client_config = ClientConfig::new();
-
-        for (key, value) in config.kafka_options.iter() {
-            // If it is a secret reference, resolve it to the actual secret string
-            match MaybeSecret::new_with_default_volume(MaybeSecretRef::new_using_pattern_match(
-                value.clone(),
-            ))? {
-                MaybeSecret::String(simple_string) => {
-                    client_config.set(key, simple_string);
-                }
-                MaybeSecret::Secret(secret_string) => {
-                    client_config.set(key, secret_string);
-                }
-            }
-        }
-
-        if let Some(log_level) = config.log_level {
-            client_config.set_log_level(rdkafka_loglevel_from(log_level));
-        }
-
-        // Context object to intercept rebalancing events and errors.
-        let context = KafkaInputContext::new();
-
-        debug!("Creating Kafka consumer");
-        // Create Kafka consumer.
-        let kafka_consumer = BaseConsumer::from_config_and_context(&client_config, context)?;
-
-        let endpoint = Arc::new(Self {
-            config,
-            state: AtomicU32::new(PipelineState::Paused as u32),
-            kafka_consumer,
-            errors: ArrayQueue::new(ERROR_BUFFER_SIZE),
-        });
-
-        Ok(endpoint)
-    }
-
+impl KafkaInputReaderInner {
     fn push_error(&self, error: KafkaError, reason: &str) {
         // `force_push` makes the queue operate as a circular buffer.
         self.errors.force_push((error, reason.to_string()));
@@ -227,8 +189,106 @@ impl KafkaInputEndpointInner {
     }
 }
 
-impl KafkaInputEndpoint {
-    fn worker_thread(endpoint: Arc<KafkaInputEndpointInner>, mut consumer: Box<dyn InputConsumer>) {
+impl KafkaInputReader {
+    fn new(
+        config: &Arc<KafkaInputConfig>,
+        mut consumer: Box<dyn InputConsumer>,
+    ) -> AnyResult<Self> {
+        // Create Kafka consumer configuration.
+        debug!("Starting Kafka input endpoint: {:?}", config);
+
+        let mut client_config = ClientConfig::new();
+
+        for (key, value) in config.kafka_options.iter() {
+            client_config.set(key, value);
+        }
+
+        if let Some(log_level) = config.log_level {
+            client_config.set_log_level(rdkafka_loglevel_from(log_level));
+        }
+
+        // Context object to intercept rebalancing events and errors.
+        let context = KafkaInputContext::new();
+
+        debug!("Creating Kafka consumer");
+        let inner = Arc::new(KafkaInputReaderInner {
+            config: config.clone(),
+            state: AtomicU32::new(PipelineState::Paused as u32),
+            kafka_consumer: BaseConsumer::from_config_and_context(&client_config, context)?,
+            errors: ArrayQueue::new(ERROR_BUFFER_SIZE),
+        });
+
+        *inner.kafka_consumer.context().endpoint.lock().unwrap() = Arc::downgrade(&inner);
+
+        let topics = config.topics.iter().map(String::as_str).collect::<Vec<_>>();
+
+        // Subscribe consumer to `topics`.
+        inner.kafka_consumer.subscribe(&topics)?;
+
+        let start = Instant::now();
+
+        // Wait for the consumer to join the group by waiting for the group
+        // rebalance protocol to be set.
+        loop {
+            // We must poll in order to receive connection failures; otherwise
+            // we'd have to rely on timeouts only.
+            match inner
+                .kafka_consumer
+                .context()
+                .deferred_logging
+                .with_deferred_logging(|| inner.kafka_consumer.poll(POLL_TIMEOUT))
+            {
+                Some(Err(e)) => {
+                    // Topic-does-not-exist error will be reported here.
+                    bail!(
+                        "failed to subscribe to topics '{topics:?}' (consumer group id '{}'): {e}",
+                        inner.config.kafka_options.get("group.id").unwrap(),
+                    );
+                }
+                Some(Ok(message)) => {
+                    // `KafkaInputContext` should instantly pause the topic upon connecting to it.
+                    // Hopefully, this guarantees that we won't see any messages from it, but if
+                    // that's not the case, there shouldn't be any harm in sending them downstream.
+                    if let Some(payload) = message.payload() {
+                        // Leave it to the controller to handle errors.  There is noone we can
+                        // forward the error to upstream.
+                        let _ = consumer.input_chunk(payload);
+                    }
+                }
+                _ => (),
+            }
+
+            // Invalid broker address and other global errors are reported here.
+            if let Some((_error, reason)) = inner.pop_error() {
+                // let (_fatal, e) = endpoint.refine_error(error);
+                bail!("error subscribing to topics {topics:?}: {reason}");
+            }
+
+            if matches!(
+                inner.kafka_consumer.rebalance_protocol(),
+                RebalanceProtocol::None
+            ) {
+                if start.elapsed()
+                    >= Duration::from_secs(inner.config.group_join_timeout_secs as u64)
+                {
+                    bail!(
+                        "failed to subscribe to topics '{topics:?}' (consumer group id '{}'), giving up after {}s",
+                        inner.config.kafka_options.get("group.id").unwrap(),
+                        inner.config.group_join_timeout_secs
+                    );
+                }
+                // println!("waiting to join the group");
+            } else {
+                break;
+            }
+        }
+
+        let endpoint_clone = inner.clone();
+        spawn(move || KafkaInputReader::worker_thread(endpoint_clone, consumer));
+        Ok(KafkaInputReader(inner))
+    }
+
+    fn worker_thread(endpoint: Arc<KafkaInputReaderInner>, mut consumer: Box<dyn InputConsumer>) {
         let mut actual_state = PipelineState::Paused;
         loop {
             // endpoint.debug_consumer();
@@ -297,84 +357,20 @@ impl KafkaInputEndpoint {
 }
 
 impl InputEndpoint for KafkaInputEndpoint {
-    fn connect(&mut self, mut consumer: Box<dyn InputConsumer>) -> AnyResult<()> {
-        *self.0.kafka_consumer.context().endpoint.lock().unwrap() = Arc::downgrade(&self.0);
-
-        let topics = self
-            .0
-            .config
-            .topics
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
-
-        // Subscribe consumer to `topics`.
-        self.0.kafka_consumer.subscribe(&topics)?;
-
-        let start = Instant::now();
-
-        // Wait for the consumer to join the group by waiting for the group
-        // rebalance protocol to be set.
-        loop {
-            // We must poll in order to receive connection failures; otherwise
-            // we'd have to rely on timeouts only.
-            match self
-                .0
-                .kafka_consumer
-                .context()
-                .deferred_logging
-                .with_deferred_logging(|| self.0.kafka_consumer.poll(POLL_TIMEOUT))
-            {
-                Some(Err(e)) => {
-                    // Topic-does-not-exist error will be reported here.
-                    bail!(
-                        "failed to subscribe to topics '{topics:?}' (consumer group id '{}'): {e}",
-                        self.0.config.kafka_options.get("group.id").unwrap(),
-                    );
-                }
-                Some(Ok(message)) => {
-                    // `KafkaInputContext` should instantly pause the topic upon connecting to it.
-                    // Hopefully, this guarantees that we won't see any messages from it, but if
-                    // that's not the case, there shouldn't be any harm in sending them downstream.
-                    if let Some(payload) = message.payload() {
-                        // Leave it to the controller to handle errors.  There is noone we can
-                        // forward the error to upstream.
-                        let _ = consumer.input_chunk(payload);
-                    }
-                }
-                _ => (),
-            }
-
-            // Invalid broker address and other global errors are reported here.
-            if let Some((_error, reason)) = self.0.pop_error() {
-                // let (_fatal, e) = self.0.refine_error(error);
-                bail!("error subscribing to topics {topics:?}: {reason}");
-            }
-
-            if matches!(
-                self.0.kafka_consumer.rebalance_protocol(),
-                RebalanceProtocol::None
-            ) {
-                if start.elapsed()
-                    >= Duration::from_secs(self.0.config.group_join_timeout_secs as u64)
-                {
-                    bail!(
-                        "failed to subscribe to topics '{topics:?}' (consumer group id '{}'), giving up after {}s",
-                        self.0.config.kafka_options.get("group.id").unwrap(),
-                        self.0.config.group_join_timeout_secs
-                    );
-                }
-                // println!("waiting to join the group");
-            } else {
-                break;
-            }
-        }
-
-        let endpoint_clone = self.0.clone();
-        spawn(move || Self::worker_thread(endpoint_clone, consumer));
-        Ok(())
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        _start_step: Step,
+    ) -> AnyResult<Box<dyn InputReader>> {
+        Ok(Box::new(KafkaInputReader::new(&self.config, consumer)?))
     }
 
+    fn is_durable(&self) -> bool {
+        false
+    }
+}
+
+impl InputReader for KafkaInputReader {
     fn pause(&self) -> AnyResult<()> {
         // Notify worker thread via the state flag.  The worker may
         // send another buffer downstream before the flag takes effect.
@@ -382,7 +378,7 @@ impl InputEndpoint for KafkaInputEndpoint {
         Ok(())
     }
 
-    fn start(&self) -> AnyResult<()> {
+    fn start(&self, _step: Step) -> AnyResult<()> {
         self.0.set_state(PipelineState::Running);
         Ok(())
     }
@@ -392,7 +388,7 @@ impl InputEndpoint for KafkaInputEndpoint {
     }
 }
 
-impl Drop for KafkaInputEndpoint {
+impl Drop for KafkaInputReader {
     fn drop(&mut self) {
         self.disconnect();
     }

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -6,6 +6,8 @@ use rdkafka::{
     error::KafkaError,
     types::RDKafkaErrorCode,
 };
+#[cfg(test)]
+use std::sync::Mutex;
 
 mod input;
 mod output;
@@ -60,5 +62,105 @@ where
             }
         }
         None | Some(_) => (false, AnyError::from(e)),
+    }
+}
+
+/// Captures and redirect log messages during tests.
+///
+/// The Rust unit test framework captures log messages during tests and, in some
+/// cases, prints them later associated with the particular test.  It does this
+/// OK in most cases, but one of the cases it does not handle is output from
+/// threads created by anything other than `std::thread` primitives.  This
+/// includes the thread created by librdkafka.  If we log anything from a
+/// context callback, then it goes directly to stderr, bypassing the unit test
+/// framework.  This makes it hard to read the unit test output and hard to
+/// attribute messages to particular tests.
+///
+/// `DeferredLogging` provides a way to capture log messages emitted by the unit
+/// tests.  A context can instantiate `DeferredLogging` and use
+/// `DeferredLogging::with_deferred_logging` to wrap calls to librdkafka
+/// functions that are likely to emit log messages.  This can be specific calls
+/// instead of every call, since we know what message the unit tests actually
+/// provoke.
+///
+/// When tests are disabled, this framework compiles to nothing.
+#[cfg(test)]
+pub(crate) struct DeferredLogging(Mutex<Option<Vec<(RDKafkaLogLevel, String, String)>>>);
+
+#[cfg(test)]
+impl DeferredLogging {
+    pub fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    /// Calls `f`, capturing log messages that occur during the call, and then
+    /// logging them in the current thread.
+    pub fn with_deferred_logging<F, R>(&self, f: F) -> R
+    where
+        F: Fn() -> R,
+    {
+        *self.0.lock().unwrap() = Some(Vec::new());
+        let r = f();
+        for (level, fac, message) in self.0.lock().unwrap().take().unwrap().drain(..) {
+            log::info!("{level:?} {fac} {message}");
+        }
+        r
+    }
+
+    /// Logs the message in the usual way, or captures it for later logging if
+    /// we're running inside `Self::with_deferred_logging`.
+    pub fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        if let Some(ref mut deferred_logging) = self.0.lock().unwrap().as_mut() {
+            deferred_logging.push((level, fac.into(), log_message.into()))
+        } else {
+            Self::default_log(level, fac, log_message)
+        }
+    }
+}
+
+#[cfg(not(test))]
+pub(crate) struct DeferredLogging;
+
+#[cfg(not(test))]
+impl DeferredLogging {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn with_deferred_logging<F, R>(&self, f: F) -> R
+    where
+        F: Fn() -> R,
+    {
+        f()
+    }
+
+    pub fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        Self::default_log(level, fac, log_message)
+    }
+}
+
+impl DeferredLogging {
+    // This is a copy of the default implementation of [`ClientContext::log`].
+    fn default_log(level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        match level {
+            RDKafkaLogLevel::Emerg
+            | RDKafkaLogLevel::Alert
+            | RDKafkaLogLevel::Critical
+            | RDKafkaLogLevel::Error => {
+                log::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Warning => {
+                log::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Notice => {
+                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Info => {
+                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Debug => {
+                log::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+        }
     }
 }

--- a/crates/adapters/src/transport/kafka/output.rs
+++ b/crates/adapters/src/transport/kafka/output.rs
@@ -290,7 +290,7 @@ impl KafkaOutputEndpoint {
 }
 
 impl OutputEndpoint for KafkaOutputEndpoint {
-    fn connect(&self, async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
+    fn connect(&mut self, async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
         // Retrieve metadata for our producer.  This makes first contact with
         // the broker, which allows us to limit the time for initialization to
         // make sure that the configuration is correct.  After this, Kafka will
@@ -339,5 +339,9 @@ impl OutputEndpoint for KafkaOutputEndpoint {
             .send(record)
             .map_err(|(err, _record)| err)?;
         Ok(())
+    }
+
+    fn is_durable(&self) -> bool {
+        false
     }
 }

--- a/crates/adapters/src/transport/kafka/test.rs
+++ b/crates/adapters/src/transport/kafka/test.rs
@@ -64,6 +64,7 @@ fn wait_for_output_unordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStru
 
 fn init_test_logger() {
     let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .is_test(true)
         .format(move |buf, record| {
             let t = chrono::Utc::now();
             let t = format!("{}", t.format("%Y-%m-%d %H:%M:%S"));

--- a/crates/adapters/src/transport/kafka/test.rs
+++ b/crates/adapters/src/transport/kafka/test.rs
@@ -283,7 +283,7 @@ format:
     let (endpoint, _consumer, zset) =
         mock_input_pipeline::<TestStruct>(serde_yaml::from_str(&config_str).unwrap()).unwrap();
 
-    endpoint.start().unwrap();
+    endpoint.start(0).unwrap();
 
     let producer = TestProducer::new();
 
@@ -320,7 +320,7 @@ format:
     assert_eq!(zset.state().flushed.len(), 0);
 
     // Receive everything after unpause.
-    endpoint.start().unwrap();
+    endpoint.start(0).unwrap();
     wait_for_output_unordered(&zset, &data);
 
     zset.reset();

--- a/crates/pipeline-types/src/transport/durable_kafka.rs
+++ b/crates/pipeline-types/src/transport/durable_kafka.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+use super::kafka::KafkaLogLevel;
+
+const fn default_max_inflight_messages() -> u32 {
+    1000
+}
+
+const fn default_initialization_timeout_secs() -> u64 {
+    10
+}
+
+/// Common configuration for reading and writing durable data in Kafka topics.
+///
+/// This is flattened into the durable Kafka input and output configs.
+#[derive(Deserialize, Clone, Debug, ToSchema)]
+pub struct CommonConfigSchema {
+    /// Options passed to `rdkafka` for consumer, producer, and admin clients,
+    /// as documented at [`librdkafka`
+    /// options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+    ///
+    /// The `bootstrap.servers` option should ordinarily be supplied.  If it is
+    /// omitted, it defaults to the value of environment variable
+    /// `REDPANDA_BROKERS` if it is set, or to `localhost` otherwise.  Other
+    /// configuration is optional.
+    #[serde(default)]
+    pub kafka_options: BTreeMap<String, String>,
+
+    /// Options passed to `rdkafka` for consumers only, as documented at
+    /// [`librdkafka`
+    /// options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+    ///
+    /// These options override `kafka_options` for consumers, and may be empty.
+    #[serde(default)]
+    pub consumer_options: BTreeMap<String, String>,
+
+    /// Options passed to `rdkafka` for producers only, as documented at
+    /// [`librdkafka`
+    /// options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+    ///
+    /// These options override `kafka_options` for producers, and may be empty.
+    #[serde(default)]
+    pub producer_options: BTreeMap<String, String>,
+
+    /// The log level of the client.
+    ///
+    /// If not specified, the log level will be calculated based on the global
+    /// log level of the `log` crate.
+    pub log_level: Option<KafkaLogLevel>,
+}
+
+/// Configuration for reading data from Kafka topics with `InputTransport`.
+#[derive(Deserialize, Clone, Debug, ToSchema)]
+pub struct KafkaDurableInputConfig {
+    /// Configuration in common with durable Kafka output.
+    #[serde(flatten)]
+    pub common: CommonConfigSchema,
+
+    /// List of topics to subscribe to.  At least one topic is required.
+    pub topics: Vec<String>,
+
+    /// Suffix to append to each data topic name, to give the name of a topic
+    /// that the connector uses for recording the division of the corresponding
+    /// data topic into steps.  Defaults to `_input-index`.
+    ///
+    /// An index topic must have the same number of partitions as its
+    /// corresponding data topic.
+    ///
+    /// If two or more durable Kafka endpoints read from overlapping sets of
+    /// topics, they must specify different `index_suffix` values.
+    pub index_suffix: Option<String>,
+
+    /// If this is true or unset, then the connector will create missing index
+    /// topics as needed.  If this is false, then a missing index topic is a
+    /// fatal error.
+    #[serde(default)]
+    pub create_missing_index: Option<bool>,
+
+    /// Maximum number of bytes in a step.  Any individual message bigger than
+    /// this will be given a step of its own.
+    pub max_step_bytes: Option<u64>,
+
+    /// Maximum number of messages in a step.
+    pub max_step_messages: Option<u64>,
+}
+
+/// Configuration for writing data to a Kafka topic with `OutputTransport`.
+#[derive(Deserialize, Debug, ToSchema)]
+pub struct KafkaDurableOutputConfig {
+    /// Configuration in common with durable Kafka output.
+    #[serde(flatten)]
+    pub common: CommonConfigSchema,
+
+    /// Topic to write to.
+    pub topic: String,
+
+    /// Maximum number of unacknowledged messages buffered by the Kafka
+    /// producer.
+    ///
+    /// Kafka producer buffers outgoing messages until it receives an
+    /// acknowledgement from the broker.  This configuration parameter
+    /// bounds the number of unacknowledged messages.  When the number of
+    /// unacknowledged messages reaches this limit, sending of a new message
+    /// blocks until additional acknowledgements arrive from the broker.
+    ///
+    /// Defaults to 1000.
+    #[serde(default = "default_max_inflight_messages")]
+    pub max_inflight_messages: u32,
+
+    /// Maximum timeout in seconds to wait for the endpoint to connect to
+    /// a Kafka broker.
+    ///
+    /// Defaults to 10.
+    #[serde(default = "default_initialization_timeout_secs")]
+    pub initialization_timeout_secs: u64,
+}

--- a/crates/pipeline-types/src/transport/mod.rs
+++ b/crates/pipeline-types/src/transport/mod.rs
@@ -1,3 +1,4 @@
+pub mod durable_kafka;
 pub mod file;
 pub mod http;
 pub mod kafka;

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -122,7 +122,17 @@ pub struct Compiler {}
 /// crate.
 const MAIN_FUNCTION: &str = r#"
 fn main() {
-    dbsp_adapters::server::server_main(|workers| circuit(workers).map(|(dbsp, catalog)| (Box::new(dbsp) as Box<dyn dbsp_adapters::DbspCircuitHandle>, Box::new(catalog) as Box<dyn dbsp_adapters::CircuitCatalog>)).map_err(|e| dbsp_adapters::ControllerError::dbsp_error(e))).unwrap_or_else(|e| {
+    dbsp_adapters::server::server_main(|workers| {
+        circuit(workers)
+            .map(|(dbsp, catalog)| {
+                (
+                    Box::new(dbsp) as Box<dyn dbsp_adapters::DbspCircuitHandle>,
+                    Box::new(catalog) as Box<dyn dbsp_adapters::CircuitCatalog>,
+                )
+            })
+            .map_err(|e| dbsp_adapters::ControllerError::dbsp_error(e))
+    })
+    .unwrap_or_else(|e| {
         eprintln!("{e}");
         std::process::exit(1);
     });

--- a/sql-to-dbsp-compiler/README.md
+++ b/sql-to-dbsp-compiler/README.md
@@ -86,7 +86,8 @@ views                                           V
 
 ## Using the compiler
 
-See the [documentation](https://www.feldera.com/docs/sql/intro)
+See the documentation in `docs/contributors/compiler.md` in this repo,
+or [online](https://www.feldera.com/docs/contributors/compiler).
 
 ## Compiler architecture
 


### PR DESCRIPTION
This series:
* Fixes some `clippy` warnings that Clippy 1.72 would issue with `-D warnings`.
* Upgrades Rust from 1.70 to 1.72.
* Adds `DurableInputTransport` for fault tolerant input (see issue #652), which requires Rust 1.72 to build successfully.
Please see the individual commit messages for more details.