### PR TITLE
dbsp_adapters: Fix dependencies for jit_integration_test.

### DIFF
--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -88,3 +88,9 @@ rust_decimal_macros = "1.32"
 name = "pipeline"
 path = "src/jit/pipeline.rs"
 required-features = ["with-kafka", "with-jit"]
+
+[[test]]
+name = "jit_integration_test"
+path = "tests/jit_integration_test.rs"
+# These tests run the `pipeline` binary built above, which requires these features:
+required-features = ["with-kafka", "with-jit"]


### PR DESCRIPTION
This test kept failing for me, because `pipeline` wasn't being built, which in turn was because I wasn't passing in the right features.  This avoids the problem.

Is this a user-visible change (yes/no): no