### PR TITLE
dbsp: Fix `galen` benchmark.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -4527,7 +4527,7 @@ mod tests {
             let fact = circuit
                 .iterate_with_condition_and_scheduler::<_, _, S>(|child| {
                     let mut counter = 0;
-                    let countdown = source.delta0(child).apply(move |parent_val| {
+                    let countdown = source.delta0(child).apply_mut(move |parent_val| {
                         if *parent_val > 0 {
                             counter = *parent_val;
                         };


### PR DESCRIPTION
Commit 7adb42449bb2 ("dbsp: Don't use `Spine` as an easy way to merge multiple batches.") broke the `galen` benchmark, e.g. see https://github.com/feldera/feldera/actions/runs/7788912540/job/21239358442:

```
Finished bench [optimized + debuginfo] target(s) in 1m 00s
Running benches/galen.rs (target/release/deps/galen-0d27487e860f1e75)
Running galen benchmark with 10 workers
thread 'dbsp-worker-0' panicked at /dbsp/crates/dbsp/src/operator/apply.rs:183:9:
not implemented
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This change triggered the problem:

```rust
                                .apply_owned_named("merge shards", |batches| {
                                    merge_batches(batches)
                                });
```

It's because `apply_owned_named` doesn't consider its closure to arrive at a fixed point, see `apply.rs`:

```rust
    fn fixedpoint(&self, _scope: Scope) -> bool {
        // TODO: either change `F` type to `Fn` from `FnMut` or
        // parameterize the operator with custom fixed point check.
        unimplemented!();
    }
```

This commit solves the problem by introducing `Fn` and `FnMut` variants of the `apply` operators and then using the `_mut` variant where needed. The default is non-`_mut`, which fixes the benchmark.

Is this a user-visible change (yes/no): no