### PR TITLE
pipeline-manager: automatically queue programs for compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   OpenAPI documentation for program, connector and service is more consistent.
   ([#1315](https://github.com/feldera/feldera/pull/1315))
 - SQL: check decimal precision while casting between decimal types ([#1300](https://github.com/feldera/feldera/pull/1300))
+- pipeline-manager: automatically queue programs for compilation (#1325)
 
 ### Removed
 

--- a/crates/pipeline_manager/migrations/V10__remove_program_status_none.sql
+++ b/crates/pipeline_manager/migrations/V10__remove_program_status_none.sql
@@ -1,0 +1,3 @@
+-- Set all programs to be automatically compiled. Removes 'none'
+-- as a valid status field in the database.
+UPDATE program SET status = 'pending' WHERE status = 'none';

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -80,15 +80,12 @@ pub(crate) struct SqlCompilerMessage {
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema, Clone)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub(crate) enum ProgramStatus {
-    /// Initial state: program has been created or modified, but the user
-    /// hasn't yet started compiling the program.
-    None,
     /// Compilation request received from the user; program has been placed
     /// in the queue.
     Pending,
     /// Compilation of SQL -> Rust in progress.
     CompilingSql,
-    /// Compiling Rust -> executable in progress
+    /// Compiling Rust -> executable in progress.
     CompilingRust,
     /// Compilation succeeded.
     #[cfg_attr(test, proptest(weight = 2))]

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -199,7 +199,7 @@ async fn program_creation() {
         name: "test1".to_string(),
         description: "program desc".to_string(),
         version: res.1,
-        status: ProgramStatus::None,
+        status: ProgramStatus::Pending,
         schema: None,
         code: None,
     };
@@ -213,7 +213,7 @@ async fn program_creation() {
         name: "test1".to_string(),
         description: "program desc".to_string(),
         version: res.1,
-        status: ProgramStatus::None,
+        status: ProgramStatus::Pending,
         schema: None,
         code: Some("ignored".to_string()),
     };
@@ -227,7 +227,7 @@ async fn program_creation() {
         name: "test1".to_string(),
         description: "program desc".to_string(),
         version: res.1,
-        status: ProgramStatus::None,
+        status: ProgramStatus::Pending,
         schema: None,
         code: None,
     };
@@ -509,7 +509,7 @@ async fn update_status() {
         .get_program_by_id(tenant_id, program_id, false)
         .await
         .unwrap();
-    assert_eq!(ProgramStatus::None, desc.status);
+    assert_eq!(ProgramStatus::Pending, desc.status);
     handle
         .db
         .set_program_status_guarded(
@@ -1928,7 +1928,7 @@ impl Storage for Mutex<DbModel> {
                     program_id,
                     name: program_name.to_owned(),
                     description: program_description.to_owned(),
-                    status: ProgramStatus::None,
+                    status: ProgramStatus::Pending,
                     schema: None,
                     version,
                     code: Some(program_code.to_owned()),
@@ -2017,14 +2017,14 @@ impl Storage for Mutex<DbModel> {
                     }
                 }
                 // If the code is updated, it overrides the schema and status
-                // changes to the equivalent of NULL.
+                // changes back to Pending.
                 let mut has_code_changed = false;
                 if let Some(code) = program_code {
                     if *code != cur_code {
                         p.code = program_code.to_owned();
                         p.version.0 += 1;
                         p.schema = None;
-                        p.status = ProgramStatus::None;
+                        p.status = ProgramStatus::Pending;
                         has_code_changed = true;
                     }
                 }

--- a/openapi.json
+++ b/openapi.json
@@ -2328,8 +2328,8 @@
         "tags": [
           "Programs"
         ],
-        "summary": "Mark a program for compilation.",
-        "description": "Mark a program for compilation.\n\nThe client can track a program's compilation status by polling the\n`/program/{program_name}` or `/programs` endpoints, and\nthen checking the `status` field of the program object.",
+        "summary": "Deprecated. Mark a program for compilation.",
+        "description": "Deprecated. Mark a program for compilation.\n\nThe client can track a program's compilation status by polling the\n`/program/{program_name}` or `/programs` endpoints, and\nthen checking the `status` field of the program object.",
         "operationId": "compile_program",
         "parameters": [
           {
@@ -3994,13 +3994,6 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Initial state: program has been created or modified, but the user\nhasn't yet started compiling the program.",
-            "enum": [
-              "None"
-            ]
-          },
-          {
-            "type": "string",
             "description": "Compilation request received from the user; program has been placed\nin the queue.",
             "enum": [
               "Pending"
@@ -4015,7 +4008,7 @@
           },
           {
             "type": "string",
-            "description": "Compiling Rust -> executable in progress",
+            "description": "Compiling Rust -> executable in progress.",
             "enum": [
               "CompilingRust"
             ]


### PR DESCRIPTION
Both our UI and API workflows always issue a compilation request
after creating or modifying programs. There is no reason to have
progams that we don't intend on compiling.

This PR automatically sets all newly created or modified programs
to be in the "Pending" state, which automatically queues them for
compilation.

The previous /compile API is now a no-op (and shouldn't break any
existing workflows).

Feature requested by @Karakatiza666 

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
