### PR TITLE
pipeline-manager: do not allow pipelines to be started mid-compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WebConsole: Add "Queued" status for pipelines whose programs are enqueued to be compiled (#1032)
 - WebConsole: Random input generator doesn't work for a decimal column (#1006)
+- pipeline-manager: do not allow pipelines to be started mid-compilation (#1081)
 
 ### Added
 

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -102,9 +102,9 @@ pub(crate) enum ProgramStatus {
 }
 
 impl ProgramStatus {
-    /// Return true if program is not yet compiled but might be in the future.
-    pub(crate) fn is_not_yet_compiled(&self) -> bool {
-        *self == ProgramStatus::None || *self == ProgramStatus::Pending
+    /// Return true if program has been successfully compiled
+    pub(crate) fn is_compiled(&self) -> bool {
+        *self == ProgramStatus::Success
     }
 
     /// Return true if the program has failed to compile (for any reason).

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -579,7 +579,7 @@ impl PipelineRevision {
         program: &ProgramDescr,
     ) -> Result<(), DBError> {
         // The program was successfully compiled and has a schema
-        if program.status.is_not_yet_compiled() || program.schema.is_none() {
+        if !program.status.is_compiled() || program.schema.is_none() {
             return Err(DBError::ProgramNotCompiled);
         }
         if program.status.has_failed_to_compile() {

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -636,12 +636,7 @@ async fn versioning_no_change_no_connectors() {
         .unwrap();
     handle
         .db
-        .set_program_status_guarded(
-            tenant_id,
-            program_id,
-            Version(1),
-            ProgramStatus::CompilingSql,
-        )
+        .set_program_status_guarded(tenant_id, program_id, Version(1), ProgramStatus::Success)
         .await
         .unwrap();
     let rc = RuntimeConfig::from_yaml("");


### PR DESCRIPTION
Pipeline validation was previously checking if the referenced program
was /being/ compiled instead of whether it was successfully compiled.
In particular, the validation would succeed when the program is in
the `CompilingRust` state.

The fix is in the validation code. The previous, indirect check was
probably an artifact from some older code. Instead we now keep it simple
and just check if the program is in the success state before we
continue. Checking whether the schema is also set should now be
redundant, but we keep it just in case the compilation pipeline changes
in the future.

We also add a simple integration test to catch this case.

Fixes #1057

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
