### PR TITLE
dbsp: Add stub `Clone` implementation for `PersistentTraceCursor`.

### DIFF
--- a/crates/dbsp/src/trace/persistent/cursor.rs
+++ b/crates/dbsp/src/trace/persistent/cursor.rs
@@ -109,6 +109,15 @@ where
     }
 }
 
+impl<'s, B> Clone for PersistentTraceCursor<'s, B>
+where
+    B: Batch + 's,
+{
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
 impl<'s, B: Batch> PersistentTraceCursor<'s, B> {
     /// Creates a new [`PersistentTraceCursor`], requires to pass a handle to
     /// the column family of the trace.


### PR DESCRIPTION
Commit 680a3215a7e6 ("dbsp: Make batch cursors clonable.") added a `Clone` bound for cursors but didn't implement it for `PersistentTraceCursor`. This passed normal CI (because it doesn't enable persistence) but failed the benchmark runs.  This fixes the problem.

It's hard to actually clone these cursors because RocksDB doesn't provide a direct way to do it.

Is this a user-visible change (yes/no): no