### PR TITLE
dbsp_adapters: Reduce number of HTTP workers in `test_pause` test to 1.

### DIFF
--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -327,6 +327,7 @@ mod test {
                         .wrap(middleware::Logger::default())
                         .service(web::resource("/test.csv").to(response))
                 })
+                .workers(1)
                 .bind(("127.0.0.1", 0))
                 .unwrap();
                 sender.send(server.addrs()[0]).unwrap();


### PR DESCRIPTION
This defaulted to the number of CPU threads, which is way too many for a trivial test.

Thanks to Lalith Suresh for reporting the problem.

Is this a user-visible change (yes/no): no