### PR TITLE
pipeline-manager: add metrics to compiler server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
 name = "duct"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4756,11 +4762,13 @@ dependencies = [
  "futures-util",
  "jsonwebtoken",
  "log",
+ "once_cell",
  "openssl",
  "pg-client-config",
  "pg-embed",
  "pipeline_types",
  "pretty_assertions",
+ "prometheus-client",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -5063,6 +5071,29 @@ dependencies = [
  "parking_lot 0.12.1",
  "protobuf",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c4f1c9d81d556458f94c98f857748130ea9737bbd6053da497503b26ea63c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -51,6 +51,8 @@ refinery = {version = "0.8.10", features = ["tokio-postgres"]}
 reqwest = {version = "0.11.18", features = ["json"]}
 url = {version = "2.4.0"}
 dirs = "5.0"
+prometheus-client = "0.22.0"
+once_cell = "1.18.0"
 
 [features]
 integration-test = []

--- a/crates/pipeline_manager/src/bin/compiler-server.rs
+++ b/crates/pipeline_manager/src/bin/compiler-server.rs
@@ -28,6 +28,9 @@ async fn main() -> anyhow::Result<()> {
         .unwrap();
     let compiler_config = compiler_config.canonicalize().unwrap();
 
+    let mut registry = pipeline_manager::metrics::init();
+    pipeline_manager::compiler::register_metrics(&mut registry);
+    pipeline_manager::metrics::create_endpoint(registry).await;
     if compiler_config.precompile {
         Compiler::precompile_dependencies(&compiler_config).await?;
         return Ok(());

--- a/crates/pipeline_manager/src/lib.rs
+++ b/crates/pipeline_manager/src/lib.rs
@@ -11,6 +11,7 @@ pub mod db;
 pub mod db_notifier;
 pub mod local_runner;
 pub mod logging;
+pub mod metrics;
 pub mod pipeline_automata;
 pub mod probe;
 pub mod retries;

--- a/crates/pipeline_manager/src/metrics.rs
+++ b/crates/pipeline_manager/src/metrics.rs
@@ -1,0 +1,35 @@
+use actix_web::{get, http::header::ContentType, web, HttpResponse, HttpServer, Responder};
+use prometheus_client::{encoding::text::encode, registry::Registry};
+
+use crate::api::ManagerError;
+
+/// Initialize a metrics registry. This registry has to be passed
+/// to every sub-system that wants to register metrics.
+pub fn init() -> Registry {
+    Registry::default()
+}
+
+/// Create a scrape endpoint for metrics on http://0.0.0.0:9000/metrics
+pub async fn create_endpoint(registry: Registry) {
+    let registry = web::Data::new(registry);
+    let _http = tokio::spawn(
+        HttpServer::new(move || {
+            actix_web::App::new()
+                .app_data(registry.clone())
+                .service(metrics)
+        })
+        .bind(("0.0.0.0", 9000))
+        .unwrap()
+        .run(),
+    );
+}
+
+/// A prometheus-compatible metrics scrape endpoint.
+#[get("/metrics")]
+async fn metrics(registry: web::Data<Registry>) -> Result<impl Responder, ManagerError> {
+    let mut buffer = String::new();
+    encode(&mut buffer, &registry).unwrap();
+    Ok(HttpResponse::Ok()
+        .content_type(ContentType::plaintext())
+        .body(buffer))
+}


### PR DESCRIPTION
This commit starts adding metrics to the pipeline-manager components. We'll start with the compiler server for now. We'll expose histograms for compiler latencies as well as a counter for the number of invocations. These two metrics are faceted by two labels: the phase (SQL vs Rust) and the status (Success vs Error).

For now, we'll always host metrics via a scrape endpoint on a different port (0.0.0.0:9000/metrics) than the usual APIs (80/8080). This is to make sure that we can avoid exposing the scraping endpoint outside the docker ensemble or cluster in a real deployment.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
