### PR TITLE
Allow pipeline manager to run without JIT support.

### DIFF
--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -128,8 +128,10 @@ async fn initialize_local_pipeline_manager_instance() -> TempDir {
     let local_runner_config = LocalRunnerConfig {
         runner_working_directory: workdir.to_owned(),
         pipeline_host: "127.0.0.1".to_owned(),
-        jit_pipeline_runner_path: std::env::var("JIT_PIPELINE_RUNNER_PATH")
-            .unwrap_or_else(|_| "../../target/debug/pipeline".to_owned()),
+        jit_pipeline_runner_path: Some(
+            std::env::var("JIT_PIPELINE_RUNNER_PATH")
+                .unwrap_or_else(|_| "../../target/debug/pipeline".to_owned()),
+        ),
     }
     .canonicalize()
     .unwrap();

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -135,7 +135,7 @@ impl ProcessRunner {
         }
 
         // Run pipeline.
-        let pipeline_process = Command::new(self.config.jit_pipeline_runner_path())
+        let pipeline_process = Command::new(self.config.jit_pipeline_runner_path().unwrap())
             .current_dir(&pipeline_dir)
             .arg("--ir")
             .arg(&ir_file_path)
@@ -159,6 +159,10 @@ impl PipelineExecutor for ProcessRunner {
         let pipeline_id = ped.pipeline_id;
 
         log::debug!("Pipeline config is '{:?}'", ped.config);
+
+        if ped.jit_mode && !self.config.jit_support_enabled() {
+            Err(RunnerError::JitSupportDisabled)?;
+        }
 
         // Create pipeline directory (delete old directory if exists); write metadata
         // and config files to it.

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -69,6 +69,7 @@ pub enum RunnerError {
         status: Option<i32>,
         stderr: String,
     },
+    JitSupportDisabled,
 }
 
 impl DetailedError for RunnerError {
@@ -89,6 +90,7 @@ impl DetailedError for RunnerError {
             }
             Self::BinaryFetchError { .. } => Cow::from("BinaryFetchError"),
             Self::SqlToJitCompilerError { .. } => Cow::from("SqlCompilerError"),
+            Self::JitSupportDisabled => Cow::from("JitSupportDisabled"),
         }
     }
 }
@@ -171,6 +173,12 @@ impl Display for RunnerError {
                     "Error compiling SQL program to JIT IR for pipeline {pipeline_id}.{status_string}\nSQL compiler stderr: {stderr}"
                 )
             }
+            Self::JitSupportDisabled => {
+                write!(
+                    f,
+                    "Cannot execute pipeline in JIT mode when running with JIT support disabled. Please update program configuration to have 'jit_mode' set to false."
+                )
+            }
         }
     }
 }
@@ -194,6 +202,7 @@ impl ResponseError for RunnerError {
             // compilation service.  SQL compiler errors are not supposed to happen
             // at this point and are reported as internal server errors.
             Self::SqlToJitCompilerError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::JitSupportDisabled => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 


### PR DESCRIPTION
Having to always build the JIT pipeline runner executable to run the pipeline manager interferes with dev workflow. This commit enables the manager to run with JIT support disabled.  Specifically, if the user does not specify the path to the JIT pipeline runner on the command line and it is not found at the default location, the manager starts successfully with a warning, but any  Aattempts to start a pipeline in JIT mode will return an error.

Is this a user-visible change (yes/no): no

cc: @Karakatiza666 

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
