### PR TITLE
Fix the web-console asset errors during rust build.

### DIFF
--- a/crates/pipeline_manager/build.rs
+++ b/crates/pipeline_manager/build.rs
@@ -1,14 +1,15 @@
 use change_detection::ChangeDetection;
 use static_files::{resource_dir, NpmBuild};
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // These are touched during the build, so it would re-build every time if we
 // don't exclude them from change detection:
-const EXCLUDE_LIST: [&str; 3] = [
+const EXCLUDE_LIST: [&str; 4] = [
     "../../web-console/node_modules",
     "../../web-console/out",
     "../../web-console/.next",
+    "../../web-console/pipline-manager-",
 ];
 
 /// The build script has two modes:
@@ -42,6 +43,19 @@ fn main() {
         .generate();
         println!("cargo:rerun-if-env-changed=NEXT_PUBLIC_MUIX_PRO_KEY");
 
+        // sets distDir in next.config.js, unfortunately it's not possible to
+        // set it to OUT_DIR because it has to be inside of the web-console directory
+        // so we take the last two parts of OUT_DIR and use them as a relative path
+        // inside of web-console/. This ensures that parallel builds don't collide
+        // with each other since the hash part of OUT_DIR is always unique.
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let out_dir_parts = out_dir.iter().collect::<Vec<_>>();
+        let rel_build_dir = out_dir_parts[out_dir_parts.len() - 2..]
+            .iter()
+            .collect::<PathBuf>();
+        env::set_var("BUILD_DIR", rel_build_dir.clone());
+        let asset_path = Path::new("../../web-console/").join(rel_build_dir);
+
         NpmBuild::new("../../web-console")
             .executable("yarn")
             .install()
@@ -50,7 +64,7 @@ fn main() {
             )
             .run("build")
             .expect("Could not run `yarn build`. Run it manually in web-console/ to debug.")
-            .target("../../web-console/out")
+            .target(asset_path)
             .to_resource_dir()
             .build()
             .unwrap();

--- a/web-console/.gitignore
+++ b/web-console/.gitignore
@@ -5,6 +5,7 @@
 /.next/
 /out/
 /build
+/pipeline-manager-*
 
 # misc
 .DS_Store

--- a/web-console/next.config.js
+++ b/web-console/next.config.js
@@ -4,13 +4,12 @@ const path = require('path')
 /** @type {import("next").NextConfig} */
 module.exports = {
   output: 'export', // https://nextjs.org/docs/app/building-your-application/deploying/static-exports
-  distDir: 'out', // Optional, default: `out`
+  distDir: process.env.BUILD_DIR || 'out',
   trailingSlash: true,
   reactStrictMode: true,
-  compiler: {
-  },
+  compiler: {},
   images: { unoptimized: true },
   experimental: {
-    esmExternals: false,
-  },
+    esmExternals: false
+  }
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

fixes this stuff  (I think)
```
➜  kubernetes-runner git:(issue-31) ✗ cargo test -- --nocapture
   Compiling pipeline-manager v0.1.6 (/Users/lalith/code/cloud/feldera/crates/pipeline_manager)
error: couldn't read /Users/lalith/code/cloud/feldera/web-console/out/_next/static/chunks/webpack-849dc3b25543c6b2.js: No such file or directory (os error 2)
  --> /Users/lalith/code/cloud/kubernetes-runner/target/debug/build/pipeline-manager-2da2ebda90645148/out/generate_sets/set_1.rs:62:62
   |
62 | ...bpack-849dc3b25543c6b2.js",n(i!("/Users/lalith/code/cloud/feldera/web-console/out/_next/static/chunks/webpack-849dc3b25543c6b2.js"),1695937463,"application/javas...
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `i` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read /Users/lalith/code/cloud/feldera/web-console/out/_next/static/chunks/app/layout-3996176ba0ff2d7e.js: No such file or directory (os error 2)
  --> /Users/lalith/code/cloud/kubernetes-runner/target/debug/build/pipeline-manager-2da2ebda90645148/out/generate_sets/set_1.rs:25:65
   |
25 | ...yout-3996176ba0ff2d7e.js",n(i!("/Users/lalith/code/cloud/feldera/web-console/out/_next/static/chunks/app/layout-3996176ba0ff2d7e.js"),1695937463,"application/jav...
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `i` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read /Users/lalith/code/cloud/feldera/web-console/out/_next/static/rEaVxAALaEfTjzN222F-f/_buildManifest.js: No such file or directory (os error 2)
 --> /Users/lalith/code/cloud/kubernetes-runner/target/debug/build/pipeline-manager-2da2ebda90645148/out/generate_sets/set_1.rs:7:67
  |
7 | ...22F-f/_buildManifest.js",n(i!("/Users/lalith/code/cloud/feldera/web-console/out/_next/static/rEaVxAALaEfTjzN222F-f/_buildManifest.js"),1695937463,"application/jav...
  |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `i` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read /Users/lalith/code/cloud/feldera/web-console/out/_next/static/rEaVxAALaEfTjzN222F-f/_ssgManifest.js: No such file or directory (os error 2)
 --> /Users/lalith/code/cloud/kubernetes-runner/target/debug/build/pipeline-manager-2da2ebda90645148/out/generate_sets/set_1.rs:6:65
  |
6 | ...zN222F-f/_ssgManifest.js",n(i!("/Users/lalith/code/cloud/feldera/web-console/out/_next/static/rEaVxAALaEfTjzN222F-f/_ssgManifest.js"),1695937463,"application/java...
  |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `i` (in Nightly builds, run with -Z macro-backtrace for more info)

error: couldn't read /Users/lalith/code/cloud/feldera/web-console/out/_next/static/css/6dc99adc98d9ee2d.css: No such file or directory (os error 2)
 --> /Users/lalith/code/cloud/kubernetes-runner/target/debug/build/pipeline-manager-2da2ebda90645148/out/generate_sets/set_1.rs:5:52
  |
5 | r.insert("_next/static/css/6dc99adc98d9ee2d.css",n(i!("/Users/lalith/code/cloud/feldera/web-console/out/_next/static/css/6dc99adc98d9ee2d.css"),1695937463,"text/css"));
  |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `i` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `pipeline-manager` (lib) due to 5 previous errors
➜  kubernetes-runner git:(issue-31) ✗
```
