### PR TITLE
[SQL] Simplify the structure of the simple end to end tests

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/jit/JitTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/jit/JitTests.java
@@ -27,6 +27,9 @@ public class JitTests extends EndToEndTests {
         super.testBoolean();
     }
 
+    @Test @Override @Ignore
+    public void testNull() { super.testNull(); }
+
     @Test @Override @Ignore("BYTEARRAY not yet supported in JIT")
     public void testByteArray() {
         super.testByteArray();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
@@ -25,16 +25,7 @@ package org.dbsp.sqlCompiler.compiler.sql.simple;
 
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
-import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.*;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDouble;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
-import org.junit.Test;
-
-import java.math.BigDecimal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 
 // Runs the EndToEnd tests but on an input stream with 3 elements each and
 // using an incremental non-optimized circuit.
@@ -45,13 +36,9 @@ public class NaiveIncrementalTests extends EndToEndTests {
         return new DBSPCompiler(options);
     }
 
-    public void invokeTestQueryBase(String query, InputOutputPair... streams) {
-        super.testQueryBase(query, streams);
-    }
-
     @Override
     public void testQuery(String query, DBSPZSetLiteral.Contents firstOutput) {
-        DBSPZSetLiteral.Contents input = this.createInput();
+        DBSPZSetLiteral.Contents input = createInput();
         DBSPZSetLiteral.Contents secondOutput = DBSPZSetLiteral.Contents.emptyWithElementType(
                 firstOutput.getElementType());
         DBSPZSetLiteral.Contents thirdOutput = secondOutput.minus(firstOutput);
@@ -65,8 +52,9 @@ public class NaiveIncrementalTests extends EndToEndTests {
         );
     }
 
+    @Override
     void testConstantOutput(String query, DBSPZSetLiteral.Contents output) {
-        DBSPZSetLiteral.Contents input = this.createInput();
+        DBSPZSetLiteral.Contents input = createInput();
         DBSPZSetLiteral.Contents e = DBSPZSetLiteral.Contents.emptyWithElementType(output.getElementType());
         this.invokeTestQueryBase(query,
                 // Add first input
@@ -78,10 +66,11 @@ public class NaiveIncrementalTests extends EndToEndTests {
         );
     }
 
+    @Override
     void testAggregate(String query,
                        DBSPZSetLiteral.Contents firstOutput,
                        DBSPZSetLiteral.Contents outputForEmptyInput) {
-        DBSPZSetLiteral.Contents input = this.createInput();
+        DBSPZSetLiteral.Contents input = createInput();
         DBSPZSetLiteral.Contents secondOutput = DBSPZSetLiteral.Contents.emptyWithElementType(
                 firstOutput.getElementType());
         DBSPZSetLiteral.Contents thirdOutput = outputForEmptyInput.minus(firstOutput);
@@ -93,304 +82,5 @@ public class NaiveIncrementalTests extends EndToEndTests {
                 // Subtract the first input
                 new InputOutputPair(input.negate(), thirdOutput)
         );
-    }
-
-    @Test @Override
-    public void constantFoldTest() {
-        String query = "SELECT 1 + 2";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(new DBSPTupleExpression(new DBSPI32Literal(3))));
-    }
-
-    @Test @Override
-    public void testByteArray() {
-        String query = "SELECT x'012345ab'";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(new DBSPBinaryLiteral(new byte[]{ 0x01, 0x23, 0x45, (byte)0xAB }))));
-    }
-
-    @Test @Override
-    public void zero() {
-        String query = "SELECT 0";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(new DBSPI32Literal(0)));
-        this.testConstantOutput(query, result);
-    }
-
-    @Test @Override
-    public void customDivisionTest() {
-        // Use a custom division operator.
-        String query = "SELECT DIVISION(1, 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void countDistinctTest() {
-        String query = "SELECT 100 + COUNT(DISTINCT - T.COL5) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(
-                                new DBSPI64Literal(101))),
-                new DBSPZSetLiteral.Contents(new DBSPTupleExpression(new DBSPI64Literal(100))));
-    }
-
-    @Test @Override
-    public void inTest() {
-        String query = "SELECT 3 in (SELECT COL5 FROM T)";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(new DBSPTupleExpression(
-                        DBSPLiteral.none(new DBSPTypeBool(CalciteObject.EMPTY, true)))),
-                new DBSPZSetLiteral.Contents(new DBSPTupleExpression(
-                        new DBSPBoolLiteral(false, true)))
-        );
-    }
-
-    @Test @Override
-    public void someTest() {
-        String query = "SELECT SOME(T.COL3) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral(true, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral())));
-    }
-
-    @Test @Override
-    public void everyTest() {
-        String query = "SELECT EVERY(T.COL3) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral(false, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral())));
-    }
-
-    @Test @Override
-    public void orTest() {
-        String query = "SELECT LOGICAL_OR(T.COL3) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral(true, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPBoolLiteral())));
-    }
-
-    @Test @Override
-    public void correlatedAggregate() {
-        String query = "SELECT Sum(r.COL1 * r.COL5) FROM T r\n" +
-                "WHERE\n" +
-                "0.5 * (SELECT Sum(r1.COL5) FROM T r1) =\n" +
-                "(SELECT Sum(r2.COL5) FROM T r2 WHERE r2.COL1 = r.COL1)";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void divZeroTest() {
-        String query = "SELECT 1 / 0";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test
-    public void decimalParse() {
-        String query = "SELECT CAST('0.5' AS DECIMAL)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPDecimalLiteral(new DBSPTypeDecimal(CalciteObject.EMPTY, DBSPTypeDecimal.MAX_PRECISION, DBSPTypeDecimal.MAX_SCALE, false),
-                                new BigDecimal("0.5")))));
-    }
-
-    @Test
-    public void decimalParseFail() {
-        String query = "SELECT CAST('blah' AS DECIMAL)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPDecimalLiteral(new DBSPTypeDecimal(CalciteObject.EMPTY, DBSPTypeDecimal.MAX_PRECISION, DBSPTypeDecimal.MAX_SCALE, false),
-                                new BigDecimal(0)))));
-    }
-
-    @Test
-    public void divZero() {
-        String query = "SELECT 'Infinity' / 0";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPDecimalLiteral(new DBSPTypeDecimal(CalciteObject.EMPTY, DBSPTypeDecimal.MAX_PRECISION, DBSPTypeDecimal.MAX_SCALE, true),
-                                null))));
-    }
-
-
-    @Test @Override
-    public void nestedDivTest() {
-        String query = "SELECT 2 / (1 / 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void geoPointTest() {
-        String query = "SELECT ST_POINT(0, 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPGeoPointLiteral(CalciteObject.EMPTY,
-                                new DBSPDoubleLiteral(0), new DBSPDoubleLiteral(0), false).some())));
-    }
-
-    @Override @Test
-    public void geoDistanceTest() {
-        String query = "SELECT ST_DISTANCE(ST_POINT(0, 0), ST_POINT(0,1))";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(new DBSPDoubleLiteral(1).some())));
-    }
-
-    @Test @Override
-    public void foldTest() {
-        String query = "SELECT + 91 + NULLIF ( + 93, + 38 )";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                new DBSPI32Literal(184, true)));
-        this.testConstantOutput(query, result);
-    }
-
-    @Test @Override
-    public void aggregateFalseTest() {
-        String query = "SELECT SUM(T.COL1) FROM T WHERE FALSE";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))));
-        this.testConstantOutput(query, result);
-    }
-
-    @Test @Override
-    public void constAggregateDoubleExpression() {
-        String query = "SELECT 34 / SUM (1), 20 / SUM(2) FROM T GROUP BY COL1";
-        this.testQuery(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(
-                                new DBSPI32Literal(17, true),
-                                new DBSPI32Literal(5, true))));
-    }
-
-    @Test @Override
-    public void constAggregateExpression2() {
-        String query = "SELECT 34 / AVG (1) FROM T GROUP BY COL1";
-        this.testQuery(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI32Literal(34, true))));
-    }
-
-    @Test @Override
-    public void aggregateTwiceTest() {
-        String query = "SELECT COUNT(T.COL1), SUM(T.COL1) FROM T";
-        this.testAggregate(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPI64Literal(2), new DBSPI32Literal(20, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI64Literal(0),
-                                DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void maxConst() {
-        String query = "SELECT MAX(6) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI32Literal(6, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void maxTest() {
-        String query = "SELECT MAX(T.COL1) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI32Literal(10, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void averageTest() {
-        String query = "SELECT AVG(T.COL1) FROM T";
-        DBSPZSetLiteral.Contents output = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                new DBSPI32Literal(10, true)));
-        this.testAggregate(query, output, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void aggregateFloatTest() {
-        String query = "SELECT SUM(T.COL2) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPDoubleLiteral(13.0, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeDouble(CalciteObject.EMPTY,true)))));
-    }
-
-    @Test @Override
-    public void optionAggregateTest() {
-        String query = "SELECT SUM(T.COL5) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI32Literal(1, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void aggregateTest() {
-        String query = "SELECT SUM(T.COL1) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(new DBSPI32Literal(20, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
-    }
-
-    @Test @Override
-    public void aggregateDistinctTest() {
-        String query = "SELECT SUM(DISTINCT T.COL1), SUM(T.COL2) FROM T";
-        this.testAggregate(query,
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(
-                                new DBSPI32Literal(10, true),
-                                new DBSPDoubleLiteral(13.0, true))),
-                new DBSPZSetLiteral.Contents(
-                        new DBSPTupleExpression(
-                                DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
-                                DBSPLiteral.none(new DBSPTypeDouble(CalciteObject.EMPTY,true)))));
-    }
-
-    @Test
-    public void testArray() {
-        String query = "SELECT ELEMENT(ARRAY [2])";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(new DBSPI32Literal(2)));
-        this.testConstantOutput(query, result);
-    }
-
-    @Test
-    public void testArrayIndex() {
-        String query = "SELECT (ARRAY [2])[1]";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(new DBSPI32Literal(2, true)));
-        this.testConstantOutput(query, result);
-    }
-
-    @Test
-    public void testArrayIndexOutOfBounds() {
-        String query = "SELECT (ARRAY [2])[3]";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))));
-        this.testConstantOutput(query, result);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/OptimizedIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/OptimizedIncrementalTests.java
@@ -32,8 +32,4 @@ public class OptimizedIncrementalTests extends NaiveIncrementalTests {
         CompilerOptions options = this.testOptions(true, true, false);
         return new DBSPCompiler(options);
     }
-
-    public void invokeTestQueryBase(String query, InputOutputPair... streams) {
-        super.testQueryBase(query, streams);
-    }
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Exactly the same tests are being run as previously, but there is less bug-prone code duplication.
This essentially moves some code from NaiveIncrementalTests to EndToEndTests