### PR TITLE
Handle correctly intemediate views in SLT tests

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -196,6 +196,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
      * an output for the circuit
      */
     public void generateOutputForNextView(boolean generate) {
+        this.frontend.generateOutputForNextView(generate);
         this.midend.generateOutputForNextView(generate);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -112,11 +112,11 @@ public class CalciteCompiler implements IWritesLogs {
     public final RelDataTypeFactory typeFactory;
     private final SqlToRelConverter.Config converterConfig;
     private final RewriteDivision astRewriter;
-    /**
-     * Perform additional type validation in top of the Calcite rules.
-     */
+    /** Perform additional type validation in top of the Calcite rules. */
     private final ValidateTypes validateTypes;
     private final IErrorReporter errorReporter;
+    /** If true the next view will be an output, otherwise it's just an intermediate result */
+    boolean generateOutputForNextView = true;
 
     /**
      * This class rewrites instances of the division operator in the SQL AST
@@ -186,6 +186,10 @@ public class CalciteCompiler implements IWritesLogs {
             // https://issues.apache.org/jira/browse/CALCITE-3394 may give a solution
             return false;
         }
+    }
+
+    public void generateOutputForNextView(boolean generate) {
+        this.generateOutputForNextView = generate;
     }
 
     /**
@@ -836,7 +840,8 @@ public class CalciteCompiler implements IWritesLogs {
                         columns, cv.query, relRoot);
                 // From Calcite's point of view we treat this view just as another table.
                 this.catalog.addTable(viewName, view.getEmulatedTable());
-                outputs.add(new OutputViewDescription(view));
+                if (this.generateOutputForNextView)
+                    outputs.add(new OutputViewDescription(view));
                 return view;
             }
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -44,7 +44,7 @@ public class Main {
     @SuppressWarnings("SpellCheckingInspection")
     public static void main(String[] argv) throws IOException {
         List<String> files = Linq.list(
-                // "test/random/select/slt_good_58.test"
+                //"test/index/between/100/slt_good_3.test"
                 /*
                 "select1.test"
                 "select2.test",

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitDbspExecutor.java
@@ -112,6 +112,7 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
     JitTestBatch runBatch(JitTestBatch batch, TestStatistics result) throws SQLException, NoSuchAlgorithmException {
         System.out.println("Running a batch of " + batch.size() + " queries");
         batch.prepareInputs(this.tablePreparation.statements);
+        batch.prepareInputs(this.viewPreparation.definitions());
         batch.setInputContents(this.getInputSets());
         boolean failed = batch.run(result);
         if (failed)
@@ -130,7 +131,7 @@ public class JitDbspExecutor extends SqlSltTestExecutor {
         result.incFiles();
         int queryNo = 0;
         int batchSize = 1;
-        int skip = 4428;  // used only for debugging
+        int skip = 0; // 710;  // used only for debugging
 
         int remainingInBatch = batchSize;
         JitTestBatch batch = new JitTestBatch(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitTestBatch.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/JitTestBatch.java
@@ -46,9 +46,9 @@ public class JitTestBatch extends TestBatch {
     }
 
     @Override
-    public void prepareInputs(List<SltSqlStatement> inputAndViewPreparation) {
+    public <T extends SltSqlStatement> void prepareInputs(Iterable<T> inputAndViewPreparation) {
         this.compiler.generateOutputForNextView(false);
-        for (SltSqlStatement statement : inputAndViewPreparation) {
+        for (T statement : inputAndViewPreparation) {
             String stat = statement.statement;
             this.compiler.compileStatement(stat, stat);
             this.compiler.throwIfErrorsOccurred();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/TestBatch.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/TestBatch.java
@@ -34,7 +34,7 @@ public abstract class TestBatch {
         return new File(Paths.get(this.filesDirectory, name).toUri());
     }
 
-    public abstract void prepareInputs(List<SltSqlStatement> inputAndViewPreparation);
+    public abstract <T extends SltSqlStatement> void prepareInputs(Iterable<T> inputAndViewPreparation);
 
     public void setInputContents(DBSPExecutor.TableValue[] inputContents) {
         this.inputContents = inputContents;


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Some SLT tests create intermediate views. With this change we handle them correctly.