### PR TITLE
Forbid empty group.id in Kafka form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhanced
 - Made connector type icons look nicer in Pipeline Builder
+- Forbid empty group.id in Kafka form
+  ([#840](https://github.com/feldera/feldera/issues/840))
+- Enable multiline text input for .pem SSL certificates
+  ([#841](https://github.com/feldera/feldera/issues/841))
 
 ## [0.1.4] - 2023-09-26
 

--- a/web-console/src/lib/components/connectors/dialogs/DebeziumInputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/DebeziumInputConnector.tsx
@@ -43,9 +43,9 @@ const schema = intersection([
     description: va.optional(va.string(), ''),
     bootstrap_servers: va.nonOptional(va.string()),
     auto_offset_reset: va.optional(va.string(), 'none'),
-    group_id: va.nonOptional(va.string()),
+    group_id: va.nonOptional(va.string([va.minLength(1, 'group.id should not be empty')])),
     topics: va.nonOptional(
-      va.array(va.string([va.minLength(1, 'Topic name should be >=1 character')]), [
+      va.array(va.string([va.minLength(1, 'Topic name should not be empty')]), [
         va.minLength(1, 'Provide at least one topic (press enter to add the topic).')
       ])
     ),

--- a/web-console/src/lib/components/connectors/dialogs/KafkaInputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/KafkaInputConnector.tsx
@@ -43,9 +43,9 @@ const schema = intersection([
     description: va.optional(va.string(), ''),
     bootstrap_servers: va.nonOptional(va.string()),
     auto_offset_reset: va.optional(va.string(), 'none'),
-    group_id: va.nonOptional(va.string()),
+    group_id: va.nonOptional(va.string([va.minLength(1, 'group.id should not be empty')])),
     topics: va.nonOptional(
-      va.array(va.string([va.minLength(1, 'Topic name should be >=1 character')]), [
+      va.array(va.string([va.minLength(1, 'Topic name should not be empty')]), [
         va.minLength(1, 'Provide at least one topic (press enter to add the topic).')
       ])
     ),

--- a/web-console/src/lib/components/connectors/dialogs/tabs/kafka/TabKafkaAuth.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/tabs/kafka/TabKafkaAuth.tsx
@@ -1,6 +1,13 @@
 import { GridItems } from '$lib/components/common/GridItems'
 import { KafkaAuthSchema } from '$lib/functions/kafka/authParamsSchema'
-import { PasswordElement, SelectElement, SwitchElement, TextFieldElement, useFormContext } from 'react-hook-form-mui'
+import {
+  PasswordElement,
+  SelectElement,
+  SwitchElement,
+  TextareaAutosizeElement,
+  TextFieldElement,
+  useFormContext
+} from 'react-hook-form-mui'
 import invariant from 'tiny-invariant'
 import { match } from 'ts-pattern'
 
@@ -166,25 +173,27 @@ const sslForm = (
     <GridItems xs={12}>
       <Tooltip title="Client's private key string (PEM format) used for authentication.">
         <div>
-          <TextFieldElement
+          <TextareaAutosizeElement
             name='ssl_key_pem'
             label='ssl.key.pem'
             size='small'
             placeholder=''
             aria-describedby='validation-host'
             fullWidth
+            resizeStyle='vertical'
           />
         </div>
       </Tooltip>
       <Tooltip title="Client's public key string (PEM format) used for authentication.">
         <div>
-          <TextFieldElement
+          <TextareaAutosizeElement
             name='ssl_certificate_pem'
             label='ssl.certificate.pem'
             size='small'
             placeholder=''
             aria-describedby='validation-host'
             fullWidth
+            resizeStyle='vertical'
           />
         </div>
       </Tooltip>
@@ -195,13 +204,14 @@ const sslForm = (
       </Tooltip>
       <Tooltip title="CA certificate string (PEM format) for verifying the broker's key.">
         <div>
-          <TextFieldElement
+          <TextareaAutosizeElement
             name='ssl_ca_pem'
             label='ssl.ca.pem'
             size='small'
             placeholder=''
             aria-describedby='validation-host'
             fullWidth
+            resizeStyle='vertical'
           />
         </div>
       </Tooltip>


### PR DESCRIPTION
Forbid empty group.id in Kafka form: Fix https://github.com/feldera/feldera/issues/840
Enable multiline input for .pem SSL certificates: Fix https://github.com/feldera/feldera/issues/841

Is this a user-visible change (yes/no): yes

