### PR TITLE
Regression in CSV parser

### DIFF
--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -547,6 +547,15 @@ async fn deploy_pipeline() {
         .await;
     assert!(req.status().is_success());
 
+    // Push more data without Windows-style newlines.
+    let req = config
+        .post_csv(
+            format!("/v0/pipelines/{}/ingress/T1", id),
+            "4\r\n5\r\n6".to_string(),
+        )
+        .await;
+    assert!(req.status().is_success());
+
     // Pause a pipeline after it is started
     let resp = config
         .post_no_body(format!("/v0/pipelines/{}/pause", id))
@@ -558,7 +567,7 @@ async fn deploy_pipeline() {
 
     // Querying quantiles should work in paused state.
     let quantiles = config.quantiles_csv(&id, "T1").await;
-    assert_eq!(&quantiles, "1,1\n2,1\n3,1\n");
+    assert_eq!(&quantiles, "1,1\n2,1\n3,1\n4,1\n5,1\n6,1\n");
 
     // Start the pipeline
     let resp = config


### PR DESCRIPTION
The CSV parser library is supposed to recognize `\r`, `\n`, and `\r\n` as line terminators, but it does it in a strange way with the `\r\n` being split in the middle.  This caused the parser to recognize the final `\n` in a block of CSV records as an invalid record.