### PR TITLE
Avoid force-shutdowns for pipelines that encounter errors during lifecycle state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Avoid shutting down pipelines when they encounter
+  errors during lifecycle state changes.
+  ([#869](https://github.com/feldera/feldera/pull/869))
+
 ## [0.1.7] - 2023-10-10
 
 ### Added


### PR DESCRIPTION
Several state transitions in the pipeline automata shutdown the pipeline the moment it encounters a failure. This behavior is undesirable in production settings where pipelines can fail for myriad reasons, and it's good to have them stick around to be diagnosed.

Pipelines can anyhow only be restarted via the /start action after an explicit shutdown by the user.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
