### PR TITLE
Implemented alternative date/time parsing options for json

### DIFF
--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -26,6 +26,7 @@ pub enum JsonFlavor {
     /// Default encoding used by Feldera, documented
     /// [here](https://www.feldera.com/docs/api/json#types).
     #[default]
+    #[serde(rename = "default")]
     Default,
     /// Debezium MySQL JSON produced by the default configuration of the Debezium
     /// [Kafka Connect connector](https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types).

--- a/crates/adapters/src/jit/json.rs
+++ b/crates/adapters/src/jit/json.rs
@@ -1,15 +1,32 @@
+use crate::format::JsonFlavor;
+
 use super::schema::{ColumnSchema, TableSchema};
 use dataflow_jit::{
     codegen::json::{JsonColumn, JsonDeserConfig, JsonSerConfig},
     ir::LayoutId,
 };
 
-fn column_from_schema(column: &ColumnSchema, slash: bool) -> JsonColumn {
+fn column_from_schema(column: &ColumnSchema, slash: bool, flavor: &JsonFlavor) -> JsonColumn {
     let slash = if slash { "/" } else { "" };
-    match column.columntype.typ.as_str() {
-        "DATE" => JsonColumn::datetime(format!("{slash}{}", column.name), "%Y-%m-%d"),
-        "TIME" => JsonColumn::datetime(format!("{slash}{}", column.name), "%H:%M:%S%.f"),
-        "TIMESTAMP" => JsonColumn::datetime(format!("{slash}{}", column.name), "%F %T%.f"),
+    match (column.columntype.typ.as_str(), flavor) {
+        ("DATE", JsonFlavor::Default) => {
+            JsonColumn::datetime(format!("{slash}{}", column.name), "%Y-%m-%d")
+        }
+        ("DATE", JsonFlavor::DebeziumMySql) => {
+            JsonColumn::date_from_days(format!("{slash}{}", column.name))
+        }
+        ("TIME", JsonFlavor::Default) => {
+            JsonColumn::datetime(format!("{slash}{}", column.name), "%H:%M:%S%.f")
+        }
+        ("TIME", JsonFlavor::DebeziumMySql) => {
+            JsonColumn::time_from_micros(format!("{slash}{}", column.name))
+        }
+        ("TIMESTAMP", JsonFlavor::Default) => {
+            JsonColumn::datetime(format!("{slash}{}", column.name), "%F %T%.f")
+        }
+        ("TIMESTAMP", JsonFlavor::DebeziumMySql) => {
+            JsonColumn::datetime(format!("{slash}{}", column.name), "%Y-%m-%dT%H:%M:%S%Z")
+        }
         _ => JsonColumn::normal(format!("{slash}{}", column.name)),
     }
 }
@@ -18,12 +35,13 @@ fn column_from_schema(column: &ColumnSchema, slash: bool) -> JsonColumn {
 pub(crate) fn build_json_deser_config(
     layout: LayoutId,
     table_schema: &TableSchema,
+    flavor: &JsonFlavor,
 ) -> JsonDeserConfig {
     let mappings = table_schema
         .fields
         .iter()
         .enumerate()
-        .map(|(index, column)| (index, column_from_schema(column, true)))
+        .map(|(index, column)| (index, column_from_schema(column, true, flavor)))
         .collect();
     JsonDeserConfig { layout, mappings }
 }
@@ -34,7 +52,12 @@ pub(crate) fn build_json_ser_config(layout: LayoutId, table_schema: &TableSchema
         .fields
         .iter()
         .enumerate()
-        .map(|(index, column)| (index, column_from_schema(column, false)))
+        .map(|(index, column)| {
+            (
+                index,
+                column_from_schema(column, false, &JsonFlavor::Default),
+            )
+        })
         .collect();
     JsonSerConfig { layout, mappings }
 }

--- a/crates/adapters/tests/sql_tests/.gitignore
+++ b/crates/adapters/tests/sql_tests/.gitignore
@@ -1,3 +1,5 @@
 port
 ir.json
 schema.json
+v1.json
+preferred_vendor.json

--- a/crates/adapters/tests/sql_tests/datetime/config.yaml
+++ b/crates/adapters/tests/sql_tests/datetime/config.yaml
@@ -2,14 +2,14 @@ workers: 8
 cpu_profiler: false
 min_batch_size_records: 0
 max_buffering_delay_usecs: 0
-name: pipeline-018ab35c-cc94-700b-8cd2-3986f46eecc4
-inputs: {}
+name: datetime-pipeline
+inputs:
 outputs:
-  preferred_vendor:
-    stream: PREFERRED_VENDOR
+  v1:
+    stream: V1
     transport:
         name: file
         config:
-          path: preferred_vendor.json
+          path: v1.json
     format:
       name: json

--- a/crates/adapters/tests/sql_tests/datetime/project.sql
+++ b/crates/adapters/tests/sql_tests/datetime/project.sql
@@ -1,0 +1,8 @@
+create table t1 (
+    d date,
+    -- TODO: JIT doesn't support the `TIME` type yet.
+    -- t time,
+    ts timestamp
+);
+
+create view v1 as select * from t1;

--- a/crates/dataflow-jit/src/codegen/intrinsics/deserialize.rs
+++ b/crates/dataflow-jit/src/codegen/intrinsics/deserialize.rs
@@ -196,6 +196,26 @@ pub(super) extern "C" fn deserialize_json_date(
     }
 }
 
+pub(super) extern "C" fn deserialize_json_date_from_days(
+    place: &mut MaybeUninit<i32>,
+    json_pointer_ptr: *const u8,
+    json_pointer_len: usize,
+    map: &Value,
+) -> bool {
+    // The json pointer we're accessing the map with
+    let json_pointer = unsafe { str_from_raw_parts(json_pointer_ptr, json_pointer_len) };
+
+    if let Some(days) = map.pointer(json_pointer).and_then(Value::as_i64) {
+        // TODO: This silently truncates, do we want that?
+        place.write(days as i32);
+        false
+
+    // Otherwise the value couldn't be found and is considered null
+    } else {
+        true
+    }
+}
+
 pub(super) extern "C" fn deserialize_json_timestamp(
     place: &mut MaybeUninit<i64>,
     json_pointer_ptr: *const u8,
@@ -222,6 +242,44 @@ pub(super) extern "C" fn deserialize_json_timestamp(
         )
     {
         place.write(date);
+        false
+
+    // Otherwise the value couldn't be found and is considered null
+    } else {
+        true
+    }
+}
+
+pub(super) extern "C" fn deserialize_json_timestamp_from_millis(
+    place: &mut MaybeUninit<i64>,
+    json_pointer_ptr: *const u8,
+    json_pointer_len: usize,
+    map: &Value,
+) -> bool {
+    // The json pointer we're accessing the map with
+    let json_pointer = unsafe { str_from_raw_parts(json_pointer_ptr, json_pointer_len) };
+
+    if let Some(millis) = map.pointer(json_pointer).and_then(Value::as_i64) {
+        place.write(millis);
+        false
+
+    // Otherwise the value couldn't be found and is considered null
+    } else {
+        true
+    }
+}
+
+pub(super) extern "C" fn deserialize_json_timestamp_from_micros(
+    place: &mut MaybeUninit<i64>,
+    json_pointer_ptr: *const u8,
+    json_pointer_len: usize,
+    map: &Value,
+) -> bool {
+    // The json pointer we're accessing the map with
+    let json_pointer = unsafe { str_from_raw_parts(json_pointer_ptr, json_pointer_len) };
+
+    if let Some(micros) = map.pointer(json_pointer).and_then(Value::as_i64) {
+        place.write(micros / 1000);
         false
 
     // Otherwise the value couldn't be found and is considered null

--- a/crates/dataflow-jit/src/codegen/intrinsics/mod.rs
+++ b/crates/dataflow-jit/src/codegen/intrinsics/mod.rs
@@ -3,9 +3,10 @@ mod serialize;
 
 use self::{
     deserialize::{
-        deserialize_json_bool, deserialize_json_date, deserialize_json_f32, deserialize_json_f64,
-        deserialize_json_i32, deserialize_json_i64, deserialize_json_string,
-        deserialize_json_timestamp,
+        deserialize_json_bool, deserialize_json_date, deserialize_json_date_from_days,
+        deserialize_json_f32, deserialize_json_f64, deserialize_json_i32, deserialize_json_i64,
+        deserialize_json_string, deserialize_json_timestamp,
+        deserialize_json_timestamp_from_micros, deserialize_json_timestamp_from_millis,
     },
     serialize::{
         byte_vec_push, byte_vec_reserve, write_date_to_byte_vec, write_decimal_to_byte_vec,
@@ -621,6 +622,9 @@ intrinsics! {
     deserialize_json_f64 = fn(ptr, ptr, usize, ptr) -> bool,
     deserialize_json_date = fn(ptr, ptr, ptr, ptr, usize, ptr) -> bool,
     deserialize_json_timestamp = fn(ptr, ptr, ptr, ptr, usize, ptr) -> bool,
+    deserialize_json_date_from_days = fn(ptr, ptr, usize, ptr) -> bool,
+    deserialize_json_timestamp_from_millis = fn(ptr, ptr, usize, ptr) -> bool,
+    deserialize_json_timestamp_from_micros = fn(ptr, ptr, usize, ptr) -> bool,
 
     byte_vec_push = fn(ptr, ptr, usize),
     byte_vec_reserve = fn(ptr, usize),
@@ -765,14 +769,14 @@ debug_primitives! {
     f64,
 }
 
-unsafe extern "C" fn date_debug(date: i32, fmt: *mut fmt::Formatter<'_>) -> bool {
+unsafe extern "C" fn date_debug(days: i32, fmt: *mut fmt::Formatter<'_>) -> bool {
     debug_assert!(!fmt.is_null());
 
     // TODO: UTC?
-    if let Some(date) = NaiveDate::from_num_days_from_ce_opt(date) {
-        write!(&mut *fmt, "{}", date.format("%Y-%m-%d")).is_ok()
+    if let Some(date) = NaiveDateTime::from_timestamp_millis(days as i64 * (86400 * 1000)) {
+        write!(&mut *fmt, "{}", date.date().format("%Y-%m-%d")).is_ok()
     } else {
-        tracing::error!("failed to create date from {date}");
+        tracing::error!("failed to create date from {days}");
         false
     }
 }

--- a/crates/dataflow-jit/src/codegen/json/mod.rs
+++ b/crates/dataflow-jit/src/codegen/json/mod.rs
@@ -54,6 +54,26 @@ impl JsonColumn {
         }
     }
 
+    pub fn date_from_days<K>(key: K) -> Self
+    where
+        K: Into<Box<str>>,
+    {
+        Self {
+            key: key.into(),
+            spec: Some(JsonColumnParseSpec::DateFromDays),
+        }
+    }
+
+    pub fn time_from_micros<K>(key: K) -> Self
+    where
+        K: Into<Box<str>>,
+    {
+        Self {
+            key: key.into(),
+            spec: Some(JsonColumnParseSpec::TimeFromMicros),
+        }
+    }
+
     pub fn key(&self) -> &str {
         &self.key
     }

--- a/crates/dataflow-jit/src/codegen/layout.rs
+++ b/crates/dataflow-jit/src/codegen/layout.rs
@@ -437,12 +437,11 @@ impl NativeLayout {
     /// Panics if `column` isn't nullable
     pub fn nullability_of(&self, column: usize) -> (BitSetType, u32, u8) {
         self.bitsets[column].unwrap_or_else(|| {
-	    panic!(
-		"{:?}: checking nullability of non-nullable column {:?}",
-		self.bitsets,
-		column
-	    )
-	})
+            panic!(
+                "{:?}: checking nullability of non-nullable column {:?}",
+                self.bitsets, column,
+            )
+        })
     }
 
     /// Returns the memory entry for the bitset backing the nullability of the

--- a/crates/dataflow-jit/src/codegen/vtable/tests.rs
+++ b/crates/dataflow-jit/src/codegen/vtable/tests.rs
@@ -394,7 +394,7 @@ mod proptests {
         utils::NativeRepr,
         ThinStr,
     };
-    use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use proptest::{
         prelude::any, prop_assert, prop_assert_eq, prop_assert_ne, prop_compose, proptest,
         strategy::Strategy, test_runner::TestCaseResult,
@@ -425,7 +425,9 @@ mod proptests {
         Bool(bool),
         // Usize(usize),
         String(String),
-        #[proptest(strategy = "date().prop_map(|date| Column::Date(date.num_days_from_ce()))")]
+        #[proptest(
+            strategy = "date().prop_map(|date| Column::Date((date.and_time(NaiveTime::MIN).timestamp_millis() / (86400 * 1000)) as i32))"
+        )]
         Date(i32),
         #[proptest(strategy = "timestamp().prop_map(|date| Column::Timestamp(date.timestamp()))")]
         Timestamp(i64),
@@ -433,8 +435,8 @@ mod proptests {
     }
 
     prop_compose! {
-        fn date()(days in NaiveDate::MIN.num_days_from_ce()..=NaiveDate::MAX.num_days_from_ce()) -> NaiveDate {
-            NaiveDate::from_num_days_from_ce_opt(days).unwrap()
+        fn date()(days in NaiveDateTime::MIN.timestamp_millis() / (86400 * 1000)..=NaiveDateTime::MAX.timestamp_millis() / (86400 * 1000)) -> NaiveDate {
+            NaiveDateTime::from_timestamp_millis(days).unwrap().date()
         }
     }
 

--- a/python/feldera-api-client/feldera_api_client/models/json_flavor.py
+++ b/python/feldera-api-client/feldera_api_client/models/json_flavor.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class JsonFlavor(str, Enum):
     DEBEZIUM_MYSQL = "debezium_mysql"
-    DEFAULT = "Default"
+    DEFAULT = "default"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -307,6 +307,8 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     /**
      * Given a list of files containing the inputs and outputs,
      * generate a configuration for the JIT runtime.
+     * WARNING: this API is only used for testing the JIT execution engine.
+     * This API is not part of the public compiler API.
      */
     public JsonNode createJitRuntimeConfig(
             List<JitIODescription> inputFiles,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITScalarType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/types/JITScalarType.java
@@ -26,7 +26,9 @@ package org.dbsp.sqlCompiler.compiler.backend.jit.ir.types;
 import com.fasterxml.jackson.databind.node.BaseJsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
+import org.dbsp.util.Utilities;
 
 public class JITScalarType extends JITType {
     protected JITScalarType(DBSPTypeCode code) {
@@ -47,6 +49,9 @@ public class JITScalarType extends JITType {
 
     @Override
     public String toString() {
+        if (this.code.jitName.isEmpty())
+            throw new UnimplementedException("Type " + Utilities.singleQuote(this.code.toString()) +
+                    " not yet supported in JIT");
         return this.code.jitName;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
@@ -29,8 +29,6 @@ import org.apache.calcite.adapter.jdbc.JdbcSchema;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.schema.SchemaPlus;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
@@ -140,7 +138,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
 
         // Allocate output files
         List<JitFileAndSerialization> outputFiles = new ArrayList<>();
-        for (DBSPZSetLiteral.Contents outputData: data.outputs) {
+        for (DBSPZSetLiteral.Contents ignored1 : data.outputs) {
             File output = File.createTempFile("output", ".json", baseDirectory);
             outputFiles.add(new JitFileAndSerialization(
                     output.getAbsolutePath(),
@@ -453,8 +451,8 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                         "    part bigint not null,\n" +
                         "    vendor bigint not null,\n" +
                         "    price decimal\n" +
-                        ");" +
-                        "" +
+                        ");\n" +
+                        "\n" +
                         "create view LOW_PRICE AS " +
                         "with LOW_PRICE_CTE AS (" +
                         "  select part, MIN(price) as price from PRICE group by part" +


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Added the ability to parse dates/times from more formats, fixes #773
Changes config format, columns should look like this now:
```json
{
    "key": "/bar",
    "spec": null,
}

{
    "key": "/bar",
    "spec": {
        "DateTimeFromStr": {
            "format": "%F"
        }
    }
}

{
    "key": "/bar",
    "spec": "TimeFromMicros",
}

{
    "key": "/bar",
    "spec": "TimeFromMillis",
}

{
    "key": "/bar",
    "spec": "DateFromDays",
}
```