### PR TITLE
pipeline-manager: share an awc::Client instance instead of creating one per ingress/egress stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- pipeline-manager: fix a resource usage problem with http streaming under high load
+  ([#1257](https://github.com/feldera/feldera/pull/1257))
+-
 ## [0.7.0] - 2024-01-09
 
 ### Added

--- a/crates/pipeline_manager/src/api/http_io.rs
+++ b/crates/pipeline_manager/src/api/http_io.rs
@@ -82,6 +82,7 @@ use super::{ManagerError, ServerState};
 async fn http_input(
     state: WebData<ServerState>,
     tenant_id: ReqData<TenantId>,
+    client: WebData<awc::Client>,
     req: HttpRequest,
     body: web::Payload,
 ) -> Result<HttpResponse, ManagerError> {
@@ -104,7 +105,14 @@ async fn http_input(
 
     state
         .runner
-        .forward_to_pipeline_as_stream(*tenant_id, pipeline_id, &endpoint, req, body)
+        .forward_to_pipeline_as_stream(
+            *tenant_id,
+            pipeline_id,
+            &endpoint,
+            req,
+            body,
+            client.as_ref(),
+        )
         .await
 }
 
@@ -177,6 +185,7 @@ async fn http_input(
 async fn http_output(
     state: WebData<ServerState>,
     tenant_id: ReqData<TenantId>,
+    client: WebData<awc::Client>,
     req: HttpRequest,
     body: web::Payload,
 ) -> Result<HttpResponse, ManagerError> {
@@ -199,6 +208,13 @@ async fn http_output(
 
     state
         .runner
-        .forward_to_pipeline_as_stream(*tenant_id, pipeline_id, &endpoint, req, body)
+        .forward_to_pipeline_as_stream(
+            *tenant_id,
+            pipeline_id,
+            &endpoint,
+            req,
+            body,
+            client.as_ref(),
+        )
         .await
 }

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -469,6 +469,7 @@ impl RunnerApi {
         endpoint: &str,
         req: HttpRequest,
         body: Payload,
+        client: &awc::Client,
     ) -> Result<HttpResponse, ManagerError> {
         let pipeline_state = self
             .db
@@ -488,8 +489,6 @@ impl RunnerApi {
         // TODO: it might be better to have ?name={}, otherwise we have to
         // restrict name format
         let url = format!("http://{location}/{endpoint}?{}", req.query_string());
-
-        let client = awc::Client::new();
 
         let mut request = client.request(req.method().clone(), url);
 


### PR DESCRIPTION
We've been seeing a repeatable issue with our deployments where demos
generating high HTTP ingress/egress traffic load, eventually hit a 502
bad gateway error in the cloud form factor.

Repeating such a workload against a local instance of the pipeline
manager revealed the issue: we we were creating too many connections
from the pipeline-manager when forwarding HTTP streams, which in turn
led to resource exhaustion. This was because we were creating a new
awc::Client instance per stream to forward HTTP streams to the pipeline.

The awc::Client::new() documentation is clear that we should be
creating at most one instance of the client per thread (and we were
definitely not respecting that).

This PR fixes this issue by sharing one instance of an awc::Client
per actix server.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
