### PR TITLE
[SQL] Use standard SQL semantics for division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - WebConsole: Add ability to edit connector configuration as JSON
+- SQL: Preliminary support for computations with bounded memory on unbounded
+  streams ([#1197](https://github.com/feldera/feldera/pull/1197))
+
+### Fixed
+- SQL: Changed semantics of division to match SQL standard
+  ([#1201](https://github.com/feldera/feldera/pull/1201))
 
 ## [0.6.0] - 2023-12-19
 

--- a/docs/sql/decimal.md
+++ b/docs/sql/decimal.md
@@ -25,7 +25,7 @@ The legal operations are ``+`` (plus, unary and binary), ``-`` (minus,
 unary and binary), ``*`` (multiplication), ``/`` (division), ``%``
 (modulus).
 
-Division or modulus by zero return ``NULL``.
+Division or modulus by zero cause a runtime error.
 
 Casting a string to a decimal value will produce the value ``0`` when
 parsing fails.

--- a/docs/sql/integer.md
+++ b/docs/sql/integer.md
@@ -13,7 +13,7 @@ unary and binary), `*` (multiplication), `/` (division), `%`
 Casting a string to an integer type will produce a runtime error if the
 string cannot be interpreted as a number.
 
-Division or modulus by zero return `NULL`.
+Division or modulus by zero cause a runtime error.
 
 ## Predefined functions on integer values
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -177,9 +177,6 @@ public class RustSqlRuntimeLibrary {
 
         if (opcode.isComparison())
             returnType = new DBSPTypeBool(CalciteObject.EMPTY, false).setMayBeNull(anyNull);
-        if (opcode.equals(DBSPOpcode.DIV))
-            // Always, for division by 0
-            returnType = returnType.setMayBeNull(true);
         if (opcode == DBSPOpcode.IS_TRUE || opcode == DBSPOpcode.IS_NOT_TRUE ||
                 opcode == DBSPOpcode.IS_FALSE || opcode == DBSPOpcode.IS_NOT_FALSE ||
                 opcode == DBSPOpcode.IS_DISTINCT || opcode == DBSPOpcode.IS_NOT_DISTINCT)
@@ -199,6 +196,7 @@ public class RustSqlRuntimeLibrary {
             tsuffixl = ltype.to(DBSPTypeBaseType.class).shortName();
             tsuffixr = (rtype == null) ? "" : rtype.to(DBSPTypeBaseType.class).shortName();
         }
+        //noinspection ConstantValue
         if (map == null)
             throw new UnimplementedException(opcode.toString());
         for (String k: map.keySet()) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -521,8 +521,6 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
             case TIMES:
                 return makeBinaryExpression(node, type, DBSPOpcode.MUL, ops);
             case DIVIDE:
-                // We enforce that the type of the result of division is always nullable
-                type = type.setMayBeNull(true);
                 return makeBinaryExpression(node, type, DBSPOpcode.DIV, ops);
             case MOD:
                 return makeBinaryExpression(node, type, DBSPOpcode.MOD, ops);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -418,6 +418,17 @@ public class Simplify extends InnerRewriteVisitor {
                     result = right;
                 }
             }
+        } else if (expression.operation.equals(DBSPOpcode.DIV)) {
+            if (right.is(DBSPLiteral.class)) {
+                DBSPLiteral rightLit = right.to(DBSPLiteral.class);
+                IsNumericType iRightType = rightType.to(IsNumericType.class);
+                if (iRightType.isOne(rightLit)) {
+                    result = left;
+                } else if (iRightType.isZero(rightLit)) {
+                    this.errorReporter.reportWarning(expression.getSourcePosition(), "Division by zero",
+                            " Division by constant zero value.");
+                } 
+            }
         }
         this.map(expression, result.cast(expression.getType()));
         return VisitDecision.STOP;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
@@ -58,11 +58,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (0,0,'0');\n" +
                 "INSERT INTO num_exp_sub VALUES (0,0,'0');\n" +
                 "INSERT INTO num_exp_mul VALUES (0,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (0,0,NULL);\n" +  // No NaN
+                //"INSERT INTO num_exp_div VALUES (0,0,NaN);\n" +  // No NaN
                 "INSERT INTO num_exp_add VALUES (0,1,'0');\n" +
                 "INSERT INTO num_exp_sub VALUES (0,1,'0');\n" +
                 "INSERT INTO num_exp_mul VALUES (0,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (0,1,NULL);\n" +  // No NaN
+                "INSERT INTO num_exp_div VALUES (0,1,'0');\n" +
                 "INSERT INTO num_exp_add VALUES (0,2,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (0,2,'34338492.215397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (0,2,'0');\n" +
@@ -98,11 +98,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (1,0,'0');\n" +
                 "INSERT INTO num_exp_sub VALUES (1,0,'0');\n" +
                 "INSERT INTO num_exp_mul VALUES (1,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (1,0,NULL);\n" + // In postgres this is NaN
+                //"INSERT INTO num_exp_div VALUES (1,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (1,1,'0');\n" +
                 "INSERT INTO num_exp_sub VALUES (1,1,'0');\n" +
                 "INSERT INTO num_exp_mul VALUES (1,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (1,1,NULL);\n" + // In postgres this is NaN
+                "INSERT INTO num_exp_div VALUES (1,1,'0');\n" +
                 "INSERT INTO num_exp_add VALUES (1,2,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (1,2,'34338492.215397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (1,2,'0');\n" +
@@ -138,11 +138,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (2,0,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (2,0,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (2,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (2,0,NULL);\n" +  // No NaN
+                //"INSERT INTO num_exp_div VALUES (2,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (2,1,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (2,1,'-34338492.215397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (2,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (2,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (2,1,2);\n" +
                 "INSERT INTO num_exp_add VALUES (2,2,'-68676984.430794094');\n" +
                 "INSERT INTO num_exp_sub VALUES (2,2,'0');\n" +
                 "INSERT INTO num_exp_mul VALUES (2,2,'1179132047626883.596862135856320209');\n" +
@@ -178,11 +178,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (3,0,'4.31');\n" +
                 "INSERT INTO num_exp_sub VALUES (3,0,'4.31');\n" +
                 "INSERT INTO num_exp_mul VALUES (3,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (3,0,NULL);\n" + // No NaN for numeric
+                //"INSERT INTO num_exp_div VALUES (3,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (3,1,'4.31');\n" +
                 "INSERT INTO num_exp_sub VALUES (3,1,'4.31');\n" +
                 "INSERT INTO num_exp_mul VALUES (3,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (3,1,Null);\n" +  // No NaN for numeric
+                "INSERT INTO num_exp_div VALUES (3,1,'3');\n" +
                 "INSERT INTO num_exp_add VALUES (3,2,'-34338487.905397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (3,2,'34338496.525397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (3,2,'-147998901.44836127257');\n" +
@@ -218,11 +218,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (4,0,'7799461.4119');\n" +
                 "INSERT INTO num_exp_sub VALUES (4,0,'7799461.4119');\n" +
                 "INSERT INTO num_exp_mul VALUES (4,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (4,0,NULL);\n" + // No NaN for numeric
+                //"INSERT INTO num_exp_div VALUES (4,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (4,1,'7799461.4119');\n" +
                 "INSERT INTO num_exp_sub VALUES (4,1,'7799461.4119');\n" +
                 "INSERT INTO num_exp_mul VALUES (4,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (4,1,NULL);\n" +  // No NaN for numeric
+                "INSERT INTO num_exp_div VALUES (4,1,'4');\n" +
                 "INSERT INTO num_exp_add VALUES (4,2,'-26539030.803497047');\n" +
                 "INSERT INTO num_exp_sub VALUES (4,2,'42137953.627297047');\n" +
                 "INSERT INTO num_exp_mul VALUES (4,2,'-267821744976817.8111137106593');\n" +
@@ -258,11 +258,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (5,0,'16397.038491');\n" +
                 "INSERT INTO num_exp_sub VALUES (5,0,'16397.038491');\n" +
                 "INSERT INTO num_exp_mul VALUES (5,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (5,0,NULL);\n" + // No NaN
+                //"INSERT INTO num_exp_div VALUES (5,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (5,1,'16397.038491');\n" +
                 "INSERT INTO num_exp_sub VALUES (5,1,'16397.038491');\n" +
                 "INSERT INTO num_exp_mul VALUES (5,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (5,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (5,1,'5');\n" +
                 "INSERT INTO num_exp_add VALUES (5,2,'-34322095.176906047');\n" +
                 "INSERT INTO num_exp_sub VALUES (5,2,'34354889.253888047');\n" +
                 "INSERT INTO num_exp_mul VALUES (5,2,'-563049578578.769242506736077');\n" +
@@ -298,11 +298,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (6,0,'93901.57763026');\n" +
                 "INSERT INTO num_exp_sub VALUES (6,0,'93901.57763026');\n" +
                 "INSERT INTO num_exp_mul VALUES (6,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (6,0,NULL);\n" + // No NaN
+                //"INSERT INTO num_exp_div VALUES (6,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (6,1,'93901.57763026');\n" +
                 "INSERT INTO num_exp_sub VALUES (6,1,'93901.57763026');\n" +
                 "INSERT INTO num_exp_mul VALUES (6,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (6,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (6,1,'6');\n" +
                 "INSERT INTO num_exp_add VALUES (6,2,'-34244590.637766787');\n" +
                 "INSERT INTO num_exp_sub VALUES (6,2,'34432393.793027307');\n" +
                 "INSERT INTO num_exp_mul VALUES (6,2,'-3224438592470.18449811926184222');\n" +
@@ -338,11 +338,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (7,0,'-83028485');\n" +
                 "INSERT INTO num_exp_sub VALUES (7,0,'-83028485');\n" +
                 "INSERT INTO num_exp_mul VALUES (7,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (7,0,NULL);\n" + // No NaN
+                //"INSERT INTO num_exp_div VALUES (7,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (7,1,'-83028485');\n" +
                 "INSERT INTO num_exp_sub VALUES (7,1,'-83028485');\n" +
                 "INSERT INTO num_exp_mul VALUES (7,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (7,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (7,1,'7');\n" +
                 "INSERT INTO num_exp_add VALUES (7,2,'-117366977.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (7,2,'-48689992.784602953');\n" +
                 "INSERT INTO num_exp_mul VALUES (7,2,'2851072985828710.485883795');\n" +
@@ -378,11 +378,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (8,0,'74881');\n" +
                 "INSERT INTO num_exp_sub VALUES (8,0,'74881');\n" +
                 "INSERT INTO num_exp_mul VALUES (8,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (8,0,NULL);\n" + // No NaN
+                //"INSERT INTO num_exp_div VALUES (8,0,NaN);\n" +
                 "INSERT INTO num_exp_add VALUES (8,1,'74881');\n" +
                 "INSERT INTO num_exp_sub VALUES (8,1,'74881');\n" +
                 "INSERT INTO num_exp_mul VALUES (8,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (8,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (8,1,'8');\n" +
                 "INSERT INTO num_exp_add VALUES (8,2,'-34263611.215397047');\n" +
                 "INSERT INTO num_exp_sub VALUES (8,2,'34413373.215397047');\n" +
                 "INSERT INTO num_exp_mul VALUES (8,2,'-2571300635581.146276407');\n" +
@@ -418,11 +418,11 @@ public class PostgresNumericTests extends SqlIoTest {
                 "INSERT INTO num_exp_add VALUES (9,0,'-24926804.045047420');\n" +
                 "INSERT INTO num_exp_sub VALUES (9,0,'-24926804.045047420');\n" +
                 "INSERT INTO num_exp_mul VALUES (9,0,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (9,0,NULL);\n" + // No NaN
+                //"INSERT INTO num_exp_div VALUES (9,0,NaN);\n" + // No NaN
                 "INSERT INTO num_exp_add VALUES (9,1,'-24926804.045047420');\n" +
                 "INSERT INTO num_exp_sub VALUES (9,1,'-24926804.045047420');\n" +
                 "INSERT INTO num_exp_mul VALUES (9,1,'0');\n" +
-                "INSERT INTO num_exp_div VALUES (9,1,NULL);\n" + // No NaN
+                "INSERT INTO num_exp_div VALUES (9,1,'9');\n" +
                 "INSERT INTO num_exp_add VALUES (9,2,'-59265296.260444467');\n" +
                 "INSERT INTO num_exp_sub VALUES (9,2,'9411688.170349627');\n" +
                 "INSERT INTO num_exp_mul VALUES (9,2,'855948866655588.453741509242968740');\n" +
@@ -617,7 +617,8 @@ public class PostgresNumericTests extends SqlIoTest {
     public void testDivision() {
         String intermediate = "CREATE VIEW num_result AS SELECT t1.id AS ID1, t2.id AS ID2, " +
                 "CAST(t1.val / t2.val AS NUMERIC(" + WIDTH + ", 10)) AS results\n" +
-                "    FROM num_data t1, num_data t2";
+                "    FROM num_data t1, num_data t2\n" +
+                "    WHERE t2.val != 0";
         String last = """
                 CREATE VIEW E AS SELECT t1.id1, t1.id2, t1.results, t2.expected
                     FROM num_result t1, num_exp_div t2
@@ -630,7 +631,8 @@ public class PostgresNumericTests extends SqlIoTest {
     public void testDivisionRound() {
         String intermediate = "CREATE VIEW num_result AS SELECT t1.id AS ID1, t2.id AS ID2, " +
                 "CAST(round(t1.val / t2.val, 10) AS NUMERIC(" + WIDTH + ", 10)) AS results\n" +
-                "    FROM num_data t1, num_data t2";
+                "    FROM num_data t1, num_data t2\n" +
+                "    WHERE t2.val != 0";
         String last = """
                 CREATE VIEW E AS SELECT t1.id1, t1.id2, t1.results, round(t2.expected, 10)
                     FROM num_result t1, num_exp_div t2

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -243,13 +243,6 @@ public class EndToEndTests extends BaseSQLTests {
         this.testQuery(query, new DBSPZSetLiteral.Contents(lit, lit));
     }
 
-    @Test @Ignore("Fails with overflow.  What should the result be?")
-    public void testOverflow() {
-        String query = "SELECT " + Integer.MIN_VALUE + "/ -1";
-        DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(new DBSPTupleExpression(new DBSPI32Literal(0, true)));
-        this.testQuery(query, result);
-    }
-
     @Test
     public void testArray() {
         String query = "SELECT ELEMENT(ARRAY [2])";
@@ -710,24 +703,19 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void divZeroTest() {
         String query = "SELECT 1 / 0";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
+        this.runtimeFail(query, "attempt to divide by zero", this.getEmptyIOPair());
     }
 
     @Test
     public void divZero0() {
         String query = "SELECT 'Infinity' / 0";
-        this.runtimeFail(query, "Invalid decimal: unknown character",
-               this.getEmptyIOPair());
+        this.runtimeFail(query, "InvalidDigit", this.getEmptyIOPair());
     }
 
     @Test
     public void nestedDivTest() {
         String query = "SELECT 2 / (1 / 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
+        this.runtimeFail(query, "attempt to divide by zero", this.getEmptyIOPair());
     }
 
     @Test
@@ -735,15 +723,6 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT x'012345ab'";
         this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
                 new DBSPTupleExpression(new DBSPBinaryLiteral(new byte[]{ 0x01, 0x23, 0x45, (byte)0xAB }))));
-    }
-
-    @Test
-    public void customDivisionTest() {
-        // Use a custom division operator.
-        String query = "SELECT DIVISION(1, 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(DBSPLiteral.none(
-                        new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
 
     @Test
@@ -854,7 +833,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT 34 / SUM (1) FROM T GROUP BY COL1";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                  new DBSPTupleExpression(
-                        new DBSPI32Literal(17, true))));
+                        new DBSPI32Literal(17))));
     }
 
     @Test
@@ -873,7 +852,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT 34 / AVG (1) FROM T GROUP BY COL1";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                  new DBSPTupleExpression(
-                        new DBSPI32Literal(34, true))));
+                        new DBSPI32Literal(34))));
     }
 
     @Test
@@ -881,7 +860,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT 34 / SUM (1), 20 / SUM(2) FROM T GROUP BY COL1";
         this.testQuery(query, new DBSPZSetLiteral.Contents(
                  new DBSPTupleExpression(
-                        new DBSPI32Literal(17, true), new DBSPI32Literal(5, true))));
+                        new DBSPI32Literal(17), new DBSPI32Literal(5))));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TrigonometryTests.java
@@ -7,48 +7,50 @@ public class TrigonometryTests extends SqlIoTest {
     // Tested using Postgres 15.2
     @Test
     public void testSin() {
+        // Postgres disagrees with us here, but currently we round off to 15 decimal places
         this.qs(
-        "SELECT sin(null);\n" +
-                " sin \n" +
-                "-----\n" +
-                "NULL\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(0);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(0.25);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0.24740395925452294\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(0.5);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0.479425538604203\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(0.75);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0.6816387600233341\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(1);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0.8414709848078965\n" +
-                "(1 row)\n" +
-                "\n" +
-                "SELECT sin(pi);\n" +
-                " sin \n" +
-                "-----\n" +
-                " 0\n" + // Postgres disagrees with us here, but currently we round off to 15 decimal places
-                "(1 row)"
+                """
+                        SELECT sin(null);
+                         sin
+                        -----
+                        NULL
+                        (1 row)
+
+                        SELECT sin(0);
+                         sin
+                        -----
+                         0
+                        (1 row)
+
+                        SELECT sin(0.25);
+                         sin
+                        -----
+                         0.24740395925452294
+                        (1 row)
+
+                        SELECT sin(0.5);
+                         sin
+                        -----
+                         0.479425538604203
+                        (1 row)
+
+                        SELECT sin(0.75);
+                         sin
+                        -----
+                         0.6816387600233341
+                        (1 row)
+
+                        SELECT sin(1);
+                         sin
+                        -----
+                         0.8414709848078965
+                        (1 row)
+
+                        SELECT sin(pi);
+                         sin
+                        -----
+                         0
+                        (1 row)"""
         );
     }
 
@@ -58,31 +60,31 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT sin(CAST(0 AS DOUBLE));
-                         sin\s
+                         sin
                         -----
                          0
                         (1 row)
 
                         SELECT sin(CAST(0.25 AS DOUBLE));
-                         sin\s
+                         sin
                         -----
                          0.24740395925452294
                         (1 row)
 
                         SELECT sin(CAST(0.5 AS DOUBLE));
-                         sin\s
+                         sin
                         -----
                          0.479425538604203
                         (1 row)
 
                         SELECT sin(CAST(0.75 AS DOUBLE));
-                         sin\s
+                         sin
                         -----
                          0.6816387600233341
                         (1 row)
 
                         SELECT sin(CAST(1 AS DOUBLE));
-                         sin\s
+                         sin
                         -----
                          0.8414709848078965
                         (1 row)"""
@@ -95,43 +97,43 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT cos(null);
-                         cos\s
+                         cos
                         -----
                         NULL
                         (1 row)
 
                         SELECT cos(0);
-                         cos\s
+                         cos
                         -----
                          1
                         (1 row)
 
                         SELECT cos(0.25);
-                         cos\s
+                         cos
                         -----
                          0.9689124217106447
                         (1 row)
 
                         SELECT cos(0.5);
-                         cos\s
+                         cos
                         -----
                          0.8775825618903728
                         (1 row)
 
                         SELECT cos(0.75);
-                         cos\s
+                         cos
                         -----
                          0.7316888688738209
                         (1 row)
 
                         SELECT cos(1);
-                         cos\s
+                         cos
                         -----
                          0.5403023058681398
                         (1 row)
 
                         SELECT cos(pi);
-                         cos\s
+                         cos
                         -----
                          -1
                         (1 row)"""
@@ -144,31 +146,31 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT cos(CAST(0 AS DOUBLE));
-                         cos\s
+                         cos
                         -----
                          1
                         (1 row)
 
                         SELECT cos(CAST(0.25 AS DOUBLE));
-                         cos\s
+                         cos
                         -----
                          0.9689124217106447
                         (1 row)
 
                         SELECT cos(CAST(0.5 AS DOUBLE));
-                         cos\s
+                         cos
                         -----
                          0.8775825618903728
                         (1 row)
 
                         SELECT cos(CAST(0.75 AS DOUBLE));
-                         cos\s
+                         cos
                         -----
                          0.7316888688738209
                         (1 row)
 
                         SELECT cos(CAST(1 AS DOUBLE));
-                         cos\s
+                         cos
                         -----
                          0.5403023058681398
                         (1 row)"""
@@ -181,7 +183,7 @@ public class TrigonometryTests extends SqlIoTest {
         this.q(
                 """
                         SELECT PI;
-                         pi\s
+                         pi
                         ----
                          3.141592653589793"""
         );
@@ -193,43 +195,43 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT tan(null);
-                         tan\s
+                         tan
                         -----
                         NULL
                         (1 row)
 
                         SELECT tan(0);
-                         tan\s
+                         tan
                         -----
                          0
                         (1 row)
 
                         SELECT tan(0.25);
-                         tan\s
+                         tan
                         -----
                          0.25534192122103627
                         (1 row)
 
                         SELECT tan(0.5);
-                         tan\s
+                         tan
                         -----
                          0.5463024898437905
                         (1 row)
 
                         SELECT tan(0.75);
-                         tan\s
+                         tan
                         -----
                          0.9315964599440725
                         (1 row)
 
                         SELECT tan(1);
-                         tan\s
+                         tan
                         -----
                          1.5574077246549023
                         (1 row)
 
                         SELECT tan(pi);
-                         tan\s
+                         tan
                         -----
                          -1.2246467991473532e-16
                         (1 row)"""
@@ -242,37 +244,37 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT tan(CAST(null as DOUBLE));
-                         tan\s
+                         tan
                         -----
                         NULL
                         (1 row)
 
                         SELECT tan(CAST(0 AS DOUBLE));
-                         tan\s
+                         tan
                         -----
                          0
                         (1 row)
 
                         SELECT tan(CAST(0.25 AS DOUBLE));
-                         tan\s
+                         tan
                         -----
                          0.25534192122103627
                         (1 row)
 
                         SELECT tan(CAST(0.5 AS DOUBLE));
-                         tan\s
+                         tan
                         -----
                          0.5463024898437905
                         (1 row)
 
                         SELECT tan(CAST(0.75 AS DOUBLE));
-                         tan\s
+                         tan
                         -----
                          0.9315964599440725
                         (1 row)
 
                         SELECT tan(CAST(1 AS DOUBLE));
-                         tan\s
+                         tan
                         -----
                          1.5574077246549023
                         (1 row)"""
@@ -285,43 +287,43 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT cot(0);
-                         cot\s
+                         cot
                         -----
                          Infinity
                         (1 row)
 
                         SELECT cot(pi);
-                         cot\s
+                         cot
                         -----
                          -8.165619676597685e+15
                         (1 row)
 
                         SELECT cot(null);
-                         cot\s
+                         cot
                         -----
                         NULL
                         (1 row)
 
                         SELECT cot(0.25);
-                         cot\s
+                         cot
                         -----
                          3.91631736464594
                         (1 row)
 
                         SELECT cot(0.5);
-                         cot\s
+                         cot
                         -----
                          1.830487721712452
                         (1 row)
 
                         SELECT cot(0.75);
-                         cot\s
+                         cot
                         -----
                          1.0734261485493772
                         (1 row)
 
                         SELECT cot(1);
-                         cot\s
+                         cot
                         -----
                          0.6420926159343306
                         (1 row)"""
@@ -334,43 +336,43 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT cot(CAST(0 AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                          Infinity
                         (1 row)
 
                         SELECT cot(pi);
-                         cot\s
+                         cot
                         -----
                          -8.165619676597685e+15
                         (1 row)
 
                         SELECT cot(CAST(null AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                         NULL
                         (1 row)
 
                         SELECT cot(CAST(0.25 AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                          3.91631736464594
                         (1 row)
 
                         SELECT cot(CAST(0.5 AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                          1.830487721712452
                         (1 row)
 
                         SELECT cot(CAST(0.75 AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                          1.0734261485493772
                         (1 row)
 
                         SELECT cot(CAST(1 AS DOUBLE));
-                         cot\s
+                         cot
                         -----
                          0.6420926159343306
                         (1 row)"""
@@ -385,73 +387,73 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT asin(null);
-                         asin\s
+                         asin
                         ------
                         NULL
                         (1 row)
 
                         SELECT asin(-2);
-                         asin\s
+                         asin
                         ------
                          NaN
                         (1 row)
 
                         SELECT asin(2);
-                         asin\s
+                         asin
                         ------
                          NaN
                         (1 row)
 
                         SELECT asin(-1);
-                         asin\s
+                         asin
                         ------
                          -1.5707963267948966
                         (1 row)
 
                         SELECT asin(-0.75);
-                         asin\s
+                         asin
                         ------
                          -0.848062078981481
                         (1 row)
 
                         SELECT asin(-0.5);
-                         asin\s
+                         asin
                         ------
                          -0.5235987755982989
                         (1 row)
 
                         SELECT asin(-0.25);
-                         asin\s
+                         asin
                         ------
                          -0.25268025514207865
                         (1 row)
 
                         SELECT asin(0);
-                         asin\s
+                         asin
                         ------
                          0
                         (1 row)
 
                         SELECT asin(0.25);
-                         asin\s
+                         asin
                         ------
                          0.25268025514207865
                         (1 row)
 
                         SELECT asin(0.5);
-                         asin\s
+                         asin
                         ------
                          0.5235987755982989
                         (1 row)
 
                         SELECT asin(0.75);
-                         asin\s
+                         asin
                         ------
                          0.848062078981481
                         (1 row)
 
                         SELECT asin(1);
-                         asin\s
+                         asin
                         ------
                          1.5707963267948966
                         (1 row)"""
@@ -466,67 +468,67 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT asin(CAST(-2 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          NaN
                         (1 row)
 
                         SELECT asin(CAST(2 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          NaN
                         (1 row)
 
                         SELECT asin(CAST(-1 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          -1.5707963267948966
                         (1 row)
 
                         SELECT asin(CAST(-0.75 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          -0.848062078981481
                         (1 row)
 
                         SELECT asin(CAST(-0.5 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          -0.5235987755982989
                         (1 row)
 
                         SELECT asin(CAST(-0.25 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          -0.25268025514207865
                         (1 row)
 
                         SELECT asin(CAST(0 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          0
                         (1 row)
 
                         SELECT asin(CAST(0.25 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          0.25268025514207865
                         (1 row)
 
                         SELECT asin(CAST(0.5 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          0.5235987755982989
                         (1 row)
 
                         SELECT asin(CAST(0.75 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          0.848062078981481
                         (1 row)
 
                         SELECT asin(CAST(1 AS DOUBLE));
-                         asin\s
+                         asin
                         ------
                          1.5707963267948966
                         (1 row)"""
@@ -541,73 +543,73 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT acos(null);
-                         acos\s
+                         acos
                         ------
                         NULL
                         (1 row)
 
                         SELECT acos(-2);
-                         acos\s
+                         acos
                         ------
                          NaN
                         (1 row)
 
                         SELECT acos(2);
-                         acos\s
+                         acos
                         ------
                          NaN
                         (1 row)
 
                         SELECT acos(-1);
-                         acos\s
+                         acos
                         ------
                          3.141592653589793
                         (1 row)
 
                         SELECT acos(-0.75);
-                         acos\s
+                         acos
                         ------
                          2.4188584057763776
                         (1 row)
 
                         SELECT acos(-0.5);
-                         acos\s
+                         acos
                         ------
                          2.0943951023931957
                         (1 row)
 
                         SELECT acos(-0.25);
-                         acos\s
+                         acos
                         ------
                          1.8234765819369754
                         (1 row)
 
                         SELECT acos(0);
-                         acos\s
+                         acos
                         ------
                          1.5707963267948966
                         (1 row)
 
                         SELECT acos(0.25);
-                         acos\s
+                         acos
                         ------
                          1.318116071652818
                         (1 row)
 
                         SELECT acos(0.5);
-                         acos\s
+                         acos
                         ------
                          1.0471975511965979
                         (1 row)
 
                         SELECT acos(0.75);
-                         acos\s
+                         acos
                         ------
                          0.7227342478134157
                         (1 row)
 
                         SELECT acos(1);
-                         acos\s
+                         acos
                         ------
                          0
                         (1 row)"""
@@ -622,67 +624,67 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT acos(CAST(-2 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          NaN
                         (1 row)
 
                         SELECT acos(CAST(2 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          NaN
                         (1 row)
 
                         SELECT acos(CAST(-1 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          3.141592653589793
                         (1 row)
 
                         SELECT acos(CAST(-0.75 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          2.4188584057763776
                         (1 row)
 
                         SELECT acos(CAST(-0.5 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          2.0943951023931957
                         (1 row)
 
                         SELECT acos(CAST(-0.25 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          1.8234765819369754
                         (1 row)
 
                         SELECT acos(CAST(0 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          1.5707963267948966
                         (1 row)
 
                         SELECT acos(CAST(0.25 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          1.318116071652818
                         (1 row)
 
                         SELECT acos(CAST(0.5 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          1.0471975511965979
                         (1 row)
 
                         SELECT acos(CAST(0.75 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          0.7227342478134157
                         (1 row)
 
                         SELECT acos(CAST(1 AS DOUBLE));
-                         acos\s
+                         acos
                         ------
                          0
                         (1 row)"""
@@ -695,61 +697,61 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT atan(null);
-                         atan\s
+                         atan
                         ------
                         NULL
                         (1 row)
 
                         SELECT atan(-1);
-                         atan\s
+                         atan
                         ------
                          -0.7853981633974483
                         (1 row)
 
                         SELECT atan(-0.75);
-                         atan\s
+                         atan
                         ------
                          -0.6435011087932844
                         (1 row)
 
                         SELECT atan(-0.5);
-                         atan\s
+                         atan
                         ------
                          -0.4636476090008061
                         (1 row)
 
                         SELECT atan(-0.25);
-                         atan\s
+                         atan
                         ------
                          -0.24497866312686414
                         (1 row)
 
                         SELECT atan(0);
-                         atan\s
+                         atan
                         ------
                          0
                         (1 row)
 
                         SELECT atan(0.25);
-                         atan\s
+                         atan
                         ------
                          0.24497866312686414
                         (1 row)
 
                         SELECT atan(0.5);
-                         atan\s
+                         atan
                         ------
                          0.4636476090008061
                         (1 row)
 
                         SELECT atan(0.75);
-                         atan\s
+                         atan
                         ------
                          0.6435011087932844
                         (1 row)
 
                         SELECT atan(1);
-                         atan\s
+                         atan
                         ------
                          0.7853981633974483
                         (1 row)"""
@@ -762,61 +764,61 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT atan(CAST(null as DOUBLE));
-                         atan\s
+                         atan
                         ------
                         NULL
                         (1 row)
 
                         SELECT atan(CAST(-1 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          -0.7853981633974483
                         (1 row)
 
                         SELECT atan(CAST(-0.75 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          -0.6435011087932844
                         (1 row)
 
                         SELECT atan(CAST(-0.5 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          -0.4636476090008061
                         (1 row)
 
                         SELECT atan(CAST(-0.25 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          -0.24497866312686414
                         (1 row)
 
                         SELECT atan(CAST(0 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          0
                         (1 row)
 
                         SELECT atan(CAST(0.25 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          0.24497866312686414
                         (1 row)
 
                         SELECT atan(CAST(0.5 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          0.4636476090008061
                         (1 row)
 
                         SELECT atan(CAST(0.75 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          0.6435011087932844
                         (1 row)
 
                         SELECT atan(CAST(1 AS DOUBLE));
-                         atan\s
+                         atan
                         ------
                          0.7853981633974483
                         (1 row)"""
@@ -829,37 +831,37 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT atan2(null, null);
-                         atan2\s
+                         atan2
                         -------
                         NULL
                         (1 row)
 
                         SELECT atan2(0, 0);
-                         atan2\s
+                         atan2
                         -------
                          0
                         (1 row)
 
                         SELECT atan2((SELECT PI), 0);
-                         atan2\s
+                         atan2
                         -------
                          1.5707963267948966
                         (1 row)
 
                         SELECT atan2(0, (SELECT PI));
-                         atan2\s
+                         atan2
                         -------
                          0
                         (1 row)
 
                         SELECT atan2(2, (SELECT PI));
-                         atan2\s
+                         atan2
                         -------
                          0.5669115049410094
                         (1 row)
 
                         SELECT atan2((SELECT PI), (SELECT PI));
-                         atan2\s
+                         atan2
                         -------
                          0.7853981633974483
                         (1 row)"""
@@ -872,25 +874,25 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT atan2(CAST(0 AS DOUBLE), CAST(0 AS DOUBLE));
-                         atan2\s
+                         atan2
                         -------
                          0
                         (1 row)
 
                         SELECT atan2((SELECT PI), CAST(0 AS DOUBLE));
-                         atan2\s
+                         atan2
                         -------
                          1.5707963267948966
                         (1 row)
 
                         SELECT atan2(CAST(0 AS DOUBLE), (SELECT PI));
-                         atan2\s
+                         atan2
                         -------
                          0
                         (1 row)
 
                         SELECT atan2(CAST(2 AS DOUBLE), (SELECT PI));
-                         atan2\s
+                         atan2
                         -------
                          0.5669115049410094
                         (1 row)"""
@@ -903,49 +905,49 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT radians(null);
-                         radians\s
+                         radians
                         ---------
                         NULL
                         (1 row)
 
                         SELECT radians(0);
-                         radians\s
+                         radians
                         ---------
                          0
                         (1 row)
 
                         SELECT radians(30);
-                         radians\s
+                         radians
                         ---------
                          0.5235987755982988
                         (1 row)
 
                         SELECT radians(45);
-                         radians\s
+                         radians
                         ---------
                          0.7853981633974483
                         (1 row)
 
                         SELECT radians(60);
-                         radians\s
+                         radians
                         ---------
                          1.0471975511965976
                         (1 row)
 
                         SELECT radians(90);
-                         radians\s
+                         radians
                         ---------
                          1.5707963267948966
                         (1 row)
 
                         SELECT radians(120);
-                         radians\s
+                         radians
                         ---------
                          2.0943951023931953
                         (1 row)
 
                         SELECT radians(180);
-                         radians\s
+                         radians
                         ---------
                          3.141592653589793
                         (1 row)"""
@@ -958,49 +960,49 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT radians(CAST(null AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                         NULL
                         (1 row)
 
                         SELECT radians(CAST(0 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          0
                         (1 row)
 
                         SELECT radians(CAST(30 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          0.5235987755982988
                         (1 row)
 
                         SELECT radians(CAST(45 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          0.7853981633974483
                         (1 row)
 
                         SELECT radians(CAST(60 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          1.0471975511965976
                         (1 row)
 
                         SELECT radians(CAST(90 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          1.5707963267948966
                         (1 row)
 
                         SELECT radians(CAST(120 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          2.0943951023931953
                         (1 row)
 
                         SELECT radians(CAST(180 AS DOUBLE));
-                         radians\s
+                         radians
                         ---------
                          3.141592653589793
                         (1 row)"""
@@ -1013,49 +1015,49 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT degrees(null);
-                         degrees\s
+                         degrees
                         ---------
                         NULL
                         (1 row)
 
                         SELECT degrees(0);
-                         degrees\s
+                         degrees
                         ---------
                          0
                         (1 row)
 
                         SELECT degrees((SELECT PI / 6));
-                         degrees\s
+                         degrees
                         ---------
                          29.999999999999996
                         (1 row)
 
-                        SELECT degrees((SELECT PI / 4));
-                         degrees\s
+                        SELECT degrees(PI / 4);
+                         degrees
                         ---------
                          45
                         (1 row)
 
-                        SELECT degrees((SELECT PI / 3));
-                         degrees\s
+                        SELECT degrees(PI / 3);
+                         degrees
                         ---------
                          59.99999999999999
                         (1 row)
 
-                        SELECT degrees((SELECT PI / 2));
-                         degrees\s
+                        SELECT degrees(PI / 2);
+                         degrees
                         ---------
                          90
                         (1 row)
 
-                        SELECT degrees((SELECT PI));
-                         degrees\s
+                        SELECT degrees(PI);
+                         degrees
                         ---------
                          180
                         (1 row)
 
-                        SELECT degrees((SELECT PI * 2));
-                         degrees\s
+                        SELECT degrees(PI * 2);
+                         degrees
                         ---------
                          360
                         (1 row)"""
@@ -1068,25 +1070,25 @@ public class TrigonometryTests extends SqlIoTest {
         this.qs(
                 """
                         SELECT sin('-3');
-                         sin\s
+                         sin
                         -----
                          -0.1411200080598672
                         (1 row)
 
                         SELECT sin(CAST(-3.0 AS DECIMAL(3, 2)));
-                         sin\s
+                         sin
                         -----
                          -0.1411200080598672
                         (1 row)
 
                         SELECT sin(CAST(-3 AS TINYINT));
-                         sin\s
+                         sin
                         -----
                          -0.1411200080598672
                         (1 row)
 
                         SELECT sin(CAST(-3 AS BIGINT));
-                         sin\s
+                         sin
                         -----
                          -0.1411200080598672
                         (1 row)"""
@@ -1097,19 +1099,23 @@ public class TrigonometryTests extends SqlIoTest {
     public void invalidInputs() {
         this.shouldFail(
                 "SELECT sin(CAST('2023-12-14' AS DATE))",
-                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<DATE>)'. Supported form(s): 'SIN(<NUMERIC>)'"
+                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<DATE>)'. " +
+                        "Supported form(s): 'SIN(<NUMERIC>)'"
         );
 
         this.shouldFail("SELECT sin(true)",
-                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<BOOLEAN>)'. Supported form(s): 'SIN(<NUMERIC>)'"
+                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<BOOLEAN>)'. " +
+                        "Supported form(s): 'SIN(<NUMERIC>)'"
         );
 
         this.shouldFail("SELECT sin(CAST('101' AS BINARY(3)))",
-                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<BINARY(3)>)'. Supported form(s): 'SIN(<NUMERIC>)'"
+                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<BINARY(3)>)'. " +
+                        "Supported form(s): 'SIN(<NUMERIC>)'"
         );
 
         this.shouldFail("SELECT sin(CAST('15:06:51.06731' AS TIME))",
-                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<TIME(0)>)'. Supported form(s): 'SIN(<NUMERIC>)'"
+                "Error in SQL statement: Cannot apply 'SIN' to arguments of type 'SIN(<TIME(0)>)'. " +
+                        "Supported form(s): 'SIN(<NUMERIC>)'"
         );
     }
 }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -732,41 +732,6 @@ where
     left.map(|x| truncate_decimal(x, right))
 }
 
-#[inline(always)]
-pub fn div_decimal_decimal(left: Decimal, right: Decimal) -> Option<Decimal> {
-    if right.is_zero() {
-        None
-    } else {
-        Some(left / right)
-    }
-}
-
-#[inline(always)]
-pub fn div_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
-    let left = left?;
-    div_decimal_decimal(left, right)
-}
-
-#[inline(always)]
-pub fn div_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
-    let right = right?;
-    div_decimal_decimal(left, right)
-}
-
-#[inline(always)]
-pub fn div_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
-    let left = left?;
-    let right = right?;
-    div_decimal_decimal(left, right)
-}
-
-#[inline(always)]
-pub fn modulo_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
-    left % right
-}
-
-some_polymorphic_function2!(modulo, decimal, Decimal, decimal, Decimal, Decimal);
-
 pub fn element<T>(array: Vec<T>) -> Option<T>
 where
     T: Copy,

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -6,7 +6,7 @@ use crate::{
     for_all_numeric_operator, some_existing_operator, some_operator,
 };
 
-use core::ops::{Add, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 use rust_decimal::Decimal;
 
 #[inline(always)]
@@ -177,138 +177,15 @@ where
 
 for_all_int_operator!(bxor);
 
-/* div for integers is implemented manually, since it does not follow the
-pattern: the base function already returns an Option */
 #[inline(always)]
-pub fn div_i16_i16(left: i16, right: i16) -> Option<i16> {
-    match right {
-        0 => None,
-        _ => Some(left / right),
-    }
+fn div<T>(left: T, right: T) -> T
+where
+    T: Div<Output = T>,
+{
+    left / right
 }
 
-#[inline(always)]
-pub fn div_i32_i32(left: i32, right: i32) -> Option<i32> {
-    match right {
-        0 => None,
-        _ => Some(left / right),
-    }
-}
-
-#[inline(always)]
-pub fn div_i64_i64(left: i64, right: i64) -> Option<i64> {
-    match right {
-        0 => None,
-        _ => Some(left / right),
-    }
-}
-
-#[inline(always)]
-pub fn div_i16N_i16(left: Option<i16>, right: i16) -> Option<i16> {
-    let left = left?;
-    div_i16_i16(left, right)
-}
-
-#[inline(always)]
-pub fn div_i32N_i32(left: Option<i32>, right: i32) -> Option<i32> {
-    let left = left?;
-    div_i32_i32(left, right)
-}
-
-#[inline(always)]
-pub fn div_i64N_i64(left: Option<i64>, right: i64) -> Option<i64> {
-    let left = left?;
-    div_i64_i64(left, right)
-}
-
-#[inline(always)]
-pub fn div_i16_i16N(left: i16, right: Option<i16>) -> Option<i16> {
-    let right = right?;
-    div_i16_i16(left, right)
-}
-
-#[inline(always)]
-pub fn div_i32_i32N(left: i32, right: Option<i32>) -> Option<i32> {
-    let right = right?;
-    div_i32_i32(left, right)
-}
-
-#[inline(always)]
-pub fn div_i64_i64N(left: i64, right: Option<i64>) -> Option<i64> {
-    let right = right?;
-    div_i64_i64(left, right)
-}
-
-#[inline(always)]
-pub fn div_i16N_i16N(left: Option<i16>, right: Option<i16>) -> Option<i16> {
-    let left = left?;
-    let right = right?;
-    div_i16_i16(left, right)
-}
-
-#[inline(always)]
-pub fn div_i32N_i32N(left: Option<i32>, right: Option<i32>) -> Option<i32> {
-    let left = left?;
-    let right = right?;
-    div_i32_i32(left, right)
-}
-
-#[inline(always)]
-pub fn div_i64N_i64N(left: Option<i64>, right: Option<i64>) -> Option<i64> {
-    let left = left?;
-    let right = right?;
-    div_i64_i64(left, right)
-}
-
-// TODO: does div F32 need to return Option?
-
-#[inline(always)]
-pub fn div_f_f(left: F32, right: F32) -> Option<F32> {
-    Some(F32::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
-    right.map(|right| F32::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
-    left.map(|left| F32::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
-    match (left, right) {
-        (None, _) => None,
-        (_, None) => None,
-        (Some(left), Some(right)) => Some(F32::new(left.into_inner() / right.into_inner())),
-    }
-}
-
-#[inline(always)]
-pub fn div_d_d(left: F64, right: F64) -> Option<F64> {
-    Some(F64::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
-    right.map(|right| F64::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
-    left.map(|left| F64::new(left.into_inner() / right.into_inner()))
-}
-
-#[inline(always)]
-pub fn div_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
-    match (left, right) {
-        (None, _) => None,
-        (_, None) => None,
-        (Some(left), Some(right)) => Some(F64::new(left.into_inner() / right.into_inner())),
-    }
-}
+for_all_numeric_operator!(div);
 
 pub fn plus_u_u(left: usize, right: usize) -> usize {
     left + right


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Fixes #1200 

Initially I thought that division is a problematic operation in SQL because it throws on division by 0, so I redefined it to return NULL. Turns out that most SQL operations can throw, so there is no point in only changing the semantics of division. This PR reverts the typing and semantics of division to its standard SQL definition.
