### PR TITLE
Don't export the output of Z1Trace.

### DIFF
--- a/crates/dbsp/src/operator/trace.rs
+++ b/crates/dbsp/src/operator/trace.rs
@@ -193,12 +193,11 @@ where
                 let bounds = TraceBounds::new();
 
                 circuit.region("trace", || {
-                    let (ExportStream { local, export }, z1feedback) = circuit
-                        .add_feedback_with_export(Z1Trace::new(
-                            false,
-                            circuit.root_scope(),
-                            bounds.clone(),
-                        ));
+                    let (local, z1feedback) = circuit.add_feedback(Z1Trace::new(
+                        false,
+                        circuit.root_scope(),
+                        bounds.clone(),
+                    ));
                     let trace = circuit.add_binary_operator_with_preference(
                         <TraceAppend<T, B, C>>::new(circuit.clone()),
                         (&local, OwnershipPreference::STRONGLY_PREFER_OWNED),
@@ -218,7 +217,6 @@ where
 
                     circuit
                         .cache_insert(DelayedTraceId::new(trace.origin_node_id().clone()), local);
-                    circuit.cache_insert(ExportId::new(trace.origin_node_id().clone()), export);
                     (trace, bounds)
                 })
             },
@@ -658,11 +656,11 @@ where
     }
 
     fn get_final_output(&mut self) -> T {
-        if self.reset_on_clock_start {
-            self.get_output()
-        } else {
-            T::new(None)
-        }
+        // We only create the operator using `add_feedback_with_export` if
+        // `reset_on_clock_start` is true, so this should never get invoked
+        // otherwise.
+        assert!(self.reset_on_clock_start);
+        self.get_output()
     }
 }
 

--- a/crates/dbsp/src/operator/upsert.rs
+++ b/crates/dbsp/src/operator/upsert.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{AddAssignByRef, HasOne, HasZero, PartialOrder, ZRingValue},
     circuit::{
         operator_traits::{BinaryOperator, Operator},
-        ExportId, ExportStream, OwnershipPreference, Scope, WithClock,
+        OwnershipPreference, Scope, WithClock,
     },
     operator::trace::{DelayedTraceId, TraceAppend, TraceBounds, TraceId, Z1Trace},
     trace::{
@@ -61,9 +61,8 @@ where
         circuit.region("update_set", || {
             let bounds = <TraceBounds<K, ()>>::unbounded();
 
-            let (ExportStream { local, export }, z1feedback) = circuit.add_feedback_with_export(
-                Z1Trace::new(false, circuit.root_scope(), bounds.clone()),
-            );
+            let (local, z1feedback) =
+                circuit.add_feedback(Z1Trace::new(false, circuit.root_scope(), bounds.clone()));
             local.mark_sharded_if(self);
 
             let delta =
@@ -95,7 +94,6 @@ where
 
             z1feedback.connect_with_preference(&trace, OwnershipPreference::STRONGLY_PREFER_OWNED);
             circuit.cache_insert(DelayedTraceId::new(trace.origin_node_id().clone()), local);
-            circuit.cache_insert(ExportId::new(trace.origin_node_id().clone()), export);
             circuit.cache_insert(
                 TraceId::new(delta.origin_node_id().clone()),
                 (trace, bounds),
@@ -157,9 +155,8 @@ where
         circuit.region("upsert", || {
             let bounds = <TraceBounds<K, V>>::unbounded();
 
-            let (ExportStream { local, export }, z1feedback) = circuit.add_feedback_with_export(
-                Z1Trace::new(false, circuit.root_scope(), bounds.clone()),
-            );
+            let (local, z1feedback) =
+                circuit.add_feedback(Z1Trace::new(false, circuit.root_scope(), bounds.clone()));
             local.mark_sharded_if(self);
 
             let delta = circuit
@@ -190,7 +187,6 @@ where
 
             z1feedback.connect_with_preference(&trace, OwnershipPreference::STRONGLY_PREFER_OWNED);
             circuit.cache_insert(DelayedTraceId::new(trace.origin_node_id().clone()), local);
-            circuit.cache_insert(ExportId::new(trace.origin_node_id().clone()), export);
             circuit.cache_insert(
                 TraceId::new(delta.origin_node_id().clone()),
                 (trace, bounds),


### PR DESCRIPTION
Strict operators (i.e., operators on the backedge of a feedback loop) have a feature that allows the parent circuit to consume the last output of the operator after its clock epoch ends.  This is useful to make the result of a fixed point computation availabel to the parent.  This behavior used to be mandatory for all strict operators.  For the `Z1Trace` operator, when configured to integrate inputs across multiple clock epochs this meant that it had to manufacture a bogus empty trace just to keep the API happy.  It turns out that empty traces are expensive when using RocksDB for persistence.

The fix is to make the export feature optional and not create an export stream for operators like `Z1Trace`, since these are not used anyway.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
