### PR TITLE
pipeline-manager: refactor automaton to be testable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -387,7 +387,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -399,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "serde",
  "version_check",
@@ -577,6 +577,16 @@ name = "askama_escape"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-attributes"
@@ -851,7 +861,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "rustls 0.20.9",
  "serde",
  "serde_json",
@@ -2360,8 +2370,8 @@ dependencies = [
  "priority-queue",
  "proptest",
  "proptest-derive",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xoshiro",
  "reqwest",
  "rkyv",
@@ -2421,7 +2431,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "psutil",
- "rand",
+ "rand 0.8.5",
  "rdkafka",
  "regex",
  "reqwest",
@@ -2458,7 +2468,7 @@ dependencies = [
  "mimalloc-rust-sys",
  "num-format",
  "paste",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rkyv",
  "rstest",
@@ -3061,6 +3071,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -3068,7 +3089,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3286,6 +3307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,6 +3505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,7 +3620,7 @@ dependencies = [
  "clap 4.4.7",
  "fancy-regex",
  "fraction",
- "getrandom",
+ "getrandom 0.2.10",
  "iso8601",
  "itoa",
  "memchr",
@@ -3943,7 +3991,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -4253,7 +4301,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -4264,7 +4312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
 ]
@@ -4368,7 +4416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4550,7 +4598,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "proptest-derive",
- "rand",
+ "rand 0.8.5",
  "refinery",
  "reqwest",
  "serde",
@@ -4566,6 +4614,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -4666,7 +4715,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -4826,8 +4875,8 @@ dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.7.5",
  "rusty-fork",
@@ -4923,14 +4972,37 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4940,7 +5012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4949,8 +5030,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "serde",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4959,7 +5049,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4968,7 +5058,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5075,7 +5165,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -5275,7 +5365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
 dependencies = [
  "cc",
- "getrandom",
+ "getrandom 0.2.10",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5418,7 +5508,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -5703,6 +5793,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -6078,7 +6179,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha1",
@@ -6266,7 +6367,7 @@ dependencies = [
  "humantime",
  "opentelemetry",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
  "tarpc-plugins",
@@ -6527,7 +6628,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2 0.5.5",
  "tokio",
  "tokio-util",
@@ -6873,6 +6974,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6936,7 +7038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "atomic",
- "getrandom",
+ "getrandom 0.2.10",
  "serde",
 ]
 
@@ -7003,6 +7105,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -7350,6 +7458,28 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079aee011e8a8e625d16df9e785de30a6b77f80a6126092d76a57375f96448da"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.5",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -68,6 +68,7 @@ actix-http = "3.3.1"
 serial_test = "2.0.0"
 aws-sdk-cognitoidentityprovider = "0.28.0"
 aws-config = "0.55.3"
+wiremock = "0.5"
 
 # Used in integration tests
 [dev-dependencies.tokio]

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -131,60 +131,52 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
     }
 
     /// Runs until the pipeline is deleted or an unexpected error occurs.
-    pub async fn run(self) -> Result<(), ManagerError> {
+    pub async fn run(mut self) -> Result<(), ManagerError> {
         let pipeline_id = self.pipeline_id;
 
-        self.do_run().await.map_err(|e| {
-            error!(
-                "Pipeline automaton '{}' terminated with error: '{e}'",
-                pipeline_id
-            );
-            e
-        })
-    }
-
-    async fn do_run(mut self) -> Result<(), ManagerError> {
         let mut poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
-
         loop {
             // Wait until the timeout expires or we get notified that
             // the desired state of the pipelime has changed.
             let _ = timeout(poll_timeout, self.notifier.notified()).await;
-            poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
+            poll_timeout = self.do_run().await.map_err(|e| {
+                error!(
+                    "Pipeline automaton '{}' terminated with error: '{e}'",
+                    pipeline_id
+                );
+                e
+            })?;
+        }
+    }
 
-            // TODO: use transactional API when ready to avoid races with a parallel
-            // `/deploy /shutdown` sequence.
-
-            // txn = db.transaction();
-            let db = self.db.lock().await;
-            let result = db
-                .get_pipeline_runtime_state(self.tenant_id, self.pipeline_id)
-                .await;
-            if let Err(e) = result {
-                match e {
-                    DBError::UnknownPipeline { pipeline_id } => {
-                        // Pipeline deletions should not lead to errors in the logs.
-                        info!("Pipeline {pipeline_id} does not exist. Shutting down pipeline automaton.");
-                        return Ok(());
-                    }
-                    _ => return Err(e.into()),
+    async fn do_run(&mut self) -> Result<Duration, ManagerError> {
+        let mut poll_timeout = Self::DEFAULT_PIPELINE_POLL_PERIOD;
+        let db = self.db.lock().await;
+        let result = db
+            .get_pipeline_runtime_state(self.tenant_id, self.pipeline_id)
+            .await;
+        drop(db);
+        if let Err(e) = result {
+            match e {
+                DBError::UnknownPipeline { pipeline_id } => {
+                    // Pipeline deletions should not lead to errors in the logs.
+                    info!(
+                        "Pipeline {pipeline_id} does not exist. Shutting down pipeline automaton."
+                    );
+                    return Ok(poll_timeout);
                 }
+                _ => return Err(e.into()),
             }
-            let mut pipeline = result.unwrap();
-
-            // Handle deployment request.
-            if pipeline.current_status == PipelineStatus::Shutdown
-                && pipeline.desired_status != PipelineStatus::Shutdown
-            {
-                self.update_pipeline_status(&mut pipeline, PipelineStatus::Provisioning, None)
-                    .await;
+        }
+        let mut pipeline = result.unwrap();
+        let transition: State = match (pipeline.current_status, pipeline.desired_status) {
+            (PipelineStatus::Shutdown, PipelineStatus::Running)
+            | (PipelineStatus::Shutdown, PipelineStatus::Paused) => {
+                let db = self.db.lock().await;
                 let revision = db
                     .get_last_committed_pipeline_revision(self.tenant_id, self.pipeline_id)
                     .await?;
-                db.update_pipeline_runtime_state(self.tenant_id, self.pipeline_id, &pipeline)
-                    .await?;
-                // txn.commit();
-                // Locate project executable.
+
                 let pipeline_id = self.pipeline_id;
                 let executable_ref = if !revision.program.jit_mode {
                     db.get_compiled_binary_ref(
@@ -202,268 +194,240 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 drop(db);
                 let execution_desc = to_execution_desc(revision, executable_ref);
 
+                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
+                // This requires start() to be idempotent. If the process crashes after start
+                // is called but before the state machine is correctly updated in the DB, then
+                // on restart, start will be called again
                 match self.pipeline_handle.start(execution_desc).await {
                     Ok(_) => {
                         info!(
                             "Pipeline {} started (Tenant {})",
                             self.pipeline_id, self.tenant_id
                         );
+                        State::Transition(PipelineStatus::Provisioning, None)
                     }
                     Err(e) => {
-                        self.mark_pipeline_as_failed(&mut pipeline, Some(e)).await?;
+                        State::Transition(PipelineStatus::Failed, Some(ErrorResponse::from(&e)))
                     }
                 }
-                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
-                continue;
-            } else {
-                // txn.commit();
-                drop(db);
             }
-
-            match (pipeline.current_status, pipeline.desired_status) {
-                // We're waiting for the pipeline's HTTP server to come online.
-                // Poll its port file.  On success, go to `Initializing` state.
-                (PipelineStatus::Provisioning, PipelineStatus::Running)
-                | (PipelineStatus::Provisioning, PipelineStatus::Paused) => {
-                    match self.pipeline_handle.get_location().await {
-                        Ok(Some(location)) => {
-                            self.update_pipeline_status(
-                                &mut pipeline,
-                                PipelineStatus::Initializing,
-                                None,
-                            )
-                            .await;
-                            pipeline.set_location(location);
-                            pipeline.set_created();
-                            self.update_pipeline_runtime_state(&pipeline).await?;
-                            poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
-                        }
-                        Ok(None) => {
-                            if Self::timeout_expired(
-                                pipeline.status_since,
-                                Self::PROVISIONING_TIMEOUT,
-                            ) {
-                                self.mark_pipeline_as_failed(
-                                    &mut pipeline,
-                                    Some(RunnerError::PipelineProvisioningTimeout {
+            // We're waiting for the pipeline's HTTP server to come online.
+            // Poll its port file.  On success, go to `Initializing` state.
+            (PipelineStatus::Provisioning, PipelineStatus::Running)
+            | (PipelineStatus::Provisioning, PipelineStatus::Paused) => {
+                match self.pipeline_handle.get_location().await {
+                    Ok(Some(location)) => {
+                        pipeline.set_location(location);
+                        pipeline.set_created();
+                        poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
+                        State::Transition(PipelineStatus::Initializing, None)
+                    }
+                    Ok(None) => {
+                        if Self::timeout_expired(pipeline.status_since, Self::PROVISIONING_TIMEOUT)
+                        {
+                            State::Transition(
+                                PipelineStatus::Failed,
+                                Some(
+                                    RunnerError::PipelineProvisioningTimeout {
                                         pipeline_id: self.pipeline_id,
                                         timeout: Self::PROVISIONING_TIMEOUT,
-                                    }),
-                                )
-                                .await?;
-                            } else {
-                                poll_timeout = Self::PROVISIONING_POLL_PERIOD;
-                            }
-                        }
-                        Err(e) => {
-                            self.mark_pipeline_as_failed(&mut pipeline, Some(e)).await?;
+                                    }
+                                    .into(),
+                                ),
+                            )
+                        } else {
+                            poll_timeout = Self::PROVISIONING_POLL_PERIOD;
+                            State::Unchanged
                         }
                     }
+                    Err(e) => {
+                        State::Transition(PipelineStatus::Failed, Some(ErrorResponse::from(&e)))
+                    }
                 }
-                // User cancels the pipeline while it's still provisioning.
-                (PipelineStatus::Provisioning, PipelineStatus::Shutdown) => {
-                    self.mark_pipeline_as_failed(&mut pipeline, <Option<RunnerError>>::None)
-                        .await?;
-                }
-                // We're waiting for the pipeline to initialize.
-                // Poll the pipeline's status.  Kill the pipeline on timeout or error.
-                // On success, go to the `PAUSED` state.
-                (PipelineStatus::Initializing, PipelineStatus::Running)
-                | (PipelineStatus::Initializing, PipelineStatus::Paused) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "stats",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            info!("Could not connect to pipeline {e:?}");
-                            // self.mark_pipeline_as_failed(&mut pipeline, Some(e)).await?;
+            }
+            // User cancels the pipeline while it's still provisioning.
+            (PipelineStatus::Provisioning, PipelineStatus::Shutdown) => {
+                State::Transition(PipelineStatus::Failed, None)
+            }
+            // We're waiting for the pipeline to initialize.
+            // Poll the pipeline's status.  Kill the pipeline on timeout or error.
+            // On success, go to the `PAUSED` state.
+            (PipelineStatus::Initializing, PipelineStatus::Running)
+            | (PipelineStatus::Initializing, PipelineStatus::Paused) => {
+                match pipeline_http_request_json_response(
+                    self.pipeline_id,
+                    Method::GET,
+                    "stats",
+                    &pipeline.location,
+                )
+                .await
+                {
+                    Err(e) => {
+                        info!("Could not connect to pipeline {e:?}");
+                        if Self::timeout_expired(
+                            pipeline.status_since,
+                            Self::INITIALIZATION_TIMEOUT,
+                        ) {
+                            State::Transition(
+                                PipelineStatus::Failed,
+                                Some(
+                                    RunnerError::PipelineInitializationTimeout {
+                                        pipeline_id: self.pipeline_id,
+                                        timeout: Self::INITIALIZATION_TIMEOUT,
+                                    }
+                                    .into(),
+                                ),
+                            )
+                        } else {
+                            poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
+                            State::Unchanged
+                        }
+                    }
+                    Ok((status, body)) => {
+                        if status.is_success() {
+                            State::Transition(PipelineStatus::Paused, None)
+                        } else if status == StatusCode::SERVICE_UNAVAILABLE {
                             if Self::timeout_expired(
                                 pipeline.status_since,
                                 Self::INITIALIZATION_TIMEOUT,
                             ) {
-                                self.mark_pipeline_as_failed(
-                                    &mut pipeline,
-                                    Some(RunnerError::PipelineInitializationTimeout {
-                                        pipeline_id: self.pipeline_id,
-                                        timeout: Self::INITIALIZATION_TIMEOUT,
-                                    }),
-                                )
-                                .await?;
-                            } else {
-                                poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
-                            }
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Paused,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                            } else if status == StatusCode::SERVICE_UNAVAILABLE {
-                                if Self::timeout_expired(
-                                    pipeline.status_since,
-                                    Self::INITIALIZATION_TIMEOUT,
-                                ) {
-                                    self.mark_pipeline_as_failed(
-                                        &mut pipeline,
-                                        Some(RunnerError::PipelineInitializationTimeout {
+                                State::Transition(
+                                    PipelineStatus::Failed,
+                                    Some(
+                                        RunnerError::PipelineInitializationTimeout {
                                             pipeline_id: self.pipeline_id,
                                             timeout: Self::INITIALIZATION_TIMEOUT,
-                                        }),
-                                    )
-                                    .await?;
-                                } else {
-                                    poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
-                                }
-                            } else {
-                                self.mark_pipeline_as_failed_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // User cancels the pipeline while it is still initalizing.
-                (PipelineStatus::Initializing, PipelineStatus::Shutdown) => {
-                    self.mark_pipeline_as_failed(&mut pipeline, <Option<RunnerError>>::None)
-                        .await?;
-                }
-                // Unpause the pipeline.
-                (PipelineStatus::Paused, PipelineStatus::Running) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "start",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.mark_pipeline_as_failed(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Running,
-                                    None,
+                                        }
+                                        .into(),
+                                    ),
                                 )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
                             } else {
-                                self.mark_pipeline_as_failed_on_error(&mut pipeline, status, &body)
-                                    .await?;
+                                poll_timeout = Self::INITIALIZATION_POLL_PERIOD;
+                                State::Unchanged
                             }
+                        } else {
+                            let error =
+                                Self::error_response_from_json(self.pipeline_id, status, &body);
+                            State::Transition(PipelineStatus::Failed, Some(error))
                         }
                     }
-                }
-                // Pause the pipeline.
-                (PipelineStatus::Running, PipelineStatus::Paused) => {
-                    match pipeline_http_request_json_response(
-                        self.pipeline_id,
-                        Method::GET,
-                        "pause",
-                        &pipeline.location,
-                    )
-                    .await
-                    {
-                        Err(e) => {
-                            self.mark_pipeline_as_failed(&mut pipeline, Some(e)).await?;
-                        }
-                        Ok((status, body)) => {
-                            if status.is_success() {
-                                self.update_pipeline_status(
-                                    &mut pipeline,
-                                    PipelineStatus::Paused,
-                                    None,
-                                )
-                                .await;
-                                self.update_pipeline_runtime_state(&pipeline).await?;
-                            } else {
-                                self.mark_pipeline_as_failed_on_error(&mut pipeline, status, &body)
-                                    .await?;
-                            }
-                        }
-                    }
-                }
-                // Issue a pipeline shutdown.
-                (PipelineStatus::Running, PipelineStatus::Shutdown)
-                | (PipelineStatus::Paused, PipelineStatus::Shutdown) => {
-                    match self.pipeline_handle.shutdown().await {
-                        Ok(_) => {
-                            self.update_pipeline_status(
-                                &mut pipeline,
-                                PipelineStatus::ShuttingDown,
-                                None,
-                            )
-                            .await;
-                            self.update_pipeline_runtime_state(&pipeline).await?;
-                            poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
-                        }
-                        Err(e) => {
-                            self.mark_pipeline_as_failed(
-                                &mut pipeline,
-                                Some(RunnerError::PipelineShutdownError {
-                                    pipeline_id: self.pipeline_id,
-                                    error: e.to_string(),
-                                }),
-                            )
-                            .await?;
-                        }
-                    }
-                }
-                // Shutdown in progress. Wait for the pipeline process to terminate.
-                (PipelineStatus::ShuttingDown, _) => {
-                    if self.pipeline_handle.check_if_shutdown().await {
-                        self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, None)
-                            .await;
-                        self.update_pipeline_runtime_state(&pipeline).await?;
-                    } else if Self::timeout_expired(pipeline.status_since, Self::SHUTDOWN_TIMEOUT) {
-                        self.mark_pipeline_as_failed(
-                            &mut pipeline,
-                            Some(RunnerError::PipelineShutdownTimeout {
-                                pipeline_id: self.pipeline_id,
-                                timeout: Self::SHUTDOWN_TIMEOUT,
-                            }),
-                        )
-                        .await?;
-                    } else {
-                        poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
-                    }
-                }
-                // User acknowledges pipeline failure by invoking the `/shutdown` endpoint.
-                // Move to the `Shutdown` state so that the pipeline can be started again.
-                (PipelineStatus::Failed, PipelineStatus::Shutdown) => {
-                    let error = pipeline.error.clone();
-                    let _ = self.pipeline_handle.shutdown().await;
-                    self.update_pipeline_status(&mut pipeline, PipelineStatus::Shutdown, error)
-                        .await;
-                    self.update_pipeline_runtime_state(&pipeline).await?;
-                }
-                // Steady-state operation.  Periodically poll the pipeline.
-                (PipelineStatus::Running, _)
-                | (PipelineStatus::Paused, _)
-                | (PipelineStatus::Failed, _) => {
-                    self.probe(&mut pipeline).await?;
-                }
-                (PipelineStatus::Shutdown, _) => {}
-                _ => {
-                    error!(
-                        "Unexpected current/desired pipeline status combination {:?}/{:?}",
-                        pipeline.current_status, pipeline.desired_status
-                    )
                 }
             }
+            // User cancels the pipeline while it is still initalizing.
+            (PipelineStatus::Initializing, PipelineStatus::Shutdown) => {
+                State::Transition(PipelineStatus::Failed, None)
+            }
+            // Unpause the pipeline.
+            (PipelineStatus::Paused, PipelineStatus::Running) => {
+                match pipeline_http_request_json_response(
+                    self.pipeline_id,
+                    Method::GET,
+                    "start",
+                    &pipeline.location,
+                )
+                .await
+                {
+                    Err(e) => State::Transition(PipelineStatus::Failed, Some(e.into())),
+                    Ok((status, body)) => {
+                        if status.is_success() {
+                            State::Transition(PipelineStatus::Running, None)
+                        } else {
+                            let error =
+                                Self::error_response_from_json(self.pipeline_id, status, &body);
+                            State::Transition(PipelineStatus::Failed, Some(error))
+                        }
+                    }
+                }
+            }
+            // Pause the pipeline.
+            (PipelineStatus::Running, PipelineStatus::Paused) => {
+                match pipeline_http_request_json_response(
+                    self.pipeline_id,
+                    Method::GET,
+                    "pause",
+                    &pipeline.location,
+                )
+                .await
+                {
+                    Err(e) => State::Transition(PipelineStatus::Failed, Some(e.into())),
+                    Ok((status, body)) => {
+                        if status.is_success() {
+                            State::Transition(PipelineStatus::Paused, None)
+                        } else {
+                            let error =
+                                Self::error_response_from_json(self.pipeline_id, status, &body);
+                            State::Transition(PipelineStatus::Failed, Some(error))
+                        }
+                    }
+                }
+            }
+            // Issue a pipeline shutdown.
+            (PipelineStatus::Running, PipelineStatus::Shutdown)
+            | (PipelineStatus::Paused, PipelineStatus::Shutdown) => {
+                match self.pipeline_handle.shutdown().await {
+                    Ok(_) => {
+                        poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
+                        State::Transition(PipelineStatus::ShuttingDown, None)
+                    }
+                    Err(e) => State::Transition(
+                        PipelineStatus::Failed,
+                        Some(
+                            RunnerError::PipelineShutdownError {
+                                pipeline_id: self.pipeline_id,
+                                error: e.to_string(),
+                            }
+                            .into(),
+                        ),
+                    ),
+                }
+            }
+            // Shutdown in progress. Wait for the pipeline process to terminate.
+            (PipelineStatus::ShuttingDown, _) => {
+                if self.pipeline_handle.check_if_shutdown().await {
+                    State::Transition(PipelineStatus::Shutdown, None)
+                } else if Self::timeout_expired(pipeline.status_since, Self::SHUTDOWN_TIMEOUT) {
+                    State::Transition(
+                        PipelineStatus::Failed,
+                        Some(
+                            RunnerError::PipelineShutdownTimeout {
+                                pipeline_id: self.pipeline_id,
+                                timeout: Self::SHUTDOWN_TIMEOUT,
+                            }
+                            .into(),
+                        ),
+                    )
+                } else {
+                    poll_timeout = Self::SHUTDOWN_POLL_PERIOD;
+                    State::Unchanged
+                }
+            }
+            // User acknowledges pipeline failure by invoking the `/shutdown` endpoint.
+            // Move to the `Shutdown` state so that the pipeline can be started again.
+            (PipelineStatus::Failed, PipelineStatus::Shutdown) => {
+                let error = pipeline.error.clone();
+                let _ = self.pipeline_handle.shutdown().await;
+                State::Transition(PipelineStatus::Shutdown, error)
+            }
+            // Steady-state operation.  Periodically poll the pipeline.
+            (PipelineStatus::Running, _)
+            | (PipelineStatus::Paused, _)
+            | (PipelineStatus::Failed, _) => self.probe(&mut pipeline).await?,
+            _ => {
+                error!(
+                    "Unexpected current/desired pipeline status combination {:?}/{:?}",
+                    pipeline.current_status, pipeline.desired_status
+                );
+                State::Unchanged
+            }
+        };
+        if let State::Transition(new_status, error) = transition {
+            pipeline.set_current_status(new_status, error);
+            self.update_pipeline_runtime_state(&pipeline).await?;
         }
+        Ok(poll_timeout)
     }
 
-    async fn probe(&mut self, pipeline: &mut PipelineRuntimeState) -> Result<(), ManagerError> {
+    async fn probe(&mut self, pipeline: &mut PipelineRuntimeState) -> Result<State, ManagerError> {
         match pipeline_http_request_json_response(
             self.pipeline_id,
             Method::GET,
@@ -475,7 +439,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             Err(e) => {
                 // Cannot reach the pipeline.
                 if pipeline.current_status != PipelineStatus::Failed {
-                    self.mark_pipeline_as_failed(pipeline, Some(e)).await?;
+                    Ok(State::Transition(PipelineStatus::Failed, Some(e.into())))
+                } else {
+                    Ok(State::Unchanged)
                 }
             }
             Ok((status, body)) => {
@@ -483,8 +449,8 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     // Pipeline responds with an error, meaning that the pipeline
                     // HTTP server is still running, but the pipeline itself failed --
                     // save it out of its misery.
-                    self.mark_pipeline_as_failed_on_error(pipeline, status, &body)
-                        .await?;
+                    let error = Self::error_response_from_json(self.pipeline_id, status, &body);
+                    Ok(State::Transition(PipelineStatus::Failed, Some(error)))
                 } else {
                     let global_metrics = if let Some(metrics) = body.get("global_metrics") {
                         metrics
@@ -512,37 +478,25 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     };
 
                     if state == "Paused" && pipeline.current_status != PipelineStatus::Paused {
-                        self.update_pipeline_status(pipeline, PipelineStatus::Paused, None)
-                            .await;
-                        self.update_pipeline_runtime_state(pipeline).await?;
+                        Ok(State::Transition(PipelineStatus::Paused, None))
                     } else if state == "Running"
                         && pipeline.current_status != PipelineStatus::Running
                     {
-                        self.update_pipeline_status(pipeline, PipelineStatus::Running, None)
-                            .await;
-                        self.update_pipeline_runtime_state(pipeline).await?;
+                        Ok(State::Transition(PipelineStatus::Running, None))
                     } else if state != "Paused"
                         && state != "Running"
                         && pipeline.current_status != PipelineStatus::Failed
                     {
-                        self.mark_pipeline_as_failed(pipeline, Some(RunnerError::HttpForwardError {
+                        Ok(State::Transition(PipelineStatus::Failed, Some(RunnerError::HttpForwardError {
                                         pipeline_id: self.pipeline_id,
                                         error: format!("Pipeline reported unexpected status '{state}', expected 'Paused' or 'Running'")
-                                    })).await?;
+                                    }.into())))
+                    } else {
+                        Ok(State::Unchanged)
                     }
                 }
             }
         }
-        Ok(())
-    }
-
-    async fn update_pipeline_status(
-        &self,
-        pipeline: &mut PipelineRuntimeState,
-        status: PipelineStatus,
-        error: Option<ErrorResponse>,
-    ) {
-        pipeline.set_current_status(status, error);
     }
 
     async fn update_pipeline_runtime_state(
@@ -562,43 +516,6 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
         Utc::now().timestamp_millis() - since.timestamp_millis() > timeout.as_millis() as i64
     }
 
-    /// Force-kill the pipeline process, set its error description.
-    ///
-    /// If the desired state of the pipeline is `Paused` or `Running`,
-    /// places pipeline in the `Failed` state to avoid instant automatic
-    /// restart.  Otherwise (the desired state was `Shutdown`), set the
-    /// state of the pipeline to `Shutdown`.
-    async fn mark_pipeline_as_failed<E>(
-        &mut self,
-        pipeline: &mut PipelineRuntimeState,
-        error: Option<E>,
-    ) -> Result<(), DBError>
-    where
-        ErrorResponse: for<'a> From<&'a E>,
-    {
-        self.update_pipeline_status(
-            pipeline,
-            PipelineStatus::Failed,
-            error.map(|e| ErrorResponse::from(&e)),
-        )
-        .await;
-        self.update_pipeline_runtime_state(pipeline).await
-    }
-
-    /// Same as `mark_pipeline_as_failed`, but deserializes `ErrorResponse` from
-    /// a JSON error returned by the pipeline.
-    async fn mark_pipeline_as_failed_on_error(
-        &mut self,
-        pipeline: &mut PipelineRuntimeState,
-        status: StatusCode,
-        error: &JsonValue,
-    ) -> Result<(), DBError> {
-        let error = Self::error_response_from_json(self.pipeline_id, status, error);
-        self.update_pipeline_status(pipeline, PipelineStatus::Failed, Some(error))
-            .await;
-        self.update_pipeline_runtime_state(pipeline).await
-    }
-
     /// Parse `ErrorResponse` from JSON. On error, builds an `ErrorResponse`
     /// with the originaln JSON content.
     fn error_response_from_json(
@@ -613,6 +530,12 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             })
         })
     }
+}
+
+/// Utility type for the pipeline automaton to describe state changes
+enum State {
+    Transition(PipelineStatus, Option<ErrorResponse>),
+    Unchanged,
 }
 
 pub async fn fetch_binary_ref(
@@ -718,4 +641,185 @@ async fn pipeline_http_request_json_response(
         })?;
 
     Ok((status, value))
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use pipeline_types::config::RuntimeConfig;
+    use tokio::sync::{Mutex, Notify};
+    use uuid::Uuid;
+
+    use crate::db::storage::Storage;
+    use crate::db::{PipelineId, PipelineStatus, ProjectDB};
+    use crate::pipeline_automata::PipelineAutomaton;
+    use crate::{api::ManagerError, auth::TenantRecord};
+
+    use super::{PipelineExecutionDesc, PipelineExecutor};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct MockPipeline {
+        uri: String,
+    }
+
+    #[async_trait]
+    impl PipelineExecutor for MockPipeline {
+        async fn start(&mut self, _ped: PipelineExecutionDesc) -> Result<(), ManagerError> {
+            Ok(())
+        }
+
+        async fn get_location(&mut self) -> Result<Option<String>, ManagerError> {
+            Ok(Some(self.uri.clone()))
+        }
+
+        async fn check_if_shutdown(&mut self) -> bool {
+            true
+        }
+
+        async fn shutdown(&mut self) -> Result<(), ManagerError> {
+            Ok(())
+        }
+    }
+
+    struct AutomatonTest {
+        conn: Arc<Mutex<ProjectDB>>,
+        automaton: PipelineAutomaton<MockPipeline>,
+    }
+
+    impl AutomatonTest {
+        async fn set_desired_state(&self, status: PipelineStatus) {
+            let automaton = &self.automaton;
+            self.conn
+                .lock()
+                .await
+                .set_pipeline_desired_status(automaton.tenant_id, automaton.pipeline_id, status)
+                .await
+                .unwrap();
+        }
+
+        async fn check_current_state(&self, status: PipelineStatus) {
+            let automaton = &self.automaton;
+            let pipeline = self
+                .conn
+                .lock()
+                .await
+                .get_pipeline_runtime_state(automaton.tenant_id, automaton.pipeline_id)
+                .await
+                .unwrap();
+            assert_eq!(status, pipeline.current_status);
+        }
+
+        async fn tick(&mut self) {
+            self.automaton.do_run().await.unwrap();
+        }
+    }
+
+    async fn setup(conn: Arc<Mutex<ProjectDB>>, uri: String) -> AutomatonTest {
+        // Create some programs and pipelines before listening for changes
+        let tenant_id = TenantRecord::default().id;
+        let program_id = Uuid::now_v7();
+
+        let (program_id, version) = conn
+            .lock()
+            .await
+            .new_program(
+                tenant_id,
+                program_id,
+                "test0",
+                "program desc",
+                "ignored",
+                true,
+            )
+            .await
+            .unwrap();
+        let _ = conn
+            .lock()
+            .await
+            .set_program_status_guarded(
+                tenant_id,
+                program_id,
+                version,
+                crate::api::ProgramStatus::Success,
+            )
+            .await
+            .unwrap();
+        let _ = conn
+            .lock()
+            .await
+            .set_program_schema(
+                tenant_id,
+                program_id,
+                crate::db::ProgramSchema {
+                    inputs: vec![],
+                    outputs: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        let rc = RuntimeConfig::from_yaml("");
+        let pipeline_id = Uuid::now_v7();
+        let _ = conn
+            .lock()
+            .await
+            .new_pipeline(
+                tenant_id,
+                pipeline_id,
+                Some(program_id),
+                "pipeline-id",
+                "2",
+                &rc,
+                &Some(vec![]),
+            )
+            .await
+            .unwrap();
+        let pipeline_id = PipelineId(pipeline_id);
+        let _ = conn
+            .lock()
+            .await
+            .create_pipeline_revision(Uuid::now_v7(), tenant_id, pipeline_id)
+            .await
+            .unwrap();
+        let notifier = Arc::new(Notify::new());
+        let automaton = PipelineAutomaton::new(
+            pipeline_id,
+            tenant_id,
+            conn.clone(),
+            notifier.clone(),
+            MockPipeline { uri },
+        );
+        AutomatonTest {
+            conn: conn.clone(),
+            automaton,
+        }
+    }
+
+    #[tokio::test]
+    async fn pipeline_start() {
+        let (conn, _temp) = crate::db::test::setup_pg().await;
+        let conn = Arc::new(tokio::sync::Mutex::new(conn));
+        // Start a background HTTP server on a random local port
+        let mock_server = MockServer::start().await;
+        let template = ResponseTemplate::new(200).set_body_json(r#"{}"#);
+
+        // Simulate /stats responses.
+        Mock::given(method("GET"))
+            .and(path("/stats"))
+            .respond_with(template)
+            .mount(&mock_server)
+            .await;
+
+        let addr = mock_server.address().to_string();
+        let mut test = setup(conn.clone(), addr).await;
+        test.set_desired_state(PipelineStatus::Paused).await;
+        test.check_current_state(PipelineStatus::Shutdown).await;
+        test.tick().await;
+        test.check_current_state(PipelineStatus::Provisioning).await;
+        test.tick().await;
+        test.check_current_state(PipelineStatus::Initializing).await;
+        test.tick().await;
+        test.check_current_state(PipelineStatus::Paused).await;
+    }
 }

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -183,6 +183,12 @@ impl Display for RunnerError {
     }
 }
 
+impl From<RunnerError> for ErrorResponse {
+    fn from(val: RunnerError) -> Self {
+        ErrorResponse::from(&val)
+    }
+}
+
 impl StdError for RunnerError {}
 
 impl ResponseError for RunnerError {


### PR DESCRIPTION
The pipeline automaton is written as one large method that blends several concerns. It is one big loop that waits on external triggers (or timeouts), advances the state machine, changes timeouts, and updates the pipeline state in the database in the state machine itself. This made it difficult to follow the automaton's behavior and to test targeted executions.

This commit breaks up the automaton to separate out triggers that tick the automaton, from the state machine and transitions, to actually reflecting state updates to the database. `PipelineHandle` API calls are still embedded within the logic to identify state transitions. In doing so, we also remove a few functions and indirections that are no longer needed.

With this commit we can now write tests where we construct an automaton that manages a mock pipeline, and step through the state machine in a controlled way.

A separate commit will add more tests.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
