### PR TITLE
ci: bump benchmark workflow to use Earthly 0.7.23 as well

### DIFF
--- a/.github/workflows/benchmark-command.yml
+++ b/.github/workflows/benchmark-command.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: earthly/actions/setup-earthly@v1
         with:
-          version: v0.7.17
+          version: v0.7.23
 
       - name: MUIX license
         run: echo "NEXT_PUBLIC_MUIX_PRO_KEY=${muix_license}" > web-console/.env && cat web-console/.env


### PR DESCRIPTION
- build: use earthly rust UDF to simplify Earthfile
- ci: use SET_CACHE_MOUNTS_ENV to correctly invoke cargo directly
- ci: remove RUST_TOOLCHAIN and RUST_BUILD_PROFILE args throughout the Earthfile
- ci: add stage to call cargo +udeps
- ci: use cargo machete anyway
- ci: remove stray --output
- ci: bump benchmark workflow to use Earthly 0.7.23 as well

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
