### PR TITLE
Use `outputsAreSets` flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ openapi.json
 
 # python
 __pycache__
+
+# pg-embed directory
+/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Two new compiler flags: `--outputsAreSets` and `--ignoreOrder`
 - Experimental Snowflake sink
   ([#774](https://github.com/feldera/feldera/issues/774))
 - WebConsole: Snowflake output connector dialog and node
   ([#859](https://github.com/feldera/feldera/issues/859))
-
 - Source and sink connector documentation
   ([#882](https://github.com/feldera/feldera/pull/882))
+- Enforce distinct outputs.  This is equivalent to applying
+  `SELECT DISTINCT` to each output view.
+  ([#871](https://github.com/feldera/feldera/issues/871))
+- Ignore outermost `ORDER BY` clauses, which don't make
+  sense for incremental queries.
+  ([#883](https://github.com/feldera/feldera/pull/8830))
 
 ## [0.1.7] - 2023-10-10
 

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -870,6 +870,8 @@ impl CompilationJob {
             .arg("-i")
             .arg("-je")
             .arg("--alltables")
+            .arg("--outputsAreSets")
+            .arg("--ignoreOrder")
             .stdin(Stdio::null())
             .stderr(Stdio::from(err_file.into_std().await))
             .stdout(Stdio::from(rust_file.into_std().await))


### PR DESCRIPTION
Use the `--outputsAreSets` compiler flag to enforce that pipelines produce distinct outputs.  See https://github.com/feldera/feldera/issues/871 for a detailed discussion.

Also use the `--ignoreOrder` compiler flag to ignore the `order by` clause in SQL.

Added an integration test for the distinct output behavior.  And while I was at it, documented steps for running integration tests, which I always forget.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
