### PR TITLE
[SQL] Handle correctly table names with spaces

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -34,7 +34,7 @@ import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.IIndentStream;
 
 import javax.annotation.Nullable;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Core representation of a dataflow graph (aka a query plan).
@@ -69,8 +69,13 @@ public class DBSPCircuit extends DBSPNode implements IDBSPOuterNode {
     }
 
     @Nullable
-    public DBSPOperator getOperator(String tableOrView) {
-        return this.circuit.getOperator(tableOrView);
+    public DBSPOperator getInput(String tableName) {
+        return this.circuit.getInput(tableName);
+    }
+
+    @Nullable
+    public DBSPOperator getOutput(String viewName) {
+        return this.circuit.getOutput(viewName);
     }
 
     /**
@@ -80,30 +85,14 @@ public class DBSPCircuit extends DBSPNode implements IDBSPOuterNode {
         return this.circuit.getOutputCount();
     }
 
-    /**
-     * The output type of the i-th output.
-     * Outputs are the views, numbered in the order of creation in the
-     * input SQL program.
-     * @param i Output number.
-     */
-    public DBSPType getOutputType(int i) {
-        return this.circuit.getOutputType(i);
-    }
-
-    /**
-     * The output type of the i-th input.
-     * Inputs are the tables, numbered in the order of creation in the
-     * input SQL program.
-     * @param i Input number.
-     */
-    public DBSPType getInputType(int i) {
-        return this.circuit.getInputType(i);
+    public DBSPType getSingleOutputType() {
+        return this.circuit.getSingleOutputType();
     }
 
     /**
      * The list of all input tables of the circuit.
      */
-    public List<String> getInputTables() {
+    public Set<String> getInputTables() {
         return this.circuit.getInputTables();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperatorBase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperatorBase.java
@@ -53,11 +53,11 @@ public abstract class DBSPAggregateOperatorBase extends DBSPUnaryOperator {
     public IIndentStream toString(IIndentStream builder) {
         this.writeComments(builder)
                 .append("let ")
-                .append(this.getName())
+                .append(this.getOutputName())
                 .append(": ")
                 .append(this.outputStreamType)
                 .append(" = ")
-                .append(this.input().getName())
+                .append(this.input().getOutputName())
                 .append(".")
                 .append(this.operation)
                 .append("(");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
@@ -43,10 +43,14 @@ public class DBSPNoopOperator extends DBSPUnaryOperator {
         return var.deref().applyClone().closure(var.asParameter());
     }
 
+    /** Some Noop operators correspond to views that are not outputs */
+    @Nullable public final String viewName;
+
     public DBSPNoopOperator(CalciteObject node, DBSPOperator source,
-                            @Nullable String comment, String outputName) {
+                            @Nullable String comment, @Nullable String viewName) {
         super(node, "map", getClosure(source.getOutputRowType()),
-                source.getType(), source.isMultiset, source, comment, outputName);
+                source.getType(), source.isMultiset, source, comment);
+        this.viewName = viewName;
     }
 
     @Override
@@ -61,7 +65,7 @@ public class DBSPNoopOperator extends DBSPUnaryOperator {
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPNoopOperator(this.getNode(), newInputs.get(0), this.comment, this.outputName);
+            return new DBSPNoopOperator(this.getNode(), newInputs.get(0), this.comment, this.viewName);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
@@ -39,13 +39,13 @@ public class DBSPSinkOperator extends DBSPOperator {
     public final String query;
     public final DBSPTypeStruct originalRowType;
 
-    public DBSPSinkOperator(CalciteObject node, String viewName,
-                            String outputName, String query, DBSPTypeStruct originalRowType,
+    public DBSPSinkOperator(CalciteObject node,
+                            String viewName, String query, DBSPTypeStruct originalRowType,
                             @Nullable String comment, DBSPOperator input) {
-        super(node, "inspect", null, input.outputType, input.isMultiset, comment, outputName);
+        super(node, "inspect", null, input.outputType, input.isMultiset, comment);
         this.addInput(input);
-        this.viewName = viewName;
         this.query = query;
+        this.viewName = viewName;
         this.originalRowType = originalRowType;
     }
 
@@ -71,7 +71,7 @@ public class DBSPSinkOperator extends DBSPOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSinkOperator(
-                    this.getNode(), this.viewName, this.outputName, this.query, this.originalRowType,
+                    this.getNode(), this.viewName, this.query, this.originalRowType,
                     this.comment, newInputs.get(0));
         return this;
     }
@@ -80,11 +80,11 @@ public class DBSPSinkOperator extends DBSPOperator {
     public IIndentStream toString(IIndentStream builder) {
         return this.writeComments(builder, this.query)
                 .append("let ")
-                .append(this.getName())
+                .append(this.getOutputName())
                 .append(": ")
                 .append(this.outputStreamType)
                 .append(" = ")
-                .append(this.input().getName())
+                .append(this.input().getOutputName())
                 .append(";");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceBaseOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceBaseOperator.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
  * Base class for source operators.
  */
 public abstract class DBSPSourceBaseOperator extends DBSPOperator {
+    public final String tableName;
+
     /**
      * Create a DBSP operator that is a source to the dataflow graph.
      * @param node        Calcite node for the statement creating the table
@@ -40,22 +42,27 @@ public abstract class DBSPSourceBaseOperator extends DBSPOperator {
      * @param isMultiset  True if the source data can be a multiset.
      * @param outputType  Type of table.
      * @param comment     A comment describing the operator.
-     * @param name        The name of the table that this operator is created from.
+     * @param tableName   The name of the table that this operator is created from.
      */
     public DBSPSourceBaseOperator(
             CalciteObject node,
             DBSPType outputType, boolean isMultiset, @Nullable String comment,
-            String name) {
-        super(node, "source " + name, null, outputType, isMultiset, comment, name);
+            String tableName) {
+        super(node, "source " + tableName, null, outputType, isMultiset, comment);
+        this.tableName = tableName;
+    }
+
+    public String getTableName() {
+        return this.tableName;
     }
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
         return this.writeComments(builder)
                 .append("let ")
-                .append(this.getName())
+                .append(this.getOutputName())
                 .append(" = ")
-                .append(this.outputName)
+                .append(this.tableName)
                 .append("();");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
@@ -56,7 +56,7 @@ public class DBSPSourceMapOperator extends DBSPSourceTableOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression unused, DBSPType outputType) {
         return new DBSPSourceMapOperator(this.getNode(), this.sourceName,
                 this.keyFields, outputType.to(DBSPTypeIndexedZSet.class), this.originalRowType,
-                this.comment, this.metadata, this.outputName);
+                this.comment, this.metadata, this.tableName);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class DBSPSourceMapOperator extends DBSPSourceTableOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSourceMapOperator(this.getNode(), this.sourceName,
                     this.keyFields, this.getOutputIndexedZSetType(), this.originalRowType,
-                    this.comment, this.metadata, this.outputName);
+                    this.comment, this.metadata, this.tableName);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
@@ -43,7 +43,7 @@ public class DBSPSourceMultisetOperator extends DBSPSourceTableOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression unused, DBSPType outputType) {
         return new DBSPSourceMultisetOperator(this.getNode(), this.sourceName,
                 outputType.to(DBSPTypeZSet.class), this.originalRowType,
-                this.comment, this.metadata, this.outputName);
+                this.comment, this.metadata, this.tableName);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class DBSPSourceMultisetOperator extends DBSPSourceTableOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSourceMultisetOperator(
                     this.getNode(), this.sourceName, this.getOutputZSetType(), this.originalRowType,
-                    this.comment, this.metadata, this.outputName);
+                    this.comment, this.metadata, this.tableName);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUnaryOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUnaryOperator.java
@@ -44,8 +44,8 @@ public abstract class DBSPUnaryOperator extends DBSPOperator {
     protected DBSPUnaryOperator(CalciteObject node, String operation,
                                 @Nullable DBSPExpression function, DBSPType outputType,
                                 boolean isMultiset, DBSPOperator source,
-                                @Nullable String comment, String outputName) {
-        super(node, operation, function, outputType, isMultiset, comment, outputName);
+                                @Nullable String comment) {
+        super(node, operation, function, outputType, isMultiset, comment);
         this.addInput(source);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
@@ -61,10 +61,10 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
 
     @Override
     public VisitDecision preorder(DBSPSourceBaseOperator node) {
-        String name = node.outputName;
+        String name = node.getOutputName();
         if (node.is(DBSPDelayOutputOperator.class))
             name = "delay";
-        this.stream.append(node.outputName)
+        this.stream.append(node.getOutputName())
                 .append(" [ shape=box,label=\"")
                 .append(node.getIdString())
                 .append(" ")
@@ -76,9 +76,9 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
 
     void addInputs(DBSPOperator node) {
         for (DBSPOperator input: node.inputs) {
-            this.stream.append(input.outputName)
+            this.stream.append(input.getOutputName())
                     .append(" -> ")
-                    .append(node.outputName)
+                    .append(node.getOutputName())
                     .append(";")
                     .newline();
         }
@@ -89,9 +89,9 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         DBSPOperator input = node.input();
         if (node.output != null) {
             // Add the edge which isn't represented explicitly in the graph
-            this.stream.append(input.outputName)
+            this.stream.append(input.getOutputName())
                     .append(" -> ")
-                    .append(node.output.outputName)
+                    .append(node.output.getOutputName())
                     .append(";")
                     .newline();
             return VisitDecision.STOP;
@@ -101,11 +101,11 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
 
     @Override
     public VisitDecision preorder(DBSPSinkOperator node) {
-        this.stream.append(node.outputName)
+        this.stream.append(node.getOutputName())
                 .append(" [ shape=box,label=\"")
                 .append(node.getIdString())
                 .append(" ")
-                .append(node.outputName)
+                .append(node.getOutputName())
                 .append("\" ]")
                 .newline();
         this.addInputs(node);
@@ -144,7 +144,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
 
     @Override
     public VisitDecision preorder(DBSPOperator node) {
-        this.stream.append(node.outputName)
+        this.stream.append(node.getOutputName())
                 .append(" [ shape=box")
                 .append(this.getColor(node))
                 .append(" label=\"")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -424,8 +424,6 @@ public class ToRustVisitor extends CircuitVisitor {
             DBSPStrLiteral json = new DBSPStrLiteral(tableDescription.asJson().toString(), false, true);
             operator.originalRowType.accept(this.innerVisitor);
             this.builder.append(">(")
-                    .append(Utilities.doubleQuote(operator.getTableName()))
-                    .append(", ")
                     .append(operator.getOutputName())
                     .append(".clone(), ")
                     .append(this.handleName(operator))
@@ -534,8 +532,6 @@ public class ToRustVisitor extends CircuitVisitor {
             this.builder.append(", ");
             operator.getOutputIndexedZSetType().weightType.accept(this.innerVisitor);
             this.builder.append(", _, _>(")
-                    .append(Utilities.doubleQuote(operator.getTableName()))
-                    .append(", ")
                     .append(operator.getOutputName())
                     .append(".clone(), ")
                     .append(this.handleName(operator))
@@ -650,8 +646,6 @@ public class ToRustVisitor extends CircuitVisitor {
             this.builder.append("catalog.register_output_zset::<_, ");
             operator.originalRowType.accept(this.innerVisitor);
             this.builder.append(">(")
-                    .append(Utilities.doubleQuote(operator.viewName))
-                    .append(", ")
                     .append(operator.input().getOutputName())
                     .append(".clone()")
                     .append(", ");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -191,7 +191,7 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPExpression agg = this.getAggregatedValue();
             if (agg.getType().mayBeNull)
                 argument = new DBSPUnaryExpression(node, this.resultType.setMayBeNull(false),
-                        DBSPOpcode.INDICATOR, agg);
+                        DBSPOpcode.INDICATOR, agg.borrow());
             else
                 argument = one;
         }
@@ -373,8 +373,9 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression plusOne = intermediateResultTypeNonNull.to(IsNumericType.class).getOne();
 
         if (aggregatedValueType.mayBeNull)
-            plusOne = new DBSPUnaryExpression(node, new DBSPTypeInteger(CalciteObject.EMPTY, 64, true,false),
-                    DBSPOpcode.INDICATOR, aggregatedValue.deepCopy()).cast(intermediateResultTypeNonNull);
+            plusOne = new DBSPUnaryExpression(node,
+                    new DBSPTypeInteger(CalciteObject.EMPTY, 64, true,false),
+                    DBSPOpcode.INDICATOR, aggregatedValue.deepCopy().borrow()).cast(intermediateResultTypeNonNull);
         if (this.isDistinct) {
             count = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CollectIdentifiers.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CollectIdentifiers.java
@@ -28,7 +28,6 @@ import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitRewriter;
 import org.dbsp.sqlCompiler.ir.DBSPFunction;
-import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPEnumValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.path.DBSPSimplePathSegment;
@@ -99,7 +98,7 @@ public class CollectIdentifiers extends InnerVisitor {
 
         @Override
         public VisitDecision preorder(DBSPOperator operator) {
-            this.identifiers.add(operator.outputName);
+            this.identifiers.add(operator.getOutputName());
             return super.preorder(operator);
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -104,7 +104,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)) {
             result = new DBSPSourceMultisetOperator(operator.getNode(), operator.sourceName,
                     outputType.to(DBSPTypeZSet.class), originalRowType, operator.comment,
-                    operator.metadata, operator.outputName);
+                    operator.metadata, operator.getTableName());
         }
         this.map(operator, result);
     }
@@ -118,7 +118,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)) {
             result = new DBSPSourceMapOperator(operator.getNode(), operator.sourceName,
                     operator.keyFields, outputType.to(DBSPTypeIndexedZSet.class), originalRowType,
-                    operator.comment, operator.metadata, operator.outputName);
+                    operator.comment, operator.metadata, operator.getTableName());
         }
         this.map(operator, result);
     }
@@ -132,8 +132,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         if (!originalRowType.sameType(operator.originalRowType)
                 || !outputType.sameType(operator.outputType)
                 || input != operator.input()) {
-            result = new DBSPSinkOperator(operator.getNode(), operator.viewName,
-                    operator.outputName, operator.query,
+            result = new DBSPSinkOperator(operator.getNode(), operator.viewName, operator.query,
                     originalRowType, operator.comment, input);
         }
         this.map(operator, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindDeadCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FindDeadCode.java
@@ -24,18 +24,22 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
-import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceBaseOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * At the end of the visit the set 'keep' contains all
@@ -116,10 +120,10 @@ public class FindDeadCode extends CircuitVisitor implements IWritesLogs {
 
     @Override
     public void endVisit() {
-        for (DBSPOperator source: this.getCircuit().circuit.inputOperators) {
+        for (DBSPSourceBaseOperator source: this.getCircuit().circuit.inputOperators.values()) {
             if (!this.reachable.contains(source) && this.warn && !this.keepAllSources)
                 this.errorReporter.reportWarning(source.getSourcePosition(),
-                        "Unused", "Table " + Utilities.singleQuote(source.outputName) +
+                        "Unused", "Table " + Utilities.singleQuote(source.tableName) +
                                 " is not used");
         }
         super.endVisit();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IncrementalizeVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IncrementalizeVisitor.java
@@ -60,7 +60,7 @@ public class IncrementalizeVisitor extends CircuitCloneVisitor {
         DBSPOperator source = this.mapped(operator.input());
         DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(operator.getNode(), source);
         DBSPSinkOperator sink = new DBSPSinkOperator(operator.getNode(), operator.viewName,
-                operator.outputName, operator.query, operator.originalRowType, operator.comment, diff);
+                operator.query, operator.originalRowType, operator.comment, diff);
         this.addOperator(diff);
         this.map(operator, sink);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IndexedInputs.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IndexedInputs.java
@@ -46,7 +46,7 @@ public class IndexedInputs extends CircuitCloneVisitor {
         DBSPSourceMapOperator set = new DBSPSourceMapOperator(
                 node.getNode(), node.sourceName, keyColumnFields,
                 ix, node.originalRowType, node.comment,
-                node.metadata, node.outputName);
+                node.metadata, node.tableName);
         this.addOperator(set);
         DBSPDeindexOperator deindex = new DBSPDeindexOperator(node.getNode(), set);
         this.map(node, deindex);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPZSetLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPZSetLiteral.java
@@ -104,8 +104,8 @@ public class DBSPZSetLiteral extends DBSPLiteral implements IDBSPContainer {
             return this.elementType;
         }
 
-        public void add(DBSPExpression expression) {
-            this.add(expression, 1);
+        public Contents add(DBSPExpression expression) {
+            return this.add(expression, 1);
         }
 
         public Contents map(Function<DBSPExpression, DBSPExpression> map, DBSPType elementType) {
@@ -117,7 +117,7 @@ public class DBSPZSetLiteral extends DBSPLiteral implements IDBSPContainer {
             return result;
         }
 
-        public void add(DBSPExpression expression, long weight) {
+        public Contents add(DBSPExpression expression, long weight) {
             // We expect the expression to be a constant value (a literal)
             if (expression.getType().code != this.getElementType().code)
                 throw new InternalCompilerError("Added element type " +
@@ -129,16 +129,18 @@ public class DBSPZSetLiteral extends DBSPLiteral implements IDBSPContainer {
                     this.data.remove(expression);
                 else
                     this.data.put(expression, weight + oldWeight);
-                return;
+                return this;
             }
             this.data.put(expression, weight);
+            return this;
         }
 
-        public void add(Contents other) {
+        public Contents add(Contents other) {
             if (!this.elementType.sameType(other.elementType))
                 throw new InternalCompilerError("Added zsets do not have the same type " +
                         this.getElementType() + " vs " + other.getElementType(), this.elementType);
             other.data.forEach(this::add);
+            return this;
         }
 
         public Contents negate() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -39,7 +39,6 @@ public class CatalogTests extends BaseSQLTests {
 
     @Test
     public void testComplex() {
-        Logger.INSTANCE.setLoggingLevel(CircuitCloneVisitor.class, 2);
         String statements = """
                 -- Git repository.
                 create table repository (

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
@@ -37,7 +37,6 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDouble;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@SuppressWarnings("SpellCheckingInspection")
 public class ComplexQueriesTest extends BaseSQLTests {
     @Test @Ignore("OVER requires only integers https://github.com/feldera/feldera/issues/653")
     public void testDateDiff() {
@@ -69,16 +68,17 @@ public class ComplexQueriesTest extends BaseSQLTests {
         this.compileRustTestCase(sql);
     }
 
-    @Test @Ignore("Not yet tested")
+    @Test @Ignore("Not yet implemented")
     public void testCrossApply() {
         String query = """
-                select d.DocumentID, ds.Status, ds.DateCreated\s
-                 from Documents as d\s
-                 cross apply\s
+                 select d.DocumentID, ds.Status, ds.DateCreated
+                 from Documents as d
+                 cross apply
                      (select top 1 Status, DateCreated
-                      from DocumentStatusLogs\s
+                      from DocumentStatusLogs
                       where DocumentID = d.DocumentId
-                      order by DateCreated desc) as ds""";
+                      order by DateCreated desc) as ds
+                """;
         this.compileRustTestCase(query);
     }
 
@@ -94,7 +94,9 @@ public class ComplexQueriesTest extends BaseSQLTests {
                   trip_distance DOUBLE PRECISION,
                   fare_amount DOUBLE PRECISION
                 );
-                CREATE VIEW V AS SELECT
+                
+                CREATE VIEW V AS
+                SELECT
                 *,
                 COUNT(*) OVER(
                    PARTITION BY  pickup_location_id
@@ -109,18 +111,17 @@ public class ComplexQueriesTest extends BaseSQLTests {
     public void testProducts() {
         String script = """
                 -- create a table
-                CREATE TABLE Products (
+                CREATE TABLE "New Products" (
                     ProductName VARCHAR NOT NULL,
                     Price INT NOT NULL);
                 -- statements separated by semicolons
                 -- create a view
                 CREATE VIEW "Products Above Average Price" AS
                 SELECT ProductName, Price
-                FROM Products
-                WHERE Price > (SELECT AVG(Price) FROM Products)
+                FROM "New Products"
+                WHERE Price > (SELECT AVG(Price) FROM "New Products")
                 -- no semicolon at end""";
-        DBSPCompiler compiler = testCompiler();
-        compiler.compileStatements(script);
+        this.compileRustTestCase(script);
     }
 
     @Test
@@ -190,7 +191,8 @@ public class ComplexQueriesTest extends BaseSQLTests {
                                 is_fraud
                             FROM (
                                 SELECT t1.*, t2.*
-                                       -- , LAG(trans_date_trans_time, 1) OVER                -- (PARTITION BY t1.cc_num  ORDER BY trans_date_trans_time ASC) AS last_txn_date
+                                       -- , LAG(trans_date_trans_time, 1) OVER
+                                       -- (PARTITION BY t1.cc_num  ORDER BY trans_date_trans_time ASC) AS last_txn_date
                                 FROM  transactions AS t1
                                 LEFT JOIN  demographics AS t2
                                 ON t1.cc_num = t2.cc_num);""";
@@ -266,7 +268,8 @@ public class ComplexQueriesTest extends BaseSQLTests {
                    ORDER BY  extract (EPOCH from  CAST (lpep_dropoff_datetime AS TIMESTAMP) )
                    -- 0.5 hour is 1800  seconds
                    RANGE BETWEEN 1800  PRECEDING AND 1 PRECEDING ) AS count_trips_window_30m_dropoff_zip,
-                case when extract (ISODOW from  CAST (lpep_dropoff_datetime AS TIMESTAMP))  > 5      then 1 else 0 end as dropoff_is_weekend
+                case when extract (ISODOW from  CAST (lpep_dropoff_datetime AS TIMESTAMP))  > 5
+                     then 1 else 0 end as dropoff_is_weekend
                 FROM green_tripdata""";
         this.compileRustTestCase(sql);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
@@ -525,7 +525,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         DBSPCircuit circuit = getCircuit(compiler);
         if (!compiler.messages.isEmpty())
             System.out.println(compiler.messages);
-        DBSPType outputType = circuit.getOutputType(0);
+        DBSPType outputType = circuit.getSingleOutputType();
         DBSPZSetLiteral.Contents result = this.parseTable(expected, outputType);
         InputOutputPair streams = new InputOutputPair(
                 this.getPreparedInputs(compiler),
@@ -638,7 +638,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
             compiler.throwIfErrorsOccurred();
         compiler.optimize();
         DBSPCircuit circuit = getCircuit(compiler);
-        DBSPType outputType = circuit.getOutputType(0);
+        DBSPType outputType = circuit.getSingleOutputType();
         DBSPZSetLiteral.Contents result = new DBSPZSetLiteral.Contents(Collections.emptyMap(), outputType);
         InputOutputPair streams = new InputOutputPair(
                 this.getPreparedInputs(compiler),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -5,7 +5,6 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
-import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.sql.simple.InputOutputPair;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -20,7 +19,6 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.util.Linq;
-import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
@@ -69,7 +67,6 @@ public class StreamingTests extends BaseSQLTests {
 
     @Test
     public void tumblingTestLimits() {
-        Logger.INSTANCE.setLoggingLevel(CalciteCompiler.class, 3);
         String sql = """
                CREATE TABLE series (
                    pickup TIMESTAMP NOT NULL LATENESS INTERVAL '1:00' HOURS TO MINUTES

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -12,7 +12,9 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDateLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
@@ -20,6 +22,8 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -128,7 +132,7 @@ public class StreamingTests extends BaseSQLTests {
                 addSub);
         // Insert tuple before last waterline, should be dropped
         data[3] = new InputOutputPair(
-                this.fromDoubleTimestamp(10.0,"2023-12-29 09:10:00"),
+                this.fromDoubleTimestamp(10.0, "2023-12-29 09:10:00"),
                 DBSPZSetLiteral.Contents.emptyWithElementType(data[0].outputs[0].elementType));
         // Insert tuple in the past, but before the last waterline
         addSub = DBSPZSetLiteral.Contents.emptyWithElementType(data[0].outputs[0].elementType);
@@ -146,6 +150,55 @@ public class StreamingTests extends BaseSQLTests {
                 this.fromDoubleTimestamp(10.0, "2023-13-30 10:00:00"),
                 this.fromDoubleTimestamp(10.0, "2023-13-30 00:00:00"));
         this.addRustTestCase("latenessTest", compiler, getCircuit(compiler), data);
+    }
+
+    @Test
+    public void blogTest() {
+        String statements = """
+                CREATE TABLE CUSTOMER(name VARCHAR NOT NULL, zipcode INT NOT NULL);
+                                
+                CREATE VIEW DENSITY AS
+                SELECT zipcode, COUNT(name)
+                FROM CUSTOMER
+                GROUP BY zipcode
+                """;
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(statements);
+        Assert.assertFalse(compiler.hasErrors());
+        DBSPExpression bob = new DBSPTupleExpression(new DBSPStringLiteral("Bob"), new DBSPI32Literal(1000));
+        DBSPType outputType = new DBSPTypeTuple(
+                new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false),
+                new DBSPTypeInteger(CalciteObject.EMPTY, 64, true, false));
+        InputOutputPair[] data = new InputOutputPair[] {
+                new InputOutputPair(
+                        DBSPZSetLiteral.Contents.emptyWithElementType(bob.getType()),
+                        DBSPZSetLiteral.Contents.emptyWithElementType(outputType)
+                ),
+                new InputOutputPair(
+                        new DBSPZSetLiteral.Contents(
+                                bob,
+                                new DBSPTupleExpression(new DBSPStringLiteral("Pam"), new DBSPI32Literal(2000)),
+                                new DBSPTupleExpression(new DBSPStringLiteral("Sue"), new DBSPI32Literal(3000)),
+                                new DBSPTupleExpression(new DBSPStringLiteral("Mike"), new DBSPI32Literal(1000))
+                        ),
+                        new DBSPZSetLiteral.Contents(
+                                new DBSPTupleExpression(new DBSPI32Literal(1000), new DBSPI64Literal(2)),
+                                new DBSPTupleExpression(new DBSPI32Literal(2000), new DBSPI64Literal(1)),
+                                new DBSPTupleExpression(new DBSPI32Literal(3000), new DBSPI64Literal(1))
+                        )
+                ),
+                new InputOutputPair(
+                        DBSPZSetLiteral.Contents.emptyWithElementType(bob.getType())
+                                .add(bob, -1)
+                                .add(new DBSPTupleExpression(new DBSPStringLiteral("Bob"), new DBSPI32Literal(2000))),
+                        DBSPZSetLiteral.Contents.emptyWithElementType(outputType)
+                                .add(new DBSPTupleExpression(new DBSPI32Literal(1000), new DBSPI64Literal(2)), -1)
+                                .add(new DBSPTupleExpression(new DBSPI32Literal(2000), new DBSPI64Literal(1)), -1)
+                                .add(new DBSPTupleExpression(new DBSPI32Literal(2000), new DBSPI64Literal(2)), 1)
+                                .add(new DBSPTupleExpression(new DBSPI32Literal(1000), new DBSPI64Literal(1)), 1)
+                )
+        };
+        this.addRustTestCase("ivm blog post", compiler, getCircuit(compiler), data);
     }
 
     @Test 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -656,7 +656,7 @@ pub fn is_null<T>(value: Option<T>) -> bool {
 }
 
 #[inline(always)]
-pub fn indicator<T>(value: Option<T>) -> i64 {
+pub fn indicator<T>(value: &Option<T>) -> i64 {
     match value {
         None => 0,
         Some(_) => 1,

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -72,7 +72,6 @@ public class Main {
                  */
         );
 
-        // Logger.INSTANCE.setLoggingLevel(Passes.class, 3);
         String[] args = {
                 "-v", "-x", "-inc",
                 "-e", "hybrid",      // executor


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Turns out that the generated Rust would not compile if table names contained spaces.
This PR removes most source of "code injection" in the Rust code.  