### PR TITLE
[SQL] Make 'emitHandles' an internal compiler options

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
@@ -159,7 +159,6 @@ public class CompilerMain {
         try {
             PrintStream stream = this.getOutputStream();
             RustFileWriter writer = new RustFileWriter(compiler, stream);
-            writer.emitCodeWithHandle(true);
             writer.add(dbsp);
             writer.write();
             stream.close();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -120,6 +120,9 @@ public class CompilerOptions {
         public String functionName = "circuit";
         @Parameter(names = "-v", description = "Output verbosity")
         public int verbosity = 0;
+        /** Internal option only: emit Rust code with handles for I/O.
+         * Testing code does not use handles. */
+        public boolean emitHandles = true;
 
         /**
          * Only compare fields that matter.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -35,7 +35,6 @@ import java.util.stream.IntStream;
 public class RustFileWriter implements ICompilerComponent {
     final List<IDBSPNode> toWrite;
     final PrintStream outputStream;
-    boolean emitHandles = false;
 
     /**
      * Various visitors gather here information about the program prior to generating code.
@@ -70,14 +69,6 @@ public class RustFileWriter implements ICompilerComponent {
         public void postorder(DBSPTypeSemigroup type) {
             RustFileWriter.this.used.semigroupSizesUsed.add(type.semigroupSize());
         }
-    }
-
-    /**
-     * If this is called with 'true' the emitted Rust code will use handles
-     * instead of explicitly-typed ZSets.
-     */
-    public void emitCodeWithHandle(boolean emit) {
-        this.emitHandles = emit;
     }
 
     /**
@@ -355,7 +346,7 @@ public class RustFileWriter implements ICompilerComponent {
                 str = ToRustInnerVisitor.toRustString(this.compiler, inner, false);
             } else {
                 DBSPCircuit outer = node.to(DBSPCircuit.class);
-                if (this.emitHandles)
+                if (this.compiler.options.ioOptions.emitHandles)
                     str = ToRustHandleVisitor.toRustString(this.compiler, outer, outer.name);
                 else
                     str = ToRustVisitor.toRustString(this.getCompiler(), outer);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -27,6 +27,7 @@ import org.dbsp.sqlCompiler.circuit.*;
 import org.dbsp.sqlCompiler.circuit.operator.*;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
@@ -188,6 +189,11 @@ public class ToRustVisitor extends CircuitVisitor {
                 .append(operator.outputName)
                 .append(");");
         return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPSourceMapOperator operator) {
+       throw new UnimplementedException();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
@@ -157,6 +157,7 @@ public class BaseSQLTests {
         options.languageOptions.throwOnError = true;
         options.languageOptions.generateInputForEveryTable = true;
         options.ioOptions.quiet = true;
+        options.ioOptions.emitHandles = false;
         options.languageOptions.incrementalize = incremental;
         options.languageOptions.optimizationLevel = optimize ? 2 : 1;
         return options;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
@@ -25,11 +25,8 @@ package org.dbsp.sqlCompiler.compiler.sql;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.sql.simple.InputOutputPair;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitCloneVisitor;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.IndexedInputs;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
@@ -38,13 +35,9 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDouble;
-import org.dbsp.util.Logger;
-import org.dbsp.util.Utilities;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.io.IOException;
 
 @SuppressWarnings("SpellCheckingInspection")
 public class ComplexQueriesTest extends BaseSQLTests {
@@ -119,311 +112,6 @@ public class ComplexQueriesTest extends BaseSQLTests {
         compiler.compileStatement(query);
         Assert.assertFalse(compiler.hasErrors());
         this.addRustTestCase("ComplexQueriesTest.smallTaxiTest", compiler, getCircuit(compiler));
-    }
-
-    // Also compiles the code using the Rust handle API
-    @Test
-    public void testComplex() throws IOException, InterruptedException {
-        String statements = "-- Git repository.\n" +
-                "create table repository (\n" +
-                "    repository_id bigint not null,\n" +
-                "    type varchar not null,\n" +
-                "    url varchar not null,\n" +
-                "    name varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Commit inside a Git repo.\n" +
-                "create table git_commit (\n" +
-                "    git_commit_id bigint not null,\n" +
-                "    repository_id bigint not null,\n" +
-                "    commit_id varchar not null,\n" +
-                "    commit_date timestamp not null,\n" +
-                "    commit_owner varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- CI pipeline.\n" +
-                "create table pipeline (\n" +
-                "    pipeline_id bigint not null,\n" +
-                "    name varchar not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint\n" +
-                ");\n" +
-                "\n" +
-                "\n" +
-                "-- Git commits used by each pipeline.\n" +
-                "create table pipeline_sources (\n" +
-                "    git_commit_id bigint not null,\n" +
-                "    pipeline_id bigint not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Binary artifact created by a CI pipeline.\n" +
-                "create table artifact (\n" +
-                "    artifact_id bigint not null,\n" +
-                "    artifact_uri varchar not null,\n" +
-                "    path varchar not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    artifact_size_in_bytes bigint not null,\n" +
-                "    artifact_type varchar not null,\n" +
-                "    builtby_pipeline_id bigint not null,\n" +
-                "    parent_artifact_id bigint\n" +
-                ");\n" +
-                "\n" +
-                "-- Vulnerabilities discovered in source code.\n" +
-                "create table vulnerability (\n" +
-                "    vulnerability_id bigint not null,\n" +
-                "    discovery_date timestamp not null,\n" +
-                "    discovered_by varchar not null,\n" +
-                "    discovered_in bigint not null /*git_commit_id*/,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    vulnerability_reference_id varchar not null,\n" +
-                "    severity varchar,\n" +
-                "    priority varchar\n" +
-                ");\n" +
-                "\n" +
-                "-- Deployed k8s objects.\n" +
-                "create table k8sobject (\n" +
-                "    k8sobject_id bigint not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    deployed_id bigint not null /*k8scluster_id*/,\n" +
-                "    deployment_type varchar not null,\n" +
-                "    k8snamespace varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Binary artifacts used to construct k8s objects.\n" +
-                "create table k8sartifact (\n" +
-                "    artifact_id bigint not null,\n" +
-                "    k8sobject_id bigint not null\n" +
-                ");\n" +
-                "\n" +
-                "-- K8s clusters.\n" +
-                "create table k8scluster (\n" +
-                "    k8scluster_id bigint not null,\n" +
-                "    k8s_uri varchar not null,\n" +
-                "    path varchar not null,\n" +
-                "    name varchar not null,\n" +
-                "    k8s_serivce_provider varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "create view pipeline_vulnerability (\n" +
-                "    pipeline_id,\n" +
-                "    vulnerability_id\n" +
-                ") as\n" +
-                "    SELECT pipeline_sources.pipeline_id as pipeline_id, " +
-                "vulnerability.vulnerability_id as vulnerability_id FROM\n" +
-                "    pipeline_sources\n" +
-                "    INNER JOIN\n" +
-                "    vulnerability\n" +
-                "    ON pipeline_sources.git_commit_id = vulnerability.discovered_in;\n" +
-                "\n" +
-                "create view artifact_vulnerability (\n" +
-                "    artifact_id,\n" +
-                "    vulnerability_id\n" +
-                ") as\n" +
-                "    SELECT artifact.artifact_id as artifact_id, " +
-                "pipeline_vulnerability.vulnerability_id as vulnerability_id FROM\n" +
-                "    artifact\n" +
-                "    INNER JOIN\n" +
-                "    pipeline_vulnerability\n" +
-                "    ON artifact.builtby_pipeline_id = pipeline_vulnerability.pipeline_id;\n" +
-                "\n" +
-                "-- Vulnerabilities that could propagate to each artifact.\n" +
-                "-- create view artifact_vulnerability ();\n" +
-                "\n" +
-                "-- Vulnerabilities in the artifact or any of its children.\n" +
-                "-- create view transitive_vulnerability ();\n" +
-                "\n" +
-                "-- create view k8sobject_vulnerability ();\n" +
-                "\n" +
-                "-- create view k8scluster_vulnerability ();\n" +
-                "\n" +
-                "-- Number of vulnerabilities.\n" +
-                "-- Most severe vulnerability.\n" +
-                "-- create view k8scluster_vulnerability_stats ();";
-        DBSPCompiler compiler = testCompiler();
-        compiler.compileStatements(statements);
-        DBSPCircuit circuit = getCircuit(compiler);
-        RustFileWriter writer = new RustFileWriter(compiler, testFilePath);
-        writer.emitCodeWithHandle(true);
-        writer.add(circuit);
-        writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, true);
-    }
-
-    @Test
-    public void testComplexWithHandle() throws IOException, InterruptedException {
-        Logger.INSTANCE.setLoggingLevel(CircuitCloneVisitor.class, 2);
-        String statements = "-- Git repository.\n" +
-                "create table repository (\n" +
-                "    repository_id bigint not null primary key,\n" +
-                "    type varchar not null,\n" +
-                "    url varchar not null,\n" +
-                "    name varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Commit inside a Git repo.\n" +
-                "create table git_commit (\n" +
-                "    git_commit_id bigint not null,\n" +
-                "    repository_id bigint not null,\n" +
-                "    commit_id varchar not null,\n" +
-                "    commit_date timestamp not null,\n" +
-                "    commit_owner varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- CI pipeline.\n" +
-                "create table pipeline (\n" +
-                "    pipeline_id bigint not null,\n" +
-                "    name varchar not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint\n" +
-                ");\n" +
-                "\n" +
-                "\n" +
-                "-- Git commits used by each pipeline.\n" +
-                "create table pipeline_sources (\n" +
-                "    git_commit_id bigint not null,\n" +
-                "    pipeline_id bigint not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Binary artifact created by a CI pipeline.\n" +
-                "create table artifact (\n" +
-                "    artifact_id bigint not null,\n" +
-                "    artifact_uri varchar not null,\n" +
-                "    path varchar not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    artifact_size_in_bytes bigint not null,\n" +
-                "    artifact_type varchar not null,\n" +
-                "    builtby_pipeline_id bigint not null,\n" +
-                "    parent_artifact_id bigint\n" +
-                ");\n" +
-                "\n" +
-                "-- Vulnerabilities discovered in source code.\n" +
-                "create table vulnerability (\n" +
-                "    vulnerability_id bigint not null,\n" +
-                "    discovery_date timestamp not null,\n" +
-                "    discovered_by varchar not null,\n" +
-                "    discovered_in bigint not null /*git_commit_id*/,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    vulnerability_reference_id varchar not null,\n" +
-                "    severity varchar,\n" +
-                "    priority varchar\n" +
-                ");\n" +
-                "\n" +
-                "-- Deployed k8s objects.\n" +
-                "create table k8sobject (\n" +
-                "    k8sobject_id bigint not null,\n" +
-                "    create_date timestamp not null,\n" +
-                "    createdby_user_id bigint not null,\n" +
-                "    update_date timestamp,\n" +
-                "    updatedby_user_id bigint,\n" +
-                "    checksum varchar not null,\n" +
-                "    checksum_type varchar not null,\n" +
-                "    deployed_id bigint not null /*k8scluster_id*/,\n" +
-                "    deployment_type varchar not null,\n" +
-                "    k8snamespace varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Binary artifacts used to construct k8s objects.\n" +
-                "create table k8sartifact (\n" +
-                "    artifact_id bigint not null,\n" +
-                "    k8sobject_id bigint not null\n" +
-                ");\n" +
-                "\n" +
-                "-- K8s clusters.\n" +
-                "create table k8scluster (\n" +
-                "    k8scluster_id bigint not null,\n" +
-                "    k8s_uri varchar not null,\n" +
-                "    path varchar not null,\n" +
-                "    name varchar not null,\n" +
-                "    k8s_serivce_provider varchar not null\n" +
-                ");\n" +
-                "\n" +
-                "-- Vulnerabilities that affect each pipeline.\n" +
-                "create view pipeline_vulnerability (\n" +
-                "    pipeline_id,\n" +
-                "    vulnerability_id\n" +
-                ") as\n" +
-                "    SELECT pipeline_sources.pipeline_id as pipeline_id, " +
-                "vulnerability.vulnerability_id as vulnerability_id FROM\n" +
-                "    pipeline_sources\n" +
-                "    INNER JOIN\n" +
-                "    vulnerability\n" +
-                "    ON pipeline_sources.git_commit_id = vulnerability.discovered_in;\n" +
-                "\n" +
-                "-- Vulnerabilities that could propagate to each artifact.\n" +
-                "create view artifact_vulnerability (\n" +
-                "    artifact_id,\n" +
-                "    vulnerability_id\n" +
-                ") as\n" +
-                "    SELECT artifact.artifact_id as artifact_id, " +
-                "pipeline_vulnerability.vulnerability_id as vulnerability_id FROM\n" +
-                "    artifact\n" +
-                "    INNER JOIN\n" +
-                "    pipeline_vulnerability\n" +
-                "    ON artifact.builtby_pipeline_id = pipeline_vulnerability.pipeline_id;\n" +
-                "\n" +
-                "-- Vulnerabilities in the artifact or any of its children.\n" +
-                "create view transitive_vulnerability(\n" +
-                "    artifact_id,\n" +
-                "    via_artifact_id,\n" +
-                "    vulnerability_id\n" +
-                ") as\n" +
-                "    SELECT artifact_id, artifact_id as via_artifact_id, " +
-                "vulnerability_id from artifact_vulnerability\n" +
-                "    UNION\n" +
-                "    (\n" +
-                "        SELECT\n" +
-                "            artifact.parent_artifact_id as artifact_id,\n" +
-                "            artifact.artifact_id as via_artifact_id,\n" +
-                "            artifact_vulnerability.vulnerability_id as vulnerability_id FROM\n" +
-                "        artifact\n" +
-                "        INNER JOIN\n" +
-                "        artifact_vulnerability\n" +
-                "        ON artifact.artifact_id = artifact_vulnerability.artifact_id\n" +
-                "        WHERE artifact.parent_artifact_id IS NOT NULL\n" +
-                "    );\n" +
-                "\n" +
-                "-- create view k8sobject_vulnerability ();\n" +
-                "\n" +
-                "-- create view k8scluster_vulnerability ();\n" +
-                "\n" +
-                "-- Number of vulnerabilities.\n" +
-                "-- Most severe vulnerability.\n" +
-                "-- create view k8scluster_vulnerability_stats ();";
-        DBSPCompiler compiler = testCompiler();
-        compiler.compileStatements(statements);
-        DBSPCircuit circuit = getCircuit(compiler);
-        IndexedInputs ii = new IndexedInputs(compiler);
-        circuit = ii.apply(circuit);
-        RustFileWriter writer = new RustFileWriter(compiler, testFilePath);
-        writer.emitCodeWithHandle(true);
-        writer.add(circuit);
-        writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, true);
     }
 
     @Test
@@ -548,6 +236,16 @@ public class ComplexQueriesTest extends BaseSQLTests {
         DBSPZSetLiteral.Contents[] outputs = new DBSPZSetLiteral.Contents[] {};
         InputOutputPair ip = new InputOutputPair(inputs, outputs);
         this.addRustTestCase("ComplexQueriesTest.demographicsTest", compiler, getCircuit(compiler), ip);
+    }
+
+    // Test for https://github.com/feldera/feldera/issues/1151
+    @Test
+    public void primaryKeyTest() {
+        String sql = "CREATE TABLE event_t ( id BIGINT NOT NULL PRIMARY KEY, local_event_dt DATE )";
+        DBSPCompiler compiler = testCompiler();
+        compiler.compileStatements(sql);
+        DBSPCircuit circuit = getCircuit(compiler);
+        this.addRustTestCase(sql, compiler, circuit);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/DBSPCompilerTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/DBSPCompilerTests.java
@@ -28,22 +28,11 @@ package org.dbsp.sqlCompiler.compiler.sql;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import static org.dbsp.sqlCompiler.compiler.sql.BaseSQLTests.testFilePath;
-
-/**
- * Tests that invoke the CalciteToDBSPCompiler.
- */
 public class DBSPCompilerTests {
     static final CompilerOptions OPTIONS = new CompilerOptions();
     private static final String DDL = "CREATE TABLE T (\n" +
@@ -52,27 +41,6 @@ public class DBSPCompilerTests {
             ", COL3 BOOLEAN NOT NULL" +
             ", COL4 VARCHAR NOT NULL" +
             ")";
-
-    @Test
-    public void docTest() throws IOException {
-        // The example given in the documentation
-        String statements = "-- define Person table\n" +
-                "CREATE TABLE Person\n" +
-                "(\n" +
-                "    name    VARCHAR,\n" +
-                "    age     INT,\n" +
-                "    present BOOLEAN\n" +
-                ");\n" +
-                "CREATE VIEW Adult AS SELECT Person.name FROM Person WHERE Person.age > 18;";
-        DBSPCompiler compiler = new DBSPCompiler(OPTIONS);
-        compiler.compileStatements(statements);
-        DBSPCircuit dbsp = compiler.getFinalCircuit("circuit");
-        PrintStream outputStream = new PrintStream(Files.newOutputStream(Paths.get(testFilePath)));
-        RustFileWriter writer = new RustFileWriter(compiler, outputStream);
-        writer.emitCodeWithHandle(true);
-        writer.add(dbsp);
-        writer.write();
-    }
 
     @Test
     public void DDLTest() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/HandlesTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/HandlesTests.java
@@ -1,0 +1,224 @@
+package org.dbsp.sqlCompiler.compiler.sql;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitCloneVisitor;
+import org.dbsp.util.Logger;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/** Tests that emit Rust code for input and outputs with handles. */
+public class HandlesTests extends BaseSQLTests {
+    @Override
+    public CompilerOptions testOptions(boolean incremental, boolean optimize) {
+        CompilerOptions result = super.testOptions(incremental, optimize);
+        result.ioOptions.emitHandles = true;
+        return result;
+    }
+
+    @Test
+    public void testSanitizeNames() throws IOException, InterruptedException {
+        String statements = "create table t1(\n" +
+                "c1 integer,\n" +
+                "\"col\" boolean,\n" +
+                "\"SPACES INSIDE\" CHAR,\n" +
+                "\"CC\" CHAR,\n" +
+                "\"quoted \"\" with quote\" CHAR,\n" +
+                "U&\"d\\0061t\\0061\" CHAR,\n" + // 'data' spelled in Unicode
+                "José CHAR,\n"  +
+                "\"Gosé\" CHAR,\n" +
+                "\"\uD83D\uDE00❤\" varchar not null,\n" +
+                "\"αβγ\" boolean not null,\n" +
+                "ΔΘ boolean not null" +
+                ");\n" +
+                "create view v1 as select * from t1;";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(statements);
+        this.addRustTestCase("docTest", compiler, getCircuit(compiler));
+    }
+
+    @Test
+    public void docTest() throws IOException, InterruptedException {
+        // The example given in the documentation
+        String statements = "-- define Person table\n" +
+                "CREATE TABLE Person\n" +
+                "(\n" +
+                "    name    VARCHAR,\n" +
+                "    age     INT,\n" +
+                "    present BOOLEAN\n" +
+                ");\n" +
+                "CREATE VIEW Adult AS SELECT Person.name FROM Person WHERE Person.age > 18;";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(statements);
+        this.addRustTestCase("docTest", compiler, getCircuit(compiler));
+    }
+
+    @Test
+    public void testComplex() throws IOException, InterruptedException {
+        Logger.INSTANCE.setLoggingLevel(CircuitCloneVisitor.class, 2);
+        String statements = "-- Git repository.\n" +
+                "create table repository (\n" +
+                "    repository_id bigint not null primary key,\n" +
+                "    type varchar not null,\n" +
+                "    url varchar not null,\n" +
+                "    name varchar not null\n" +
+                ");\n" +
+                "\n" +
+                "-- Commit inside a Git repo.\n" +
+                "create table git_commit (\n" +
+                "    git_commit_id bigint not null,\n" +
+                "    repository_id bigint not null,\n" +
+                "    commit_id varchar not null,\n" +
+                "    commit_date timestamp not null,\n" +
+                "    commit_owner varchar not null\n" +
+                ");\n" +
+                "\n" +
+                "-- CI pipeline.\n" +
+                "create table pipeline (\n" +
+                "    pipeline_id bigint not null,\n" +
+                "    name varchar not null,\n" +
+                "    create_date timestamp not null,\n" +
+                "    createdby_user_id bigint not null,\n" +
+                "    update_date timestamp,\n" +
+                "    updatedby_user_id bigint\n" +
+                ");\n" +
+                "\n" +
+                "\n" +
+                "-- Git commits used by each pipeline.\n" +
+                "create table pipeline_sources (\n" +
+                "    git_commit_id bigint not null,\n" +
+                "    pipeline_id bigint not null\n" +
+                ");\n" +
+                "\n" +
+                "-- Binary artifact created by a CI pipeline.\n" +
+                "create table artifact (\n" +
+                "    artifact_id bigint not null,\n" +
+                "    artifact_uri varchar not null,\n" +
+                "    path varchar not null,\n" +
+                "    create_date timestamp not null,\n" +
+                "    createdby_user_id bigint not null,\n" +
+                "    update_date timestamp,\n" +
+                "    updatedby_user_id bigint,\n" +
+                "    checksum varchar not null,\n" +
+                "    checksum_type varchar not null,\n" +
+                "    artifact_size_in_bytes bigint not null,\n" +
+                "    artifact_type varchar not null,\n" +
+                "    builtby_pipeline_id bigint not null,\n" +
+                "    parent_artifact_id bigint\n" +
+                ");\n" +
+                "\n" +
+                "-- Vulnerabilities discovered in source code.\n" +
+                "create table vulnerability (\n" +
+                "    vulnerability_id bigint not null,\n" +
+                "    discovery_date timestamp not null,\n" +
+                "    discovered_by varchar not null,\n" +
+                "    discovered_in bigint not null /*git_commit_id*/,\n" +
+                "    update_date timestamp,\n" +
+                "    updatedby_user_id bigint,\n" +
+                "    checksum varchar not null,\n" +
+                "    checksum_type varchar not null,\n" +
+                "    vulnerability_reference_id varchar not null,\n" +
+                "    severity varchar,\n" +
+                "    priority varchar\n" +
+                ");\n" +
+                "\n" +
+                "-- Deployed k8s objects.\n" +
+                "create table k8sobject (\n" +
+                "    k8sobject_id bigint not null,\n" +
+                "    create_date timestamp not null,\n" +
+                "    createdby_user_id bigint not null,\n" +
+                "    update_date timestamp,\n" +
+                "    updatedby_user_id bigint,\n" +
+                "    checksum varchar not null,\n" +
+                "    checksum_type varchar not null,\n" +
+                "    deployed_id bigint not null /*k8scluster_id*/,\n" +
+                "    deployment_type varchar not null,\n" +
+                "    k8snamespace varchar not null\n" +
+                ");\n" +
+                "\n" +
+                "-- Binary artifacts used to construct k8s objects.\n" +
+                "create table k8sartifact (\n" +
+                "    artifact_id bigint not null,\n" +
+                "    k8sobject_id bigint not null\n" +
+                ");\n" +
+                "\n" +
+                "-- K8s clusters.\n" +
+                "create table k8scluster (\n" +
+                "    k8scluster_id bigint not null,\n" +
+                "    k8s_uri varchar not null,\n" +
+                "    path varchar not null,\n" +
+                "    name varchar not null,\n" +
+                "    k8s_serivce_provider varchar not null\n" +
+                ");\n" +
+                "\n" +
+                "-- Vulnerabilities that affect each pipeline.\n" +
+                "create view pipeline_vulnerability (\n" +
+                "    pipeline_id,\n" +
+                "    vulnerability_id\n" +
+                ") as\n" +
+                "    SELECT pipeline_sources.pipeline_id as pipeline_id, " +
+                "vulnerability.vulnerability_id as vulnerability_id FROM\n" +
+                "    pipeline_sources\n" +
+                "    INNER JOIN\n" +
+                "    vulnerability\n" +
+                "    ON pipeline_sources.git_commit_id = vulnerability.discovered_in;\n" +
+                "\n" +
+                "-- Vulnerabilities that could propagate to each artifact.\n" +
+                "create view artifact_vulnerability (\n" +
+                "    artifact_id,\n" +
+                "    vulnerability_id\n" +
+                ") as\n" +
+                "    SELECT artifact.artifact_id as artifact_id, " +
+                "pipeline_vulnerability.vulnerability_id as vulnerability_id FROM\n" +
+                "    artifact\n" +
+                "    INNER JOIN\n" +
+                "    pipeline_vulnerability\n" +
+                "    ON artifact.builtby_pipeline_id = pipeline_vulnerability.pipeline_id;\n" +
+                "\n" +
+                "-- Vulnerabilities in the artifact or any of its children.\n" +
+                "create view transitive_vulnerability(\n" +
+                "    artifact_id,\n" +
+                "    via_artifact_id,\n" +
+                "    vulnerability_id\n" +
+                ") as\n" +
+                "    SELECT artifact_id, artifact_id as via_artifact_id, " +
+                "vulnerability_id from artifact_vulnerability\n" +
+                "    UNION\n" +
+                "    (\n" +
+                "        SELECT\n" +
+                "            artifact.parent_artifact_id as artifact_id,\n" +
+                "            artifact.artifact_id as via_artifact_id,\n" +
+                "            artifact_vulnerability.vulnerability_id as vulnerability_id FROM\n" +
+                "        artifact\n" +
+                "        INNER JOIN\n" +
+                "        artifact_vulnerability\n" +
+                "        ON artifact.artifact_id = artifact_vulnerability.artifact_id\n" +
+                "        WHERE artifact.parent_artifact_id IS NOT NULL\n" +
+                "    );\n" +
+                "\n" +
+                "-- create view k8sobject_vulnerability ();\n" +
+                "\n" +
+                "-- create view k8scluster_vulnerability ();\n" +
+                "\n" +
+                "-- Number of vulnerabilities.\n" +
+                "-- Most severe vulnerability.\n" +
+                "-- create view k8scluster_vulnerability_stats ();";
+        DBSPCompiler compiler = testCompiler();
+        compiler.compileStatements(statements);
+        this.addRustTestCase("docTest", compiler, getCircuit(compiler));
+    }
+
+    // Test for https://github.com/feldera/feldera/issues/1151
+    @Test
+    public void primaryKeyTest() {
+        // This is identical to ComplexQueriesTest.primaryKeyTest, but here
+        // we generate code in a different way.
+        String sql = "CREATE TABLE event_t ( id BIGINT NOT NULL PRIMARY KEY, local_event_dt DATE )";
+        DBSPCompiler compiler = testCompiler();
+        compiler.compileStatements(sql);
+        DBSPCircuit circuit = getCircuit(compiler);
+        this.addRustTestCase(sql, compiler, circuit);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -226,7 +226,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
     }
 
-    @SuppressWarnings("SqlDialectInspection")
     @Test
     public void rustSqlTest() throws IOException, InterruptedException, SQLException {
         String filepath = BaseSQLTests.rustDirectory + "/" + "test.db";
@@ -632,33 +631,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         Assert.assertEquals(t0, "T_0");
         String t1 = gen.freshName("T");
         Assert.assertEquals(t1, "T_1");
-    }
-
-    @Test
-    public void testSanitizeNames() throws IOException, InterruptedException {
-        String statements = "create table t1(\n" +
-                "c1 integer,\n" +
-                "\"col\" boolean,\n" +
-                "\"SPACES INSIDE\" CHAR,\n" +
-                "\"CC\" CHAR,\n" +
-                "\"quoted \"\" with quote\" CHAR,\n" +
-                "U&\"d\\0061t\\0061\" CHAR,\n" + // 'data' spelled in Unicode
-                "José CHAR,\n"  +
-                "\"Gosé\" CHAR,\n" +
-                "\"\uD83D\uDE00❤\" varchar not null,\n" +
-                "\"αβγ\" boolean not null,\n" +
-                "ΔΘ boolean not null" +
-        ");\n" +
-                "create view v1 as select * from t1;";
-        DBSPCompiler compiler = testCompiler();
-        compiler.compileStatements(statements);
-        DBSPCircuit circuit = getCircuit(compiler);
-        RustFileWriter writer = new RustFileWriter(compiler, testFilePath);
-        // Check that the structs generated have legal names.
-        writer.emitCodeWithHandle(true);
-        writer.add(circuit);
-        writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, true);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
@@ -73,15 +73,14 @@ import java.util.regex.Pattern;
  * one or multiple queries.
  */
 public abstract class SqlIoTest extends BaseSQLTests {
-    /**
-     * Override this method to prepare the tables on
-     * which the tests are built.
-     */
+    /** Override this method to prepare the tables on
+     * which the tests are built. */
     public void prepareData(DBSPCompiler compiler) {}
 
     public CompilerOptions getOptions(boolean optimize) {
         CompilerOptions options = new CompilerOptions();
         options.ioOptions.quiet = true;
+        options.ioOptions.emitHandles = false;
         options.languageOptions.throwOnError = true;
         options.languageOptions.optimizationLevel = optimize ? 2 : 0;
         options.languageOptions.generateInputForEveryTable = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TestCase.java
@@ -13,6 +13,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
 import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
@@ -79,8 +80,15 @@ class TestCase {
         List<DBSPStatement> list = new ArrayList<>();
         if (!this.name.isEmpty())
             list.add(new DBSPComment(this.name));
+        boolean handles = this.compiler.options.ioOptions.emitHandles;
+        DBSPExpression[] circuitArguments = new DBSPExpression[0];
+        if (handles) {
+            circuitArguments = new DBSPExpression[1];
+            circuitArguments[0] = new DBSPUSizeLiteral(1);
+        }
         DBSPLetStatement circuit = new DBSPLetStatement("circuit",
-                new DBSPApplyExpression(this.circuit.name, DBSPTypeAny.getDefault()), true);
+                new DBSPApplyExpression(this.circuit.name, DBSPTypeAny.getDefault(), circuitArguments),
+                true);
         list.add(circuit);
         Simplify simplify = new Simplify(new StderrErrorReporter());
         int pair = 0;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpchTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpchTest.java
@@ -1,19 +1,16 @@
 package org.dbsp.sqlCompiler.compiler.sql.suites;
 
-import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.sql.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.TestUtil;
-import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
-import org.dbsp.util.Utilities;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class TpchTest extends BaseSQLTests {
     @Test
-    public void compileTpch() throws IOException, InterruptedException {
+    public void compileTpch() throws IOException {
         String tpch = TestUtil.readStringFromResourceFile("tpch.sql");
         CompilerOptions options = this.testOptions(true, true);
         DBSPCompiler compiler = new DBSPCompiler(options);
@@ -22,10 +19,6 @@ public class TpchTest extends BaseSQLTests {
         compiler.compileStatements(tpch);
         System.err.println(compiler.messages);
         compiler.throwIfErrorsOccurred();
-        DBSPCircuit circuit = getCircuit(compiler);
-        RustFileWriter writer = new RustFileWriter(compiler, testFilePath);
-        writer.add(circuit);
-        writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, true);
+        this.addRustTestCase("tpch", compiler, getCircuit(compiler));
     }
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1151 

We generate code in different ways for the pipeline and for testing locally. This centralizes this information into a new "internal" compiler flag, `emitHandles`. The flag is internal because it is not exposed as a compiler command-line option. It can be only modified programmatically.

I have moved several tests which need this flag into a common file, the testing infrastructure makes sure that you can only run together tests that have the same compiler flags.

