### PR TITLE
[SQL] Preliminary support for bounded memory computation on streams

### DIFF
--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -1346,7 +1346,7 @@ mod test {
     fn set_test_circuit(circuit: &RootCircuit) -> AnyResult<UpsertHandle<usize, bool>> {
         let (stream, handle) = circuit.add_input_set::<usize, isize>();
         let watermark = stream.waterline(|| 0, |k, ()| *k, |k1, k2| max(*k1, *k2));
-        stream.integrate_trace_retain_keys(&watermark, |ts, k| *k >= ts.saturating_sub(10));
+        stream.integrate_trace_retain_keys(&watermark, |k, ts| *k >= ts.saturating_sub(10));
 
         let mut expected_batches = output_set_updates().into_iter();
 
@@ -1461,7 +1461,7 @@ mod test {
             |k, v| (*k, *v),
             |ts1, ts2| (max(ts1.0, ts2.0), max(ts1.1, ts2.1)),
         );
-        stream.integrate_trace_retain_values(&watermark, |ts, v| *v >= ts.1.saturating_sub(10));
+        stream.integrate_trace_retain_values(&watermark, |v, ts| *v >= ts.1.saturating_sub(10));
 
         let mut expected_batches = output_map_updates().into_iter();
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOutputOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOutputOperator.java
@@ -20,20 +20,20 @@ import java.util.List;
  */
 @NonCoreIR
 public class DBSPDelayOutputOperator extends DBSPSourceBaseOperator {
-    public DBSPDelayOutputOperator(CalciteObject node, DBSPType outputType,
+    public DBSPDelayOutputOperator(CalciteObject node, DBSPType outputType, boolean isMultiset,
                                    @Nullable String comment) {
-        super(node, outputType, comment, new NameGen("delay").nextName());
+        super(node, outputType, isMultiset, comment, new NameGen("delay").nextName());
     }
 
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
-        return new DBSPDelayOutputOperator(this.getNode(), outputType, this.comment);
+        return new DBSPDelayOutputOperator(this.getNode(), outputType, this.isMultiset, this.comment);
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPDelayOutputOperator(this.getNode(), this.outputType, this.comment);
+            return new DBSPDelayOutputOperator(this.getNode(), this.outputType, this.isMultiset, this.comment);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -1,0 +1,68 @@
+package org.dbsp.sqlCompiler.circuit.operator;
+
+import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.monotone.ValueProjection;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+public class DBSPIntegrateTraceRetainKeysOperator extends DBSPOperator {
+    protected DBSPIntegrateTraceRetainKeysOperator(
+            CalciteObject node, DBSPExpression expression,
+            DBSPOperator data, DBSPOperator control) {
+        super(node, "integrate_trace_retain_keys", expression, data.getType(), data.isMultiset);
+        this.addInput(data);
+        this.addInput(control);
+    }
+
+    public static DBSPIntegrateTraceRetainKeysOperator create(
+            CalciteObject node, DBSPOperator data, ValueProjection dataProjection, DBSPOperator control) {
+        DBSPType controlType = control.getType();
+        DBSPType leftSliceType = dataProjection.getProjectionResultType();
+        assert leftSliceType.sameType(controlType):
+                "Projection type does not match control type " + leftSliceType + "/" + controlType;
+
+        DBSPType keyType = data.getOutputIndexedZSetType().keyType;
+        DBSPVariablePath dataArg = new DBSPVariablePath("d", keyType);
+        DBSPParameter param = new DBSPParameter(dataArg.variable, dataArg.getType().ref());
+
+        DBSPVariablePath controlArg = new DBSPVariablePath("c", controlType.ref());
+        DBSPExpression compare = DBSPControlledFilterOperator.generateTupleCompare(
+                dataArg, controlArg.deref().field(0));
+        DBSPExpression closure = compare.closure(param, controlArg.asParameter());
+        return new DBSPIntegrateTraceRetainKeysOperator(node, closure, data, control);
+    }
+
+    @Override
+    public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
+        return new DBSPIntegrateTraceRetainKeysOperator(
+                this.getNode(), Objects.requireNonNull(expression),
+                this.inputs.get(0), this.inputs.get(1));
+    }
+
+    @Override
+    public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
+        assert newInputs.size() == 2: "Expected 2 inputs, got " + newInputs.size();
+        if (force || this.inputsDiffer(newInputs))
+            return new DBSPIntegrateTraceRetainKeysOperator(
+                    this.getNode(), this.getFunction(),
+                    newInputs.get(0), newInputs.get(1));
+        return this;
+    }
+
+    @Override
+    public void accept(CircuitVisitor visitor) {
+        visitor.push(this);
+        VisitDecision decision = visitor.preorder(this);
+        if (!decision.stop())
+            visitor.postorder(this);
+        visitor.pop(this);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceBaseOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceBaseOperator.java
@@ -37,15 +37,16 @@ public abstract class DBSPSourceBaseOperator extends DBSPOperator {
      * Create a DBSP operator that is a source to the dataflow graph.
      * @param node        Calcite node for the statement creating the table
      *                    that this node is created from.
+     * @param isMultiset  True if the source data can be a multiset.
      * @param outputType  Type of table.
      * @param comment     A comment describing the operator.
      * @param name        The name of the table that this operator is created from.
      */
     public DBSPSourceBaseOperator(
             CalciteObject node,
-            DBSPType outputType, @Nullable String comment,
+            DBSPType outputType, boolean isMultiset, @Nullable String comment,
             String name) {
-        super(node, "source " + name, null, outputType, false, comment, name);
+        super(node, "source " + name, null, outputType, isMultiset, comment, name);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
@@ -37,7 +37,7 @@ public class DBSPSourceMapOperator extends DBSPSourceTableOperator {
             CalciteObject node, CalciteObject sourceName, List<Integer> keyFields,
             DBSPTypeIndexedZSet outputType, DBSPTypeStruct originalRowType, @Nullable String comment,
             InputTableMetadata metadata, String name) {
-        super(node, sourceName, outputType, originalRowType, comment, metadata, name);
+        super(node, sourceName, outputType, originalRowType, false, comment, metadata, name);
         this.keyFields = keyFields;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
@@ -27,7 +27,7 @@ public class DBSPSourceMultisetOperator extends DBSPSourceTableOperator {
             CalciteObject node, CalciteObject sourceName,
             DBSPTypeZSet outputType, DBSPTypeStruct originalRowType, @Nullable String comment,
             InputTableMetadata metadata, String name) {
-        super(node, sourceName, outputType, originalRowType, comment, metadata, name);
+        super(node, sourceName, outputType, originalRowType, true, comment, metadata, name);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceTableOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceTableOperator.java
@@ -27,14 +27,15 @@ public abstract class DBSPSourceTableOperator extends DBSPSourceBaseOperator {
      *                    that this node is created from.
      * @param sourceName  Calcite node for the identifier naming the table.
      * @param outputType  Type of table.
+     * @param isMultiset  True if the source can produce multiset values.
      * @param comment     A comment describing the operator.
      * @param name        The name of the table that this operator is created from.
      */
     public DBSPSourceTableOperator(
             CalciteObject node, CalciteObject sourceName,
-            DBSPType outputType, DBSPTypeStruct originalRowType, @Nullable String comment,
-            InputTableMetadata metadata, String name) {
-        super(node, outputType, comment, name);
+            DBSPType outputType, DBSPTypeStruct originalRowType, boolean isMultiset,
+            @Nullable String comment, InputTableMetadata metadata, String name) {
+        super(node, outputType, isMultiset, comment, name);
         this.originalRowType = originalRowType;
         this.sourceName = sourceName;
         this.metadata = metadata;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -322,6 +322,9 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs {
     public void postorder(DBSPControlledFilterOperator operator) { this.replace(operator); }
 
     @Override
+    public void postorder(DBSPIntegrateTraceRetainKeysOperator operator) { this.replace(operator); }
+
+    @Override
     public void postorder(DBSPWaterlineOperator operator) { this.replace(operator); }
 
     public DBSPPartialCircuit getResult() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -51,7 +51,7 @@ public class CircuitOptimizer implements ICompilerComponent {
     @SuppressWarnings("ConstantValue")
     CircuitTransform monotonicity() {
         return circuit -> {
-            final boolean debug = true;
+            final boolean debug = false;
 
             if (debug)
                 ToDotVisitor.toDot(compiler, "original.jpg", true, "jpg", circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -51,7 +51,7 @@ public class CircuitOptimizer implements ICompilerComponent {
     @SuppressWarnings("ConstantValue")
     CircuitTransform monotonicity() {
         return circuit -> {
-            final boolean debug = false;
+            final boolean debug = true;
 
             if (debug)
                 ToDotVisitor.toDot(compiler, "original.jpg", true, "jpg", circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -240,11 +240,17 @@ public abstract class CircuitVisitor
         return this.preorder(node.to(DBSPOperator.class));
     }
 
-    public VisitDecision preorder(DBSPSourceBaseOperator node) { return this.preorder(node.to(DBSPOperator.class)); }
+    public VisitDecision preorder(DBSPSourceBaseOperator node) {
+        return this.preorder(node.to(DBSPOperator.class));
+    }
 
-    public VisitDecision preorder(DBSPDelayOutputOperator node) { return this.preorder(node.to(DBSPSourceBaseOperator.class)); }
+    public VisitDecision preorder(DBSPDelayOutputOperator node) {
+        return this.preorder(node.to(DBSPSourceBaseOperator.class));
+    }
 
-    public VisitDecision preorder(DBSPSourceTableOperator node) { return this.preorder(node.to(DBSPSourceBaseOperator.class)); }
+    public VisitDecision preorder(DBSPSourceTableOperator node) {
+        return this.preorder(node.to(DBSPSourceBaseOperator.class));
+    }
 
     public VisitDecision preorder(DBSPSourceMultisetOperator node) {
         return this.preorder(node.to(DBSPSourceTableOperator.class));
@@ -267,6 +273,10 @@ public abstract class CircuitVisitor
     }
 
     public VisitDecision preorder(DBSPControlledFilterOperator node) {
+        return this.preorder(node.to(DBSPOperator.class));
+    }
+
+    public VisitDecision preorder(DBSPIntegrateTraceRetainKeysOperator node) {
         return this.preorder(node.to(DBSPOperator.class));
     }
 
@@ -441,6 +451,10 @@ public abstract class CircuitVisitor
     }
 
     public void postorder(DBSPControlledFilterOperator node) {
+        this.postorder(node.to(DBSPOperator.class));
+    }
+
+    public void postorder(DBSPIntegrateTraceRetainKeysOperator node) {
         this.postorder(node.to(DBSPOperator.class));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindDeadCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindDeadCode.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
@@ -89,6 +90,12 @@ public class FindDeadCode extends CircuitVisitor implements IWritesLogs {
     public VisitDecision preorder(DBSPSourceMapOperator operator) {
         if (this.keepAllSources)
             this.keep(operator);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPIntegrateTraceRetainKeysOperator operator) {
+        this.keep(operator);
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
@@ -63,7 +63,7 @@ public class ExpandOperators extends CircuitCloneVisitor {
 
         DBSPOperator input = this.mapped(operator.input());
         DBSPDelayOutputOperator delayOutput = new DBSPDelayOutputOperator(
-                operator.getNode(), operator.outputType, operator.comment);
+                operator.getNode(), operator.outputType, operator.input().isMultiset, operator.comment);
         this.addOperator(delayOutput);
         DBSPSumOperator sum = new DBSPSumOperator(operator.getNode(), input, delayOutput);
         this.map(operator, sum);
@@ -81,7 +81,7 @@ public class ExpandOperators extends CircuitCloneVisitor {
 
         DBSPOperator input = this.mapped(operator.input());
         DBSPDelayOutputOperator delayOutput = new DBSPDelayOutputOperator(
-                operator.getNode(), operator.outputType, operator.comment);
+                operator.getNode(), operator.outputType, operator.input().isMultiset, operator.comment);
         this.addOperator(delayOutput);
         DBSPSumOperator sum = new DBSPSumOperator(operator.getNode(), input, delayOutput);
         this.addOperator(sum);
@@ -167,7 +167,7 @@ public class ExpandOperators extends CircuitCloneVisitor {
         DBSPIntegrateOperator integral = new DBSPIntegrateOperator(operator.getNode(), input);
         this.addOperator(integral);
         DBSPDelayOutputOperator delayOutput = new DBSPDelayOutputOperator(
-                operator.getNode(), operator.outputType, operator.comment);
+                operator.getNode(), operator.outputType, false, operator.comment);
         this.addOperator(delayOutput);
         DBSPOperator result = new DBSPPartitionedRadixTreeAggregateOperator(
                 operator.getNode(), operator.function, operator.aggregate, input, integral, delayOutput);
@@ -193,7 +193,7 @@ public class ExpandOperators extends CircuitCloneVisitor {
         this.addOperator(prta);
 
         DBSPDelayOutputOperator delayOutput = new DBSPDelayOutputOperator(
-                operator.getNode(), operator.outputType, operator.comment);
+                operator.getNode(), operator.outputType, false, operator.comment);
         this.addOperator(delayOutput);
 
         DBSPPartitionedRollingAggregateOperator ra = new DBSPPartitionedRollingAggregateOperator(operator.getNode(),
@@ -220,7 +220,7 @@ public class ExpandOperators extends CircuitCloneVisitor {
 
         DBSPOperator input = this.mapped(operator.input());
         DBSPDelayOutputOperator delayOutput = new DBSPDelayOutputOperator(
-                operator.getNode(), operator.outputType, operator.comment);
+                operator.getNode(), operator.outputType, false, operator.comment);
         this.addOperator(delayOutput);
 
         DBSPUpsertOperator upsert = new DBSPUpsertOperator(operator.getNode(), input, delayOutput);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TestCase.java
@@ -57,7 +57,7 @@ class TestCase {
     public final String message;
 
     TestCase(String name, String javaTestName, DBSPCompiler compiler,
-             DBSPCircuit circuit, String message, InputOutputPair... data) {
+             DBSPCircuit circuit, @Nullable String message, InputOutputPair... data) {
         this.name = name;
         this.javaTestName = javaTestName;
         this.circuit = circuit;


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This implementation uses the DBSP `integrate_trace_retain_keys` operator to throw away group keys that will never be updated. It is used in conjunction with the lateness dataflow analysis to control the memory consumption of streams of monotone values. That operator has a very funky semantics, so the hope is that at some point we can do this in a simpler way.

This implementation is incomplete; it only handles (group-by)+aggregate operators and it is only limited to some simple graph topologies. 

We still have to handle:
- joins
- upserts as inserted after aggregates, inputs, and before outputs
- streams that have multiple consumers

