### PR TITLE
Minor improvements to simplify debugging

### DIFF
--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -186,8 +186,8 @@ pub use circuit_handle::DbspCircuitHandle;
 pub use server::{ErrorResponse, PipelineError};
 
 pub use catalog::{
-    Catalog, CircuitCatalog, DeCollectionHandle, DeCollectionStream, OutputQueryHandles, SerBatch,
-    SerCollectionHandle,
+    Catalog, CircuitCatalog, DeCollectionHandle, DeCollectionStream, OutputQueryHandles,
+    RecordFormat, SerBatch, SerCollectionHandle, SerCursor,
 };
 pub use format::{Encoder, InputFormat, OutputConsumer, OutputFormat, ParseError, Parser};
 

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -9,6 +9,7 @@ use dbsp::{
     utils::Tup2,
     CollectionHandle, DBData, DBWeight, OrdIndexedZSet, RootCircuit, Stream, UpsertHandle, ZSet,
 };
+use std::fmt::Debug;
 
 use super::{DeMapHandle, DeSetHandle, DeZSetHandle, SerCollectionHandleImpl, SqlSerdeConfig};
 
@@ -28,9 +29,10 @@ impl Catalog {
             + SerializeWithContext<SqlSerdeConfig>
             + From<Z::Key>
             + Clone
+            + Debug
             + Send
             + 'static,
-        Z: ZSet + Send + Sync,
+        Z: ZSet + Debug + Send + Sync,
         Z::R: ZRingValue + Into<i64> + Sync,
         Z::Key: Sync + From<D>,
     {
@@ -54,10 +56,11 @@ impl Catalog {
         D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
             + SerializeWithContext<SqlSerdeConfig>
             + From<Z::Key>
+            + Debug
             + Clone
             + Send
             + 'static,
-        Z: ZSet + Send + Sync,
+        Z: ZSet + Debug + Send + Sync,
         Z::R: ZRingValue + Into<i64> + Sync,
         Z::Key: Sync + From<D>,
     {
@@ -97,6 +100,7 @@ impl Catalog {
         VD: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
             + SerializeWithContext<SqlSerdeConfig>
             + From<V>
+            + Debug
             + Clone
             + Send
             + 'static,
@@ -116,10 +120,11 @@ impl Catalog {
         D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
             + SerializeWithContext<SqlSerdeConfig>
             + From<Z::Key>
+            + Debug
             + Clone
             + Send
             + 'static,
-        Z: ZSet + Send + Sync,
+        Z: ZSet + Debug + Send + Sync,
         Z::R: ZRingValue + Into<i64> + Sync,
         Z::Key: Sync + From<D>,
     {
@@ -235,6 +240,7 @@ impl Catalog {
         VD: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
             + SerializeWithContext<SqlSerdeConfig>
             + From<V>
+            + Debug
             + Clone
             + Send
             + 'static,

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -9,6 +9,7 @@ use crate::{
     trace::Batch,
     Circuit, DBData, DBWeight, OrdIndexedZSet, OrdZSet, Runtime, Stream,
 };
+use std::fmt::Debug;
 use std::{
     borrow::Cow,
     hash::{Hash, Hasher},
@@ -50,7 +51,7 @@ impl RootCircuit {
     /// See [`InputHandle`] for more details.
     pub fn add_input_stream<T>(&self) -> (Stream<Self, T>, InputHandle<T>)
     where
-        T: Default + Clone + Send + 'static,
+        T: Default + Debug + Clone + Send + 'static,
     {
         let (input, input_handle) = Input::new(|x| x);
         let stream = self.add_source(input);
@@ -1022,7 +1023,7 @@ where
 
 impl<IT, OT, F> SourceOperator<OT> for Input<IT, OT, F>
 where
-    IT: Default + 'static,
+    IT: Default + Debug + 'static,
     OT: 'static,
     F: Fn(IT) -> OT + 'static,
 {

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -7,6 +7,7 @@ use crate::{
     trace::{Batch, Spine, Trace},
     Circuit, Runtime, Stream,
 };
+use std::fmt::Debug;
 use std::{
     borrow::Cow,
     hash::{Hash, Hasher},
@@ -17,7 +18,7 @@ use typedmap::TypedMapKey;
 
 impl<T> Stream<RootCircuit, T>
 where
-    T: Clone + Send + 'static,
+    T: Debug + Clone + Send + 'static,
 {
     /// Create an output handle that makes the contents of `self` available
     /// outside the circuit.
@@ -278,7 +279,7 @@ where
 
 impl<T> SinkOperator<T> for Output<T>
 where
-    T: Clone + 'static,
+    T: Debug + Clone + 'static,
 {
     fn eval(&mut self, val: &T) {
         self.mailbox.set(Some(val.clone()));

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -939,7 +939,7 @@
 //! )> {
 //!     let (input_stream, input_handle) =
 //!             circuit.add_input_zset::<Record, i64>();      
-//!     // ... #     let subset = input_stream.filter(|r| {
+//! #     let subset = input_stream.filter(|r| {
 //! #         r.location == "England"
 //! #             || r.location == "Northern Ireland"
 //! #             || r.location == "Scotland"
@@ -970,7 +970,8 @@
 //!
 //! fn main() -> Result<()> {
 //!     let (circuit, (input_handle, output_handle)) =
-//! RootCircuit::build(build_circuit)?; #     let path = format!(
+//! RootCircuit::build(build_circuit)?;
+//! #     let path = format!(
 //! #         "{}/examples/tutorial/vaccinations.csv",
 //! #         env!("CARGO_MANIFEST_DIR")
 //! #     );
@@ -982,7 +983,7 @@
 //! #
 //! #     circuit.step()?;
 //! #
-//!     // ...
+//!
 //!     output_handle
 //!         .consolidate()
 //!         .iter()

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -13,7 +13,6 @@ pub mod timestamp;
 pub use geopoint::GeoPoint;
 pub use interval::LongInterval;
 pub use interval::ShortInterval;
-use num_traits::Float;
 pub use source::{SourcePosition, SourcePositionRange};
 pub use timestamp::Date;
 pub use timestamp::Time;
@@ -26,7 +25,6 @@ use dbsp::{
     UpsertHandle,
 };
 use num::{Signed, ToPrimitive};
-use num_traits::Zero;
 use rust_decimal::{Decimal, MathematicalOps};
 use std::fmt::Debug;
 use std::marker::PhantomData;


### PR DESCRIPTION
- Implemented `Debug` for `dyn SerBatch`, so we can easily debug-print
  circuit outputs in the `adapters` crate.

- Added `Debug` trait bounds to `Input` and `Output` DBSP operator to
  make sure we can always debug-print circuit inputs and outputs.

- Added a couple of missing exports to the `adapters` crate to allow
  accessing the catalog API from outside.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
