### PR TITLE
pipeline-manager: add health checks for DB connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#822](https://github.com/feldera/feldera/pull/822))
 - Support input tables with primary keys
   ([#826](https://github.com/feldera/feldera/issues/826))
+- Add health check endpoints to pipeline-manager components
+  ([#855](https://github.com/feldera/feldera/pull/855))
 
 ## [0.1.5] - 2023-10-10
 

--- a/crates/pipeline_manager/src/bin/compiler-server.rs
+++ b/crates/pipeline_manager/src/bin/compiler-server.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use clap::{Args, Command, FromArgMatches};
 
@@ -31,10 +32,17 @@ async fn main() -> anyhow::Result<()> {
         Compiler::precompile_dependencies(&compiler_config).await?;
         return Ok(());
     }
-    let db: ProjectDB = ProjectDB::connect(
-        &database_config,
-        #[cfg(feature = "pg-embed")]
-        None,
+    let db: ProjectDB = pipeline_manager::retries::retry_async(
+        || async {
+            ProjectDB::connect(
+                &database_config,
+                #[cfg(feature = "pg-embed")]
+                None,
+            )
+            .await
+        },
+        30,
+        Duration::from_secs(1),
     )
     .await
     .unwrap();

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -2247,6 +2247,13 @@ impl Storage for ProjectDB {
         let _res = conn.execute(&stmt, &[&program_id.0, &version.0]).await?;
         Ok(())
     }
+
+    async fn check_connection(&self) -> Result<(), DBError> {
+        let conn = self.pool.get().await?;
+        let stmt = conn.prepare_cached("SELECT 1").await?;
+        let _res = conn.execute(&stmt, &[]).await?;
+        Ok(())
+    }
 }
 
 impl ProjectDB {

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -430,4 +430,7 @@ pub(crate) trait Storage {
         program_id: ProgramId,
         version: Version,
     ) -> Result<(), DBError>;
+
+    /// Check connectivity to the DB
+    async fn check_connection(&self) -> Result<(), DBError>;
 }

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -2413,4 +2413,8 @@ impl Storage for Mutex<DbModel> {
     ) -> Result<(), DBError> {
         todo!("Unimplemented");
     }
+
+    async fn check_connection(&self) -> Result<(), DBError> {
+        todo!("Unimplemented");
+    }
 }

--- a/crates/pipeline_manager/src/lib.rs
+++ b/crates/pipeline_manager/src/lib.rs
@@ -12,4 +12,6 @@ pub mod db_notifier;
 pub mod local_runner;
 pub mod logging;
 pub mod pipeline_automata;
+pub mod probe;
+pub mod retries;
 pub mod runner;

--- a/crates/pipeline_manager/src/probe.rs
+++ b/crates/pipeline_manager/src/probe.rs
@@ -1,0 +1,69 @@
+use std::{sync::Arc, time::Duration};
+
+use actix_web::{HttpResponse, ResponseError};
+use chrono::{DateTime, Local};
+use log::{debug, error};
+use tokio::sync::Mutex;
+
+use crate::{
+    api::ManagerError,
+    db::{storage::Storage, ProjectDB},
+};
+
+#[derive(Debug)]
+pub struct Probe {
+    pub last_checked: DateTime<Local>,
+    pub last_error: Option<ManagerError>,
+}
+
+async fn check_if_db_reachable(
+    probe: Arc<Mutex<Probe>>,
+    db: Arc<Mutex<ProjectDB>>,
+    interval: Duration,
+) {
+    loop {
+        let now = Local::now();
+        let res = db.lock().await.check_connection().await;
+        let mut probe = probe.lock().await;
+        probe.last_checked = now;
+        probe.last_error = res.err().map(|e| e.into());
+        debug!("DB reachability probe: {:?}", probe);
+        drop(probe);
+        tokio::time::sleep(interval).await;
+    }
+}
+
+impl Probe {
+    pub async fn new(db: Arc<Mutex<ProjectDB>>) -> Arc<Mutex<Probe>> {
+        let probe = Probe {
+            last_checked: Local::now(),
+            last_error: None,
+        };
+        let probe = Arc::new(Mutex::new(probe));
+        tokio::spawn(check_if_db_reachable(
+            probe.clone(),
+            db,
+            Duration::from_secs(5),
+        ));
+        probe
+    }
+
+    pub fn status_as_http_response(&self) -> Result<HttpResponse, ManagerError> {
+        match &self.last_error {
+            Some(e) => {
+                error!(
+                    "/healthz probe returning error (last_checked: {:?}, last_error: {})",
+                    self.last_checked, e
+                );
+                Ok(e.error_response())
+            }
+            None => {
+                debug!(
+                    "/healthz probe returning ok (last_checked: {:?})",
+                    self.last_checked,
+                );
+                Ok(HttpResponse::Ok().into())
+            }
+        }
+    }
+}

--- a/crates/pipeline_manager/src/retries.rs
+++ b/crates/pipeline_manager/src/retries.rs
@@ -1,0 +1,25 @@
+use std::{future::Future, time::Duration};
+
+pub async fn retry_async<T, E, O, F: FnMut() -> O>(
+    mut f: F,
+    retries: i32,
+    interval: Duration,
+) -> Result<T, E>
+where
+    O: Future<Output = Result<T, E>>,
+{
+    let mut count = 0;
+    loop {
+        let result = f().await;
+
+        if result.is_ok() {
+            break result;
+        } else {
+            if count > retries {
+                break result;
+            }
+            tokio::time::sleep(interval).await;
+            count += 1;
+        }
+    }
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN /root/.cargo/bin/cargo chef prepare --recipe-path recipe.json
 # layer for faster incremental builds of source-code only changes
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=pipeline-manager --no-default-features
+RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --package=pipeline-manager --no-default-features
 COPY . .
 # web-console build tools:
 # - nodejs

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl --fail --request GET --url http://localhost:8080/v0/pipelines"
+          "curl --fail --request GET --url http://localhost:8080/healthz"
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
* Adds endpoints that can be invoked by external tools for health checks. For the pipeline-manager services, this primarily means checking for DB connectivity. We can extend this over time with more detailed info.
* This patch also makes these services attempt connecting to the DB several times on startup instead of failing immediately and going into crash-restart loops.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
