### PR TITLE
Change default secrets directory and update related terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#957](https://github.com/feldera/feldera/pull/957))
 - Secrets can be referenced using a string pattern
   in the Kafka connector input and output configuration
-  ([#949](https://github.com/feldera/feldera/pull/949))
+  ([#949](https://github.com/feldera/feldera/pull/949),
+  [#970](https://github.com/feldera/feldera/pull/970))
 - Number of records in the pipeline table in the web
   console is no longer rounded
   ([#967](https://github.com/feldera/feldera/pull/967))

--- a/crates/adapters/src/transport/kafka/input.rs
+++ b/crates/adapters/src/transport/kafka/input.rs
@@ -142,9 +142,9 @@ impl KafkaInputEndpointInner {
 
         for (key, value) in config.kafka_options.iter() {
             // If it is a secret reference, resolve it to the actual secret string
-            match MaybeSecret::new_with_default_volume(MaybeSecretRef::new_using_pattern_match(
-                value.clone(),
-            ))? {
+            match MaybeSecret::new_using_default_directory(
+                MaybeSecretRef::new_using_pattern_match(value.clone()),
+            )? {
                 MaybeSecret::String(simple_string) => {
                     client_config.set(key, simple_string);
                 }

--- a/crates/adapters/src/transport/kafka/output.rs
+++ b/crates/adapters/src/transport/kafka/output.rs
@@ -276,9 +276,9 @@ impl KafkaOutputEndpoint {
 
         for (key, value) in config.kafka_options.iter() {
             // If it is a secret reference, resolve it to the actual secret string
-            match MaybeSecret::new_with_default_volume(MaybeSecretRef::new_using_pattern_match(
-                value.clone(),
-            ))? {
+            match MaybeSecret::new_using_default_directory(
+                MaybeSecretRef::new_using_pattern_match(value.clone()),
+            )? {
                 MaybeSecret::String(simple_string) => {
                     client_config.set(key, simple_string);
                 }


### PR DESCRIPTION
Changes the default secrets directory from `/etc/secret-volume` to `/etc/secrets`.
In addition, changes some comment and variable terminology to be more in line with a directory in which there are secrets as files.

Is this a user-visible change (yes/no): yes