### PR TITLE
Earthfile: Check that `cargo doc` succeeds during the CI build.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -84,6 +84,8 @@ clippy:
     ENV WEBUI_BUILD_DIR=/dbsp/web-console/out
     COPY ( +build-webui/out ) ./web-console/out
     DO rust+CARGO --args="clippy -- -D warnings"
+    ENV RUSTDOCFLAGS="-D warnings"
+    DO rust+CARGO --args="doc --no-deps"
 
 install-python-deps:
     FROM +install-deps


### PR DESCRIPTION
It's easy to make mistakes in documentation and forget to check them with `cargo doc` before submitting.  This will find those problems.  With this commit, `cargo doc` problems will fail something like this:

```
             +clippy *failed* | --> RUN set -e; cargo $args; cargo sweep -r -t $EARTHLY_SWEEP_DAYS; cargo sweep -r -i;
             +clippy *failed* |     Checking pipeline_types v0.1.0 (/dbsp/crates/pipeline-types)
             +clippy *failed* |     Checking feldera-storage v0.1.0 (/dbsp/crates/feldera-storage)
             +clippy *failed* |  Documenting feldera-storage v0.1.0 (/dbsp/crates/feldera-storage)
             +clippy *failed* |  Documenting pipeline_types v0.1.0 (/dbsp/crates/pipeline-types)
             +clippy *failed* |    Compiling pipeline-manager v0.8.0 (/dbsp/crates/pipeline_manager)
             +clippy *failed* |  Documenting pipeline-manager v0.8.0 (/dbsp/crates/pipeline_manager)
             +clippy *failed* |     Checking dbsp v0.2.0 (/dbsp/crates/dbsp)
             +clippy *failed* |  Documenting dbsp v0.2.0 (/dbsp/crates/dbsp)
             +clippy *failed* | error: unresolved link to `xyzzy`
             +clippy *failed* |  --> crates/feldera-storage/src/lib.rs:1:8
             +clippy *failed* |   |
             +clippy *failed* | 1 | //!  [`xyzzy`]
             +clippy *failed* |   |        ^^^^^ no item named `xyzzy` in scope
             +clippy *failed* |   |
             +clippy *failed* |   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
             +clippy *failed* |   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
             +clippy *failed* |   = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`

             +clippy *failed* | error: could not document `feldera-storage`
```

Is this a user-visible change (yes/no): no