### PR TITLE
Fixup start_manager.sh for CORS.

### DIFF
--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -49,4 +49,5 @@ cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --bin pipeline-manager $RUST_BUILD
     --runner-working-directory="${WORKING_DIR_ABS}" \
     --sql-compiler-home="${SQL_COMPILER_DIR}" \
     --dbsp-override-path="${ROOT_DIR}" \
+    --allowed-origins="http://localhost:8080" \
     ${DB_CONNECTION_STRING}


### PR DESCRIPTION
Pipeline manager now requires an extra argument to be accessible even from localhost.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
