### PR TITLE
Apply retainment policies to traces

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1403,7 +1403,7 @@ impl OutputConsumer for OutputProbe {
 #[cfg(test)]
 mod test {
     use crate::{
-        test::{generate_test_batch, test_circuit, wait, TestStruct},
+        test::{generate_test_batch, test_circuit, wait, TestStruct, DEFAULT_TIMEOUT_MS},
         Controller, PipelineConfig,
     };
     use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
@@ -1484,7 +1484,7 @@ outputs:
             controller.start();
 
             // Wait for the pipeline to output all records.
-            wait(|| controller.pipeline_complete(), None);
+            wait(|| controller.pipeline_complete(), DEFAULT_TIMEOUT_MS);
 
             assert_eq!(controller.status().output_status().get(&0).unwrap().transmitted_records(), data.len() as u64);
 

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -1,5 +1,5 @@
 use crate::{
-    test::{wait, MockDeZSet, TestStruct},
+    test::{wait, MockDeZSet, TestStruct, DEFAULT_TIMEOUT_MS},
     InputFormat,
 };
 use anyhow::{anyhow, bail, Result as AnyResult};
@@ -282,7 +282,7 @@ impl BufferConsumer {
         let num_records: usize = data.iter().map(Vec::len).sum();
 
         // println!("waiting for {num_records} records");
-        wait(|| self.len() == num_records, None);
+        wait(|| self.len() == num_records, DEFAULT_TIMEOUT_MS);
         //println!("{num_records} records received: {:?}",
         // received_data.lock().unwrap().iter().map(|r| r.id).collect::<Vec<_>>());
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -33,6 +33,8 @@ pub use mock_output_consumer::MockOutputConsumer;
 pub struct TestLogger;
 pub static TEST_LOGGER: TestLogger = TestLogger;
 
+pub static DEFAULT_TIMEOUT_MS: u128 = 600_000;
+
 impl Log for TestLogger {
     fn enabled(&self, _metadata: &Metadata) -> bool {
         true
@@ -48,17 +50,15 @@ impl Log for TestLogger {
 /// Wait for `predicate` to become `true`.
 ///
 /// Returns the number of milliseconds elapsed or `None` on timeout.
-pub fn wait<P>(mut predicate: P, timeout_ms: Option<u128>) -> Option<u128>
+pub fn wait<P>(mut predicate: P, timeout_ms: u128) -> Option<u128>
 where
     P: FnMut() -> bool,
 {
     let start = Instant::now();
 
     while !predicate() {
-        if let Some(timeout_ms) = timeout_ms {
-            if start.elapsed().as_millis() >= timeout_ms {
-                return None;
-            }
+        if start.elapsed().as_millis() >= timeout_ms {
+            return None;
         }
         sleep(Duration::from_millis(10));
     }

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -218,7 +218,7 @@ impl OutputEndpoint for FileOutputEndpoint {
 mod test {
     use crate::{
         deserialize_without_context,
-        test::{mock_input_pipeline, wait},
+        test::{mock_input_pipeline, wait, DEFAULT_TIMEOUT_MS},
     };
     use csv::WriterBuilder as CsvWriterBuilder;
     use serde::{Deserialize, Serialize};
@@ -285,7 +285,10 @@ format:
 
         // Unpause the endpoint, wait for the data to appear at the output.
         endpoint.start().unwrap();
-        wait(|| zset.state().flushed.len() == test_data.len(), None);
+        wait(
+            || zset.state().flushed.len() == test_data.len(),
+            DEFAULT_TIMEOUT_MS,
+        );
         for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
             assert!(polarity);
             assert_eq!(val, &test_data[i]);
@@ -340,7 +343,10 @@ format:
 
             // Unpause the endpoint, wait for the data to appear at the output.
             endpoint.start().unwrap();
-            wait(|| zset.state().flushed.len() == test_data.len(), None);
+            wait(
+                || zset.state().flushed.len() == test_data.len(),
+                DEFAULT_TIMEOUT_MS,
+            );
             for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
                 assert!(polarity);
                 assert_eq!(val, &test_data[i]);
@@ -364,7 +370,7 @@ format:
                 // println!("result: {:?}", state.parser_result);
                 state.parser_result.is_some() && !state.parser_result.as_ref().unwrap().1.is_empty()
             },
-            None,
+            DEFAULT_TIMEOUT_MS,
         );
 
         assert!(zset.state().buffered.is_empty());

--- a/crates/adapters/src/transport/kafka/test.rs
+++ b/crates/adapters/src/transport/kafka/test.rs
@@ -2,7 +2,7 @@ use crate::{
     test::{
         generate_test_batches,
         kafka::{BufferConsumer, KafkaResources, TestProducer},
-        mock_input_pipeline, test_circuit, wait, MockDeZSet, TestStruct,
+        mock_input_pipeline, test_circuit, wait, MockDeZSet, TestStruct, DEFAULT_TIMEOUT_MS,
     },
     Controller, PipelineConfig,
 };
@@ -23,7 +23,10 @@ use std::{
 fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
     let num_records: usize = data.iter().map(Vec::len).sum();
 
-    wait(|| zset.state().flushed.len() == num_records, None);
+    wait(
+        || zset.state().flushed.len() == num_records,
+        DEFAULT_TIMEOUT_MS,
+    );
 
     for (i, val) in data.iter().flat_map(|data| data.iter()).enumerate() {
         assert_eq!(&zset.state().flushed[i].0, val);
@@ -34,7 +37,10 @@ fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct
 fn wait_for_output_unordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
     let num_records: usize = data.iter().map(Vec::len).sum();
 
-    wait(|| zset.state().flushed.len() == num_records, None);
+    wait(
+        || zset.state().flushed.len() == num_records,
+        DEFAULT_TIMEOUT_MS,
+    );
 
     let mut data_sorted = data
         .iter()

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -527,17 +527,17 @@ impl<D> StreamValue<D> {
 ///     over a partition.
 ///
 ///   * If the application can discard data that arrives too out-of-order, use
-///     [`Stream::partitioned_rolling_aggregate_with_watermark`], which can be
+///     [`Stream::partitioned_rolling_aggregate_with_waterline`], which can be
 ///     more memory-efficient.  This form of rolling aggregation requires a
-///     "watermark" stream, which is a stream of times (scalars, not batches or
+///     "waterline" stream, which is a stream of times (scalars, not batches or
 ///     Z sets) that reports the earliest time that can be updated.  Use
-///     [`Stream::watermark_monotonic`] to conveniently produce the watermark
+///     [`Stream::waterline_monotonic`] to conveniently produce the waterline
 ///     stream.
 ///
-///     [`Stream::partitioned_rolling_aggregate_with_watermark`] operates on an
-///     `IndexedZSet` and, in addition to the aggregrator, range, and watermark
+///     [`Stream::partitioned_rolling_aggregate_with_waterline`] operates on an
+///     `IndexedZSet` and, in addition to the aggregrator, range, and waterline
 ///     stream, it takes a function to map a record to a partition. It discards
-///     input before the watermark, partitions it, aggregates it, and returns
+///     input before the waterline, partitions it, aggregates it, and returns
 ///     the result as a `PartitionedIndexedZSet`.
 ///
 /// ## Windowing

--- a/crates/dbsp/src/operator/communication/shard.rs
+++ b/crates/dbsp/src/operator/communication/shard.rs
@@ -133,6 +133,7 @@ where
                                 &runtime,
                                 Runtime::worker_index(),
                                 Some(location),
+                                Default::default,
                                 move |batch: IB, batches: &mut Vec<OB>| {
                                     Self::shard_batch(&batch, num_workers, &mut builders, batches);
                                 },

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -1345,7 +1345,7 @@ mod test {
 
     fn set_test_circuit(circuit: &RootCircuit) -> AnyResult<UpsertHandle<usize, bool>> {
         let (stream, handle) = circuit.add_input_set::<usize, isize>();
-        let watermark = stream.watermark(|| 0, |k, ()| *k, |k1, k2| max(*k1, *k2));
+        let watermark = stream.waterline(|| 0, |k, ()| *k, |k1, k2| max(*k1, *k2));
         stream.integrate_trace_retain_keys(&watermark, |ts, k| *k >= ts.saturating_sub(10));
 
         let mut expected_batches = output_set_updates().into_iter();
@@ -1456,7 +1456,7 @@ mod test {
 
     fn map_test_circuit(circuit: &RootCircuit) -> AnyResult<UpsertHandle<usize, Option<usize>>> {
         let (stream, handle) = circuit.add_input_map::<usize, usize, isize>();
-        let watermark = stream.watermark(
+        let watermark = stream.waterline(
             || (0, 0),
             |k, v| (*k, *v),
             |ts1, ts2| (max(ts1.0, ts2.0), max(ts1.1, ts2.1)),

--- a/crates/dbsp/src/operator/time_series/mod.rs
+++ b/crates/dbsp/src/operator/time_series/mod.rs
@@ -2,7 +2,7 @@ mod partitioned;
 mod radix_tree;
 mod range;
 mod rolling_aggregate;
-mod watermark;
+mod waterline;
 mod window;
 
 pub use partitioned::{

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -729,7 +729,7 @@ mod test {
                 input_stream.map_index(|(partition, (ts, val))| (*ts, (*partition, *val)));
 
             let watermark =
-                input_by_time.watermark_monotonic(move |ts| ts.saturating_sub(lateness));
+                input_by_time.watermark_monotonic(|| 0, move |ts| ts.saturating_sub(lateness));
 
             let aggregator = <Fold<_, DefaultSemigroup<_>, _, _>>::new(
                 0i64,

--- a/crates/dbsp/src/operator/time_series/watermark.rs
+++ b/crates/dbsp/src/operator/time_series/watermark.rs
@@ -1,7 +1,7 @@
 use crate::{
     operator::communication::new_exchange_operators,
     trace::{cursor::Cursor, BatchReader, Rkyv},
-    Circuit, NumEntries, RootCircuit, Runtime, Stream,
+    Circuit, DBData, NumEntries, RootCircuit, Runtime, Stream,
 };
 use size_of::SizeOf;
 use std::{cmp::max, panic::Location};
@@ -32,12 +32,17 @@ where
     /// computed as the maximum of the previous watermark and the largest
     /// watermark in the new input batch.
     #[track_caller]
-    pub fn watermark_monotonic<W, TS>(&self, watermark_func: W) -> Stream<RootCircuit, TS>
+    pub fn watermark_monotonic<WF, IF, TS>(
+        &self,
+        init: IF,
+        watermark_func: WF,
+    ) -> Stream<RootCircuit, TS>
     where
-        W: Fn(&B::Key) -> TS + 'static,
-        TS: Ord + Clone + Default + SizeOf + NumEntries + Send + Rkyv + 'static,
+        IF: Fn() -> TS + 'static,
+        WF: Fn(&B::Key) -> TS + 'static,
+        TS: Ord + Clone + SizeOf + NumEntries + Send + Rkyv + 'static,
     {
-        let local_watermark = self.stream_fold(TS::default(), move |old_watermark, batch| {
+        let local_watermark = self.stream_fold(init(), move |old_watermark, batch| {
             let mut cursor = batch.cursor();
             cursor.fast_forward_keys();
             match cursor.get_key() {
@@ -56,6 +61,7 @@ where
                 &runtime,
                 Runtime::worker_index(),
                 Some(Location::caller()),
+                init,
                 move |watermark: TS, watermarks: &mut Vec<TS>| {
                     for _ in 0..num_workers {
                         watermarks.push(watermark.clone());
@@ -76,8 +82,103 @@ where
     }
 }
 
+impl<B> Stream<RootCircuit, B>
+where
+    B: BatchReader + Clone + 'static,
+{
+    /// Computes the least upper bound over all records that occurred in the
+    /// stream with respect to some user-defined lattice.
+    ///
+    /// The primary use of this function is in time series analytics in
+    /// computing the largest timestamp observed in the stream, which can in
+    /// turn be used in computing retainment policies for data in this
+    /// stream and streams derived from it (see
+    /// [`Stream::integrate_trace_retain_keys`] and
+    /// [`Stream::integrate_trace_retain_values`]).
+    ///
+    /// Note: the notion of time here is distinct from the DBSP logical time and
+    /// represents one or several physical timestamps embedded in the input
+    /// data.
+    ///
+    /// In the special case where timestamps form a total order and the input
+    /// stream is indexed by time, the
+    /// [`watermark_monotonic`](`Stream::watermark_monotonic`) function can
+    /// be used instead of this method to compute the bound more
+    /// efficiently.
+    ///
+    /// # Arguments
+    ///
+    /// * `init` - initial value of the bound, usually the bottom element of the
+    ///   lattice.
+    /// * `extract_ts` - extracts a timestamp from a key-value pair.
+    /// * `least_upper_bound` - computes the least upper bound of two
+    ///   timestamps.
+    #[track_caller]
+    pub fn watermark<TS, WF, IF, LB>(
+        &self,
+        init: IF,
+        extract_ts: WF,
+        least_upper_bound: LB,
+    ) -> Stream<RootCircuit, TS>
+    where
+        IF: Fn() -> TS + 'static,
+        WF: Fn(&B::Key, &B::Val) -> TS + 'static,
+        LB: Fn(&TS, &TS) -> TS + Clone + 'static,
+        TS: DBData + NumEntries,
+    {
+        let least_upper_bound_clone = least_upper_bound.clone();
+
+        let local_watermark = self.stream_fold(init(), move |old_watermark, batch| {
+            let mut watermark = old_watermark;
+
+            let mut cursor = batch.cursor();
+
+            while cursor.key_valid() {
+                while cursor.val_valid() {
+                    watermark = least_upper_bound_clone(
+                        &watermark,
+                        &extract_ts(cursor.key(), cursor.val()),
+                    );
+                    cursor.step_val();
+                }
+                cursor.step_key();
+            }
+            watermark
+        });
+
+        if let Some(runtime) = Runtime::runtime() {
+            let num_workers = runtime.num_workers();
+            if num_workers == 1 {
+                return local_watermark;
+            }
+
+            let (sender, receiver) = new_exchange_operators(
+                &runtime,
+                Runtime::worker_index(),
+                Some(Location::caller()),
+                init,
+                move |watermark: TS, watermarks: &mut Vec<TS>| {
+                    for _ in 0..num_workers {
+                        watermarks.push(watermark.clone());
+                    }
+                },
+                move |result, watermark| {
+                    *result = least_upper_bound(result, &watermark);
+                },
+            );
+
+            self.circuit()
+                .add_exchange(sender, receiver, &local_watermark)
+        } else {
+            local_watermark
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::cmp::max;
+
     use crate::Runtime;
 
     fn test_watermark_monotonic(workers: usize) {
@@ -86,7 +187,7 @@ mod tests {
         let (mut dbsp, input_handle) = Runtime::init_circuit(workers, move |circuit| {
             let (stream, handle) = circuit.add_input_zset();
             stream
-                .watermark_monotonic(|ts| ts + 5)
+                .watermark_monotonic(|| 0, |ts| ts + 5)
                 .inspect(move |watermark| {
                     if Runtime::worker_index() == 0 {
                         assert_eq!(watermark, &expected_watermarks.next().unwrap());
@@ -119,5 +220,52 @@ mod tests {
     #[test]
     fn test_watermark_monotonic4() {
         test_watermark_monotonic(4);
+    }
+
+    fn test_watermark(workers: usize) {
+        let mut expected_watermarks = vec![(-10, 1), (100, 3), (100, 7), (250, 7)].into_iter();
+
+        let (mut dbsp, input_handle) = Runtime::init_circuit(workers, move |circuit| {
+            let (stream, handle) = circuit.add_input_indexed_zset::<i32, i32, _>();
+            stream
+                .watermark(
+                    || (i32::MIN, i32::MIN),
+                    |k, v| (*k, *v),
+                    |(ts1_left, ts2_left), (ts1_right, ts2_right)| {
+                        (max(*ts1_left, *ts1_right), max(*ts2_left, *ts2_right))
+                    },
+                )
+                .inspect(move |watermark| {
+                    if Runtime::worker_index() == 0 {
+                        assert_eq!(watermark, &expected_watermarks.next().unwrap());
+                    }
+                });
+            Ok(handle)
+        })
+        .unwrap();
+
+        input_handle.append(&mut vec![(-100, (-5, 1)), (-10, (1, 1)), (-200, (1, 1))]);
+        dbsp.step().unwrap();
+
+        input_handle.append(&mut vec![(0, (1, 1)), (-100, (2, 1)), (100, (3, 1))]);
+        dbsp.step().unwrap();
+
+        input_handle.append(&mut vec![(50, (5, 1)), (-200, (-10, 1)), (99, (7, 1))]);
+        dbsp.step().unwrap();
+
+        input_handle.append(&mut vec![(130, (1, 1)), (140, (1, 1)), (250, (1, 1))]);
+        dbsp.step().unwrap();
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn test_watermark1() {
+        test_watermark(1);
+    }
+
+    #[test]
+    fn test_watermark4() {
+        test_watermark(4);
     }
 }

--- a/crates/dbsp/src/operator/time_series/window.rs
+++ b/crates/dbsp/src/operator/time_series/window.rs
@@ -458,7 +458,7 @@ mod test {
         let (mut dbsp, input_handle) = Runtime::init_circuit(8, |circuit| {
             let (input, input_handle) = circuit.add_input_zset::<isize, isize>();
             let bounds = input
-                .watermark_monotonic(|ts| *ts)
+                .watermark_monotonic(|| 0, |ts| *ts)
                 .apply(|ts| (*ts - 1000, *ts));
 
             let bound = TraceBound::new();

--- a/crates/dbsp/src/operator/time_series/window.rs
+++ b/crates/dbsp/src/operator/time_series/window.rs
@@ -458,7 +458,7 @@ mod test {
         let (mut dbsp, input_handle) = Runtime::init_circuit(8, |circuit| {
             let (input, input_handle) = circuit.add_input_zset::<isize, isize>();
             let bounds = input
-                .watermark_monotonic(|| 0, |ts| *ts)
+                .waterline_monotonic(|| 0, |ts| *ts)
                 .apply(|ts| (*ts - 1000, *ts));
 
             let bound = TraceBound::new();

--- a/crates/nexmark/src/queries/q5.rs
+++ b/crates/nexmark/src/queries/q5.rs
@@ -83,7 +83,7 @@ pub fn q5(input: NexmarkStream) -> Q5Stream {
 
     // Extract the largest timestamp from the input stream. We will use it as
     // current time. Set watermark to `WATERMARK_INTERVAL_SECONDS` in the past.
-    let watermark = bids_by_time.watermark_monotonic(
+    let watermark = bids_by_time.waterline_monotonic(
         || 0,
         |date_time| date_time - WATERMARK_INTERVAL_SECONDS * 1000,
     );

--- a/crates/nexmark/src/queries/q7.rs
+++ b/crates/nexmark/src/queries/q7.rs
@@ -54,7 +54,7 @@ pub fn q7(input: NexmarkStream) -> Q7Stream {
     // from the input stream for the current time, with the window ending at the
     // previous 10 second multiple.
     // Set the watermark to `WATERMARK_INTERVAL_SECONDS` in the past.
-    let watermark = bids_by_time.watermark_monotonic(
+    let watermark = bids_by_time.waterline_monotonic(
         || 0,
         |date_time| date_time - WATERMARK_INTERVAL_SECONDS * 1000,
     );

--- a/crates/nexmark/src/queries/q8.rs
+++ b/crates/nexmark/src/queries/q8.rs
@@ -61,7 +61,7 @@ pub fn q8(input: NexmarkStream) -> Q8Stream {
 
     // Use the latest auction for the watermark
     let watermark =
-        auctions_by_time.watermark_monotonic(|| 0, |date_time| date_time - TUMBLE_SECONDS * 1000);
+        auctions_by_time.waterline_monotonic(|| 0, |date_time| date_time - TUMBLE_SECONDS * 1000);
     let window_bounds = watermark.apply(|watermark| {
         let watermark_rounded = *watermark - (*watermark % (TUMBLE_SECONDS * 1000));
         (


### PR DESCRIPTION
Part of work on #873.

This PR implements an API to specify data retainment policies for keys and/or values in a trace.

Background
==========

Relations that store time series data typically have the property that any new updates can only affect records with recent timestamps.  Depending on how the relation is used in queries this might mean that, while records with older timestamps still exist in the relation, they cannot affect any future incremental computation and therefore don't need to be stored.

Design
======

We support two mechanisms to specify and eventually discard such unused records.

The first (already existing) mechanism, exposed via the `Stream::integrate_trace_with_bound` method, is only applicable when keys and/or values in the collection are ordered by time.  It allows _each_ consumer of the trace to specify a lower bound on the keys and values it is interested in.  The effective bound is the minimum of all bounds specified by individual consumers.

The second mechanism, implemented in this commit is more general and allows the caller to specify arbitrary conditions on keys and values in the trace.  Keys (values) that don't satisfy the condition are eventually reclaimed by the trace.  This mechanism is applicable to collections that are not ordered by time.  Hence it doesn't require rearranging the data in time order.  Furthermore, it is applicable to collections that contain multiple timestamp column.  Such multidimensional timestamps only form a lattice, not a total order.

Unlike the first mechanism, this mechanism only allows one global condition to be applied to the stream.  This bound affects _all_ operators that use the trace of the stream, i.e., call `integrate_trace` (or `trace` in the root scope) on it. This includes for instance `join`, `aggregate`, and `distinct`.  All such operators will reference the same instance of a trace.  Therefore bounds specified by this API must be based on a global analysis of the entire program.

The two mechanisms described above interact in different ways for keys and values.  For keys, the lower bound and the retainment condition are independent and can be active at the same time.  Internally, they are enforced using different techniques.  Lower bounds are enforced at essentially zero cost.  The retention condition is more expensive, but more general.

For values, only one of the two mechanisms can be enabled for any given stream.  Whenever a retainment condition is specified it supersedes any lower bounds constraints.

Correctness
===========

Retainment policies set using the new API apply to all consumers of the trace.  An incorrect policy may reclaim keys that are still needed by some of the operators, leading to incorrect results.  Computing a correct retainment policy can be a subtle and error prone task, which is probably best left to automatic tools like compilers.

In this commit
=============

* `watermark` operator - computes the lower upper bound of all timestamps in the stream without assuming that timestamps form a total order or that the data is indexed by time

* `integrate_trace_retain_key`, `integrate_trace_retain_value` operators can be used to apply a retainment policy to keys and/or values in a trace.

* Along the way, generalized the exchange operator not to require the output type to implement `Default`.  The user sets the initial value of the accumulator explicitly now.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
