### PR TITLE
Fix casts in SQL

### DIFF
--- a/docs/sql/casts.md
+++ b/docs/sql/casts.md
@@ -16,3 +16,15 @@ An explicit cast can be specified in three ways:
 The rules for implicit casts are complex; we [inherit these
 rules](https://calcite.apache.org/docs/reference.html#conversion-contexts-and-strategies)
 from Calcite.
+
+In general SQL casts may discard low order digits but never high order
+digits.  A cast form a wide to a narrow datatype which cannot
+represent the value in the target type will generate a runtime error.
+Note however that casts to floating point values never generate
+runtime errors, since they use "infinity" values to represent out of
+range values.
+
+Conversions from decimal and floating point types to integer types
+always truncate the decimal digits (round towards zero).  For example,
+`CAST(2.9 AS INTEGER)` returns 2, while `CAST(-2.9 AS INTEGER)`
+returns -2.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPNode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPNode.java
@@ -95,9 +95,10 @@ public abstract class DBSPNode
     }
 
     public static void startLog() {
-        DEBUG_DETERMINISM = true;
-        log = new ArrayList<>();
-        previousLog = readLog();
+        if (DEBUG_DETERMINISM) {
+            log = new ArrayList<>();
+            previousLog = readLog();
+        }
     }
 
     public static void done() {

--- a/sql-to-dbsp-compiler/lib/sqllib/Cargo.toml
+++ b/sql-to-dbsp-compiler/lib/sqllib/Cargo.toml
@@ -20,6 +20,7 @@ paste = { version = "1.0.12" }
 regex = { version = "1.9.1" }
 rkyv = "0.7.42"
 hex = "0.4.3"
+num-traits = "0.2"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -9,6 +9,7 @@ use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use dbsp::algebra::{HasOne, HasZero, F32, F64};
 use num::{FromPrimitive, One, ToPrimitive, Zero};
 use rust_decimal::Decimal;
+use num_traits::cast::NumCast;
 
 /////////// cast to b
 
@@ -1026,17 +1027,17 @@ macro_rules! cast_to_i_i {
         ::paste::paste! {
             #[inline]
             pub fn [<cast_to_ $result_type _ $arg_type_name>]( value: $arg_type ) -> $result_type {
-                value as $result_type
+                $result_type::try_from(value).unwrap()
             }
 
             #[inline]
             pub fn [<cast_to_ $result_type _ $arg_type_name N>]( value: Option<$arg_type> ) -> $result_type {
-                value.unwrap() as $result_type
+                $result_type::try_from(value.unwrap()).unwrap()
             }
 
             #[inline]
             pub fn [<cast_to_ $result_type N_ $arg_type_name >]( value: $arg_type ) -> Option<$result_type> {
-                Some(value as $result_type)
+                Some($result_type::try_from(value).unwrap())
             }
 
             #[inline]
@@ -1082,45 +1083,77 @@ macro_rules! cast_to_i {
 
             #[inline]
             pub fn [< cast_to_ $result_type _decimal >](value: Decimal) -> $result_type {
-                value.[<to_ $result_type >]().unwrap()
+                value.trunc().[<to_ $result_type >]().unwrap()
             }
 
             #[inline]
             pub fn [< cast_to_ $result_type N_decimal >](value: Decimal) -> Option<$result_type> {
-                Some(value.[<to_ $result_type >]().unwrap())
+                Some(value.trunc().[<to_ $result_type >]().unwrap())
             }
 
             #[inline]
             pub fn [< cast_to_ $result_type N_decimalN >](value: Option<Decimal>) -> Option<$result_type> {
                 let value = value?;
-                [< cast_to_ $result_type N_decimal >](value)
+                [< cast_to_ $result_type N_decimal >](value.trunc())
             }
 
             #[inline]
             pub fn [< cast_to_ $result_type _decimalN >](value: Option<Decimal>) -> $result_type {
-                [< cast_to_ $result_type _decimal >](value.unwrap())
+                [< cast_to_ $result_type _decimal >](value.unwrap().trunc())
             }
 
-            // From floats
+            // F64
 
             #[inline]
             pub fn [< cast_to_ $result_type _d >](value: F64) -> $result_type {
-                value.into_inner() as $result_type
+                let value = value.into_inner().trunc();
+                <$result_type as NumCast>::from(value).unwrap()
             }
 
             #[inline]
             pub fn [< cast_to_ $result_type _dN >](value: Option<F64>) -> $result_type {
-                value.unwrap().into_inner() as $result_type
+                let value = value.unwrap().into_inner().trunc();
+                <$result_type as NumCast>::from(value).unwrap()
             }
 
             #[inline]
+            pub fn [< cast_to_ $result_type N_d >](value: F64) -> Option<$result_type> {
+                let value = value.into_inner().trunc();
+                Some(<$result_type as NumCast>::from(value).unwrap())
+            }
+
+            #[inline]
+            pub fn [< cast_to_ $result_type N_dN >](value: Option<F64>) -> Option<$result_type> {
+                let value = value?;
+                let value = value.into_inner().trunc();
+                Some(<$result_type as NumCast>::from(value).unwrap())
+            }
+
+            // F32
+
+            #[inline]
             pub fn [< cast_to_ $result_type _f >](value: F32) -> $result_type {
-                value.into_inner() as $result_type
+                let value = value.into_inner().trunc();
+                <$result_type as NumCast>::from(value).unwrap()
             }
 
             #[inline]
             pub fn [< cast_to_ $result_type _fN >](value: Option<F32>) -> $result_type {
-                value.unwrap().into_inner() as $result_type
+                let value = value.unwrap().into_inner().trunc();
+                <$result_type as NumCast>::from(value).unwrap()
+            }
+
+            #[inline]
+            pub fn [< cast_to_ $result_type N_f >](value: F32) -> Option<$result_type> {
+                let value = value.into_inner().trunc();
+                Some(<$result_type as NumCast>::from(value).unwrap())
+            }
+
+            #[inline]
+            pub fn [< cast_to_ $result_type N_fN >](value: Option<F32>) -> Option<$result_type> {
+                let value = value?;
+                let value = value.into_inner().trunc();
+                Some(<$result_type as NumCast>::from(value).unwrap())
             }
 
             // From string

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -8,8 +8,8 @@ use crate::{geopoint::*, interval::*, timestamp::*};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use dbsp::algebra::{HasOne, HasZero, F32, F64};
 use num::{FromPrimitive, One, ToPrimitive, Zero};
-use rust_decimal::Decimal;
 use num_traits::cast::NumCast;
+use rust_decimal::Decimal;
 
 /////////// cast to b
 

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -315,7 +315,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
     public TestStatistics execute(SltTestFile file, OptionsParser.SuppliedOptions options)
             throws SQLException {
         this.startTest();
-        int batchSize = 1;
+        int batchSize = 500;
         String name = file.toString();
         if (name.contains("/"))
             name = name.substring(name.lastIndexOf('/') + 1);


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This implements the same semantics for casts as the Calcite simplification code.
Note that there are several open bugs against calcite's handling of casts, so this has to be continued.
Fixes #1048 