### PR TITLE
Decouple DB migrations from connection setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#855](https://github.com/feldera/feldera/pull/855))
 - Added documentation for deploying Feldera Cloud on AWS EKS.
   ([#850](https://github.com/feldera/feldera/pull/850))
+- DB migration until now was performed during DB connection setup. Now, users
+  running the standalone services must invoke the new migrations binary to
+  explicitly perform database upgrades. The pipeline-manager binary retains the
+  old behavior for convenience.
+  ([#856](https://github.com/feldera/feldera/pull/856))
 
 ### Fixed
 

--- a/crates/pipeline_manager/src/auth.rs
+++ b/crates/pipeline_manager/src/auth.rs
@@ -708,7 +708,7 @@ mod test {
         test::call_service(&app, req).await
     }
 
-    #[tokio::test]
+    #[actix_web::test]
     async fn invalid_url() {
         let url = "http://localhost/doesnotexist".to_owned();
         let res = fetch_jwk_aws_cognito_keys(&url).await;

--- a/crates/pipeline_manager/src/bin/api-server.rs
+++ b/crates/pipeline_manager/src/bin/api-server.rs
@@ -26,14 +26,19 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|err| err.exit())
         .unwrap();
     let api_config = api_config.canonicalize().unwrap();
-    let db: ProjectDB = pipeline_manager::retries::retry_async(
+    let db = pipeline_manager::retries::retry_async(
         || async {
-            ProjectDB::connect(
+            let db = ProjectDB::connect(
                 &database_config,
                 #[cfg(feature = "pg-embed")]
                 None,
             )
-            .await
+            .await;
+            if let Ok(d) = db {
+                d.check_migrations().await
+            } else {
+                db
+            }
         },
         30,
         Duration::from_secs(1),

--- a/crates/pipeline_manager/src/bin/compiler-server.rs
+++ b/crates/pipeline_manager/src/bin/compiler-server.rs
@@ -34,12 +34,17 @@ async fn main() -> anyhow::Result<()> {
     }
     let db: ProjectDB = pipeline_manager::retries::retry_async(
         || async {
-            ProjectDB::connect(
+            let db = ProjectDB::connect(
                 &database_config,
                 #[cfg(feature = "pg-embed")]
                 None,
             )
-            .await
+            .await;
+            if let Ok(d) = db {
+                d.check_migrations().await
+            } else {
+                db
+            }
         },
         30,
         Duration::from_secs(1),

--- a/crates/pipeline_manager/src/bin/migrations.rs
+++ b/crates/pipeline_manager/src/bin/migrations.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use clap::{Args, Command, FromArgMatches};
+
+use colored::Colorize;
+
+use pipeline_manager::config::DatabaseConfig;
+use pipeline_manager::db::ProjectDB;
+
+// A binary to run DB migrations
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let name = "[migrations]".magenta();
+    pipeline_manager::logging::init_logging(name);
+    let cli = Command::new("Feldera DB migrations");
+    let cli = DatabaseConfig::augment_args(cli);
+    let matches = cli.get_matches();
+    let database_config = DatabaseConfig::from_arg_matches(&matches)
+        .map_err(|err| err.exit())
+        .unwrap();
+    let db: ProjectDB = pipeline_manager::retries::retry_async(
+        || async {
+            ProjectDB::connect(
+                &database_config,
+                #[cfg(feature = "pg-embed")]
+                None,
+            )
+            .await
+        },
+        30,
+        Duration::from_secs(1),
+    )
+    .await
+    .unwrap();
+    db.run_migrations().await?;
+    Ok(())
+}

--- a/crates/pipeline_manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline_manager/src/bin/pipeline-manager.rs
@@ -71,6 +71,8 @@ async fn main() -> anyhow::Result<()> {
     )
     .await
     .unwrap();
+    // Run migrations before starting any service
+    db.run_migrations().await?;
     let db = Arc::new(Mutex::new(db));
     let db_clone = db.clone();
     let _compiler = tokio::spawn(async move {

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -154,9 +154,7 @@ pub(crate) async fn setup_pg() -> (ProjectDB, tokio_postgres::Config) {
     log::debug!("tests connecting to: {config:#?}");
 
     config.dbname(&test_db);
-    let conn = ProjectDB::with_config(config.clone(), &Some("".to_string()))
-        .await
-        .unwrap();
+    let conn = ProjectDB::with_config(config.clone()).await.unwrap();
 
     (conn, config)
 }

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -112,9 +112,8 @@ pub(crate) async fn setup_pg() -> (ProjectDB, tempfile::TempDir) {
         .await
         .unwrap();
     let db_uri = pg.db_uri.clone();
-    let conn = ProjectDB::connect_inner(&db_uri, &Some("".to_string()), Some(pg))
-        .await
-        .unwrap();
+    let conn = ProjectDB::connect_inner(&db_uri, Some(pg)).await.unwrap();
+    conn.run_migrations().await.unwrap();
     (conn, _temp_dir)
 }
 
@@ -155,6 +154,7 @@ pub(crate) async fn setup_pg() -> (ProjectDB, tokio_postgres::Config) {
 
     config.dbname(&test_db);
     let conn = ProjectDB::with_config(config.clone()).await.unwrap();
+    conn.run_migrations().await.unwrap();
 
     (conn, config)
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -117,6 +117,10 @@ FROM gcr.io/distroless/cc-debian12 AS local-runner
 COPY --from=builder /app/target/release/local-runner local-runner
 ENTRYPOINT ["./local-runner", "--runner-working-directory=/working-dir"]
 
+# DB Migrations
+FROM gcr.io/distroless/cc-debian12 AS migrations
+COPY --from=builder /app/target/release/migrations migrations
+ENTRYPOINT ["./migrations"]
 
 ##### The stages below are used to build the demo container
 


### PR DESCRIPTION
We currently perform database migrations while initializing connections. This is fraught with risks in a production setting (e.g., makes rollbacks difficult).

This PR separates out running migrations from the connection initialization code. The pipeline-manager all-in-one binary should appear no different than before. The individual service binaries however no longer run migrations on their own. They are complemented with a new binary that does nothing but connect to the DB and runs the migration.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
