### PR TITLE
Add newline in the end of an NDJSON block.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ __pycache__
 
 # pg-embed directory
 /data
+
+# clone of the benchmark repo
+gh-pages

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -178,9 +178,8 @@ impl Encoder for JsonEncoder {
                         } else {
                             buffer.push(b',');
                         }
-                    } else if num_records > 0 {
-                        buffer.push(b'\n');
                     }
+
                     // FIXME: an alternative to building JSON manually is to create an
                     // `InsDelUpdate` instance and serialize that, but it would require
                     // packaging the serialized key as `serde_json::RawValue`, which is
@@ -248,6 +247,9 @@ impl Encoder for JsonEncoder {
                         num_records += 1;
                         self.seq_number += 1;
                     }
+                    if !self.config.array {
+                        buffer.push(b'\n');
+                    }
 
                     if num_records >= self.config.buffer_size_records || buffer_full {
                         if self.config.array {
@@ -270,7 +272,7 @@ impl Encoder for JsonEncoder {
 
         if num_records > 0 {
             if self.config.array {
-                buffer.push(b']');
+                buffer.extend_from_slice(b"]\n");
             }
             self.output_consumer.push_buffer(&buffer);
             buffer.clear();

--- a/crates/adapters/tests/jit_integration_test.rs
+++ b/crates/adapters/tests/jit_integration_test.rs
@@ -181,7 +181,8 @@ fn supply_chain_test() {
 
     let expected_output = r#"{"insert":{"PART_ID":1,"PART_NAME":"Flux Capacitor","VENDOR_ID":2,"VENDOR_NAME":"HyperDrive Innovations","PRICE":10000}}
 {"insert":{"PART_ID":2,"PART_NAME":"Warp Core","VENDOR_ID":1,"VENDOR_NAME":"Gravitech Dynamics","PRICE":15000}}
-{"insert":{"PART_ID":3,"PART_NAME":"Kyber Crystal","VENDOR_ID":3,"VENDOR_NAME":"DarkMatter Devices","PRICE":9000}}"#;
+{"insert":{"PART_ID":3,"PART_NAME":"Kyber Crystal","VENDOR_ID":3,"VENDOR_NAME":"DarkMatter Devices","PRICE":9000}}
+"#;
 
     assert_eq!(
         fs::read_to_string("tests/sql_tests/supply_chain/preferred_vendor.json").unwrap(),
@@ -221,7 +222,8 @@ fn datetime_test() {
     server_thread.shutdown();
     assert_eq!(
         fs::read_to_string("tests/sql_tests/datetime/v1.json").unwrap(),
-        r#"{"insert":{"D":"2016-01-16","TS":"2018-06-20 13:37:03"}}"#
+        r#"{"insert":{"D":"2016-01-16","TS":"2018-06-20 13:37:03"}}
+"#
     );
     let mut serialized = serde_json::from_str::<serde_json::Value>(
         &fs::read_to_string("tests/sql_tests/datetime/v1-snowflake.json").unwrap(),


### PR DESCRIPTION
We used to not place a newline in the end of a batch of ND-JSON records. The issue with this is that when multiple such batches are stored in a file, sent over HTTP or some other transport that doesn't have well-defined message boundaries, there is no newline between two batches, making it invalid ND-JSON.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
