### PR TITLE
[SQL] run time error for arithmetic overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- SQL: Changed the semantics of integer arithmetic to match SQL standard ([#1247](https://github.com/feldera/feldera/pull/1247))
 
 ## [0.7.0] - 2024-01-09
 

--- a/docs/sql/integer.md
+++ b/docs/sql/integer.md
@@ -2,9 +2,7 @@
 
 There are four supported integer datatypes, `TINYINT` (8 bits),
 `SMALLINT` (16 bits), `INTEGER` (32 bits), and `BIGINT` (64
-bits).  These are represented as two's complement values, and
-computations on these types obey the standard two's complement
-semantics, including overflow.
+bits).
 
 The legal operations are `+` (plus, unary and binary), `-` (minus,
 unary and binary), `*` (multiplication), `/` (division), `%`
@@ -44,6 +42,9 @@ Casting a string to an integer type will produce a runtime error if the
 string cannot be interpreted as a number.
 
 Division or modulus by zero cause a runtime error.
+
+Operations that cause integer overflow or underflow (example: multiplication or division
+of minimum integer value by -1) produce run time errors.
 
 ## Predefined functions on integer values
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TinyintTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TinyintTests.java
@@ -316,10 +316,9 @@ public class TinyintTests extends SqlIoTest {
         );
     }
 
-    // Ignored because this fails in Postgres but here we get:
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test
     public void testSelectOverflow() {
-        String error_message = "TINYINT out of range";
+        String error_message = "overflow";
         this.qf("SELECT i.f1, i.f1 * 2::TINYINT AS x FROM INT_TBL i", error_message);
         this.qf( "SELECT i.f1, i.f1 + '2'::TINYINT AS x FROM INT_TBL i", error_message);
         this.qf("SELECT i.f1, i.f1 - '2'::TINYINT AS x FROM INT_TBL i", error_message);
@@ -336,7 +335,7 @@ public class TinyintTests extends SqlIoTest {
         );
     }
 
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test @Ignore("fails for Calcite optimized version")
     public void testTINYINTMINOverflowError() {
         this.qf("SELECT (-128)::tinyint * (-1)::tinyint", "attempt to multiply with overflow");
         this.qf("SELECT (-128)::tinyint / (-1)::tinyint", "attempt to divide with overflow");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TinyintTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/TinyintTests.java
@@ -318,10 +318,9 @@ public class TinyintTests extends SqlIoTest {
 
     @Test
     public void testSelectOverflow() {
-        String error_message = "overflow";
-        this.qf("SELECT i.f1, i.f1 * 2::TINYINT AS x FROM INT_TBL i", error_message);
-        this.qf( "SELECT i.f1, i.f1 + '2'::TINYINT AS x FROM INT_TBL i", error_message);
-        this.qf("SELECT i.f1, i.f1 - '2'::TINYINT AS x FROM INT_TBL i", error_message);
+        this.qf("SELECT i.f1, i.f1 * 2::TINYINT AS x FROM INT_TBL i", "attempt to multiply with overflow");
+        this.qf( "SELECT i.f1, i.f1 + '2'::TINYINT AS x FROM INT_TBL i", "attempt to add with overflow");
+        this.qf("SELECT i.f1, i.f1 - '2'::TINYINT AS x FROM INT_TBL i", "attempt to subtract with overflow");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt2Tests.java
@@ -268,30 +268,11 @@ public class PostgresInt2Tests extends SqlIoTest {
         );
     }
 
-    // Ignored because this fails in Postgres but here we get:
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test
     public void testSelectOverflow() {
-        String error_message = "INT2 out of range";
-        // We get:
-        // L: (Some(-32767), Some(2))x1 --> wraps around
-        // L: (Some(-1234), Some(-2468))x1
-        // L: (Some(0), Some(0))x1
-        // L: (Some(1234), Some(2468))x1
-        // L: (Some(32767), Some(-2))x1 --> wraps around
-        // Taken from: https://github.com/postgres/postgres/blob/c161ab74f76af8e0f3c6b349438525ad9575683b/src/test/regress/expected/int2.out#L202C1-L203C30
-        this.runtimeFail("SELECT i.f1, i.f1 * 2::INT2 AS x FROM INT2_TBL i", error_message, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-32767), Some(-32765))x1
-        // L: (Some(-1234), Some(-1232))x1
-        // L: (Some(0), Some(2))x1
-        // L: (Some(1234), Some(1236))x1
-        // L: (Some(32767), Some(-32767))x1 --> wraps around
-        // https://github.com/postgres/postgres/blob/c161ab74f76af8e0f3c6b349438525ad9575683b/src/test/regress/expected/int2.out#L223
-        this.runtimeFail( "SELECT i.f1, i.f1 + '2'::INT2 AS x FROM INT2_TBL i", error_message, this.getEmptyIOPair());
-
-        // Similarly,
-        this.runtimeFail("SELECT i.f1, i.f1 - '2'::INT2 AS x FROM INT2_TBL i;", error_message, this.getEmptyIOPair());
+        this.qf("SELECT i.f1, i.f1 * 2::INT2 AS x FROM INT2_TBL i", "attempt to multiply with overflow");
+        this.qf( "SELECT i.f1, i.f1 + '2'::INT2 AS x FROM INT2_TBL i", "attempt to add with overflow");
+        this.qf("SELECT i.f1, i.f1 - '2'::INT2 AS x FROM INT2_TBL i", "attempt to subtract with overflow");
     }
 
     @Test
@@ -305,9 +286,8 @@ public class PostgresInt2Tests extends SqlIoTest {
         );
     }
 
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test @Ignore("fails for Calcite optimized version")
     public void testINT2MINOverflowError() {
-        // This fails in Postgres, but we get: `-32768`
         this.runtimeFail("SELECT (-32768)::int2 * (-1)::int2", "attempt to multiply with overflow", this.getEmptyIOPair());
 
         this.runtimeFail("SELECT (-32768)::int2 / (-1)::int2", "attempt to divide with overflow", this.getEmptyIOPair());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt4Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt4Tests.java
@@ -285,57 +285,15 @@ public class PostgresInt4Tests extends SqlIoTest {
     }
 
     // Check PostgresInt2Tests::testSelectOverflow for details
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test
     public void testSelectOverflow() {
         String error = "overflow";
-
-        // We get:
-        // L: (Some(-2147483647), Some(2))x1 --> wraps around
-        // L: (Some(-123456), Some(-246912))x1
-        // L: (Some(0), Some(0))x1
-        // L: (Some(123456), Some(246912))x1
-        // L: (Some(2147483647), Some(-2))x1 --> wraps around
-        this.runtimeFail("SELECT i.f1, i.f1 * '2'::INT2 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-2147483647), Some(2))x1 --> wraps around
-        // L: (Some(-123456), Some(-246912))x1
-        // L: (Some(0), Some(0))x1
-        // L: (Some(123456), Some(246912))x1
-        // L: (Some(2147483647), Some(-2))x1 --> wraps around
-        this.runtimeFail("SELECT i.f1, i.f1 * '2'::INT4 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-2147483647), Some(-2147483645))x1
-        // L: (Some(-123456), Some(-123454))x1
-        // L: (Some(0), Some(2))x1
-        // L: (Some(123456), Some(123458))x1
-        // L: (Some(2147483647), Some(-2147483647))x1 --> wraps around
-        this.runtimeFail("SELECT i.f1, i.f1 + '2'::INT2 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-2147483647), Some(-2147483645))x1
-        // L: (Some(-123456), Some(-123454))x1
-        // L: (Some(0), Some(2))x1
-        // L: (Some(123456), Some(123458))x1
-        // L: (Some(2147483647), Some(-2147483647))x1 --> wraps around
-        this.runtimeFail("SELECT i.f1, i.f1 + '2'::INT4 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-2147483647), Some(2147483647))x1 --> wraps around
-        // L: (Some(-123456), Some(-123458))x1
-        // L: (Some(0), Some(-2))x1
-        // L: (Some(123456), Some(123454))x1
-        // L: (Some(2147483647), Some(2147483645))x1
-        this.runtimeFail("SELECT i.f1, i.f1 - '2'::INT2 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
-
-        // We get:
-        // L: (Some(-2147483647), Some(2147483647))x1 --> wraps around
-        // L: (Some(-123456), Some(-123458))x1
-        // L: (Some(0), Some(-2))x1
-        // L: (Some(123456), Some(123454))x1
-        // L: (Some(2147483647), Some(2147483645))x1
-        this.runtimeFail("SELECT i.f1, i.f1 - '2'::INT4 AS x FROM INT4_TBL i", error, this.getEmptyIOPair());
+        this.qf("SELECT i.f1, i.f1 * '2'::INT2 AS x FROM INT4_TBL i", error);
+        this.qf("SELECT i.f1, i.f1 * '2'::INT4 AS x FROM INT4_TBL i", error);
+        this.qf("SELECT i.f1, i.f1 + '2'::INT2 AS x FROM INT4_TBL i", error);
+        this.qf("SELECT i.f1, i.f1 + '2'::INT4 AS x FROM INT4_TBL i", error);
+        this.qf("SELECT i.f1, i.f1 - '2'::INT2 AS x FROM INT4_TBL i", error);
+        this.qf("SELECT i.f1, i.f1 - '2'::INT4 AS x FROM INT4_TBL i", error);
     }
 
     @Test
@@ -349,10 +307,10 @@ public class PostgresInt4Tests extends SqlIoTest {
         );
     }
 
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test @Ignore("fails for Calcite optimized version")
     public void testINT4MINOverflowError() {
-        this.runtimeFail("SELECT (-2147483648)::int4 * (-1)::int2", "attempt to multiply with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-2147483648)::int4 / (-1)::int2", "attempt to divide with overflow", this.getEmptyIOPair());
+        this.qf("SELECT (-2147483648)::int4 * (-1)::int2", "attempt to multiply with overflow");
+        this.qf("SELECT (-2147483648)::int4 / (-1)::int2", "attempt to divide with overflow");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt8Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt8Tests.java
@@ -539,15 +539,9 @@ public class PostgresInt8Tests extends SqlIoTest {
         );
     }
 
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test
     public void testSelectOverflow() {
-        // This should error and overflow, but we get:
-        // L: (Some(123), Some(456), Some(56088))x1
-        // L: (Some(123), Some(4567890123456789), Some(561850485185185047))x1
-        // L: (Some(4567890123456789), Some(-4567890123456789), Some(-4868582358072306617))x1 --> should've errored
-        // L: (Some(4567890123456789), Some(123), Some(561850485185185047))x1
-        // L: (Some(4567890123456789), Some(4567890123456789), Some(4868582358072306617))x1 --> should've errored
-        this.runtimeFail("SELECT q1, q2, q1 * q2 AS multiply FROM INT8_TBL", "out of range", this.getEmptyIOPair());
+        this.qf("SELECT q1, q2, q1 * q2 AS multiply FROM INT8_TBL", "overflow");
     }
 
     @Test
@@ -581,13 +575,13 @@ public class PostgresInt8Tests extends SqlIoTest {
         );
     }
 
-    @Test @Ignore("Integer wrapping: https://github.com/feldera/feldera/issues/1186")
+    @Test @Ignore("fails for Calcite optimized version")
     public void testINT64MINOverflowError() {
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 * (-1)::int64", "attempt to multiply with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 / (-1)::int64", "attempt to divide with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 * (-1)::int4", "attempt to multiply with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 / (-1)::int4", "attempt to divide with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 * (-1)::int2", "attempt to multiply with overflow", this.getEmptyIOPair());
-        this.runtimeFail("SELECT (-9223372036854775808)::int64 / (-1)::int2", "attempt to divide with overflow", this.getEmptyIOPair());
+        this.qf("SELECT (-9223372036854775808)::int64 * (-1)::int64", "attempt to multiply with overflow");
+        this.qf("SELECT (-9223372036854775808)::int64 / (-1)::int64", "attempt to divide with overflow");
+        this.qf("SELECT (-9223372036854775808)::int64 * (-1)::int4", "attempt to multiply with overflow");
+        this.qf("SELECT (-9223372036854775808)::int64 / (-1)::int4", "attempt to divide with overflow");
+        this.qf("SELECT (-9223372036854775808)::int64 * (-1)::int2", "attempt to multiply with overflow");
+        this.qf("SELECT (-9223372036854775808)::int64 / (-1)::int2", "attempt to divide with overflow");
     }
 }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -340,6 +340,16 @@ macro_rules! some_operator {
 
             some_existing_operator!($func_name, $short_name, $arg_type, $ret_type);
         }
+    };
+    ($func_name: ident, $new_func_name: ident, $short_name: ident, $arg_type: ty, $ret_type: ty) => {
+        ::paste::paste! {
+            #[inline(always)]
+            pub fn [<$new_func_name _ $short_name _ $short_name >]( arg0: $arg_type, arg1: $arg_type ) -> $ret_type {
+                $func_name(arg0, arg1)
+            }
+
+            some_existing_operator!($new_func_name, $short_name, $arg_type, $ret_type);
+        }
     }
 }
 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -329,6 +329,12 @@ macro_rules! some_existing_operator {
 // - f_t_tN(x: Option<T>, y: T) -> Option<U>
 // - f_tN_tN(x: Option<T>, y: Option<T>) -> Option<U>
 // The resulting functions return Some only if all arguments are 'Some'.
+//
+// Has two variants:
+// - Takes the name of the existing function, the generated functions will have
+// this prefix
+// - Takes the name of the existing function, and the prefix for the generated
+// functions
 #[macro_export]
 macro_rules! some_operator {
     ($func_name: ident, $short_name: ident, $arg_type: ty, $ret_type: ty) => {

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -1,6 +1,8 @@
+use std::ops::{Add, Div, Mul, Sub};
+
 use dbsp::algebra::{F32, F64};
 use num::PrimInt;
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
+use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ToPrimitive};
 
 use crate::{
     for_all_compare, for_all_int_compare, for_all_int_operator, for_all_numeric_compare,
@@ -93,66 +95,17 @@ where
 }
 
 for_all_int_operator!(plus);
+some_operator!(plus, decimal, Decimal, Decimal);
 
-pub fn plus_f_f(left: F32, right: F32) -> F32 {
+fn fp_plus<T>(left: T, right: T) -> T
+where
+    T: Add<Output = T>,
+{
     left + right
 }
 
-pub fn plus_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
-    let left = left?;
-    Some(plus_f_f(left, right))
-}
-
-pub fn plus_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
-    let right = right?;
-    Some(plus_f_f(left, right))
-}
-
-pub fn plus_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
-    let left = left?;
-    let right = right?;
-    Some(plus_f_f(left, right))
-}
-
-pub fn plus_d_d(left: F64, right: F64) -> F64 {
-    left + right
-}
-
-pub fn plus_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
-    let left = left?;
-    Some(plus_d_d(left, right))
-}
-
-pub fn plus_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
-    let right = right?;
-    Some(plus_d_d(left, right))
-}
-
-pub fn plus_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
-    let left = left?;
-    let right = right?;
-    Some(plus_d_d(left, right))
-}
-
-pub fn plus_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
-    left + right
-}
-
-pub fn plus_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
-    let left = left?;
-    Some(plus_decimal_decimal(left, right))
-}
-
-pub fn plus_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
-    let right = right?;
-    Some(plus_decimal_decimal(left, right))
-}
-
-pub fn plus_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
-    let left = left?;
-    let right = right?;
-    Some(plus_decimal_decimal(left, right))
-}
+some_operator!(fp_plus, plus, f, F32, F32);
+some_operator!(fp_plus, plus, d, F64, F64);
 
 #[inline(always)]
 fn minus<T>(left: T, right: T) -> T
@@ -164,66 +117,17 @@ where
 }
 
 for_all_int_operator!(minus);
+some_operator!(minus, decimal, Decimal, Decimal);
 
-pub fn minus_f_f(left: F32, right: F32) -> F32 {
+fn fp_minus<T>(left: T, right: T) -> T
+where
+    T: Sub<Output = T>,
+{
     left - right
 }
 
-pub fn minus_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
-    let left = left?;
-    Some(minus_f_f(left, right))
-}
-
-pub fn minus_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
-    let right = right?;
-    Some(minus_f_f(left, right))
-}
-
-pub fn minus_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
-    let left = left?;
-    let right = right?;
-    Some(minus_f_f(left, right))
-}
-
-pub fn minus_d_d(left: F64, right: F64) -> F64 {
-    left - right
-}
-
-pub fn minus_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
-    let left = left?;
-    Some(minus_d_d(left, right))
-}
-
-pub fn minus_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
-    let right = right?;
-    Some(minus_d_d(left, right))
-}
-
-pub fn minus_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
-    let left = left?;
-    let right = right?;
-    Some(minus_d_d(left, right))
-}
-
-pub fn minus_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
-    left - right
-}
-
-pub fn minus_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
-    let left = left?;
-    Some(minus_decimal_decimal(left, right))
-}
-
-pub fn minus_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
-    let right = right?;
-    Some(minus_decimal_decimal(left, right))
-}
-
-pub fn minus_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
-    let left = left?;
-    let right = right?;
-    Some(minus_decimal_decimal(left, right))
-}
+some_operator!(fp_minus, minus, f, F32, F32);
+some_operator!(fp_minus, minus, d, F64, F64);
 
 #[inline(always)]
 fn modulo<T>(left: T, right: T) -> T
@@ -249,66 +153,17 @@ where
 }
 
 for_all_int_operator!(times);
+some_operator!(times, decimal, Decimal, Decimal);
 
-pub fn times_f_f(left: F32, right: F32) -> F32 {
+fn fp_times<T>(left: T, right: T) -> T
+where
+    T: Mul<Output = T>,
+{
     left * right
 }
 
-pub fn times_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
-    let left = left?;
-    Some(times_f_f(left, right))
-}
-
-pub fn times_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
-    let right = right?;
-    Some(times_f_f(left, right))
-}
-
-pub fn times_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
-    let left = left?;
-    let right = right?;
-    Some(times_f_f(left, right))
-}
-
-pub fn times_d_d(left: F64, right: F64) -> F64 {
-    left * right
-}
-
-pub fn times_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
-    let left = left?;
-    Some(times_d_d(left, right))
-}
-
-pub fn times_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
-    let right = right?;
-    Some(times_d_d(left, right))
-}
-
-pub fn times_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
-    let left = left?;
-    let right = right?;
-    Some(times_d_d(left, right))
-}
-
-pub fn times_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
-    left * right
-}
-
-pub fn times_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
-    let left = left?;
-    Some(times_decimal_decimal(left, right))
-}
-
-pub fn times_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
-    let right = right?;
-    Some(times_decimal_decimal(left, right))
-}
-
-pub fn times_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
-    let left = left?;
-    let right = right?;
-    Some(times_decimal_decimal(left, right))
-}
+some_operator!(fp_times, times, f, F32, F32);
+some_operator!(fp_times, times, d, F64, F64);
 
 /*
 
@@ -367,7 +222,7 @@ for_all_int_operator!(bxor);
 #[inline(always)]
 fn div<T>(left: T, right: T) -> T
 where
-    T: CheckedDiv + PrimInt,
+    T: CheckedDiv + ToPrimitive,
 {
     let panic_message = if Some(0) == right.to_isize() {
         "attempt to divide by zero"
@@ -379,66 +234,17 @@ where
 }
 
 for_all_int_operator!(div);
+some_operator!(div, decimal, Decimal, Decimal);
 
-pub fn div_f_f(left: F32, right: F32) -> F32 {
+fn fp_div<T>(left: T, right: T) -> T
+where
+    T: Div<Output = T>,
+{
     left / right
 }
 
-pub fn div_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
-    let left = left?;
-    Some(div_f_f(left, right))
-}
-
-pub fn div_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
-    let right = right?;
-    Some(div_f_f(left, right))
-}
-
-pub fn div_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
-    let left = left?;
-    let right = right?;
-    Some(div_f_f(left, right))
-}
-
-pub fn div_d_d(left: F64, right: F64) -> F64 {
-    left / right
-}
-
-pub fn div_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
-    let left = left?;
-    Some(div_d_d(left, right))
-}
-
-pub fn div_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
-    let right = right?;
-    Some(div_d_d(left, right))
-}
-
-pub fn div_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
-    let left = left?;
-    let right = right?;
-    Some(div_d_d(left, right))
-}
-
-pub fn div_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
-    left / right
-}
-
-pub fn div_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
-    let left = left?;
-    Some(div_decimal_decimal(left, right))
-}
-
-pub fn div_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
-    let right = right?;
-    Some(div_decimal_decimal(left, right))
-}
-
-pub fn div_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
-    let left = left?;
-    let right = right?;
-    Some(div_decimal_decimal(left, right))
-}
+some_operator!(fp_div, div, f, F32, F32);
+some_operator!(fp_div, div, d, F64, F64);
 
 pub fn plus_u_u(left: usize, right: usize) -> usize {
     left + right

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -1,12 +1,12 @@
 use dbsp::algebra::{F32, F64};
 use num::PrimInt;
+use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 
 use crate::{
     for_all_compare, for_all_int_compare, for_all_int_operator, for_all_numeric_compare,
-    for_all_numeric_operator, some_existing_operator, some_operator,
+    some_existing_operator, some_operator,
 };
 
-use core::ops::{Add, Div, Mul, Sub};
 use rust_decimal::Decimal;
 
 #[inline(always)]
@@ -86,22 +86,144 @@ for_all_compare!(gte, bool);
 #[inline(always)]
 fn plus<T>(left: T, right: T) -> T
 where
-    T: Add<Output = T>,
+    T: CheckedAdd,
 {
+    left.checked_add(&right)
+        .expect("attempt to add with overflow")
+}
+
+for_all_int_operator!(plus);
+
+pub fn plus_f_f(left: F32, right: F32) -> F32 {
     left + right
 }
 
-for_all_numeric_operator!(plus);
+pub fn plus_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
+    let left = left?;
+    Some(plus_f_f(left, right))
+}
+
+pub fn plus_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
+    let right = right?;
+    Some(plus_f_f(left, right))
+}
+
+pub fn plus_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
+    let left = left?;
+    let right = right?;
+    Some(plus_f_f(left, right))
+}
+
+pub fn plus_d_d(left: F64, right: F64) -> F64 {
+    left + right
+}
+
+pub fn plus_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
+    let left = left?;
+    Some(plus_d_d(left, right))
+}
+
+pub fn plus_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
+    let right = right?;
+    Some(plus_d_d(left, right))
+}
+
+pub fn plus_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
+    let left = left?;
+    let right = right?;
+    Some(plus_d_d(left, right))
+}
+
+pub fn plus_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
+    left + right
+}
+
+pub fn plus_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
+    let left = left?;
+    Some(plus_decimal_decimal(left, right))
+}
+
+pub fn plus_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
+    let right = right?;
+    Some(plus_decimal_decimal(left, right))
+}
+
+pub fn plus_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
+    let left = left?;
+    let right = right?;
+    Some(plus_decimal_decimal(left, right))
+}
 
 #[inline(always)]
 fn minus<T>(left: T, right: T) -> T
 where
-    T: Sub<Output = T>,
+    T: CheckedSub,
 {
+    left.checked_sub(&right)
+        .expect("attempt to subtract with overflow")
+}
+
+for_all_int_operator!(minus);
+
+pub fn minus_f_f(left: F32, right: F32) -> F32 {
     left - right
 }
 
-for_all_numeric_operator!(minus);
+pub fn minus_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
+    let left = left?;
+    Some(minus_f_f(left, right))
+}
+
+pub fn minus_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
+    let right = right?;
+    Some(minus_f_f(left, right))
+}
+
+pub fn minus_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
+    let left = left?;
+    let right = right?;
+    Some(minus_f_f(left, right))
+}
+
+pub fn minus_d_d(left: F64, right: F64) -> F64 {
+    left - right
+}
+
+pub fn minus_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
+    let left = left?;
+    Some(minus_d_d(left, right))
+}
+
+pub fn minus_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
+    let right = right?;
+    Some(minus_d_d(left, right))
+}
+
+pub fn minus_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
+    let left = left?;
+    let right = right?;
+    Some(minus_d_d(left, right))
+}
+
+pub fn minus_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
+    left - right
+}
+
+pub fn minus_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
+    let left = left?;
+    Some(minus_decimal_decimal(left, right))
+}
+
+pub fn minus_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
+    let right = right?;
+    Some(minus_decimal_decimal(left, right))
+}
+
+pub fn minus_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
+    let left = left?;
+    let right = right?;
+    Some(minus_decimal_decimal(left, right))
+}
 
 #[inline(always)]
 fn modulo<T>(left: T, right: T) -> T
@@ -120,12 +242,73 @@ for_all_int_operator!(modulo);
 #[inline(always)]
 fn times<T>(left: T, right: T) -> T
 where
-    T: Mul<Output = T>,
+    T: CheckedMul,
 {
+    left.checked_mul(&right)
+        .expect("attempt to multiply with overflow")
+}
+
+for_all_int_operator!(times);
+
+pub fn times_f_f(left: F32, right: F32) -> F32 {
     left * right
 }
 
-for_all_numeric_operator!(times);
+pub fn times_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
+    let left = left?;
+    Some(times_f_f(left, right))
+}
+
+pub fn times_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
+    let right = right?;
+    Some(times_f_f(left, right))
+}
+
+pub fn times_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
+    let left = left?;
+    let right = right?;
+    Some(times_f_f(left, right))
+}
+
+pub fn times_d_d(left: F64, right: F64) -> F64 {
+    left * right
+}
+
+pub fn times_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
+    let left = left?;
+    Some(times_d_d(left, right))
+}
+
+pub fn times_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
+    let right = right?;
+    Some(times_d_d(left, right))
+}
+
+pub fn times_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
+    let left = left?;
+    let right = right?;
+    Some(times_d_d(left, right))
+}
+
+pub fn times_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
+    left * right
+}
+
+pub fn times_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
+    let left = left?;
+    Some(times_decimal_decimal(left, right))
+}
+
+pub fn times_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
+    let right = right?;
+    Some(times_decimal_decimal(left, right))
+}
+
+pub fn times_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
+    let left = left?;
+    let right = right?;
+    Some(times_decimal_decimal(left, right))
+}
 
 /*
 
@@ -184,12 +367,78 @@ for_all_int_operator!(bxor);
 #[inline(always)]
 fn div<T>(left: T, right: T) -> T
 where
-    T: Div<Output = T>,
+    T: CheckedDiv + PrimInt,
 {
+    let panic_message = if Some(0) == right.to_isize() {
+        "attempt to divide by zero"
+    } else {
+        "attempt to divide with overflow"
+    };
+
+    left.checked_div(&right).expect(panic_message)
+}
+
+for_all_int_operator!(div);
+
+pub fn div_f_f(left: F32, right: F32) -> F32 {
     left / right
 }
 
-for_all_numeric_operator!(div);
+pub fn div_fN_f(left: Option<F32>, right: F32) -> Option<F32> {
+    let left = left?;
+    Some(div_f_f(left, right))
+}
+
+pub fn div_f_fN(left: F32, right: Option<F32>) -> Option<F32> {
+    let right = right?;
+    Some(div_f_f(left, right))
+}
+
+pub fn div_fN_fN(left: Option<F32>, right: Option<F32>) -> Option<F32> {
+    let left = left?;
+    let right = right?;
+    Some(div_f_f(left, right))
+}
+
+pub fn div_d_d(left: F64, right: F64) -> F64 {
+    left / right
+}
+
+pub fn div_dN_d(left: Option<F64>, right: F64) -> Option<F64> {
+    let left = left?;
+    Some(div_d_d(left, right))
+}
+
+pub fn div_d_dN(left: F64, right: Option<F64>) -> Option<F64> {
+    let right = right?;
+    Some(div_d_d(left, right))
+}
+
+pub fn div_dN_dN(left: Option<F64>, right: Option<F64>) -> Option<F64> {
+    let left = left?;
+    let right = right?;
+    Some(div_d_d(left, right))
+}
+
+pub fn div_decimal_decimal(left: Decimal, right: Decimal) -> Decimal {
+    left / right
+}
+
+pub fn div_decimalN_decimal(left: Option<Decimal>, right: Decimal) -> Option<Decimal> {
+    let left = left?;
+    Some(div_decimal_decimal(left, right))
+}
+
+pub fn div_decimal_decimalN(left: Decimal, right: Option<Decimal>) -> Option<Decimal> {
+    let right = right?;
+    Some(div_decimal_decimal(left, right))
+}
+
+pub fn div_decimalN_decimalN(left: Option<Decimal>, right: Option<Decimal>) -> Option<Decimal> {
+    let left = left?;
+    let right = right?;
+    Some(div_decimal_decimal(left, right))
+}
 
 pub fn plus_u_u(left: usize, right: usize) -> usize {
     left + right


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes (updates the docs)

Partially Fixes: #1186 
Fixes: #1243 

This PR fixes the run time implementation by using the `checked` version of the arithmetic operation. However, the Calcite optimized code still overflows. 