### PR TITLE
Connector secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([940](https://github.com/feldera/feldera/pull/940))
 - Restructure and expansion of cloud documentation
   ([#957](https://github.com/feldera/feldera/pull/957))
+- Secrets can be referenced using a string pattern
+  in the Kafka connector input and output configuration
+  ([#949](https://github.com/feldera/feldera/pull/949))
 
 ### Fixed
 - Reduce Docker logging noise from Kafka connect and Redpanda.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "psutil",
  "rand",
  "rdkafka",
+ "regex",
  "reqwest",
  "rkyv",
  "rust_decimal",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -61,6 +61,7 @@ rkyv = "0.7.42"
 csv-core = "0.1.10"
 rust_decimal = "1.32.0"
 rand = "0.8.5"
+regex = "1.10.2"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 psutil = "3.2.2"

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -43,6 +43,8 @@ pub mod http;
 
 pub mod url;
 
+mod secret_resolver;
+
 #[cfg(feature = "with-kafka")]
 pub(crate) mod kafka;
 

--- a/crates/adapters/src/transport/secret_resolver.rs
+++ b/crates/adapters/src/transport/secret_resolver.rs
@@ -1,0 +1,329 @@
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::fs;
+use std::path::Path;
+
+use anyhow::{anyhow, Result as AnyResult};
+use log::debug;
+use pipeline_types::secret_ref::MaybeSecretRef;
+use regex::Regex;
+
+/// Enumeration which holds a simple string or a resolved secret's string.
+///
+/// This enumeration exists such that a resolved secret's string is not shown
+/// upon formatting (irrespective if `Display` or `Debug`). This is preferable
+/// over using a simple `String`, which would show its content upon formatting.
+///
+/// Creation of a secret happens using [MaybeSecret::new], which resolves the
+/// secret reference it potentially receives to the actual secret string.
+#[derive(Clone, PartialEq, Eq)]
+pub enum MaybeSecret {
+    String(String),
+    Secret(String),
+}
+
+impl Display for MaybeSecret {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            MaybeSecret::String(simple_string) => {
+                write!(f, "String(\"{}\")", simple_string)
+            }
+            MaybeSecret::Secret(_) => {
+                write!(f, "Secret(***)")
+            }
+        }
+    }
+}
+
+impl Debug for MaybeSecret {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Use Display formatting
+        write!(f, "{}", self)
+    }
+}
+
+impl MaybeSecret {
+    /// Path to the default secret volume.
+    pub const DEFAULT_SECRET_VOLUME_PATH: &'static str = "/etc/secret-volume";
+
+    /// Regex pattern for a valid secret reference name.
+    ///
+    /// A secret reference can only contain a-z and 0-9. There can be connecting
+    /// hyphens (-), though not at the start, not at the end, and not two in
+    /// succession. It cannot be empty.
+    ///
+    /// Valid examples:
+    /// "example", "example-1", "example-of-this"
+    ///
+    /// Invalid examples:
+    /// "", "example--1", "example_1", "-", "Example#1", "example-"
+    pub const PATTERN_VALID_SECRET_REF: &'static str = r"^[a-z0-9]+(-[a-z0-9]+)*$";
+
+    /// Checks whether the provided secret reference follows
+    /// the valid secret reference pattern:
+    /// [PATTERN_VALID_SECRET_REF](Self::PATTERN_VALID_SECRET_REF).
+    fn is_valid_secret_ref_format(secret_ref: &str) -> bool {
+        let re = Regex::new(Self::PATTERN_VALID_SECRET_REF).unwrap();
+        re.is_match(secret_ref)
+    }
+
+    /// Resolves a potential secret reference to a secret or simply return the
+    /// string if it is a string. The default secret volume is used.
+    /// More information regarding resolution is detailed in
+    /// [MaybeSecret::new].
+    pub fn new_with_default_volume(value: MaybeSecretRef) -> AnyResult<Self> {
+        Self::new(Path::new(Self::DEFAULT_SECRET_VOLUME_PATH), value)
+    }
+
+    /// Resolves a potential secret reference to a secret or simply return the
+    /// string if it is a string.
+    ///
+    /// The current resolution method is through the mounted secret volume
+    /// ("/path/to/secret/volume"). A secret reference "example" will have the
+    /// secret string fetched from the file at
+    /// "/path/to/secret/volume/.example".
+    ///
+    /// Note: prefixing each file with a dot is a convention from the Kubernetes
+    /// documentation for secret keys: https://kubernetes.io/docs/concepts/configuration/secret/
+    /// (such that they are are hidden in `ls -l` and require `ls -la` to show).
+    pub fn new(secret_volume_path: &Path, value: MaybeSecretRef) -> AnyResult<Self> {
+        match value {
+            MaybeSecretRef::String(simple_string) => Ok(Self::String(simple_string)),
+            MaybeSecretRef::SecretRef(secret_ref) => {
+                // Check format
+                if !Self::is_valid_secret_ref_format(&secret_ref) {
+                    return Err(anyhow!(
+                        "Secret reference does not follow valid format: {}",
+                        secret_ref
+                    ));
+                }
+
+                // Create the file path by appending the filename
+                let filename = ".".to_string() + &secret_ref;
+                let file_path = secret_volume_path.join(filename);
+
+                // Check that metadata can be retrieved before actually trying to read
+                // from it. This provides a more user-friendly distinguishing error message
+                // for the file not being present at all versus the file not being readable
+                // (e.g., because it is a directory, or insufficient permission).
+                match fs::metadata(&file_path) {
+                    Ok(_) => match fs::read_to_string(&file_path) {
+                        Ok(content) => {
+                            debug!("Secret reference resolution successful: {}", secret_ref);
+                            Ok(Self::Secret(content))
+                        },
+                        Err(err) => Err(anyhow!(
+                                "Could not resolve secret reference {} as file: {:?} (is it readable on the mounted secret volume?) -- read failed: {}",
+                                secret_ref, file_path, err
+                        ))
+                    },
+                    Err(err) => Err(anyhow!(
+                        "Could not resolve secret reference {} as file: {:?} (was it added to the mounted secret volume?) -- metadata check failed: {}",
+                        secret_ref, file_path, err
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::fs::File;
+    use std::io::Write;
+
+    use super::MaybeSecret;
+    use pipeline_types::secret_ref::MaybeSecretRef;
+
+    #[test]
+    fn test_new_string() {
+        match MaybeSecret::new_with_default_volume(MaybeSecretRef::String("example".to_string())) {
+            Ok(MaybeSecret::String(simple_string)) => {
+                assert_eq!("example", simple_string);
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_secret_success() {
+        // Create a temporary directory which acts as the mounted secret volume.
+        // Create a file there with the secret reference name ".the-secret".
+        // The file contains the secret string "example".
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path();
+        let file_path = &dir_path.join(".the-secret");
+        let mut file = File::create(file_path).unwrap();
+        file.write_all(b"example").unwrap();
+        println!("Temporary directory: {:?}", dir_path);
+        println!("Temporary file: {:?}", file_path);
+
+        // Check that a secret with the provided filename as reference is correctly
+        // resolved
+        match MaybeSecret::new(
+            dir_path,
+            MaybeSecretRef::SecretRef("the-secret".to_string()),
+        ) {
+            Ok(MaybeSecret::Secret(secret_string)) => {
+                assert_eq!("example", secret_string);
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_format_check() {
+        let valid = vec![
+            "example",
+            "example-1",
+            "example-of-this",
+            "e",
+            "ab",
+            "example-abcde",
+        ];
+        for secret_ref in valid {
+            assert!(MaybeSecret::is_valid_secret_ref_format(
+                &secret_ref.to_string()
+            ));
+        }
+        let invalid = vec![
+            "",
+            "example--1",
+            "example_1",
+            "-",
+            "Example#1",
+            "example-",
+            "a-",
+            "-b",
+            "-a-",
+            "--",
+            "EXAMPLE",
+        ];
+        for secret_ref in invalid {
+            assert!(!MaybeSecret::is_valid_secret_ref_format(
+                &secret_ref.to_string()
+            ));
+        }
+    }
+
+    #[test]
+    fn test_new_secret_failure_invalid_format() {
+        match MaybeSecret::new_with_default_volume(MaybeSecretRef::SecretRef(
+            "-example".to_string(),
+        )) {
+            Ok(_) => {
+                assert!(false);
+            }
+            Err(err) => {
+                assert_eq!(
+                    err.to_string(),
+                    "Secret reference does not follow valid format: -example"
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_secret_failure_file_does_not_exist() {
+        // Create a temporary directory which acts as the mounted secret volume.
+        // No file is created inside explicitly.
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path();
+        println!("Temporary directory: {:?}", dir_path);
+
+        // Provide the deleted file path
+        match MaybeSecret::new(
+            dir_path,
+            MaybeSecretRef::SecretRef("the-secret".to_string()),
+        ) {
+            Ok(_) => {
+                assert!(false);
+            }
+            Err(err) => {
+                let err_string = err.to_string();
+                assert!(err_string.starts_with(format!(
+                    "Could not resolve secret reference {} as file: {:?} (was it added to the mounted secret volume?) -- metadata check failed: ",
+                    "the-secret", dir_path.join(".the-secret")
+                ).as_str()));
+                // The exact string of the file system error is not matched, as
+                // it might vary system-to-system
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_secret_failure_file_is_a_dir() {
+        // Create a temporary directory which acts as the mounted secret volume.
+        // A directory is created inside.
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path();
+        let file_path = &dir_path.join(".the-secret");
+        fs::create_dir(file_path).unwrap();
+        println!("Temporary directory: {:?}", dir_path);
+        println!("Temporary file: {:?}", file_path);
+
+        // Provide the file path which is a directory
+        match MaybeSecret::new(
+            dir_path,
+            MaybeSecretRef::SecretRef("the-secret".to_string()),
+        ) {
+            Ok(_) => {
+                assert!(false);
+            }
+            Err(err) => {
+                let err_string = err.to_string();
+                assert!(err_string.starts_with(format!(
+                    "Could not resolve secret reference {} as file: {:?} (is it readable on the mounted secret volume?) -- read failed: ",
+                    "the-secret", dir_path.join(".the-secret")
+                ).as_str()));
+                // The exact string of the file system error is not matched, as
+                // it might vary system-to-system
+            }
+        }
+    }
+
+    #[test]
+    fn test_format() {
+        assert_eq!(
+            "String(\"example123\")",
+            format!("{}", MaybeSecret::String("example123".to_string()))
+        );
+        assert_eq!(
+            "String(\"example123\")",
+            format!("{:?}", MaybeSecret::String("example123".to_string()))
+        );
+        assert_eq!(
+            "Secret(***)",
+            format!("{}", MaybeSecret::Secret("example123".to_string()))
+        );
+        assert_eq!(
+            "Secret(***)",
+            format!("{:?}", MaybeSecret::Secret("example123".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_internal_strings() {
+        match MaybeSecret::String("example123".to_string()) {
+            MaybeSecret::String(simple_string) => {
+                assert_eq!(simple_string, "example123");
+            }
+            MaybeSecret::Secret(_) => {
+                assert!(false);
+            }
+        }
+        match MaybeSecret::Secret("example123".to_string()) {
+            MaybeSecret::String(_) => {
+                assert!(false);
+            }
+            MaybeSecret::Secret(secret_string) => {
+                assert_eq!(secret_string, "example123");
+            }
+        }
+    }
+}

--- a/crates/pipeline-types/src/lib.rs
+++ b/crates/pipeline-types/src/lib.rs
@@ -2,4 +2,5 @@ pub mod config;
 pub mod error;
 pub mod format;
 pub mod query;
+pub mod secret_ref;
 pub mod transport;

--- a/crates/pipeline-types/src/secret_ref.rs
+++ b/crates/pipeline-types/src/secret_ref.rs
@@ -1,0 +1,178 @@
+use std::fmt;
+use std::fmt::Formatter;
+
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+/// Enumeration which holds a string or a secret reference which is
+/// not yet resolved.
+///
+/// Instantiation is done either directly, using deserialization or
+/// by matching a basic string to a particular pattern. Note that
+/// the former two allow simple strings to be instantiated that
+/// the latter with the pattern would normally map into secret
+/// reference.
+///
+/// This class is located in the pipeline-types crate because in future
+/// versions it will likely become an object within the API.
+/// Deserialization is implemented already for that reason.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, ToSchema)]
+pub enum MaybeSecretRef {
+    #[serde(rename = "string")]
+    String(String),
+    #[serde(rename = "secret_ref")]
+    SecretRef(String),
+}
+
+impl fmt::Display for MaybeSecretRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl MaybeSecretRef {
+    /// Determines whether a given string value refers to a secret or is simply
+    /// a string based on whether it matches the pattern.
+    ///
+    /// A secret must follow the pattern:
+    /// "${secret:secret-identifier}"
+    ///
+    /// For example for a secret identified by "database-1-user":
+    /// "${secret:database-1-user}"
+    ///
+    /// Any string value which does not follow the above pattern is determined
+    /// to be a simple string.
+    ///
+    /// Note that here is not checked whether the secret identifier can be
+    /// resolved, nor is specified which requirements the resolver has for
+    /// the identifier to be valid.
+    pub fn new_using_pattern_match(value: String) -> MaybeSecretRef {
+        if value.starts_with("${secret:") && value.ends_with('}') {
+            // Because the pattern only has ASCII characters, they are encoded as single
+            // bytes. The secret reference is extracted by slicing away the
+            // first 9 bytes and the last byte.
+            let from_idx_incl = 9;
+            let till_idx_excl = value.len() - 1;
+            MaybeSecretRef::SecretRef(value[from_idx_incl..till_idx_excl].to_string())
+        } else {
+            MaybeSecretRef::String(value)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MaybeSecretRef;
+
+    #[test]
+    fn test_format() {
+        assert_eq!(
+            format!("{}", MaybeSecretRef::String("example123".to_string())),
+            "String(\"example123\")"
+        );
+        assert_eq!(
+            format!("{:?}", MaybeSecretRef::String("example123".to_string())),
+            "String(\"example123\")"
+        );
+        assert_eq!(
+            format!("{}", MaybeSecretRef::SecretRef("example123".to_string())),
+            "SecretRef(\"example123\")"
+        );
+        assert_eq!(
+            format!("{:?}", MaybeSecretRef::SecretRef("example123".to_string())),
+            "SecretRef(\"example123\")"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_string() {
+        let data = "{ \"string\": \"example123\" }";
+        assert_eq!(
+            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
+            MaybeSecretRef::String("example123".to_string())
+        );
+        let data = "!string \"example123\"";
+        assert_eq!(
+            serde_yaml::from_str::<MaybeSecretRef>(data).unwrap(),
+            MaybeSecretRef::String("example123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_secret_ref() {
+        let data = "{ \"secret_ref\": \"example456\" }";
+        assert_eq!(
+            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
+            MaybeSecretRef::SecretRef("example456".to_string())
+        );
+        let data = "!secret_ref \"example456\"";
+        assert_eq!(
+            serde_yaml::from_str::<MaybeSecretRef>(data).unwrap(),
+            MaybeSecretRef::SecretRef("example456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_string() {
+        let test_values_and_expectations = vec![
+            ("", MaybeSecretRef::String("".to_string())),
+            ("a", MaybeSecretRef::String("a".to_string())),
+            ("abc", MaybeSecretRef::String("abc".to_string())),
+            (
+                "/some/path/to/file.txt",
+                MaybeSecretRef::String("/some/path/to/file.txt".to_string()),
+            ),
+            ("$abc", MaybeSecretRef::String("$abc".to_string())),
+            ("${secret", MaybeSecretRef::String("${secret".to_string())),
+            ("}", MaybeSecretRef::String("}".to_string())),
+            ("${secre:}", MaybeSecretRef::String("${secre:}".to_string())),
+            // Unicode "Slightly Smiling Face": U+1F642
+            ("\u{1F642}", MaybeSecretRef::String("\u{1F642}".to_string())),
+        ];
+        for (value, expectation) in test_values_and_expectations {
+            assert_eq!(
+                MaybeSecretRef::new_using_pattern_match(value.to_string()),
+                expectation
+            );
+        }
+    }
+
+    #[test]
+    fn test_secret_ref() {
+        let test_values_and_expectations = vec![
+            ("${secret:}", MaybeSecretRef::SecretRef("".to_string())),
+            ("${secret:a}", MaybeSecretRef::SecretRef("a".to_string())),
+            (
+                "${secret:abc}",
+                MaybeSecretRef::SecretRef("abc".to_string()),
+            ),
+            (
+                "${secret:/some/path/to/file.txt}",
+                MaybeSecretRef::SecretRef("/some/path/to/file.txt".to_string()),
+            ),
+            (
+                "${secret:$abc}",
+                MaybeSecretRef::SecretRef("$abc".to_string()),
+            ),
+            (
+                "${secret:${secret:}}",
+                MaybeSecretRef::SecretRef("${secret:}".to_string()),
+            ),
+            (
+                "${secret:${secret:abc}}",
+                MaybeSecretRef::SecretRef("${secret:abc}".to_string()),
+            ),
+            // Unicode "Slightly Smiling Face": U+1F642
+            (
+                "${secret:\u{1F642}}",
+                MaybeSecretRef::SecretRef("\u{1F642}".to_string()),
+            ),
+        ];
+        for (value, expectation) in test_values_and_expectations {
+            assert_eq!(
+                MaybeSecretRef::new_using_pattern_match(value.to_string()),
+                expectation
+            );
+        }
+    }
+}


### PR DESCRIPTION
**Overview:**

* Secret reference: add enumeration type `SimpleStringOrSecretReference` with constructor that takes in a string. If the string follows the `${secret:example}` pattern, it returns a secret reference to `example`. Else, it returns a simple
  string with the direct content. Its pattern is similar to that of [Kafka Connect / Debezium](https://debezium.io/blog/2019/12/13/externalized-secrets/).

* Secret resolver: converts a secret reference to the secret string it refers to.

  - Resolution options: currently, only secret references named "^[a-z0-9]+(-[a-z0-9]+)*$" are allowed, and are resolved by checking if a file "/etc/secret-volume/.example" exists (e.g., for the secret named `example`). This file needs to be made available by mounting the secret volume in advance.

  - Resolution result is a `SimpleOrSecretString` instead of just a `String`, such that if it is formatted for logs, it does not show the content for the secret variant. Of course, this only lasts until it must be passed as a plain String to the underlying connector library (e.g., `librdkafka`).
  
* Both conversion to potential secret reference (to `SimpleStringOrSecretReference`) and  resolution (to `SimpleOrSecretString`) are currently done at the latest possible point (latest resolution). They will be decoupled if secret references are directly integrated into the API (see future directions).
  
* Current implementation: secrets through pattern are enabled only for the additional config properties of the Kafka input and Kafka output connector.


**Possible future directions:**

* Integration of secret references directly into the API (i.e., using a dedicated type to which is deserialized, like `SimpleStringOrSecretReference` (already added deserialization for it)). This would require changes at the core API, the Python API wrapper and the web console, as they would need to pass an object other than a basic string. It would remove the need for a secret pattern (although this could still be provided as a UI input method).
  
* Allow secrets to be specified in Docker demo via adding mounted volume at `/etc/secret-volume` of the pipeline manager.

* Additional resolution sources: external providers, maybe environment variables

* Only at the pipeline the secret reference is resolved. There could already be earlier checks in place to warn if the secret reference does not exist (e.g., in the UI).


**Pattern matching considerations:**

* A string must follow the `${secret:example}` pattern to be parsed as a secret reference. As such, it is impossible to have strings that follow the pattern.
  
* Because of this, there is one scenario in which the secret pattern matching would have an undesirable effect:
  1. The user has a secret named `example`, intended for an input field for connector A
  2. The user wants to enter the literal string `${secret:example}` for an input field for connector B
  3. Rather than the literal string `${secret:example}` being sent, instead the secret string
     behind the `example` secret is sent to connector B
* This is highly unlikely as (1) it is exceedingly unlikely a user wants to enter a string following the pattern literally, and (2) the user must have already created a secret with the exact internal name and must match it exactly in the literal string. Because of (2), the user must already be aware of secrets and their pattern syntax (having created a secret), and as such the user wanting to enter a literal string like in (1) is improbable.


**Motivation why it is not done with Yaml transformation:**

* Technically, we could also before deserializing the config `YamlValue` replace any Yaml/Json-specific construct (e.g., `!secret_ref: "example`) or any pattern-following Yaml-String with the Yaml-String containing the resolved secret. This would make the connector oblivious to whether it is a secret or not. However, this would make it format in any potential future logs.
  
* The Yaml replacement could also be a `SimpleStringOrSecretRef`, but if the replacement is scoped to the entire YamlValue it would require changing the type of all strings. Scoping it only to a subset of the YamlValue (e.g., only the ones under the `kafka_options` key of the top mapping) would be possible, but would yield no difference in the current pattern-matching implementation and would need the Yaml conversion to become config-aware rather than just directly deserializing.
  
* It would also just be an inbetween solution, as an even better way is the integration of secret references directly into the API (see above), which would make them directly deserialize from Yaml without config-awareness.


Is this a user-visible change (yes/no): yes