### PR TITLE
[SQL] Add the mathematical constant PI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SQL: support for trigonometric functions `sin` and `cos` ([#1118](https://github.com/feldera/feldera/pull/1118))
+- SQL: support for mathematical constant `PI` ([#1123](https://github.com/feldera/feldera/pull/1123))
+
 ## [0.5.0] - 2023-12-05
 
 ### Fixed
@@ -24,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL: parser support for 'DEFAULT' column values in DDL (#1061)
 - pipeline-manager: add Service to database and API
   ([#1074](https://github.com/feldera/feldera/pull/1074))
-- SQL: support for trigonometric functions `sin` and `cos` ([#1118](https://github.com/feldera/feldera/pull/1118))
-- SQL: support for mathematical constant `PI` ([#1123](https://github.com/feldera/feldera/pull/1123))
 
 ## [0.4.0] - 2023-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pipeline-manager: add Service to database and API
   ([#1074](https://github.com/feldera/feldera/pull/1074))
 - SQL: support for trigonometric functions `sin` and `cos` ([#1118](https://github.com/feldera/feldera/pull/1118))
+- SQL: support for mathematical constant `PI` ([#1123](https://github.com/feldera/feldera/pull/1123))
 
 ## [0.4.0] - 2023-11-21
 

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -92,4 +92,8 @@ REAL '1.23'  -- string style
     <td><code>COS(value)</code></td>
     <td>The cosine of value as radians. <code>cos</code> only supports argument of type double, so all other types are cast to double. Returns a double.</td>
   </tr>
+  <tr>
+    <td><code>PI</code></td>
+    <td>Returns the approximate value of <code>PI</code> as double.</td>
+  </tr>
 </table>

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -38,6 +38,9 @@ Casting a string to a floating-point value will produce the value
 Casting a value that is out of the supported range to a floating
 point type will produce a value that is `inf` or `-inf`.
 
+Casting a floating-point value to string, `float` is rounded off 
+to 6 decimal places and `double` is rounded off to 15 decimal places.
+
 Please note that numeric values with a decimal point have the
 `decimal` type by default.  To write a floating-point literal you have
 to include the `e` for exponent using the following grammar:
@@ -94,6 +97,6 @@ REAL '1.23'  -- string style
   </tr>
   <tr>
     <td><code>PI</code></td>
-    <td>Returns the approximate value of <code>PI</code> as double.</td>
+    <td>Returns the approximate value of <code>PI</code> as double. Note that <code>()</code> is not required. Example: <code>SELECT PI;</code></td>
   </tr>
 </table>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -624,6 +624,9 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                         return this.compilePolymorphicFunction(call, node, type,
                                 ops, 2);
                     }
+                    case "pi": {
+                        return this.compileFunction(call, node, type, ops, 0);
+                    }
                     case "sin":
                     case "cos":
                     {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
@@ -44,10 +44,10 @@ public class TrigonometryTests extends SqlIoTest {
                 " 0.8414709848078965\n" +
                 "(1 row)\n" +
                 "\n" +
-                "SELECT sin(3.14);\n" +
+                "SELECT sin(pi);\n" +
                 " sin \n" +
                 "-----\n" +
-                " 0.0015926529164868282\n" +
+                " 0\n" + // Postgres disagrees with us here, but currently we round off to 15 decimal places
                 "(1 row)"
         );
     }
@@ -86,10 +86,10 @@ public class TrigonometryTests extends SqlIoTest {
                         " 0.8414709848078965\n" +
                         "(1 row)\n" +
                         "\n" +
-                        "SELECT sin(CAST(3.14 AS DOUBLE));\n" +
+                        "SELECT sin(CAST(pi AS DOUBLE));\n" +
                         " sin \n" +
                         "-----\n" +
-                        " 0.0015926529164868282\n" +
+                        " 0\n" +
                         "(1 row)"
         );
     }
@@ -134,10 +134,10 @@ public class TrigonometryTests extends SqlIoTest {
                 " 0.5403023058681398\n" +
                 "(1 row)\n" +
                 "\n" +
-                "SELECT cos(3.14);\n" +
+                "SELECT cos(pi);\n" +
                 " cos \n" +
                 "-----\n" +
-                " -0.9999987317275395\n" +
+                " -1\n" +
                 "(1 row)"
         );
     }
@@ -176,11 +176,22 @@ public class TrigonometryTests extends SqlIoTest {
                         " 0.5403023058681398\n" +
                         "(1 row)\n" +
                         "\n" +
-                        "SELECT cos(CAST(3.14 AS DOUBLE));\n" +
+                        "SELECT cos(CAST(pi AS DOUBLE));\n" +
                         " cos \n" +
                         "-----\n" +
-                        " -0.9999987317275395\n" +
+                        " -1\n" +
                         "(1 row)"
+        );
+    }
+
+    // Tested using Postgres 15.2
+    @Test
+    public void testPi() {
+        this.q(
+            "SELECT PI;\n" +
+            " pi \n" +
+            "----\n" +
+            " 3.141592653589793"
         );
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
@@ -84,12 +84,6 @@ public class TrigonometryTests extends SqlIoTest {
                         " sin \n" +
                         "-----\n" +
                         " 0.8414709848078965\n" +
-                        "(1 row)\n" +
-                        "\n" +
-                        "SELECT sin(CAST(pi AS DOUBLE));\n" +
-                        " sin \n" +
-                        "-----\n" +
-                        " 0\n" +
                         "(1 row)"
         );
     }
@@ -174,12 +168,6 @@ public class TrigonometryTests extends SqlIoTest {
                         " cos \n" +
                         "-----\n" +
                         " 0.5403023058681398\n" +
-                        "(1 row)\n" +
-                        "\n" +
-                        "SELECT cos(CAST(pi AS DOUBLE));\n" +
-                        " cos \n" +
-                        "-----\n" +
-                        " -1\n" +
                         "(1 row)"
         );
     }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -889,6 +889,12 @@ some_polymorphic_function1!(sign, f, F32, F32);
 some_polymorphic_function1!(sign, d, F64, F64);
 some_polymorphic_function1!(sign, decimal, Decimal, Decimal);
 
+// PI
+#[inline(always)]
+pub fn pi() -> F64 {
+    std::f64::consts::PI.into()
+}
+
 /////////// Trigonometric Fucntions //////////////
 
 #[inline(always)]


### PR DESCRIPTION
* Also updates the sin and cos tests to use PI instead of 3.14

Is this a user-visible change (yes/no): yes

Fixes: #1115 
