### PR TITLE
dbsp: Don't use `Spine` as an easy way to merge multiple batches.

### DIFF
--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -4,7 +4,7 @@ use crate::{
         operator_traits::{BinarySinkOperator, Operator, SinkOperator},
         LocalStoreMarker, OwnershipPreference, RootCircuit, Scope,
     },
-    trace::{Batch, Spine, Trace},
+    trace::{merge_batches, Batch},
     Circuit, Runtime, Stream,
 };
 use std::fmt::Debug;
@@ -233,14 +233,7 @@ where
     /// to `take_from_worker` return `None`. `consolidate` skips `None` results
     /// when computing the consolidated batch.
     pub fn consolidate(&self) -> T {
-        let batches = self.take_from_all();
-        let mut spine = Spine::new(None);
-
-        for batch in batches {
-            spine.insert(batch);
-        }
-
-        spine.consolidate().unwrap_or_else(|| T::empty(()))
+        merge_batches(self.take_from_all())
     }
 }
 


### PR DESCRIPTION
A few pieces of code used a `Spine` to merge a collection of batches.  This does more work than necessary, since `Spine` is all about merging batches with different times.  This commit replaces these users by a new function `merge_batches()`.

There is one remaining case that maybe should be replaced too, which is the use of `Spine` in `RecursiveStream`.  I'm not sure about that one because it adds batches one-by-one instead of all at once and therefore might benefit from how `Spine` could reduce intermediate data sizes by adding weights to zero.  That's data-dependent though.

Is this a user-visible change (yes/no): no