### PR TITLE
python: use explicit names for file-type attached-connectors

### DIFF
--- a/demo/demo_notebooks/fraud_detection.ipynb
+++ b/demo/demo_notebooks/fraud_detection.ipynb
@@ -235,9 +235,9 @@
     "def run_query(transaction_file: str, output_file: str):\n",
     "    config = DBSPPipelineConfig(project, 6)\n",
     "\n",
-    "    config.add_file_input(stream = 'DEMOGRAPHICS', filepath = demographics_path, format = CsvInputFormatConfig())\n",
-    "    config.add_file_input(stream = 'TRANSACTIONS', filepath = transaction_file, format = CsvInputFormatConfig())\n",
-    "    config.add_file_output(stream = 'FEATURES', filepath = output_file, format = CsvOutputFormatConfig())\n",
+    "    config.add_file_input(stream = 'DEMOGRAPHICS', filepath = demographics_path, format = CsvInputFormatConfig(), name = 'demographics')\n",
+    "    config.add_file_input(stream = 'TRANSACTIONS', filepath = transaction_file, format = CsvInputFormatConfig(), name = 'transactions')\n",
+    "    config.add_file_output(stream = 'FEATURES', filepath = output_file, format = CsvOutputFormatConfig(), name = 'features')\n",
     "\n",
     "    config.run_to_completion()"
    ]

--- a/python/dbsp/pipeline.py
+++ b/python/dbsp/pipeline.py
@@ -176,13 +176,14 @@ class DBSPPipelineConfig:
             )
         )
 
-    def add_file_input(self, stream: str, filepath: str, format: FormatConfig):
+    def add_file_input(self, stream: str, filepath: str, format: FormatConfig, name: str):
         """Add an input connector that reads data from a file to the pipeline configuration.
 
         Args:
             stream (str): Input table the connector is connected to.
             filepath (str): File to read data from.
             format (FormatConfig): Data format specification, e.g., CsvInputFormatConfig().
+            name (str): Attached connector name
         """
         self.add_input(
             stream,
@@ -198,13 +199,14 @@ class DBSPPipelineConfig:
             name
         )
 
-    def add_file_output(self, stream: str, filepath: str, format: FormatConfig):
+    def add_file_output(self, stream: str, filepath: str, format: FormatConfig, name: str):
         """Add an output connector that reads data from a file to the pipeline configuration.
 
         Args:
             stream (str): What view the connector is connected to.
             filepath (str): File to write to.
             format (FormatConfig): Data format specification, e.g., CsvOutputFormatConfig().
+            name (str): Attached connector name
         """
         self.add_output(
             stream,

--- a/python/test.py
+++ b/python/test.py
@@ -148,11 +148,11 @@ def main():
             suffix='.csv', prefix='output', text=True)
         os.close(outfd)
         pipeline.add_file_input(stream='DEMOGRAPHICS',
-                            filepath=dempath, format=CsvInputFormatConfig())
+                            filepath=dempath, format=CsvInputFormatConfig(), name="demographics")
         pipeline.add_file_input(stream='TRANSACTIONS',
-                            filepath=transpath, format=CsvInputFormatConfig())
+                            filepath=transpath, format=CsvInputFormatConfig(), name="transactions")
         pipeline.add_file_output(stream='TRANSACTIONS_WITH_DEMOGRAPHICS',
-                            filepath=outpath, format=CsvOutputFormatConfig())
+                            filepath=outpath, format=CsvOutputFormatConfig(), name="transactions_with_demographics")
 
     program.compile()
     print("Project compiled")


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/1024

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
