### PR TITLE
Improved profiling API.

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -305,7 +305,7 @@ impl WorkerThread {
                 // Use a very short prefix because Linux truncates thread names
                 // after 15 bytes.
                 "dkw-{}",
-                config.data_topics.get(0).unwrap_or(&"".into())
+                config.data_topics.first().unwrap_or(&"".into())
             ))
             .spawn(move || {
                 if let Err(error) = worker_thread.run() {

--- a/crates/adapters/src/transport/kafka/ft/mod.rs
+++ b/crates/adapters/src/transport/kafka/ft/mod.rs
@@ -438,7 +438,7 @@ fn count_partitions_in_topic<C: ConsumerContext>(
     let metadata = consumer
         .fetch_metadata(Some(topic), Duration::from_secs(10))
         .with_context(|| format!("Failed to read metadata for topic {topic}"))?;
-    let Some(metadata_topic) = metadata.topics().get(0) else {
+    let Some(metadata_topic) = metadata.topics().first() else {
         // Should not happen: if `topic` doesn't exist, the server should
         // tell us that.
         bail!("Kafka server returned no results for {topic}")

--- a/crates/dbsp/examples/orgchart.rs
+++ b/crates/dbsp/examples/orgchart.rs
@@ -120,7 +120,29 @@ fn main() -> Result<()> {
         dbsp.step().unwrap();
         println!("Changes from adjusting {employee}'s manager:");
         print_output(&output);
+
+        let profile = dbsp.retrieve_profile().unwrap();
+        println!("total used bytes: {}", profile.total_used_bytes().unwrap());
+        println!(
+            "total allocated bytes: {}",
+            profile.total_allocated_bytes().unwrap()
+        );
+        println!(
+            "total shared bytes: {}",
+            profile.total_shared_bytes().unwrap()
+        );
+        println!(
+            "num table entries: {}",
+            profile.total_relation_size().unwrap()
+        );
     }
+
+    let profile = dbsp.retrieve_profile().unwrap();
+
+    println!(
+        "used bytes profile: {:?}",
+        profile.used_bytes_profile().unwrap()
+    );
 
     dbsp.kill().unwrap();
 

--- a/crates/dbsp/src/circuit/metadata.rs
+++ b/crates/dbsp/src/circuit/metadata.rs
@@ -7,6 +7,26 @@ use std::{
     time::Duration,
 };
 
+/// Attribute that represents the total number of bytes used by a stateful
+/// operator. This includes bytes used to store the actual state, but not the
+/// excess pre-allocated capacity available inside operator's internal data
+/// structures (see [`ALLOCATED_BYTES_LABEL`]).
+pub const USED_BYTES_LABEL: &str = "used bytes";
+
+/// Attribute that represents the total number of bytes allocated by a stateful
+/// operator. This value can be larger than the number of bytes used by the
+/// operator since it includes excess pre-allocated capacity inside operator's
+/// internal data structures (see [`USED_BYTES_LABEL`]).
+pub const ALLOCATED_BYTES_LABEL: &str = "allocated bytes";
+
+/// Attribute that represents the number of shared bytes used by a stateful
+/// operator, i.e., bytes that are shared behind things like `Arc` or `Rc`.
+pub const SHARED_BYTES_LABEL: &str = "shared bytes";
+
+/// Attribute that represents the number of entries stored by a stateful
+/// operator, e.g., the number of entries in a trace.
+pub const NUM_ENTRIES_LABEL: &str = "total size";
+
 /// An operator's location within the source program
 pub type OperatorLocation = Option<&'static Location<'static>>;
 
@@ -32,6 +52,13 @@ impl OperatorMeta {
         Self {
             entries: Vec::with_capacity(capacity),
         }
+    }
+
+    pub fn get(&self, attribute: &str) -> Option<MetaItem> {
+        self.entries
+            .iter()
+            .find(|(label, _item)| label == attribute)
+            .map(|(_label, item)| item.clone())
     }
 }
 

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -1,5 +1,6 @@
 //! Distinct operator.
 
+use crate::circuit::metadata::{SHARED_BYTES_LABEL, USED_BYTES_LABEL};
 use crate::{
     algebra::{AddByRef, HasOne, HasZero, IndexedZSet, Lattice, PartialOrder, Present, ZRingValue},
     circuit::{
@@ -559,9 +560,9 @@ where
 
         meta.extend(metadata! {
             "total updates" => MetaItem::bytes(size),
-            "used bytes" => MetaItem::bytes(bytes.used_bytes()),
+            USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
             "allocations" => bytes.distinct_allocations(),
-            "shared bytes" => MetaItem::bytes(bytes.shared_bytes()),
+            SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
     }
 

--- a/crates/dbsp/src/operator/join.rs
+++ b/crates/dbsp/src/operator/join.rs
@@ -1,5 +1,6 @@
 //! Relational join operator.
 
+use crate::circuit::metadata::{NUM_ENTRIES_LABEL, SHARED_BYTES_LABEL, USED_BYTES_LABEL};
 use crate::{
     algebra::{IndexedZSet, Lattice, MulByRef, PartialOrder, ZRingValue, ZSet},
     circuit::{
@@ -699,11 +700,11 @@ where
         }
 
         meta.extend(metadata! {
-            "total size" => total_size,
+            NUM_ENTRIES_LABEL => total_size,
             "batch sizes" => batch_sizes,
-            "used bytes" => MetaItem::bytes(bytes.used_bytes()),
+            USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
             "allocations" => bytes.distinct_allocations(),
-            "shared bytes" => MetaItem::bytes(bytes.shared_bytes()),
+            SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
             "left inputs" => self.stats.lhs_tuples,
             "right inputs" => self.stats.rhs_tuples,
             "computed outputs" => self.stats.output_tuples,

--- a/crates/dbsp/src/operator/trace.rs
+++ b/crates/dbsp/src/operator/trace.rs
@@ -1,3 +1,6 @@
+use crate::circuit::metadata::{
+    ALLOCATED_BYTES_LABEL, NUM_ENTRIES_LABEL, SHARED_BYTES_LABEL, USED_BYTES_LABEL,
+};
 use crate::{
     circuit::{
         metadata::{MetaItem, OperatorMeta},
@@ -830,11 +833,11 @@ where
             .unwrap_or_default();
 
         meta.extend(metadata! {
-            "total size" => total_size,
-            "allocated bytes" => MetaItem::bytes(bytes.total_bytes()),
-            "used bytes" => MetaItem::bytes(bytes.used_bytes()),
+            NUM_ENTRIES_LABEL => total_size,
+            ALLOCATED_BYTES_LABEL => MetaItem::bytes(bytes.total_bytes()),
+            USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
             "allocations" => bytes.distinct_allocations(),
-            "shared bytes" => MetaItem::bytes(bytes.shared_bytes()),
+            SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
     }
 

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -1,5 +1,8 @@
 //! z^-1 operator delays its input by one timestamp.
 
+use crate::circuit::metadata::{
+    ALLOCATED_BYTES_LABEL, NUM_ENTRIES_LABEL, SHARED_BYTES_LABEL, USED_BYTES_LABEL,
+};
 use crate::{
     algebra::HasZero,
     circuit::{
@@ -361,12 +364,12 @@ where
         };
 
         meta.extend(metadata! {
-            "total size" => total_size,
+            NUM_ENTRIES_LABEL => total_size,
             "batch sizes" => MetaItem::Array(batch_sizes),
-            "allocated bytes" => MetaItem::bytes(total_bytes.total_bytes()),
-            "used bytes" => MetaItem::bytes(total_bytes.used_bytes()),
+            ALLOCATED_BYTES_LABEL => MetaItem::bytes(total_bytes.total_bytes()),
+            USED_BYTES_LABEL => MetaItem::bytes(total_bytes.used_bytes()),
             "allocations" => total_bytes.distinct_allocations(),
-            "shared bytes" => MetaItem::bytes(total_bytes.shared_bytes()),
+            SHARED_BYTES_LABEL => MetaItem::bytes(total_bytes.shared_bytes()),
         });
     }
 

--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -9,9 +9,13 @@ use crate::{
     monitor::TraceMonitor,
     RootCircuit,
 };
+use size_of::HumanBytes;
 use std::{borrow::Cow, collections::HashMap, fmt::Write};
 
 mod cpu;
+use crate::circuit::metadata::{
+    ALLOCATED_BYTES_LABEL, NUM_ENTRIES_LABEL, SHARED_BYTES_LABEL, USED_BYTES_LABEL,
+};
 pub use cpu::CPUProfiler;
 
 /// Rudimentary circuit profiler.
@@ -24,6 +28,294 @@ pub struct Profiler {
     circuit: RootCircuit,
 }
 
+/// Runtime profile of an individual DBSP worker thread.
+#[derive(Clone, Default)]
+pub struct WorkerProfile {
+    metadata: HashMap<GlobalNodeId, OperatorMeta>,
+}
+
+impl WorkerProfile {
+    fn new(metadata: HashMap<GlobalNodeId, OperatorMeta>) -> Self {
+        Self { metadata }
+    }
+
+    /// Returns the profile for a specific attribute.
+    ///
+    /// The returned hashmap contains id's of nodes that have the specified
+    /// attribute along with the value of the attribute.
+    pub fn attribute_profile(&self, attr: &str) -> HashMap<GlobalNodeId, MetaItem> {
+        let mut result = HashMap::new();
+
+        for (id, meta) in self.metadata.iter() {
+            if let Some(item) = meta.get(attr) {
+                result.insert(id.clone(), item);
+            }
+        }
+
+        result
+    }
+
+    /// Returns the profile for a specific attribute of type
+    /// [`MetaItem::Bytes`].
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Bytes`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_profile_as_bytes(
+        &self,
+        attr: &str,
+    ) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        let mut result = HashMap::new();
+
+        for (id, meta) in self.attribute_profile(attr).into_iter() {
+            if let MetaItem::Bytes(bytes) = meta {
+                result.insert(id, bytes);
+            } else {
+                return Err(meta);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Returns the sum of values of an attribute of type [`MetaItem::Bytes`]
+    /// across all nodes.
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Bytes`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_total_as_bytes(&self, attr: &str) -> Result<HumanBytes, MetaItem> {
+        Ok(HumanBytes::new(
+            self.attribute_profile_as_bytes(attr)?
+                .into_iter()
+                .fold(0u64, |acc, (_, item)| acc + item.bytes),
+        ))
+    }
+
+    /// Returns the profile for a specific attribute of type [`MetaItem::Int`].
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Int`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_profile_as_int(
+        &self,
+        attr: &str,
+    ) -> Result<HashMap<GlobalNodeId, usize>, MetaItem> {
+        let mut result = HashMap::new();
+
+        for (id, meta) in self.attribute_profile(attr).into_iter() {
+            if let MetaItem::Int(val) = meta {
+                result.insert(id, val);
+            } else {
+                return Err(meta);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Returns the sum of values of an attribute of type [`MetaItem::Int`]
+    /// across all nodes.
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Int`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_total_as_int(&self, attr: &str) -> Result<usize, MetaItem> {
+        Ok(self
+            .attribute_profile_as_int(attr)?
+            .into_iter()
+            .fold(0usize, |acc, (_, item)| acc + item))
+    }
+
+    /// Returns the number of entries stored in each stateful operator.
+    pub fn relation_size_profile(&self) -> Result<HashMap<GlobalNodeId, usize>, MetaItem> {
+        self.attribute_profile_as_int(NUM_ENTRIES_LABEL)
+    }
+
+    /// Returns the total number of entries across all stateful operators.
+    pub fn total_relation_size(&self) -> Result<usize, MetaItem> {
+        self.attribute_total_as_int(NUM_ENTRIES_LABEL)
+    }
+
+    /// Returns the number of used bytes for each stateful operator.
+    pub fn used_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(USED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of bytes used by all stateful operators.
+    pub fn total_used_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(USED_BYTES_LABEL)
+    }
+
+    /// Returns the number of allocated bytes for each stateful operator.
+    pub fn allocated_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(ALLOCATED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of allocated bytes across all stateful
+    /// operators.
+    pub fn total_allocated_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(ALLOCATED_BYTES_LABEL)
+    }
+
+    /// Returns the number of shared bytes for each stateful operator.
+    pub fn shared_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(SHARED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of shared bytes across all stateful operators.
+    pub fn total_shared_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(SHARED_BYTES_LABEL)
+    }
+}
+
+/// Runtime profiles collected from all DBSP worker threads.
+pub struct DbspProfile {
+    pub worker_profiles: Vec<WorkerProfile>,
+}
+
+impl crate::profile::DbspProfile {
+    pub fn new(worker_profiles: Vec<WorkerProfile>) -> Self {
+        Self { worker_profiles }
+    }
+
+    /// Compute aggregate profile for a specific attribute across all workers.
+    ///
+    /// # Arguments
+    ///
+    /// - `attr` - attribute name
+    /// - `default` - default value of the attribute
+    /// - `combine` - combines a value of the attribute with a new value
+    ///   retrieved from a `MetaItem`. Fails if the `MetaItem` has incorrect
+    ///   type for the attribute.
+    pub fn attribute_profile<T, DF, CF>(
+        &self,
+        attr: &str,
+        default: DF,
+        combine: CF,
+    ) -> Result<HashMap<GlobalNodeId, T>, MetaItem>
+    where
+        DF: Fn() -> T,
+        CF: Fn(&T, &MetaItem) -> Result<T, MetaItem>,
+    {
+        let mut result = HashMap::new();
+
+        for profile in self.worker_profiles.iter() {
+            let new = profile.attribute_profile(attr);
+            for (id, item) in new.into_iter() {
+                let entry = result.entry(id).or_insert_with(&default);
+                *entry = combine(entry, &item)?;
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Compute aggregate profile of an attribute of type [`MetaItem::Bytes`] by
+    /// summing up the values of the attribute across all workers.
+    pub fn attribute_profile_as_bytes(
+        &self,
+        attr: &str,
+    ) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile(
+            attr,
+            || HumanBytes::new(0),
+            |bytes, item| match item {
+                MetaItem::Bytes(new_bytes) => Ok(HumanBytes::new(bytes.bytes + new_bytes.bytes)),
+                _ => Err(item.clone()),
+            },
+        )
+    }
+
+    /// Returns the sum of values of an attribute of type [`MetaItem::Bytes`]
+    /// across all nodes and all worker threads.
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Bytes`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_total_as_bytes(&self, attr: &str) -> Result<HumanBytes, MetaItem> {
+        let mut acc = 0;
+
+        for profile in self.worker_profiles.iter() {
+            acc += profile.attribute_total_as_bytes(attr)?.bytes;
+        }
+
+        Ok(HumanBytes::new(acc))
+    }
+
+    /// Compute aggregate profile of an attribute of type [`MetaItem::Int`] by
+    /// summing up the values of the attribute across all workers.
+    pub fn attribute_profile_as_int(
+        &self,
+        attr: &str,
+    ) -> Result<HashMap<GlobalNodeId, usize>, MetaItem> {
+        self.attribute_profile(
+            attr,
+            || 0,
+            |val, item| match item {
+                MetaItem::Int(new_val) => Ok(val + new_val),
+                _ => Err(item.clone()),
+            },
+        )
+    }
+
+    /// Returns the sum of values of an attribute of type [`MetaItem::Int`]
+    /// across all nodes and all worker threads.
+    ///
+    /// Fails if the profile contains an attribute with the specified name and a
+    /// type that is different from [`MetaItem::Int`].  On error, returns
+    /// the value of the attribute that caused the failure.
+    pub fn attribute_total_as_int(&self, attr: &str) -> Result<usize, MetaItem> {
+        let mut acc = 0usize;
+
+        for profile in self.worker_profiles.iter() {
+            acc += profile.attribute_total_as_int(attr)?;
+        }
+
+        Ok(acc)
+    }
+
+    /// Returns the number of table entries stored in each stateful operator.
+    pub fn relation_size_profile(&self) -> Result<HashMap<GlobalNodeId, usize>, MetaItem> {
+        self.attribute_profile_as_int(NUM_ENTRIES_LABEL)
+    }
+
+    /// Returns the total number of table entries across all stateful operators.
+    pub fn total_relation_size(&self) -> Result<usize, MetaItem> {
+        self.attribute_total_as_int(NUM_ENTRIES_LABEL)
+    }
+
+    /// Returns the number of used bytes for each stateful operator.
+    pub fn used_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(USED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of bytes used by all stateful operators.
+    pub fn total_used_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(USED_BYTES_LABEL)
+    }
+
+    /// Returns the number of allocated bytes for each stateful operator.
+    pub fn allocated_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(ALLOCATED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of allocated bytes across all stateful
+    /// operators.
+    pub fn total_allocated_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(ALLOCATED_BYTES_LABEL)
+    }
+
+    /// Returns the number of shared bytes for each stateful operator.
+    pub fn shared_bytes_profile(&self) -> Result<HashMap<GlobalNodeId, HumanBytes>, MetaItem> {
+        self.attribute_profile_as_bytes(SHARED_BYTES_LABEL)
+    }
+
+    /// Returns the total number of shared bytes across all stateful operators.
+    pub fn total_shared_bytes(&self) -> Result<HumanBytes, MetaItem> {
+        self.attribute_total_as_bytes(SHARED_BYTES_LABEL)
+    }
+}
+
+// Public profiler API
 impl Profiler {
     /// Create profiler; attach it to `circuit`.
     ///
@@ -46,8 +338,7 @@ impl Profiler {
         self.cpu_profiler.attach(&self.circuit, "cpu_profiler");
     }
 
-    /// Dump profile in graphviz format.
-    pub fn dump_profile(&self) -> String {
+    pub fn profile(&self) -> WorkerProfile {
         let mut metadata = HashMap::<GlobalNodeId, OperatorMeta>::new();
 
         // Make sure we add metadata for the root node.
@@ -102,9 +393,16 @@ impl Profiler {
             }
         }
 
+        WorkerProfile::new(metadata)
+    }
+
+    /// Dump profile in graphviz format.
+    pub fn dump_profile(&self) -> String {
+        let profile = self.profile();
+
         let graph = self.monitor.visualize_circuit_annotate(|node_id| {
             let mut output = String::with_capacity(1024);
-            let meta = metadata.get(node_id).cloned().unwrap_or_default();
+            let meta = profile.metadata.get(node_id).cloned().unwrap_or_default();
 
             for (label, item) in meta.iter() {
                 write!(output, "{label}: ").unwrap();

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -247,7 +247,7 @@ impl Storage for ProjectDB {
             .await?;
         let res = manager.query(&stmt, &[]).await?;
 
-        if let Some(row) = res.get(0) {
+        if let Some(row) = res.first() {
             let program_id: ProgramId = ProgramId(row.get(0));
             let version: Version = Version(row.get(1));
             let tenant_id: TenantId = TenantId(row.get(2));


### PR DESCRIPTION
DBSP implements low-level profiling functionality that allows measuring the memory and CPU usage of individual operators.  Previously this functionality was only accessible through the `dump_profile()` API, which dumps per-worker-thread profile to dot files for manual inspection.

This commit adds a richer profiling API, which for example allows tracking the memory usage of a circuit programmatically.  This can be used for example to make sure that the circuit runs with bounded memory.

- Added the `retrive_profile()` method to the `DBSPHandle` API.  The method returns a `DbspProfile` object, which contains a vector of per-worker thread profiles, which can be inspected individually.

- In addition, `DbspProfile` provides methods to compute aggregated profiles of individual attributes, such as total memory used by each stateful operator.

- There is a usage example for the new API in examples/orgchart.rs.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
