### PR TITLE
docker: streamline Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,13 @@
 # The base image contains tools to build the code given that
 # we need a Java and Rust compiler to run alongside the pipeline manager
 # as of now. This will change later.
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 ENV DEBIAN_FRONTEND noninteractive
+# These two environment variables are used to make openssl-sys pick
+# up libssl-dev and statically link it. Without it, our build defaults
+# to building a vendored version of OpenSSL.
+ENV OPENSSL_NO_VENDOR=1
+ENV OPENSSL_STATIC=1
 RUN apt update --fix-missing && apt install \
   # pkg-config is required for cargo to find libssl
   libssl-dev pkg-config \
@@ -11,7 +16,7 @@ RUN apt update --fix-missing && apt install \
   # To install rust
   curl  \
   # For running the SQL compiler
-  openjdk-19-jre-headless -y \
+  openjdk-21-jre-headless -y \
   # Install locale-gen
   locales \
   # To add the nodesource debian repository
@@ -29,37 +34,67 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
 # to cache the requisite dependencies
 FROM base as chef
 RUN /root/.cargo/bin/cargo install cargo-chef
-RUN /root/.cargo/bin/cargo install cargo-make
 WORKDIR app
 
-# Cache dependencies from rust
-FROM chef AS planner
-COPY . .
-RUN /root/.cargo/bin/cargo chef prepare --recipe-path recipe.json
-
-# Use the recipe.json file to build dependencies first and cache that
-# layer for faster incremental builds of source-code only changes
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --package=pipeline-manager --no-default-features
-COPY . .
-# web-console build tools:
+# Build web-ui
+FROM base as web-ui-builder
 # - nodejs
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ENV NODE_MAJOR=20
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update --fix-missing && apt install nodejs -y
-# - yarn
 RUN npm install --global yarn openapi-typescript-codegen
-RUN /root/.cargo/bin/cargo build --release --package=pipeline-manager --no-default-features
+# - yarn
+COPY web-console/package.json ./web-console/package.json
+COPY web-console/yarn.lock ./web-console/yarn.lock
+RUN cd web-console && yarn install
+# Use a glob here so that the .env file's presence is optional. This should
+# not fail in our CI/CD builds and if it does, we should see a MUIX license
+# error in the UI
+COPY web-console/.env* web-console/
+COPY web-console/public web-console/public
+COPY web-console/src web-console/src
+COPY web-console/.editorconfig web-console/
+COPY web-console/.eslintrc.json web-console/
+COPY web-console/.prettierrc.js web-console/
+COPY web-console/next-env.d.ts ./web-console/next-env.d.ts
+COPY web-console/next.config.js ./web-console/next.config.js
+COPY web-console/next.d.ts ./web-console/next.d.ts
+COPY web-console/tsconfig.json ./web-console/tsconfig.json
+RUN cd web-console && yarn build
+
+# Cache dependencies from rust
+FROM chef AS planner
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY crates crates
+RUN mkdir sql-to-dbsp-compiler
+COPY sql-to-dbsp-compiler/lib sql-to-dbsp-compiler/lib
+RUN /root/.cargo/bin/cargo chef prepare --recipe-path recipe.json
+
+# Use the recipe.json file to build dependencies first and cache that
+# layer for faster incremental builds of source-code only changes
+FROM chef AS builder
+ENV CARGO_INCREMENTAL=0
+COPY --from=planner /app/recipe.json recipe.json
+RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=pipeline-manager --no-default-features
+COPY Cargo.toml Cargo.toml
+COPY Cargo.lock Cargo.lock
+COPY crates crates
+RUN mkdir sql-to-dbsp-compiler || true
+COPY sql-to-dbsp-compiler/lib sql-to-dbsp-compiler/lib
+COPY --from=web-ui-builder /web-console/out web-console-out
+ENV WEBUI_BUILD_DIR=/app/web-console-out
+RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --no-default-features
 
 # Java build can be performed in parallel
 FROM base as javabuild
 RUN apt install maven -y
 RUN mkdir sql
 COPY sql-to-dbsp-compiler /sql/sql-to-dbsp-compiler
-RUN cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -ntp -DskipTests package
+RUN --mount=type=cache,target=/root/.m2 \
+    cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -ntp -DskipTests package
 
 # Minimal image for running the pipeline manager
 FROM base as release
@@ -143,7 +178,7 @@ COPY ./demo/project_demo00-SecOps/simulator/ .
 RUN /root/.cargo/bin/cargo build --release
 
 # The dev target adds an rpk client and demo projects
-FROM ubuntu:22.04 AS client
+FROM ubuntu:24.04 AS client
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH="$PATH:/root/.cargo/bin"
 COPY demo demo


### PR DESCRIPTION
This commit removes a few inefficiencies from the Dockerfile.

* Avoid `COPY . .`, which copies over a lot of junk during local builds, and only selectively copy the files we need.
* Builds the web-server and java components in parallel with the pipeline-manager.
* Avoids building the split-up pipeline-manager components since we build them separately in our internal workflows.
* Sets two environment variables during the CI build to force `openssl-sys` to pick up libssl-dev and statically link it in to the binary. The first compilation (either via precompilation or otherwise), drops from 75s to 51s for me with this change.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
