### PR TITLE
dbsp: Fix build with `--features=persistence`.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -174,21 +174,12 @@ build-nexmark:
     FROM +build-dbsp
     DO rust+CARGO --args="build --package dbsp_nexmark"
 
-CARGO_TEST:
-    COMMAND
-    ARG package
-    ARG features
-    ARG test_args
-    DO rust+CARGO --args="test --package $package \
-        $(if [ -z $features ]; then printf -- --features $features; fi) \
-        -- $test_args"
-
 test-dbsp:
     FROM +build-dbsp
     # Limit test execution to tests in trace::persistent::tests, because
     # executing everything takes too long and (in theory) the proptests we have
     # should ensure equivalence with the DRAM trace implementation:
-    DO +CARGO_TEST --package=dbsp --features=persistence --test_args=trace::persistent::tests
+    DO rust+CARGO --args="test --package=dbsp --features=persistence -- trace::persistent::tests"
     DO rust+CARGO --args="test --package dbsp"
     DO rust+CARGO --args="test --package feldera-storage"
 

--- a/crates/dbsp/src/trace/persistent/cursor.rs
+++ b/crates/dbsp/src/trace/persistent/cursor.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use rkyv::to_bytes;
+use feldera_storage::file::to_bytes;
 use rocksdb::{BoundColumnFamily, DBRawIterator};
 
 use super::trace::PersistedValue;

--- a/crates/dbsp/src/trace/persistent/trace.rs
+++ b/crates/dbsp/src/trace/persistent/trace.rs
@@ -5,9 +5,10 @@ use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use feldera_storage::file::to_bytes;
 use rand::Rng;
 use rkyv::ser::Serializer;
-use rkyv::{to_bytes, Archive, Archived, Deserialize, Fallible, Serialize};
+use rkyv::{Archive, Archived, Deserialize, Fallible, Serialize};
 use rocksdb::compaction_filter::Decision;
 use rocksdb::{BoundColumnFamily, MergeOperands, Options, WriteBatch};
 use size_of::SizeOf;


### PR DESCRIPTION
The problem was that the persistence code was using `rkyv::to_bytes`, which only works with one particular serializer that we're no longer using. This commit adds an equivalent for our serializer and switches the persistence code (and one other caller) to use it.

Thanks to @gz for reporting the problem.


Fixes: de643bf89bc1 ("Use storage backends in layer files and adapt dbsp to the changes.")

Is this a user-visible change (yes/no): no