### PR TITLE
WebConsole: Fix regression of deleting rows 

### DIFF
--- a/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
+++ b/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
@@ -24,7 +24,7 @@ export function useInsertDeleteRows() {
         force,
         'json',
         isArray ? JSONbig.stringify(rows) : rows.map(row => JSONbig.stringify(row)).join(''),
-        true
+        isArray
       )
     }
   })


### PR DESCRIPTION
Regression is caused by refactoring where the same argument is passed in different conditions
