### PR TITLE
Fix a bug in Pipeline Management table where sometimes pipeline action buttons do not send requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix a bug in Pipeline Management table where sometimes pipeline action buttons do not send requests
+
 ## [0.3.1] - 2023-11-09
 
 ### Fixed

--- a/web-console/src/lib/functions/common/tanstack.ts
+++ b/web-console/src/lib/functions/common/tanstack.ts
@@ -1,6 +1,6 @@
 import { ApiError } from '$lib/services/manager'
 
-import { QueryClient, Updater, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, QueryFilters, Updater, UseQueryOptions } from '@tanstack/react-query'
 
 type FunctionType = (...args: any) => any
 type Arguments<F extends FunctionType> = F extends (...args: infer A) => any ? A : never
@@ -40,5 +40,6 @@ export const setQueryData = <R>(
 
 export const getQueryData = <R>(
   queryClient: QueryClient,
-  query: { queryKey: readonly unknown[]; queryFn: () => Promise<R> }
-) => queryClient.getQueryData<R>(query.queryKey)
+  query: { queryKey: readonly unknown[]; queryFn: () => Promise<R> },
+  filters?: QueryFilters
+) => queryClient.getQueryData<R>(query.queryKey, filters)


### PR DESCRIPTION
The issue was that when checking if start/pause/shutdown request is redundant, a stale request cache was used to determine current pipeline status. Since the previous mutation the cache for `.pipelineStatus()` query was invalidated, but by default `getQueryData()` returns both valid and stale cache. By adding { stale: false } filter, we ensure that only valid status data is used for the check. Also we apply status consolidation via `consolidatePipelineStatus()` to `.pipelineStatus()` query, just like to `.pipelines()` query, to ensure identical behavior.