### PR TITLE
Reducing the IO-uring queue depth.

### DIFF
--- a/crates/feldera-storage/src/backend/monoio_impl/mod.rs
+++ b/crates/feldera-storage/src/backend/monoio_impl/mod.rs
@@ -35,7 +35,7 @@ use super::StorageExecutor;
 pub(crate) mod tests;
 
 /// Number of entries an IO-ring will have.
-pub const MAX_RING_ENTRIES: u32 = 32768;
+pub const MAX_RING_ENTRIES: u32 = 4096;
 
 /// Helper function that opens files as direct IO files on linux.
 async fn open_as_direct<P: AsRef<Path>>(


### PR DESCRIPTION
The CI OOM error always happens during runtime creation. We have a pretty high queue depth for the IO-uring which means more memory is needed for it. Maybe reducing this will help for now.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
