### PR TITLE
Separate edit and delete row action buttons into respective parent components

### DIFF
--- a/web-console/src/lib/components/common/table/EntityTable.tsx
+++ b/web-console/src/lib/components/common/table/EntityTable.tsx
@@ -11,13 +11,9 @@ import DataGridToolbar from '$lib/components/common/table/DataGridToolbar'
 import { ErrorOverlay } from '$lib/components/common/table/ErrorOverlay'
 import { Children, Dispatch, MutableRefObject, ReactNode, useEffect, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import IconPencil from '~icons/bx/pencil'
-import IconTrashAlt from '~icons/bx/trash-alt'
 
 import Card from '@mui/material/Card'
-import IconButton from '@mui/material/IconButton'
-import Tooltip from '@mui/material/Tooltip'
-import { GridRenderCellParams, GridValidRowModel } from '@mui/x-data-grid-pro'
+import { GridValidRowModel } from '@mui/x-data-grid-pro'
 import { GridApiPro } from '@mui/x-data-grid-pro/models/gridApiPro'
 import { UseQueryResult } from '@tanstack/react-query'
 
@@ -39,12 +35,9 @@ export type EntityTableProps<TData extends GridValidRowModel> = {
   setRows: (rows: TData[]) => void
   fetchRows: UseQueryResult<TData[], unknown>
   onUpdateRow?: (newRow: TData, oldRow: TData) => TData
-  onDeleteRow?: Dispatch<TData>
   onDuplicateClicked?: Dispatch<TData>
-  editRowBtnProps?: { onClick?: Dispatch<TData>; href?: (value: TData) => string }
   hasSearch?: boolean
   hasFilter?: boolean
-  addActions?: boolean
   tableProps: DataGridProProps<TData>
   apiRef?: MutableRefObject<GridApiPro>
   toolbarChildren?: ReactNode
@@ -61,45 +54,11 @@ const EntityTable = <TData extends GridValidRowModel>(props: EntityTableProps<TD
     page: 0
   })
 
-  const { setRows, fetchRows, onUpdateRow, onDeleteRow, editRowBtnProps, tableProps, addActions } = props
+  const { setRows, fetchRows, onUpdateRow, tableProps } = props
 
   const [filteredData, setFilteredData] = useState<TData[]>([])
 
   const { isPending, isError, data, error } = fetchRows
-
-  if (addActions && tableProps.columns.at(-1)?.field !== 'actions') {
-    tableProps.columns = tableProps.columns.concat({
-      flex: 0.1,
-      minWidth: 90,
-      sortable: false,
-      field: 'actions',
-      headerName: 'Actions',
-      renderCell: (params: GridRenderCellParams) => {
-        return (
-          <>
-            {editRowBtnProps && (
-              <Tooltip title='Edit'>
-                <IconButton
-                  size='small'
-                  href={(href => (href ? href(params.row) : ''))(editRowBtnProps?.href)}
-                  onClick={(onClick => (onClick ? () => onClick(params.row) : undefined))(editRowBtnProps?.onClick)}
-                >
-                  <IconPencil fontSize={20} />
-                </IconButton>
-              </Tooltip>
-            )}
-            {onDeleteRow && (
-              <Tooltip title='Delete'>
-                <IconButton size='small' onClick={() => onDeleteRow(params.row)}>
-                  <IconTrashAlt fontSize={20} />
-                </IconButton>
-              </Tooltip>
-            )}
-          </>
-        )
-      }
-    })
-  }
 
   useEffect(() => {
     if (!isPending && !isError) {

--- a/web-console/src/lib/components/connectors/drawer/SelectSourceTable.tsx
+++ b/web-console/src/lib/components/connectors/drawer/SelectSourceTable.tsx
@@ -68,13 +68,7 @@ const SelectSourceTable = (props: {
         m: 5
       }}
     >
-      <EntityTable
-        tableProps={tableProps}
-        setRows={setRows}
-        fetchRows={fetchQuery}
-        hasFilter={false}
-        addActions={false}
-      />
+      <EntityTable tableProps={tableProps} setRows={setRows} fetchRows={fetchQuery} hasFilter={false} />
     </Card>
   )
 }

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -242,7 +242,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
               <Tooltip title='Import Data'>
                 <IconButton
                   size='small'
-                  href={`/streaming/inspection/?pipeline_id=${descriptor.pipeline_id}&relation=${params.row.relation.name}&tab=insert`}
+                  href={`/streaming/inspection/?pipeline_id=${descriptor.pipeline_id}&relation=${params.row.relation.name}#insert`}
                 >
                   <IconUpload fontSize={20} />
                 </IconButton>

--- a/web-console/src/lib/compositions/useHashPart.ts
+++ b/web-console/src/lib/compositions/useHashPart.ts
@@ -1,9 +1,9 @@
 import { tuple } from '$lib/functions/common/tuple'
 import { useParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 // https://stackoverflow.com/questions/69343932/how-to-detect-change-in-the-url-hash-in-next-js
-export const useHashPart = () => {
+export const useHashPart = <T extends string>() => {
   const [hash, setHash] = useState(('window' in globalThis && window.location.hash) || '')
 
   // https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
@@ -15,14 +15,17 @@ export const useHashPart = () => {
     }
   }, [params, hash, setHash])
 
-  const updateHash = (str: string) => {
-    window.location.hash = str
-    setHash(str)
-  }
+  const updateHash = useCallback(
+    (str: T) => {
+      window.location.hash = str
+      setHash(str)
+    },
+    [setHash]
+  )
 
   useEffect(() => {
     const onWindowHashChange = () => {
-      updateHash(window.location.hash.slice(1))
+      updateHash(window.location.hash.slice(1) as T)
     }
 
     window.addEventListener('hashchange', onWindowHashChange)
@@ -31,7 +34,7 @@ export const useHashPart = () => {
       window.removeEventListener('hashchange', onWindowHashChange)
       window.removeEventListener('load', onWindowHashChange)
     }
-  }, [])
+  }, [updateHash])
 
-  return tuple(hash, updateHash)
+  return tuple(hash as T, updateHash)
 }


### PR DESCRIPTION
Commit 1: Keeping predefined action buttons inside EntityTable component complicates adding anchors for UI testing and goes against dependency injection principle. Having similar "duplicates" of Edit and Delete buttons for each table simplifies the code and doesn't add much verbosity.

Commit 2: Fix unable to switch between INSERT and BROWSE tabs on Pipeline Data page (Fix https://github.com/feldera/feldera/issues/1044)