### PR TITLE
[SQL] Add safe_add() function for Integer and Decimal datatypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL: parser support for 'DEFAULT' column values in DDL (#1061)
 - pipeline-manager: add Service to database and API
   ([#1074](https://github.com/feldera/feldera/pull/1074))
+- [SQL] Add safe_add() function for Integer and Decimal datatypes ([#1086](https://github.com/feldera/feldera/pull/1086))
 
 ## [0.4.0] - 2023-11-21
 

--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -119,13 +119,13 @@ pub struct ApiServerConfig {
     /// If the auth_provider is aws-cognito, there are two more
     /// environment variables that need to be set. This is required
     /// to make use of the AWS hosted login UI
-    /// (see https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html#cognito-user-pools-app-integration-amplify):
+    /// (see <https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html#cognito-user-pools-app-integration-amplify>):
     ///
     /// AWS_COGNITO_LOGIN_URL
     /// AWS_COGNITO_LOGOUT_URL
     ///
     /// These two URLs correspond to the login and logout endpoints.
-    /// See here: https://docs.aws.amazon.com/cognito/latest/developerguide/login-endpoint.html
+    /// See here: <https://docs.aws.amazon.com/cognito/latest/developerguide/login-endpoint.html>
     /// There is one caveat though. You need to remove the "state"
     /// and "redirect_uri" URL parameers from the login/logout URLs.
     /// We expect to remove this requirement in the future.

--- a/docs/sql/decimal.md
+++ b/docs/sql/decimal.md
@@ -73,5 +73,9 @@ parsing fails.
     <td><code>LOG10(value)</code></td>
     <td>The logarithm base 10 of value. Produces a runtime error for values less than or equal to zero.</td>
   </tr>
+  <tr>
+    <td><code>SAFE_ADD(left, right)</code></td>
+    <td>equivalent to the addition operator (<code>+</code>) but returns <code>NULL</code> if overflow occurs.</td>
+  </tr>
 </table>
 

--- a/docs/sql/integer.md
+++ b/docs/sql/integer.md
@@ -28,6 +28,10 @@ Division or modulus by zero return `NULL`.
     <td><code>MOD(left, right)</code></td>
     <td>integer modulus. Same as <code>left % right</code>.</td>
   </tr>
+  <tr>
+    <td><code>SAFE_ADD(left, right)</code></td>
+    <td>equivalent to the addition operator (<code>+</code>) but returns <code>NULL</code> if overflow occurs.</td>
+  </tr>
 </table>
 
 ## Operations not supported

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -56,6 +56,7 @@ public class RustSqlRuntimeLibrary {
         this.arithmeticFunctions.put("lte", DBSPOpcode.LTE);
         this.arithmeticFunctions.put("gte", DBSPOpcode.GTE);
         this.arithmeticFunctions.put("plus", DBSPOpcode.ADD);
+        this.arithmeticFunctions.put("safe_add", DBSPOpcode.SAFE_ADD);
         this.arithmeticFunctions.put("minus", DBSPOpcode.SUB);
         this.arithmeticFunctions.put("modulo", DBSPOpcode.MOD);
         this.arithmeticFunctions.put("times", DBSPOpcode.MUL);
@@ -179,6 +180,8 @@ public class RustSqlRuntimeLibrary {
             returnType = new DBSPTypeBool(CalciteObject.EMPTY, false).setMayBeNull(anyNull);
         if (opcode.equals(DBSPOpcode.DIV))
             // Always, for division by 0
+            returnType = returnType.setMayBeNull(true);
+        if (opcode.equals(DBSPOpcode.SAFE_ADD))
             returnType = returnType.setMayBeNull(true);
         if (opcode == DBSPOpcode.IS_TRUE || opcode == DBSPOpcode.IS_NOT_TRUE ||
                 opcode == DBSPOpcode.IS_FALSE || opcode == DBSPOpcode.IS_NOT_FALSE ||

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -682,6 +682,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                         return makeBinaryExpressions(node, type, DBSPOpcode.CONCAT, ops);
                     case "array":
                         return this.compileFunction(call, node, type, ops, 0);
+                    case "safe_add":
+                        return makeBinaryExpression(node, type, DBSPOpcode.SAFE_ADD, ops);
                 }
                 throw new UnimplementedException(node);
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -19,6 +19,7 @@ public enum DBSPOpcode {
 
     // Binary operations
     ADD("+", false),
+    SAFE_ADD("safe_add", false),
     SUB("-", false),
     MUL("*", false),
     DIV("/", false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SafeAddTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SafeAddTests.java
@@ -1,0 +1,50 @@
+package org.dbsp.sqlCompiler.compiler.sql.simple;
+import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
+import org.junit.Test;
+
+public class SafeAddTests extends SqlIoTest {
+    @Test
+    public void testSimpleInt() {
+        this.q("SELECT SAFE_ADD(2, 3) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                "5"
+        );
+    }
+
+    @Test
+    public void testOverflowInt() {
+        this.q("SELECT SAFE_ADD(9223372036854775807, 2) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                " "
+        );
+    }
+
+    @Test
+    public void testUnderflowInt() {
+        this.q("SELECT SAFE_ADD(-9223372036854775807, -2) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                " "
+        );
+    }
+
+    @Test
+    public void testDecimal() {
+        this.q("SELECT SAFE_ADD(9.9, 1.0) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                "10.9"
+        );
+    }
+
+    @Test
+    public void testDecimalInt() {
+        this.q("SELECT SAFE_ADD(9.9, 1) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                "10.9"
+        );
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SafeAddTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SafeAddTests.java
@@ -1,50 +1,79 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SafeAddTests extends SqlIoTest {
     @Test
-    public void testSimpleInt() {
-        this.q("SELECT SAFE_ADD(2, 3) as 'result';\n" +
+    public void testSafeAdd() {
+        this.qs(
+                "SELECT SAFE_ADD(2, 3) as 'result';\n" +
                 " result \n" +
                 "--------\n" +
-                "5"
+                "5\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT SAFE_ADD(9223372036854775807, 2) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                " \n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT SAFE_ADD(-9223372036854775807, -2) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                " \n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT SAFE_ADD(9.9, 1.0) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                "10.9\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT SAFE_ADD(9.9, 1) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                "10.9\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT SAFE_ADD(CAST(125 AS TINYINT), CAST(2 AS TINYINT)) as 'result';\n" +
+                " result \n" +
+                "--------\n" +
+                " 127\n" +
+                "(1 row)\n" +
+                "\n"
         );
     }
 
     @Test
-    public void testOverflowInt() {
-        this.q("SELECT SAFE_ADD(9223372036854775807, 2) as 'result';\n" +
+    @Ignore
+    public void testSafeAddWithCasts() {
+        this.q(
+        "SELECT SAFE_ADD(CAST(32767 AS SMALLINT), CAST(2 AS SMALLINT)) as 'result';\n" +
                 " result \n" +
                 "--------\n" +
-                " "
+                " \n"
         );
     }
 
     @Test
-    public void testUnderflowInt() {
-        this.q("SELECT SAFE_ADD(-9223372036854775807, -2) as 'result';\n" +
+    @Ignore
+    public void testSafeAddWithNestedSelectCast() {
+        this.q("SELECT SAFE_ADD((SELECT CAST(2 AS SMALLINT)), (SELECT CAST(4 AS SMALLINT))) as 'result';\n" +
                 " result \n" +
                 "--------\n" +
-                " "
+                " 6\n"
         );
     }
 
     @Test
-    public void testDecimal() {
-        this.q("SELECT SAFE_ADD(9.9, 1.0) as 'result';\n" +
+    @Ignore
+    public void testSafeAddDecimalOverflow() {
+        this.q("SELECT SAFE_ADD(9, cast(9.999999999999999999e75 as DECIMAL(38, 19))) as 'result';\n" +
                 " result \n" +
                 "--------\n" +
-                "10.9"
-        );
-    }
-
-    @Test
-    public void testDecimalInt() {
-        this.q("SELECT SAFE_ADD(9.9, 1) as 'result';\n" +
-                " result \n" +
-                "--------\n" +
-                "10.9"
+                " \n"
         );
     }
 }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -1,5 +1,5 @@
 use dbsp::algebra::{F32, F64};
-use num::PrimInt;
+use num::{CheckedAdd, PrimInt};
 
 use crate::{
     for_all_compare, for_all_int_compare, for_all_int_operator, for_all_numeric_compare,
@@ -313,3 +313,17 @@ pub fn div_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
 pub fn plus_u_u(left: usize, right: usize) -> usize {
     left + right
 }
+
+#[inline(always)]
+pub fn safe_add<T>(left: T, right: T) -> Option<T>
+where
+    T: CheckedAdd,
+{
+    left.checked_add(&right)
+}
+
+some_operator!(safe_add, i8, i8, Option<i8>);
+some_operator!(safe_add, i16, i16, Option<i16>);
+some_operator!(safe_add, i32, i32, Option<i32>);
+some_operator!(safe_add, i64, i64, Option<i64>);
+some_operator!(safe_add, decimal, Decimal, Option<Decimal>);


### PR DESCRIPTION
The `safe_add` is equivalent to the `+` operator but returns `NULL` if overflow occurs.

Is this a user-visible change (yes/no): yes