### PR TITLE
sql-compiler: bump source version to JDK 19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Our known dependencies are:
     - cmake
     - libdev-ssl
 - SQL Compiler
-  - a Java Virtual Machine (at least Java 8)
+  - a Java Virtual Machine (at least Java 19)
     - maven
   - graphviz
 - Cloud and UI

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -13,8 +13,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <calcite.version>1.36.0</calcite.version>
     </properties>

--- a/sql-to-dbsp-compiler/slt/pom.xml
+++ b/sql-to-dbsp-compiler/slt/pom.xml
@@ -13,8 +13,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Bump the source versions to 19, which should make a slew of quality-of-life features available to the compiler (records, local variable type inference, switch expressions etc).

Looked into using JDK 21. openjdk-21 is the latest JDK release (it's also LTS), but is not yet packaged for Ubuntu 22.04 which we use in our Docker builds. If we upgrade to Ubuntu 23.10 that should work too.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
