### PR TITLE
dbsp_adapters: Fix config string in ignored test.

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -237,7 +237,7 @@ fn test_empty_input() {
     let config_str = r#"
 topics: [empty]
 log_level: debug
-fault_tolerance: {{}}
+fault_tolerance: {}
 "#
     .to_string();
 


### PR DESCRIPTION
I didn't spot this in testing the previous commit because it was ignored.


Fixes: e6391827d8cf ("dbsp_adapters: Unify `kafka` and `durable_kafka` transports.")

Is this a user-visible change (yes/no): no