### PR TITLE
pipeline-manager: add PUT endpoints for Programs, Pipelines, and Connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- SQL: Changed the semantics of integer arithmetic to match SQL standard ([#1247](https://github.com/feldera/feldera/pull/1247))
+
+### Added
+-  pipeline-manager: add PUT endpoints for Programs, Pipelines, and Connectors (#1248)
 
 ### Fixed
 - pipeline-manager: fix a resource usage problem with http streaming under high load
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebConsole: UI sends HTTP request in an infinite loop (#1085)
 
 ### Changed
+- SQL: Changed the semantics of integer arithmetic to match SQL standard ([#1247](https://github.com/feldera/feldera/pull/1247))
 - pipeline-manager: use names instead of IDs in API endpoints (#1214)
 - WebConsole: use names instead of IDs in API endpoints (#1214)
 

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -116,10 +116,12 @@ request is rejected."
         program::get_program,
         program::new_program,
         program::update_program,
+        program::create_or_replace_program,
         program::compile_program,
         program::delete_program,
         pipeline::new_pipeline,
         pipeline::update_pipeline,
+        pipeline::create_or_replace_pipeline,
         pipeline::list_pipelines,
         pipeline::pipeline_stats,
         pipeline::get_pipeline,
@@ -132,6 +134,7 @@ request is rejected."
         connector::get_connector,
         connector::new_connector,
         connector::update_connector,
+        connector::create_or_replace_connector,
         connector::delete_connector,
         service::list_services,
         service::get_service,
@@ -214,15 +217,21 @@ request is rejected."
         program::NewProgramResponse,
         program::UpdateProgramRequest,
         program::UpdateProgramResponse,
+        program::CreateOrReplaceProgramRequest,
+        program::CreateOrReplaceProgramResponse,
         program::CompileProgramRequest,
         pipeline::NewPipelineRequest,
         pipeline::NewPipelineResponse,
         pipeline::UpdatePipelineRequest,
         pipeline::UpdatePipelineResponse,
+        pipeline::CreateOrReplacePipelineRequest,
+        pipeline::CreateOrReplacePipelineResponse,
         connector::NewConnectorRequest,
         connector::NewConnectorResponse,
         connector::UpdateConnectorRequest,
         connector::UpdateConnectorResponse,
+        connector::CreateOrReplaceConnectorRequest,
+        connector::CreateOrReplaceConnectorResponse,
         service::NewServiceRequest,
         service::NewServiceResponse,
         service::UpdateServiceRequest,
@@ -267,10 +276,12 @@ fn api_scope() -> Scope {
         .service(program::get_program)
         .service(program::new_program)
         .service(program::update_program)
+        .service(program::create_or_replace_program)
         .service(program::compile_program)
         .service(program::delete_program)
         .service(pipeline::new_pipeline)
         .service(pipeline::update_pipeline)
+        .service(pipeline::create_or_replace_pipeline)
         .service(pipeline::list_pipelines)
         .service(pipeline::pipeline_stats)
         .service(pipeline::get_pipeline)
@@ -283,6 +294,7 @@ fn api_scope() -> Scope {
         .service(connector::get_connector)
         .service(connector::new_connector)
         .service(connector::update_connector)
+        .service(connector::create_or_replace_connector)
         .service(connector::delete_connector)
         .service(service::list_services)
         .service(service::get_service)

--- a/crates/pipeline_manager/src/api/program.rs
+++ b/crates/pipeline_manager/src/api/program.rs
@@ -62,7 +62,7 @@ pub(crate) struct NewProgramRequest {
     #[schema(example = "Example description")]
     description: String,
     /// SQL code of the program.
-    #[schema(example = "CREATE TABLE Example(name varchar);")]
+    #[schema(example = "CREATE TABLE example(name VARCHAR);")]
     code: String,
 }
 

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -1077,7 +1077,14 @@ mod test {
         let tenant_id = TenantRecord::default().id;
         db.lock()
             .await
-            .new_program(tenant_id, Uuid::now_v7(), pname, "program desc", "ignored")
+            .new_program(
+                tenant_id,
+                Uuid::now_v7(),
+                pname,
+                "program desc",
+                "ignored",
+                None,
+            )
             .await
             .unwrap()
     }

--- a/crates/pipeline_manager/src/db/program.rs
+++ b/crates/pipeline_manager/src/db/program.rs
@@ -243,18 +243,16 @@ pub(crate) async fn new_program(
     program_name: &str,
     program_description: &str,
     program_code: &str,
+    txn: Option<&Transaction<'_>>,
 ) -> Result<(ProgramId, Version), DBError> {
     debug!("new_program {program_name} {program_description} {program_code}");
-    let manager = db.pool.get().await?;
+    let query = "INSERT INTO program (id, version, tenant_id, name, description, 
+                                      code, schema, status, error, status_since)
+                 VALUES($1, 1, $2, $3, $4, $5, NULL, $6, $7, now());";
     let (status, error) = ProgramStatus::None.to_columns();
-    let stmt = manager
-            .prepare_cached(
-                "INSERT INTO program (id, version, tenant_id, name, description, code, schema, status, error, status_since)
-                        VALUES($1, 1, $2, $3, $4, $5, NULL, $6, $7, now());",
-            )
-            .await?;
-    manager
-        .execute(
+    let row = if let Some(txn) = txn {
+        let stmt = txn.prepare_cached(query).await?;
+        txn.execute(
             &stmt,
             &[
                 &id,
@@ -267,9 +265,26 @@ pub(crate) async fn new_program(
             ],
         )
         .await
-        .map_err(ProjectDB::maybe_unique_violation)
+    } else {
+        let manager = db.pool.get().await?;
+        let stmt = manager.prepare_cached(query).await?;
+        manager
+            .execute(
+                &stmt,
+                &[
+                    &id,
+                    &tenant_id.0,
+                    &program_name,
+                    &program_description,
+                    &program_code,
+                    &status,
+                    &error,
+                ],
+            )
+            .await
+    };
+    row.map_err(ProjectDB::maybe_unique_violation)
         .map_err(|e| ProjectDB::maybe_tenant_id_foreign_key_constraint_err(e, tenant_id, None))?;
-
     Ok((ProgramId(id), Version(1)))
 }
 
@@ -277,7 +292,6 @@ pub(crate) async fn new_program(
 /// also accepts an optional version to do guarded updates to the code.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_program(
-    db: &ProjectDB,
     tenant_id: TenantId,
     program_id: ProgramId,
     program_name: &Option<String>,
@@ -286,12 +300,11 @@ pub(crate) async fn update_program(
     status: &Option<ProgramStatus>,
     schema: &Option<ProgramSchema>,
     guard: Option<Version>,
+    txn: &Transaction<'_>,
 ) -> Result<Version, DBError> {
-    let mut manager = db.pool.get().await?;
     // Only increment `version` if new code actually differs from the
     // current version. Only apply a change if the version matched the
     // guard.
-    let txn = manager.transaction().await?;
     let get_version = txn
         .prepare_cached("SELECT version, code FROM program WHERE tenant_id = $1 AND id = $2 ")
         .await?;
@@ -370,17 +383,13 @@ pub(crate) async fn update_program(
         .await
         .map_err(ProjectDB::maybe_unique_violation)?;
     if let Some(row) = row {
-        txn.commit().await?;
         Ok(Version(row.get(0)))
     } else {
-        txn.rollback().await?;
         Err(DBError::UnknownProgram { program_id })
     }
 }
 
 /// Retrieve program descriptor.
-///
-/// Returns `None` if `program_id` is not found in the database.
 pub(crate) async fn get_program_by_id(
     db: &ProjectDB,
     tenant_id: TenantId,

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -43,6 +43,7 @@ pub(crate) trait Storage {
             &None,
             &Some(schema),
             None,
+            None,
         )
         .await?;
         Ok(())
@@ -70,6 +71,7 @@ pub(crate) trait Storage {
             &Some(status),
             &None,
             Some(expected_version),
+            None,
         )
         .await?;
         Ok(())
@@ -83,6 +85,7 @@ pub(crate) trait Storage {
         program_name: &str,
         program_description: &str,
         program_code: &str,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<(ProgramId, Version), DBError>;
 
     /// Update program name, description and, optionally, code.
@@ -97,6 +100,7 @@ pub(crate) trait Storage {
         status: &Option<ProgramStatus>,
         schema: &Option<ProgramSchema>,
         guard: Option<Version>,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<Version, DBError>;
 
     /// Retrieve program descriptor.
@@ -164,6 +168,7 @@ pub(crate) trait Storage {
         pipeline_description: &str,
         config: &RuntimeConfig,
         connectors: &Option<Vec<AttachedConnector>>,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<(PipelineId, Version), DBError>;
 
     /// Update existing config.
@@ -179,6 +184,7 @@ pub(crate) trait Storage {
         pipeline_description: &str,
         config: &Option<RuntimeConfig>,
         connectors: &Option<Vec<AttachedConnector>>,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<Version, DBError>;
 
     /// Get input/output status for an attached connector.
@@ -260,6 +266,7 @@ pub(crate) trait Storage {
         name: &str,
         description: &str,
         config: &ConnectorConfig,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<ConnectorId, DBError>;
 
     /// Retrieve connectors list from the DB.
@@ -277,6 +284,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         name: &str,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<ConnectorDescr, DBError>;
 
     /// Update existing connector config.
@@ -289,6 +297,7 @@ pub(crate) trait Storage {
         connector_name: &str,
         description: &str,
         config: &Option<ConnectorConfig>,
+        txn: Option<&Transaction<'_>>,
     ) -> Result<(), DBError>;
 
     /// Delete connector from the database.

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -190,6 +190,7 @@ async fn program_creation() {
             "test1",
             "program desc",
             "ignored",
+            None,
         )
         .await
         .unwrap();
@@ -248,6 +249,7 @@ async fn duplicate_program() {
             "test1",
             "program desc",
             "ignored",
+            None,
         )
         .await;
     let res = handle
@@ -258,6 +260,7 @@ async fn duplicate_program() {
             "test1",
             "program desc",
             "ignored",
+            None,
         )
         .await
         .expect_err("Expecting unique violation");
@@ -277,6 +280,7 @@ async fn program_code() {
             "test1",
             "program desc",
             "create table t1(c1 integer);",
+            None,
         )
         .await
         .unwrap();
@@ -305,6 +309,7 @@ async fn update_program() {
             "test1",
             "program desc",
             "create table t1(c1 integer);",
+            None,
         )
         .await
         .unwrap();
@@ -318,6 +323,7 @@ async fn update_program() {
             &Some("create table t2(c2 integer);".to_string()),
             &None,
             &None,
+            None,
             None,
         )
         .await;
@@ -341,6 +347,7 @@ async fn update_program() {
             &None,
             &None,
             None,
+            None,
         )
         .await;
     let results = handle.db.list_programs(tenant_id, false).await.unwrap();
@@ -362,6 +369,7 @@ async fn program_queries() {
             "test1",
             "program desc",
             "create table t1(c1 integer);",
+            None,
         )
         .await
         .unwrap();
@@ -396,6 +404,7 @@ async fn program_config() {
             "a",
             "b",
             &test_connector_config(),
+            None,
         )
         .await
         .unwrap();
@@ -416,6 +425,7 @@ async fn program_config() {
             "2",
             &rc,
             &Some(vec![ac.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -444,6 +454,7 @@ async fn project_pending() {
             "test1",
             "project desc",
             "ignored",
+            None,
         )
         .await
         .unwrap();
@@ -455,6 +466,7 @@ async fn project_pending() {
             "test2",
             "project desc",
             "ignored",
+            None,
         )
         .await
         .unwrap();
@@ -489,6 +501,7 @@ async fn update_status() {
             "test1",
             "program desc",
             "create table t1(c1 integer);",
+            None,
         )
         .await
         .unwrap();
@@ -528,6 +541,7 @@ async fn duplicate_attached_conn_name() {
             "a",
             "b",
             &test_connector_config(),
+            None,
         )
         .await
         .unwrap();
@@ -554,6 +568,7 @@ async fn duplicate_attached_conn_name() {
             "2",
             &rc,
             &Some(vec![ac, ac2]),
+            None,
         )
         .await
         .expect_err("duplicate attached connector name");
@@ -571,6 +586,7 @@ async fn update_conn_name() {
             "a",
             "b",
             &test_connector_config(),
+            None,
         )
         .await
         .unwrap();
@@ -591,12 +607,13 @@ async fn update_conn_name() {
             "2",
             &rc,
             &Some(vec![ac]),
+            None,
         )
         .await
         .unwrap();
     handle
         .db
-        .update_connector(tenant_id, connector_id, "not-a", "b", &None)
+        .update_connector(tenant_id, connector_id, "not-a", "b", &None, None)
         .await
         .unwrap();
     let pipeline = handle
@@ -709,7 +726,7 @@ async fn versioning_no_change_no_connectors() {
 
     let (program_id, _) = handle
         .db
-        .new_program(tenant_id, Uuid::now_v7(), "", "", "")
+        .new_program(tenant_id, Uuid::now_v7(), "", "", "", None)
         .await
         .unwrap();
     handle
@@ -728,6 +745,7 @@ async fn versioning_no_change_no_connectors() {
             "",
             &rc,
             &None,
+            None,
         )
         .await
         .unwrap();
@@ -761,6 +779,7 @@ async fn versioning() {
             "test1",
             "program desc",
             "only schema matters--this isn't compiled",
+            None,
         )
         .await
         .unwrap();
@@ -794,7 +813,7 @@ async fn versioning() {
     };
     let connector_id1: ConnectorId = handle
         .db
-        .new_connector(tenant_id, Uuid::now_v7(), "a", "b", &config1)
+        .new_connector(tenant_id, Uuid::now_v7(), "a", "b", &config1, None)
         .await
         .unwrap();
     let mut ac1 = AttachedConnector {
@@ -805,7 +824,7 @@ async fn versioning() {
     };
     handle
         .db
-        .new_connector(tenant_id, Uuid::now_v7(), "d", "e", &config2)
+        .new_connector(tenant_id, Uuid::now_v7(), "d", "e", &config2, None)
         .await
         .unwrap();
     let mut ac2 = AttachedConnector {
@@ -825,6 +844,7 @@ async fn versioning() {
             "2",
             &rc,
             &Some(vec![ac1.clone(), ac2.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -842,6 +862,7 @@ async fn versioning() {
             &Some("only schema matters--this isn't compiled2".to_string()),
             &None,
             &None,
+            None,
             None,
         )
         .await
@@ -926,6 +947,7 @@ async fn versioning() {
             "2",
             &Some(gp_config.clone()),
             &Some(vec![ac1.clone(), ac2.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -948,6 +970,7 @@ async fn versioning() {
             "2",
             &Some(gp_config.clone()),
             &Some(vec![ac1.clone(), ac2.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -963,7 +986,7 @@ async fn versioning() {
     };
     handle
         .db
-        .update_connector(tenant_id, connector_id1, "a", "b", &Some(config3))
+        .update_connector(tenant_id, connector_id1, "a", "b", &Some(config3), None)
         .await
         .unwrap();
     let r4 = commit_check(&handle, tenant_id, pipeline_id).await;
@@ -981,6 +1004,7 @@ async fn versioning() {
             "2",
             &Some(gp_config.clone()),
             &Some(vec![ac1.clone(), ac2.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -998,6 +1022,7 @@ async fn versioning() {
             "2",
             &Some(gp_config.clone()),
             &Some(vec![ac1.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -1018,6 +1043,7 @@ async fn versioning() {
                 ..gp_config
             }),
             &Some(vec![ac1.clone()]),
+            None,
         )
         .await
         .unwrap();
@@ -1480,19 +1506,19 @@ fn db_impl_behaves_like_model() {
                             StorageAction::NewProgram(tenant_id, id, name, description, code) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response =
-                                    model.new_program(tenant_id, id, &name, &description, &code).await;
+                                    model.new_program(tenant_id, id, &name, &description, &code, None).await;
                                 let impl_response =
-                                    handle.db.new_program(tenant_id, id, &name, &description, &code).await;
+                                    handle.db.new_program(tenant_id, id, &name, &description, &code, None).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::UpdateProgram(tenant_id, program_id, name, description, code, guard) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response = model
-                                    .update_program(tenant_id, program_id, &name, &description, &code, &None, &None, guard)
+                                    .update_program(tenant_id, program_id, &name, &description, &code, &None, &None, guard, None)
                                     .await;
                                 let impl_response = handle
                                     .db
-                                    .update_program(tenant_id, program_id, &name, &description, &code, &None, &None, guard)
+                                    .update_program(tenant_id, program_id, &name, &description, &code, &None, &None, guard, None)
                                     .await;
                                 check_responses(i, model_response, impl_response);
                             }
@@ -1593,19 +1619,19 @@ fn db_impl_behaves_like_model() {
                             StorageAction::NewPipeline(tenant_id, id, program_name, name, description, config, connectors) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response =
-                                    model.new_pipeline(tenant_id, id, &program_name, &name, &description, &config, &connectors.clone()).await;
+                                    model.new_pipeline(tenant_id, id, &program_name, &name, &description, &config, &connectors.clone(), None).await;
                                 let impl_response =
-                                    handle.db.new_pipeline(tenant_id, id, &program_name, &name, &description, &config, &connectors).await;
+                                    handle.db.new_pipeline(tenant_id, id, &program_name, &name, &description, &config, &connectors, None).await;
                                     check_responses(i, model_response, impl_response);
                             }
                             StorageAction::UpdatePipeline(tenant_id, pipeline_id, program_name, name, description, config, connectors) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response = model
-                                    .update_pipeline(tenant_id, pipeline_id, &program_name, &name, &description, &config, &connectors.clone())
+                                    .update_pipeline(tenant_id, pipeline_id, &program_name, &name, &description, &config, &connectors.clone(), None)
                                     .await;
                                 let impl_response = handle
                                     .db
-                                    .update_pipeline(tenant_id, pipeline_id, &program_name, &name, &description, &config, &connectors)
+                                    .update_pipeline(tenant_id, pipeline_id, &program_name, &name, &description, &config, &connectors, None)
                                     .await;
                                 check_responses(i, model_response, impl_response);
                             }
@@ -1638,9 +1664,9 @@ fn db_impl_behaves_like_model() {
                             StorageAction::NewConnector(tenant_id, id, name, description, config) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response =
-                                    model.new_connector(tenant_id, id, &name, &description, &config).await;
+                                    model.new_connector(tenant_id, id, &name, &description, &config, None).await;
                                 let impl_response =
-                                    handle.db.new_connector(tenant_id, id, &name, &description, &config).await;
+                                    handle.db.new_connector(tenant_id, id, &name, &description, &config, None).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::GetConnectorById(tenant_id,connector_id) => {
@@ -1651,16 +1677,16 @@ fn db_impl_behaves_like_model() {
                             }
                             StorageAction::GetConnectorByName(tenant_id,name) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
-                                let model_response = model.get_connector_by_name(tenant_id, &name).await;
-                                let impl_response = handle.db.get_connector_by_name(tenant_id, &name).await;
+                                let model_response = model.get_connector_by_name(tenant_id, &name, None).await;
+                                let impl_response = handle.db.get_connector_by_name(tenant_id, &name, None).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::UpdateConnector(tenant_id,connector_id, name, description, config) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response =
-                                    model.update_connector(tenant_id, connector_id, &name, &description, &config).await;
+                                    model.update_connector(tenant_id, connector_id, &name, &description, &config, None).await;
                                 let impl_response =
-                                    handle.db.update_connector(tenant_id, connector_id, &name, &description, &config).await;
+                                    handle.db.update_connector(tenant_id, connector_id, &name, &description, &config, None).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::DeleteConnector(tenant_id, connector_name) => {
@@ -1808,6 +1834,7 @@ impl Storage for Mutex<DbModel> {
         program_name: &str,
         program_description: &str,
         program_code: &str,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<(super::ProgramId, super::Version)> {
         let mut s = self.lock().await;
         if s.programs.keys().any(|k| k.1 == ProgramId(id)) {
@@ -1854,6 +1881,7 @@ impl Storage for Mutex<DbModel> {
         status: &Option<ProgramStatus>,
         schema: &Option<ProgramSchema>,
         guard: Option<Version>,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<super::Version> {
         let mut s = self.lock().await;
         let (program_descr, _) = s
@@ -2174,6 +2202,7 @@ impl Storage for Mutex<DbModel> {
         config: &RuntimeConfig,
         // TODO: not clear why connectors is an option here
         connectors: &Option<Vec<AttachedConnector>>,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<(super::PipelineId, super::Version)> {
         let mut s = self.lock().await;
         let db_connectors = s.connectors.clone();
@@ -2261,6 +2290,7 @@ impl Storage for Mutex<DbModel> {
         pipeline_description: &str,
         config: &Option<RuntimeConfig>,
         connectors: &Option<Vec<AttachedConnector>>,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<Version> {
         let mut s = self.lock().await;
         let db_connectors = s.connectors.clone();
@@ -2482,6 +2512,7 @@ impl Storage for Mutex<DbModel> {
         name: &str,
         description: &str,
         config: &ConnectorConfig,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<super::ConnectorId> {
         let mut s = self.lock().await;
         if s.connectors.keys().any(|k| k.1 == ConnectorId(id)) {
@@ -2534,6 +2565,7 @@ impl Storage for Mutex<DbModel> {
         &self,
         tenant_id: TenantId,
         name: &str,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<ConnectorDescr> {
         let s = self.lock().await;
         s.connectors
@@ -2553,6 +2585,7 @@ impl Storage for Mutex<DbModel> {
         connector_name: &str,
         description: &str,
         config: &Option<ConnectorConfig>,
+        _txn: Option<&Transaction<'_>>,
     ) -> DBResult<()> {
         let mut s = self.lock().await;
         // `connector_id` needs to exist

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -262,6 +262,7 @@ mod test {
                     &format!("test{i}").to_string(),
                     "program desc",
                     "ignored",
+                    None,
                 )
                 .await
                 .unwrap();
@@ -278,6 +279,7 @@ mod test {
                     "2",
                     &rc,
                     &Some(vec![]),
+                    None,
                 )
                 .await
                 .unwrap();
@@ -309,6 +311,7 @@ mod test {
                     &None,
                     &None,
                     None,
+                    None,
                 )
                 .await;
             let pipeline_name = &format!("{i}");
@@ -323,6 +326,7 @@ mod test {
                     "some new description",
                     &None,
                     &None,
+                    None,
                 )
                 .await;
             let n = rx.recv().await.unwrap();
@@ -373,7 +377,14 @@ mod test {
         let _ = conn
             .lock()
             .await
-            .new_program(tenant_id, program_id, "test0", "program desc", "ignored")
+            .new_program(
+                tenant_id,
+                program_id,
+                "test0",
+                "program desc",
+                "ignored",
+                None,
+            )
             .await
             .unwrap();
         let rc = RuntimeConfig::from_yaml("");
@@ -389,6 +400,7 @@ mod test {
                 "2",
                 &rc,
                 &Some(vec![]),
+                None,
             )
             .await
             .unwrap();

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -726,7 +726,14 @@ mod test {
         let (program_id, version) = conn
             .lock()
             .await
-            .new_program(tenant_id, program_id, "test0", "program desc", "ignored")
+            .new_program(
+                tenant_id,
+                program_id,
+                "test0",
+                "program desc",
+                "ignored",
+                None,
+            )
             .await
             .unwrap();
         let _ = conn
@@ -766,6 +773,7 @@ mod test {
                 "2",
                 &rc,
                 &Some(vec![]),
+                None,
             )
             .await
             .unwrap();

--- a/openapi.json
+++ b/openapi.json
@@ -437,6 +437,77 @@
           }
         ]
       },
+      "put": {
+        "tags": [
+          "Connectors"
+        ],
+        "summary": "Create or replace a connector.",
+        "description": "Create or replace a connector.",
+        "operationId": "create_or_replace_connector",
+        "parameters": [
+          {
+            "name": "connector_name",
+            "in": "path",
+            "description": "Unique connector name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrReplaceProgramRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Connector updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceConnectorResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Connector created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceConnectorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A connector with this name already exists in the database.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "details": null,
+                  "error_code": "DuplicateName",
+                  "message": "An entity with this name already exists"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      },
       "delete": {
         "tags": [
           "Connectors"
@@ -782,6 +853,77 @@
                   },
                   "error_code": "UnknownPipeline",
                   "message": "Unknown pipeline id '2e79afe1-ff4d-44d3-af5f-9397de7746c0'"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Create or replace a pipeline.",
+        "description": "Create or replace a pipeline.",
+        "operationId": "create_or_replace_pipeline",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrReplaceProgramRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Pipeline updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceProgramResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Pipeline created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceProgramResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A pipeline with this name already exists in the database.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "details": null,
+                  "error_code": "DuplicateName",
+                  "message": "An entity with this name already exists"
                 }
               }
             }
@@ -1972,6 +2114,77 @@
           }
         ]
       },
+      "put": {
+        "tags": [
+          "Programs"
+        ],
+        "summary": "Create or replace a program.",
+        "description": "Create or replace a program.",
+        "operationId": "create_or_replace_program",
+        "parameters": [
+          {
+            "name": "program_name",
+            "in": "path",
+            "description": "Unique program name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrReplaceProgramRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Program updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceProgramResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Program created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateOrReplaceProgramResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A program with this name already exists in the database.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "details": null,
+                  "error_code": "DuplicateName",
+                  "message": "An entity with this name already exists"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      },
       "delete": {
         "tags": [
           "Programs"
@@ -2738,6 +2951,118 @@
         "format": "uuid",
         "description": "Unique connector id."
       },
+      "CreateOrReplaceConnectorRequest": {
+        "type": "object",
+        "description": "Request to create or replace a connector",
+        "required": [
+          "description",
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/ConnectorConfig"
+          },
+          "description": {
+            "type": "string",
+            "description": "New connector description."
+          }
+        }
+      },
+      "CreateOrReplaceConnectorResponse": {
+        "type": "object",
+        "description": "Response to a create or replace connector request.",
+        "required": [
+          "connector_id"
+        ],
+        "properties": {
+          "connector_id": {
+            "$ref": "#/components/schemas/ConnectorId"
+          }
+        }
+      },
+      "CreateOrReplacePipelineRequest": {
+        "type": "object",
+        "description": "Request to create or replace an existing pipeline.",
+        "required": [
+          "description",
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/RuntimeConfig"
+          },
+          "connectors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttachedConnector"
+            },
+            "description": "Attached connectors.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Pipeline description."
+          },
+          "program_name": {
+            "type": "string",
+            "description": "Name of the program to create a pipeline for.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateOrReplacePipelineResponse": {
+        "type": "object",
+        "description": "Response to a pipeline create or replace request.",
+        "required": [
+          "pipeline_id",
+          "version"
+        ],
+        "properties": {
+          "pipeline_id": {
+            "$ref": "#/components/schemas/PipelineId"
+          },
+          "version": {
+            "$ref": "#/components/schemas/Version"
+          }
+        }
+      },
+      "CreateOrReplaceProgramRequest": {
+        "type": "object",
+        "description": "Request to create or replace a Feldera program.",
+        "required": [
+          "description",
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "SQL code of the program.",
+            "example": "CREATE TABLE Example(name varchar);"
+          },
+          "description": {
+            "type": "string",
+            "description": "Program description.",
+            "example": "Example description"
+          }
+        }
+      },
+      "CreateOrReplaceProgramResponse": {
+        "type": "object",
+        "description": "Response to a new program request.",
+        "required": [
+          "program_id",
+          "version"
+        ],
+        "properties": {
+          "program_id": {
+            "$ref": "#/components/schemas/ProgramId"
+          },
+          "version": {
+            "$ref": "#/components/schemas/Version"
+          }
+        }
+      },
       "CsvEncoderConfig": {
         "type": "object",
         "properties": {
@@ -3303,7 +3628,7 @@
           "code": {
             "type": "string",
             "description": "SQL code of the program.",
-            "example": "CREATE TABLE Example(name varchar);"
+            "example": "CREATE TABLE example(name VARCHAR);"
           },
           "description": {
             "type": "string",

--- a/python/feldera-api-client/feldera_api_client/api/connectors/create_or_replace_connector.py
+++ b/python/feldera-api-client/feldera_api_client/api/connectors/create_or_replace_connector.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_or_replace_connector_response import CreateOrReplaceConnectorResponse
+from ...models.create_or_replace_program_request import CreateOrReplaceProgramRequest
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    connector_name: str,
+    *,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Dict[str, Any]:
+    pass
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "put",
+        "url": "/v0/connectors/{connector_name}".format(
+            connector_name=connector_name,
+        ),
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = CreateOrReplaceConnectorResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = CreateOrReplaceConnectorResponse.from_dict(response.json())
+
+        return response_201
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    """Create or replace a connector.
+
+     Create or replace a connector.
+
+    Args:
+        connector_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        connector_name=connector_name,
+        json_body=json_body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    """Create or replace a connector.
+
+     Create or replace a connector.
+
+    Args:
+        connector_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceConnectorResponse, ErrorResponse]
+    """
+
+    return sync_detailed(
+        connector_name=connector_name,
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    """Create or replace a connector.
+
+     Create or replace a connector.
+
+    Args:
+        connector_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        connector_name=connector_name,
+        json_body=json_body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceConnectorResponse, ErrorResponse]]:
+    """Create or replace a connector.
+
+     Create or replace a connector.
+
+    Args:
+        connector_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceConnectorResponse, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            connector_name=connector_name,
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/feldera-api-client/feldera_api_client/api/pipelines/create_or_replace_pipeline.py
+++ b/python/feldera-api-client/feldera_api_client/api/pipelines/create_or_replace_pipeline.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_or_replace_program_request import CreateOrReplaceProgramRequest
+from ...models.create_or_replace_program_response import CreateOrReplaceProgramResponse
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pipeline_name: str,
+    *,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Dict[str, Any]:
+    pass
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "put",
+        "url": "/v0/pipelines/{pipeline_name}".format(
+            pipeline_name=pipeline_name,
+        ),
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = CreateOrReplaceProgramResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = CreateOrReplaceProgramResponse.from_dict(response.json())
+
+        return response_201
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pipeline_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a pipeline.
+
+     Create or replace a pipeline.
+
+    Args:
+        pipeline_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_name=pipeline_name,
+        json_body=json_body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pipeline_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a pipeline.
+
+     Create or replace a pipeline.
+
+    Args:
+        pipeline_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceProgramResponse, ErrorResponse]
+    """
+
+    return sync_detailed(
+        pipeline_name=pipeline_name,
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pipeline_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a pipeline.
+
+     Create or replace a pipeline.
+
+    Args:
+        pipeline_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_name=pipeline_name,
+        json_body=json_body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pipeline_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a pipeline.
+
+     Create or replace a pipeline.
+
+    Args:
+        pipeline_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceProgramResponse, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            pipeline_name=pipeline_name,
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/feldera-api-client/feldera_api_client/api/programs/create_or_replace_program.py
+++ b/python/feldera-api-client/feldera_api_client/api/programs/create_or_replace_program.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_or_replace_program_request import CreateOrReplaceProgramRequest
+from ...models.create_or_replace_program_response import CreateOrReplaceProgramResponse
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    program_name: str,
+    *,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Dict[str, Any]:
+    pass
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "put",
+        "url": "/v0/programs/{program_name}".format(
+            program_name=program_name,
+        ),
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = CreateOrReplaceProgramResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = CreateOrReplaceProgramResponse.from_dict(response.json())
+
+        return response_201
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    program_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a program.
+
+     Create or replace a program.
+
+    Args:
+        program_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_name=program_name,
+        json_body=json_body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    program_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a program.
+
+     Create or replace a program.
+
+    Args:
+        program_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceProgramResponse, ErrorResponse]
+    """
+
+    return sync_detailed(
+        program_name=program_name,
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    program_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a program.
+
+     Create or replace a program.
+
+    Args:
+        program_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[CreateOrReplaceProgramResponse, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_name=program_name,
+        json_body=json_body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    program_name: str,
+    *,
+    client: AuthenticatedClient,
+    json_body: CreateOrReplaceProgramRequest,
+) -> Optional[Union[CreateOrReplaceProgramResponse, ErrorResponse]]:
+    """Create or replace a program.
+
+     Create or replace a program.
+
+    Args:
+        program_name (str):
+        json_body (CreateOrReplaceProgramRequest): Request to create or replace a Feldera program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[CreateOrReplaceProgramResponse, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            program_name=program_name,
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/feldera-api-client/feldera_api_client/models/__init__.py
+++ b/python/feldera-api-client/feldera_api_client/models/__init__.py
@@ -11,6 +11,12 @@ from .column_type import ColumnType
 from .compile_program_request import CompileProgramRequest
 from .connector_config import ConnectorConfig
 from .connector_descr import ConnectorDescr
+from .create_or_replace_connector_request import CreateOrReplaceConnectorRequest
+from .create_or_replace_connector_response import CreateOrReplaceConnectorResponse
+from .create_or_replace_pipeline_request import CreateOrReplacePipelineRequest
+from .create_or_replace_pipeline_response import CreateOrReplacePipelineResponse
+from .create_or_replace_program_request import CreateOrReplaceProgramRequest
+from .create_or_replace_program_response import CreateOrReplaceProgramResponse
 from .csv_encoder_config import CsvEncoderConfig
 from .csv_parser_config import CsvParserConfig
 from .egress_mode import EgressMode
@@ -105,6 +111,12 @@ __all__ = (
     "CompileProgramRequest",
     "ConnectorConfig",
     "ConnectorDescr",
+    "CreateOrReplaceConnectorRequest",
+    "CreateOrReplaceConnectorResponse",
+    "CreateOrReplacePipelineRequest",
+    "CreateOrReplacePipelineResponse",
+    "CreateOrReplaceProgramRequest",
+    "CreateOrReplaceProgramResponse",
     "CsvEncoderConfig",
     "CsvParserConfig",
     "EgressMode",

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_connector_request.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_connector_request.py
@@ -1,37 +1,38 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
 
 from attrs import define, field
 
-T = TypeVar("T", bound="NewProgramRequest")
+if TYPE_CHECKING:
+    from ..models.connector_config import ConnectorConfig
+
+
+T = TypeVar("T", bound="CreateOrReplaceConnectorRequest")
 
 
 @define
-class NewProgramRequest:
-    """Request to create a new Feldera program.
+class CreateOrReplaceConnectorRequest:
+    """Request to create or replace a connector
 
     Attributes:
-        code (str): SQL code of the program. Example: CREATE TABLE example(name VARCHAR);.
-        description (str): Program description. Example: Example description.
-        name (str): Program name. Example: Example program.
+        config (ConnectorConfig): A data connector's configuration
+        description (str): New connector description.
     """
 
-    code: str
+    config: "ConnectorConfig"
     description: str
-    name: str
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        code = self.code
+        config = self.config.to_dict()
+
         description = self.description
-        name = self.name
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "code": code,
+                "config": config,
                 "description": description,
-                "name": name,
             }
         )
 
@@ -39,21 +40,20 @@ class NewProgramRequest:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.connector_config import ConnectorConfig
+
         d = src_dict.copy()
-        code = d.pop("code")
+        config = ConnectorConfig.from_dict(d.pop("config"))
 
         description = d.pop("description")
 
-        name = d.pop("name")
-
-        new_program_request = cls(
-            code=code,
+        create_or_replace_connector_request = cls(
+            config=config,
             description=description,
-            name=name,
         )
 
-        new_program_request.additional_properties = d
-        return new_program_request
+        create_or_replace_connector_request.additional_properties = d
+        return create_or_replace_connector_request
 
     @property
     def additional_keys(self) -> List[str]:

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_connector_response.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_connector_response.py
@@ -2,36 +2,28 @@ from typing import Any, Dict, List, Type, TypeVar
 
 from attrs import define, field
 
-T = TypeVar("T", bound="NewProgramRequest")
+T = TypeVar("T", bound="CreateOrReplaceConnectorResponse")
 
 
 @define
-class NewProgramRequest:
-    """Request to create a new Feldera program.
+class CreateOrReplaceConnectorResponse:
+    """Response to a create or replace connector request.
 
     Attributes:
-        code (str): SQL code of the program. Example: CREATE TABLE example(name VARCHAR);.
-        description (str): Program description. Example: Example description.
-        name (str): Program name. Example: Example program.
+        connector_id (str): Unique connector id.
     """
 
-    code: str
-    description: str
-    name: str
+    connector_id: str
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        code = self.code
-        description = self.description
-        name = self.name
+        connector_id = self.connector_id
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "code": code,
-                "description": description,
-                "name": name,
+                "connector_id": connector_id,
             }
         )
 
@@ -40,20 +32,14 @@ class NewProgramRequest:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        code = d.pop("code")
+        connector_id = d.pop("connector_id")
 
-        description = d.pop("description")
-
-        name = d.pop("name")
-
-        new_program_request = cls(
-            code=code,
-            description=description,
-            name=name,
+        create_or_replace_connector_response = cls(
+            connector_id=connector_id,
         )
 
-        new_program_request.additional_properties = d
-        return new_program_request
+        create_or_replace_connector_response.additional_properties = d
+        return create_or_replace_connector_response
 
     @property
     def additional_keys(self) -> List[str]:

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_pipeline_request.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_pipeline_request.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.attached_connector import AttachedConnector
+    from ..models.runtime_config import RuntimeConfig
+
+
+T = TypeVar("T", bound="CreateOrReplacePipelineRequest")
+
+
+@define
+class CreateOrReplacePipelineRequest:
+    """Request to create or replace an existing pipeline.
+
+    Attributes:
+        config (RuntimeConfig): Global pipeline configuration settings. This is the publicly
+            exposed type for users to configure pipelines.
+        description (str): Pipeline description.
+        connectors (Union[Unset, None, List['AttachedConnector']]): Attached connectors.
+        program_name (Union[Unset, None, str]): Name of the program to create a pipeline for.
+    """
+
+    config: "RuntimeConfig"
+    description: str
+    connectors: Union[Unset, None, List["AttachedConnector"]] = UNSET
+    program_name: Union[Unset, None, str] = UNSET
+
+    def to_dict(self) -> Dict[str, Any]:
+        config = self.config.to_dict()
+
+        description = self.description
+        connectors: Union[Unset, None, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.connectors, Unset):
+            if self.connectors is None:
+                connectors = None
+            else:
+                connectors = []
+                for connectors_item_data in self.connectors:
+                    connectors_item = connectors_item_data.to_dict()
+
+                    connectors.append(connectors_item)
+
+        program_name = self.program_name
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(
+            {
+                "config": config,
+                "description": description,
+            }
+        )
+        if connectors is not UNSET:
+            field_dict["connectors"] = connectors
+        if program_name is not UNSET:
+            field_dict["program_name"] = program_name
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.attached_connector import AttachedConnector
+        from ..models.runtime_config import RuntimeConfig
+
+        d = src_dict.copy()
+        config = RuntimeConfig.from_dict(d.pop("config"))
+
+        description = d.pop("description")
+
+        connectors = []
+        _connectors = d.pop("connectors", UNSET)
+        for connectors_item_data in _connectors or []:
+            connectors_item = AttachedConnector.from_dict(connectors_item_data)
+
+            connectors.append(connectors_item)
+
+        program_name = d.pop("program_name", UNSET)
+
+        create_or_replace_pipeline_request = cls(
+            config=config,
+            description=description,
+            connectors=connectors,
+            program_name=program_name,
+        )
+
+        return create_or_replace_pipeline_request

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_pipeline_response.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_pipeline_response.py
@@ -2,36 +2,32 @@ from typing import Any, Dict, List, Type, TypeVar
 
 from attrs import define, field
 
-T = TypeVar("T", bound="NewProgramRequest")
+T = TypeVar("T", bound="CreateOrReplacePipelineResponse")
 
 
 @define
-class NewProgramRequest:
-    """Request to create a new Feldera program.
+class CreateOrReplacePipelineResponse:
+    """Response to a pipeline create or replace request.
 
     Attributes:
-        code (str): SQL code of the program. Example: CREATE TABLE example(name VARCHAR);.
-        description (str): Program description. Example: Example description.
-        name (str): Program name. Example: Example program.
+        pipeline_id (str): Unique pipeline id.
+        version (int): Version number.
     """
 
-    code: str
-    description: str
-    name: str
+    pipeline_id: str
+    version: int
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        code = self.code
-        description = self.description
-        name = self.name
+        pipeline_id = self.pipeline_id
+        version = self.version
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "code": code,
-                "description": description,
-                "name": name,
+                "pipeline_id": pipeline_id,
+                "version": version,
             }
         )
 
@@ -40,20 +36,17 @@ class NewProgramRequest:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        code = d.pop("code")
+        pipeline_id = d.pop("pipeline_id")
 
-        description = d.pop("description")
+        version = d.pop("version")
 
-        name = d.pop("name")
-
-        new_program_request = cls(
-            code=code,
-            description=description,
-            name=name,
+        create_or_replace_pipeline_response = cls(
+            pipeline_id=pipeline_id,
+            version=version,
         )
 
-        new_program_request.additional_properties = d
-        return new_program_request
+        create_or_replace_pipeline_response.additional_properties = d
+        return create_or_replace_pipeline_response
 
     @property
     def additional_keys(self) -> List[str]:

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_program_request.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_program_request.py
@@ -2,28 +2,25 @@ from typing import Any, Dict, List, Type, TypeVar
 
 from attrs import define, field
 
-T = TypeVar("T", bound="NewProgramRequest")
+T = TypeVar("T", bound="CreateOrReplaceProgramRequest")
 
 
 @define
-class NewProgramRequest:
-    """Request to create a new Feldera program.
+class CreateOrReplaceProgramRequest:
+    """Request to create or replace a Feldera program.
 
     Attributes:
-        code (str): SQL code of the program. Example: CREATE TABLE example(name VARCHAR);.
+        code (str): SQL code of the program. Example: CREATE TABLE Example(name varchar);.
         description (str): Program description. Example: Example description.
-        name (str): Program name. Example: Example program.
     """
 
     code: str
     description: str
-    name: str
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         code = self.code
         description = self.description
-        name = self.name
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -31,7 +28,6 @@ class NewProgramRequest:
             {
                 "code": code,
                 "description": description,
-                "name": name,
             }
         )
 
@@ -44,16 +40,13 @@ class NewProgramRequest:
 
         description = d.pop("description")
 
-        name = d.pop("name")
-
-        new_program_request = cls(
+        create_or_replace_program_request = cls(
             code=code,
             description=description,
-            name=name,
         )
 
-        new_program_request.additional_properties = d
-        return new_program_request
+        create_or_replace_program_request.additional_properties = d
+        return create_or_replace_program_request
 
     @property
     def additional_keys(self) -> List[str]:

--- a/python/feldera-api-client/feldera_api_client/models/create_or_replace_program_response.py
+++ b/python/feldera-api-client/feldera_api_client/models/create_or_replace_program_response.py
@@ -2,36 +2,32 @@ from typing import Any, Dict, List, Type, TypeVar
 
 from attrs import define, field
 
-T = TypeVar("T", bound="NewProgramRequest")
+T = TypeVar("T", bound="CreateOrReplaceProgramResponse")
 
 
 @define
-class NewProgramRequest:
-    """Request to create a new Feldera program.
+class CreateOrReplaceProgramResponse:
+    """Response to a new program request.
 
     Attributes:
-        code (str): SQL code of the program. Example: CREATE TABLE example(name VARCHAR);.
-        description (str): Program description. Example: Example description.
-        name (str): Program name. Example: Example program.
+        program_id (str): Unique program id.
+        version (int): Version number.
     """
 
-    code: str
-    description: str
-    name: str
+    program_id: str
+    version: int
     additional_properties: Dict[str, Any] = field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        code = self.code
-        description = self.description
-        name = self.name
+        program_id = self.program_id
+        version = self.version
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "code": code,
-                "description": description,
-                "name": name,
+                "program_id": program_id,
+                "version": version,
             }
         )
 
@@ -40,20 +36,17 @@ class NewProgramRequest:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        code = d.pop("code")
+        program_id = d.pop("program_id")
 
-        description = d.pop("description")
+        version = d.pop("version")
 
-        name = d.pop("name")
-
-        new_program_request = cls(
-            code=code,
-            description=description,
-            name=name,
+        create_or_replace_program_response = cls(
+            program_id=program_id,
+            version=version,
         )
 
-        new_program_request.additional_properties = d
-        return new_program_request
+        create_or_replace_program_response.additional_properties = d
+        return create_or_replace_program_response
 
     @property
     def additional_keys(self) -> List[str]:


### PR DESCRIPTION
- pipeline-manager: add PUT endpoints to create-or-replace programs, pipelines and connectors
- pipeline-manager: run create_or_replace_program() within a transaction
- pipeline-manager: run create_or_replace_connector() within a transaction
- pipeline-manager: run create_or_replace_pipeline() within a transaction

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
