### PR TITLE
sql-compiler: remove SLT from SQL-compiler dependencies

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -207,11 +207,6 @@
             <version>${calcite.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.hydromatic</groupId>
-            <artifactId>sql-logic-test</artifactId>
-            <version>0.3</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/942

The jar size goes down from 135M to 28M.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
