### PR TITLE
Simplify trait bounds in dbsp.

### DIFF
--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -24,6 +24,7 @@ default = ["with-serde"]
 persistence = ["rocksdb", "uuid"]
 with-serde = ["serde"]
 with-csv = ["csv"]
+with-arbitrary = ["proptest", "proptest-derive"]
 
 [dependencies]
 num = "0.4.0"
@@ -57,6 +58,8 @@ tarpc = { version = "0.33.0", features = ["full"] }
 futures = "0.3"
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread"] }
 log = "0.4.20"
+proptest-derive = { version = "0.3.0", optional = true }
+proptest = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 csv = "1.2.2"

--- a/crates/dbsp/src/trace/layers/column_layer/builders.rs
+++ b/crates/dbsp/src/trace/layers/column_layer/builders.rs
@@ -1,15 +1,12 @@
 use crate::{
-    algebra::{AddAssignByRef, HasZero},
     trace::layers::{
         advance, column_layer::ColumnLayer, Builder, Cursor, MergeBuilder, Trie, TupleBuilder,
     },
     utils::assume,
+    DBData, DBWeight,
 };
 use size_of::SizeOf;
-use std::{
-    cmp::{min, Ordering},
-    ops::AddAssign,
-};
+use std::cmp::{min, Ordering};
 
 /// A builder for ordered values
 #[derive(SizeOf, Debug, Clone)]
@@ -32,8 +29,8 @@ impl<K, R> ColumnLayerBuilder<K, R> {
 
 impl<K, R> Builder for ColumnLayerBuilder<K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     type Trie = ColumnLayer<K, R>;
 
@@ -56,8 +53,8 @@ where
 
 impl<K, R> MergeBuilder for ColumnLayerBuilder<K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     fn with_capacity(left: &Self::Trie, right: &Self::Trie) -> Self {
         let capacity = Trie::keys(left) + Trie::keys(right);
@@ -274,8 +271,8 @@ where
 
 impl<K, R> TupleBuilder for ColumnLayerBuilder<K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     type Item = (K, R);
 

--- a/crates/dbsp/src/trace/layers/column_layer/cursor.rs
+++ b/crates/dbsp/src/trace/layers/column_layer/cursor.rs
@@ -21,8 +21,8 @@ where
 
 impl<'s, K, R> ColumnLayerCursor<'s, K, R>
 where
-    K: Ord + Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     pub const fn new(pos: usize, storage: &'s ColumnLayer<K, R>, bounds: (usize, usize)) -> Self {
         Self {
@@ -79,8 +79,8 @@ where
 
 impl<'s, K, R> Cursor<'s> for ColumnLayerCursor<'s, K, R>
 where
-    K: Ord + Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Key = K;
 

--- a/crates/dbsp/src/trace/layers/column_layer/mod.rs
+++ b/crates/dbsp/src/trace/layers/column_layer/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::{assume, cast_uninit_vec, sample_slice},
     DBData, DBWeight, NumEntries,
 };
-#[cfg(test)]
+#[cfg(feature = "proptest-derive")]
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use rand::Rng;
 use rkyv::{Archive, Deserialize, Serialize};
@@ -43,7 +43,7 @@ where
     pub lower_bound: usize,
 }
 
-#[cfg(test)]
+#[cfg(feature = "proptest-derive")]
 impl<K: Arbitrary + 'static, R: Arbitrary + 'static> Arbitrary for ColumnLayer<K, R> {
     type Parameters = usize;
 

--- a/crates/dbsp/src/trace/layers/erased/erased_key_leaf/builders.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_key_leaf/builders.rs
@@ -1,5 +1,4 @@
 use crate::{
-    algebra::{AddByRef, HasZero},
     trace::{
         consolidation::consolidate_from,
         layers::{
@@ -7,9 +6,10 @@ use crate::{
             Builder, Cursor, MergeBuilder, Trie, TupleBuilder,
         },
     },
+    DBData, DBWeight,
 };
 use size_of::SizeOf;
-use std::{marker::PhantomData, ops::AddAssign};
+use std::marker::PhantomData;
 
 /// A builder for ordered values
 #[derive(SizeOf)]
@@ -20,8 +20,8 @@ pub struct TypedErasedKeyLeafBuilder<K, R> {
 
 impl<K, R> Builder for TypedErasedKeyLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + HasZero + Eq + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Trie = TypedErasedKeyLeaf<K, R>;
 
@@ -39,8 +39,8 @@ where
 
 impl<K, R> MergeBuilder for TypedErasedKeyLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddByRef + AddAssign + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     fn with_capacity(left: &Self::Trie, right: &Self::Trie) -> Self {
         let capacity = Trie::keys(left) + Trie::keys(right);
@@ -104,8 +104,8 @@ where
 
 impl<K, R> TupleBuilder for TypedErasedKeyLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + HasZero + Eq + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Item = (K, R);
 
@@ -160,8 +160,8 @@ impl<K, R> UnorderedTypedLayerBuilder<K, R> {
 
 impl<K, R> Builder for UnorderedTypedLayerBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Trie = TypedErasedKeyLeaf<K, R>;
 
@@ -187,8 +187,8 @@ where
 
 impl<K, R> TupleBuilder for UnorderedTypedLayerBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Item = (K, R);
 

--- a/crates/dbsp/src/trace/layers/erased/erased_key_leaf/cursor.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_key_leaf/cursor.rs
@@ -28,8 +28,8 @@ where
 
 impl<'a, K, R> TypedKeyLeafCursor<'a, K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     pub const fn new(
         pos: usize,
@@ -84,8 +84,8 @@ where
 
 impl<'s, K, R> Cursor<'s> for TypedKeyLeafCursor<'s, K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     type Item<'k> = (&'k K, &'k R)
     where

--- a/crates/dbsp/src/trace/layers/erased/erased_key_leaf/mod.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_key_leaf/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
     trace::layers::{advance_erased, Trie},
     utils::{uninit_vec, DynVec, DynVecVTable},
-    NumEntries,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -341,8 +341,8 @@ impl<K, R> TypedErasedKeyLeaf<K, R> {
 
 impl<K, R> Trie for TypedErasedKeyLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + AddAssign + AddByRef + HasZero + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Item = (K, R);
     type Cursor<'s> = TypedKeyLeafCursor<'s, K, R>
@@ -378,8 +378,8 @@ where
 // TODO: by-value merge
 impl<K, R> Add<Self> for TypedErasedKeyLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     type Output = Self;
 
@@ -397,8 +397,8 @@ where
 
 impl<K, R> AddAssign<Self> for TypedErasedKeyLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     fn add_assign(&mut self, rhs: Self) {
         if !rhs.is_empty() {
@@ -410,8 +410,8 @@ where
 
 impl<K, R> AddAssignByRef for TypedErasedKeyLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     fn add_assign_by_ref(&mut self, other: &Self) {
         if !other.is_empty() {
@@ -423,8 +423,8 @@ where
 
 impl<K, R> AddByRef for TypedErasedKeyLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: Clone + Eq + HasZero + AddAssign + AddByRef + 'static,
+    K: DBData + IntoErasedData,
+    R: DBWeight,
 {
     fn add_by_ref(&self, rhs: &Self) -> Self {
         self.merge(rhs)

--- a/crates/dbsp/src/trace/layers/erased/erased_leaf/builders.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_leaf/builders.rs
@@ -5,6 +5,7 @@ use crate::trace::{
         Builder, Cursor, MergeBuilder, Trie, TupleBuilder,
     },
 };
+use crate::{DBData, DBWeight};
 use size_of::SizeOf;
 use std::marker::PhantomData;
 
@@ -17,8 +18,8 @@ pub struct TypedErasedLeafBuilder<K, R> {
 
 impl<K, R> Builder for TypedErasedLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Trie = TypedErasedLeaf<K, R>;
 
@@ -36,8 +37,8 @@ where
 
 impl<K, R> MergeBuilder for TypedErasedLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     fn with_capacity(left: &Self::Trie, right: &Self::Trie) -> Self {
         let capacity = Trie::keys(left) + Trie::keys(right);
@@ -105,8 +106,8 @@ where
 
 impl<K, R> TupleBuilder for TypedErasedLeafBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Item = (K, R);
 
@@ -168,8 +169,8 @@ impl<K, R> UnorderedTypedLayerBuilder<K, R> {
 
 impl<K, R> Builder for UnorderedTypedLayerBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Trie = TypedErasedLeaf<K, R>;
 
@@ -196,8 +197,8 @@ where
 
 impl<K, R> TupleBuilder for UnorderedTypedLayerBuilder<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Item = (K, R);
 

--- a/crates/dbsp/src/trace/layers/erased/erased_leaf/cursor.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_leaf/cursor.rs
@@ -16,8 +16,8 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct TypedLayerCursor<'a, K, R>
 where
-    K: Ord + Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     pos: isize,
     storage: &'a ErasedLeaf,
@@ -27,8 +27,8 @@ where
 
 impl<'a, K, R> TypedLayerCursor<'a, K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     pub const fn new(
         pos: usize,
@@ -83,8 +83,8 @@ where
 
 impl<'s, K, R> Cursor<'s> for TypedLayerCursor<'s, K, R>
 where
-    K: Ord + Clone + 'static,
-    R: Clone + 'static,
+    K: DBData,
+    R: DBWeight,
 {
     type Item<'k> = (&'k K, &'k R)
     where

--- a/crates/dbsp/src/trace/layers/erased/erased_leaf/mod.rs
+++ b/crates/dbsp/src/trace/layers/erased/erased_leaf/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef},
     trace::layers::{advance_erased, Trie},
     utils::{uninit_vec, DynVec, DynVecVTable},
-    NumEntries,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -373,8 +373,8 @@ impl<K, R> TypedErasedLeaf<K, R> {
 
 impl<K, R> Trie for TypedErasedLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Item = (K, R);
     type Cursor<'s> = TypedLayerCursor<'s, K, R>
@@ -410,8 +410,8 @@ where
 // TODO: by-value merge
 impl<K, R> Add<Self> for TypedErasedLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     type Output = Self;
 
@@ -429,8 +429,8 @@ where
 
 impl<K, R> AddAssign<Self> for TypedErasedLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     fn add_assign(&mut self, rhs: Self) {
         if !rhs.is_empty() {
@@ -442,8 +442,8 @@ where
 
 impl<K, R> AddAssignByRef for TypedErasedLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     fn add_assign_by_ref(&mut self, other: &Self) {
         if !other.is_empty() {
@@ -455,8 +455,8 @@ where
 
 impl<K, R> AddByRef for TypedErasedLeaf<K, R>
 where
-    K: IntoErasedData,
-    R: IntoErasedDiff,
+    K: DBData + IntoErasedData,
+    R: DBWeight + IntoErasedDiff,
 {
     fn add_by_ref(&self, rhs: &Self) -> Self {
         self.merge(rhs)

--- a/crates/dbsp/src/trace/layers/mod.rs
+++ b/crates/dbsp/src/trace/layers/mod.rs
@@ -20,6 +20,7 @@ mod test;
 pub use advance::{advance, advance_erased, advance_raw, retreat};
 
 use crate::algebra::HasZero;
+use crate::DBData;
 use size_of::SizeOf;
 use std::{
     fmt::Debug,
@@ -214,7 +215,7 @@ pub trait Cursor<'s> {
         Self: 'k;
 
     /// Key used to search the contents of the cursor.
-    type Key;
+    type Key: DBData;
 
     type ValueStorage: Trie;
 

--- a/crates/dbsp/src/trace/layers/ordered/mod.rs
+++ b/crates/dbsp/src/trace/layers/ordered/mod.rs
@@ -30,6 +30,7 @@ use textwrap::indent;
 /// .. offs[i+1]]`.
 // False positive from clippy
 #[derive(Debug, SizeOf, PartialEq, Eq, Clone, Archive, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct OrderedLayer<K, L, O = usize>
 where
     K: 'static,
@@ -106,7 +107,7 @@ impl<K, L, O> OrderedLayer<K, L, O> {
 
 impl<K, L, O> OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -139,7 +140,7 @@ impl<K, V, R, O> OrderedLayer<K, ColumnLayer<V, R>, O> {
 
 impl<K, L, O> NumEntries for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie + NumEntries,
     O: OrdOffset,
 {
@@ -156,7 +157,7 @@ where
 
 impl<K, L, O> NegByRef for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie + NegByRef,
     O: OrdOffset,
 {
@@ -176,7 +177,7 @@ where
 
 impl<K, L, O> Neg for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie + Neg<Output = L>,
     O: OrdOffset,
 {
@@ -199,7 +200,7 @@ where
 // TODO: by-value merge
 impl<K, L, O> Add<Self> for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -219,7 +220,7 @@ where
 
 impl<K, L, O> AddAssign<Self> for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -235,7 +236,7 @@ where
 
 impl<K, L, O> AddAssignByRef for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -248,7 +249,7 @@ where
 
 impl<K, L, O> AddByRef for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -259,7 +260,7 @@ where
 
 impl<K, L, O> Trie for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -363,7 +364,7 @@ impl<K, L, O> OrderedBuilder<K, L, O> {
         (trie1, lower1, upper1): (&<Self as Builder>::Trie, &mut usize, usize),
         (trie2, lower2, upper2): (&<Self as Builder>::Trie, &mut usize, usize),
     ) where
-        K: Ord + Clone,
+        K: DBData,
         L: MergeBuilder,
         O: OrdOffset,
     {
@@ -418,7 +419,7 @@ impl<K, L, O> OrderedBuilder<K, L, O> {
         (trie2, lower2, upper2): (&<Self as Builder>::Trie, &mut usize, usize),
         filter: &F,
     ) where
-        K: Ord + Clone,
+        K: DBData,
         L: MergeBuilder,
         O: OrdOffset,
         F: Fn(&K) -> bool,
@@ -526,7 +527,7 @@ where
 
 impl<K, L, O> Builder for OrderedBuilder<K, L, O>
 where
-    K: Ord + Clone + 'static,
+    K: DBData,
     L: Builder,
     O: OrdOffset,
 {
@@ -553,7 +554,7 @@ where
 
 impl<K, L, O> OrderedBuilder<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     L: MergeBuilder,
     O: OrdOffset,
 {
@@ -735,7 +736,7 @@ where
 
 impl<K, V, L, O> OrderedBuilder<K, L, O>
 where
-    K: Ord + Clone,
+    K: DBData,
     O: OrdOffset,
     L: MergeBuilder,
     <L as Builder>::Trie: 'static,
@@ -933,7 +934,7 @@ where
 
 impl<K, L, O> MergeBuilder for OrderedBuilder<K, L, O>
 where
-    K: Ord + Clone + 'static,
+    K: DBData,
     L: MergeBuilder,
     O: OrdOffset,
 {
@@ -1077,7 +1078,7 @@ where
 
 impl<K, L, O> TupleBuilder for OrderedBuilder<K, L, O>
 where
-    K: Ord + Clone + 'static,
+    K: DBData,
     L: TupleBuilder,
     O: OrdOffset,
 {
@@ -1146,7 +1147,7 @@ where
 
 impl<'s, K, O, L> Clone for OrderedCursor<'s, K, O, L>
 where
-    K: Ord,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
     L::Cursor<'s>: Clone,
@@ -1170,7 +1171,7 @@ where
 
 impl<'s, K, L, O> OrderedCursor<'s, K, O, L>
 where
-    K: Ord,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {
@@ -1215,7 +1216,7 @@ where
 
 impl<'s, K, L, O> Cursor<'s> for OrderedCursor<'s, K, O, L>
 where
-    K: Ord,
+    K: DBData,
     L: Trie,
     O: OrdOffset,
 {

--- a/crates/dbsp/src/trace/layers/ordered_leaf.rs
+++ b/crates/dbsp/src/trace/layers/ordered_leaf.rs
@@ -1,7 +1,7 @@
 //! Implementation using ordered keys and exponential search.
 
 use crate::{
-    algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
+    algebra::{AddAssignByRef, AddByRef, NegByRef},
     trace::layers::{advance, retreat, Builder, Cursor, MergeBuilder, Trie, TupleBuilder},
     DBData, DBWeight, NumEntries,
 };
@@ -30,8 +30,8 @@ impl<K, R> OrderedLeaf<K, R> {
 
 impl<K, R> OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     /// Truncate layer at the first key greater than or equal to `lower_bound`.
     pub fn truncate_keys_below(&mut self, lower_bound: &K) {
@@ -42,8 +42,8 @@ where
 
 impl<K, R> Trie for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Item = (K, R);
     type Cursor<'s> = OrderedLeafCursor<'s, K, R> where K: 's, R: 's;
@@ -109,8 +109,8 @@ where
 
 impl<K, R> AddAssign<Self> for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     fn add_assign(&mut self, rhs: Self) {
         if !rhs.is_empty() {
@@ -121,8 +121,8 @@ where
 
 impl<K, R> AddAssignByRef for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     fn add_assign_by_ref(&mut self, other: &Self) {
         if !other.is_empty() {
@@ -133,8 +133,8 @@ where
 
 impl<K, R> AddByRef for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     fn add_by_ref(&self, rhs: &Self) -> Self {
         self.merge(rhs)
@@ -143,7 +143,7 @@ where
 
 impl<K, R> NegByRef for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
+    K: DBData,
     R: NegByRef,
 {
     fn neg_by_ref(&self) -> Self {
@@ -160,7 +160,7 @@ where
 
 impl<K, R> Neg for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
+    K: DBData,
     R: Neg<Output = R>,
 {
     type Output = Self;
@@ -175,8 +175,8 @@ where
 
 impl<K, R> NumEntries for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBWeight,
 {
     fn num_entries_shallow(&self) -> usize {
         self.vals.len()
@@ -196,9 +196,7 @@ pub struct OrderedLeafBuilder<K, R> {
     pub vals: Vec<(K, R)>,
 }
 
-impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> Builder
-    for OrderedLeafBuilder<K, R>
-{
+impl<K: DBData, R: DBWeight> Builder for OrderedLeafBuilder<K, R> {
     type Trie = OrderedLeaf<K, R>;
     fn boundary(&mut self) -> usize {
         self.vals.len()
@@ -211,9 +209,7 @@ impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> Build
     }
 }
 
-impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> MergeBuilder
-    for OrderedLeafBuilder<K, R>
-{
+impl<K: DBData, R: DBWeight> MergeBuilder for OrderedLeafBuilder<K, R> {
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
             vals: Vec::with_capacity(
@@ -401,9 +397,7 @@ impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> Merge
     }
 }
 
-impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> TupleBuilder
-    for OrderedLeafBuilder<K, R>
-{
+impl<K: DBData, R: DBWeight> TupleBuilder for OrderedLeafBuilder<K, R> {
     type Item = (K, R);
 
     fn new() -> Self {
@@ -471,7 +465,7 @@ where
 
 impl<'s, K, R> Cursor<'s> for OrderedLeafCursor<'s, K, R>
 where
-    K: Eq + Ord + Clone,
+    K: DBData,
     R: Clone,
 {
     type Key = K;

--- a/crates/dbsp/src/trace/layers/unordered.rs
+++ b/crates/dbsp/src/trace/layers/unordered.rs
@@ -1,6 +1,7 @@
 use crate::trace::layers::{
     column_layer::ColumnLayer, Builder, Cursor, MergeBuilder, Trie, TupleBuilder,
 };
+use crate::{DBData, DBWeight};
 use size_of::SizeOf;
 
 /// A layer of unordered values
@@ -52,8 +53,8 @@ impl<K, R> UnorderedLeaf<K, R> {
 
 impl<K, R> Trie for UnorderedLeaf<K, R>
 where
-    K: Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Item = (K, R);
 
@@ -113,7 +114,7 @@ impl<'a, K, R> UnorderedCursor<'a, K, R> {
     }
 }
 
-impl<'s, K, R> Cursor<'s> for UnorderedCursor<'s, K, R> {
+impl<'s, K: DBData, R: DBWeight> Cursor<'s> for UnorderedCursor<'s, K, R> {
     type Key = K;
 
     type Item<'k> = &'k K
@@ -192,8 +193,8 @@ impl<K, R> UnorderedMergeBuilder<K, R> {
 
 impl<K, R> Builder for UnorderedMergeBuilder<K, R>
 where
-    K: Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Trie = UnorderedLeaf<K, R>;
 
@@ -208,8 +209,8 @@ where
 
 impl<K, R> MergeBuilder for UnorderedMergeBuilder<K, R>
 where
-    K: Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     fn with_capacity(left: &Self::Trie, right: &Self::Trie) -> Self {
         Self {
@@ -320,8 +321,8 @@ impl<K, R> UnorderedLeafBuilder<K, R> {
 
 impl<K, R> Builder for UnorderedLeafBuilder<K, R>
 where
-    K: Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Trie = UnorderedLeaf<K, R>;
 
@@ -336,8 +337,8 @@ where
 
 impl<K, R> TupleBuilder for UnorderedLeafBuilder<K, R>
 where
-    K: Clone,
-    R: Clone,
+    K: DBData,
+    R: DBWeight,
 {
     type Item = (K, R);
 

--- a/crates/dbsp/src/trace/ord/indexed_zset_batch.rs
+++ b/crates/dbsp/src/trace/ord/indexed_zset_batch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algebra::{AddAssignByRef, AddByRef, MonoidValue, NegByRef},
+    algebra::{AddAssignByRef, AddByRef, NegByRef},
     time::AntichainRef,
     trace::{
         layers::{
@@ -120,9 +120,9 @@ where
 
 impl<K, V, R, O> NegByRef for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone,
-    V: Ord + Clone,
-    R: MonoidValue + NegByRef,
+    K: DBData,
+    V: DBData,
+    R: DBWeight + NegByRef,
     O: OrdOffset,
 {
     #[inline]
@@ -135,9 +135,9 @@ where
 
 impl<K, V, R, O> Neg for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone,
-    V: Ord + Clone,
-    R: MonoidValue + Neg<Output = R>,
+    K: DBData,
+    V: DBData,
+    R: DBWeight + Neg<Output = R>,
     O: OrdOffset,
 {
     type Output = Self;
@@ -153,9 +153,9 @@ where
 // TODO: by-value merge
 impl<K, V, R, O> Add<Self> for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     type Output = Self;
@@ -170,9 +170,9 @@ where
 
 impl<K, V, R, O> AddAssign<Self> for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]
@@ -183,9 +183,9 @@ where
 
 impl<K, V, R, O> AddAssignByRef for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]
@@ -196,9 +196,9 @@ where
 
 impl<K, V, R, O> AddByRef for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]
@@ -417,9 +417,9 @@ where
 #[derive(Debug, SizeOf)]
 pub struct OrdIndexedZSetCursor<'s, K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone + 'static,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset + PartialEq,
 {
     cursor: OrderedCursor<'s, K, O, ColumnLayer<V, R>>,
@@ -427,9 +427,9 @@ where
 
 impl<'s, K, V, R, O> Cursor<K, V, (), R> for OrdIndexedZSetCursor<'s, K, V, R, O>
 where
-    K: Ord + Clone,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     fn key(&self) -> &K {
@@ -556,7 +556,7 @@ pub struct OrdIndexedZSetBuilder<K, V, R, O>
 where
     K: Ord,
     V: Ord,
-    R: MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     builder: IndexBuilder<K, V, R, O>,

--- a/crates/dbsp/src/trace/ord/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/key_batch.rs
@@ -237,9 +237,9 @@ where
 #[derive(SizeOf)]
 pub struct OrdKeyMerger<K, T, R, O = usize>
 where
-    K: Ord + Clone + 'static,
-    T: Lattice + Ord + Clone + 'static,
-    R: MonoidValue,
+    K: DBData,
+    T: DBData + Lattice,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     // first batch, and position therein.
@@ -318,9 +318,9 @@ where
 pub struct OrdKeyCursor<'s, K, T, R, O = usize>
 where
     O: OrdOffset,
-    K: Ord + Clone + 'static,
-    T: Lattice + Ord + Clone + 'static,
-    R: MonoidValue,
+    K: DBData,
+    T: DBData + Lattice,
+    R: DBWeight + MonoidValue,
 {
     valid: bool,
     cursor: OrderedCursor<'s, K, O, ColumnLayer<T, R>>,
@@ -328,9 +328,9 @@ where
 
 impl<'s, K, T, R, O> Cursor<K, (), T, R> for OrdKeyCursor<'s, K, T, R, O>
 where
-    K: Ord + Clone,
-    T: Lattice + Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    T: DBData + Lattice + Ord + Clone,
+    R: DBWeight,
     O: OrdOffset,
 {
     fn key(&self) -> &K {

--- a/crates/dbsp/src/trace/ord/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/val_batch.rs
@@ -281,10 +281,10 @@ where
 #[derive(SizeOf)]
 pub struct OrdValMerger<K, V, T, R, O = usize>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone + 'static,
-    T: Lattice + Ord + Clone + Debug + 'static,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    T: DBData + Lattice,
+    R: DBWeight,
     O: OrdOffset,
 {
     // first batch, and position therein.
@@ -387,10 +387,10 @@ where
 #[derive(Debug, SizeOf)]
 pub struct OrdValCursor<'s, K, V, T, R, O = usize>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone + 'static,
-    T: Lattice + Ord + Clone + 'static,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    T: Lattice + DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     cursor: OrderedCursor<'s, K, O, OrderedLayer<V, ColumnLayer<T, R>, O>>,
@@ -398,10 +398,10 @@ where
 
 impl<'s, K, V, T, R, O> Cursor<K, V, T, R> for OrdValCursor<'s, K, V, T, R, O>
 where
-    K: Ord + Clone,
-    V: Ord + Clone,
-    T: Lattice + Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    T: Lattice + DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     fn key(&self) -> &K {

--- a/crates/dbsp/src/trace/ord/zset_batch.rs
+++ b/crates/dbsp/src/trace/ord/zset_batch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algebra::{AddAssignByRef, AddByRef, HasZero, MonoidValue, NegByRef},
+    algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
     time::AntichainRef,
     trace::{
         consolidation::consolidate_payload_from,
@@ -125,7 +125,7 @@ impl<K, R> Default for OrdZSet<K, R> {
 impl<K, R> NegByRef for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue + NegByRef,
+    R: DBWeight + NegByRef,
 {
     fn neg_by_ref(&self) -> Self {
         Self {
@@ -137,7 +137,7 @@ where
 impl<K, R> Neg for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue + Neg<Output = R>,
+    R: DBWeight + Neg<Output = R>,
 {
     type Output = Self;
 
@@ -152,7 +152,7 @@ where
 impl<K, R> Add<Self> for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     type Output = Self;
 
@@ -166,7 +166,7 @@ where
 impl<K, R> AddAssign<Self> for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     fn add_assign(&mut self, rhs: Self) {
         self.layer.add_assign(rhs.layer);
@@ -176,7 +176,7 @@ where
 impl<K, R> AddAssignByRef for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     fn add_assign_by_ref(&mut self, rhs: &Self) {
         self.layer.add_assign_by_ref(&rhs.layer);
@@ -186,7 +186,7 @@ where
 impl<K, R> AddByRef for OrdZSet<K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     fn add_by_ref(&self, rhs: &Self) -> Self {
         Self {


### PR DESCRIPTION
We add the DBWeight+DBData trait throughout the layer API, this prepares for storage because it ensures that the types in the layers are serializable.

It also makes trait changes in the future less painful (hopefully) as we only have to change the DBWeight and DBData traits.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
