### PR TITLE
Custom Kafka Connect docker image.

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,11 +3,13 @@ on:
     - cron: '0 0 * * *'
   release:
       types: [published]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   PIPELINE_MANAGER_IMAGE: ghcr.io/${{ github.repository_owner }}/pipeline-manager
   DEMO_IMAGE: ghcr.io/${{ github.repository_owner }}/demo-container
+  KAFKA_CONNECT_IMAGE:  ghcr.io/${{ github.repository_owner }}/kafka-connect
 
 jobs:
   build-and-push-image:
@@ -43,6 +45,19 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
 
+      - name: Docker meta (kafka-connect)
+        id: meta_kafka_connect
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.KAFKA_CONNECT_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build Kafka Connect container
+        run: |
+          cd deploy && \
+          docker build --target kafka-connect -t ${{ env.KAFKA_CONNECT_IMAGE }}  .
+
       - name: Run integration tests
         run: |
           cd deploy && \
@@ -71,7 +86,7 @@ jobs:
       # Push untagged images when the workflow is not triggered by a release
       - name: Push containers
         if: github.event_name != 'release'
-        run: docker push ${{ env.PIPELINE_MANAGER_IMAGE }} && docker push ${{ env.DEMO_IMAGE }}
+        run: docker push ${{ env.PIPELINE_MANAGER_IMAGE }} && docker push ${{ env.DEMO_IMAGE }} && docker push ${{ env.KAFKA_CONNECT_IMAGE }}
 
       # Tagged DBSP image
       - name: Push (pipeline-manager)
@@ -95,6 +110,18 @@ jobs:
           push: true
           tags: ${{ steps.meta_demo.outputs.tags }}
           labels: ${{ steps.meta_demo.outputs.labels }}
+
+      # Tagged Kafka Connect image
+      - name: Push (kafka-connect)
+        uses: docker/build-push-action@v4
+        if: github.event_name == 'release'
+        with:
+          context: .
+          file: deploy/Dockerfile
+          target: kafka-connect
+          push: true
+          tags: ${{ steps.meta_kafka_connect.outputs.tags }}
+          labels: ${{ steps.meta_kafka_connect.outputs.labels }}
 
       - uses: actions/delete-package-versions@v4
         with:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -167,6 +167,13 @@ RUN apt update && apt install pkg-config \
   && apt remove python3-pip unzip pkg-config -y && apt autoremove -y
 CMD bash
 
+# Kafka connect with all Debezium connectors + the Snowflake connector.
+FROM debezium/connect:2.3 AS kafka-connect
+RUN mkdir /kafka/connect/snowflake-kafka-connector
+RUN cd /kafka/connect/snowflake-kafka-connector \
+    && curl -LO https://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/2.1.0/snowflake-kafka-connector-2.1.0.jar \
+    && curl -LO https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.1/bc-fips-1.0.1.jar \
+    && curl -LO https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
 
 # By default, only build the release version
 FROM release

--- a/deploy/docker-compose-debezium.yml
+++ b/deploy/docker-compose-debezium.yml
@@ -4,7 +4,7 @@ services:
   # Kafka connect.
   # TODO: add a healthcheck to this container.
   connect:
-    image: debezium/connect:2.3
+    image: ghcr.io/feldera/kafka-connect:${FELDERA_VERSION:-0.1.6}
     depends_on:
       redpanda:
         condition: service_healthy
@@ -28,7 +28,17 @@ services:
       MYSQL_USER: mysqluser
       MYSQL_PASSWORD: mysqlpw
     healthcheck:
-      test: ["CMD", "mysqladmin" , "-u", "$$MYSQL_USER",  "-p$$MYSQL_PASSWORD" ,"ping", "-h", "localhost"]
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "-u",
+          "$$MYSQL_USER",
+          "-p$$MYSQL_PASSWORD",
+          "ping",
+          "-h",
+          "localhost"
+        ]
       interval: 5s
       timeout: 20s
       # MySQL can be _very_ slow to start.


### PR DESCRIPTION
In preparation for adding support for the Snowflake output connector, we replace the pre-built Kafka Connect image from Debezium with a custom one that adds Snowflake connector classes to the image.  There are a couple of Kafka Connect base images we could build upon, including one from Confluent, but that one seems to assume Apache Kafka and may not work well with Redpanda (first thing it did when I tried it is complain about not having Zookeeper around :) ).

In addition, we want the image to contain Debezium connectors, so building on the Debezium image from RedHat seemed like a good choice.

This commit:
1. Adds a Kafka Connect container build step to Earthfile
2. Adds identical instructions for building the connector to Dockerfile
3. Sets up github CI to build the container along with other Feldera containers.

While I was at it, I also added a trigger to the `containers.yml` to allow triggering the container build workflow manually.  This is useful if we want to build the containers without waiting for the cronjob.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
