### PR TITLE
demo: sec-ops: standalone rework

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd deploy && \
-          SECOPS_DEMO_ARGS="--prepare-args 500000" RUST_LOG=debug,tokio_postgres=info docker compose -f docker-compose.yml -f docker-compose-dev.yml --profile demo up --build --force-recreate --exit-code-from demo --renew-anon-volumes
+          SECOPS_DEMO_ARGS="--num-pipelines=500000" RUST_LOG=debug,tokio_postgres=info docker compose -f docker-compose.yml -f docker-compose-dev.yml --profile demo up --build --force-recreate --exit-code-from demo --renew-anon-volumes
 
       # Disable until we bring the Kubernetes workflows up to speed
       #

--- a/Earthfile
+++ b/Earthfile
@@ -340,7 +340,7 @@ test-docker-compose:
                 --pull docker.redpanda.com/vectorized/redpanda:v23.2.3 \
                 --load ghcr.io/feldera/pipeline-manager:latest=+build-pipeline-manager-container \
                 --load ghcr.io/feldera/demo-container:latest=+build-demo-container
-        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--prepare-args 200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo
+        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--num-pipelines=200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo
     END
 
 # Test whether the stable container image runs with our Docker compose file
@@ -355,9 +355,9 @@ test-docker-compose-stable:
                 --pull ghcr.io/feldera/pipeline-manager:0.6.0 \
                 --load ghcr.io/feldera/pipeline-manager:latest=+build-pipeline-manager-container \
                 --pull ghcr.io/feldera/demo-container:0.6.0
-        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--prepare-args 200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo && \
+        RUN COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--num-pipelines=200000" RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo && \
             # This should run the latest version of the code and in the process, trigger a migration.
-            COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--prepare-args 200000" FELDERA_VERSION=latest RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml up -d db pipeline-manager redpanda && \
+            COMPOSE_HTTP_TIMEOUT=120 SECOPS_DEMO_ARGS="--num-pipelines=200000" FELDERA_VERSION=latest RUST_LOG=debug,tokio_postgres=info docker-compose -f docker-compose.yml up -d db pipeline-manager redpanda && \
             sleep 10 && \
             # Exercise a few simple workflows in the API
             curl http://localhost:8080/v0/programs &&  \

--- a/demo/demo-container.sh
+++ b/demo/demo-container.sh
@@ -10,7 +10,7 @@
 # this way the user will see the two programs and pipelines straight away.
 # Make sure the script returns an error if one of the demo scripts fails.
 
-(cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile ${SECOPS_DEMO_ARGS})&
+(cd demo/project_demo00-SecOps && python3 -u run.py --api-url http://pipeline-manager:8080 ${SECOPS_DEMO_ARGS})&
 pid1=$!
 echo pid1 $pid1
 (cd demo/project_demo06-SupplyChainTutorial && python3 run.py --dbsp_url http://pipeline-manager:8080 --actions prepare create compile)&

--- a/demo/project_demo00-SecOps/README.md
+++ b/demo/project_demo00-SecOps/README.md
@@ -1,0 +1,34 @@
+# Demo: SecOps
+
+## Getting started
+
+1. Bring up a Feldera instance, for example reachable at `http://localhost:8080`.
+
+2. Bring up a Redpanda instance, for example reachable by both
+   script and Feldera instance at `redpanda:9092`
+
+3. Set environment variable for the script: `export REDPANDA_BROKERS=redpanda:9092`
+
+4. Run the following:
+   ```
+   cd demo/project_demo00-SecOps
+   python3 run.py --api-url="pipeline-manager:8080" --num-pipelines=200000
+   ```
+   
+5. Note that the pipeline does not start automatically, but requires
+   to be manually started via the web console or by issuing:
+   ```
+   curl -X POST http://localhost:8080/v0/pipelines/demo-sec-ops-pipeline/shutdown
+   curl -X POST http://localhost:8080/v0/pipelines/demo-sec-ops-pipeline/start
+   ```
+   
+6. Progress can be seen via the web console or by issuing:
+   ```
+   curl -X GET http://localhost:8080/v0/pipelines/demo-sec-ops-pipeline/stats
+   ```
+
+## Usage
+
+```
+python3 run.py --help
+```

--- a/demo/project_demo00-SecOps/run.py
+++ b/demo/project_demo00-SecOps/run.py
@@ -1,30 +1,94 @@
-from itertools import islice
+import time
+import requests
+import argparse
+from typing import List
 import os
-import sys
 import subprocess
 from shutil import which
+from plumbum.cmd import rpk
 
-from dbsp import DBSPPipelineConfig
-from dbsp import JsonInputFormatConfig, JsonOutputFormatConfig
-from dbsp import KafkaInputConfig
-from dbsp import KafkaOutputConfig
-
-# Import
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".."))
-from demo import *
-
-SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+# Required files
+DEMO_DIR = os.path.join(os.path.dirname(__file__))
+PROJECT_SQL = os.path.join(DEMO_DIR, "project.sql")
 
 
-def prepare(args=[]):
-    if len(args) == 1:
-        num_pipelines = args[0]
-    else:
-        num_pipelines = "-1"
+def main():
+    # Command-line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-url", required=True, help="Feldera API URL (e.g., http://localhost:8080 )")
+    parser.add_argument("--num-pipelines", required=False, help="number of SecOps pipelines to simulate")
+    parsed_args = parser.parse_args()
+    api_url = parsed_args.api_url
+    num_pipelines = "-1" if parsed_args.num_pipelines is None else parsed_args.num_pipelines
+    pipeline_to_redpanda_server = "redpanda:9092"
+
+    # Program
+    program_name = "demo-sec-ops-program"
+    program_sql = open(PROJECT_SQL).read()
+    program_version = create_program(api_url, {}, program_sql, program_name)
+    compile_program(api_url, {}, program_name, program_version)
+
+    # Connectors
+    connectors = []
+    for (name, stream, topic_topics, is_input) in [
+        ("secops_pipeline", 'PIPELINE',  ["secops_pipeline"], True),
+        ("secops_pipeline_sources", 'PIPELINE_SOURCES', ["secops_pipeline_sources"], True),
+        ("secops_artifact", 'ARTIFACT', ["secops_artifact"], True),
+        ("secops_vulnerability", 'VULNERABILITY', ["secops_vulnerability"], True),
+        ("secops_cluster", 'K8SCLUSTER', ["secops_cluster"], True),
+        ("secops_k8sobject", 'K8SOBJECT', ["secops_k8sobject"], True),
+        ("secops_vulnerability_stats", 'K8SCLUSTER_VULNERABILITY_STATS', "secops_vulnerability_stats", False),
+    ]:
+        create_connector(api_url, {}, name, {
+            "format": {
+                "name": "json",
+                "config": {
+                    "update_format": "insert_delete"
+                }
+            },
+            "transport": {
+                "name": "kafka",
+                "config": {
+                    "bootstrap.servers": pipeline_to_redpanda_server,
+                    "topic": topic_topics
+                } if not is_input else (
+                    {
+                        "bootstrap.servers": pipeline_to_redpanda_server,
+                        "topics": topic_topics,
+                        "auto.offset.reset": "earliest",
+                        "group.id": "secops_pipeline_sources",
+                        "enable.auto.commit": "true",
+                        "enable.auto.offset.store": "true",
+                    }
+                    if stream == "PIPELINE_SOURCES" else
+                    {
+                        "bootstrap.servers": pipeline_to_redpanda_server,
+                        "topics": topic_topics,
+                        "auto.offset.reset": "earliest"
+                    }
+                )
+            }
+        })
+        connectors.append({
+            "connector_name": name,
+            "is_input": is_input,
+            "name": name,
+            "relation_name": stream
+        })
+
+    # Pipeline
+    pipeline_name = "demo-sec-ops-pipeline"
+    create_pipeline(
+        api_url,
+        {},
+        program_name,
+        pipeline_name,
+        num_workers=8,
+        connectors=connectors
+    )
 
     # Create output topic before running the simulator, which will never return.
-    from plumbum.cmd import rpk
-
+    print("(Re-)creating topic secops_vulnerability_stats...")
     rpk["topic", "delete", "secops_vulnerability_stats"]()
     rpk[
         "topic",
@@ -35,12 +99,14 @@ def prepare(args=[]):
         "-c",
         "retention.bytes=100000000",
     ]()
+    print("(Re-)created topic secops_vulnerability_stats")
 
+    # Start running the simulator
     if which("cargo") is None:
         # Expect a pre-built binary in simulator/secops_simulator. Used
         # by the Docker container workflow where we don't want to use cargo run.
         cmd = ["./secops_simulator", "%s" % num_pipelines]
-        subprocess.run(cmd, cwd=os.path.join(SCRIPT_DIR, "simulator"))
+        subprocess.run(cmd, cwd=os.path.join(DEMO_DIR, "simulator"))
     else:
         cmd = ["cargo", "run", "--release", "--", "%s" % num_pipelines]
         # Override --release if RUST_BUILD_PROFILE is set
@@ -48,78 +114,152 @@ def prepare(args=[]):
             cmd[2] = os.environ["RUST_BUILD_PROFILE"]
         new_env = os.environ.copy()
         new_env["RUST_LOG"] = "debug"
-        subprocess.run(cmd, cwd=os.path.join(SCRIPT_DIR, "simulator"), env=new_env)
+        subprocess.run(cmd, cwd=os.path.join(DEMO_DIR, "simulator"), env=new_env)
 
 
-def make_config(project):
-    config = DBSPPipelineConfig(project, 8, "SecOps Pipeline")
+###############################################################################
+# HELPER FUNCTIONS BELOW
 
-    config.add_kafka_input(
-        name="secops_pipeline",
-        stream="PIPELINE",
-        config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_pipeline"], "auto.offset.reset": "earliest"}
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_input(
-        name="secops_pipeline_sources",
-        stream="PIPELINE_SOURCES",
-        config=KafkaInputConfig.from_dict(
-            {
-                "topics": ["secops_pipeline_sources"],
-                "auto.offset.reset": "earliest",
-                "group.id": "secops_pipeline_sources",
-                "enable.auto.commit": "true",
-                "enable.auto.offset.store": "true",
-            }
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_input(
-        name="secops_artifact",
-        stream="ARTIFACT",
-        config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_artifact"], "auto.offset.reset": "earliest"}
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_input(
-        name="secops_vulnerability",
-        stream="VULNERABILITY",
-        config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_vulnerability"], "auto.offset.reset": "earliest"}
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_input(
-        name="secops_cluster",
-        stream="K8SCLUSTER",
-        config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_cluster"], "auto.offset.reset": "earliest"}
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_input(
-        name="secops_k8sobject",
-        stream="K8SOBJECT",
-        config=KafkaInputConfig.from_dict(
-            {"topics": ["secops_k8sobject"], "auto.offset.reset": "earliest"}
-        ),
-        format=JsonInputFormatConfig(update_format="insert_delete"),
-    )
-    config.add_kafka_output(
-        name="secops_vulnerability_stats",
-        stream="K8SCLUSTER_VULNERABILITY_STATS",
-        config=KafkaOutputConfig.from_dict({"topic": "secops_vulnerability_stats"}),
-        format=JsonOutputFormatConfig(),
-    )
 
-    config.save()
-    return config
+def create_program(
+        api_url: str,
+        headers: dict,
+        program_sql: str,
+        program_name: str,
+        program_description: str = ""
+) -> str:
+    """
+    Creates a Feldera program. Patches existing program if exists, else posts.
+    Function version: 0.0.1
+
+    :param api_url:               URL of the Feldera REST API (e.g., "http://localhost:8080")
+    :param headers:               Headers to add to each HTTP request
+    :param program_sql:           Program SQL
+    :param program_name:          Program name
+    :param program_description:   (Optional) Program description
+
+    :return: Program version
+    """
+    print(f"Creating program {program_name}...")
+    program = {
+        "name": program_name,
+        "description": program_description,
+        "code": program_sql,
+    }
+    existing_programs = [entry["name"] for entry in requests.get(api_url + "/v0/programs", headers=headers).json()]
+    if program["name"] in existing_programs:
+        response = requests.patch(f"{api_url}/v0/programs/{program_name}", json=program, headers=headers)
+    else:
+        response = requests.post(f"{api_url}/v0/programs", json=program, headers=headers)
+    response.raise_for_status()
+    program_version = response.json()["version"]
+    print(f"Created program {program_name} (version: {program_version})")
+    return program_version
+
+
+def compile_program(
+        api_url: str,
+        headers: dict,
+        program_name: str,
+        program_version: str
+):
+    """
+    Compiles a Feldera program (returns when compilation is completed).
+    Function version: 0.0.1
+
+    :param api_url:               URL of the Feldera REST API (e.g., "http://localhost:8080")
+    :param headers:               Headers to add to each HTTP request
+    :param program_name:          Program name
+    :param program_version:       Program version
+    """
+    print("Starting program compilation...")
+    requests.post(
+        f"{api_url}/v0/programs/{program_name}/compile", json={"version": program_version}, headers=headers
+    ).raise_for_status()
+    while True:
+        status = requests.get(f"{api_url}/v0/programs/{program_name}", headers=headers).json()["status"]
+        print(f"Program status: {status}")
+        if status == "Success":
+            break
+        elif status != "Pending" and status != "CompilingRust" and status != "CompilingSql":
+            print(f"Failed program compilation with status {status}")
+            exit(1)
+        time.sleep(5)
+    print(f"Program {program_name} is compiled")
+
+
+def create_connector(
+        api_url: str,
+        headers: dict,
+        connector_name: str,
+        connector_config: dict,
+        connector_description: str = "",
+):
+    """
+    Creates a connector provided its configuration.
+    Function version: 0.0.1
+
+    :param api_url:                URL of the Feldera REST API (e.g., "http://localhost:8080")
+    :param headers:                Headers to add to each HTTP request
+    :param connector_name:         Connector name
+    :param connector_config:       Connector configuration
+    :param connector_description:  (Optional) Connector description
+    """
+    connector = {
+        "name": connector_name,
+        "description": connector_description,
+        "config": connector_config,
+    }
+    print(f"Creating connector {connector_name}...")
+    existing_connectors = [entry["name"] for entry in requests.get(f"{api_url}/v0/connectors").json()]
+    if connector_name in existing_connectors:
+        response = requests.patch(f"{api_url}/v0/connectors/{connector_name}", json=connector, headers=headers)
+    else:
+        response = requests.post(f"{api_url}/v0/connectors", json=connector, headers=headers)
+    response.raise_for_status()
+    print(f"Created connector {connector_name}")
+
+
+def create_pipeline(
+        api_url: str,
+        headers: dict,
+        program_name: str,
+        pipeline_name: str,
+        pipeline_description: str = "",
+        num_workers: int = 8,
+        connectors: List[dict] = None
+):
+    """
+    Creates a pipeline provided the program. Patches existing pipeline if exists, else posts.
+    Function version: 0.0.1
+
+    :param api_url:               URL of the Feldera REST API (e.g., "http://localhost:8080")
+    :param headers:               Headers to add to each HTTP request
+    :param program_name:          Program name
+    :param pipeline_name:         Pipeline name
+    :param pipeline_description:  (Optional) Pipeline description
+    :param num_workers:           (Optional) Number of workers (default: 8)
+    :param connectors:            (Optional) List of connector names to attach to the pipeline
+    """
+    pipeline = {
+        "name": pipeline_name,
+        "description": pipeline_description,
+        "config": {"workers": num_workers},
+        "program_name": program_name,
+        "connectors": [] if connectors is None else connectors,
+    }
+    print(f"Creating pipeline {pipeline_name}...")
+    existing_pipelines = [
+        pipeline["descriptor"]["name"]
+        for pipeline in requests.get(api_url + "/v0/pipelines", headers=headers).json()
+    ]
+    if pipeline["name"] in existing_pipelines:
+        response = requests.patch(f"{api_url}/v0/pipelines/{pipeline_name}", json=pipeline, headers=headers)
+    else:
+        response = requests.post(f"{api_url}/v0/pipelines", json=pipeline, headers=headers)
+    response.raise_for_status()
+    print(f"Created pipeline {pipeline_name}")
 
 
 if __name__ == "__main__":
-    run_demo(
-        "SecOps demo", os.path.join(SCRIPT_DIR, "project.sql"), make_config, prepare
-    )
+    main()


### PR DESCRIPTION
Changes the sec-ops demo to be standalone:
- Removes python demo and dbsp dependency
- README with up-to-date instructions

Is this a user-visible change (yes/no): yes