### PR TITLE
Persist data grid column configuration on page refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#826](https://github.com/feldera/feldera/issues/826))
 - Add health check endpoints to pipeline-manager components
   ([#855](https://github.com/feldera/feldera/pull/855))
-- Web Console: Add confirmation dialog for delete actions
-  ([#766](https://github.com/feldera/feldera/issues/766))
 - Added documentation for deploying Feldera Cloud on AWS EKS.
   ([#850](https://github.com/feldera/feldera/pull/850))
 - DB migration until now was performed during DB connection setup. Now, users
@@ -51,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly perform database upgrades. The pipeline-manager binary retains the
   old behavior for convenience.
   ([#856](https://github.com/feldera/feldera/pull/856))
+- WebConsole: data tables' column configuration is preserved between page refreshes
+  ([#696](https://github.com/feldera/feldera/issues/696))
 
 ### Fixed
 
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Debezium MySQL input connector
   ([#813](https://github.com/feldera/feldera/issues/813))
+- WebConsole: Add confirmation dialog for delete actions
+  ([#766](https://github.com/feldera/feldera/issues/766))
 
 ### Added
 

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -57,6 +57,7 @@
     "ahooks": "^3.7.8",
     "apexcharts": "^3.41.1",
     "apexcharts-clevision": "^3.28.5",
+    "array-join": "^3.1.1",
     "clsx": "^2.0.0",
     "csv-parse": "^5.4.0",
     "d3-format": "^3.1.0",

--- a/web-console/src/lib/components/common/table/DataGridProDeclarative.tsx
+++ b/web-console/src/lib/components/common/table/DataGridProDeclarative.tsx
@@ -1,0 +1,77 @@
+import { reorderElement, replaceElement } from '$lib/functions/common/array'
+import { fullJoin } from 'array-join'
+
+import { DataGridPro, DataGridProProps, GridColDef, GridValidRowModel } from '@mui/x-data-grid-pro'
+
+export type DataGridColumnViewModel = { field: string; width?: number; flex?: number }[]
+
+export type DataGridProDeclarativeProps<Model extends GridValidRowModel = any> = Omit<
+  DataGridProProps<Model>,
+  'onFilterModelChange' | 'onColumnVisibilityModelChange'
+> & {
+  columnViewModel?: DataGridColumnViewModel
+  setColumnViewModel?: (model: NonNullable<DataGridProDeclarativeProps<Model>['columnViewModel']>) => void
+  setColumnVisibilityModel?: DataGridProProps<Model>['onColumnVisibilityModelChange']
+  setFilterModel?: DataGridProProps<Model>['onFilterModelChange']
+}
+
+const deriveColumnViewModel = <Model extends GridValidRowModel>(
+  cols: GridColDef<Model>[],
+  viewModel: DataGridColumnViewModel
+) =>
+  viewModel.length === cols.length // check if columnViewModel is applicable to the columns in the table
+    ? viewModel
+    : cols.map(c => ({ field: c.field, width: c.width, flex: c.flex })) // derive initial columnViewModel from column definition
+
+/**
+ * At this time API for DataGridPro is somewhat inconsistent.
+ * This wrapper is designed to provide a declarative API
+ * for a better separation between Grid data and its presentation model.
+ * @param props
+ * @returns
+ */
+export function DataGridProDeclarative<Model extends GridValidRowModel>({
+  columnViewModel = [],
+  setColumnViewModel = () => {},
+  columns: originalColumns,
+  ...props
+}: DataGridProDeclarativeProps<Model>) {
+  columnViewModel = deriveColumnViewModel(originalColumns, columnViewModel)
+
+  // Overwrite values of originalColumns, but preserve the order of columnViewModel
+  const columns: GridColDef<Model>[] = fullJoin(
+    columnViewModel,
+    originalColumns,
+    c => c.field,
+    c => c.field,
+    (v, d) => (d ? [{ ...d, ...(v ?? {}) }] : [])
+  ).flat()
+  return (
+    <DataGridPro
+      onColumnOrderChange={change =>
+        setColumnViewModel(reorderElement(columnViewModel, change.oldIndex, change.targetIndex))
+      }
+      onColumnWidthChange={change =>
+        setColumnViewModel(
+          replaceElement(columnViewModel, e =>
+            e.field === change.colDef.field
+              ? {
+                  ...e,
+                  width: change.width,
+                  flex: 0 // set flex to 0 to let the change in the width be visible
+                }
+              : null
+          )
+        )
+      }
+      {...{
+        onFilterModelChange: props.setFilterModel,
+        onColumnVisibilityModelChange: props.setColumnVisibilityModel,
+        columns,
+        ...props
+      }}
+    />
+  )
+}
+
+export { DataGridProDeclarative as DataGridPro, type DataGridProDeclarativeProps as DataGridProProps }

--- a/web-console/src/lib/components/common/table/EntityTable.tsx
+++ b/web-console/src/lib/components/common/table/EntityTable.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { DataGridFooter } from '$lib/components/common/table/DataGridFooter'
+import { DataGridPro, DataGridProProps } from '$lib/components/common/table/DataGridProDeclarative'
 import DataGridSearch from '$lib/components/common/table/DataGridSearch'
 import DataGridToolbar from '$lib/components/common/table/DataGridToolbar'
 import { ErrorOverlay } from '$lib/components/common/table/ErrorOverlay'
@@ -15,7 +16,7 @@ import { Icon } from '@iconify/react'
 import Card from '@mui/material/Card'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
-import { DataGridPro, DataGridProProps, GridRenderCellParams, GridValidRowModel } from '@mui/x-data-grid-pro'
+import { GridRenderCellParams, GridValidRowModel } from '@mui/x-data-grid-pro'
 import { GridApiPro } from '@mui/x-data-grid-pro/models/gridApiPro'
 import { UseQueryResult } from '@tanstack/react-query'
 

--- a/web-console/src/lib/components/common/table/ResetColumnViewButton.tsx
+++ b/web-console/src/lib/components/common/table/ResetColumnViewButton.tsx
@@ -1,0 +1,24 @@
+import { Icon } from '@iconify/react'
+import { IconButton, Tooltip } from '@mui/material'
+import { GridCallbackDetails, GridColumnVisibilityModel } from '@mui/x-data-grid-pro'
+
+import { DataGridColumnViewModel } from './DataGridProDeclarative'
+
+export const ResetColumnViewButton = (props: {
+  setColumnViewModel?: (
+    val: DataGridColumnViewModel | ((prevState: DataGridColumnViewModel) => DataGridColumnViewModel)
+  ) => void
+  setColumnVisibilityModel?: (model: GridColumnVisibilityModel, details: GridCallbackDetails<any>) => void
+}) => {
+  const resetColumnView = () => {
+    props.setColumnViewModel?.call(undefined, [])
+    props.setColumnVisibilityModel?.call(undefined, {}, {})
+  }
+  return (
+    <Tooltip title='Reset column headers'>
+      <IconButton onClick={resetColumnView}>
+        <Icon icon='bx:move-horizontal' />
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/web-console/src/lib/components/layouts/AuthProvider.tsx
+++ b/web-console/src/lib/components/layouts/AuthProvider.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { authContext, useAuthStore } from '$lib/compositions/auth/useAuth'
+import { isEmptyObject } from '$lib/functions/common/object'
 import { OpenAPI } from '$lib/services/manager'
 import { PipelineManagerQuery } from '$lib/services/pipelineManagerQuery'
 import { ReactNode } from 'react'
-import { isEmptyObject } from 'src/lib/functions/common/object'
 import { match, P } from 'ts-pattern'
 
 import { GoogleOAuthProvider } from '@react-oauth/google'

--- a/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
+++ b/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
@@ -7,7 +7,7 @@ import { PipelineManagerQuery } from '$lib/services/pipelineManagerQuery'
 import { LS_PREFIX } from '$lib/types/localStorage'
 import dayjs from 'dayjs'
 import Papa from 'papaparse'
-import { ChangeEvent, Dispatch, MutableRefObject, SetStateAction, useCallback } from 'react'
+import { ChangeEvent, Dispatch, MutableRefObject, ReactNode, SetStateAction, useCallback } from 'react'
 
 import { Icon } from '@iconify/react'
 import { useLocalStorage } from '@mantine/hooks'
@@ -35,6 +35,7 @@ const ImportToolbar = (props: {
   setLoading: Dispatch<SetStateAction<boolean>>
   apiRef: MutableRefObject<GridApi>
   rows: Row[]
+  children: ReactNode
 }) => {
   const { relation, setRows, pipelineRevision, setLoading, apiRef, rows } = props
 
@@ -127,6 +128,7 @@ const ImportToolbar = (props: {
       <Button size='small' onClick={handleInsertRows} startIcon={<Icon icon='mdi:upload' />} color='info'>
         Insert Rows
       </Button>
+      {props.children}
     </GridToolbarContainer>
   ) : (
     <></>

--- a/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
@@ -1,18 +1,23 @@
 // Browse the contents of a table or a view.
 
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
+import { DataGridPro } from '$lib/components/common/table/DataGridProDeclarative'
+import { ResetColumnViewButton } from '$lib/components/common/table/ResetColumnViewButton'
 import { InspectionToolbar } from '$lib/components/streaming/inspection/InspectionToolbar'
 import { PercentilePagination } from '$lib/components/streaming/inspection/PercentilePagination'
+import { useDataGridPresentationLocalStorage } from '$lib/compositions/persistence/dataGrid'
 import useQuantiles from '$lib/compositions/streaming/inspection/useQuantiles'
 import useTableUpdater from '$lib/compositions/streaming/inspection/useTableUpdater'
 import { useAsyncError } from '$lib/functions/common/react'
 import { Row, rowToAnchor } from '$lib/functions/ddl'
 import { NeighborhoodQuery, OpenAPI, Pipeline, Relation } from '$lib/services/manager'
 import { PipelineManagerQuery } from '$lib/services/pipelineManagerQuery'
+import { LS_PREFIX } from '$lib/types/localStorage'
 import { useCallback, useEffect, useState } from 'react'
+import invariant from 'tiny-invariant'
 
 import Card from '@mui/material/Card'
-import { DataGridPro, GridPaginationModel, GridRowSelectionModel } from '@mui/x-data-grid-pro'
+import { GridPaginationModel, GridRowSelectionModel } from '@mui/x-data-grid-pro'
 import { useQuery } from '@tanstack/react-query'
 
 const FETCH_QUANTILES = 100
@@ -37,7 +42,12 @@ const DEFAULT_NEIGHBORHOOD: NeighborhoodQuery = { before: PAGE_SIZE, after: PAGE
 // backwards X times until we reach the beginning.
 const INITIAL_PAGINATION_MODEL: GridPaginationModel = { pageSize: PAGE_SIZE, page: 1000 }
 
-export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
+/**
+ * This specialized hook manages logic required for keeping rows up to date.
+ * @param param
+ * @returns
+ */
+const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
   const [relation, setRelation] = useState<Relation | undefined>(undefined)
   const [paginationModel, setPaginationModel] = useState(INITIAL_PAGINATION_MODEL)
   const [neighborhood, setNeighborhood] = useState<NeighborhoodQuery>(DEFAULT_NEIGHBORHOOD)
@@ -50,7 +60,7 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
   const tableUpdater = useTableUpdater()
 
   const throwError = useAsyncError()
-  const pipelineRevisionQuery = useQuery(PipelineManagerQuery.pipelineLastRevision(pipeline?.descriptor.pipeline_id))
+  const pipelineRevisionQuery = useQuery(PipelineManagerQuery.pipelineLastRevision(pipeline.descriptor.pipeline_id))
 
   // If a revision is loaded, find the requested relation that we want to
   // monitor. We use it to display the table headers etc.
@@ -80,37 +90,38 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
   // initial snapshot and subsequent changes. We use setRows to update the rows
   // in the table.
   useEffect(() => {
-    if (relation !== undefined) {
-      const controller = new AbortController()
-      const url = new URL(
-        OpenAPI.BASE +
-          '/pipelines/' +
-          pipeline.descriptor.pipeline_id +
-          '/egress/' +
-          name +
-          '?format=csv&query=neighborhood&mode=watch'
-      )
-      tableUpdater(url, neighborhood, setRows, setLoading, relation, controller).then(
-        () => {
-          // nothing to do here, the tableUpdater will update the table
-        },
-        (error: any) => {
-          if (error.name != 'AbortError') {
-            throwError(error)
-          } else {
-            // The AbortError is expected when we leave the view
-            // (controller.abort() below will trigger it)
-            // -- so nothing to do here
-          }
+    if (!relation) {
+      return
+    }
+    const controller = new AbortController()
+    const url = new URL(
+      OpenAPI.BASE +
+        '/pipelines/' +
+        pipeline.descriptor.pipeline_id +
+        '/egress/' +
+        name +
+        '?format=csv&query=neighborhood&mode=watch'
+    )
+    tableUpdater(url, neighborhood, setRows, setLoading, relation, controller).then(
+      () => {
+        // nothing to do here, the tableUpdater will update the table
+      },
+      (error: any) => {
+        if (error.name != 'AbortError') {
+          throwError(error)
+        } else {
+          // The AbortError is expected when we leave the view
+          // (controller.abort() below will trigger it)
+          // -- so nothing to do here
         }
-      )
-
-      return () => {
-        // If we leave the view, we abort the fetch request otherwise it remains
-        // active (the browser and backend only keep a limited number of active
-        // requests and we don't want to exhaust that limit)
-        controller.abort()
       }
+    )
+
+    return () => {
+      // If we leave the view, we abort the fetch request otherwise it remains
+      // active (the browser and backend only keep a limited number of active
+      // requests and we don't want to exhaust that limit)
+      controller.abort()
     }
   }, [pipeline, name, relation, tableUpdater, throwError, neighborhood])
 
@@ -122,37 +133,38 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     // the neighborhood query is established. If we do it simultaneously,
     // somehow this led to an issue with sometimes not loading/displaying
     // anything at all (seems like a backend bug).
-    if (relation !== undefined && rows.length > 0 && quantiles === undefined) {
-      const controller = new AbortController()
-      const url = new URL(
-        OpenAPI.BASE +
-          '/pipelines/' +
-          pipeline.descriptor.pipeline_id +
-          '/egress/' +
-          name +
-          '?format=csv&query=quantiles&mode=snapshot'
-      )
-      quantileLoader(url, setQuantiles, relation, controller).then(
-        () => {
-          // nothing to do here, the tableUpdater will update the table
-        },
-        (error: any) => {
-          if (error.name != 'AbortError') {
-            throwError(error)
-          } else {
-            // The AbortError is expected when we leave the view
-            // (controller.abort() below will trigger it)
-            // -- so nothing to do here
-          }
+    if (!relation || rows.length === 0 || quantiles !== undefined) {
+      return
+    }
+    const controller = new AbortController()
+    const url = new URL(
+      OpenAPI.BASE +
+        '/pipelines/' +
+        pipeline.descriptor.pipeline_id +
+        '/egress/' +
+        name +
+        '?format=csv&query=quantiles&mode=snapshot'
+    )
+    quantileLoader(url, setQuantiles, relation, controller).then(
+      () => {
+        // nothing to do here, the tableUpdater will update the table
+      },
+      (error: any) => {
+        if (error.name != 'AbortError') {
+          throwError(error)
+        } else {
+          // The AbortError is expected when we leave the view
+          // (controller.abort() below will trigger it)
+          // -- so nothing to do here
         }
-      )
-
-      return () => {
-        // If we leave the view, we abort the fetch request otherwise it remains
-        // active (the browser and backend only keeps a limited number of active
-        // requests and we don't want to exhaust that limit)
-        controller.abort()
       }
+    )
+
+    return () => {
+      // If we leave the view, we abort the fetch request otherwise it remains
+      // active (the browser and backend only keeps a limited number of active
+      // requests and we don't want to exhaust that limit)
+      controller.abort()
     }
   }, [pipeline, name, relation, quantileLoader, rows, throwError, quantiles])
 
@@ -219,13 +231,66 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     setNeighborhood({ ...DEFAULT_NEIGHBORHOOD, anchor })
   }
 
+  return {
+    relation,
+    rows,
+    onQuantileSelected,
+    quantile,
+    setQuantile,
+    quantiles,
+    pipeline,
+    isLoading,
+    handlePaginationModelChange,
+    paginationModel,
+    pipelineRevisionQuery
+  }
+}
+
+export const InspectionTable = (props: InspectionTableProps) => {
+  const { relation, ...data } = useInspectionTable(props)
+
+  if (!relation) {
+    return <></>
+  }
+
+  return <InspectionTableImpl {...{ relation, ...data }} />
+}
+
+/**
+ * Encapsulates all logic that requires a valid Relation for consistency
+ * @param param
+ * @returns
+ */
+const InspectionTableImpl = ({
+  relation,
+  rows,
+  onQuantileSelected,
+  quantile,
+  setQuantile,
+  quantiles,
+  pipeline,
+  isLoading,
+  handlePaginationModelChange,
+  paginationModel,
+  pipelineRevisionQuery
+}: ReturnType<typeof useInspectionTable>) => {
+  invariant(relation)
   const [rowSelectionModel, setRowSelectionModel] = useState<GridRowSelectionModel>([])
 
   const isReadonly =
     !!pipelineRevisionQuery.data &&
-    (pipelineRevisionQuery.data.program.schema?.outputs.some(r => r.name === relation?.name) ?? false)
+    (pipelineRevisionQuery.data.program.schema?.outputs.some(r => r.name === relation.name) ?? false)
 
-  return relation ? (
+  const defaultColumnVisibility = {
+    genId: false,
+    rowCount: false
+  }
+  const gridPersistence = useDataGridPresentationLocalStorage({
+    key: LS_PREFIX + `settings/streaming/inspection/${pipeline.descriptor.pipeline_id}/${relation.name}`,
+    defaultColumnVisibility
+  })
+
+  return (
     <Card>
       <DataGridPro
         autoHeight
@@ -233,14 +298,6 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
         disableColumnFilter
         density='compact'
         getRowId={(row: Row) => row.genId}
-        initialState={{
-          columns: {
-            columnVisibilityModel: {
-              genId: false,
-              rowCount: false
-            }
-          }
-        }}
         columns={relation.fields
           .map((col: any) => {
             return {
@@ -293,7 +350,13 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
             pipelineId: pipeline.descriptor.pipeline_id,
             status: pipeline.state.current_status,
             relation: relation.name,
-            isReadonly
+            isReadonly,
+            children: (
+              <ResetColumnViewButton
+                setColumnViewModel={gridPersistence.setColumnViewModel}
+                setColumnVisibilityModel={() => gridPersistence.setColumnVisibilityModel(defaultColumnVisibility)}
+              />
+            )
           }
         }}
         loading={isLoading}
@@ -303,12 +366,10 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
         rows={rows.filter((row: any) => row.genId >= 0 && row.genId < PAGE_SIZE)}
         paginationMode='server'
         pageSizeOptions={[PAGE_SIZE]}
-        onPaginationModelChange={model => handlePaginationModelChange(model)}
+        onPaginationModelChange={handlePaginationModelChange}
         paginationModel={paginationModel}
         checkboxSelection={!isReadonly}
-        onRowSelectionModelChange={newRowSelectionModel => {
-          setRowSelectionModel(newRowSelectionModel)
-        }}
+        onRowSelectionModelChange={setRowSelectionModel}
         rowSelectionModel={rowSelectionModel}
         // Next two lines are a work-around because DataGridPro needs an
         // accurate rowCount for pagination to work which we don't have.
@@ -316,6 +377,7 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
         // This can be removed once the following issue is resolved:
         // https://github.com/mui/mui-x/issues/409
         rowCount={Number.MAX_VALUE}
+        {...gridPersistence}
         sx={{
           '.MuiTablePagination-displayedRows': {
             display: 'none' // 👈 hide huge pagination number
@@ -323,7 +385,5 @@ export const InspectionTable = ({ pipeline, name }: InspectionTableProps) => {
         }}
       />
     </Card>
-  ) : (
-    <></>
   )
 }

--- a/web-console/src/lib/components/streaming/inspection/InspectionToolbar.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionToolbar.tsx
@@ -45,6 +45,7 @@ export const InspectionToolbar = (
         }}
       />
       {!props.isReadonly && <RowDeleteButton onDeleteRows={onDeleteRows}></RowDeleteButton>}
+      {props.children}
     </GridToolbarContainer>
   )
 }

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -5,11 +5,14 @@
 
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
 import { DataGridFooter } from '$lib/components/common/table/DataGridFooter'
+import { DataGridPro, DataGridProProps } from '$lib/components/common/table/DataGridProDeclarative'
 import DataGridSearch from '$lib/components/common/table/DataGridSearch'
 import DataGridToolbar from '$lib/components/common/table/DataGridToolbar'
+import { ResetColumnViewButton } from '$lib/components/common/table/ResetColumnViewButton'
 import AnalyticsPipelineTput from '$lib/components/streaming/management/AnalyticsPipelineTput'
 import PipelineMemoryGraph from '$lib/components/streaming/management/PipelineMemoryGraph'
 import { PipelineRevisionStatusChip } from '$lib/components/streaming/management/RevisionStatus'
+import { useDataGridPresentationLocalStorage } from '$lib/compositions/persistence/dataGrid'
 import { ClientPipelineStatus, usePipelineStateStore } from '$lib/compositions/streaming/management/StatusContext'
 import useDeletePipeline from '$lib/compositions/streaming/management/useDeletePipeline'
 import usePausePipeline from '$lib/compositions/streaming/management/usePausePipeline'
@@ -39,7 +42,7 @@ import { LS_PREFIX } from '$lib/types/localStorage'
 import { format } from 'd3-format'
 import dayjs from 'dayjs'
 import Link from 'next/link'
-import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import CustomChip from 'src/@core/components/mui/chip'
 import { match, P } from 'ts-pattern'
 
@@ -60,8 +63,6 @@ import ListSubheader from '@mui/material/ListSubheader'
 import Paper from '@mui/material/Paper'
 import Tooltip from '@mui/material/Tooltip'
 import {
-  DataGridPro,
-  DataGridProProps,
   GRID_DETAIL_PANEL_TOGGLE_COL_DEF,
   GridColDef,
   GridRenderCellParams,
@@ -507,6 +508,10 @@ export default function PipelineTable() {
     setExpandedRows(newExpandedRows)
   }
 
+  const gridPersistence = useDataGridPresentationLocalStorage({
+    key: LS_PREFIX + 'settings/streaming/management/grid'
+  })
+
   return (
     <Card>
       <DataGridPro
@@ -534,6 +539,7 @@ export default function PipelineTable() {
           toolbar: {
             children: [
               btnAdd,
+              <ResetColumnViewButton key='1' {...gridPersistence} />,
               <div style={{ marginLeft: 'auto' }} key='2' />,
               <DataGridSearch fetchRows={pipelineQuery} setFilteredData={setFilteredData} key='99' />
             ]
@@ -544,6 +550,7 @@ export default function PipelineTable() {
         }}
         detailPanelExpandedRowIds={expandedRows}
         onDetailPanelExpandedRowIdsChange={updateExpandedRows}
+        {...gridPersistence}
       />
     </Card>
   )

--- a/web-console/src/lib/compositions/persistence/dataGrid.ts
+++ b/web-console/src/lib/compositions/persistence/dataGrid.ts
@@ -1,0 +1,34 @@
+import { DataGridColumnViewModel } from '$lib/components/common/table/DataGridProDeclarative'
+
+import { useLocalStorage } from '@mantine/hooks'
+import { GridColumnVisibilityModel, GridFilterModel } from '@mui/x-data-grid-pro'
+
+/**
+ * Persist DataGrid's column presentation and applied filters
+ */
+export function useDataGridPresentationLocalStorage({
+  key,
+  defaultColumnVisibility = {}
+}: {
+  key: string
+  defaultColumnVisibility?: GridColumnVisibilityModel
+}) {
+  const [columnVisibilityModel, setColumnVisibilityModel] = useLocalStorage<GridColumnVisibilityModel>({
+    key: key + '/visibility',
+    defaultValue: defaultColumnVisibility
+  })
+  const [filterModel, setFilterModel] = useLocalStorage<GridFilterModel>({
+    key: key + '/filters'
+  })
+  const [columnViewModel, setColumnViewModel] = useLocalStorage<DataGridColumnViewModel>({
+    key: key + '/columnView'
+  })
+  return {
+    columnVisibilityModel,
+    setColumnVisibilityModel,
+    filterModel,
+    setFilterModel,
+    columnViewModel,
+    setColumnViewModel
+  }
+}

--- a/web-console/src/lib/functions/common/array.ts
+++ b/web-console/src/lib/functions/common/array.ts
@@ -29,3 +29,42 @@ export function assertUnion<T extends readonly string[]>(union: T, val: string):
   }
   return val
 }
+
+/**
+ * Mutates the array
+ * @param array
+ * @param fromIndex
+ * @param toIndex
+ * @returns
+ */
+export function reorderElement<T>(array: T[], fromIndex: number, toIndex: number) {
+  if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= array.length || toIndex >= array.length) {
+    // No need to move if the indices are the same or out of bounds.
+    return array
+  }
+
+  const [movedElement] = array.splice(fromIndex, 1)
+
+  array.splice(toIndex, 0, movedElement)
+
+  return array
+}
+
+/**
+ * Replaces the first element in the array for which the replacement result isn't null
+ * Mutates the array
+ * @param array
+ * @param replacement
+ * @returns
+ */
+export function replaceElement<T>(array: T[], replacement: (t: T) => T | null) {
+  let value = null as T | null
+  for (const [i, e] of array.entries()) {
+    value = replacement(e)
+    if (value !== null) {
+      array[i] = value
+      break
+    }
+  }
+  return array
+}

--- a/web-console/src/lib/functions/common/object.ts
+++ b/web-console/src/lib/functions/common/object.ts
@@ -5,3 +5,19 @@
  */
 export const isEmptyObject = (obj: unknown): obj is Record<never, never> =>
   typeof obj === 'object' && obj !== null && Object.keys(obj).length === 0
+
+/**
+ * Removes undefined fields of an object
+ * Mutates the object
+ * @see https://stackoverflow.com/questions/25421233/javascript-removing-undefined-fields-from-an-object
+ * @param obj
+ * @returns
+ */
+export function pruneObj<T extends Record<string | number | symbol, unknown>>(obj: T) {
+  for (const prop in obj) {
+    if (obj.hasOwnProperty(prop) && obj[prop] === undefined) {
+      delete obj[prop]
+    }
+  }
+  return obj
+}

--- a/web-console/yarn.lock
+++ b/web-console/yarn.lock
@@ -1186,6 +1186,11 @@ array-includes@^3.1.5, array-includes@^3.1.6:
     get-intrinsic "^1.1.3"
     is-string "^1.0.7"
 
+array-join@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/array-join/-/array-join-3.1.1.tgz#b693cf9f28a598f8f8fc1016063689a60b3d04ff"
+  integrity sha512-SLPBxwUinI6tz6lUyAcoN+rVMtjnaUb2l3dZmpuFXWs2o71ksQo92vBVU5OPnDrPbodJpXGLfJwMRIVaBEwCCA==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"


### PR DESCRIPTION
Also created a wrapper over MUI DataGridPro to enable more declarative API.

Fix https://github.com/feldera/feldera/issues/696