### PR TITLE
Remove runtime dependency of Monaco Editor

### DIFF
--- a/web-console/src/app/(root)/(authenticated)/layout.tsx
+++ b/web-console/src/app/(root)/(authenticated)/layout.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import { useAuth } from '$lib/compositions/auth/useAuth'
+import * as monaco from 'monaco-editor'
 import { redirect } from 'next/navigation'
 import { ReactNode } from 'react'
+
+import { loader } from '@monaco-editor/react'
 
 export default (props: { children: ReactNode }) => {
   const { auth } = useAuth()
@@ -12,3 +15,7 @@ export default (props: { children: ReactNode }) => {
 
   return props.children
 }
+
+// Configure monaco-editor to statically bundle required resources
+// https://www.npmjs.com/package/@monaco-editor/react#use-monaco-editor-as-an-npm-package
+loader.config({ monaco })


### PR DESCRIPTION
This change forces all and only required files of monaco-editor to statically bundle in the deployment
Fix https://github.com/feldera/feldera/issues/865: Ensure WebConsole dependencies do not load third party resources - when following Feldera Basics tutorial no external requests were performed.