### PR TITLE
Add tutorial as the second demo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a demo based on the "Feldera: The Basics" tutorial.  People who don't
+  want to manually complete all steps in the tutorial can instead play with the
+  pre-built pipeline.
+  ([#822](https://github.com/feldera/feldera/pull/822))
+
 ## [0.1.5] - 2023-10-10
 
 ### Added
 
-- Add Debezium input connector
+- Add Debezium MySQL input connector
   ([#813](https://github.com/feldera/feldera/issues/813))
 
 ### Fixed

--- a/crates/pipeline_manager/src/api.rs
+++ b/crates/pipeline_manager/src/api.rs
@@ -178,6 +178,7 @@ request is rejected."
         dbsp_adapters::FormatConfig,
         dbsp_adapters::transport::FileInputConfig,
         dbsp_adapters::transport::FileOutputConfig,
+        dbsp_adapters::transport::UrlInputConfig,
         dbsp_adapters::transport::KafkaInputConfig,
         dbsp_adapters::transport::KafkaOutputConfig,
         dbsp_adapters::transport::KafkaLogLevel,

--- a/demo/demo-container.sh
+++ b/demo/demo-container.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script runs inside the demo container and brings up a subset of Feldera demos,
+# currently the SecOps demo and the Supply Chain Tutorial demo.
+
+# In CI mode, it passes an argument ($SECOPS_DEMO_ARGS) to the SecOps simulator to make
+# sure that it exits after generating a fixed number of outputs.
+
+# Start the two demos in parallel.  Compilation will still happen serially, but
+# this way the user will see the two programs and pipelines straight away.
+# Make sure the script returns an error if one of the demo scripts fails.
+
+(cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile ${SECOPS_DEMO_ARGS})&
+pid1=$!
+echo pid1 $pid1
+(cd demo/project_demo06-SupplyChainTutorial && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile)&
+pid2=$!
+wait $pid1
+status1=$?
+echo SecOps demo script exited with status $status1
+wait $pid2
+status2=$?
+echo SupplyChainTutorial demo script exited with status $status2
+if [ $status1 -ne 0 ]; then exit $status1; fi
+if [ $status2 -ne 0 ]; then exit $status2; fi

--- a/demo/project_demo06-SupplyChainTutorial/project.sql
+++ b/demo/project_demo06-SupplyChainTutorial/project.sql
@@ -1,0 +1,50 @@
+-- SQL program for the Feldera Basics tutorial: https://www.feldera.com/docs/tutorials/basics/
+
+create table VENDOR (
+    id bigint not null primary key,
+    name varchar,
+    address varchar
+);
+
+create table PART (
+    id bigint not null primary key,
+    name varchar
+);
+
+create table PRICE (
+    part bigint not null,
+    vendor bigint not null,
+    price decimal
+);
+
+-- Lowest available price for each part across all vendors.
+create view LOW_PRICE (
+    part,
+    price
+) as
+    select part, MIN(price) as price from PRICE group by part;
+
+-- Lowest available price for each part along with part and vendor details.
+create view PREFERRED_VENDOR (
+    part_id,
+    part_name,
+    vendor_id,
+    vendor_name,
+    price
+) as
+    select
+        PART.id as part_id,
+        PART.name as part_name,
+        VENDOR.id as vendor_id,
+        VENDOR.name as vendor_name,
+        PRICE.price
+    from
+        PRICE,
+        PART,
+        VENDOR,
+        LOW_PRICE
+    where
+        PRICE.price = LOW_PRICE.price AND
+        PRICE.part = LOW_PRICE.part AND
+        PART.id = PRICE.part AND
+        VENDOR.id = PRICE.vendor;

--- a/demo/project_demo06-SupplyChainTutorial/run.py
+++ b/demo/project_demo06-SupplyChainTutorial/run.py
@@ -1,0 +1,91 @@
+from itertools import islice
+import os
+import sys
+import subprocess
+from shutil import which
+
+from dbsp import DBSPPipelineConfig
+from dbsp import JsonInputFormatConfig, JsonOutputFormatConfig
+from dbsp import KafkaInputConfig
+from dbsp import KafkaOutputConfig
+from dbsp import UrlInputConfig
+
+# Import
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".."))
+from demo import *
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+
+
+def prepare(args=[]):
+    from plumbum.cmd import rpk
+
+    rpk["topic", "delete", "price"]()
+    rpk["topic", "create", "price"]()
+    rpk["topic", "delete", "preferred_vendor"]()
+    rpk["topic", "create", "preferred_vendor"]()
+
+
+def make_config(project):
+    config = DBSPPipelineConfig(
+        project,
+        8,
+        "Feldera Basics Tutorial Pipeline",
+        "See https://www.feldera.com/docs/tutorials/basics/",
+    )
+
+    config.add_url_input(
+        name="tutorial-part-s3",
+        stream="PART",
+        config=UrlInputConfig.from_dict(
+            {"path": "https://feldera-basics-tutorial.s3.amazonaws.com/part.json"}
+        ),
+        format=JsonInputFormatConfig(update_format="insert_delete"),
+    )
+    config.add_url_input(
+        name="tutorial-vendor-s3",
+        stream="VENDOR",
+        config=UrlInputConfig.from_dict(
+            {"path": "https://feldera-basics-tutorial.s3.amazonaws.com/vendor.json"}
+        ),
+        format=JsonInputFormatConfig(update_format="insert_delete"),
+    )
+    config.add_url_input(
+        name="tutorial-price-s3",
+        stream="PRICE",
+        config=UrlInputConfig.from_dict(
+            {"path": "https://feldera-basics-tutorial.s3.amazonaws.com/price.json"}
+        ),
+        format=JsonInputFormatConfig(update_format="insert_delete"),
+    )
+
+    config.add_kafka_input(
+        name="tutorial-price-redpanda",
+        stream="PRICE",
+        config=KafkaInputConfig.from_dict(
+            {
+                "topics": ["price"],
+                "group.id": "tutorial-price",
+                "auto.offset.reset": "earliest",
+            }
+        ),
+        format=JsonInputFormatConfig(update_format="insert_delete"),
+    )
+    config.add_kafka_output(
+        name="tutorial-preferred_vendor-redpanda",
+        stream="PREFERRED_VENDOR",
+        config=KafkaOutputConfig.from_dict({"topic": "preferred_vendor"}),
+        format=JsonOutputFormatConfig(),
+    )
+
+    config.save()
+    return config
+
+
+if __name__ == "__main__":
+    run_demo(
+        "Feldera Basics Tutorial",
+        os.path.join(SCRIPT_DIR, "project.sql"),
+        make_config,
+        prepare,
+    )

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -16,8 +16,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-     db:
-       condition: service_healthy
+      db:
+        condition: service_healthy
     stop_grace_period: 0s
     environment:
       - RUST_BACKTRACE=1
@@ -30,14 +30,17 @@ services:
       - --use-auth=${USE_AUTH:-false}
     healthcheck:
       # TODO: add `/status` endpoint.
-      test: ["CMD-SHELL", "curl --fail --request GET --url http://localhost:8080/v0/pipelines"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl --fail --request GET --url http://localhost:8080/v0/pipelines"
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
 
-
   redpanda:
-    profiles: ["demo", "debezium"]
+    profiles: [ "demo", "debezium" ]
     command:
       - redpanda
       - start
@@ -70,16 +73,22 @@ services:
       - 19092:19092
       - 19644:9644
     healthcheck:
-      test: ["CMD-SHELL", "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "rpk cluster health | grep -E 'Healthy:.+true' || exit 1"
+        ]
       interval: 10s
       timeout: 3s
       retries: 5
       start_period: 5s
 
   demo:
-    profiles: ["demo"]
+    profiles: [ "demo" ]
     depends_on:
       pipeline-manager:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
     image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.1.6}
     environment:
@@ -87,8 +96,26 @@ services:
       - REDPANDA_BROKERS=redpanda:9092
       - SECOPS_DEMO_ARGS
       - RUST_LOG=info
+
+    # Run the demos after giving the service some time to initialize
+    # Start the two demos in parallel.  Compilation will still happen serially, but
+    # this way the user will see the two programs and pipelines straight away.
+    # Make sure the script returns an error if one of the demo scripts fails.
     command:
       - bash
       - -c
-      # Run the SecOps demo after giving the service some time to initialize
-      - "sleep 5 && cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile $${SECOPS_DEMO_ARGS}"
+      - |
+        sleep 1
+        (cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile $${SECOPS_DEMO_ARGS})&
+        pid1=$$!
+        echo pid1 $$pid1
+        (cd demo/project_demo06-SupplyChainTutorial && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile)&
+        pid2=$$!
+        wait $$pid1
+        status1=$$?
+        echo SecOps demo script exited with status $$status1
+        wait $$pid2
+        status2=$$?
+        echo SupplyChainTutorial demo script exited with status $$status2
+        if [ $$status1 -ne 0 ]; then exit $$status1; fi
+        if [ $$status2 -ne 0 ]; then exit $$status2; fi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -98,24 +98,9 @@ services:
       - RUST_LOG=info
 
     # Run the demos after giving the service some time to initialize
-    # Start the two demos in parallel.  Compilation will still happen serially, but
-    # this way the user will see the two programs and pipelines straight away.
-    # Make sure the script returns an error if one of the demo scripts fails.
     command:
       - bash
       - -c
       - |
         sleep 1
-        (cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile $${SECOPS_DEMO_ARGS})&
-        pid1=$$!
-        echo pid1 $$pid1
-        (cd demo/project_demo06-SupplyChainTutorial && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile)&
-        pid2=$$!
-        wait $$pid1
-        status1=$$?
-        echo SecOps demo script exited with status $$status1
-        wait $$pid2
-        status2=$$?
-        echo SupplyChainTutorial demo script exited with status $$status2
-        if [ $$status1 -ne 0 ]; then exit $$status1; fi
-        if [ $$status2 -ne 0 ]; then exit $$status2; fi
+        demo/demo-container.sh

--- a/docs/tutorials/basics/part1.md
+++ b/docs/tutorials/basics/part1.md
@@ -21,6 +21,22 @@ Make sure that you have Feldera up and running by following the [Getting
 Started](/intro.md) guide.  Open the Feldera Web Console on
 [localhost:8080](http://localhost:8080).
 
+:::tip For the impatient
+
+If you started Feldera using the demo profile as described in the [Getting
+Started](/intro.md) guide, it has created a couple of SQL programs and
+pipelines.  One of these programs, called
+"Feldera Basics Tutorial" and the associated pipeline
+"Feldera Basics Tutorial Pipeline" are identical to the ones
+we will manually create in this three-part tutorial.
+
+We recommend that you follow the tutorial and build your own Feldera
+pipeline, but if you'd like to accelerate the journey, feel free
+to skim the tutorial and explore the resulting pipeline without
+going through all the steps.
+
+:::
+
 ## Step 1. Declare input tables
 
 We start with modeling input data as SQL tables.  In the Feldera Web Console,

--- a/docs/tutorials/basics/part3.md
+++ b/docs/tutorials/basics/part3.md
@@ -106,6 +106,8 @@ rpk -X brokers=127.0.0.1:19092 cluster metadata
 
 ### Create input/output topics
 
+
+
 Create a pair of Redpanda topics that will be used to send input updates
 to the `PRICE` table and receive output changes from the `PREFERRED_VENDOR` view.
 

--- a/python/dbsp/__init__.py
+++ b/python/dbsp/__init__.py
@@ -13,6 +13,7 @@ from .connector import JsonInputFormatConfig
 from .connector import JsonOutputFormatConfig
 from .connector import JsonParserConfig
 from .connector import JsonEncoderConfig
+from .connector import UrlInputConfig
 from .connector import KafkaInputConfig
 from .connector import KafkaOutputConfig
 from .connector import FileInputConfig

--- a/python/dbsp/connector.py
+++ b/python/dbsp/connector.py
@@ -9,6 +9,7 @@ from feldera_api_client.models.transport_config import TransportConfig
 from feldera_api_client.models.format_config import FormatConfig
 from feldera_api_client.models.input_endpoint_config import InputEndpointConfig
 from feldera_api_client.models.output_endpoint_config import OutputEndpointConfig
+from feldera_api_client.models.url_input_config import UrlInputConfig
 from feldera_api_client.models.kafka_input_config import KafkaInputConfig
 from feldera_api_client.models.kafka_output_config import KafkaOutputConfig
 from feldera_api_client.models.file_input_config import FileInputConfig
@@ -30,12 +31,18 @@ from feldera_api_client.models.connector_descr import ConnectorDescr
 class DBSPConnector:
     "A connector that can be attached to configs."
 
-    def __init__(self, api_client, name: str, transport: "TransportConfig", format: "FormatConfig", description: str = ''):
+    def __init__(
+        self,
+        api_client,
+        name: str,
+        transport: "TransportConfig",
+        format: "FormatConfig",
+        description: str = "",
+    ):
         self.api_client = api_client
         # If the connector already exists we make sure to get its id so it will
         # just update on save
-        response = list_connectors.sync_detailed(
-            client=self.api_client, name=name)
+        response = list_connectors.sync_detailed(client=self.api_client, name=name)
         if isinstance(response.parsed, list):
             self.connector_id = response.parsed[0].connector_id
         else:
@@ -70,7 +77,8 @@ class DBSPConnector:
                 config=ConnectorConfig.from_dict(self.config),
             )
             response = new_connector.sync_detailed(
-                client=self.api_client, json_body=body).unwrap("Failed to create the connector")
+                client=self.api_client, json_body=body
+            ).unwrap("Failed to create the connector")
             self.connector_id = response.connector_id
         else:
             body = UpdateConnectorRequest(
@@ -79,30 +87,32 @@ class DBSPConnector:
                 config=ConnectorConfig.from_dict(self.config),
             )
             response = update_connector.sync_detailed(
-                connector_id=self.connector_id,
-                client=self.api_client, json_body=body).unwrap("Failed to update the connector")
+                connector_id=self.connector_id, client=self.api_client, json_body=body
+            ).unwrap("Failed to update the connector")
 
     def delete(self):
         "Delete the existing connector."
         if self.connector_id is not None:
             delete_connector.sync_detailed(connector_id=self.connector_id).unwrap(
-                "Failed to add the connector")
+                "Failed to add the connector"
+            )
 
 
 class CsvInputFormatConfig(FormatConfig):
     def __init__(self):
-        super().__init__('csv', CsvParserConfig())
+        super().__init__("csv", CsvParserConfig())
 
 
 class CsvOutputFormatConfig(FormatConfig):
     def __init__(self, **csv_config_options):
-        super().__init__('csv', CsvEncoderConfig.from_dict(csv_config_options))
+        super().__init__("csv", CsvEncoderConfig.from_dict(csv_config_options))
+
 
 class JsonInputFormatConfig(FormatConfig):
     def __init__(self, **json_config_options):
-        super().__init__('json', JsonParserConfig.from_dict(json_config_options))
+        super().__init__("json", JsonParserConfig.from_dict(json_config_options))
 
 
 class JsonOutputFormatConfig(FormatConfig):
     def __init__(self, **json_config_options):
-        super().__init__('json', JsonEncoderConfig.from_dict(json_config_options))
+        super().__init__("json", JsonEncoderConfig.from_dict(json_config_options))

--- a/python/dbsp/pipeline.py
+++ b/python/dbsp/pipeline.py
@@ -15,6 +15,7 @@ from feldera_api_client.models.kafka_input_config import KafkaInputConfig
 from feldera_api_client.models.kafka_output_config import KafkaOutputConfig
 from feldera_api_client.models.file_input_config import FileInputConfig
 from feldera_api_client.models.file_output_config import FileOutputConfig
+from feldera_api_client.models.url_input_config import UrlInputConfig
 from feldera_api_client.models.new_pipeline_request import NewPipelineRequest
 from feldera_api_client.models.update_pipeline_request import UpdatePipelineRequest
 from feldera_api_client.models.attached_connector import AttachedConnector
@@ -38,13 +39,19 @@ class DBSPPipelineConfig:
     """Pipeline configuration specified by the user when creating
     a new pipeline instance."""
 
-    def __init__(self, project: DBSPProgram, workers: int, name: str = '<anon>', description: str = ''):
+    def __init__(
+        self,
+        project: DBSPProgram,
+        workers: int,
+        name: str = "<anon>",
+        description: str = "",
+    ):
         self.project = project
         self.api_client = self.project.api_client
         self.pipeline_config = PipelineConfig(
             workers=workers,
             inputs=PipelineConfigInputs(),
-            outputs=PipelineConfigOutputs()
+            outputs=PipelineConfigOutputs(),
         )
         self.pipeline_id = None
         self.pipeline_version = None
@@ -61,14 +68,39 @@ class DBSPPipelineConfig:
         """
         connector.save()
 
-        self.attached_connectors.append(AttachedConnector(
-            connector_id=connector.connector_id,
-            is_input=True,
-            name=uuid.uuid4().hex if name is None else name,
-            relation_name=stream,
-        ))
+        self.attached_connectors.append(
+            AttachedConnector(
+                connector_id=connector.connector_id,
+                is_input=True,
+                name=uuid.uuid4().hex if name is None else name,
+                relation_name=stream,
+            )
+        )
 
-    def add_kafka_input(self, name: str, stream: str, config: KafkaInputConfig, format: FormatConfig):
+    def add_url_input(
+        self, name: str, stream: str, config: UrlInputConfig, format: FormatConfig
+    ):
+        """Add an input connector that reads data from a URL.
+
+        Args:
+            name (str): Name of the input connector.
+            stream (str): The table name to connect to.
+            config (UrlInputConfig): Config for the new URL connector.
+            format (FormatConfig): Data format specification, e.g., CsvInputFormatConfig().
+        """
+        self.add_input(
+            stream,
+            DBSPConnector(
+                self.api_client,
+                name,
+                TransportConfig(name="url", config=config),
+                format=format,
+            ),
+        )
+
+    def add_kafka_input(
+        self, name: str, stream: str, config: KafkaInputConfig, format: FormatConfig
+    ):
         """Add an input connector that reads data from Kafka to the pipeline configuration.
 
         Args:
@@ -79,9 +111,13 @@ class DBSPPipelineConfig:
         """
         self.add_input(
             stream,
-            DBSPConnector(self.api_client, name, TransportConfig(
-                name="kafka",
-                config=config), format=format))
+            DBSPConnector(
+                self.api_client,
+                name,
+                TransportConfig(name="kafka", config=config),
+                format=format,
+            ),
+        )
 
     def add_http_input(self, stream: str, name: str, format: FormatConfig):
         """Add an HTTP input endpoint
@@ -92,11 +128,15 @@ class DBSPPipelineConfig:
         """
         self.add_input(
             stream,
-            DBSPConnector(self.api_client, name, TransportConfig(
-                name="http"), format=format),
-            name = name)
+            DBSPConnector(
+                self.api_client, name, TransportConfig(name="http"), format=format
+            ),
+            name=name,
+        )
 
-    def add_kafka_output(self, name: str, stream: str, config: KafkaOutputConfig, format: FormatConfig):
+    def add_kafka_output(
+        self, name: str, stream: str, config: KafkaOutputConfig, format: FormatConfig
+    ):
         """Add a Kafka output connector to the pipeline configuration.
 
         Args:
@@ -107,9 +147,13 @@ class DBSPPipelineConfig:
         """
         self.add_output(
             stream,
-            DBSPConnector(self.api_client, name, TransportConfig(
-                name="kafka",
-                config=config), format=format))
+            DBSPConnector(
+                self.api_client,
+                name,
+                TransportConfig(name="kafka", config=config),
+                format=format,
+            ),
+        )
 
     def add_output(self, stream: str, connector: DBSPConnector, name: str = None):
         """Add an output connector to the pipeline configuration.
@@ -120,12 +164,14 @@ class DBSPPipelineConfig:
         """
         connector.save()
 
-        self.attached_connectors.append(AttachedConnector(
-            connector_id=connector.connector_id,
-            is_input=False,
-            name=uuid.uuid4().hex if name is None else name,
-            relation_name=stream,
-        ))
+        self.attached_connectors.append(
+            AttachedConnector(
+                connector_id=connector.connector_id,
+                is_input=False,
+                name=uuid.uuid4().hex if name is None else name,
+                relation_name=stream,
+            )
+        )
 
     def add_file_input(self, stream: str, filepath: str, format: FormatConfig):
         """Add an input connector that reads data from a file to the pipeline configuration.
@@ -137,9 +183,16 @@ class DBSPPipelineConfig:
         """
         self.add_input(
             stream,
-            DBSPConnector(self.api_client, filepath, TransportConfig(
-                name="file",
-                config=FileInputConfig.from_dict(dict({'path': filepath}))), format=format))
+            DBSPConnector(
+                self.api_client,
+                filepath,
+                TransportConfig(
+                    name="file",
+                    config=FileInputConfig.from_dict(dict({"path": filepath})),
+                ),
+                format=format,
+            ),
+        )
 
     def add_file_output(self, stream: str, filepath: str, format: FormatConfig):
         """Add an output connector that reads data from a file to the pipeline configuration.
@@ -151,9 +204,16 @@ class DBSPPipelineConfig:
         """
         self.add_output(
             stream,
-            DBSPConnector(self.api_client, filepath, TransportConfig(
-                name="file",
-                config=FileOutputConfig.from_dict(dict({'path': filepath}))), format=format))
+            DBSPConnector(
+                self.api_client,
+                filepath,
+                TransportConfig(
+                    name="file",
+                    config=FileOutputConfig.from_dict(dict({"path": filepath})),
+                ),
+                format=format,
+            ),
+        )
 
     def add_http_output(self, stream: str, name: str, format: FormatConfig):
         """Add an HTTP output endpoint
@@ -164,23 +224,26 @@ class DBSPPipelineConfig:
         """
         self.add_output(
             stream,
-            DBSPConnector(self.api_client, name, TransportConfig(
-                name="http"), format=format),
-            name)
+            DBSPConnector(
+                self.api_client, name, TransportConfig(name="http"), format=format
+            ),
+            name,
+        )
 
     def runtime_config(self) -> str:
         """Produce a pipeline configuration object."""
         config = self.pipeline_config.to_dict().copy()
-        del config['inputs']
-        del config['outputs']
+        del config["inputs"]
+        del config["outputs"]
         return RuntimeConfig.from_dict(config)
 
     def save(self):
         "Save the pipeline configuration to DBSP."
-        resp = list_pipelines.sync_detailed(
-            client=self.api_client, name=self.name)
+        resp = list_pipelines.sync_detailed(client=self.api_client, name=self.name)
         if resp.status_code == HTTPStatus.OK:
-            self.pipeline_id = resp.unwrap("Failed to unwrap pipeline %s" % (self.name))[0].descriptor.pipeline_id
+            self.pipeline_id = resp.unwrap(
+                "Failed to unwrap pipeline %s" % (self.name)
+            )[0].descriptor.pipeline_id
 
         if self.pipeline_id == None:
             body = NewPipelineRequest(
@@ -190,8 +253,9 @@ class DBSPPipelineConfig:
                 config=self.runtime_config(),
                 connectors=self.attached_connectors,
             )
-            response = new_pipeline.sync_detailed(client=self.api_client, json_body=body).unwrap(
-                "Failed to create pipeline config")
+            response = new_pipeline.sync_detailed(
+                client=self.api_client, json_body=body
+            ).unwrap("Failed to create pipeline config")
             self.pipeline_id = response.pipeline_id
             self.pipeline_version = response.version
         else:
@@ -203,7 +267,8 @@ class DBSPPipelineConfig:
                 connectors=self.attached_connectors,
             )
             response = update_pipeline.sync_detailed(
-                pipeline_id=self.pipeline_id, client=self.api_client, json_body=body).unwrap("Failed to update pipeline config")
+                pipeline_id=self.pipeline_id, client=self.api_client, json_body=body
+            ).unwrap("Failed to update pipeline config")
             self.pipeline_version = response.version
 
     def run(self):
@@ -217,7 +282,8 @@ class DBSPPipelineConfig:
         """
         self.save()
         pipeline_action.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id, action='start').unwrap("Failed to start pipeline")
+            client=self.api_client, pipeline_id=self.pipeline_id, action="start"
+        ).unwrap("Failed to start pipeline")
         self.wait_for_status(PipelineStatus.RUNNING, 60.0)
 
     def pause(self):
@@ -228,7 +294,8 @@ class DBSPPipelineConfig:
             dbsp.DBSPServerError: If the DBSP server returns an error.
         """
         pipeline_action.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id, action='pause').unwrap("Failed to pause pipeline")
+            client=self.api_client, pipeline_id=self.pipeline_id, action="pause"
+        ).unwrap("Failed to pause pipeline")
 
     def start(self):
         """Resume a paused pipeline.
@@ -238,7 +305,8 @@ class DBSPPipelineConfig:
             dbsp.DBSPServerError: If the DBSP server returns an error.
         """
         pipeline_action.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id, action='start').unwrap("Failed to start pipeline")
+            client=self.api_client, pipeline_id=self.pipeline_id, action="start"
+        ).unwrap("Failed to start pipeline")
 
     def wait(self, timeout: float = sys.maxsize):
         """Wait for the pipeline to process all inputs to completion.
@@ -253,12 +321,12 @@ class DBSPPipelineConfig:
         start = time.time()
         while time.time() - start < timeout:
             status = self.stats()
-            if status['global_metrics']['pipeline_complete'] == True:
+            if status["global_metrics"]["pipeline_complete"] == True:
                 return
             time.sleep(0.5)
         raise TimeoutException(
-            "Timeout waiting for the pipeline to complete after " + str(timeout) + "s")
-
+            "Timeout waiting for the pipeline to complete after " + str(timeout) + "s"
+        )
 
     def run_to_completion(self, timeout: float = sys.maxsize):
         """Launch a new pipeline, wait for it to run to completion, and delete the pipeline.
@@ -285,18 +353,27 @@ class DBSPPipelineConfig:
             httpx.TimeoutException: If the request takes longer than Client.timeout.
             dbsp.DBSPServerError: If the DBSP server returns an error.
         """
-        status = get_pipeline.sync_detailed(client=self.api_client, pipeline_id=self.pipeline_id).unwrap(
-            "Failed to retrieve pipeline status")
+        status = get_pipeline.sync_detailed(
+            client=self.api_client, pipeline_id=self.pipeline_id
+        ).unwrap("Failed to retrieve pipeline status")
         return status
 
-    def wait_for_status(self, expected_status: PipelineStatus, timeout: float = sys.maxsize):
-        start = time.time();
+    def wait_for_status(
+        self, expected_status: PipelineStatus, timeout: float = sys.maxsize
+    ):
+        start = time.time()
         while True:
-            status = self.status().state.current_status;
+            status = self.status().state.current_status
             if status == expected_status:
                 break
             if time.time() - start > timeout:
-                raise TimeoutException("Timeout waiting for the pipeline to reach expected status " + str(expected_status) + ".  Current status is" + str(status) + ".")
+                raise TimeoutException(
+                    "Timeout waiting for the pipeline to reach expected status "
+                    + str(expected_status)
+                    + ".  Current status is"
+                    + str(status)
+                    + "."
+                )
             time.sleep(0.5)
 
     def stats(self) -> Dict[str, Any]:
@@ -307,7 +384,8 @@ class DBSPPipelineConfig:
             dbsp.DBSPServerError: If the DBSP server returns an error.
         """
         status = pipeline_stats.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id).unwrap("Failed to retrieve pipeline status")
+            client=self.api_client, pipeline_id=self.pipeline_id
+        ).unwrap("Failed to retrieve pipeline status")
         return status.additional_properties
 
     def delete(self):
@@ -322,11 +400,13 @@ class DBSPPipelineConfig:
         """
 
         pipeline_action.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id, action='shutdown').unwrap("Failed to pause pipeline")
+            client=self.api_client, pipeline_id=self.pipeline_id, action="shutdown"
+        ).unwrap("Failed to pause pipeline")
         self.wait_for_status(PipelineStatus.SHUTDOWN, 60.0)
 
         pipeline_delete.sync_detailed(
-            client=self.api_client, pipeline_id=self.pipeline_id).unwrap("Failed to delete pipeline")
+            client=self.api_client, pipeline_id=self.pipeline_id
+        ).unwrap("Failed to delete pipeline")
 
         time.sleep(1.0)
         self.pipeline_id = None

--- a/python/feldera-api-client/feldera_api_client/models/__init__.py
+++ b/python/feldera-api-client/feldera_api_client/models/__init__.py
@@ -68,6 +68,7 @@ from .update_pipeline_request import UpdatePipelineRequest
 from .update_pipeline_response import UpdatePipelineResponse
 from .update_program_request import UpdateProgramRequest
 from .update_program_response import UpdateProgramResponse
+from .url_input_config import UrlInputConfig
 
 __all__ = (
     "AttachedConnector",
@@ -138,4 +139,5 @@ __all__ = (
     "UpdatePipelineResponse",
     "UpdateProgramRequest",
     "UpdateProgramResponse",
+    "UrlInputConfig",
 )

--- a/python/feldera-api-client/feldera_api_client/models/url_input_config.py
+++ b/python/feldera-api-client/feldera_api_client/models/url_input_config.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define, field
+
+T = TypeVar("T", bound="UrlInputConfig")
+
+
+@define
+class UrlInputConfig:
+    """Configuration for reading data from an HTTP or HTTPS URL with
+    [`UrlInputTransport`].
+
+        Attributes:
+            path (str): URL.
+    """
+
+    path: str
+    additional_properties: Dict[str, Any] = field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        path = self.path
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "path": path,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        path = d.pop("path")
+
+        url_input_config = cls(
+            path=path,
+        )
+
+        url_input_config.additional_properties = d
+        return url_input_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
I created a new demo based on the "Feldera: The Basics" tutorial.  The idea is that people who are too lazy to go through all the steps in the tutorial can just play with the resulting pipeline.

- Added missing Python API to create URL input connectors.
- Added `project_demo06-SupplyChainTutorial` demo, which creates and configures the pipeline described in the tutorial using API with one difference:  it doesn't set Kafka broker address in the connectors, so that the pipeline picks them up from the `REDPANDA_BROKERS` env variable. This way the demo works both in docker and locally.
- Modified `docker-compose.yml` to create the new demo, along with the SecOps demo in the demo profile.
  - In the process, added a dependency on the redpanda container to the demo, so it doesn't start until redpanda is up and running, and reduced the demo startup timeout from 5 to 1 seconds.  Perhaps even that is unnecessary.
- Updated the tutorial to point impatient users to the pre-made demo.

One issue with this is that we now compile two programs when running with `--profile demo`, so it takes longer for the demo pipeline to become available.  We could use a separate profile for the tutorial, but that's going to become confusing and unwieldy.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
