### PR TITLE
pipeline-manager: explicitly set allowed origins in Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -84,7 +84,7 @@ COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql
 # Run the precompile phase to speed up Rust compilations during deployment
 RUN ./pipeline-manager --bind-address=0.0.0.0 --api-server-working-directory=/working-dir --compiler-working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor --precompile
 ENV BANNER_ADDR localhost
-ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir", "--compiler-working-directory=/working-dir", "--runner-working-directory=/working-dir", "--sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler", "--dbsp-override-path=/database-stream-processor"]
+ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir", "--compiler-working-directory=/working-dir", "--runner-working-directory=/working-dir", "--sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler", "--dbsp-override-path=/database-stream-processor", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080"]
 
 # Standalone api-server
 FROM gcr.io/distroless/cc-debian12 AS api-server

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     tty: true
     image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-0.7.0}
     ports:
+      # If you change the host side of the port mapping here, don't forget to
+      # also add a corresponding --allowed-origins argument to the pipeline
+      # manager command below (e.g., --allowed-origins "http://localhost:xyz").
+      # Otherwise, browsers will complain about CORS errors
       - "8080:8080"
     depends_on:
       db:


### PR DESCRIPTION
Docker compose's virtual networking meddles with the CORS
configuration. This commit explicitly sets the allowed origins
to include http://localhost:8080 and the docs domain
to help our Docker Compose form factor.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
