### PR TITLE
Adjustments for Debezium decimal parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "f6cd65a4b849ace0b7f6daeebcc1a1d111282227ca745458c61dbf670e52a597"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -472,15 +472,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "0238ca56c96dfa37bdf7c373c8886dd591322500aceeeccdb2216fe06dc2f796"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f2db9467baa66a700abce2a18c5ad793f6f83310aca1284796fc3921d113fd"
+checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
 dependencies = [
  "async-lock",
  "async-task",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af361a844928cb7d36590d406709473a1b574f443094422ef166daa3b493208"
+checksum = "c99f3cb3f9ff89f7d718fbb942c9eb91bedff12e396adf09a622dfe7ffec2bc2"
 dependencies = [
  "async-io",
  "async-lock",
@@ -1684,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive 4.4.2",
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2297,7 +2297,7 @@ dependencies = [
  "bitflags 2.4.0",
  "bitvec",
  "chrono",
- "clap 4.4.5",
+ "clap 4.4.6",
  "cranelift",
  "cranelift-codegen",
  "cranelift-jit",
@@ -2399,7 +2399,7 @@ dependencies = [
  "change-detection",
  "chrono",
  "circular-queue",
- "clap 4.4.5",
+ "clap 4.4.6",
  "colored",
  "crossbeam",
  "csv",
@@ -2426,6 +2426,7 @@ dependencies = [
  "reqwest",
  "rkyv",
  "rust_decimal",
+ "rust_decimal_macros",
  "rustls 0.20.9",
  "serde",
  "serde_json",
@@ -3578,7 +3579,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.4",
  "bytecount",
- "clap 4.4.5",
+ "clap 4.4.6",
  "fancy-regex",
  "fraction",
  "getrandom",
@@ -4526,7 +4527,7 @@ dependencies = [
  "cached 0.43.0",
  "change-detection",
  "chrono",
- "clap 4.4.5",
+ "clap 4.4.6",
  "colored",
  "dbsp_adapters",
  "deadpool-postgres",
@@ -5366,6 +5367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal_macros"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86444b802de0b10ac5e563b5ddb43b541b9705de4e01a50e82194d2b183c1835"
+dependencies = [
+ "quote 1.0.33",
+ "rust_decimal",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5758,9 +5769,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
  "lazy_static",
 ]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -81,6 +81,7 @@ futures-timer = "3.0.2"
 test_bin = "0.4.0"
 reqwest = "0.11.20"
 serial_test = "2.0.0"
+rust_decimal_macros = "1.32"
 
 [build-dependencies]
 static-files = "0.2.3"

--- a/demo/project_demo05-DebeziumMySQL/run.py
+++ b/demo/project_demo05-DebeziumMySQL/run.py
@@ -44,6 +44,7 @@ def prepare(args=[]):
             "schema.history.internal.kafka.topic": "schema-changes.inventory.internal",
             "schema.history.internal.kafka.bootstrap.servers": "redpanda:9092",
             "include.schema.changes": "true",
+            "decimal.handling.mode": "string",
         },
     }
     response = requests.post(

--- a/docs/api/json.md
+++ b/docs/api/json.md
@@ -73,17 +73,17 @@ the JSON encoding of a row would look like this:
 
 ## Types
 
-| Type                                    | Example                                         |
-|-----------------------------------------|-------------------------------------------------|
-| BOOLEAN                                 | `true`, `false`                                 |
-| TINYINT,SMALLINT, INTEGER, BIGINT       |  `1`, `-9`                                      |
-| FLOAT, DOUBLE, DECIMAL                  | `-1.40`, `12.53`, `1e20`                        |
-| VARCHAR, CHAR, STRING                   | `abc`                                           |
-| TIME                                    | `12:12:33`, `23:59:29.483`, `23:59:09.483221092`|
-| TIMESTAMP                               | `2024-02-25 12:12:33`                           |
-| DATE                                    | `2024-02-25`                                    |
-| BIGINT ARRAY                            | `[1, 2]`                                        |
-| VARCHAR ARRAY ARRAY                     | `[[ 'abc', '123'], ['c', 'sql']]`               |
+| Type                                    | Example                                                 |
+|-----------------------------------------|---------------------------------------------------------|
+| BOOLEAN                                 | `true`, `false`                                         |
+| TINYINT,SMALLINT, INTEGER, BIGINT       |  `1`, `-9`                                              |
+| FLOAT, DOUBLE, DECIMAL                  | `-1.40`, `"-1.40"`, `12.53`, `"12.53"`, `1e20`, `"1e20"`|
+| VARCHAR, CHAR, STRING                   | `abc`                                                   |
+| TIME                                    | `12:12:33`, `23:59:29.483`, `23:59:09.483221092`        |
+| TIMESTAMP                               | `2024-02-25 12:12:33`                                   |
+| DATE                                    | `2024-02-25`                                            |
+| BIGINT ARRAY                            | `[1, 2]`                                                |
+| VARCHAR ARRAY ARRAY                     | `[[ 'abc', '123'], ['c', 'sql']]`                       |
 
 ### `BOOLEAN`
 
@@ -97,8 +97,11 @@ Types](../sql/types.md)), otherwise an error is returned on ingress.
 ### Decimals (`DECIMAL` / `NUMERIC`)
 
 Both the scientific notation (e.g., `3e234`) and standard floating point numbers
-(`1.23`) are valid. The value must fit within the specified range or
-precision, otherwise an error is returned.
+(`1.23`) are valid. The parser will accept decimals formatted as JSON numbers
+(`1.234`) or strings (`"1.234"`).  The latter representation is more robust as it
+avoids loss of precision during parsing (the Rust JSON parser we use represents all
+fractional numbers as 64-bit floating point numbers internally,  which can cause loss
+of precision for decimal numbers that cannot be accurately represented in that way).
 
 ### Floating point numbers (`FLOAT`, `DOUBLE`)
 
@@ -207,7 +210,7 @@ format
 {"part": 1, "vendor": 2, "price": 30000}
 ```
 
-is equivalent to 
+is equivalent to
 
 ```json
 {"insert": {"part": 1, "vendor": 2, "price": 30000}}


### PR DESCRIPTION
Debezium uses a very unfortunate default representation of decimal numbers that only encodes the digits, leaving it up to the consumer to infer the position of the decimal dot.  This cannot be done in a robust and efficient way.  The most obvious approach is to infer the scale of the number from the SQL table definitions that we have, but these definitions are not guaranteed to precisely match the source DB, esp when it comes to decimal precision.  An alternative is to infer it from the table schema that Debezium attaches to each record by default.  But including the schema in each message is exceedingly expensive, so we should allow (and recommend) the users to disable it, so that's also not a good solution.

When the schema registry is available, a reference to the schema registry can be used instead of inlining the schema in each record.  But that's also problematic for multiple reasons.  First, the schema registry may not always be configured.  Second, some schema registry implementations don't support JSON schemas, e.g., Redpanda only supports Avro and Protobuf.  Overall, while we do want to add support for schema registries going forward, I strongly prefer to be able to parse JSON without relying on one.

In summary, I don't see a clean solution at the moment.  As a temporary solution that doesn't require any extra work on our part, I suggest we require the user to configure their Debezium connectors to use string encoding of decimals (which we already support!).  All it takes is adding one line to the connector config:

```
"decimal.handling.mode": "string",
```

This PR:

- Adds the above config option to our Debezium demo.
- Adds decimals to our deserialization tests.
- Clarifies in the docs that we support and prefer string representation for decimals in JSON.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
