### PR TITLE
pipeline-manager: add a feature flag to disable static-site serving

### DIFF
--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -53,6 +53,7 @@ url = {version = "2.4.0"}
 
 [features]
 integration-test = []
+no-web-ui = []
 
 [build-dependencies]
 change-detection = "1.2"

--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -622,7 +622,7 @@ async fn pipeline_panic() {
 
     // The manager should discover the error next time it polls the pipeline.
     let pipeline = config
-        .wait_for_pipeline_status(&id, PipelineStatus::Failed, Duration::from_millis(20_000))
+        .wait_for_pipeline_status(&id, PipelineStatus::Failed, Duration::from_millis(60_000))
         .await;
 
     assert_eq!(


### PR DESCRIPTION
When using the pipeline-manager as a library, we don't necessarily need static site serving. This allows such projects to avoid having the web-console be involved in every build.

This commit was also done in response to a regression potentially introduced by 5bade13802c9f14ec44ed274fb4f78d405e1ee88, which causes the the pipeline manager build to break when used as a dependency. What seems to happen is that generated assets referred to by the following line in `api.rs`:

``` include!(concat!(env!("OUT_DIR"), "/generated.rs")); ```

...are no longer available on incremental rebuilds, presumably due to some misconfiguration in `build.rs`.

Is this a user-visible change (yes/no): no