### PR TITLE
Avoid using persistent Spines for thread communication.

### DIFF
--- a/crates/dbsp/src/operator/communication/gather.rs
+++ b/crates/dbsp/src/operator/communication/gather.rs
@@ -5,9 +5,12 @@ use crate::{
         GlobalNodeId, OwnershipPreference, Scope,
     },
     circuit_cache_key,
-    trace::{spine_fueled::Spine, Batch, Trace},
+    trace::{Batch, Trace},
     Circuit, Runtime, Stream,
 };
+// Import `spine_fueled::Spine`` here instead of `trace::Spine`` because it is
+// strictly used for non-persistent data-communication between threads.
+use crate::trace::spine_fueled::Spine;
 use arc_swap::ArcSwap;
 use crossbeam::atomic::AtomicConsume;
 use crossbeam_utils::CachePadded;

--- a/crates/dbsp/src/operator/communication/shard.rs
+++ b/crates/dbsp/src/operator/communication/shard.rs
@@ -8,9 +8,12 @@ use crate::{
     circuit::GlobalNodeId,
     circuit_cache_key, default_hash,
     operator::communication::exchange::new_exchange_operators,
-    trace::{cursor::Cursor, Batch, BatchReader, Builder, Spine, Trace},
+    trace::{cursor::Cursor, Batch, BatchReader, Builder, Trace},
     Circuit, Runtime, Stream,
 };
+// Import `spine_fueled::Spine` here instead of `trace::Spine` because it is
+// strictly used for non-persistent data-communication between threads.
+use crate::trace::spine_fueled::Spine;
 use std::{hash::Hash, panic::Location};
 
 circuit_cache_key!(ShardId<C, D>((GlobalNodeId, ShardingPolicy) => Stream<C, D>));


### PR DESCRIPTION
This fix makes sure we use spine_fueled::Spine in
the communication module where we dont need persistent traces. Otherwise we would find ourselves creating (and dropping) new rocksdb column families quite a bit during regular operation (which doesn't scale and is very slow)

See also:
https://github.com/facebook/rocksdb/blob/543191f2eacadf14e3aa6ff9a08f85a8ad82da95/include/rocksdb/db.h#L365

With this commit no new PersistentTraces are created after startup which leads to much better performance with multiple cores:

nexmark q16 with 1 / 8 cores before:
~17s / ~4635s
nexmark q16 with 1 / 8 cores now:
~13s / ~39s

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
