### PR TITLE
Simplify Earthfile using rust UDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.7.17
+          version: v0.7.23
       - uses: actions/checkout@v3
         # By default a merge commit is checked out. If you look at the SHA that
         # is checked out, it doesn't match your local commit SHA. Rather it's

--- a/Earthfile
+++ b/Earthfile
@@ -47,10 +47,10 @@ install-rust:
         --component clippy \
         --component rustfmt \
         --component llvm-tools-preview
-    RUN cargo install --locked --force --version 0.5.0 cargo-machete
     RUN cargo install --locked --force --version 0.36.11 cargo-make
     RUN cargo install --locked --force --version 0.5.22 cargo-llvm-cov
     RUN cargo install --locked --force --version 0.1.61 cargo-chef
+    RUN cargo install --locked --force --version 0.1.45 cargo-udeps
     RUN rustup --version
     RUN cargo --version
     RUN rustc --version
@@ -67,7 +67,13 @@ rust-sources:
 formatting-check:
     FROM +rust-sources
     COPY --keep-ts rustfmt.toml rustfmt.toml
-    DO rust+CARGO --args="+nightly  fmt --all -- --check"
+    DO rust+CARGO --args="+nightly fmt --all -- --check"
+
+udeps:
+    FROM +rust-sources
+    ENV WEBUI_BUILD_DIR=/dbsp/web-console/out
+    COPY ( +build-webui/out ) ./web-console/out
+    DO rust+CARGO --args="+nightly udeps"
 
 install-python-deps:
     FROM +install-deps
@@ -484,6 +490,7 @@ benchmark:
 
 all-tests:
     BUILD +formatting-check
+    BUILD +udeps
     BUILD +test-rust
     BUILD +test-python
     BUILD +python-bindings-checker

--- a/Earthfile
+++ b/Earthfile
@@ -47,10 +47,10 @@ install-rust:
         --component clippy \
         --component rustfmt \
         --component llvm-tools-preview
+    RUN cargo install --locked --force --version 0.5.0 cargo-machete
     RUN cargo install --locked --force --version 0.36.11 cargo-make
     RUN cargo install --locked --force --version 0.5.22 cargo-llvm-cov
     RUN cargo install --locked --force --version 0.1.61 cargo-chef
-    RUN cargo install --locked --force --version 0.1.45 cargo-udeps
     RUN rustup --version
     RUN cargo --version
     RUN rustc --version
@@ -69,11 +69,9 @@ formatting-check:
     COPY --keep-ts rustfmt.toml rustfmt.toml
     DO rust+CARGO --args="+nightly fmt --all -- --check"
 
-udeps:
+machete:
     FROM +rust-sources
-    ENV WEBUI_BUILD_DIR=/dbsp/web-console/out
-    COPY ( +build-webui/out ) ./web-console/out
-    DO rust+CARGO --args="+nightly udeps"
+    DO rust+CARGO --args="machete crates/"
 
 install-python-deps:
     FROM +install-deps
@@ -490,7 +488,7 @@ benchmark:
 
 all-tests:
     BUILD +formatting-check
-    BUILD +udeps
+    BUILD +machete
     BUILD +test-rust
     BUILD +test-python
     BUILD +python-bindings-checker

--- a/Earthfile
+++ b/Earthfile
@@ -173,7 +173,7 @@ test-sql:
 
 build-nexmark:
     FROM +build-dbsp
-    DO rust+CARGO --args="build --package dbsp_nexmark" --output="debug/[^/\.]+"
+    DO rust+CARGO --args="build --package dbsp_nexmark"
     DO rust+CARGO --args="clippy --package dbsp_nexmark -- -D warnings"
     DO rust+CARGO --args="test --package dbsp_nexmark --no-run"
 
@@ -205,7 +205,6 @@ test-adapters:
         RUN --mount=$EARTHLY_RUST_CARGO_HOME_CACHE --mount=$EARTHLY_RUST_TARGET_CACHE docker run -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v23.2.3 \
             redpanda start --smp 2  && \
             sleep 5 && \
-            # XXX: DO rust+CARGO --args="test --package dbsp_adapters --package sqllib"
             cargo test --package dbsp_adapters --package sqllib
     END
 
@@ -223,7 +222,6 @@ test-manager:
             # Sleep until postgres is up (otherwise we get connection reset if we connect too early)
             # (See: https://github.com/docker-library/docs/blob/master/postgres/README.md#caveats)
             sleep 3 && \
-            # XXX: DO rust+CARGO --args="test --package pipeline-manager"
             cargo test --package pipeline-manager
     END
     # We keep the test binary around so we can run integration tests later. This incantation is used to find the


### PR DESCRIPTION
Removes the workarounds we'd used to cache our rust builds better in Earthly. We instead use Earthly's rust UDC: https://github.com/earthly/lib/tree/main/rust#set_cache_mounts_env

Also removes the rust toolchain/build arguments being scattered throughout the Earthfile that weren't being used. If a build or action wants to tune these, they can set the environment variables at the top.

I think we could simplify the file even further by only executing cargo build once (instead of per-package), but I didn't go there yet.

~~Replaces cargo machete with `cargo +nightly udeps`.~~

I removed the audit phase given we've been ignoring the results of`cargo audit`.

Is this a user-visible change (yes/no): no
<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
