### PR TITLE
pipeline-manager: allow any origin by default

### DIFF
--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -206,9 +206,7 @@ impl ApiServerConfig {
                     cors = cors.allowed_origin(origin);
                 }
             } else {
-                // Add this as a default origin so users can try out the
-                // REST API from the generated documentation
-                cors = cors.allowed_origin("https://www.feldera.com");
+                cors = cors.allow_any_origin();
             }
             cors.allowed_methods(vec!["GET", "POST", "PATCH", "PUT", "DELETE"])
                 .allowed_headers(vec![header::AUTHORIZATION, header::ACCEPT])


### PR DESCRIPTION
Keep the default behavior when using cors to allow any origin.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
