### PR TITLE
Fail on timeout in tests.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1484,7 +1484,7 @@ outputs:
             controller.start();
 
             // Wait for the pipeline to output all records.
-            wait(|| controller.pipeline_complete(), DEFAULT_TIMEOUT_MS);
+            wait(|| controller.pipeline_complete(), DEFAULT_TIMEOUT_MS).unwrap();
 
             assert_eq!(controller.status().output_status().get(&0).unwrap().transmitted_records(), data.len() as u64);
 

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -282,7 +282,7 @@ impl BufferConsumer {
         let num_records: usize = data.iter().map(Vec::len).sum();
 
         // println!("waiting for {num_records} records");
-        wait(|| self.len() == num_records, DEFAULT_TIMEOUT_MS);
+        wait(|| self.len() == num_records, DEFAULT_TIMEOUT_MS).unwrap();
         //println!("{num_records} records received: {:?}",
         // received_data.lock().unwrap().iter().map(|r| r.id).collect::<Vec<_>>());
 

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -288,7 +288,8 @@ format:
         wait(
             || zset.state().flushed.len() == test_data.len(),
             DEFAULT_TIMEOUT_MS,
-        );
+        )
+        .unwrap();
         for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
             assert!(polarity);
             assert_eq!(val, &test_data[i]);
@@ -346,7 +347,8 @@ format:
             wait(
                 || zset.state().flushed.len() == test_data.len(),
                 DEFAULT_TIMEOUT_MS,
-            );
+            )
+            .unwrap();
             for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
                 assert!(polarity);
                 assert_eq!(val, &test_data[i]);
@@ -371,7 +373,8 @@ format:
                 state.parser_result.is_some() && !state.parser_result.as_ref().unwrap().1.is_empty()
             },
             DEFAULT_TIMEOUT_MS,
-        );
+        )
+        .unwrap();
 
         assert!(zset.state().buffered.is_empty());
         assert!(zset.state().flushed.is_empty());

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -361,7 +361,7 @@ bar,false,-10
 
         // Unpause the endpoint, wait for the data to appear at the output.
         endpoint.start().unwrap();
-        wait(|| n_recs(&zset) == test_data.len(), DEFAULT_TIMEOUT_MS);
+        wait(|| n_recs(&zset) == test_data.len(), DEFAULT_TIMEOUT_MS).unwrap();
         for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
             assert!(polarity);
             assert_eq!(val, &test_data[i]);
@@ -389,7 +389,8 @@ bar,false,-10
         wait(
             || consumer.state().endpoint_error.is_some(),
             DEFAULT_TIMEOUT_MS,
-        );
+        )
+        .unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
Add `.unwrap()`'s to `adapters` tests to make sure the tests fail on timeout.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
