### PR TITLE
Typo in build.rs

### DIFF
--- a/crates/pipeline_manager/build.rs
+++ b/crates/pipeline_manager/build.rs
@@ -9,7 +9,7 @@ const EXCLUDE_LIST: [&str; 4] = [
     "../../web-console/node_modules",
     "../../web-console/out",
     "../../web-console/.next",
-    "../../web-console/pipline-manager-",
+    "../../web-console/pipeline-manager-",
 ];
 
 /// The build script has two modes:


### PR DESCRIPTION
Typo in build.rs caused excessive pipeline manager re-compilation.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
