### PR TITLE
pipeline-manager: do not print misleading error on shutdown -> shutdown transition

### DIFF
--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -412,6 +412,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             (PipelineStatus::Running, _)
             | (PipelineStatus::Paused, _)
             | (PipelineStatus::Failed, _) => self.probe(&mut pipeline).await?,
+            (PipelineStatus::Shutdown, PipelineStatus::Shutdown) => State::Unchanged,
             _ => {
                 error!(
                     "Unexpected current/desired pipeline status combination {:?}/{:?}",


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
