### PR TITLE
Fix `supply_chain_test`.

### DIFF
--- a/crates/adapters/tests/jit_integration_test.rs
+++ b/crates/adapters/tests/jit_integration_test.rs
@@ -179,15 +179,18 @@ fn supply_chain_test() {
     sleep(Duration::from_millis(2_000));
     server_thread.shutdown();
 
-    let expected_output = r#"{"insert":{"PART_ID":1,"PART_NAME":"Flux Capacitor","VENDOR_ID":2,"VENDOR_NAME":"HyperDrive Innovations","PRICE":10000}}
-{"insert":{"PART_ID":2,"PART_NAME":"Warp Core","VENDOR_ID":1,"VENDOR_NAME":"Gravitech Dynamics","PRICE":15000}}
-{"insert":{"PART_ID":3,"PART_NAME":"Kyber Crystal","VENDOR_ID":3,"VENDOR_NAME":"DarkMatter Devices","PRICE":9000}}
-"#;
+    let expected_output = vec![
+        r#"{"insert":{"PART_ID":1,"PART_NAME":"Flux Capacitor","VENDOR_ID":2,"VENDOR_NAME":"HyperDrive Innovations","PRICE":10000}}"#.to_string(),
+        r#"{"insert":{"PART_ID":2,"PART_NAME":"Warp Core","VENDOR_ID":1,"VENDOR_NAME":"Gravitech Dynamics","PRICE":15000}}"#.to_string(),
+        r#"{"insert":{"PART_ID":3,"PART_NAME":"Kyber Crystal","VENDOR_ID":3,"VENDOR_NAME":"DarkMatter Devices","PRICE":9000}}"#.to_string(),
+    ];
 
-    assert_eq!(
-        fs::read_to_string("tests/sql_tests/supply_chain/preferred_vendor.json").unwrap(),
-        expected_output,
-    );
+    // The multithreaded circuit can produce outputs in non-deterministic order.
+    let output = fs::read_to_string("tests/sql_tests/supply_chain/preferred_vendor.json").unwrap();
+    let mut lines = output.lines().collect::<Vec<_>>();
+    lines.sort();
+
+    assert_eq!(expected_output, lines);
 }
 
 #[test]


### PR DESCRIPTION
This `supply_chain_test` integration test assumed fixed order of output rows, which is not guaranteed with multiple worker threads.  This caused non-deterministic test failures in CI.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
