### PR TITLE
Remove aliases for instances of the `Spine` type.

### DIFF
--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -9,7 +9,7 @@ use crate::{
         Circuit, GlobalNodeId, Scope, Stream, WithClock,
     },
     circuit_cache_key,
-    trace::{ord::OrdValSpine, Batch, BatchReader, Builder, Cursor as TraceCursor, Trace},
+    trace::{spine_fueled::Spine, Batch, BatchReader, Builder, Cursor as TraceCursor, Trace},
     DBTimestamp, OrdIndexedZSet, Timestamp,
 };
 use size_of::SizeOf;
@@ -142,8 +142,13 @@ where
                             circuit.add_binary_operator(
                                 DistinctIncremental::new(circuit.clone()),
                                 &stream,
-                                // TODO use OrdIndexedZSetSpine if `Z::Val = ()`
-                                &stream.trace::<OrdValSpine<Z::Key, Z::Val, <C as WithClock>::Time, Z::R>>(),
+                                &stream.trace::<Spine<
+                                    <<C as WithClock>::Time as Timestamp>::OrdValBatch<
+                                        Z::Key,
+                                        Z::Val,
+                                        Z::R,
+                                    >,
+                                >>(),
                             )
                         }
                         .mark_sharded()

--- a/crates/dbsp/src/trace/ord/mod.rs
+++ b/crates/dbsp/src/trace/ord/mod.rs
@@ -33,16 +33,3 @@ pub use indexed_zset_batch::OrdIndexedZSet;
 pub use key_batch::OrdKeyBatch;
 pub use val_batch::OrdValBatch;
 pub use zset_batch::OrdZSet;
-
-use crate::trace::Spine;
-
-/// A trace implementation using a spine of ordered lists.
-pub type OrdValSpine<K, V, T, R, O = usize> = Spine<OrdValBatch<K, V, T, R, O>>;
-
-/// A trace implementation for empty values using a spine of ordered lists.
-pub type OrdKeySpine<K, T, R, O = usize> = Spine<OrdKeyBatch<K, T, R, O>>;
-
-/// A trace implementation using a [`Spine`] of [`OrdZSet`].
-pub type OrdZSetSpine<K, R> = Spine<OrdZSet<K, R>>;
-
-pub type OrdIndexedZSetSpine<K, V, R, O = usize> = Spine<OrdIndexedZSet<K, V, R, O>>;


### PR DESCRIPTION
There were some type aliases for `Spine` based on various types, but most of them were entirely unused except for one that was used in a single place. This removes all of them to clarify their importance (none).

Is this a user-visible change (yes/no): no