### PR TITLE
Fixes and minor improvements leading up to fault tolerance integration

### DIFF
--- a/crates/adapters/README.md
+++ b/crates/adapters/README.md
@@ -7,22 +7,6 @@ controller that controls the execution of a DBSP circuit along with
 its input and output adapters, and a DBSP server that exposes the
 controller API over HTTP and through a web interface.
 
-## Test notes
-
-The unit tests write `librdkafka` log messages to `stdout` regardless
-of `--nocapture`.  This is because the Cargo test harness only
-captures output from the thread started by the harness itself, and
-`librdkafka` runs in a separate thread.
-
-The tests will output several log messages like the following.  These
-do not indicate an error, and you should not run a server on
-port 11111.  These messages indicate that a negative test that
-specifies an invalid Kafka server address was successful.
-
-```
-ERROR - librdkafka: FAIL [thrd:localhost:11111/bootstrap]: localhost:11111/bootstrap: Connect to ipv6#[::1]:11111 failed: Connection refused (after 0ms in state CONNECT)
-```
-
 ## Dependencies
 
 The test code has the following dependencies:

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -155,7 +155,7 @@ impl Controller {
             let inner = inner.clone();
 
             // A channel to communicate circuit initialization status.
-            // The `citcuit_factory` closure must be invoked in the context of
+            // The `circuit_factory` closure must be invoked in the context of
             // the circuit thread, because the circuit handle it returns doesn't
             // implement `Send`.  So we need this channel to communicate circuit
             // initialization status back to this thread.

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -159,9 +159,6 @@ where
     let args = ServerArgs::try_parse().map_err(|e| ControllerError::cli_args_error(&e))?;
 
     run_server(args, circuit_factory).map_err(|e| {
-        // Write to stderror in case the error happened before logging
-        // has been enabled.
-        eprintln!("{e}");
         error!("{e}");
         e
     })

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -37,28 +37,59 @@ pub struct KafkaResources {
 // Checks `consumer` to make sure that all of the topics in `topics` are
 // accessible and have the specified number of partitions.
 fn check_topics<C: ClientContext>(consumer: &Client<C>, topics: &[(&str, i32)]) -> AnyResult<()> {
+    // Retrieve the list of all topics and then filter it.  If the broker is
+    // configured to automatically create topics, then asking for each of them
+    // individually will create them, which is no good for topics we want to
+    // delete.
+    let metadata = consumer.fetch_metadata(None, Duration::from_secs(1))?;
+
     for &(topic, partitions) in topics.iter() {
-        let m = consumer
-            .fetch_metadata(Some(topic), Duration::from_secs(1))
-            .map_err(|e| anyhow!("topic {topic}: {e}"))?;
-        let cur_partitions = m
+        let cur_partitions = metadata
             .topics()
-            .get(0)
-            .map(|topic| topic.partitions().len() as i32)
-            .unwrap_or_default();
+            .iter()
+            .find(|m| m.name() == topic)
+            .map(|mt| mt.partitions().len())
+            .unwrap_or(0) as i32;
         if cur_partitions != partitions {
-            bail!("{topic} only has {cur_partitions} partitions, waiting for {partitions}");
+            bail!("{topic} has {cur_partitions} partitions, waiting for {partitions}");
         }
-        consumer
-            .fetch_watermarks(topic, 0, Duration::from_secs(1))
-            .map_err(|e| anyhow!("topic {topic}: {e}"))?;
+        if partitions > 0 {
+            consumer
+                .fetch_watermarks(topic, 0, Duration::from_secs(1))
+                .map_err(|e| anyhow!("topic {topic}: {e}"))?;
+        }
     }
     Ok(())
+}
+
+fn wait_for_completion<C: ClientContext>(admin_client: &AdminClient<C>, topics: &[(&str, i32)]) {
+    let topic_names = topics
+        .iter()
+        .map(|(topic_name, _partitions)| &**topic_name)
+        .collect::<Vec<_>>();
+
+    let start = Instant::now();
+    let mut backoff = 100;
+    let mut n_retries = 0;
+    while let Err(err) = check_topics(admin_client.inner(), topics) {
+        info!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, retrying: {err}");
+        if start.elapsed() > MAX_TOPIC_PROBE_TIMEOUT {
+            panic!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, giving up after {}ms: {err}", MAX_TOPIC_PROBE_TIMEOUT.as_millis());
+        }
+        sleep(Duration::from_millis(backoff));
+        backoff = 1000.min(backoff * 2);
+        n_retries += 1;
+    }
+    if n_retries > 0 {
+        info!("KafkaResources::create_topics {topic_names:?}: success after {n_retries} tries");
+    }
 }
 
 /// An object that creates Kafka topics on startup and deletes them
 /// on drop.  Helps make sure that test runs don't leave garbage behind.
 impl KafkaResources {
+    /// `(topic, n_partitions)` creates a topic with `n_partitions` partitions.
+    /// If `n_partitions` is 0 then the topic is deleted instead.
     pub fn create_topics(topics: &[(&str, i32)]) -> Self {
         // Kafka does not handle topic deletion and creation consistently when
         // multiple operations are performed in parallel, so serialize calls to
@@ -74,40 +105,32 @@ impl KafkaResources {
             .set_log_level(RDKafkaLogLevel::Debug);
         let admin_client = AdminClient::from_config(&admin_config).unwrap();
 
-        let new_topics = topics
-            .iter()
-            .map(|(topic_name, partitions)| {
-                NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1))
-            })
-            .collect::<Vec<_>>();
-        let topic_names = topics
-            .iter()
-            .map(|(topic_name, _partitions)| &**topic_name)
-            .collect::<Vec<_>>();
-
         // Delete topics if they exist from previous failed runs that crashed before
         // cleaning up.  Otherwise, it may take a long time to re-join a
         // group whose members are dead, plus the old topics may contain
         // messages that will mess up our tests.
-        let _ = block_on(admin_client.delete_topics(&topic_names, &AdminOptions::new()));
+        //
+        // We wait for deletion to finish before creating topics, because Kafka
+        // doesn't seem to always do what we want if we tell it to re-create a
+        // topic before it's been fully deleted.
+        let delete_topics = topics
+            .iter()
+            .map(|(topic_name, _partitions)| &**topic_name)
+            .collect::<Vec<_>>();
+        let _ = block_on(admin_client.delete_topics(&delete_topics, &AdminOptions::new()));
+        let deleted_topics: Vec<_> = topics.iter().map(|(name, _)| (*name, 0)).collect();
+        wait_for_completion(&admin_client, &deleted_topics[..]);
 
+        // Now create the topics and wait for the creations to complete.
+        let new_topics = topics
+            .iter()
+            .filter_map(|(topic_name, partitions)| {
+                (*partitions > 0)
+                    .then(|| NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1)))
+            })
+            .collect::<Vec<_>>();
         block_on(admin_client.create_topics(&new_topics, &AdminOptions::new())).unwrap();
-
-        let start = Instant::now();
-        let mut backoff = 100;
-        let mut n_retries = 0;
-        while let Err(err) = check_topics(admin_client.inner(), topics) {
-            info!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, retrying: {err}");
-            if start.elapsed() > MAX_TOPIC_PROBE_TIMEOUT {
-                panic!("KafkaResources::create_topics {topic_names:?}: unable to connect to newly created topics, giving up after {}ms: {err}", MAX_TOPIC_PROBE_TIMEOUT.as_millis());
-            }
-            sleep(Duration::from_millis(backoff));
-            backoff = 1000.min(backoff * 2);
-            n_retries += 1;
-        }
-        if n_retries > 0 {
-            info!("KafkaResources::create_topics {topic_names:?}: success after {n_retries} tries");
-        }
+        wait_for_completion(&admin_client, topics);
 
         Self {
             admin_client,

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -6,6 +6,8 @@ use rdkafka::{
     error::KafkaError,
     types::RDKafkaErrorCode,
 };
+#[cfg(test)]
+use std::sync::Mutex;
 
 mod input;
 mod output;
@@ -60,5 +62,105 @@ where
             }
         }
         None | Some(_) => (false, AnyError::from(e)),
+    }
+}
+
+/// Captures and redirect log messages during tests.
+///
+/// The Rust unit test framework captures log messages during tests and, in some
+/// cases, prints them later associated with the particular test.  It does this
+/// OK in most cases, but one of the cases it does not handle is output from
+/// threads created by anything other than `std::thread` primitives.  This
+/// includes the thread created by librdkafka.  If we log anything from a
+/// context callback, then it goes directly to stderr, bypassing the unit test
+/// framework.  This makes it hard to read the unit test output and hard to
+/// attribute messages to particular tests.
+///
+/// `DeferredLogging` provides a way to capture log messages emitted by the unit
+/// tests.  A context can instantiate `DeferredLogging` and use
+/// `DeferredLogging::with_deferred_logging` to wrap calls to librdkafka
+/// functions that are likely to emit log messages.  This can be specific calls
+/// instead of every call, since we know what message the unit tests actually
+/// provoke.
+///
+/// When tests are disabled, this framework compiles to nothing.
+#[cfg(test)]
+pub(crate) struct DeferredLogging(Mutex<Option<Vec<(RDKafkaLogLevel, String, String)>>>);
+
+#[cfg(test)]
+impl DeferredLogging {
+    pub fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    /// Calls `f`, capturing log messages that occur during the call, and then
+    /// logging them in the current thread.
+    pub fn with_deferred_logging<F, R>(&self, f: F) -> R
+    where
+        F: Fn() -> R,
+    {
+        *self.0.lock().unwrap() = Some(Vec::new());
+        let r = f();
+        for (level, fac, message) in self.0.lock().unwrap().take().unwrap().drain(..) {
+            log::info!("{level:?} {fac} {message}");
+        }
+        r
+    }
+
+    /// Logs the message in the usual way, or captures it for later logging if
+    /// we're running inside `Self::with_deferred_logging`.
+    pub fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        if let Some(ref mut deferred_logging) = self.0.lock().unwrap().as_mut() {
+            deferred_logging.push((level, fac.into(), log_message.into()))
+        } else {
+            Self::default_log(level, fac, log_message)
+        }
+    }
+}
+
+#[cfg(not(test))]
+pub(crate) struct DeferredLogging;
+
+#[cfg(not(test))]
+impl DeferredLogging {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn with_deferred_logging<F, R>(&self, f: F) -> R
+    where
+        F: Fn() -> R,
+    {
+        f()
+    }
+
+    pub fn log(&self, level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        Self::default_log(level, fac, log_message)
+    }
+}
+
+impl DeferredLogging {
+    // This is a copy of the default implementation of [`ClientContext::log`].
+    fn default_log(level: RDKafkaLogLevel, fac: &str, log_message: &str) {
+        match level {
+            RDKafkaLogLevel::Emerg
+            | RDKafkaLogLevel::Alert
+            | RDKafkaLogLevel::Critical
+            | RDKafkaLogLevel::Error => {
+                log::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Warning => {
+                log::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Notice => {
+                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Info => {
+                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Debug => {
+                log::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+        }
     }
 }

--- a/crates/adapters/src/transport/kafka/test.rs
+++ b/crates/adapters/src/transport/kafka/test.rs
@@ -64,6 +64,7 @@ fn wait_for_output_unordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStru
 
 fn init_test_logger() {
     let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .is_test(true)
         .format(move |buf, record| {
             let t = chrono::Utc::now();
             let t = format!("{}", t.format("%Y-%m-%d %H:%M:%S"));

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -122,7 +122,17 @@ pub struct Compiler {}
 /// crate.
 const MAIN_FUNCTION: &str = r#"
 fn main() {
-    dbsp_adapters::server::server_main(|workers| circuit(workers).map(|(dbsp, catalog)| (Box::new(dbsp) as Box<dyn dbsp_adapters::DbspCircuitHandle>, Box::new(catalog) as Box<dyn dbsp_adapters::CircuitCatalog>)).map_err(|e| dbsp_adapters::ControllerError::dbsp_error(e))).unwrap_or_else(|e| {
+    dbsp_adapters::server::server_main(|workers| {
+        circuit(workers)
+            .map(|(dbsp, catalog)| {
+                (
+                    Box::new(dbsp) as Box<dyn dbsp_adapters::DbspCircuitHandle>,
+                    Box::new(catalog) as Box<dyn dbsp_adapters::CircuitCatalog>,
+                )
+            })
+            .map_err(|e| dbsp_adapters::ControllerError::dbsp_error(e))
+    })
+    .unwrap_or_else(|e| {
         eprintln!("{e}");
         std::process::exit(1);
     });

--- a/sql-to-dbsp-compiler/README.md
+++ b/sql-to-dbsp-compiler/README.md
@@ -86,7 +86,8 @@ views                                           V
 
 ## Using the compiler
 
-See the [documentation](https://www.feldera.com/docs/sql/intro)
+See the documentation in `docs/contributors/compiler.md` in this repo,
+or [online](https://www.feldera.com/docs/contributors/compiler).
 
 ## Compiler architecture
 


### PR DESCRIPTION
This is a resubmission of the small fixes and improvements that lead up to the fault tolerance code. These commits are a subset of those reverted yesterday with commit a23d48134877 ("dbsp_adapters: Temporarily roll back fault tolerance series."). Now, these commits have gone through and passed CI three times, so I do not think that these are a problem, and I will re-merge them.

Is this a user-visible change (yes/no): no
