### PR TITLE
WebConsole safe temp fix: enable auth for egress streaming http request

### DIFF
--- a/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
@@ -11,7 +11,7 @@ import useQuantiles from '$lib/compositions/streaming/inspection/useQuantiles'
 import { useTableUpdater } from '$lib/compositions/streaming/inspection/useTableUpdater'
 import { useAsyncError } from '$lib/functions/common/react'
 import { Row, rowToAnchor } from '$lib/functions/ddl'
-import { Field, NeighborhoodQuery, OpenAPI, Relation } from '$lib/services/manager'
+import { EgressMode, Field, NeighborhoodQuery, OutputQuery, Relation } from '$lib/services/manager'
 import { PipelineManagerQuery } from '$lib/services/pipelineManagerQuery'
 import { LS_PREFIX } from '$lib/types/localStorage'
 import { Pipeline } from '$lib/types/pipeline'
@@ -99,16 +99,22 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
       return
     }
     const controller = new AbortController()
-    const url = new URL(
-      OpenAPI.BASE +
-        '/v0' +
-        '/pipelines/' +
-        pipeline.descriptor.pipeline_id +
-        '/egress/' +
-        name +
-        '?format=csv&query=neighborhood&mode=watch'
-    )
-    updateTable(url, neighborhood, setRows, setLoading, relation, controller).then(
+    updateTable(
+      [
+        pipeline.descriptor.pipeline_id,
+        name,
+        'csv',
+        OutputQuery.NEIGHBORHOOD,
+        EgressMode.WATCH,
+        undefined,
+        undefined,
+        neighborhood
+      ],
+      setRows,
+      setLoading,
+      relation,
+      controller
+    ).then(
       () => {
         // nothing to do here, the tableUpdater will update the table
       },
@@ -143,16 +149,13 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
       return
     }
     const controller = new AbortController()
-    const url = new URL(
-      OpenAPI.BASE +
-        '/v0' +
-        '/pipelines/' +
-        pipeline.descriptor.pipeline_id +
-        '/egress/' +
-        name +
-        '?format=csv&query=quantiles&mode=snapshot'
-    )
-    quantileLoader(url, setQuantiles, relation, controller).then(
+
+    quantileLoader(
+      [pipeline.descriptor.pipeline_id, name, 'csv', OutputQuery.QUANTILES, EgressMode.SNAPSHOT],
+      setQuantiles,
+      relation,
+      controller
+    ).then(
       () => {
         // nothing to do here, the tableUpdater will update the table
       },

--- a/web-console/src/lib/functions/common/tanstack.ts
+++ b/web-console/src/lib/functions/common/tanstack.ts
@@ -4,11 +4,9 @@
  */
 
 import { ApiError } from '$lib/services/manager'
+import { Arguments, FunctionType } from '$lib/types/common/function'
 
 import { InvalidateQueryFilters, QueryClient, QueryFilters, Updater, UseQueryOptions } from '@tanstack/react-query'
-
-type FunctionType = (...args: any) => any
-type Arguments<F extends FunctionType> = F extends (...args: infer A) => any ? A : never
 
 type QueryType<U extends Record<string, FunctionType>, P extends keyof U> = {
   queryKey: readonly unknown[]

--- a/web-console/src/lib/services/HttpInputOutputService.ts
+++ b/web-console/src/lib/services/HttpInputOutputService.ts
@@ -1,0 +1,73 @@
+import type { EgressMode } from './manager/models/EgressMode'
+import type { NeighborhoodQuery } from './manager/models/NeighborhoodQuery'
+import type { OutputQuery } from './manager/models/OutputQuery'
+
+import { ApiRequestOptions } from './manager/core/ApiRequestOptions'
+import { OpenAPIConfig } from './manager/core/OpenAPI'
+import { getQueryString, request as __request } from './manager/core/request'
+
+/**
+ * TODO:
+ * This function borrows implementation from '$lib/services/manager/services/HttpInputOutputService.ts'
+ * It is a part of temporary fix to use only some of the code generated with OpenAPI codegen
+ * All usages of this function should eventually be refactored out
+ */
+export function httpOutputOptions(
+  pipelineId: string,
+  tableName: string,
+  format: string,
+  query?: OutputQuery | null,
+  mode?: EgressMode | null,
+  quantiles?: number | null,
+  array?: boolean | null,
+  requestBody?: NeighborhoodQuery | null
+) {
+  return {
+    method: 'POST' as const,
+    url: '/v0/pipelines/{pipeline_id}/egress/{table_name}',
+    path: {
+      pipeline_id: pipelineId,
+      table_name: tableName
+    },
+    query: {
+      format: format,
+      query: query,
+      mode: mode,
+      quantiles: quantiles,
+      array: array
+    },
+    body: requestBody,
+    mediaType: 'application/json',
+    errors: {
+      400: `Unknown data format specified in the '?format=' argument.`,
+      404: `Specified table or view does not exist.`,
+      410: `Pipeline is not currently running because it has been shutdown or not yet started.`,
+      500: `Request failed.`
+    }
+  }
+}
+
+/**
+ * TODO:
+ * This function borrows implementation from '$lib/services/manager/services/manager/core/request.ts'
+ * It is a part of temporary fix to use only some of the code generated with OpenAPI codegen
+ * All usages of this function should eventually be refactored out
+ */
+export const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+  const encoder = config.ENCODE_PATH || encodeURI
+
+  const path = options.url
+    .replace('{api-version}', config.VERSION)
+    .replace(/{(.*?)}/g, (substring: string, group: string) => {
+      if (options.path?.hasOwnProperty(group)) {
+        return encoder(String(options.path[group]))
+      }
+      return substring
+    })
+
+  const url = `${config.BASE}${path}`
+  if (options.query) {
+    return `${url}${getQueryString(options.query)}`
+  }
+  return url
+}

--- a/web-console/src/lib/types/common/function.ts
+++ b/web-console/src/lib/types/common/function.ts
@@ -1,0 +1,2 @@
+export type FunctionType = (...args: any) => any
+export type Arguments<F extends FunctionType> = F extends (...args: infer A) => any ? A : never


### PR DESCRIPTION
This should be robust enough until the proper fix that would directly use method generated from OpenAPI spec and build on top of it.