### PR TITLE
Add trailing slash to Cognito redirect_uri

### DIFF
--- a/web-console/src/app/(root)/(blank)/auth/aws/page.tsx
+++ b/web-console/src/app/(root)/(blank)/auth/aws/page.tsx
@@ -13,7 +13,7 @@ export default () => {
     const logoutUrlBase64 = params['state']
     const logoutUrl = Buffer.from(params['state'], 'base64')
       .toString('utf8')
-      .replace('{redirectUri}', encodeURIComponent(window.location.origin + '/auth/aws'))
+      .replace('{redirectUri}', encodeURIComponent(window.location.origin + '/auth/aws/'))
       .replace('{state}', logoutUrlBase64)
 
     setAuth({

--- a/web-console/src/app/(root)/(blank)/login/page.tsx
+++ b/web-console/src/app/(root)/(blank)/login/page.tsx
@@ -46,7 +46,7 @@ export default () => {
 const AwsLoginButton = (props: { loginUrl: string; logoutUrl: string; children: ReactNode }) => {
   const theme = useTheme()
   const url = (props.loginUrl + '&redirect_uri={redirectUri}&state={state}')
-    .replace('{redirectUri}', encodeURIComponent(window.location.origin + '/auth/aws'))
+    .replace('{redirectUri}', encodeURIComponent(window.location.origin + '/auth/aws/'))
     .replace(
       '{state}',
       Buffer.from(props.logoutUrl + '&redirect_uri={redirectUri}&state={state}', 'utf8').toString('base64')


### PR DESCRIPTION
Static Web Console app served by Pipeline Manager requires using trailing slashes in page URLs. This commit fixes missing trailing slash in redirect URL passed to Cognito