### PR TITLE
Debezium demo container version to 0.1.6

### DIFF
--- a/deploy/docker-compose-debezium.yml
+++ b/deploy/docker-compose-debezium.yml
@@ -44,7 +44,7 @@ services:
         condition: service_started
       mysql:
         condition: service_healthy
-    image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.1.3}
+    image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.1.6}
     environment:
       RUST_BACKTRACE: "1"
       REDPANDA_BROKERS: "redpanda:9092"


### PR DESCRIPTION
Update version of the Debezium demo container to 0.1.6 (was 0.1.3 before).

Is this a user-visible change (yes/no): no