### PR TITLE
docker: mysql healthcheck: USE database instead of SELECT 1

### DIFF
--- a/deploy/docker-compose-debezium.yml
+++ b/deploy/docker-compose-debezium.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_USER: mysqluser
       MYSQL_PASSWORD: mysqlpw
     healthcheck:
-      test: ["CMD-SHELL", "mysql -h localhost -u $$MYSQL_USER -p$$MYSQL_PASSWORD -e 'SELECT 1;'" ]
+      test: ["CMD-SHELL", "mysql -h localhost -u $$MYSQL_USER -p$$MYSQL_PASSWORD -e 'USE inventory;'"]
       interval: 5s
       timeout: 20s
       # MySQL can be _very_ slow to start.


### PR DESCRIPTION
In its initialization, MySQL first starts up a temporary server. This server is afterwards stopped and replaced at start-up with the actual server. It appears that even executing a query like `SELECT 1;` is not sufficient to check that the actual server is running and not the temporary one. Only near the very end of the temporary server, the entrypoint SQL is run (creating the databases therein). As such, `USE database;` is less likely to return success than `SELECT 1;` during the temporary server lifetime, and is thus a better health check (albeit, not perfect).

Latest CI run that likely failed because the MySQL was not yet started:
https://github.com/feldera/feldera/actions/runs/7705263364/job/20998907686?pr=1355

Is this a user-visible change (yes/no): no
