### PR TITLE
Support patch semantics for upserts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- API: Generalized upsert operation that allows partial modifications to table records ([#1296](https://github.com/feldera/feldera/pull/1296))
 - SQL: Functions on binary string (octet_length, position, overlay, substring) ([#1264](https://github.com/feldera/feldera/pull/1264))
 - pipeline-manager: add PUT endpoints for Programs, Pipelines, and Connectors (#1248)
 - Documentation: Adding a markdown page for videos (#1126)

--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -53,11 +53,11 @@ where
 /// an [`UpsertHandle`](`dbsp::UpsertHandle`) and pushes serialized relational
 /// data to the associated input stream record-by-record.  The client passes a
 /// byte array with a serialized data record (e.g., in JSON or CSV format)
-/// to [`insert`](`Self::insert`) and [`delete`](`Self::delete`) methods.
-/// The record gets deserialized into the strongly typed representation
-/// expected by the input stream and gets buffered inside the handle.
-/// The [`flush`](`Self::flush`) method pushes all buffered data to the
-/// underlying [`CollectionHandle`](`dbsp::CollectionHandle`) or
+/// to [`insert`](`Self::insert`), [`delete`](`Self::delete`), and
+/// [`update`](`Self::update`) methods. The record gets deserialized into the
+/// strongly typed representation expected by the input stream and gets buffered
+/// inside the handle. The [`flush`](`Self::flush`) method pushes all buffered
+/// data to the underlying [`CollectionHandle`](`dbsp::CollectionHandle`) or
 /// [`UpsertHandle`](`dbsp::UpsertHandle`).
 ///
 /// Instances of this trait are created by calling
@@ -91,6 +91,15 @@ pub trait DeCollectionStream: Send {
     /// representation is corrupted or does not match the value or key
     /// type of the underlying input stream.
     fn delete(&mut self, data: &[u8]) -> AnyResult<()>;
+
+    /// Buffer a new update that will modify an existing record.
+    ///
+    /// This method can only be called on streams created with
+    /// [`RootCircuit::add_input_map`](`dbsp::RootCircuit::add_input_map`)
+    /// and will fail on other streams.  The serialized record must match
+    /// the update type of this stream, specified as a type argument to
+    /// [`Catalog::register_input_map`].
+    fn update(&mut self, data: &[u8]) -> AnyResult<()>;
 
     /// Reserve space for at least `reservation` more updates in the
     /// internal input buffer.

--- a/crates/adapters/src/format/json/mod.rs
+++ b/crates/adapters/src/format/json/mod.rs
@@ -69,6 +69,10 @@ pub struct InsDelUpdate<T> {
     /// from the table.
     #[serde(skip_serializing_if = "Option::is_none")]
     delete: Option<T>,
+    /// When present and not `null`, this field specifies an update to an
+    /// existing record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    update: Option<T>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -329,12 +329,14 @@ mod test {
                     table: None,
                     insert: Some(val),
                     delete: None,
+                    update: None,
                 }
             } else {
                 Self {
                     table: None,
                     insert: None,
                     delete: Some(val),
+                    update: None,
                 }
             }
         }

--- a/crates/adapters/src/static_compile/deserialize_with_context.rs
+++ b/crates/adapters/src/static_compile/deserialize_with_context.rs
@@ -455,7 +455,7 @@ deserialize_struct!(NeighborhoodDescr(K, V: Default)[4]{
 /// - On error, reports the name of the field that failed to parse.
 #[macro_export]
 macro_rules! deserialize_table_record {
-    ($table:ident[$sql_table:tt, $num_cols:expr]{$(($field_name:ident, $column_name:tt, $case_sensitive:tt, $type:ty, $init:expr)),* }) => {
+    ($table:ident[$sql_table:tt, $num_cols:expr]{$(($field_name:ident, $column_name:tt, $case_sensitive:tt, $type:ty, $init:expr $(, $postprocess:expr)*)),* }) => {
         #[allow(non_snake_case)]
         #[allow(unused_variables)]
         #[allow(unused_mut)]
@@ -498,6 +498,7 @@ macro_rules! deserialize_table_record {
                                     // deserializer type `D`, so we instead encode it as a JSON
                                     // object, which the client will have to parse.
                                     $field_name = Some(map.next_value_seed(<$crate::DeserializationContext<$crate::SqlSerdeConfig, $type>>::new(self.context))
+                                                  $(.map($postprocess))*
                                                   .map_err(|e| serde::de::Error::custom(serde_json::to_string(&$crate::FieldParseError{field: $column_name.to_string(), description: e.to_string()}).unwrap()))?);
                                 } else
                             )*

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -1,5 +1,5 @@
 use crate::{
-    test::{wait, MockDeZSet, TestStruct, DEFAULT_TIMEOUT_MS},
+    test::{wait, MockDeZSet, MockUpdate, TestStruct, DEFAULT_TIMEOUT_MS},
     InputFormat,
 };
 use anyhow::{anyhow, bail, Result as AnyResult};
@@ -216,7 +216,7 @@ impl TestProducer {
 /// Consumer thread: read from output topic, deserialize to a shared buffer.
 pub struct BufferConsumer {
     thread_handle: Option<JoinHandle<()>>,
-    buffer: MockDeZSet<TestStruct>,
+    buffer: MockDeZSet<TestStruct, TestStruct>,
     shutdown_flag: Arc<AtomicBool>,
 }
 
@@ -341,7 +341,10 @@ impl BufferConsumer {
         let mut received = self.buffer.state().flushed.clone();
         received.sort();
         assert_eq!(
-            expected.into_iter().map(|x| (x, true)).collect::<Vec<_>>(),
+            expected
+                .into_iter()
+                .map(|x| MockUpdate::Insert(x))
+                .collect::<Vec<_>>(),
             received
         );
     }

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -7,26 +7,68 @@ use crate::{
 };
 use anyhow::Result as AnyResult;
 use std::{
+    fmt::Debug,
     mem::take,
     sync::{Arc, Mutex, MutexGuard},
 };
 
-/// Inner state of `MockDeZSet`.
-pub struct MockDeZSetState<T> {
-    /// Buffered records that haven't been flushed yet.
-    pub buffered: Vec<(T, bool)>,
-
-    /// Records flushed since the last `reset`.
-    pub flushed: Vec<(T, bool)>,
+#[derive(Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub enum MockUpdate<T, U> {
+    Insert(T),
+    Delete(T),
+    Update(U),
 }
 
-impl<T> Default for MockDeZSetState<T> {
+impl<T: Debug, U: Debug> MockUpdate<T, U> {
+    pub fn with_polarity(val: T, polarity: bool) -> Self {
+        if polarity {
+            Self::Insert(val)
+        } else {
+            Self::Delete(val)
+        }
+    }
+
+    pub fn unwrap_insert(&self) -> &T {
+        if let Self::Insert(val) = self {
+            val
+        } else {
+            panic!("MockUpdate {self:?} is not an insert")
+        }
+    }
+
+    pub fn unwrap_delete(&self) -> &T {
+        if let Self::Delete(val) = self {
+            val
+        } else {
+            panic!("MockUpdate {self:?} is not a delete")
+        }
+    }
+
+    pub fn unwrap_update(&self) -> &U {
+        if let Self::Update(val) = self {
+            val
+        } else {
+            panic!("MockUpdate {self:?} is not an update")
+        }
+    }
+}
+
+/// Inner state of `MockDeZSet`.
+pub struct MockDeZSetState<T, U> {
+    /// Buffered records that haven't been flushed yet.
+    pub buffered: Vec<MockUpdate<T, U>>,
+
+    /// Records flushed since the last `reset`.
+    pub flushed: Vec<MockUpdate<T, U>>,
+}
+
+impl<T, U> Default for MockDeZSetState<T, U> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T> MockDeZSetState<T> {
+impl<T, U> MockDeZSetState<T, U> {
     pub fn new() -> Self {
         Self {
             buffered: Vec::new(),
@@ -41,22 +83,22 @@ impl<T> MockDeZSetState<T> {
     }
 }
 
-pub struct MockDeZSet<T>(Arc<Mutex<MockDeZSetState<T>>>);
+pub struct MockDeZSet<T, U>(Arc<Mutex<MockDeZSetState<T, U>>>);
 
-impl<T> Default for MockDeZSet<T> {
+impl<T, U> Default for MockDeZSet<T, U> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 /// Mock implementation of `DeCollectionHandle`.
-impl<T> Clone for MockDeZSet<T> {
+impl<T, U> Clone for MockDeZSet<T, U> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<T> MockDeZSet<T> {
+impl<T, U> MockDeZSet<T, U> {
     pub fn new() -> Self {
         Self(Arc::new(Mutex::new(MockDeZSetState::new())))
     }
@@ -65,29 +107,32 @@ impl<T> MockDeZSet<T> {
         self.0.lock().unwrap().reset();
     }
 
-    pub fn state(&self) -> MutexGuard<MockDeZSetState<T>> {
+    pub fn state(&self) -> MutexGuard<MockDeZSetState<T, U>> {
         self.0.lock().unwrap()
     }
 }
 
-impl<T> DeCollectionHandle for MockDeZSet<T>
+impl<T, U> DeCollectionHandle for MockDeZSet<T, U>
 where
     T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
 {
     fn configure_deserializer(
         &self,
         record_format: RecordFormat,
     ) -> Result<Box<dyn DeCollectionStream>, ControllerError> {
         match record_format {
-            RecordFormat::Csv => Ok(Box::new(
-                MockDeZSetStream::<CsvDeserializerFromBytes<_>, T>::new(
-                    self.clone(),
-                    SqlSerdeConfig::default(),
-                ),
-            )),
+            RecordFormat::Csv => Ok(Box::new(MockDeZSetStream::<
+                CsvDeserializerFromBytes<_>,
+                T,
+                U,
+            >::new(
+                self.clone(), SqlSerdeConfig::default()
+            ))),
             RecordFormat::Json(flavor) => Ok(Box::new(MockDeZSetStream::<
                 JsonDeserializerFromBytes<SqlSerdeConfig>,
                 T,
+                U,
             >::new(
                 self.clone(),
                 SqlSerdeConfig::from(flavor),
@@ -97,17 +142,17 @@ where
 }
 
 #[derive(Clone)]
-pub struct MockDeZSetStream<De, T> {
-    handle: MockDeZSet<T>,
+pub struct MockDeZSetStream<De, T, U> {
+    handle: MockDeZSet<T, U>,
     deserializer: De,
     config: SqlSerdeConfig,
 }
 
-impl<De, T> MockDeZSetStream<De, T>
+impl<De, T, U> MockDeZSetStream<De, T, U>
 where
     De: DeserializerFromBytes<SqlSerdeConfig>,
 {
-    pub fn new(handle: MockDeZSet<T>, config: SqlSerdeConfig) -> Self {
+    pub fn new(handle: MockDeZSet<T, U>, config: SqlSerdeConfig) -> Self {
         Self {
             handle,
             deserializer: De::create(config.clone()),
@@ -116,20 +161,42 @@ where
     }
 }
 
-impl<De, T> DeCollectionStream for MockDeZSetStream<De, T>
+impl<De, T, U> DeCollectionStream for MockDeZSetStream<De, T, U>
 where
     T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
     De: DeserializerFromBytes<SqlSerdeConfig> + Send + 'static,
 {
     fn insert(&mut self, data: &[u8]) -> AnyResult<()> {
         let val = DeserializerFromBytes::deserialize::<T>(&mut self.deserializer, data)?;
-        self.handle.0.lock().unwrap().buffered.push((val, true));
+        self.handle
+            .0
+            .lock()
+            .unwrap()
+            .buffered
+            .push(MockUpdate::Insert(val));
         Ok(())
     }
 
     fn delete(&mut self, data: &[u8]) -> AnyResult<()> {
         let val = DeserializerFromBytes::deserialize::<T>(&mut self.deserializer, data)?;
-        self.handle.0.lock().unwrap().buffered.push((val, false));
+        self.handle
+            .0
+            .lock()
+            .unwrap()
+            .buffered
+            .push(MockUpdate::Delete(val));
+        Ok(())
+    }
+
+    fn update(&mut self, data: &[u8]) -> AnyResult<()> {
+        let val = DeserializerFromBytes::deserialize::<U>(&mut self.deserializer, data)?;
+        self.handle
+            .0
+            .lock()
+            .unwrap()
+            .buffered
+            .push(MockUpdate::Update(val));
         Ok(())
     }
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -26,7 +26,7 @@ mod mock_output_consumer;
 pub use data::{
     generate_test_batch, generate_test_batches, generate_test_batches_with_weights, TestStruct,
 };
-pub use mock_dezset::MockDeZSet;
+pub use mock_dezset::{MockDeZSet, MockUpdate};
 pub use mock_input_consumer::MockInputConsumer;
 pub use mock_output_consumer::MockOutputConsumer;
 
@@ -74,13 +74,14 @@ where
 /// │MockInputConsumer├──►│parser├──►│MockDeZSet│
 /// └─────────────────┘   └──────┘   └──────────┘
 /// ```
-pub fn mock_parser_pipeline<T>(
+pub fn mock_parser_pipeline<T, U>(
     config: &FormatConfig,
-) -> AnyResult<(MockInputConsumer, MockDeZSet<T>)>
+) -> AnyResult<(MockInputConsumer, MockDeZSet<T, U>)>
 where
     T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
 {
-    let input_handle = <MockDeZSet<T>>::new();
+    let input_handle = <MockDeZSet<T, U>>::new();
     let consumer = MockInputConsumer::from_handle(&input_handle, config);
     Ok((consumer, input_handle))
 }
@@ -97,11 +98,12 @@ where
 /// │endpoint├──►│MockInputConsumer├──►│parser├──►│MockDeZSet│
 /// └────────┘   └─────────────────┘   └──────┘   └──────────┘
 /// ```
-pub fn mock_input_pipeline<T>(
+pub fn mock_input_pipeline<T, U>(
     config: InputEndpointConfig,
-) -> AnyResult<(Box<dyn InputReader>, MockInputConsumer, MockDeZSet<T>)>
+) -> AnyResult<(Box<dyn InputReader>, MockInputConsumer, MockDeZSet<T, U>)>
 where
     T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
 {
     let (consumer, input_handle) = mock_parser_pipeline(&config.connector_config.format)?;
 

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -291,8 +291,10 @@ format:
         }
         writer.flush().unwrap();
 
-        let (endpoint, consumer, zset) =
-            mock_input_pipeline::<TestStruct>(serde_yaml::from_str(&config_str).unwrap()).unwrap();
+        let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
+            serde_yaml::from_str(&config_str).unwrap(),
+        )
+        .unwrap();
 
         sleep(Duration::from_millis(10));
 
@@ -306,9 +308,8 @@ format:
             || zset.state().flushed.len() == test_data.len(),
             DEFAULT_TIMEOUT_MS,
         );
-        for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
-            assert!(polarity);
-            assert_eq!(val, &test_data[i]);
+        for (i, upd) in zset.state().flushed.iter().enumerate() {
+            assert_eq!(upd.unwrap_insert(), &test_data[i]);
         }
     }
 
@@ -343,8 +344,10 @@ format:
             .has_headers(false)
             .from_writer(temp_file.as_file());
 
-        let (endpoint, consumer, zset) =
-            mock_input_pipeline::<TestStruct>(serde_yaml::from_str(&config_str).unwrap()).unwrap();
+        let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
+            serde_yaml::from_str(&config_str).unwrap(),
+        )
+        .unwrap();
 
         for _ in 0..10 {
             for val in test_data.iter().cloned() {
@@ -364,9 +367,8 @@ format:
                 || zset.state().flushed.len() == test_data.len(),
                 DEFAULT_TIMEOUT_MS,
             );
-            for (i, (val, polarity)) in zset.state().flushed.iter().enumerate() {
-                assert!(polarity);
-                assert_eq!(val, &test_data[i]);
+            for (i, upd) in zset.state().flushed.iter().enumerate() {
+                assert_eq!(upd.unwrap_insert(), &test_data[i]);
             }
             endpoint.pause().unwrap();
 

--- a/crates/dbsp/src/operator/input_upsert.rs
+++ b/crates/dbsp/src/operator/input_upsert.rs
@@ -1,0 +1,344 @@
+use crate::{
+    algebra::{AddAssignByRef, HasOne, HasZero, PartialOrder, ZRingValue},
+    circuit::{
+        operator_traits::{BinaryOperator, Operator},
+        OwnershipPreference, Scope, WithClock,
+    },
+    operator::trace::{DelayedTraceId, TraceAppend, TraceBounds, TraceId, Z1Trace},
+    trace::{
+        consolidation::consolidate, cursor::Cursor, Batch, BatchReader, Builder, Filter, Spine,
+        Trace,
+    },
+    utils::VecExt,
+    Circuit, DBData, DBTimestamp, Stream, Timestamp,
+};
+use rkyv::{Archive, Deserialize, Serialize};
+use size_of::SizeOf;
+use std::{borrow::Cow, marker::PhantomData, ops::Neg};
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    SizeOf,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Archive,
+    Serialize,
+    Deserialize,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+pub enum Update<V: DBData, U: DBData> {
+    Insert(V),
+    #[default]
+    Delete,
+    Update(U),
+}
+
+pub type PatchFunc<V, U> = Box<dyn Fn(&mut V, U)>;
+
+impl<C, K, V, U> Stream<C, Vec<(K, Update<V, U>)>>
+where
+    K: DBData,
+    V: DBData,
+    U: DBData,
+    C: Circuit,
+    <C as WithClock>::Time: DBTimestamp,
+{
+    /// Convert an input stream of upserts into a stream of updates to a
+    /// relation.
+    ///
+    /// The input stream carries changes to a key/value map in the form of
+    /// _upserts_.  An upsert assigns a new value to a key (or deletes the key
+    /// from the map) without explicitly removing the old value, if any.  The
+    /// operator converts upserts into batches of updates, which is the input
+    /// format of most DBSP operators.
+    ///
+    /// The operator assumes that the input vector is sorted by key; however,
+    /// unlike the [`Stream::upsert`] operator it allows the vector to
+    /// contain multiple updates per key.  Updates are applied one by one in
+    /// order, and the output of the operator reflects cumulative effect of
+    /// the updates.  Additionally, unlike the [`Stream::upsert`] operator,
+    /// which only supports inserts, which overwrite the entire value with a
+    /// new value, and deletions, this operator also supports updates that
+    /// modify the contents of a value, e.g., overwriting some of its
+    /// fields.  Type argument `U` defines the format of modifications,
+    /// and the `patch_func` function applies update of type `U` to a value of
+    /// type `V`.
+    ///
+    /// This is a stateful operator that internally maintains the trace of the
+    /// collection.
+    pub fn input_upsert<B>(&self, patch_func: PatchFunc<V, U>) -> Stream<C, B>
+    where
+        B::R: DBData + ZRingValue,
+        B: Batch<Key = K, Val = V, Time = ()>,
+    {
+        let circuit = self.circuit();
+
+        // We build the following circuit to implement the upsert semantics.
+        // The collection is accumulated into a trace using integrator
+        // (UntimedTraceAppend + Z1Trace = integrator).  The `InputUpsert`
+        // operator evaluates each upsert command in the input stream against
+        // the trace and computes a batch of updates to be added to the trace.
+        //
+        // ```text
+        //                               ┌────────────────────────────►
+        //                               │
+        //                               │
+        //  self        ┌───────────┐    │        ┌───────────┐  trace
+        // ────────────►│InputUpsert├────┴───────►│TraceAppend├────┐
+        //              └───────────┘   delta     └───────────┘    │
+        //                      ▲                  ▲               │
+        //                      │                  │               │
+        //                      │                  │   ┌───────┐   │
+        //                      └──────────────────┴───┤Z1Trace│◄──┘
+        //                         z1trace             └───────┘
+        // ```
+        circuit.region("input_upsert", || {
+            let bounds = <TraceBounds<K, V>>::unbounded();
+
+            let (local, z1feedback) =
+                circuit.add_feedback(Z1Trace::new(false, circuit.root_scope(), bounds.clone()));
+            local.mark_sharded_if(self);
+
+            let delta = circuit
+                .add_binary_operator(
+                    <InputUpsert<
+                        Spine<<<C as WithClock>::Time as Timestamp>::OrdValBatch<K, V, B::R>>,
+                        U,
+                        B,
+                    >>::new(bounds.clone(), patch_func),
+                    &local,
+                    &self.try_sharded_version(),
+                )
+                .mark_distinct();
+            delta.mark_sharded_if(self);
+
+            let trace = circuit.add_binary_operator_with_preference(
+                <TraceAppend<
+                    Spine<<<C as WithClock>::Time as Timestamp>::OrdValBatch<K, V, B::R>>,
+                    B,
+                    C,
+                >>::new(circuit.clone()),
+                (&local, OwnershipPreference::STRONGLY_PREFER_OWNED),
+                (
+                    &delta.try_sharded_version(),
+                    OwnershipPreference::PREFER_OWNED,
+                ),
+            );
+            trace.mark_sharded_if(self);
+
+            z1feedback.connect_with_preference(&trace, OwnershipPreference::STRONGLY_PREFER_OWNED);
+            circuit.cache_insert(DelayedTraceId::new(trace.origin_node_id().clone()), local);
+            circuit.cache_insert(
+                TraceId::new(delta.origin_node_id().clone()),
+                (trace, bounds),
+            );
+            delta
+        })
+    }
+}
+
+pub struct InputUpsert<T, U, B>
+where
+    T: BatchReader,
+{
+    time: T::Time,
+    patch_func: PatchFunc<T::Val, U>,
+    bounds: TraceBounds<T::Key, T::Val>,
+    phantom: PhantomData<B>,
+}
+
+impl<T, U, B> InputUpsert<T, U, B>
+where
+    T: BatchReader,
+{
+    pub fn new(bounds: TraceBounds<T::Key, T::Val>, patch_func: PatchFunc<T::Val, U>) -> Self {
+        Self {
+            time: T::Time::clock_start(),
+            bounds,
+            patch_func,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, U, B> Operator for InputUpsert<T, U, B>
+where
+    T: BatchReader,
+    U: 'static,
+    B: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("InputUpsert")
+    }
+    fn clock_end(&mut self, scope: Scope) {
+        self.time = self.time.advance(scope + 1);
+    }
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+fn passes_filter<T>(filter: &Option<Filter<T>>, val: &T) -> bool {
+    if let Some(filter) = filter {
+        filter(val)
+    } else {
+        true
+    }
+}
+
+impl<T, U, B> BinaryOperator<T, Vec<(T::Key, Update<T::Val, U>)>, B> for InputUpsert<T, U, B>
+where
+    T: Trace,
+    T::R: ZRingValue,
+    U: DBData,
+    B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R>,
+{
+    fn eval(&mut self, trace: &T, updates: &Vec<(T::Key, Update<T::Val, U>)>) -> B {
+        // Inputs must be sorted by key
+        debug_assert!(updates.is_sorted_by(|(k1, _), (k2, _)| k1.partial_cmp(k2)));
+
+        let mut trace_cursor = trace.cursor();
+
+        let mut builder = B::Builder::with_capacity((), updates.len() * 2);
+        let mut key_updates: Vec<(T::Val, T::R)> = Vec::new();
+
+        let val_filter = self.bounds.effective_val_filter();
+        let key_filter = self.bounds.key_filter();
+        let key_bound = self.bounds.effective_key_bound();
+
+        // Current key for which we are processing updates.
+        let mut cur_key: Option<T::Key> = None;
+
+        // Current value associated with the key after applying all processed updates
+        // to it.
+        let mut cur_val: Option<T::Val> = None;
+
+        // Set to true when the value associated with the current key doesn't
+        // satisfy `val_filter`, hence refuse to remove this value and process
+        // all updates for this key.
+        let mut skip_key = false;
+
+        for (key, upd) in updates {
+            if let Some(key_bound) = &key_bound {
+                if key < key_bound {
+                    // TODO: report lateness violation.
+                    continue;
+                }
+            }
+
+            if !passes_filter(&key_filter, key) {
+                // TODO: report lateness violation.
+                continue;
+            }
+
+            // We finished processing updates for the previous key. Push them to the
+            // builder and generate a retraction for the new key.
+            if cur_key.as_ref() != Some(key) {
+                // Push updates for the previous key to the builder.
+                if let Some(cur_key) = cur_key.take() {
+                    if let Some(val) = cur_val.take() {
+                        key_updates.push((val, HasOne::one()));
+                    }
+                    consolidate(&mut key_updates);
+                    builder.extend(
+                        key_updates
+                            .drain(..)
+                            .map(|(val, w)| (B::item_from(cur_key.clone(), val), w)),
+                    );
+                }
+
+                skip_key = false;
+                cur_key = Some(key.clone());
+                cur_val = None;
+
+                // Generate retraction if `key` is present in the trace.
+                trace_cursor.seek_key(key);
+
+                if trace_cursor.key_valid() && trace_cursor.key() == key {
+                    // println!("{}: found key in trace_cursor", Runtime::worker_index());
+                    while trace_cursor.val_valid() {
+                        let mut weight = T::R::zero();
+                        trace_cursor.map_times(|t, w| {
+                            if t.less_equal(&self.time) {
+                                weight.add_assign_by_ref(w);
+                            };
+                        });
+
+                        if !weight.is_zero() {
+                            let val = trace_cursor.val().clone();
+
+                            if passes_filter(&val_filter, &val) {
+                                key_updates.push((val.clone(), weight.neg()));
+                                cur_val = Some(val);
+                            } else {
+                                skip_key = true;
+                                // TODO: report lateness violation.
+                            }
+                        }
+
+                        trace_cursor.step_val();
+                    }
+                }
+            }
+
+            if !skip_key {
+                match upd {
+                    Update::Delete => {
+                        // TODO: if cur_val.is_none(), report missing key.
+                        cur_val = None;
+                    }
+                    Update::Insert(val) => {
+                        if passes_filter(&val_filter, val) {
+                            cur_val = Some(val.clone());
+                        } else {
+                            // TODO: report lateness violation.
+                        }
+                    }
+                    Update::Update(upd) => {
+                        if let Some(val) = &cur_val {
+                            let mut val = val.clone();
+                            (self.patch_func)(&mut val, upd.clone());
+                            if passes_filter(&val_filter, &val) {
+                                cur_val = Some(val);
+                            } else {
+                                // TODO: report lateness violation.
+                            }
+                        } else {
+                            // TODO: report missing key.
+                        }
+                    }
+                }
+            }
+        }
+
+        // Push updates for the last key.
+        if let Some(cur_key) = cur_key.take() {
+            if let Some(val) = cur_val.take() {
+                key_updates.push((val, HasOne::one()));
+            }
+
+            consolidate(&mut key_updates);
+            builder.extend(
+                key_updates
+                    .drain(..)
+                    .map(|(val, w)| (B::item_from(cur_key.clone(), val), w)),
+            );
+        }
+
+        self.time = self.time.advance(0);
+        builder.done()
+    }
+
+    fn input_preference(&self) -> (OwnershipPreference, OwnershipPreference) {
+        (
+            OwnershipPreference::PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        )
+    }
+}

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -6,6 +6,7 @@ pub mod communication;
 pub mod recursive;
 
 pub(crate) mod apply;
+pub(crate) mod input_upsert;
 pub(crate) mod inspect;
 pub(crate) mod upsert;
 
@@ -50,7 +51,7 @@ pub use generator::{Generator, GeneratorNested};
 pub use group::CmpFunc;
 pub use index::Index;
 use input::Mailbox;
-pub use input::{CollectionHandle, InputHandle, UpsertHandle};
+pub use input::{CollectionHandle, InputHandle, Update, UpsertHandle};
 pub use inspect::Inspect;
 pub use join::Join;
 pub use join_range::StreamJoinRange;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeStruct.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeStruct.java
@@ -215,9 +215,7 @@ public class DBSPTypeStruct extends DBSPType {
                 .append("}");
     }
 
-    /**
-     * Generate a tuple type by ignoring the struct and field names.
-     */
+    /** Generate a tuple type by ignoring the struct and field names. */
     public DBSPTypeTuple toTuple() {
         List<DBSPType> types = Linq.list(Linq.map(this.fields.values(), f -> f.type));
         return new DBSPTypeTuple(this.getNode(), types);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -201,4 +201,21 @@ public class CatalogTests extends BaseSQLTests {
         DBSPCircuit circuit = getCircuit(compiler);
         this.addRustTestCase(sql, compiler, circuit);
     }
+
+    @Test
+    public void updateTest() {
+        String sql = """
+                create table t1(
+                            id1 bigint not null,
+                            id2 bigint,
+                            str1 varchar not null,
+                            str2 varchar,
+                            int1 bigint not null,
+                            int2 bigint,
+                            primary key(id1, id2))""";
+        DBSPCompiler compiler = testCompiler();
+        compiler.compileStatements(sql);
+        DBSPCircuit circuit = getCircuit(compiler);
+        this.addRustTestCase(sql, compiler, circuit);
+    }
 }


### PR DESCRIPTION
This commit extends our support for UPSERT operations to allow partial modifications to existing records in the database.

The UPSERT operation is defined for tables with primary keys and allows overwriting an existing record associated with a key without explicitly deleting it first.  Previously, it required specifying the entire new value of the record.  Oftentimes the user needs to update only some of the fields of the record without explicitly listing all other fields (e.g., the value of a counter increased by 1, while its other properties haven't changed).  In fact, they may not even have access to the values of all other fields.

The new form of the UPSERT operator allows exactly that.  It is currently only supported for JSON inputs in the insert/delete format. We introduce the "update" operation (in addition to "insert" and "delete"):

```json
{"update": {"field1": "value1", "field2": null}}
```

The new operation is subject to these rules:

- The update record must contain all fields that form the primary key.

- The update record can contan any subset of other fields.  If non of the fields are specified, the operation is a no-op.  If all fields are specified, the operation is equivalen to an insert.

- Nullable columns are treated in a special way: if the value of the column is not specified, the column will not be modified by the upsert, if the column is specified with JSON value `null`, then the column will be set to NULL in SQL.
- Updates to non-existing keys are ignored.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
