### PR TITLE
web-console: number of records in pipeline table is no longer rounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Secrets can be referenced using a string pattern
   in the Kafka connector input and output configuration
   ([#949](https://github.com/feldera/feldera/pull/949))
+- Number of records in the pipeline table in the web
+  console is no longer rounded
+  ([#967](https://github.com/feldera/feldera/pull/967))
 
 ### Fixed
 - Reduce Docker logging noise from Kafka connect and Redpanda.

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -173,7 +173,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
               direction === 'input'
                 ? metrics.input.get(params.row.relation.name)?.total_records
                 : metrics.output.get(params.row.relation.name)?.transmitted_records
-            return format('.1s')(records || 0)
+            return format(',')(records || 0)
           } else {
             // TODO: we need to count records also when relation doesn't have
             // connections in the backend.


### PR DESCRIPTION
Removes any rounding of the number of records, instead directly printing the number (see also [#926](https://github.com/feldera/feldera/issues/926)).

Is this a user-visible change (yes/no): yes