### PR TITLE
pipeline-manager: fold ResourceConfig into RuntimeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Fixed
 
 - [SQL] Fix bugs in parsing of KEY and FOREIGN KEY constraints
@@ -33,12 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#932](https://github.com/feldera/feldera/issues/932))
 - WebConsole: Pipeline failure state in Pipeline Management isn't cleared immediately - no longer reproduces
   ([#1012](https://github.com/feldera/feldera/issues/1012))
+- REST API: Fold ResourceConfig into RuntimeConfig to allow users to configure resources
+  ([#1035](https://github.com/feldera/feldera/pull/1035))
 
 ### Added
 
 - [SQL] New aggregation functions: `BIT_AND`, `BIT_OR`, `BIT_XOR`.
   Concatenation for `BINARY values`.  `TO_HEX` function.
   ([#996](https://github.com/feldera/feldera/pull/996))
+- pipeline-manager now exposes a scrape endpoint for metrics, starting with the compiler service
+  ([#1031](https://github.com/feldera/feldera/pull/1031))
 
 ## [0.3.2] - 2023-11-10
 

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -26,6 +26,9 @@ const fn default_workers() -> u16 {
 
 /// Pipeline configuration specified by the user when creating
 /// a new pipeline instance.
+///
+/// This is the shape of the overall pipeline configuration, but is not
+/// the publicly exposed type with which users configure pipelines.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct PipelineConfig {
     /// Global controller configuration.
@@ -42,14 +45,10 @@ pub struct PipelineConfig {
     /// Output endpoint configuration.
     #[serde(default)]
     pub outputs: BTreeMap<Cow<'static, str>, OutputEndpointConfig>,
-
-    /// Resource reservations and limits. This is enforced
-    /// only in Feldera Cloud.
-    #[serde(default)]
-    pub resources: ResourceConfig,
 }
 
-/// Global pipeline configuration settings.
+/// Global pipeline configuration settings. This is the publicly
+/// exposed type for users to configure pipelines.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct RuntimeConfig {
     /// Number of DBSP worker threads.
@@ -74,6 +73,11 @@ pub struct RuntimeConfig {
     /// get buffered by the controller, defaults to 0.
     #[serde(default)]
     pub max_buffering_delay_usecs: u64,
+
+    /// Resource reservations and limits. This is enforced
+    /// only in Feldera Cloud.
+    #[serde(default)]
+    pub resources: ResourceConfig,
 }
 
 impl RuntimeConfig {

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -12,8 +12,7 @@ use futures_util::TryFutureExt;
 use log::{debug, error, info};
 use openssl::sha;
 use pipeline_types::config::{
-    ConnectorConfig, InputEndpointConfig, OutputEndpointConfig, PipelineConfig, ResourceConfig,
-    RuntimeConfig,
+    ConnectorConfig, InputEndpointConfig, OutputEndpointConfig, PipelineConfig, RuntimeConfig,
 };
 use pipeline_types::error::ErrorResponse;
 use pipeline_types::query::OutputQuery;
@@ -713,7 +712,6 @@ impl PipelineRevision {
             global: pipeline.config.clone(),
             inputs: expanded_inputs,
             outputs: expanded_outputs,
-            resources: ResourceConfig::default(),
         };
 
         Ok(pc)

--- a/python/feldera-api-client/feldera_api_client/models/new_pipeline_request.py
+++ b/python/feldera-api-client/feldera_api_client/models/new_pipeline_request.py
@@ -17,7 +17,8 @@ class NewPipelineRequest:
     """Request to create a new pipeline.
 
     Attributes:
-        config (RuntimeConfig): Global pipeline configuration settings.
+        config (RuntimeConfig): Global pipeline configuration settings. This is the publicly
+            exposed type for users to configure pipelines.
         description (str): Config description.
         name (str): Config name.
         connectors (Union[Unset, None, List['AttachedConnector']]): Attached connectors.

--- a/python/feldera-api-client/feldera_api_client/models/pipeline_config.py
+++ b/python/feldera-api-client/feldera_api_client/models/pipeline_config.py
@@ -18,6 +18,9 @@ class PipelineConfig:
     """Pipeline configuration specified by the user when creating
     a new pipeline instance.
 
+    This is the shape of the overall pipeline configuration, but is not
+    the publicly exposed type with which users configure pipelines.
+
         Attributes:
             inputs (PipelineConfigInputs): Input endpoint configuration.
             cpu_profiler (Union[Unset, bool]): Enable CPU profiler.
@@ -31,20 +34,20 @@ class PipelineConfig:
                 across all endpoints) or `max_buffering_delay_usecs` microseconds
                 have passed since at least one input records has been buffered.
                 Defaults to 0.
+            resources (Union[Unset, ResourceConfig]):
             workers (Union[Unset, int]): Number of DBSP worker threads.
             name (Union[Unset, None, str]): Pipeline name
             outputs (Union[Unset, PipelineConfigOutputs]): Output endpoint configuration.
-            resources (Union[Unset, ResourceConfig]):
     """
 
     inputs: "PipelineConfigInputs"
     cpu_profiler: Union[Unset, bool] = UNSET
     max_buffering_delay_usecs: Union[Unset, int] = UNSET
     min_batch_size_records: Union[Unset, int] = UNSET
+    resources: Union[Unset, "ResourceConfig"] = UNSET
     workers: Union[Unset, int] = UNSET
     name: Union[Unset, None, str] = UNSET
     outputs: Union[Unset, "PipelineConfigOutputs"] = UNSET
-    resources: Union[Unset, "ResourceConfig"] = UNSET
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -53,15 +56,15 @@ class PipelineConfig:
         cpu_profiler = self.cpu_profiler
         max_buffering_delay_usecs = self.max_buffering_delay_usecs
         min_batch_size_records = self.min_batch_size_records
+        resources: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.resources, Unset):
+            resources = self.resources.to_dict()
+
         workers = self.workers
         name = self.name
         outputs: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.outputs, Unset):
             outputs = self.outputs.to_dict()
-
-        resources: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.resources, Unset):
-            resources = self.resources.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -76,14 +79,14 @@ class PipelineConfig:
             field_dict["max_buffering_delay_usecs"] = max_buffering_delay_usecs
         if min_batch_size_records is not UNSET:
             field_dict["min_batch_size_records"] = min_batch_size_records
+        if resources is not UNSET:
+            field_dict["resources"] = resources
         if workers is not UNSET:
             field_dict["workers"] = workers
         if name is not UNSET:
             field_dict["name"] = name
         if outputs is not UNSET:
             field_dict["outputs"] = outputs
-        if resources is not UNSET:
-            field_dict["resources"] = resources
 
         return field_dict
 
@@ -102,6 +105,13 @@ class PipelineConfig:
 
         min_batch_size_records = d.pop("min_batch_size_records", UNSET)
 
+        _resources = d.pop("resources", UNSET)
+        resources: Union[Unset, ResourceConfig]
+        if isinstance(_resources, Unset):
+            resources = UNSET
+        else:
+            resources = ResourceConfig.from_dict(_resources)
+
         workers = d.pop("workers", UNSET)
 
         name = d.pop("name", UNSET)
@@ -113,22 +123,15 @@ class PipelineConfig:
         else:
             outputs = PipelineConfigOutputs.from_dict(_outputs)
 
-        _resources = d.pop("resources", UNSET)
-        resources: Union[Unset, ResourceConfig]
-        if isinstance(_resources, Unset):
-            resources = UNSET
-        else:
-            resources = ResourceConfig.from_dict(_resources)
-
         pipeline_config = cls(
             inputs=inputs,
             cpu_profiler=cpu_profiler,
             max_buffering_delay_usecs=max_buffering_delay_usecs,
             min_batch_size_records=min_batch_size_records,
+            resources=resources,
             workers=workers,
             name=name,
             outputs=outputs,
-            resources=resources,
         )
 
         pipeline_config.additional_properties = d

--- a/python/feldera-api-client/feldera_api_client/models/pipeline_descr.py
+++ b/python/feldera-api-client/feldera_api_client/models/pipeline_descr.py
@@ -18,7 +18,8 @@ class PipelineDescr:
 
     Attributes:
         attached_connectors (List['AttachedConnector']):
-        config (RuntimeConfig): Global pipeline configuration settings.
+        config (RuntimeConfig): Global pipeline configuration settings. This is the publicly
+            exposed type for users to configure pipelines.
         description (str):
         name (str):
         pipeline_id (str): Unique pipeline id.

--- a/python/feldera-api-client/feldera_api_client/models/pipeline_revision.py
+++ b/python/feldera-api-client/feldera_api_client/models/pipeline_revision.py
@@ -20,6 +20,9 @@ class PipelineRevision:
         Attributes:
             config (PipelineConfig): Pipeline configuration specified by the user when creating
                 a new pipeline instance.
+
+                This is the shape of the overall pipeline configuration, but is not
+                the publicly exposed type with which users configure pipelines.
             connectors (List['ConnectorDescr']): The versioned connectors.
             pipeline (PipelineDescr): Pipeline descriptor.
             program (ProgramDescr): Program descriptor.

--- a/python/feldera-api-client/feldera_api_client/models/runtime_config.py
+++ b/python/feldera-api-client/feldera_api_client/models/runtime_config.py
@@ -1,34 +1,41 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define, field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.resource_config import ResourceConfig
+
 
 T = TypeVar("T", bound="RuntimeConfig")
 
 
 @define
 class RuntimeConfig:
-    """Global pipeline configuration settings.
+    """Global pipeline configuration settings. This is the publicly
+    exposed type for users to configure pipelines.
 
-    Attributes:
-        cpu_profiler (Union[Unset, bool]): Enable CPU profiler.
-        max_buffering_delay_usecs (Union[Unset, int]): Maximal delay in microseconds to wait for
-            `min_batch_size_records` to
-            get buffered by the controller, defaults to 0.
-        min_batch_size_records (Union[Unset, int]): Minimal input batch size.
+        Attributes:
+            cpu_profiler (Union[Unset, bool]): Enable CPU profiler.
+            max_buffering_delay_usecs (Union[Unset, int]): Maximal delay in microseconds to wait for
+                `min_batch_size_records` to
+                get buffered by the controller, defaults to 0.
+            min_batch_size_records (Union[Unset, int]): Minimal input batch size.
 
-            The controller delays pushing input records to the circuit until at
-            least `min_batch_size_records` records have been received (total
-            across all endpoints) or `max_buffering_delay_usecs` microseconds
-            have passed since at least one input records has been buffered.
-            Defaults to 0.
-        workers (Union[Unset, int]): Number of DBSP worker threads.
+                The controller delays pushing input records to the circuit until at
+                least `min_batch_size_records` records have been received (total
+                across all endpoints) or `max_buffering_delay_usecs` microseconds
+                have passed since at least one input records has been buffered.
+                Defaults to 0.
+            resources (Union[Unset, ResourceConfig]):
+            workers (Union[Unset, int]): Number of DBSP worker threads.
     """
 
     cpu_profiler: Union[Unset, bool] = UNSET
     max_buffering_delay_usecs: Union[Unset, int] = UNSET
     min_batch_size_records: Union[Unset, int] = UNSET
+    resources: Union[Unset, "ResourceConfig"] = UNSET
     workers: Union[Unset, int] = UNSET
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
@@ -36,6 +43,10 @@ class RuntimeConfig:
         cpu_profiler = self.cpu_profiler
         max_buffering_delay_usecs = self.max_buffering_delay_usecs
         min_batch_size_records = self.min_batch_size_records
+        resources: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.resources, Unset):
+            resources = self.resources.to_dict()
+
         workers = self.workers
 
         field_dict: Dict[str, Any] = {}
@@ -47,6 +58,8 @@ class RuntimeConfig:
             field_dict["max_buffering_delay_usecs"] = max_buffering_delay_usecs
         if min_batch_size_records is not UNSET:
             field_dict["min_batch_size_records"] = min_batch_size_records
+        if resources is not UNSET:
+            field_dict["resources"] = resources
         if workers is not UNSET:
             field_dict["workers"] = workers
 
@@ -54,6 +67,8 @@ class RuntimeConfig:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.resource_config import ResourceConfig
+
         d = src_dict.copy()
         cpu_profiler = d.pop("cpu_profiler", UNSET)
 
@@ -61,12 +76,20 @@ class RuntimeConfig:
 
         min_batch_size_records = d.pop("min_batch_size_records", UNSET)
 
+        _resources = d.pop("resources", UNSET)
+        resources: Union[Unset, ResourceConfig]
+        if isinstance(_resources, Unset):
+            resources = UNSET
+        else:
+            resources = ResourceConfig.from_dict(_resources)
+
         workers = d.pop("workers", UNSET)
 
         runtime_config = cls(
             cpu_profiler=cpu_profiler,
             max_buffering_delay_usecs=max_buffering_delay_usecs,
             min_batch_size_records=min_batch_size_records,
+            resources=resources,
             workers=workers,
         )
 

--- a/python/feldera-api-client/feldera_api_client/models/update_pipeline_request.py
+++ b/python/feldera-api-client/feldera_api_client/models/update_pipeline_request.py
@@ -19,7 +19,8 @@ class UpdatePipelineRequest:
     Attributes:
         description (str): New pipeline description.
         name (str): New pipeline name.
-        config (Union[Unset, None, RuntimeConfig]): Global pipeline configuration settings.
+        config (Union[Unset, None, RuntimeConfig]): Global pipeline configuration settings. This is the publicly
+            exposed type for users to configure pipelines.
         connectors (Union[Unset, None, List['AttachedConnector']]): Attached connectors.
 
             - If absent, existing connectors will be kept unmodified.


### PR DESCRIPTION
`PipelineConfig` is an internal constructed type whereas `RuntimeConfig` can be publicly supplied by a REST client. `ResourceConfig` being in `PipelineConfig` meant that it could not be explicitly configured by clients. We therefore move `ResourceConfig` into `RuntimeConfig` to allow external configuration.

Fixes #1026 

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
