### PR TITLE
[SQL] decimal rounding and truncation tests

### DIFF
--- a/docs/sql/decimal.md
+++ b/docs/sql/decimal.md
@@ -29,34 +29,11 @@ unary and binary), ``*`` (multiplication), ``/`` (division), ``%``
 (modulus).
 
 Modulus happens as follows: 
-<table>
-    <caption>mod = x % y</caption>
-    <tr>
-        <th>x</th>
-        <th>y</th>
-        <th>mod</th>
-    </tr>
-    <tr>
-        <td> 1.12 </td>
-        <td> 0.3 </td>
-        <td> 0.22 </td>
-    </tr>
-    <tr>
-        <td> 1.12 </td>
-        <td> -0.3 </td>
-        <td> 0.22 </td>
-    </tr>
-    <tr>
-        <td> -1.12 </td>
-        <td> 0.3 </td>
-        <td> -0.22 </td>
-    </tr>
-    <tr>
-        <td> -1.12 </td>
-        <td> -0.3 </td>
-        <td> -0.22 </td>
-    </tr>
-</table>
+For: ``mod = x % y``
+- if ``x >= 0`` and ``y > 0`` then: ``x - (floor(x / y) * y)``
+- if ``x >= 0`` and ``y < 0`` then: ``x % abs(y)``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % y``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % abs(y)``
 
 Division or modulus by zero cause a runtime error.
 

--- a/docs/sql/decimal.md
+++ b/docs/sql/decimal.md
@@ -28,6 +28,36 @@ The legal operations are ``+`` (plus, unary and binary), ``-`` (minus,
 unary and binary), ``*`` (multiplication), ``/`` (division), ``%``
 (modulus).
 
+Modulus happens as follows: 
+<table>
+    <caption>mod = x % y</caption>
+    <tr>
+        <th>x</th>
+        <th>y</th>
+        <th>mod</th>
+    </tr>
+    <tr>
+        <td> 1.12 </td>
+        <td> 0.3 </td>
+        <td> 0.22 </td>
+    </tr>
+    <tr>
+        <td> 1.12 </td>
+        <td> -0.3 </td>
+        <td> 0.22 </td>
+    </tr>
+    <tr>
+        <td> -1.12 </td>
+        <td> 0.3 </td>
+        <td> -0.22 </td>
+    </tr>
+    <tr>
+        <td> -1.12 </td>
+        <td> -0.3 </td>
+        <td> -0.22 </td>
+    </tr>
+</table>
+
 Division or modulus by zero cause a runtime error.
 
 Casting a string to a decimal value will produce a run time error if
@@ -89,6 +119,10 @@ But invalid casts such as: ``CAST('1234.1234' AS DECIMAL(6, 3))`` will throw a r
   <tr>
     <td><code>ROUND(value, digits)</code></td>
     <td>where <code>digits</code> is an integer value. Round the value to the specified number of <em>decimal</em> digits after the decimal point.</td>
+  </tr>
+  <tr>
+    <td><code>TRUNCATE(value)</code></td>
+    <td>same as <code>TRUNCATE(value, 0)</code></td>
   </tr>
   <tr>
     <td><code>TRUNCATE(value, digits)</code></td>

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -31,34 +31,11 @@ unary and binary), `*` (multiplication), `/` (division), `%`
 (modulus).
 
 Modulus happens as follows:
-<table>
-    <caption>mod = x % y</caption>
-    <tr>
-        <th>x</th>
-        <th>y</th>
-        <th>mod</th>
-    </tr>
-    <tr>
-        <td> 1.12 </td>
-        <td> 0.3 </td>
-        <td> 0.22 </td>
-    </tr>
-    <tr>
-        <td> 1.12 </td>
-        <td> -0.3 </td>
-        <td> 0.22 </td>
-    </tr>
-    <tr>
-        <td> -1.12 </td>
-        <td> 0.3 </td>
-        <td> -0.22 </td>
-    </tr>
-    <tr>
-        <td> -1.12 </td>
-        <td> -0.3 </td>
-        <td> -0.22 </td>
-    </tr>
-</table>
+For: ``mod = x % y``
+- if ``x >= 0`` and ``y > 0`` then: ``x - (floor(x / y) * y)``
+- if ``x >= 0`` and ``y < 0`` then: ``x % abs(y)``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % y``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % abs(y)``
 
 Division by zero returns Infinity, (or `NaN` in case of `0e0 / 0e0`).
 Modulus by zero return `NaN`.

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -27,7 +27,7 @@ an example is `NaN` raised to the zero power yields one.
 In sorting order `NaN` is considered greater than all other values.
 
 The legal operations are `+` (plus, unary and binary), `-` (minus,
-unary and binary), `*` (multiplication), `/` (division).
+unary and binary), `*` (multiplication), `/` (division), `%`
 (modulus).
 
 Division by zero returns Infinity, (or `NaN` in case of `0e0 / 0e0`).

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -30,6 +30,36 @@ The legal operations are `+` (plus, unary and binary), `-` (minus,
 unary and binary), `*` (multiplication), `/` (division), `%`
 (modulus).
 
+Modulus happens as follows:
+<table>
+    <caption>mod = x % y</caption>
+    <tr>
+        <th>x</th>
+        <th>y</th>
+        <th>mod</th>
+    </tr>
+    <tr>
+        <td> 1.12 </td>
+        <td> 0.3 </td>
+        <td> 0.22 </td>
+    </tr>
+    <tr>
+        <td> 1.12 </td>
+        <td> -0.3 </td>
+        <td> 0.22 </td>
+    </tr>
+    <tr>
+        <td> -1.12 </td>
+        <td> 0.3 </td>
+        <td> -0.22 </td>
+    </tr>
+    <tr>
+        <td> -1.12 </td>
+        <td> -0.3 </td>
+        <td> -0.22 </td>
+    </tr>
+</table>
+
 Division by zero returns Infinity, (or `NaN` in case of `0e0 / 0e0`).
 Modulus by zero return `NaN`.
 

--- a/docs/sql/integer.md
+++ b/docs/sql/integer.md
@@ -9,6 +9,15 @@ unary and binary), `*` (multiplication), `/` (division), `%`
 (modulus).
 
 Modulus involving negative numbers happens as follows:
+
+For: ``mod = x % y``
+- if ``x >= 0`` and ``y > 0`` then: ``x - (floor(x / y) * y)``
+- if ``x >= 0`` and ``y < 0`` then: ``x % abs(y)``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % y``
+- if ``x < 0`` and ``y > 0`` then: ``- abs(x) % abs(y)``
+
+Example:
+
 <table>
     <caption>mod = x % y</caption>
     <tr>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -691,6 +691,13 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                         DBSPType rightType = right.getType();
                         if (!rightType.is(DBSPTypeInteger.class))
                             throw new UnimplementedException("ROUND expects a constant second argument", node);
+
+                        // convert to int32
+                        DBSPTypeInteger rightInt = rightType.to(DBSPTypeInteger.class);
+                        if (rightInt.getWidth() != 32) {
+                            right = right.cast(new DBSPTypeInteger(right.getNode(), 32, true, rightType.mayBeNull));
+                        }
+
                         String function = opName + "_" +
                                 leftType.baseTypeWithSuffix();
                         return new DBSPApplyExpression(node, function, type, left, right);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -245,7 +245,7 @@ public class Simplify extends InnerRewriteVisitor {
                     if (value.precision() > decType.precision) {
                         this.errorReporter.reportError(expression.getSourcePosition(),
                                 "Invalid DECIMAL",
-                                "cannot represent " + value + " as DECIMAL(" + decType.precision + ", " + decType.scale +
+                                "cannot represent " + lit + " as DECIMAL(" + decType.precision + ", " + decType.scale +
                                         "): precision of DECIMAL type too small to represent value"
                         );
                     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -243,8 +243,10 @@ public class Simplify extends InnerRewriteVisitor {
                     DBSPTypeDecimal decType = type.to(DBSPTypeDecimal.class);
                     value = value.setScale(decType.scale, RoundingMode.DOWN);
                     if (value.precision() > decType.precision) {
-                        throw new IllegalArgumentException("Value " + value +
-                                " cannot be represented with precision " + decType.precision);
+                        this.errorReporter.reportError(expression.getSourcePosition(),
+                                "Invalid DECIMAL",
+                                "cannot represent " + value + " as DECIMAL(" + decType.precision + ", " + decType.scale + ")"
+                        );
                     }
                     result = new DBSPDecimalLiteral(source.getNode(), type, value);
                 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -245,7 +245,8 @@ public class Simplify extends InnerRewriteVisitor {
                     if (value.precision() > decType.precision) {
                         this.errorReporter.reportError(expression.getSourcePosition(),
                                 "Invalid DECIMAL",
-                                "cannot represent " + value + " as DECIMAL(" + decType.precision + ", " + decType.scale + ")"
+                                "cannot represent " + value + " as DECIMAL(" + decType.precision + ", " + decType.scale +
+                                        "): precision of DECIMAL type too small to represent value"
                         );
                     }
                     result = new DBSPDecimalLiteral(source.getNode(), type, value);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -247,7 +247,7 @@ public class FunctionsTest extends SqlIoTest {
                 5""");
     }
 
-    // Tested on Postgres
+    // Tested on Postgres and some taken from MySQL
     @Test
     public void testDecimalRounding() {
         this.qs("""
@@ -334,6 +334,43 @@ public class FunctionsTest extends SqlIoTest {
                 ------
                  -0.12
                 (1 row)
+                
+                -- the following tests are from mysql
+                select cast('1.00000001335143196001808973960578441619873046875E-10' as decimal(30,15));
+                     decimal
+                -------------------
+                 0.000000000100000
+                (1 row)
+                
+                select ln(14000) as c1, cast(ln(14000) as decimal(5,3)) as c2, cast(ln(14000) as decimal(5,3)) as c3;
+                        c1         |  c2   |  c3
+                -------------------+-------+-------
+                 9.546812608597396 | 9.547 | 9.547
+                (1 row)
+                
+                select cast(143.481 as decimal(4,1));
+                 cast(143.481 as decimal(4,1))
+                -------------------------------
+                143.5
+                (1 row)
+                
+                select cast(143.481 as decimal(4,0));
+                 cast(143.481 as decimal(4,0))
+                -------------------------------
+                143
+                (1 row)
+                
+                select cast(-3.4 as decimal(2,1));
+                 cast(-3.4 as decimal(2,1))
+                -------------------------------
+                -3.4
+                (1 row)
+                
+                select cast(98.6 as decimal(2,0));
+                 cast(98.6 as decimal(2,0))
+                -------------------------------
+                99
+                (1 row)
                 """
         );
     }
@@ -349,6 +386,19 @@ public class FunctionsTest extends SqlIoTest {
                 // The compiler rounds `1234.1236` to `1234.124` before calling the rust code
                 "cannot represent 1234.124 as DECIMAL(6, 3)"
         );
+
+        this.shouldFail("select cast(1234.1234 AS DECIMAL(6, 3))",
+                "cannot represent 1234.123 as DECIMAL(6, 3)"
+        );
+
+        this.shouldFail("select cast(1234.1236 AS DECIMAL(6, 3))",
+                "cannot represent 1234.123 as DECIMAL(6, 3)"
+        );
+
+        // this only fails in runtime
+        this.shouldFail("select cast(143.481 as decimal(2, 1))", "cannot represent 143.4 as DECIMAL(2, 1)");
+        this.runtimeConstantFail("select cast(99.6 as decimal(2, 0))", "cannot represent 99.6 as DECIMAL(2, 0)");
+        this.shouldFail("select cast(-13.4 as decimal(2,1))", "cannot represent -13.4 as DECIMAL(2, 1)");
     }
 
     @Test
@@ -587,6 +637,391 @@ public class FunctionsTest extends SqlIoTest {
                 ------
                 null
                 (1 row)
+                """
+        );
+    }
+
+    @Test
+    public void testRound() {
+        this.qs("""
+                select round(15.1);
+                 round(15.1)
+                ------------
+                 15
+                (1 row)
+                
+                select round(15.4);
+                 round(15.4)
+                ------------
+                 15
+                (1 row)
+                
+                select round(15.5);
+                 round(15.5)
+                ------------
+                 16
+                (1 row)
+                
+                select round(15.6);
+                 round(15.6)
+                ------------
+                 16
+                (1 row)
+                
+                select round(15.9);
+                 round(15.9)
+                ------------
+                 16
+                (1 row)
+                
+                select round(-15.1);
+                 round(-15.1)
+                ------------
+                 -15
+                (1 row)
+                
+                select round(-15.4);
+                 round(-15.4)
+                ------------
+                 -15
+                (1 row)
+                
+                select round(-15.5);
+                 round(-15.5)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(-15.6);
+                 round(-15.6)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(-15.9);
+                 round(-15.9)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(15.1,1);
+                 round(15.1,1)
+                ------------
+                 15.1
+                (1 row)
+                
+                select round(15.4,1);
+                 round(15.4,1)
+                ------------
+                 15.4
+                (1 row)
+                
+                select round(15.5,1);
+                 round(15.5,1)
+                ------------
+                 15.5
+                (1 row)
+                
+                select round(15.6,1);
+                 round(15.6,1)
+                ------------
+                 15.6
+                (1 row)
+                
+                select round(15.9,1);
+                 round(15.9,1)
+                ------------
+                 15.9
+                (1 row)
+                
+                select round(-15.1,1);
+                round(-15.1,1)
+                ------------
+                 -15.1
+                (1 row)
+                
+                select round(-15.4,1);
+                round(-15.4,1)
+                ------------
+                 -15.4
+                (1 row)
+                
+                select round(-15.5,1);
+                round(-15.5,1)
+                ------------
+                 -15.5
+                (1 row)
+                
+                select round(-15.6,1);
+                round(-15.6,1)
+                ------------
+                 -15.6
+                (1 row)
+                
+                select round(-15.9,1);
+                round(-15.9,1)
+                ------------
+                 -15.9
+                (1 row)
+                
+                select round(15.1,0);
+                round(15.1,0)
+                ------------
+                 15
+                (1 row)
+                
+                select round(15.4,0);
+                 round(15.4,0)
+                ------------
+                 15
+                (1 row)
+                
+                select round(15.5,0);
+                round(15.5,0)
+                ------------
+                 16
+                (1 row)
+                
+                select round(15.6,0);
+                round(15.6,0)
+                ------------
+                 16
+                (1 row)
+                
+                select round(15.9,0);
+                round(15.9,0)
+                ------------
+                 16
+                (1 row)
+                
+                select round(-15.1,0);
+                round(-15.1,0)
+                ------------
+                 -15
+                (1 row)
+                
+                select round(-15.4,0);
+                round(-15.4,0)
+                ------------
+                 -15
+                (1 row)
+                
+                select round(-15.5,0);
+                round(-15.5,0)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(-15.6,0);
+                round(-15.6,0)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(-15.9,0);
+                round(-15.9,0)
+                ------------
+                 -16
+                (1 row)
+                
+                select round(15.1,-1);
+                round(15.1,-1)
+                ------------
+                 20
+                (1 row)
+                
+                select round(15.4,-1);
+                round(15.4,-1)
+                ------------
+                 20
+                (1 row)
+                
+                select round(15.5,-1);
+                round(15.5,-1)
+                ------------
+                 20
+                (1 row)
+                
+                select round(15.6,-1);
+                round(15.6,-1)
+                ------------
+                 20
+                (1 row)
+                
+                select round(15.9,-1);
+                round(15.9,-1)
+                ------------
+                 20
+                (1 row)
+                
+                select round(-15.1,-1);
+                round(-15.1,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.4,-1);
+                round(-15.4,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.5,-1);
+                round(-15.5,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.6,-1);
+                round(-15.6,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.91,-1);
+                round(-15.91,-1)
+                ------------
+                 -20
+                (1 row)
+                """
+        );
+    }
+
+    @Test
+    public void testTruncate() {
+        this.qs("""
+                select truncate(5678.123451,0);
+                truncate(5678.123451,0)
+                -----
+                5678
+                (1 row)
+                
+                select truncate(5678.123451,1);
+                truncate(5678.123451,1)
+                -----
+                5678.1
+                (1 row)
+                
+                select truncate(5678.123451,2);
+                truncate(5678.123451,2)
+                -----
+                5678.12
+                (1 row)
+                
+                select truncate(5678.123451,3);
+                truncate(5678.123451,3)
+                -----
+                5678.123
+                (1 row)
+                
+                select truncate(5678.123451,4);
+                truncate(5678.123451,4)
+                -----
+                5678.1234
+                (1 row)
+                
+                select truncate(5678.123451,5);
+                truncate(5678.123451,5)
+                -----
+                5678.12345
+                (1 row)
+                
+                select truncate(5678.123451,6);
+                truncate(5678.123451,6)
+                -----
+                5678.123451
+                (1 row)
+                
+                select truncate(5678.123451,-1);
+                truncate(5678.123451,-1)
+                -----
+                5670
+                (1 row)
+                
+                select truncate(5678.123451,-2);
+                truncate(5678.123451,-2)
+                -----
+                5600
+                (1 row)
+                
+                select truncate(5678.123451,-3);
+                truncate(5678.123451,-3)
+                -----
+                5000
+                (1 row)
+                
+                select truncate(5678.123451,-4);
+                truncate(5678.123451,-4)
+                -----
+                0
+                (1 row)
+                
+                select truncate(-5678.123451,0);
+                truncate(-5678.123451,0)
+                -----
+                -5678
+                (1 row)
+                
+                select truncate(-5678.123451,1);
+                truncate(-5678.123451,1)
+                -----
+                -5678.1
+                (1 row)
+                
+                select truncate(-5678.123451,2);
+                truncate(-5678.123451,2)
+                -----
+                -5678.12
+                (1 row)
+                
+                select truncate(-5678.123451,3);
+                truncate(-5678.123451,3)
+                -----
+                -5678.123
+                (1 row)
+                
+                select truncate(-5678.123451,4);
+                truncate(-5678.123451,4)
+                -----
+                -5678.1234
+                (1 row)
+                
+                select truncate(-5678.123451,5);
+                truncate(-5678.123451,5)
+                -----
+                -5678.12345
+                (1 row)
+                
+                select truncate(-5678.123451,6);
+                truncate(-5678.123451,6)
+                -----
+                -5678.123451
+                (1 row)
+                
+                select truncate(-5678.123451,-1);
+                truncate(-5678.123451,-1)
+                -----
+                -5670
+                (1 row)
+                
+                select truncate(-5678.123451,-2);
+                truncate(-5678.123451,-2)
+                -----
+                -5600
+                (1 row)
+                
+                select truncate(-5678.123451,-3);
+                truncate(-5678.123451,-3)
+                -----
+                -5000
+                (1 row)
+                
+                select truncate(-5678.123451,-4);
+                truncate(-5678.123451,-4)
+                -----
+                0
+                (1 row)
+                
                 """
         );
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -388,15 +388,16 @@ public class FunctionsTest extends SqlIoTest {
         );
 
         this.shouldFail("select cast(1234.1234 AS DECIMAL(6, 3))",
-                "cannot represent 1234.123 as DECIMAL(6, 3)"
+                "cannot represent 1234.1234 as DECIMAL(6, 3)"
         );
 
         this.shouldFail("select cast(1234.1236 AS DECIMAL(6, 3))",
-                "cannot represent 1234.123 as DECIMAL(6, 3)"
+                "cannot represent 1234.1236 as DECIMAL(6, 3)"
         );
 
+        this.shouldFail("select cast(143.481 as decimal(2, 1))", "cannot represent 143.481 as DECIMAL(2, 1)");
+
         // this only fails in runtime
-        this.shouldFail("select cast(143.481 as decimal(2, 1))", "cannot represent 143.4 as DECIMAL(2, 1)");
         this.runtimeConstantFail("select cast(99.6 as decimal(2, 0))", "cannot represent 99.6 as DECIMAL(2, 0)");
         this.shouldFail("select cast(-13.4 as decimal(2,1))", "cannot represent -13.4 as DECIMAL(2, 1)");
     }
@@ -639,6 +640,11 @@ public class FunctionsTest extends SqlIoTest {
                 (1 row)
                 """
         );
+    }
+
+    @Test
+    public void testRoundDecimalDecimal() {
+        this.shouldFail("SELECT round(15.1, 1.0)", "Error in SQL statement: Cannot apply 'ROUND' to arguments of type 'ROUND(<DECIMAL(3, 1)>, <DECIMAL(2, 1)>)'. Supported form(s): 'ROUND(<NUMERIC>, <INTEGER>)'");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -249,7 +249,7 @@ public class FunctionsTest extends SqlIoTest {
 
     // Tested on Postgres and some taken from MySQL
     @Test
-    public void testDecimalRounding() {
+    public void testRounding() {
         this.qs("""
                 select CAST((CAST('1234.1264' AS DECIMAL(8, 4))) AS DECIMAL(6, 2));
                  cast
@@ -883,6 +883,24 @@ public class FunctionsTest extends SqlIoTest {
                 ------------
                  -20
                 (1 row)
+                
+                select round(-15.91,-1::tinyint);
+                round(-15.91,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.91,-1::smallint);
+                round(-15.91,-1)
+                ------------
+                 -20
+                (1 row)
+                
+                select round(-15.91,-1::int);
+                round(-15.91,-1)
+                ------------
+                 -20
+                (1 row)
                 """
         );
     }
@@ -890,6 +908,12 @@ public class FunctionsTest extends SqlIoTest {
     @Test
     public void testTruncate() {
         this.qs("""
+                select truncate(5678.123451);
+                truncate(5678.123451)
+                -----
+                5678
+                (1 row)
+                
                 select truncate(5678.123451,0);
                 truncate(5678.123451,0)
                 -----
@@ -1022,7 +1046,44 @@ public class FunctionsTest extends SqlIoTest {
                 0
                 (1 row)
                 
+                select truncate(5678.123451,1::tinyint);
+                truncate(5678.123451,1)
+                -----
+                5678.1
+                (1 row)
+                
+                select truncate(5678.123451,1::smallint);
+                truncate(5678.123451,1)
+                -----
+                5678.1
+                (1 row)
+                
+                select truncate(5678.123451,1::int);
+                truncate(5678.123451,1)
+                -----
+                5678.1
+                (1 row)
                 """
+        );
+    }
+
+    @Test @Ignore("https://github.com/feldera/feldera/issues/1379")
+    public void testRoundBigInt() {
+        this.q("""
+                SELECT round(123.123, 2::bigint);
+                 round
+                -------
+                 123.12"""
+        );
+    }
+
+    @Test @Ignore("https://github.com/feldera/feldera/issues/1379")
+    public void testTruncateBigInt() {
+        this.q("""
+                select truncate(5678.123451,1::bigint);
+                truncate(5678.123451,1)
+                -----
+                5678.1"""
         );
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
@@ -951,4 +951,127 @@ FROM (SELECT 10*cosd(a), 10*sind(a)
         this.runtimeFail("select log(-1, 0)", "Unable to calculate log(-1, 0)", this.getEmptyIOPair());
         this.runtimeFail("select log(-1, -1)", "Unable to calculate log(-1, -1)", this.getEmptyIOPair());
     }
+
+    // Moved here from `PostgresNumericTests`
+    @Test
+    public void testFpDiv() {
+        // no div or mod defined for fp, so I removed these
+        this.q("WITH v(x) AS\n" +
+                "  (VALUES(0E0),(1E0),(-1E0),(4.2E0),(CAST ('Infinity' AS DOUBLE)),(CAST ('-Infinity' AS DOUBLE))," +
+                "(CAST ('nan' AS DOUBLE)))\n" +
+                "SELECT x1, x2,\n" +
+                "  x1 / x2 AS quot\n" +
+                //"  x1 % x2 AS m,\n" +
+                //"  div(x1, x2) AS div\n" +
+                "FROM v AS v1(x1), v AS v2(x2) WHERE x2 != 0E0;\n" +
+                "    x1     |    x2     |          quot            \n" +
+                "-----------+-----------+--------------------------\n" +
+                "         0 |         1 |  0.00000000000000000000 \n" +
+                "         1 |         1 |  1.00000000000000000000 \n" +
+                "        -1 |         1 | -1.00000000000000000000 \n" +
+                "       4.2 |         1 |      4.2000000000000000 \n" +
+                "  Infinity |         1 |                Infinity \n" +
+                " -Infinity |         1 |               -Infinity \n" +
+                "       NaN |         1 |                     NaN \n" +
+                "         0 |        -1 | -0.00000000000000000000 \n" +
+                "         1 |        -1 | -1.00000000000000000000 \n" +
+                "        -1 |        -1 |  1.00000000000000000000 \n" +
+                "       4.2 |        -1 |     -4.2000000000000000 \n" +
+                "  Infinity |        -1 |               -Infinity \n" +
+                " -Infinity |        -1 |                Infinity \n" +
+                "       NaN |        -1 |                     NaN \n" +
+                "         0 |       4.2 |  0.00000000000000000000 \n" +
+                "         1 |       4.2 |  0.23809523809523809524 \n" +
+                "        -1 |       4.2 | -0.23809523809523809524 \n" +
+                "       4.2 |       4.2 |  1.00000000000000000000 \n" +
+                "  Infinity |       4.2 |                Infinity \n" +
+                " -Infinity |       4.2 |               -Infinity \n" +
+                "       NaN |       4.2 |                     NaN \n" +
+                "         0 |  Infinity |                       0 \n" +
+                "         1 |  Infinity |                       0 \n" +
+                "        -1 |  Infinity |                      -0 \n" +
+                "       4.2 |  Infinity |                       0 \n" +
+                "  Infinity |  Infinity |                     NaN \n" +
+                " -Infinity |  Infinity |                     NaN \n" +
+                "       NaN |  Infinity |                     NaN \n" +
+                "         0 | -Infinity |                      -0 \n" +
+                "         1 | -Infinity |                      -0 \n" +
+                "        -1 | -Infinity |                       0 \n" +
+                "       4.2 | -Infinity |                      -0 \n" +
+                "  Infinity | -Infinity |                     NaN \n" +
+                " -Infinity | -Infinity |                     NaN \n" +
+                "       NaN | -Infinity |                     NaN \n" +
+                "         0 |       NaN |                     NaN \n" +
+                "         1 |       NaN |                     NaN \n" +
+                "        -1 |       NaN |                     NaN \n" +
+                "       4.2 |       NaN |                     NaN \n" +
+                "  Infinity |       NaN |                     NaN \n" +
+                " -Infinity |       NaN |                     NaN \n" +
+                "       NaN |       NaN |                     NaN ");
+    }
+
+    // Moved here from `PostgresNumericTests`
+    @Test
+    public void testSpecialValues() {
+        // This test was written with NUMERIC values, but was converted to FP
+        this.q(
+                """
+                        WITH v(x) AS (VALUES(0E0),(1E0),(-1E0),(4.2E0),(CAST ('Infinity' AS DOUBLE)),(CAST ('-Infinity' AS DOUBLE)),(CAST ('nan' AS DOUBLE)))
+                        SELECT x1, x2,
+                          x1 + x2 AS s,
+                          x1 - x2 AS diff,
+                          x1 * x2 AS prod
+                        FROM v AS v1(x1), v AS v2(x2);
+                            x1     |    x2     |    sum    |   diff    |   prod   \s
+                        -----------+-----------+-----------+-----------+-----------
+                                 0 |         0 |         0 |         0 |         0
+                                 0 |         1 |         1 |        -1 |         0
+                                 0 |        -1 |        -1 |         1 |        -0
+                                 0 |       4.2 |       4.2 |      -4.2 |       0.0
+                                 0 |  Infinity |  Infinity | -Infinity |       NaN
+                                 0 | -Infinity | -Infinity |  Infinity |       NaN
+                                 0 |       NaN |       NaN |       NaN |       NaN
+                                 1 |         0 |         1 |         1 |         0
+                                 1 |         1 |         2 |         0 |         1
+                                 1 |        -1 |         0 |         2 |        -1
+                                 1 |       4.2 |       5.2 |      -3.2 |       4.2
+                                 1 |  Infinity |  Infinity | -Infinity |  Infinity
+                                 1 | -Infinity | -Infinity |  Infinity | -Infinity
+                                 1 |       NaN |       NaN |       NaN |       NaN
+                                -1 |         0 |        -1 |        -1 |        -0
+                                -1 |         1 |         0 |        -2 |        -1
+                                -1 |        -1 |        -2 |         0 |         1
+                                -1 |       4.2 |       3.2 |      -5.2 |      -4.2
+                                -1 |  Infinity |  Infinity | -Infinity | -Infinity
+                                -1 | -Infinity | -Infinity |  Infinity |  Infinity
+                                -1 |       NaN |       NaN |       NaN |       NaN
+                               4.2 |         0 |       4.2 |       4.2 |       0.0
+                               4.2 |         1 |       5.2 |       3.2 |       4.2
+                               4.2 |        -1 |       3.2 |       5.2 |      -4.2
+                               4.2 |       4.2 |       8.4 |       0.0 |     17.64
+                               4.2 |  Infinity |  Infinity | -Infinity |  Infinity
+                               4.2 | -Infinity | -Infinity |  Infinity | -Infinity
+                               4.2 |       NaN |       NaN |       NaN |       NaN
+                          Infinity |         0 |  Infinity |  Infinity |       NaN
+                          Infinity |         1 |  Infinity |  Infinity |  Infinity
+                          Infinity |        -1 |  Infinity |  Infinity | -Infinity
+                          Infinity |       4.2 |  Infinity |  Infinity |  Infinity
+                          Infinity |  Infinity |  Infinity |       NaN |  Infinity
+                          Infinity | -Infinity |       NaN |  Infinity | -Infinity
+                          Infinity |       NaN |       NaN |       NaN |       NaN
+                         -Infinity |         0 | -Infinity | -Infinity |       NaN
+                         -Infinity |         1 | -Infinity | -Infinity | -Infinity
+                         -Infinity |        -1 | -Infinity | -Infinity |  Infinity
+                         -Infinity |       4.2 | -Infinity | -Infinity | -Infinity
+                         -Infinity |  Infinity |       NaN | -Infinity | -Infinity
+                         -Infinity | -Infinity | -Infinity |       NaN |  Infinity
+                         -Infinity |       NaN |       NaN |       NaN |       NaN
+                               NaN |         0 |       NaN |       NaN |       NaN
+                               NaN |         1 |       NaN |       NaN |       NaN
+                               NaN |        -1 |       NaN |       NaN |       NaN
+                               NaN |       4.2 |       NaN |       NaN |       NaN
+                               NaN |  Infinity |       NaN |       NaN |       NaN
+                               NaN | -Infinity |       NaN |       NaN |       NaN
+                               NaN |       NaN |       NaN |       NaN |       NaN""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
@@ -1074,4 +1074,34 @@ FROM (SELECT 10*cosd(a), 10*sind(a)
                                NaN | -Infinity |       NaN |       NaN |       NaN
                                NaN |       NaN |       NaN |       NaN |       NaN""");
     }
+
+    @Test
+    public void testModulo() {
+        this.qs("""
+                select 1.12::DOUBLE % 0.3::DOUBLE;
+                 ?column?
+                ----------
+                     0.22
+                (1 row)
+                                
+                select 1.12::DOUBLE % -0.3::DOUBLE;
+                 ?column?
+                ----------
+                     0.22
+                (1 row)
+                                
+                select -1.12::DOUBLE % 0.3::DOUBLE;
+                 ?column?
+                ----------
+                    -0.22
+                (1 row)
+                                
+                select -1.12::DOUBLE % -0.3::DOUBLE;
+                 ?column?
+                ----------
+                    -0.22
+                (1 row)
+                """
+        );
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
@@ -815,6 +815,36 @@ public class PostgresNumericTests extends SqlIoTest {
     }
 
     @Test
+    public void testModulo() {
+        this.qs("""
+                select 1.12 % 0.3;
+                 ?column?
+                ----------
+                     0.22
+                (1 row)
+                                
+                select 1.12 % -0.3;
+                 ?column?
+                ----------
+                     0.22
+                (1 row)
+                                
+                select -1.12 % 0.3;
+                 ?column?
+                ----------
+                    -0.22
+                (1 row)
+                                
+                select -1.12 % -0.3;
+                 ?column?
+                ----------
+                    -0.22
+                (1 row)
+                """
+        );
+    }
+
+    @Test
     public void testFunctionsNumeric0() {
         // dropped unsupported values inf, nan, etc.
         this.q("""

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
@@ -697,70 +697,6 @@ public class PostgresNumericTests extends SqlIoTest {
         this.testTwoViews(intermediate, last);
     }
 
-    @Test
-    public void testSpecialValues() {
-        // This test was written with NUMERIC values, but was converted to FP
-        this.q(
-                """
-                        WITH v(x) AS (VALUES(0E0),(1E0),(-1E0),(4.2E0),(CAST ('Infinity' AS DOUBLE)),(CAST ('-Infinity' AS DOUBLE)),(CAST ('nan' AS DOUBLE)))
-                        SELECT x1, x2,
-                          x1 + x2 AS s,
-                          x1 - x2 AS diff,
-                          x1 * x2 AS prod
-                        FROM v AS v1(x1), v AS v2(x2);
-                            x1     |    x2     |    sum    |   diff    |   prod   \s
-                        -----------+-----------+-----------+-----------+-----------
-                                 0 |         0 |         0 |         0 |         0
-                                 0 |         1 |         1 |        -1 |         0
-                                 0 |        -1 |        -1 |         1 |        -0
-                                 0 |       4.2 |       4.2 |      -4.2 |       0.0
-                                 0 |  Infinity |  Infinity | -Infinity |       NaN
-                                 0 | -Infinity | -Infinity |  Infinity |       NaN
-                                 0 |       NaN |       NaN |       NaN |       NaN
-                                 1 |         0 |         1 |         1 |         0
-                                 1 |         1 |         2 |         0 |         1
-                                 1 |        -1 |         0 |         2 |        -1
-                                 1 |       4.2 |       5.2 |      -3.2 |       4.2
-                                 1 |  Infinity |  Infinity | -Infinity |  Infinity
-                                 1 | -Infinity | -Infinity |  Infinity | -Infinity
-                                 1 |       NaN |       NaN |       NaN |       NaN
-                                -1 |         0 |        -1 |        -1 |        -0
-                                -1 |         1 |         0 |        -2 |        -1
-                                -1 |        -1 |        -2 |         0 |         1
-                                -1 |       4.2 |       3.2 |      -5.2 |      -4.2
-                                -1 |  Infinity |  Infinity | -Infinity | -Infinity
-                                -1 | -Infinity | -Infinity |  Infinity |  Infinity
-                                -1 |       NaN |       NaN |       NaN |       NaN
-                               4.2 |         0 |       4.2 |       4.2 |       0.0
-                               4.2 |         1 |       5.2 |       3.2 |       4.2
-                               4.2 |        -1 |       3.2 |       5.2 |      -4.2
-                               4.2 |       4.2 |       8.4 |       0.0 |     17.64
-                               4.2 |  Infinity |  Infinity | -Infinity |  Infinity
-                               4.2 | -Infinity | -Infinity |  Infinity | -Infinity
-                               4.2 |       NaN |       NaN |       NaN |       NaN
-                          Infinity |         0 |  Infinity |  Infinity |       NaN
-                          Infinity |         1 |  Infinity |  Infinity |  Infinity
-                          Infinity |        -1 |  Infinity |  Infinity | -Infinity
-                          Infinity |       4.2 |  Infinity |  Infinity |  Infinity
-                          Infinity |  Infinity |  Infinity |       NaN |  Infinity
-                          Infinity | -Infinity |       NaN |  Infinity | -Infinity
-                          Infinity |       NaN |       NaN |       NaN |       NaN
-                         -Infinity |         0 | -Infinity | -Infinity |       NaN
-                         -Infinity |         1 | -Infinity | -Infinity | -Infinity
-                         -Infinity |        -1 | -Infinity | -Infinity |  Infinity
-                         -Infinity |       4.2 | -Infinity | -Infinity | -Infinity
-                         -Infinity |  Infinity |       NaN | -Infinity | -Infinity
-                         -Infinity | -Infinity | -Infinity |       NaN |  Infinity
-                         -Infinity |       NaN |       NaN |       NaN |       NaN
-                               NaN |         0 |       NaN |       NaN |       NaN
-                               NaN |         1 |       NaN |       NaN |       NaN
-                               NaN |        -1 |       NaN |       NaN |       NaN
-                               NaN |       4.2 |       NaN |       NaN |       NaN
-                               NaN |  Infinity |       NaN |       NaN |       NaN
-                               NaN | -Infinity |       NaN |       NaN |       NaN
-                               NaN |       NaN |       NaN |       NaN |       NaN""");
-    }
-
     @Test @Ignore("https://issues.apache.org/jira/browse/CALCITE-5795")
     public void testCast() {
         this.q(
@@ -804,63 +740,6 @@ public class PostgresNumericTests extends SqlIoTest {
     }
 
     @Test
-    public void testFpDiv() {
-        // no div or mod defined for fp, so I removed these
-        this.q("WITH v(x) AS\n" +
-                "  (VALUES(0E0),(1E0),(-1E0),(4.2E0),(CAST ('Infinity' AS DOUBLE)),(CAST ('-Infinity' AS DOUBLE))," +
-                "(CAST ('nan' AS DOUBLE)))\n" +
-                "SELECT x1, x2,\n" +
-                "  x1 / x2 AS quot\n" +
-                //"  x1 % x2 AS m,\n" +
-                //"  div(x1, x2) AS div\n" +
-                "FROM v AS v1(x1), v AS v2(x2) WHERE x2 != 0E0;\n" +
-                "    x1     |    x2     |          quot            \n" +
-                "-----------+-----------+--------------------------\n" +
-                "         0 |         1 |  0.00000000000000000000 \n" +
-                "         1 |         1 |  1.00000000000000000000 \n" +
-                "        -1 |         1 | -1.00000000000000000000 \n" +
-                "       4.2 |         1 |      4.2000000000000000 \n" +
-                "  Infinity |         1 |                Infinity \n" +
-                " -Infinity |         1 |               -Infinity \n" +
-                "       NaN |         1 |                     NaN \n" +
-                "         0 |        -1 | -0.00000000000000000000 \n" +
-                "         1 |        -1 | -1.00000000000000000000 \n" +
-                "        -1 |        -1 |  1.00000000000000000000 \n" +
-                "       4.2 |        -1 |     -4.2000000000000000 \n" +
-                "  Infinity |        -1 |               -Infinity \n" +
-                " -Infinity |        -1 |                Infinity \n" +
-                "       NaN |        -1 |                     NaN \n" +
-                "         0 |       4.2 |  0.00000000000000000000 \n" +
-                "         1 |       4.2 |  0.23809523809523809524 \n" +
-                "        -1 |       4.2 | -0.23809523809523809524 \n" +
-                "       4.2 |       4.2 |  1.00000000000000000000 \n" +
-                "  Infinity |       4.2 |                Infinity \n" +
-                " -Infinity |       4.2 |               -Infinity \n" +
-                "       NaN |       4.2 |                     NaN \n" +
-                "         0 |  Infinity |                       0 \n" +
-                "         1 |  Infinity |                       0 \n" +
-                "        -1 |  Infinity |                      -0 \n" +
-                "       4.2 |  Infinity |                       0 \n" +
-                "  Infinity |  Infinity |                     NaN \n" +
-                " -Infinity |  Infinity |                     NaN \n" +
-                "       NaN |  Infinity |                     NaN \n" +
-                "         0 | -Infinity |                      -0 \n" +
-                "         1 | -Infinity |                      -0 \n" +
-                "        -1 | -Infinity |                       0 \n" +
-                "       4.2 | -Infinity |                      -0 \n" +
-                "  Infinity | -Infinity |                     NaN \n" +
-                " -Infinity | -Infinity |                     NaN \n" +
-                "       NaN | -Infinity |                     NaN \n" +
-                "         0 |       NaN |                     NaN \n" +
-                "         1 |       NaN |                     NaN \n" +
-                "        -1 |       NaN |                     NaN \n" +
-                "       4.2 |       NaN |                     NaN \n" +
-                "  Infinity |       NaN |                     NaN \n" +
-                " -Infinity |       NaN |                     NaN \n" +
-                "       NaN |       NaN |                     NaN ");
-    }
-
-    @Test
     public void testCastOutOfRange() {
         this.shouldFail("SELECT CAST(1 AS NUMERIC(10, 20)) % 2",
                 "Illegal type: DECIMAL type must have scale <= precision");
@@ -896,53 +775,43 @@ public class PostgresNumericTests extends SqlIoTest {
                 "       4.2 |       4.2 |  1.00000000000000000000 |  0.0");
     }
 
-    // We don't support 'Infinity' for Decimal
-    // We don't support NaN for Decimal
-    //SELECT '0'::numeric / '0';
-    //ERROR:  division by zero
-    //SELECT 'inf'::numeric % '0';
-    //ERROR:  division by zero
-    //SELECT '-inf'::numeric % '0';
-    //ERROR:  division by zero
-    //SELECT 'nan'::numeric % '0';
-    // ?column?
-    //----------
-    //      NaN
-    //(1 row)
-    //
-    //SELECT '0'::numeric % '0';
-    //ERROR:  division by zero
-    //SELECT div('inf'::numeric, '0');
-    //ERROR:  division by zero
-    //SELECT div('-inf'::numeric, '0');
-    //ERROR:  division by zero
-    //SELECT div('nan'::numeric, '0');
-    // div
-    //-----
-    // NaN
-    //(1 row)
-    //
-    //SELECT div('0'::numeric, '0');
-    //ERROR:  division by zero
-
     @Test
-    public void testFunctions0() {
-        // TODO: this test was written with NUMERIC values, but was converted to FP
-        this.q("""
-                WITH v(x) AS
-                  (VALUES(0E0),(1E0),(-1E0),(4.2E0),(-7.777E0),(CAST('inf' AS DOUBLE)),(CAST('-inf' AS DOUBLE)),(CAST('nan' AS DOUBLE)))
-                SELECT x, -x as minusx, abs(x), floor(x), ceil(x), sign(x)
-                FROM v;
-                     x     |  minusx   |   abs    |   floor   |   ceil    | sign \s
-                -----------+-----------+----------+-----------+-----------+-------
-                         0 |        -0 |        0 |         0 |         0 |    0\s
-                         1 |        -1 |        1 |         1 |         1 |    1\s
-                        -1 |         1 |        1 |        -1 |        -1 |   -1\s
-                       4.2 |      -4.2 |      4.2 |         4 |         5 |    1\s
-                    -7.777 |     7.777 |    7.777 |        -8 |        -7 |   -1\s
-                  Infinity | -Infinity | Infinity |  Infinity |  Infinity |    1\s
-                 -Infinity |  Infinity | Infinity | -Infinity | -Infinity |   -1\s
-                       NaN |       NaN |      NaN |       NaN |       NaN |  NaN\s""");
+    public void testDivByZero() {
+        this.qf("SELECT '0'::numeric / '0'", "divide by zero");
+
+        //SELECT 'inf'::numeric % '0';
+        this.qf("SELECT '1'::numeric % '0'", "Division by zero");
+
+        //SELECT '-inf'::numeric % '0';
+        //SELECT 'nan'::numeric % '0';
+        this.qf("SELECT '-1'::numeric % '0'", "Division by zero");
+
+        //SELECT '0'::numeric % '0';
+        this.qf("SELECT '0'::numeric % '0'", "Division by zero");
+
+        //SELECT div('inf'::numeric, '0');
+        //SELECT div('-inf'::numeric, '0');
+        //SELECT div('nan'::numeric, '0');
+        //SELECT div('0'::numeric, '0');
+    }
+
+    // this is not a postgres test
+    @Test
+    public void testModuloMinusOne() {
+        this.qs("""
+                SELECT 2::DECIMAL % -1::DECIMAL;
+                 decimal
+                ---------
+                 0
+                (1 row)
+                
+                SELECT 2.1::DECIMAL(2, 1) % -1.1::DECIMAL(2, 1);
+                 decimal
+                ---------
+                 1.0
+                (1 row)
+                """
+        );
     }
 
     @Test
@@ -965,7 +834,7 @@ public class PostgresNumericTests extends SqlIoTest {
     @Test
     public void testFunctions1() {
         // Removed the unsupported inf, nan, etc. values
-        // This test makes not sense for FP
+        // This test makes no sense for FP
         // 'trunc' has been renamed to 'truncate'
         this.q("""
                 WITH v(x) AS
@@ -1021,9 +890,10 @@ public class PostgresNumericTests extends SqlIoTest {
                       4.2 | 2.049390153191920""");
     }
 
-    // TODO: Calcite thinks that sqrt(-1) should produce a runtime error
-    // SELECT sqrt('-1'::numeric);
-    //ERROR:  cannot take square root of a negative number
+    @Test
+    public void testSqrtError() {
+        this.qf("SELECT sqrt('-1'::numeric)", "Unable to compute sqrt of -1");
+    }
 
     @Test
     public void testLog() {

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -242,7 +242,7 @@ pub fn cast_to_decimal_decimal(value: Decimal, precision: u32, scale: u32) -> De
     let to_int_part_precision = precision - scale;
 
     if to_int_part_precision < int_part_precision {
-        panic!("cannot represent {value} as DECIMAL({precision}, {scale})")
+        panic!("cannot represent {value} as DECIMAL({precision}, {scale}): precision of DECIMAL type too small to represent value")
     }
 
     result

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -228,7 +228,10 @@ pub fn cast_to_decimal_decimal(value: Decimal, precision: u32, scale: u32) -> De
     // '1234.5678' -> DECIMAL(6, 2) is fine as the integer part fits in 4 digits
     // but to DECIMAL(6, 3) would error as we can't fit '1234' in 3 digits
 
-    let int_part_precision = value
+    let mut result = value;
+    result.rescale(scale);
+
+    let int_part_precision = result
         .trunc()
         .mantissa()
         .checked_abs()
@@ -242,8 +245,6 @@ pub fn cast_to_decimal_decimal(value: Decimal, precision: u32, scale: u32) -> De
         panic!("cannot represent {value} as DECIMAL({precision}, {scale})")
     }
 
-    let mut result = value;
-    result.rescale(scale);
     result
 }
 
@@ -1225,6 +1226,16 @@ macro_rules! cast_to_i {
             #[inline]
             pub fn [<cast_to_ $result_type _sN >](value: Option<String>) -> $result_type {
                 value.unwrap().trim().parse().unwrap()
+            }
+
+            #[inline]
+            pub fn [<cast_to_ $result_type N_s >](value: String) -> Option<$result_type> {
+                value.trim().parse().ok()
+            }
+
+            #[inline]
+            pub fn [<cast_to_ $result_type N_sN >](value: Option<String>) -> Option<$result_type> {
+                value.unwrap().trim().parse().ok()
             }
 
             // From other integers

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -143,6 +143,25 @@ where
 
 for_all_int_operator!(modulo);
 
+fn f32_modulo(left: F32, right: F32) -> F32 {
+    F32::new(left.into_inner() % right.into_inner())
+}
+
+some_operator!(f32_modulo, modulo, f, F32, F32);
+
+fn f64_modulo(left: F64, right: F64) -> F64 {
+    F64::new(left.into_inner() % right.into_inner())
+}
+
+some_operator!(f64_modulo, modulo, d, F64, F64);
+
+#[inline(always)]
+fn decimal_modulo(left: Decimal, right: Decimal) -> Decimal {
+    left % right
+}
+
+some_operator!(decimal_modulo, modulo, decimal, Decimal, Decimal);
+
 #[inline(always)]
 fn times<T>(left: T, right: T) -> T
 where


### PR DESCRIPTION
* [SQL] modulo for fp and decimal
Modulo was already defined for fp and decimal in the docs but not implemented in Rust, this PR adds those implementations. 

This PR also adds tests for decimal type rounding and truncation. 
- Adds support for negative values while for rounding and truncation to be consistent with Postgres and MySQL. 

Is this a user-visible change (yes/no): no

Fixes: #1327 
