### PR TITLE
Fix connector logos not displayed in Add Source Drawer on Pipeline Builder page in Firefox

### DIFF
--- a/web-console/src/lib/components/connectors/drawer/AddSourceDrawer.tsx
+++ b/web-console/src/lib/components/connectors/drawer/AddSourceDrawer.tsx
@@ -84,7 +84,7 @@ const IoSelectBox = (props: {
                   style={{
                     height: 64,
                     objectFit: 'cover',
-                    width: 'fit-content',
+                    width: '100%',
                     padding: 6,
                     fill: theme.palette.text.primary
                   }}


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes
