### PR TITLE
[SQL] compiler bugfixes in JIT code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `--lenient` SQL compiler flag to allow views with multiple
+  columns with the same name.
 - Added a demo based on the "Feldera: The Basics" tutorial.  People who don't
   want to manually complete all steps in the tutorial can instead play with the
   pre-built pipeline.

--- a/docs/contributors/compiler.md
+++ b/docs/contributors/compiler.md
@@ -41,6 +41,10 @@ Usage: sql-to-dbsp [options] Input file to compile
   Options:
     -h, --help, -?
       Show this message and exit
+    --lenient
+      Lenient SQL validation.  If true it allows duplicate column names in a 
+      view 
+      Default: false
     -O
       Optimization level (0, 1, or 2)
       Default: 2
@@ -75,6 +79,9 @@ Usage: sql-to-dbsp [options] Input file to compile
       Emit a JSON file containing the schema of all views and tables involved
     -o
       Output file; stdout if null
+    -q
+      Quiet: do not print warnings
+      Default: false      
 $ ./sql-to-dbsp x.sql -o ../temp/src/lib.rs
 ```
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -108,6 +108,9 @@ public class CompilerOptions {
         @Parameter(names = "-d", description = "SQL syntax dialect used",
                    converter = SqlLexicalRulesConverter.class)
         public Lex lexicalRules;
+        @Parameter(names = "--lenient",
+                description = "Lenient SQL validation.  If true it allows duplicate column names in a view")
+        public boolean lenient = false;
 
         IO() {
             this.lexicalRules = Lex.ORACLE;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -83,7 +83,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     /**
      * Where does the compiled program come from?
      */
-    enum InputSource {
+    public enum InputSource {
         /**
          * No data source set yet.
          */
@@ -184,8 +184,10 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         if (warning)
             this.hasWarnings = true;
         this.messages.reportError(range, warning, errorType, message);
-        if (!warning && this.options.optimizerOptions.throwOnError)
+        if (!warning && this.options.optimizerOptions.throwOnError) {
+            System.err.println(this.messages);
             throw new CompilationError("Error during compilation");
+        }
     }
 
     /**

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitInnerVisitor.java
@@ -301,8 +301,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
     }
 
     JITInstruction add(JITInstruction instruction) {
-        this.getCurrentBlock().add(instruction);
-        return instruction;
+        return this.getCurrentBlock().add(instruction);
     }
 
     void newContext() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitInnerVisitor.java
@@ -290,9 +290,6 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
     }
 
     public JITInstructionRef constantBool(boolean value) {
-        JITInstructionRef exists = this.getCurrentBlock().getBooleanConstant(value);
-        if (exists.isValid())
-            return exists;
         return this.accept(new DBSPBoolLiteral(value)).value;
     }
 
@@ -300,7 +297,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
         return this.jitVisitor.scalarType(expression.getType());
     }
 
-    JITInstruction add(JITInstruction instruction) {
+    JITInstructionRef add(JITInstruction instruction) {
         return this.getCurrentBlock().add(instruction);
     }
 
@@ -380,7 +377,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
                 isNull = arg;
             else  {
                 isNull = this.insertBinary(JITBinaryInstruction.Operation.OR,
-                        isNull, arg, JITBoolType.INSTANCE, "");
+                        isNull, arg, JITBoolType.INSTANCE, expression.toString());
             }
         }
 
@@ -403,7 +400,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
 
         JITScalarType jitResultType = this.convertType(resultType).to(JITScalarType.class);
         long id = this.nextInstructionId();
-        JITInstruction call = this.add(new JITFunctionCall(id, name, args, argumentTypes, jitResultType));
+        JITInstructionRef call = this.add(new JITFunctionCall(id, name, args, argumentTypes, jitResultType));
         JITInstructionPair result;
 
         if (isNull.isValid()) {
@@ -415,7 +412,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
             JITInstructionRef param;
             if (resultType.code != VOID) {
                 param = this.addParameter(nextBlock, jitResultType);
-                next.addArgument(call.getInstructionReference());
+                next.addArgument(call);
             } else {
                 param = JITInstructionRef.INVALID;
             }
@@ -562,13 +559,12 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
         boolean mayBeNull = expression.getType().mayBeNull;
         JITConstantInstruction value = new JITConstantInstruction(
                 this.nextInstructionId(), type, literal, true);
-        this.add(value);
-
+        JITInstructionRef valueInstr = this.add(value);
         JITInstructionRef isNull = JITInstructionRef.INVALID;
         if (mayBeNull) {
             isNull = this.constantBool(expression.isNull);
         }
-        JITInstructionPair pair = new JITInstructionPair(value.getInstructionReference(), isNull);
+        JITInstructionPair pair = new JITInstructionPair(valueInstr, isNull);
         this.map(expression, pair);
         return VisitDecision.STOP;
     }
@@ -695,9 +691,8 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
         if (sourceType.equals(destType))
             // This can happen for casts that only change nullability
             return source;
-        JITInstruction cast = this.add(new JITCastInstruction(
+        return this.add(new JITCastInstruction(
                 this.nextInstructionId(), source, sourceType, destType, comment));
-        return cast.getInstructionReference();
     }
 
     /**
@@ -718,24 +713,22 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
         condition.mustBeValid();
         left.mustBeValid();
         right.mustBeValid();
-        JITInstructionRef False = this.getCurrentBlock().getBooleanConstant(false);
-        JITInstructionRef True = this.getCurrentBlock().getBooleanConstant(true);
+        JITInstructionRef False = this.constantBool(false);
+        JITInstructionRef True = this.constantBool(true);
 
         if (condition.equals(False))
             return right;
         if (condition.equals(True))
             return left;
-        JITInstruction mux = this.add(new JITMuxInstruction(this.nextInstructionId(),
+        return this.add(new JITMuxInstruction(this.nextInstructionId(),
                 condition, left, right, valueType, comment));
-        return mux.getInstructionReference();
     }
 
     JITInstructionRef insertUnary(JITUnaryInstruction.Operation opcode,
                                   JITInstructionRef operand, JITType type, String comment) {
         operand.mustBeValid();
-        JITInstruction result = this.add(
+        return this.add(
                 new JITUnaryInstruction(this.nextInstructionId(), opcode, operand, type, comment));
-        return result.getInstructionReference();
     }
 
     JITInstructionRef insertBinary(JITBinaryInstruction.Operation opcode,
@@ -743,9 +736,8 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
                                 JITType type, String comment) {
         left.mustBeValid();
         right.mustBeValid();
-        JITInstruction result = this.add(new JITBinaryInstruction(
+        return this.add(new JITBinaryInstruction(
                 this.nextInstructionId(), opcode, left, right, type, comment));
-        return result.getInstructionReference();
     }
 
     JITInstructionRef addParameter(JITBlock block, JITType type) {
@@ -891,11 +883,11 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
             // TODO: replace with uninit
             DBSPLiteral numericZero = numeric.getZero();
             JITLiteral jitZero = new JITLiteral(numericZero, type);
-            JITInstruction zero = this.add(
+            JITInstructionRef zero = this.add(
                     new JITConstantInstruction(this.nextInstructionId(), type, jitZero, true));
             // (right == 0)
             JITInstructionRef compare = this.insertBinary(JITBinaryInstruction.Operation.EQ,
-                    zero.getInstructionReference(), right.value, type, "");
+                    zero, right.value, type, "");
             JITBlock isZero = this.newBlock();
             JITBlock isNotZero = this.newBlock();
             JITBlock next = this.newBlock();
@@ -912,7 +904,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
             JITBlockDestination zeroToNext = next.createDestination();
             zeroToNext.addArgument(True);
             // result can be 0
-            zeroToNext.addArgument(zero.getInstructionReference());
+            zeroToNext.addArgument(zero);
             JITJumpTerminator jump = new JITJumpTerminator(zeroToNext);
             isZero.terminate(jump);
 
@@ -1197,11 +1189,11 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
 
     @Override
     public VisitDecision preorder(DBSPFieldExpression expression) {
-        JITInstruction isNull = null;
+        JITInstructionRef isNull = JITInstructionRef.INVALID;
         JITInstructionPair sourceId = this.accept(expression.expression);
         JITRowType sourceType = this.typeCatalog.convertTupleType(
                 expression.expression.getType(), this.jitVisitor);
-        JITInstruction load = this.add(new JITLoadInstruction(
+        JITInstructionRef load = this.add(new JITLoadInstruction(
                 this.nextInstructionId(), sourceId.value, sourceType,
                 expression.fieldNo, convertScalarType(expression), expression.toString()));
         if (needsNull(expression)) {
@@ -1231,7 +1223,7 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
         if (type.isScalarType()) {
             JITScalarType scalarType = type.to(JITScalarType.class);
             if (!needsNull(expression)) {
-                JITInstruction copy = this.add(new JITCopyInstruction(this.nextInstructionId(), source.value, scalarType));
+                JITInstructionRef copy = this.add(new JITCopyInstruction(this.nextInstructionId(), source.value, scalarType));
                 this.map(expression, new JITInstructionPair(copy));
                 return VisitDecision.STOP;
             } else {
@@ -1243,17 +1235,17 @@ public class ToJitInnerVisitor extends InnerVisitor implements IWritesLogs {
                 this.getCurrentBlock().terminate(branch);
                 this.setCurrentBlock(isNull);
 
-                JITInstruction uninit = this.add(new JITUninitInstruction(
+                JITInstructionRef uninit = this.add(new JITUninitInstruction(
                         this.nextInstructionId(), scalarType, "if (" + expression + ").is_null"));
                 JITBlockDestination nextDestination = next.createDestination();
-                nextDestination.addArgument(uninit.getInstructionReference());
+                nextDestination.addArgument(uninit);
                 JITJumpTerminator jump = new JITJumpTerminator(nextDestination);
                 this.getCurrentBlock().terminate(jump);
 
                 this.setCurrentBlock(isNotNull);
-                JITInstruction copy = this.add(new JITCopyInstruction(this.nextInstructionId(), source.value, scalarType));
+                JITInstructionRef copy = this.add(new JITCopyInstruction(this.nextInstructionId(), source.value, scalarType));
                 nextDestination = next.createDestination();
-                nextDestination.addArgument(copy.getInstructionReference());
+                nextDestination.addArgument(copy);
                 jump = new JITJumpTerminator(nextDestination);
                 this.getCurrentBlock().terminate(jump);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ToJitVisitor.java
@@ -112,18 +112,18 @@ public class ToJitVisitor extends CircuitVisitor implements IWritesLogs {
                 .newline();
 
         IRTransform normalizer = this.normalizer(simpleParameters);
-        function = normalizer.apply(function).to(DBSPClosureExpression.class);
-        function = this.tupleEachParameter(function);
+        final DBSPClosureExpression function0 = normalizer.apply(function).to(DBSPClosureExpression.class);
+        final DBSPClosureExpression function1 = this.tupleEachParameter(function0);
 
         Logger.INSTANCE.belowLevel(this, 4)
                 .append("Converting function to JIT")
                 .newline()
-                .append(function.toString())
+                .append(function1.toString())
                 .newline();
-        DBSPType resultType = function.getResultType();
+        DBSPType resultType = function1.getResultType();
         JITParameterMapping mapping = new JITParameterMapping(this.getTypeCatalog());
 
-        for (DBSPParameter param: function.parameters)
+        for (DBSPParameter param: function1.parameters)
             mapping.addParameter(param, JITParameter.Direction.IN, this);
 
         // If the result type is a scalar, it is marked as a result type.
@@ -131,7 +131,7 @@ public class ToJitVisitor extends CircuitVisitor implements IWritesLogs {
         JITScalarType returnType = mapping.addReturn(resultType, this);
 
         List<JITBlock> blocks = ToJitInnerVisitor.convertClosure(
-                this.errorReporter, this, mapping, function, this.getTypeCatalog());
+                this.errorReporter, this, mapping, function1, this.getTypeCatalog());
         JITFunction result = new JITFunction(mapping.parameters, blocks, returnType);
         Logger.INSTANCE.belowLevel(this, 4)
                 .append(result.toAssembly())

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/cfg/JITBlock.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/cfg/JITBlock.java
@@ -107,7 +107,7 @@ public class JITBlock extends JITNode implements IJITId {
         return instruction.getInstructionReference();
     }
 
-    public void add(JITInstruction instruction) {
+    public JITInstruction add(JITInstruction instruction) {
         if (this.terminator != null)
             throw new InternalCompilerError("Block already terminated while adding instruction ", instruction);
         this.instructions.add(instruction);
@@ -115,11 +115,12 @@ public class JITBlock extends JITNode implements IJITId {
             JITConstantInstruction cst = instruction.to(JITConstantInstruction.class);
             if (cst.value.literal.is(DBSPBoolLiteral.class)) {
                 DBSPBoolLiteral lit = cst.value.literal.to(DBSPBoolLiteral.class);
-                if (cst.value.literal.isNull) return;
+                if (cst.value.literal.isNull) return instruction;
                 boolean b = Objects.requireNonNull(lit.value);
                 this.constants.put(b, instruction);
             }
         }
+        return instruction;
     }
 
     public JITInstructionRef addParameter(JITReference instruction, JITType type) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/cfg/JITBlock.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/cfg/JITBlock.java
@@ -95,6 +95,7 @@ public class JITBlock extends JITNode implements IJITId {
         if (this.terminator != null)
             throw new InternalCompilerError("Block already terminated while adding instruction ", instruction);
         for (JITInstruction existing: this.instructions) {
+            // It's probably best to compare in this direction
             if (instruction.same(existing))
                 return existing.getInstructionReference();
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITBinaryInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITBinaryInstruction.java
@@ -65,7 +65,6 @@ public class JITBinaryInstruction extends JITInstruction {
     public final JITInstructionRef right;
     public final JITType type;
 
-
     public JITBinaryInstruction(long id, Operation operation,
                                 JITInstructionRef left,
                                 JITInstructionRef right,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITBinaryInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITBinaryInstruction.java
@@ -103,4 +103,14 @@ public class JITBinaryInstruction extends JITInstruction {
                 .append(" ")
                 .append(this.right);
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITBinaryInstruction ob = other.as(JITBinaryInstruction.class);
+        if (ob == null)
+            return false;
+        return this.left.equals(ob.left) &&
+                this.right.equals(ob.right) &&
+                this.operation.equals(ob.operation);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCastInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCastInstruction.java
@@ -29,8 +29,6 @@ import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITNode;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ir.types.JITType;
 import org.dbsp.util.IIndentStream;
 
-import java.util.Optional;
-
 public class JITCastInstruction extends JITInstruction {
     public final JITInstructionRef operand;
     public final JITType sourceType;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCastInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCastInstruction.java
@@ -29,6 +29,8 @@ import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITNode;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ir.types.JITType;
 import org.dbsp.util.IIndentStream;
 
+import java.util.Optional;
+
 public class JITCastInstruction extends JITInstruction {
     public final JITInstructionRef operand;
     public final JITType sourceType;
@@ -63,5 +65,15 @@ public class JITCastInstruction extends JITInstruction {
                 .append(this.operand)
                 .append(" as ")
                 .append(this.destinationType);
+    }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITCastInstruction oc = other.as(JITCastInstruction.class);
+        if (oc == null)
+            return false;
+        return this.operand.equals(oc.operand) &&
+                this.sourceType.sameType(oc.sourceType) &&
+                this.destinationType.sameType(oc.destinationType);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITConstantInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITConstantInstruction.java
@@ -65,6 +65,15 @@ public class JITConstantInstruction extends JITInstruction {
     }
 
     @Override
+    public boolean same(JITInstruction other) {
+        JITConstantInstruction oc = other.as(JITConstantInstruction.class);
+        if (oc == null)
+            return false;
+        return this.type.sameType(oc.type) &&
+                this.value.literal.sameValue(oc.value.literal);
+    }
+
+    @Override
     public IIndentStream toString(IIndentStream builder) {
         return super.toString(builder)
                 .append(" ")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
@@ -29,6 +29,8 @@ import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITNode;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ir.types.JITScalarType;
 import org.dbsp.util.IIndentStream;
 
+import java.util.Optional;
+
 public class JITCopyInstruction extends JITInstruction {
     public final JITInstructionRef operand;
     public final JITScalarType type;
@@ -52,5 +54,13 @@ public class JITCopyInstruction extends JITInstruction {
         return super.toString(builder)
                 .append(" ")
                 .append(this.operand);
+    }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITCopyInstruction oc = other.as(JITCopyInstruction.class);
+        if (oc == null)
+            return false;
+        return this.operand.equals(oc.operand);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
@@ -56,9 +56,7 @@ public class JITCopyInstruction extends JITInstruction {
 
     @Override
     public boolean same(JITInstruction other) {
-        JITCopyInstruction oc = other.as(JITCopyInstruction.class);
-        if (oc == null)
-            return false;
-        return this.operand.equals(oc.operand);
+        // Two copy instructions are never equivalent due to the side effects
+        return false;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITCopyInstruction.java
@@ -29,8 +29,6 @@ import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITNode;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ir.types.JITScalarType;
 import org.dbsp.util.IIndentStream;
 
-import java.util.Optional;
-
 public class JITCopyInstruction extends JITInstruction {
     public final JITInstructionRef operand;
     public final JITScalarType type;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITFunctionCall.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITFunctionCall.java
@@ -55,6 +55,13 @@ public class JITFunctionCall extends JITInstruction {
     }
 
     @Override
+    public boolean same(JITInstruction other) {
+        // Currently two function calls are never considered to be the same.
+        // Perhaps this should be revisited.
+        return false;
+    }
+
+    @Override
     public BaseJsonNode instructionAsJson() {
         // { "Call": {
         //    "function": "some.func",

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITInstruction.java
@@ -97,4 +97,13 @@ public abstract class JITInstruction extends JITNode implements IJITId {
         this.toString(str);
         return sps.toString();
     }
+
+    /**
+     * True if these two instructions are equivalent.
+     * This means that they perform the same operation on the same inputs.
+     * In general, instructions that have side-effects are never equivalent to other instructions.
+     * (This would assume that the two instructions are in the same basic block, but
+     *  that is not checked).
+     */
+    public abstract boolean same(JITInstruction other);
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITIsNullInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITIsNullInstruction.java
@@ -58,4 +58,13 @@ public class JITIsNullInstruction extends JITInstruction {
                 .append(this.column)
                 .append("]");
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITIsNullInstruction on = other.as(JITIsNullInstruction.class);
+        if (on == null)
+            return false;
+        return this.target.equals(on.target) &&
+                this.column == on.column;
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITLoadInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITLoadInstruction.java
@@ -69,4 +69,14 @@ public class JITLoadInstruction extends JITInstruction {
                 .append(this.column)
                 .append("]");
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITLoadInstruction ol = other.as(JITLoadInstruction.class);
+        if (ol == null)
+            return false;
+        return this.source.equals(ol.source) &&
+                this.column == ol.column &&
+                this.sourceType.sameType(ol.sourceType);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITMuxInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITMuxInstruction.java
@@ -68,4 +68,14 @@ public class JITMuxInstruction extends JITInstruction {
                 .append(" : ")
                 .append(this.right);
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITMuxInstruction oc = other.as(JITMuxInstruction.class);
+        if (oc == null)
+            return false;
+        return this.condition.equals(oc.condition) &&
+                this.left.equals(oc.left) &&
+                this.right.equals(oc.right);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITSetNullInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITSetNullInstruction.java
@@ -70,4 +70,10 @@ public class JITSetNullInstruction extends JITInstruction {
                 .append("]=")
                 .append(this.source);
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        // Two instructions that setnull are never considered to be equivalent.
+        return false;
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITStoreInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITStoreInstruction.java
@@ -78,4 +78,11 @@ public class JITStoreInstruction extends JITInstruction {
                 .append("]=")
                 .append(this.source);
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        // Two store instructions are never considered the same
+        // even if they have the same operands.
+        return false;
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUnaryInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUnaryInstruction.java
@@ -50,8 +50,9 @@ public class JITUnaryInstruction extends JITInstruction {
     public final JITInstructionRef operand;
     public final JITType type;
 
-    public JITUnaryInstruction(long id, Operation operation, JITInstructionRef operand, JITType type) {
-        super(id, "UnaryOp");
+    public JITUnaryInstruction(long id, Operation operation, JITInstructionRef operand, JITType type,
+                               String comment) {
+        super(id, "UnaryOp", comment);
         this.operation = operation;
         this.operand = operand;
         this.type = type;
@@ -73,7 +74,8 @@ public class JITUnaryInstruction extends JITInstruction {
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append(this.id)
+        return this.commentToString(builder)
+                .append(this.id)
                 .append(" ")
                 .append(this.operation.toString())
                 .append(" ")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUnaryInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUnaryInstruction.java
@@ -81,4 +81,13 @@ public class JITUnaryInstruction extends JITInstruction {
                 .append(" ")
                 .append(this.operand);
     }
+
+    @Override
+    public boolean same(JITInstruction other) {
+        JITUnaryInstruction ob = other.as(JITUnaryInstruction.class);
+        if (ob == null)
+            return false;
+        return this.operand.equals(ob.operand) &&
+                this.operation.equals(ob.operation);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUninitInstruction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/instructions/JITUninitInstruction.java
@@ -45,6 +45,12 @@ public class JITUninitInstruction extends JITInstruction {
     }
 
     @Override
+    public boolean same(JITInstruction other) {
+        // Two uninit instructions are never considered the same.
+        return false;
+    }
+
+    @Override
     protected BaseJsonNode instructionAsJson() {
         ObjectNode result = jsonFactory().createObjectNode();
         ObjectNode valueNode = result.putObject("value");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITKVType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITKVType.java
@@ -55,6 +55,15 @@ public class JITKVType extends JITType implements IJitKvOrRowType {
     }
 
     @Override
+    public boolean sameType(JITType other) {
+        JITKVType ok = other.as(JITKVType.class);
+        if (ok == null)
+            return false;
+        return this.key.sameType(ok.key) &&
+                this.value.sameType(ok.value);
+    }
+
+    @Override
     public void addDescriptionTo(ObjectNode parent, String label) {
         ObjectNode map = parent.putObject(label);
         ArrayNode array = map.putArray("Map");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITRowType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITRowType.java
@@ -62,6 +62,11 @@ public class JITRowType extends JITType implements IJITId, IJitKvOrRowType {
         public String toString() {
             return (this.nullable ? "?" : "") + this.type;
         }
+
+        public boolean sameType(NullableScalarType other) {
+            return this.nullable == other.nullable &&
+                    this.type.sameType(other.type);
+        }
     }
 
     public final long id;
@@ -124,6 +129,19 @@ public class JITRowType extends JITType implements IJITId, IJitKvOrRowType {
     @Override
     public IIndentStream toString(IIndentStream builder) {
         return builder.append(this.toString());
+    }
+
+    @Override
+    public boolean sameType(JITType other) {
+        JITRowType or = other.as(JITRowType.class);
+        if (or == null)
+            return false;
+        if (this.fields.size() != or.fields.size())
+            return false;
+        for (int i = 0; i < this.fields.size(); i++)
+            if (!this.fields.get(i).sameType(or.fields.get(i)))
+                return false;
+        return true;
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITScalarType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITScalarType.java
@@ -48,6 +48,11 @@ public class JITScalarType extends JITType {
     }
 
     @Override
+    public boolean sameType(JITType other) {
+        return this.code == other.code;
+    }
+
+    @Override
     public String toString() {
         if (this.code.jitName.isEmpty())
             throw new UnimplementedException("Type " + Utilities.singleQuote(this.code.toString()) +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITType.java
@@ -43,4 +43,9 @@ public abstract class JITType extends JITNode {
     public IIndentStream toString(IIndentStream builder) {
         return builder.append(this.toString());
     }
+
+    /**
+     * True if these two types are equivalent: same fields, same types.
+     */
+    public abstract boolean sameType(JITType other);
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -334,7 +334,7 @@ public class AggregateCompiler implements ICompilerComponent {
 
         if (aggregatedValueType.mayBeNull)
             plusOne = new DBSPUnaryExpression(node, new DBSPTypeInteger(CalciteObject.EMPTY, INT64,64, true,false),
-                    DBSPOpcode.INDICATOR, aggregatedValue);
+                    DBSPOpcode.INDICATOR, aggregatedValue.deepCopy());
         if (this.isDistinct) {
             count = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPAggregate.java
@@ -213,12 +213,12 @@ public class DBSPAggregate extends DBSPNode implements IDBSPInnerNode {
 
         List<DBSPStatement> body = new ArrayList<>();
         List<DBSPExpression> tmps = new ArrayList<>();
+        int start = 0;
         for (int i = 0; i < closures.length; i++) {
             DBSPClosureExpression closure = closures[i];
             String tmp = "tmp" + i;
             DBSPExpression[] args = new DBSPExpression[closure.parameters.length];
             for (int j = 0; j < args.length; j++) {
-                int start = 0;
                 DBSPType paramType = closure.parameters[j].getType();
                 if (paramType.is(DBSPTypeRef.class))
                     paramType = paramType.to(DBSPTypeRef.class).type;
@@ -226,12 +226,13 @@ public class DBSPAggregate extends DBSPNode implements IDBSPInnerNode {
                     DBSPTypeTupleBase tuple = paramType.to(DBSPTypeTupleBase.class);
                     DBSPExpression[] argFields = new DBSPExpression[tuple.size()];
                     for (int k = 0; k < tuple.size(); k++) {
-                        argFields[k] = resultParams[j].field(i + start);
+                        argFields[k] = resultParams[j].field(start);
                         start++;
                     }
                     args[j] = tuple.makeTuple(argFields);
                 } else {
-                    args[j] = resultParams[j].field(i + start);
+                    args[j] = resultParams[j].field(start);
+                    start++;
                 }
             }
             DBSPExpression init = closure.call(args);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -662,6 +662,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                 CompilerOptions compilerOptions = new CompilerOptions();
                 compilerOptions.optimizerOptions.incrementalize = incremental.get();
                 compilerOptions.optimizerOptions.throwOnError = options.stopAtFirstError;
+                compilerOptions.ioOptions.lenient = true;
                 DBSPExecutor result = new DBSPExecutor(options, compilerOptions, "csv");
                 Set<String> bugs = options.readBugsFile();
                 result.avoid(bugs);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
@@ -148,7 +148,7 @@ public class DbspJdbcExecutor extends DBSPExecutor {
                 rows.add(row);
             }
             rs.close();
-            if (rows.size() == 0)
+            if (rows.isEmpty())
                 return new DBSPZSetLiteral(new DBSPTypeTuple(colTypes), new DBSPTypeWeight());
             return new DBSPZSetLiteral(new DBSPTypeWeight(), rows.toArray(new DBSPExpression[0]));
         }
@@ -286,6 +286,7 @@ public class DbspJdbcExecutor extends DBSPExecutor {
                         .as(DBSPExecutor.class);
                 CompilerOptions compilerOptions = Objects.requireNonNull(dbsp).compilerOptions;
                 compilerOptions.optimizerOptions.throwOnError = options.stopAtFirstError;
+                compilerOptions.ioOptions.lenient = true;
                 DbspJdbcExecutor result = new DbspJdbcExecutor(
                         Objects.requireNonNull(inner), options, compilerOptions);
                 Set<String> bugs = options.readBugsFile();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
@@ -10,13 +10,10 @@ import net.hydromatic.sqllogictest.SqlTestQueryOutputDescription;
 import net.hydromatic.sqllogictest.TestStatistics;
 import net.hydromatic.sqllogictest.executors.JdbcExecutor;
 import net.hydromatic.sqllogictest.executors.SqlSltTestExecutor;
-import org.dbsp.sqlCompiler.compiler.StderrErrorReporter;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.backend.ToCsvVisitor;
-import org.dbsp.sqlCompiler.compiler.backend.ToSqlVisitor;
 import org.dbsp.sqlCompiler.compiler.backend.jit.JitFileAndSerialization;
 import org.dbsp.sqlCompiler.compiler.backend.jit.JitIODescription;
 import org.dbsp.sqlCompiler.compiler.backend.jit.JitSerializationKind;
@@ -24,7 +21,7 @@ import org.dbsp.sqlCompiler.compiler.backend.jit.ToJitVisitor;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITProgram;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.*;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeZSet;
 import org.dbsp.sqllogictest.SqlTestPrepareInput;
@@ -325,7 +322,133 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
         }
     }
 
-    static final IErrorReporter errorReporter = new StderrErrorReporter();
+    Row getValue(DBSPTupleExpression rs, String columnTypes) {
+        Row row = new Row();
+        for(int i = 0; i < columnTypes.length(); ++i) {
+            char c = columnTypes.charAt(i);
+            DBSPLiteral value = rs.get(i).to(DBSPLiteral.class);
+            if (value.isNull) {
+                row.add("NULL");
+                continue;
+            }
+            switch (c) {
+                case 'I': {
+                    long integer;
+                    switch (value.getType().code) {
+                        case BOOL:
+                            integer = Objects.requireNonNull(value.to(DBSPBoolLiteral.class).value) ? 1 : 0;
+                            break;
+                        case DECIMAL:
+                            integer = Objects.requireNonNull(value.to(DBSPDecimalLiteral.class).value).longValue();
+                            break;
+                        case DOUBLE:
+                            integer = Objects.requireNonNull(value.to(DBSPDoubleLiteral.class).value).longValue();
+                            break;
+                        case FLOAT:
+                            integer = Objects.requireNonNull(value.to(DBSPFloatLiteral.class).value).longValue();
+                            break;
+                        case INT32:
+                            integer = Objects.requireNonNull(value.to(DBSPI32Literal.class).value);
+                            break;
+                        case INT64:
+                            integer = Objects.requireNonNull(value.to(DBSPI64Literal.class).value);
+                            break;
+                        case STRING:
+                            try {
+                                integer = Long.parseLong(Objects.requireNonNull(value.to(DBSPStringLiteral.class).value));
+                            } catch (NumberFormatException ex) {
+                                integer = 0;
+                            }
+                            break;
+                        default:
+                            integer = 0;
+                            break;
+                    }
+                    row.add(String.format("%d", integer));
+                    break;
+                }
+                case 'R': {
+                    double d;
+                    switch (value.getType().code) {
+                        case BOOL:
+                            d = Objects.requireNonNull(value.to(DBSPBoolLiteral.class).value) ? 1 : 0;
+                            break;
+                        case DECIMAL:
+                            d = Objects.requireNonNull(value.to(DBSPDecimalLiteral.class).value).doubleValue();
+                            break;
+                        case DOUBLE:
+                            d = Objects.requireNonNull(value.to(DBSPDoubleLiteral.class).value);
+                            break;
+                        case FLOAT:
+                            d = Objects.requireNonNull(value.to(DBSPFloatLiteral.class).value);
+                            break;
+                        case INT32:
+                            d = Objects.requireNonNull(value.to(DBSPI32Literal.class).value);
+                            break;
+                        case INT64:
+                            d = Objects.requireNonNull(value.to(DBSPI64Literal.class).value);
+                            break;
+                        case STRING:
+                            try {
+                                d = Double.parseDouble(Objects.requireNonNull(value.to(DBSPStringLiteral.class).value));
+                            } catch (NumberFormatException ex) {
+                                d = 0;
+                            }
+                            break;
+                        default:
+                            d = 0;
+                            break;
+                    }
+                    row.add(String.format("%.3f", d));
+                    break;
+                }
+                case 'T': {
+                    String s;
+                    switch (value.getType().code) {
+                        case BOOL:
+                            s = Objects.requireNonNull(value.to(DBSPBoolLiteral.class).value) ? "1" : "0";
+                            break;
+                        case DECIMAL:
+                            s = Objects.requireNonNull(value.to(DBSPDecimalLiteral.class).value).toString();
+                            break;
+                        case DOUBLE:
+                            s = Objects.requireNonNull(value.to(DBSPDoubleLiteral.class).value).toString();
+                            break;
+                        case FLOAT:
+                            s = Objects.requireNonNull(value.to(DBSPFloatLiteral.class).value).toString();
+                            break;
+                        case INT32:
+                            s = Objects.requireNonNull(value.to(DBSPI32Literal.class).value).toString();
+                            break;
+                        case INT64:
+                            s = Objects.requireNonNull(value.to(DBSPI64Literal.class).value).toString();
+                            break;
+                        case STRING:
+                            s = Objects.requireNonNull(value.to(DBSPStringLiteral.class).value);
+                            break;
+                        default:
+                            throw new RuntimeException("Unexpected type " + value);
+                    }
+                    StringBuilder result = new StringBuilder();
+
+                    for (int j = 0; j < s.length(); ++j) {
+                        char sc = s.charAt(j);
+                        if (sc < ' ' || sc > '~') {
+                            sc = '@';
+                        }
+
+                        result.append(sc);
+                    }
+
+                    row.add(result.toString());
+                    break;
+                }
+                default:
+                    throw new RuntimeException("Unexpected column type " + c);
+            }
+        }
+        return row;
+    }
 
     /**
      * Validate output.  Return 'true' if we need to stop executing.
@@ -335,8 +458,6 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
                            DBSPZSetLiteral.Contents actual,
                            SqlTestQueryOutputDescription description,
                            TestStatistics statistics) throws NoSuchAlgorithmException {
-        StringBuilder builder = new StringBuilder();
-        ToSqlVisitor visitor = new ToSqlVisitor(errorReporter, builder);
         Rows rows = new Rows();
         for (Map.Entry<DBSPExpression, Long> entry: actual.data.entrySet()) {
             if (entry.getValue() <= 0)
@@ -345,14 +466,7 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
                                 "Produced negative result", entry.toString(), null));
             for (long i = 0; i < entry.getValue(); i++) {
                 DBSPTupleExpression tuple = entry.getKey().to(DBSPTupleExpression.class);
-                Row row = new Row();
-                for (int j = 0; j < tuple.size(); j++) {
-                    DBSPExpression expr = tuple.get(j);
-                    // clear builder
-                    builder.setLength(0);
-                    expr.accept(visitor);
-                    row.add(builder.toString());
-                }
+                Row row = this.getValue(tuple, Objects.requireNonNull(description.columnTypes));
                 rows.add(row);
             }
         }
@@ -410,7 +524,7 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
                 options.stopAtFirstError, options.verbosity);
         result.incFiles();
         int queryNo = 0;
-        int skip = 758;  // used only for debugging
+        int skip = 0;  // used only for debugging
         for (ISqlTestOperation operation : testFile.fileContents) {
             SltSqlStatement stat = operation.as(SltSqlStatement.class);
             if (stat != null) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
@@ -410,7 +410,7 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
                 options.stopAtFirstError, options.verbosity);
         result.incFiles();
         int queryNo = 0;
-        int skip = 0;  // used only for debugging
+        int skip = 758;  // used only for debugging
         for (ISqlTestOperation operation : testFile.fileContents) {
             SltSqlStatement stat = operation.as(SltSqlStatement.class);
             if (stat != null) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -178,7 +178,6 @@ public class Utilities {
     public static void runProcess(String directory, Map<String, String> environment, String[] commands)
             throws IOException, InterruptedException {
         File out = File.createTempFile("out", ".tmp", new File("."));
-        out.deleteOnExit();
         ProcessBuilder processBuilder = new ProcessBuilder()
                 .command(commands)
                 .directory(new File(directory))
@@ -197,8 +196,12 @@ public class Utilities {
             for (String s: strings)
                 System.out.println(s);
         }
-        if (exitCode != 0)
+        if (exitCode != 0) {
             throw new RuntimeException("Process failed with exit code " + exitCode);
+        } else {
+            @SuppressWarnings("unused")
+            boolean success = out.delete();
+        }
     }
 
     public static void runProcess(String directory, String... commands) throws IOException, InterruptedException {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -243,7 +243,7 @@ public class Utilities {
                 "cranelift_jit=off,dataflow_jit::ir::function::passes=off");
         Utilities.runProcess(directory, env,
                 new String[] {
-                        "cargo", "run", // "--release",
+                        "cargo", "run", "--release",
                         "-p", "dataflow-jit", "--bin", "dataflow-jit",
                         "--features", "binary", "--", "run", program, config });
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
@@ -135,6 +135,12 @@ public class BaseSQLTests {
     protected void addRustTestCase(String name, DBSPCompiler compiler, DBSPCircuit circuit, InputOutputPair... streams) {
         compiler.messages.show(System.err);
         compiler.messages.clear();
+        if (this.currentTestInformation.startsWith("Jit") &&
+            !compiler.options.ioOptions.jit) {
+            // Got confused on setting options a few times, this will help catch such mistakes
+            throw new RuntimeException("JIT test " + this.currentTestInformation +
+                    " without JIT compiler option?" + compiler.options);
+        }
         TestCase test = new TestCase(name, this.currentTestInformation, compiler, circuit, streams);
         testsToRun.add(test);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
@@ -472,7 +472,7 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void joinTest() {
-        String query = "SELECT T1.COL3, T2.COL3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL1";
+        String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL1";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral(false)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral(true)),
@@ -482,7 +482,7 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void joinNullableTest() {
-        String query = "SELECT T1.COL3, T2.COL3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL5";
+        String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL5";
         this.testQuery(query, empty);
     }
 
@@ -511,7 +511,7 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void leftOuterJoinTest() {
-        String query = "SELECT T1.COL3, T2.COL3 FROM T AS T1 LEFT JOIN T AS T2 ON T1.COL1 = T2.COL5";
+        String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 LEFT JOIN T AS T2 ON T1.COL1 = T2.COL5";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true), new DBSPBoolLiteral())
@@ -520,7 +520,7 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void rightOuterJoinTest() {
-        String query = "SELECT T1.COL3, T2.COL3 FROM T AS T1 RIGHT JOIN T AS T2 ON T1.COL1 = T2.COL5";
+        String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 RIGHT JOIN T AS T2 ON T1.COL1 = T2.COL5";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                 new DBSPTupleExpression(new DBSPBoolLiteral(), new DBSPBoolLiteral(false)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(), new DBSPBoolLiteral(true))
@@ -529,7 +529,7 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void fullOuterJoinTest() {
-        String query = "SELECT T1.COL3, T2.COL3 FROM T AS T1 FULL OUTER JOIN T AS T2 ON T1.COL1 = T2.COL5";
+        String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 FULL OUTER JOIN T AS T2 ON T1.COL1 = T2.COL5";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true), new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true, true), new DBSPBoolLiteral()),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitBoolTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitBoolTests.java
@@ -1,12 +1,9 @@
 package org.dbsp.sqlCompiler.compiler.jit;
 
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
-import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.postgres.PostgresNumericTests;
-import org.junit.Ignore;
+import org.dbsp.sqlCompiler.compiler.postgres.PostgresBoolTests;
 
-@Ignore("Not yet implemented")
-public class JitPostgresNumericTests extends PostgresNumericTests {
+public class JitBoolTests extends PostgresBoolTests {
     @Override
     public CompilerOptions getOptions(boolean optimize) {
         CompilerOptions options = super.getOptions(optimize);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitPostgresDateTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitPostgresDateTest.java
@@ -6,6 +6,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class JitPostgresDateTest extends PostgresDateTests {
+    @Override
     public CompilerOptions getOptions(boolean optimize) {
         CompilerOptions options = super.getOptions(optimize);
         options.ioOptions.jit = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBaseTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBaseTest.java
@@ -321,8 +321,11 @@ public abstract class PostgresBaseTest extends BaseSQLTests {
                 result = new DBSPStringLiteral(CalciteObject.EMPTY, fieldType, data, StandardCharsets.UTF_8);
             }
         } else if (fieldType.is(DBSPTypeBool.class)) {
-            boolean value = trimmed.equalsIgnoreCase("t") || trimmed.equalsIgnoreCase("true");
-            result = new DBSPBoolLiteral(CalciteObject.EMPTY, fieldType, value);
+            boolean isTrue = trimmed.equalsIgnoreCase("t") || trimmed.equalsIgnoreCase("true");
+            boolean isFalse = trimmed.equalsIgnoreCase("f") || trimmed.equalsIgnoreCase("false");
+            if (!isTrue && !isFalse)
+                throw new RuntimeException("Cannot parse boolean value " + Utilities.singleQuote(trimmed));
+            result = new DBSPBoolLiteral(CalciteObject.EMPTY, fieldType, isTrue);
         } else if (fieldType.is(DBSPTypeVec.class)) {
             DBSPTypeVec vec = fieldType.to(DBSPTypeVec.class);
             // TODO: this does not handle nested arrays

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBoolTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBoolTests.java
@@ -1,11 +1,33 @@
 package org.dbsp.sqlCompiler.compiler.postgres;
 
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.junit.Test;
 
 /**
  * <a href="https://github.com/postgres/postgres/blob/master/src/test/regress/expected/boolean.out">boolean.out</a>
  */
 public class PostgresBoolTests extends PostgresBaseTest {
+    @Override
+    public void prepareData(DBSPCompiler compiler) {
+        compiler.compileStatements(
+                        // "CREATE TABLE BOOLTBL1 (f1 bool);\n" +
+                        // "INSERT INTO BOOLTBL1 (f1) VALUES (bool 't');\n" +
+                        // "INSERT INTO BOOLTBL1 (f1) VALUES (bool 'True');\n" +
+                        // "INSERT INTO BOOLTBL1 (f1) VALUES (bool 'true');\n" +
+                        // "CREATE TABLE BOOLTBL2 (f1 bool);\n" +
+                        // "INSERT INTO BOOLTBL2 (f1) VALUES (bool 'f');\n" +
+                        // "INSERT INTO BOOLTBL2 (f1) VALUES (bool 'false');\n" +
+                        // "INSERT INTO BOOLTBL2 (f1) VALUES (bool 'False');\n" +
+                        // "INSERT INTO BOOLTBL2 (f1) VALUES (bool 'FALSE');" +
+                        "CREATE TABLE BOOLTBL3 (d text, b bool, o int);\n" +
+                        "INSERT INTO BOOLTBL3 (d, b, o) VALUES ('true', true, 1);\n" +
+                        "INSERT INTO BOOLTBL3 (d, b, o) VALUES ('false', false, 2);\n" +
+                        "INSERT INTO BOOLTBL3 (d, b, o) VALUES ('null', null, 3);\n" +
+                        "CREATE TABLE booltbl4(isfalse bool, istrue bool, isnul bool);\n" +
+                        "INSERT INTO booltbl4 VALUES (false, true, null);\n"
+        );
+    }
+
     @Test
     public void testOne() {
         this.q("SELECT 1 as 'one';\n" + " one \n" +
@@ -50,4 +72,137 @@ public class PostgresBoolTests extends PostgresBaseTest {
     // SELECT bool '000' AS error;
     // SELECT bool '' AS error;
     // ERROR:  invalid input syntax for type boolean: ""
+
+    @Test
+    public void testIs() {
+        this.q("SELECT\n" +
+                "    d,\n" +
+                "    b IS TRUE AS istrue,\n" +
+                "    b IS NOT TRUE AS isnottrue,\n" +
+                "    b IS FALSE AS isfalse,\n" +
+                "    b IS NOT FALSE AS isnotfalse,\n" +
+                "    b IS UNKNOWN AS isunknown,\n" +
+                "    b IS NOT UNKNOWN AS isnotunknown\n" +
+                "FROM booltbl3;\n" +
+                "   d   | istrue | isnottrue | isfalse | isnotfalse | isunknown | isnotunknown \n" +
+                "-------+--------+-----------+---------+------------+-----------+--------------\n" +
+                " true|   t      | f         | f       | t          | f         | t\n" +
+                " false|  f      | t         | t       | f          | f         | t\n" +
+                " null|   f      | t         | f       | t          | t         | f");
+    }
+
+    @Test
+    public void testShortcut() {
+        // This is not from Postgres
+        this.q("SELECT v0, v1, v0 OR v1 FROM " +
+                "(SELECT b AS v0 FROM BOOLTBL3) CROSS JOIN (SELECT b as v1 FROM BOOLTBL3);\n" +
+                " v0 | v1 | v0 OR v1 \n" +
+                "--------------------\n" +
+                " t  | t  | t\n" +
+                " t  | f  | t\n" +
+                " f  | t  | t\n" +
+                " f  | f  | f\n" +
+                "null| t  | t\n" +
+                "null| f  |null\n" +
+                " t  |null| t\n" +
+                " f  |null|null\n" +
+                "null|null|null");
+        this.q("SELECT v0, v1, v0 AND v1 FROM " +
+                "(SELECT b AS v0 FROM BOOLTBL3) CROSS JOIN (SELECT b as v1 FROM BOOLTBL3);\n" +
+                " v0 | v1 | v0 AND v1 \n" +
+                "--------------------\n" +
+                " t  | t  | t\n" +
+                " t  | f  | f\n" +
+                " f  | t  | f\n" +
+                " f  | f  | f\n" +
+                "null| t  |null\n" +
+                "null| f  | f\n" +
+                " t  |null|null\n" +
+                " f  |null| f\n" +
+                "null|null|null");
+        this.q("SELECT v0, NOT v0 FROM " +
+                "(SELECT b AS v0 FROM BOOLTBL3);\n" +
+                " v0 | NOT v0 \n" +
+                "---------------\n" +
+                " t  | f\n" +
+                " f  | t\n" +
+                "null|null");
+    }
+
+    @Test
+    public void testBool() {
+        this.qs("SELECT istrue AND isnul AND istrue FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT istrue AND istrue AND isnul FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isnul AND istrue AND istrue FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isfalse AND isnul AND istrue FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " f\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT istrue AND isfalse AND isnul FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " f\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isnul AND istrue AND isfalse FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " f\n" +
+                "(1 row)\n" +
+                "\n" +
+                "-- OR expression need to return null if there's any nulls and none\n" +
+                "-- of the value is true\n" +
+                "SELECT isfalse OR isnul OR isfalse FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isfalse OR isfalse OR isnul FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isnul OR isfalse OR isfalse FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                "null\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isfalse OR isnul OR istrue FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " t\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT istrue OR isfalse OR isnul FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " t\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT isnul OR istrue OR isfalse FROM booltbl4;\n" +
+                " ?column? \n" +
+                "----------\n" +
+                " t\n" +
+                "(1 row)");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
@@ -666,22 +666,22 @@ public class PostgresStringTests extends PostgresBaseTest {
 
     @Test
     public void testLikeCombinations() {
-        this.q("SELECT 'foo' LIKE '_%' as t, 'f' LIKE '_%' as t, '' LIKE '_%' as f;\n" +
-                " t | t | f \n" +
-                "---+---+---\n" +
-                " t | t | f");
-        this.q("SELECT 'foo' LIKE '%_' as t, 'f' LIKE '%_' as t, '' LIKE '%_' as f;\n" +
-                " t | t | f \n" +
-                "---+---+---\n" +
-                " t | t | f");
-        this.q("SELECT 'foo' LIKE '__%' as t, 'foo' LIKE '___%' as t, 'foo' LIKE '____%' as f;\n" +
-                " t | t | f \n" +
-                "---+---+---\n" +
-                " t | t | f");
-        this.q("SELECT 'foo' LIKE '%__' as t, 'foo' LIKE '%___' as t, 'foo' LIKE '%____' as f;\n" +
-                " t | t | f \n" +
-                "---+---+---\n" +
-                " t | t | f");
+        this.q("SELECT 'foo' LIKE '_%' as t, 'f' LIKE '_%' as t0, '' LIKE '_%' as f;\n" +
+                " t | t0 | f \n" +
+                "---+----+---\n" +
+                " t | t  | f");
+        this.q("SELECT 'foo' LIKE '%_' as t, 'f' LIKE '%_' as t0, '' LIKE '%_' as f;\n" +
+                " t | t0 | f \n" +
+                "---+----+---\n" +
+                " t | t  | f");
+        this.q("SELECT 'foo' LIKE '__%' as t, 'foo' LIKE '___%' as t0, 'foo' LIKE '____%' as f;\n" +
+                " t | t0 | f \n" +
+                "---+----+---\n" +
+                " t | t  | f");
+        this.q("SELECT 'foo' LIKE '%__' as t, 'foo' LIKE '%___' as t0, 'foo' LIKE '%____' as f;\n" +
+                " t | t0 | f \n" +
+                "---+----+---\n" +
+                " t | t  | f");
         this.q("SELECT 'jack' LIKE '%____%' AS t;\n" +
                 " t \n" +
                 "---\n" +


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Fixes several bugs in JIT code generation.
This also adds a compiler flag that guides the compiler behavior when a view has multiple columns with the same name. The default is to reject such programs, but the --lenient flag transforms this into a warning.
