### PR TITLE
pipeline-manager: avoid using OpenAPI Servers for endpoint base paths

### DIFF
--- a/crates/pipeline_manager/src/api/api_key.rs
+++ b/crates/pipeline_manager/src/api/api_key.rs
@@ -66,6 +66,7 @@ pub(crate) struct ApiKeyNameQuery {
         )
     ),
     params(ApiKeyNameQuery),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "API keys"
 )]
@@ -103,6 +104,7 @@ pub(crate) async fn list_api_keys(
     params(
         ("api_key_name" = String, Path, description = "Unique API key name")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "API keys"
 )]
@@ -134,6 +136,7 @@ pub(crate) async fn get_api_key(
     params(
         ("api_key_name" = String, Path, description = "Unique API key name")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "API keys"
 )]
@@ -164,6 +167,7 @@ pub(crate) async fn delete_api_key(
             , body = ErrorResponse
             , example = json!(examples::duplicate_name())),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "API keys"
 )]

--- a/crates/pipeline_manager/src/api/connector.rs
+++ b/crates/pipeline_manager/src/api/connector.rs
@@ -61,6 +61,7 @@ pub struct ConnectorIdOrNameQuery {
         )
     ),
     params(ConnectorIdOrNameQuery),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Connectors"
 )]
@@ -103,6 +104,7 @@ async fn list_connectors(
     responses(
         (status = OK, description = "Connector successfully created.", body = NewConnectorResponse),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Connectors"
 )]
@@ -159,6 +161,7 @@ pub(crate) struct UpdateConnectorResponse {}
     params(
         ("connector_id" = Uuid, Path, description = "Unique connector identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Connectors"
 )]
@@ -205,6 +208,7 @@ async fn update_connector(
     params(
         ("connector_id" = Uuid, Path, description = "Unique connector identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Connectors"
 )]
@@ -239,6 +243,7 @@ async fn delete_connector(
     params(
         ("connector_id" = Uuid, Path, description = "Unique connector identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Connectors"
 )]

--- a/crates/pipeline_manager/src/api/http_io.rs
+++ b/crates/pipeline_manager/src/api/http_io.rs
@@ -69,6 +69,7 @@ use super::{ManagerError, ServerState};
         ("array" = Option<bool>, Query, description = "Set to `true` if updates in this stream are packaged into JSON arrays (used in conjunction with `format=json`). The default values is `false`."),
         ("update_format" = Option<JsonUpdateFormat>, Query, description = "JSON data change event format (used in conjunction with `format=json`).  The default value is 'insert_delete'."),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "HTTP input/output",
     request_body(
@@ -168,6 +169,7 @@ async fn http_input(
         description = "When the `query` parameter is set to 'neighborhood', the body of the request must contain a neighborhood specification.",
         content_type = "application/json",
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "HTTP input/output"
 )]

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -44,7 +44,7 @@ use pipeline_types::error::ErrorResponse;
 use std::{env, net::TcpListener, sync::Arc};
 use tokio::sync::Mutex;
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
-use utoipa::{openapi::Server, Modify, OpenApi};
+use utoipa::{Modify, OpenApi};
 use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
@@ -58,24 +58,9 @@ use crate::runner::RunnerApi;
 
 use crate::auth::TenantId;
 
-struct ServerAddon;
-
-// We use this to add a server variable to the OpenAPI spec
-// rendered by the swagger-ui
-// https://docs.rs/utoipa/1.0.1/utoipa/trait.Modify.html
-//
-// Note, even though this percolates to the OpenAPI spec,
-// the openapi-python-generator ignores it.
-// See: https://github.com/openapi-generators/openapi-python-client/issues/112
-impl Modify for ServerAddon {
-    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
-        openapi.servers = Some(vec![Server::new("/v0")])
-    }
-}
-
 #[derive(OpenApi)]
 #[openapi(
-    modifiers(&ServerAddon, &SecurityAddon),
+    modifiers(&SecurityAddon),
     info(
         title = "Feldera API",
         description = r"

--- a/crates/pipeline_manager/src/api/pipeline.rs
+++ b/crates/pipeline_manager/src/api/pipeline.rs
@@ -108,6 +108,7 @@ fn parse_pipeline_action(req: &HttpRequest) -> Result<&str, ManagerError> {
             )
         ),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -159,6 +160,7 @@ pub(crate) async fn new_pipeline(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -197,6 +199,7 @@ pub(crate) async fn update_pipeline(
         (status = OK, description = "Pipeline list retrieved successfully.", body = [Pipeline])
     ),
     params(PipelineIdOrNameQuery),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -242,6 +245,7 @@ pub(crate) async fn list_pipelines(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -293,6 +297,7 @@ pub(crate) async fn pipeline_deployed(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -324,6 +329,7 @@ pub(crate) async fn pipeline_stats(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -366,6 +372,7 @@ pub(crate) async fn get_pipeline(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -419,6 +426,7 @@ pub(crate) async fn get_pipeline_config(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -487,6 +495,7 @@ pub(crate) async fn pipeline_validate(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier"),
         ("action" = String, Path, description = "Pipeline action [start, pause, shutdown]")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]
@@ -543,6 +552,7 @@ pub(crate) async fn pipeline_action(
     params(
         ("pipeline_id" = Uuid, Path, description = "Unique pipeline identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Pipelines"
 )]

--- a/crates/pipeline_manager/src/api/program.rs
+++ b/crates/pipeline_manager/src/api/program.rs
@@ -112,6 +112,7 @@ pub(crate) struct UpdateProgramResponse {
         )
     ),
     params(ProgramIdOrNameQuery, WithCodeQuery),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]
@@ -170,6 +171,7 @@ pub(crate) async fn get_programs(
         ("program_id" = Uuid, Path, description = "Unique program identifier"),
         WithCodeQuery
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]
@@ -204,6 +206,7 @@ async fn get_program(
             , body = ErrorResponse
             , example = json!(examples::duplicate_name())),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]
@@ -263,6 +266,7 @@ async fn new_program(
     params(
         ("program_id" = Uuid, Path, description = "Unique program identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]
@@ -317,6 +321,7 @@ async fn update_program(
     params(
         ("program_id" = Uuid, Path, description = "Unique program identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]
@@ -368,6 +373,7 @@ async fn compile_program(
     params(
         ("program_id" = Uuid, Path, description = "Unique program identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Programs"
 )]

--- a/crates/pipeline_manager/src/api/service.rs
+++ b/crates/pipeline_manager/src/api/service.rs
@@ -72,6 +72,7 @@ pub(crate) struct UpdateServiceResponse {}
         )
     ),
     params(ServiceIdOrNameQuery),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Services"
 )]
@@ -114,6 +115,7 @@ async fn list_services(
     responses(
         (status = OK, description = "Service successfully created.", body = NewServiceResponse),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Services"
 )]
@@ -155,6 +157,7 @@ async fn new_service(
     params(
         ("service_id" = Uuid, Path, description = "Unique service identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Services"
 )]
@@ -195,6 +198,7 @@ async fn update_service(
     params(
         ("service_id" = Uuid, Path, description = "Unique service identifier")
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Services"
 )]
@@ -229,6 +233,7 @@ async fn delete_service(
     params(
         ("service_id" = Uuid, Path, description = "Unique service identifier"),
     ),
+    context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     tag = "Services"
 )]

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -12,7 +12,7 @@ def execute(
     prepare_fn=None,
     verify_fn=None,
 ):
-    dbsp = DBSPConnection(dbsp_url + "/v0")
+    dbsp = DBSPConnection(dbsp_url)
     sql_code = open(code_file, "r").read()
     program = dbsp.create_or_replace_program(name=name, sql_code=sql_code)
     pipeline = make_pipeline_fn(program)

--- a/demo/demo_notebooks/fraud_detection.ipynb
+++ b/demo/demo_notebooks/fraud_detection.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "from dbsp import DBSPConnection\n",
     "\n",
-    "dbsp = DBSPConnection(\"http://localhost:8080/v0\")\n",
+    "dbsp = DBSPConnection(\"http://localhost:8080\")\n",
     "project = dbsp.create_or_replace_program(name = \"fraud_feature_query\", sql_code = \"\"\"\n",
     "CREATE TABLE demographics (\n",
     "    cc_num FLOAT64 NOT NULL,\n",

--- a/python/feldera-api-client/feldera_api_client/api/api_keys/create_api_key.py
+++ b/python/feldera-api-client/feldera_api_client/api/api_keys/create_api_key.py
@@ -21,7 +21,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/api_keys",
+        "url": "/v0/api_keys",
         "json": json_json_body,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/api_keys/delete_api_key.py
+++ b/python/feldera-api-client/feldera_api_client/api/api_keys/delete_api_key.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "delete",
-        "url": "/api_keys/{api_key_name}".format(
+        "url": "/v0/api_keys/{api_key_name}".format(
             api_key_name=api_key_name,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/api_keys/get_api_key.py
+++ b/python/feldera-api-client/feldera_api_client/api/api_keys/get_api_key.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/api_keys/{api_key_name}".format(
+        "url": "/v0/api_keys/{api_key_name}".format(
             api_key_name=api_key_name,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/api_keys/list_api_keys.py
+++ b/python/feldera-api-client/feldera_api_client/api/api_keys/list_api_keys.py
@@ -23,7 +23,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/api_keys",
+        "url": "/v0/api_keys",
         "params": params,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/connectors/delete_connector.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/delete_connector.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "delete",
-        "url": "/connectors/{connector_id}".format(
+        "url": "/v0/connectors/{connector_id}".format(
             connector_id=connector_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/connectors/get_connector.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/get_connector.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/connectors/{connector_id}".format(
+        "url": "/v0/connectors/{connector_id}".format(
             connector_id=connector_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/connectors/list_connectors.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/list_connectors.py
@@ -26,7 +26,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/connectors",
+        "url": "/v0/connectors",
         "params": params,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/connectors/new_connector.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/new_connector.py
@@ -20,7 +20,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/connectors",
+        "url": "/v0/connectors",
         "json": json_json_body,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/connectors/update_connector.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/update_connector.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     return {
         "method": "patch",
-        "url": "/connectors/{connector_id}".format(
+        "url": "/v0/connectors/{connector_id}".format(
             connector_id=connector_id,
         ),
         "json": json_json_body,

--- a/python/feldera-api-client/feldera_api_client/api/http_inputoutput/http_input.py
+++ b/python/feldera-api-client/feldera_api_client/api/http_inputoutput/http_input.py
@@ -38,7 +38,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/pipelines/{pipeline_id}/ingress/{table_name}".format(
+        "url": "/v0/pipelines/{pipeline_id}/ingress/{table_name}".format(
             pipeline_id=pipeline_id,
             table_name=table_name,
         ),

--- a/python/feldera-api-client/feldera_api_client/api/http_inputoutput/http_output.py
+++ b/python/feldera-api-client/feldera_api_client/api/http_inputoutput/http_output.py
@@ -51,7 +51,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/pipelines/{pipeline_id}/egress/{table_name}".format(
+        "url": "/v0/pipelines/{pipeline_id}/egress/{table_name}".format(
             pipeline_id=pipeline_id,
             table_name=table_name,
         ),

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/get_pipeline.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/get_pipeline.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines/{pipeline_id}".format(
+        "url": "/v0/pipelines/{pipeline_id}".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/get_pipeline_config.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/get_pipeline_config.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines/{pipeline_id}/config".format(
+        "url": "/v0/pipelines/{pipeline_id}/config".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/list_pipelines.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/list_pipelines.py
@@ -25,7 +25,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines",
+        "url": "/v0/pipelines",
         "params": params,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/new_pipeline.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/new_pipeline.py
@@ -21,7 +21,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/pipelines",
+        "url": "/v0/pipelines",
         "json": json_json_body,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_action.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_action.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/pipelines/{pipeline_id}/{action}".format(
+        "url": "/v0/pipelines/{pipeline_id}/{action}".format(
             pipeline_id=pipeline_id,
             action=action,
         ),

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_delete.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_delete.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "delete",
-        "url": "/pipelines/{pipeline_id}".format(
+        "url": "/v0/pipelines/{pipeline_id}".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_deployed.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_deployed.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines/{pipeline_id}/deployed".format(
+        "url": "/v0/pipelines/{pipeline_id}/deployed".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_stats.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_stats.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines/{pipeline_id}/stats".format(
+        "url": "/v0/pipelines/{pipeline_id}/stats".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_validate.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/pipeline_validate.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/pipelines/{pipeline_id}/validate".format(
+        "url": "/v0/pipelines/{pipeline_id}/validate".format(
             pipeline_id=pipeline_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/update_pipeline.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/update_pipeline.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     return {
         "method": "patch",
-        "url": "/pipelines/{pipeline_id}".format(
+        "url": "/v0/pipelines/{pipeline_id}".format(
             pipeline_id=pipeline_id,
         ),
         "json": json_json_body,

--- a/python/feldera-api-client/feldera_api_client/api/programs/compile_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/compile_program.py
@@ -21,7 +21,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/programs/{program_id}/compile".format(
+        "url": "/v0/programs/{program_id}/compile".format(
             program_id=program_id,
         ),
         "json": json_json_body,

--- a/python/feldera-api-client/feldera_api_client/api/programs/delete_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/delete_program.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "delete",
-        "url": "/programs/{program_id}".format(
+        "url": "/v0/programs/{program_id}".format(
             program_id=program_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/programs/get_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/get_program.py
@@ -24,7 +24,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/programs/{program_id}".format(
+        "url": "/v0/programs/{program_id}".format(
             program_id=program_id,
         ),
         "params": params,

--- a/python/feldera-api-client/feldera_api_client/api/programs/get_programs.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/get_programs.py
@@ -29,7 +29,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/programs",
+        "url": "/v0/programs",
         "params": params,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/programs/new_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/new_program.py
@@ -21,7 +21,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/programs",
+        "url": "/v0/programs",
         "json": json_json_body,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/programs/update_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/update_program.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     return {
         "method": "patch",
-        "url": "/programs/{program_id}".format(
+        "url": "/v0/programs/{program_id}".format(
             program_id=program_id,
         ),
         "json": json_json_body,

--- a/python/feldera-api-client/feldera_api_client/api/services/delete_service.py
+++ b/python/feldera-api-client/feldera_api_client/api/services/delete_service.py
@@ -16,7 +16,7 @@ def _get_kwargs(
 
     return {
         "method": "delete",
-        "url": "/services/{service_id}".format(
+        "url": "/v0/services/{service_id}".format(
             service_id=service_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/services/get_service.py
+++ b/python/feldera-api-client/feldera_api_client/api/services/get_service.py
@@ -17,7 +17,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/services/{service_id}".format(
+        "url": "/v0/services/{service_id}".format(
             service_id=service_id,
         ),
     }

--- a/python/feldera-api-client/feldera_api_client/api/services/list_services.py
+++ b/python/feldera-api-client/feldera_api_client/api/services/list_services.py
@@ -26,7 +26,7 @@ def _get_kwargs(
 
     return {
         "method": "get",
-        "url": "/services",
+        "url": "/v0/services",
         "params": params,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/services/new_service.py
+++ b/python/feldera-api-client/feldera_api_client/api/services/new_service.py
@@ -20,7 +20,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/services",
+        "url": "/v0/services",
         "json": json_json_body,
     }
 

--- a/python/feldera-api-client/feldera_api_client/api/services/update_service.py
+++ b/python/feldera-api-client/feldera_api_client/api/services/update_service.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     return {
         "method": "patch",
-        "url": "/services/{service_id}".format(
+        "url": "/v0/services/{service_id}".format(
             service_id=service_id,
         ),
         "json": json_json_body,

--- a/python/test.py
+++ b/python/test.py
@@ -119,7 +119,6 @@ CREATE VIEW transactions_with_demographics as
 
 def main():
     url = "http://localhost:8080" if len(sys.argv) <= 1 else sys.argv[1]
-    url = url + "/v0" # API endpoint
     dbsp = DBSPConnection(url)
     connector_type = "file" if len(sys.argv) <= 2 else "http"
     print("Connection established")


### PR DESCRIPTION
We've been using OpenAPI `Servers` section to prepend `/v0` to all API
endpoints. This was a hacky workaround from a while ago to add base 
URLs to all endpoints.

This is no longer appropriate because we have authenticated API
endpoints (under the `/v0` scope) and unauthenticated endpoints (e.g., to
get the authentication config). Using `Servers` makes the Typescript
OpenAPI codegen append `/v0` to all endpoints, including the
authentication config, which was incorrect.

We instead revert to specifying `context_path = "/v0"` for each API
endpoint in the `/v0` scope. `utoipa` cannot infer this automatically 
based on the Actix scope, which would have been ideal.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
