### PR TITLE
Adjust lifetime bound.

### DIFF
--- a/crates/dbsp/src/trace/layers/mod.rs
+++ b/crates/dbsp/src/trace/layers/mod.rs
@@ -221,7 +221,7 @@ pub trait Cursor<'s> {
     fn keys(&self) -> usize;
 
     /// Reveals the current item.
-    fn item(&self) -> Self::Item<'s>;
+    fn item(&self) -> Self::Item<'_>;
 
     /// Returns cursor over values associted with the current key.
     fn values(&self) -> <Self::ValueStorage as Trie>::Cursor<'s>;
@@ -401,7 +401,7 @@ impl<'s> Cursor<'s> for () {
     fn keys(&self) -> usize {
         0
     }
-    fn item(&self) -> Self::Item<'s> {
+    fn item(&self) -> Self::Item<'_> {
         &()
     }
     fn values(&self) {}


### PR DESCRIPTION
The lifetime should only be bound on the cursor itself rather than the storage.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
