### PR TITLE
Add SKIP_BUILD_WEBCONSOLE env variable.

### DIFF
--- a/crates/pipeline_manager/build.rs
+++ b/crates/pipeline_manager/build.rs
@@ -20,6 +20,12 @@ const EXCLUDE_LIST: [&str; 3] = [
 /// The first mode is useful in CI builds to cache the website build so it
 /// doesn't get built many times due to changing rustc flags.
 fn main() {
+    if env::var("SKIP_BUILD_WEBCONSOLE").is_ok() {
+        // Create a new directory called empty
+        std::fs::create_dir_all("./empty").unwrap();
+        return resource_dir("./empty").build().unwrap();
+    }
+
     if let Ok(webui_out_folder) = env::var("WEBUI_BUILD_DIR") {
         ChangeDetection::path(&webui_out_folder)
             .path("build.rs")


### PR DESCRIPTION
This skips the build of the JS/HTML assets for web-console during the manager build and doesn't include them. e.g., the manager will serve a 404 error on the URL.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
