### PR TITLE
Top-K operator with custom comparison function.

### DIFF
--- a/crates/dbsp/src/operator/group/custom_ord.rs
+++ b/crates/dbsp/src/operator/group/custom_ord.rs
@@ -1,0 +1,91 @@
+use std::{
+    cmp::Ordering,
+    fmt::{self, Debug, Formatter},
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+};
+
+use rkyv::{Archive, Deserialize, Serialize};
+use size_of::SizeOf;
+
+/// Custom comparison function.
+pub trait CmpFunc<T>: Send + 'static {
+    fn cmp(left: &T, right: &T) -> Ordering;
+}
+
+/// Wrapper around type `T` that uses `F` instead of
+/// `Ord::cmp` to compare values.
+#[derive(SizeOf, Archive, Serialize, Deserialize)]
+pub struct WithCustomOrd<T, F> {
+    pub val: T,
+    phantom: PhantomData<F>,
+}
+
+impl<T, F> Debug for WithCustomOrd<T, F>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WithCustomOrd")
+            .field("val", &self.val)
+            .finish()
+    }
+}
+
+impl<T, F> Clone for WithCustomOrd<T, F>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.val.clone())
+    }
+}
+
+impl<T, F> PartialEq<Self> for WithCustomOrd<T, F>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.val.eq(&other.val)
+    }
+}
+
+impl<T, F> Hash for WithCustomOrd<T, F>
+where
+    T: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.val.hash(state);
+    }
+}
+
+impl<T, F> Eq for WithCustomOrd<T, F> where T: PartialEq {}
+
+impl<T, F> WithCustomOrd<T, F> {
+    pub fn new(val: T) -> Self {
+        Self {
+            val,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F> Ord for WithCustomOrd<T, F>
+where
+    Self: Eq + PartialOrd,
+    F: CmpFunc<T>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        F::cmp(&self.val, &other.val)
+    }
+}
+
+impl<T, F> PartialOrd for WithCustomOrd<T, F>
+where
+    Self: Eq,
+    F: CmpFunc<T>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/dbsp/src/operator/group/mod.rs
+++ b/crates/dbsp/src/operator/group/mod.rs
@@ -16,11 +16,14 @@ use crate::{
 };
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 
+mod custom_ord;
 mod lag;
 mod topk;
 
 #[cfg(test)]
 mod test;
+
+pub use custom_ord::CmpFunc;
 
 /// Specifies the order in which a group transformer produces output tuples.
 #[derive(PartialEq, Eq)]

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -47,6 +47,7 @@ pub use delta0::Delta0;
 pub use distinct::Distinct;
 pub use filter_map::{FilterKeys, FilterMap, FilterVals, FlatMap, Map, MapKeys};
 pub use generator::{Generator, GeneratorNested};
+pub use group::CmpFunc;
 pub use index::Index;
 use input::Mailbox;
 pub use input::{CollectionHandle, InputHandle, UpsertHandle};


### PR DESCRIPTION
Existing implementations of top-k use natural ordering of values in a group, which may require rearranging the data so that the natural ordering matches the ORDER BY clause in the SQL query, and even that isn't sufficient when sorting by multiple columns, e.g., `ORDER BY COL1 ASCENDING, COL2 DESCENDING`.

We add a new top-K operator parameterized with a user-defined comparison function.  Internally, the operator wraps values in the input stream in a wrapper type that implements `trait Ord` by invoking the user-defined comparison function, invokes `topk_asc` on the resulting transformed batches and removes the wrapper from values in the resulting output batches.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
