### PR TITLE
Fix WebConsole calling incorrect endpoint for receiving egress data

### DIFF
--- a/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
@@ -101,6 +101,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     const controller = new AbortController()
     const url = new URL(
       OpenAPI.BASE +
+        '/v0' +
         '/pipelines/' +
         pipeline.descriptor.pipeline_id +
         '/egress/' +
@@ -144,6 +145,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     const controller = new AbortController()
     const url = new URL(
       OpenAPI.BASE +
+        '/v0' +
         '/pipelines/' +
         pipeline.descriptor.pipeline_id +
         '/egress/' +


### PR DESCRIPTION
Introduced by recent change of OpenAPI base path
This is a temporary fix: manually add a v0 scope to a url
Will be replaced with usage of a safer generated code in the next commit

