### PR TITLE
[SQL] Reorder filter and project using Calcite

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -263,6 +263,9 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                     continue;
                 FrontEndStatement fe = this.frontend.compile(
                         node.toString(), node, comment, this.inputTables, this.outputViews);
+                if (fe == null)
+                    // error during compilation
+                    continue;
                 this.midend.compile(fe);
             }
         } catch (SqlParseException e) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -1056,7 +1056,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 SqlOperator operator = agg.getOperator();
                 if (operator instanceof SqlRankFunction) {
                     SqlRankFunction rank = (SqlRankFunction) operator;
-                    // Aggregate functions seem always to be at th end.
+                    // Aggregate functions seem always to be at the end.
                     // The window always seems to collect all fields.
                     int rankIndex = inputRowType.size();
                     RelNode parent = this.getParent();
@@ -1377,7 +1377,9 @@ public class CalciteToDBSPCompiler extends RelVisitor
             return o;
         } else if (statement.is(CreateTableStatement.class) ||
                 statement.is(DropTableStatement.class)) {
-            this.tableContents.execute(statement);
+            boolean success = this.tableContents.execute(statement);
+            if (!success)
+                return null;
             CreateTableStatement create = statement.as(CreateTableStatement.class);
             if (create != null) {
                 // We create an input for the circuit.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
@@ -72,7 +72,9 @@ public class TableContents implements ICompilerComponent {
         return Utilities.getExists(this.tableContents, tableName);
     }
 
-    public void execute(FrontEndStatement statement) {
+    /** "Execute" a DDL statement.
+     * @return True on success. */
+    public boolean execute(FrontEndStatement statement) {
         if (statement.is(CreateTableStatement.class)) {
             CreateTableStatement create = statement.to(CreateTableStatement.class);
             Utilities.putNew(this.tableCreation, create.relationName, create);
@@ -88,6 +90,7 @@ public class TableContents implements ICompilerComponent {
             if (this.tableContents != null)
                 this.tableContents.remove(drop.tableName);
         }
+        return true;
     }
 
     public CreateTableStatement getTableDefinition(String tableName) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -121,6 +121,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -403,12 +404,13 @@ public class CalciteCompiler implements IWritesLogs {
      * We do program-dependent optimization, since some optimizations
      * are buggy and don't always work.
      */
-    List<HepProgram> getOptimizationStages(RelNode rel) {
+    LinkedHashMap<String, HepProgram> getOptimizationStages(RelNode rel) {
+        LinkedHashMap<String, HepProgram> result = new LinkedHashMap<>();
         if (this.options.languageOptions.optimizationLevel < 1)
             // For optimization levels below 1 we don't even apply Calcite optimizations.
             // Note that this may cause compilation to fail, since our compiler does not
             // handle all possible RelNode programs.
-            return Linq.list();
+            return result;
 
         HepProgram constantFold = createProgram(
                 CoreRules.COERCE_INPUTS,
@@ -425,7 +427,8 @@ public class CalciteCompiler implements IWritesLogs {
                 //CoreRules.PROJECT_VALUES_MERGE
                 CoreRules.AGGREGATE_VALUES
         );
-        // Remove empty collections
+        Utilities.putNew(result, "Constant fold", constantFold);
+
         HepProgram removeEmpty = createProgram(
                 PruneEmptyRules.UNION_INSTANCE,
                 PruneEmptyRules.INTERSECT_INSTANCE,
@@ -437,13 +440,19 @@ public class CalciteCompiler implements IWritesLogs {
                 PruneEmptyRules.JOIN_LEFT_INSTANCE,
                 PruneEmptyRules.JOIN_RIGHT_INSTANCE,
                 PruneEmptyRules.SORT_FETCH_ZERO_INSTANCE);
+        Utilities.putNew(result, "Remove empty relations", removeEmpty);
+
         HepProgram window = createProgram(
                 CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW
         );
+        Utilities.putNew(result, "Expand windows", window);
+
         HepProgram distinctAggregates = createProgram(
                 // Convert DISTINCT aggregates into separate computations and join the results
                 CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN
         );
+        Utilities.putNew(result,"Isolate DISTINCT aggregates", distinctAggregates);
+
         HepProgram multiJoins = new HepProgramBuilder()
                 // Join order optimization
                 .addRuleInstance(CoreRules.FILTER_INTO_JOIN)
@@ -452,18 +461,25 @@ public class CalciteCompiler implements IWritesLogs {
                 .addRuleInstance(CoreRules.PROJECT_MULTI_JOIN_MERGE)
                 .addRuleInstance(CoreRules.MULTI_JOIN_OPTIMIZE_BUSHY)
                 .build();
+        if (!avoidBushyJoin(rel))
+            Utilities.putNew(result, "Join order optimization", multiJoins);
+
         HepProgram move = createProgram(
                 CoreRules.PROJECT_CORRELATE_TRANSPOSE,
-                CoreRules.PROJECT_SET_OP_TRANSPOSE
+                CoreRules.PROJECT_SET_OP_TRANSPOSE,
+                CoreRules.FILTER_PROJECT_TRANSPOSE
                 //CoreRules.PROJECT_JOIN_TRANSPOSE  // This rule is unsound
         );
+        Utilities.putNew(result, "Move projections", move);
+
         HepProgram mergeNodes = createProgram(
                 CoreRules.PROJECT_MERGE,
                 CoreRules.MINUS_MERGE,
                 CoreRules.UNION_MERGE,
                 CoreRules.AGGREGATE_MERGE,
                 CoreRules.INTERSECT_MERGE);
-        // Remove unused code
+        Utilities.putNew(result, "Merge identical operations", mergeNodes);
+
         HepProgram remove = createProgram(
                 CoreRules.AGGREGATE_REMOVE,
                 CoreRules.UNION_REMOVE,
@@ -471,11 +487,8 @@ public class CalciteCompiler implements IWritesLogs {
                 CoreRules.PROJECT_JOIN_JOIN_REMOVE,
                 CoreRules.PROJECT_JOIN_REMOVE
                 );
-        if (avoidBushyJoin(rel))
-            return Linq.list(constantFold, removeEmpty, window,
-                    distinctAggregates, move, mergeNodes, remove);
-        return Linq.list(constantFold, removeEmpty, window, distinctAggregates,
-                move, multiJoins, mergeNodes, remove);
+        Utilities.putNew(result, "Remove dead code", remove);
+        return result;
             /*
         return Linq.list(
                 CoreRules.AGGREGATE_PROJECT_PULL_UP_CONSTANTS,
@@ -558,19 +571,17 @@ public class CalciteCompiler implements IWritesLogs {
                 .decrease()
                 .newline();
 
-        int stage = 0;
-        for (HepProgram program: this.getOptimizationStages(rel)) {
-            HepPlanner planner = new HepPlanner(program);
+        for (Map.Entry<String, HepProgram> entry: this.getOptimizationStages(rel).entrySet()) {
+            HepPlanner planner = new HepPlanner(entry.getValue());
             planner.setRoot(rel);
             rel = planner.findBestExp();
             Logger.INSTANCE.belowLevel(this, 3)
-                    .append("After optimizer stage ")
-                    .append(stage)
+                    .append("After ")
+                    .append(entry.getKey())
                     .increase()
                     .append(getPlan(rel))
                     .decrease()
                     .newline();
-            stage++;
         }
 
         Logger.INSTANCE.belowLevel(this, 2)
@@ -801,6 +812,7 @@ public class CalciteCompiler implements IWritesLogs {
      * @param inputs       If not null, add here a JSON description of the tables defined by the statement, if any.
      * @param outputs      If not null, add here a JSON description of the views defined by the statement, if any.
      */
+    @Nullable
     public FrontEndStatement compile(
             String sqlStatement,
             SqlNode node,
@@ -841,7 +853,9 @@ public class CalciteCompiler implements IWritesLogs {
                      */
                 }
                 CreateTableStatement table = new CreateTableStatement(node, sqlStatement, tableName, comment, cols);
-                this.catalog.addTable(tableName, table.getEmulatedTable());
+                boolean success = this.catalog.addTable(tableName, table.getEmulatedTable(), this.errorReporter, table);
+                if (!success)
+                    return null;
                 inputs.add(new InputTableDescription(table));
                 return table;
             } else if (node.getKind().equals(SqlKind.CREATE_VIEW)) {
@@ -867,7 +881,9 @@ public class CalciteCompiler implements IWritesLogs {
                         Catalog.identifierToString(cv.name), comment,
                         columns, cv.query, relRoot);
                 // From Calcite's point of view we treat this view just as another table.
-                this.catalog.addTable(viewName, view.getEmulatedTable());
+                boolean success = this.catalog.addTable(viewName, view.getEmulatedTable(), this.errorReporter, view);
+                if (!success)
+                    return null;
                 if (this.generateOutputForNextView)
                     outputs.add(new OutputViewDescription(view));
                 return view;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/FrontEndStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/FrontEndStatement.java
@@ -24,7 +24,7 @@
 package org.dbsp.sqlCompiler.compiler.frontend.statements;
 
 import org.apache.calcite.sql.SqlNode;
-import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.util.ICastable;
 
@@ -51,4 +51,6 @@ public abstract class FrontEndStatement implements ICastable {
     public CalciteObject getCalciteObject() {
         return CalciteObject.create(this.node);
     }
+
+    public SourcePositionRange getPosition() { return new SourcePositionRange(this.node.getParserPosition()); }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestUtil.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestUtil.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler;
 
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
+import org.dbsp.util.Utilities;
 import org.junit.Assert;
 
 import java.io.BufferedReader;
@@ -37,6 +38,6 @@ public class TestUtil {
         if (text.contains(contents))
             return;
         System.out.println(text);
-        Assert.fail();
+        Assert.fail("Expected message to contain " + Utilities.singleQuote(contents));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TopKTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TopKTests.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.sql.simple;
 
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -56,12 +57,94 @@ public class TopKTests extends SqlIoTest {
                 " 1          | S1| 2011-07-29  \n" +
                 " 2          | S1| 2011-07-28  \n" +
                 " 3          | S1| 2011-08-02  \n" +
+                "(3 rows)\n" +
+                "\n" +
+                "WITH cte AS\n" +
+                "(\n" +
+                "   SELECT *,\n" +
+                "         ?() OVER (PARTITION BY DocumentID ORDER BY DateCreated DESC) AS rn\n" +  // ? is a parameter
+                "   FROM DocumentStatusLog\n" +
+                ")\n" +
+                "SELECT DocumentId, Status, DateCreated\n" +
+                "FROM cte\n" +
+                "WHERE rn <= 1;\n" +
+                " DocumentID | Status | DateCreated \n" +
+                "-----------------------------------\n" +
+                " 1          | S1| 2011-09-02  \n" +
+                " 3          | S1| 2011-08-02  \n" +
+                " 2          | S3| 2011-08-01  \n" +
                 "(3 rows)";
         for (String function : new String[]{"RANK", "DENSE_RANK", "ROW_NUMBER"}) {
             String q = paramQuery.replace("?", function);
             // Same result for all 3 functions
             this.qs(q, false);
         }
+    }
+
+    @Test
+    public void issue1174() {
+        String sql = "CREATE TABLE event_t (\n" +
+                "id BIGINT NOT NULL PRIMARY KEY,\n" +
+                "site_id BIGINT NOT NULL,\n" +
+                "event_type_id BIGINT NOT NULL,\n" +
+                "event_date BIGINT NOT NULL, -- epoch\n" +
+                "event_clear_date BIGINT -- epoch\n" +
+                ");\n" +
+                "\n" +
+                "CREATE VIEW EVENT_DURATION_V AS\n" +
+                "SELECT (event_date - event_clear_date) AS duration\n" +
+                ",      event_type_id\n" +
+                ",      site_id\n" +
+                "FROM   event_t\n" +
+                "WHERE  event_clear_date IS NOT NULL\n" +
+                ";\n" +
+                "\n" +
+                "CREATE VIEW TOP_EVENT_DURATIONS_V AS\n" +
+                "SELECT (duration * -1) as duration\n" +
+                ",      event_type_id\n" +
+                "FROM   (SELECT duration\n" +
+                "        ,      event_type_id\n" +
+                "        ,      ROW_NUMBER() OVER (PARTITION BY event_type_id\n" +
+                "                                  ORDER BY duration ASC) AS rnum\n" +
+                "        FROM   EVENT_DURATION_V)\n" +
+                "WHERE   rnum <= 3\n" +
+                ";";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        Assert.assertEquals(0, compiler.messages.errorCount());
+    }
+
+    @Test
+    public void issue1175() {
+        String sql = "CREATE TABLE event_t (\n" +
+                "id BIGINT NOT NULL PRIMARY KEY,\n" +
+                "site_id BIGINT NOT NULL,\n" +
+                "event_type_id BIGINT NOT NULL,\n" +
+                "event_date BIGINT NOT NULL, -- epoch\n" +
+                "event_clear_date BIGINT -- epoch\n" +
+                ");\n" +
+                "\n" +
+                "CREATE VIEW EVENT_DURATION_V AS\n" +
+                "SELECT (event_date - event_clear_date) AS duration\n" +
+                ",      event_type_id\n" +
+                ",      site_id\n" +
+                "FROM   event_t\n" +
+                "WHERE  event_clear_date IS NOT NULL\n" +
+                ";\n" +
+                "\n" +
+                "CREATE VIEW TOP_EVENT_DURATIONS_V AS\n" +
+                "SELECT (duration * -1) as duration\n" +
+                ",      event_type_id\n" +
+                "FROM   (SELECT duration\n" +
+                "        ,      event_type_id\n" +
+                "        ,      ROW_NUMBER() OVER (PARTITION BY event_type_id\n" +
+                "                                  ORDER BY duration ASC) AS rnum\n" +
+                "        FROM   EVENT_DURATION_V)\n" +
+                "WHERE   rnum <= 3\n" +
+                ";";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        Assert.assertEquals(0, compiler.messages.errorCount());
     }
 
     @Test @Ignore("RANK aggregate not implemented without TopK")


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1174 

In SQL one cannot naturally write a GROUP-BY TOPK query; one has to use a specific incantation using ROW_NUMBER and a WHERE. The compiler tries to recognize this pattern, but the recognition is brittle. By using the Calcite optimization to reorder filters and projections we make this slightly more robust.

There is also a fix to give good error messages when two tables with the same name are defined.