### PR TITLE
Add support for case (in)sensitive table names in WebConsole

### DIFF
--- a/web-console/src/app/(root)/(authenticated)/(app)/streaming/builder/page.tsx
+++ b/web-console/src/app/(root)/(authenticated)/(app)/streaming/builder/page.tsx
@@ -9,7 +9,6 @@ import MissingSchemaDialog from '$lib/components/streaming/builder/NoSchemaDialo
 import { PipelineGraph } from '$lib/components/streaming/builder/PipelineBuilder'
 import { connectorConnects, useAddConnector } from '$lib/compositions/streaming/builder/useAddIoNode'
 import { useBuilderState } from '$lib/compositions/streaming/builder/useBuilderState'
-import { useDeleteNode } from '$lib/compositions/streaming/builder/useDeleteNode'
 import { useReplacePlaceholder } from '$lib/compositions/streaming/builder/useSqlPlaceholderClick'
 import { useUpdatePipeline } from '$lib/compositions/streaming/builder/useUpdatePipeline'
 import { useHashPart } from '$lib/compositions/useHashPart'
@@ -144,7 +143,6 @@ const useRenderPipelineEffect = (
     ...pipelineManagerQuery.connectors(),
     refetchInterval: 2000
   })
-  const deleteNode = useDeleteNode(() => {})
   const render = () => {
     if (saveState === 'isSaving' || saveState === 'isModified') {
       return
@@ -239,13 +237,9 @@ const useRenderPipelineEffect = (
   }
 
   useEffect(render, [
-    connectorsQuery.isPending,
-    connectorsQuery.isError,
     connectorsQuery.data,
     pipeline.program_name,
     pipeline.attached_connectors,
-    projectsQuery.isPending,
-    projectsQuery.isError,
     projectsQuery.data,
     replacePlaceholder,
     addConnector,
@@ -253,7 +247,6 @@ const useRenderPipelineEffect = (
     saveState,
     setNodes,
     getNodes,
-    deleteNode,
     setMissingSchemaDialog
   ])
 }

--- a/web-console/src/app/(root)/(authenticated)/(app)/streaming/inspection/page.tsx
+++ b/web-console/src/app/(root)/(authenticated)/(app)/streaming/inspection/page.tsx
@@ -6,7 +6,7 @@ import { ErrorOverlay } from '$lib/components/common/table/ErrorOverlay'
 import { InsertionTable } from '$lib/components/streaming/import/InsertionTable'
 import { InspectionTable } from '$lib/components/streaming/inspection/InspectionTable'
 import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQuery'
-import { caseDependentName, caseDependentNameEq, getCaseIndependentName } from '$lib/functions/felderaRelation'
+import { caseDependentNameEq, getCaseDependentName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { Relation } from '$lib/services/manager'
 import { Pipeline, PipelineStatus } from '$lib/types/pipeline'
 import { useSearchParams } from 'next/navigation'
@@ -172,7 +172,7 @@ export default () => {
       if (
         caseIndependentName &&
         views &&
-        views.find(caseDependentNameEq(caseDependentName(caseIndependentName))) &&
+        views.find(caseDependentNameEq(getCaseDependentName(caseIndependentName))) &&
         tab === 'insert'
       ) {
         setTab('browse')
@@ -184,11 +184,11 @@ export default () => {
   }
   const { tables, views } = pipelineRevision
   const relationType = (() => {
-    const validTable = tables.find(caseDependentNameEq(caseDependentName(caseIndependentName)))
+    const validTable = tables.find(caseDependentNameEq(getCaseDependentName(caseIndependentName)))
     if (validTable) {
       return 'table'
     }
-    const validView = views.find(caseDependentNameEq(caseDependentName(caseIndependentName)))
+    const validView = views.find(caseDependentNameEq(getCaseDependentName(caseIndependentName)))
     if (validView) {
       return 'view'
     }

--- a/web-console/src/app/(root)/(authenticated)/(app)/streaming/inspection/page.tsx
+++ b/web-console/src/app/(root)/(authenticated)/(app)/streaming/inspection/page.tsx
@@ -183,11 +183,17 @@ export default () => {
     return <></>
   }
   const { tables, views } = pipelineRevision
-  const relationType = tables.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
-    ? 'table'
-    : views.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
-      ? 'view'
-      : undefined
+  const relationType = (() => {
+    const validTable = tables.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
+    if (validTable) {
+      return 'table'
+    }
+    const validView = views.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
+    if (validView) {
+      return 'view'
+    }
+    return undefined
+  })()
 
   if (!relationType) {
     return (

--- a/web-console/src/lib/components/streaming/builder/NodeTypes/InputNode.tsx
+++ b/web-console/src/lib/components/streaming/builder/NodeTypes/InputNode.tsx
@@ -36,7 +36,7 @@ const InputNode = ({ id, data }: NodeProps<{ connector: ConnectorDescr }>) => {
       return (
         targetNode !== undefined &&
         targetNode.type === 'sqlProgram' &&
-        connection.targetHandle != null &&
+        connection.targetHandle !== null &&
         connection.targetHandle.startsWith('table-')
       )
     } else {

--- a/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
+++ b/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
@@ -5,6 +5,7 @@ import { Handle, Node } from '$lib/components/streaming/builder/NodeTypes'
 import { useDeleteNode, useDeleteNodeProgram } from '$lib/compositions/streaming/builder/useDeleteNode'
 import { useDeleteDialog } from '$lib/compositions/useDialog'
 import { zipDefault } from '$lib/functions/common/tuple'
+import { escapeRelationName, quotifyRelationName } from '$lib/functions/felderaRelation'
 import { ProgramDescr, Relation } from '$lib/services/manager'
 import { Connection, getConnectedEdges, NodeProps, Position, useReactFlow } from 'reactflow'
 import { TextIcon } from 'src/lib/components/common/TextIcon'
@@ -17,7 +18,7 @@ import Avatar from '@mui/material/Avatar'
 import Chip from '@mui/material/Chip'
 import IconButton from '@mui/material/IconButton'
 
-function SqlTableNode(props: { name: string }) {
+function SqlTableNode(props: { relation: Relation }) {
   const { getNode, getEdges } = useReactFlow()
 
   // Only allow the connection if it's coming from an input node
@@ -37,8 +38,8 @@ function SqlTableNode(props: { name: string }) {
   return (
     <Box sx={{ ml: -6, mt: 3 }} style={{ position: 'relative' }}>
       <Chip
-        sx={{ ml: 9 }}
-        label={props.name}
+        sx={{ ml: 9, '.MuiChip-label': { textTransform: 'none' } }}
+        label={quotifyRelationName(props.relation)}
         color='secondary'
         avatar={
           <Avatar>
@@ -48,18 +49,18 @@ function SqlTableNode(props: { name: string }) {
       />
       {/* The table- prefix is important for the isValidConnection logic */}
       <Handle
-        id={'table-' + props.name}
+        id={'table-' + escapeRelationName(quotifyRelationName(props.relation))}
         type='target'
         position={Position.Left}
         isConnectable={true}
         isValidConnection={isValidConnection}
-        data-testid={'box-handle-table-' + props.name}
+        data-testid={'box-handle-table-' + quotifyRelationName(props.relation)}
       />
     </Box>
   )
 }
 
-function SqlViewNode(props: { name: string }) {
+function SqlViewNode(props: { relation: Relation }) {
   const { getNode } = useReactFlow()
 
   // Only allow the connection if we're going from a view to an output node
@@ -75,8 +76,8 @@ function SqlViewNode(props: { name: string }) {
   return (
     <Box sx={{ mr: -6, mt: 3, textAlign: 'right' }} style={{ position: 'relative' }}>
       <Chip
-        sx={{ mr: 9 }}
-        label={props.name}
+        sx={{ mr: 9, '.MuiChip-label': { textTransform: 'none' } }}
+        label={quotifyRelationName(props.relation)}
         color='secondary'
         avatar={
           <Avatar>
@@ -86,12 +87,12 @@ function SqlViewNode(props: { name: string }) {
       />
       {/* The view- prefix is important for the isValidConnection functions */}
       <Handle
-        id={'view-' + props.name}
+        id={'view-' + escapeRelationName(quotifyRelationName(props.relation))}
         type='source'
         position={Position.Right}
         isConnectable={true}
         isValidConnection={isValidConnection}
-        data-testid={'box-handle-view-' + props.name}
+        data-testid={'box-handle-view-' + quotifyRelationName(props.relation)}
       />
     </Box>
   )
@@ -137,8 +138,8 @@ export function SqlNode({ id, data }: NodeProps<{ label: string; program: Progra
           ([input, output], idx) => {
             return (
               <Stack direction='row' spacing={2} key={idx} sx={{ width: '100%' }}>
-                <Box sx={{ textAlign: 'left' }}>{input && <SqlTableNode name={input.name} />}</Box>
-                <Box sx={{ textAlign: 'right', width: '100%' }}> {output && <SqlViewNode name={output.name} />}</Box>
+                <Box sx={{ textAlign: 'left' }}>{input && <SqlTableNode relation={input} />}</Box>
+                <Box sx={{ textAlign: 'right', width: '100%' }}> {output && <SqlViewNode relation={output} />}</Box>
               </Stack>
             )
           }

--- a/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
+++ b/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
@@ -5,7 +5,7 @@ import { Handle, Node } from '$lib/components/streaming/builder/NodeTypes'
 import { useDeleteNode, useDeleteNodeProgram } from '$lib/compositions/streaming/builder/useDeleteNode'
 import { useDeleteDialog } from '$lib/compositions/useDialog'
 import { zipDefault } from '$lib/functions/common/tuple'
-import { escapeRelationName, quotifyRelationName } from '$lib/functions/felderaRelation'
+import { escapeRelationName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ProgramDescr, Relation } from '$lib/services/manager'
 import { Connection, getConnectedEdges, NodeProps, Position, useReactFlow } from 'reactflow'
 import { TextIcon } from 'src/lib/components/common/TextIcon'
@@ -39,7 +39,7 @@ function SqlTableNode(props: { relation: Relation }) {
     <Box sx={{ ml: -6, mt: 3 }} style={{ position: 'relative' }}>
       <Chip
         sx={{ ml: 9, '.MuiChip-label': { textTransform: 'none' } }}
-        label={quotifyRelationName(props.relation)}
+        label={getCaseIndependentName(props.relation)}
         color='secondary'
         avatar={
           <Avatar>
@@ -49,12 +49,12 @@ function SqlTableNode(props: { relation: Relation }) {
       />
       {/* The table- prefix is important for the isValidConnection logic */}
       <Handle
-        id={'table-' + escapeRelationName(quotifyRelationName(props.relation))}
+        id={'table-' + escapeRelationName(getCaseIndependentName(props.relation))}
         type='target'
         position={Position.Left}
         isConnectable={true}
         isValidConnection={isValidConnection}
-        data-testid={'box-handle-table-' + quotifyRelationName(props.relation)}
+        data-testid={'box-handle-table-' + getCaseIndependentName(props.relation)}
       />
     </Box>
   )
@@ -77,7 +77,7 @@ function SqlViewNode(props: { relation: Relation }) {
     <Box sx={{ mr: -6, mt: 3, textAlign: 'right' }} style={{ position: 'relative' }}>
       <Chip
         sx={{ mr: 9, '.MuiChip-label': { textTransform: 'none' } }}
-        label={quotifyRelationName(props.relation)}
+        label={getCaseIndependentName(props.relation)}
         color='secondary'
         avatar={
           <Avatar>
@@ -87,12 +87,12 @@ function SqlViewNode(props: { relation: Relation }) {
       />
       {/* The view- prefix is important for the isValidConnection functions */}
       <Handle
-        id={'view-' + escapeRelationName(quotifyRelationName(props.relation))}
+        id={'view-' + escapeRelationName(getCaseIndependentName(props.relation))}
         type='source'
         position={Position.Right}
         isConnectable={true}
         isValidConnection={isValidConnection}
-        data-testid={'box-handle-view-' + quotifyRelationName(props.relation)}
+        data-testid={'box-handle-view-' + getCaseIndependentName(props.relation)}
       />
     </Box>
   )

--- a/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
+++ b/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
@@ -10,6 +10,7 @@ import BigNumber from 'bignumber.js'
 import dayjs from 'dayjs'
 import Papa from 'papaparse'
 import { ChangeEvent, Dispatch, MutableRefObject, ReactNode, SetStateAction, useCallback } from 'react'
+import { quotifyRelationName } from 'src/lib/functions/felderaRelation'
 import JSONbig from 'true-json-bigint'
 import IconDuplicate from '~icons/bx/duplicate'
 import IconPlusCircle from '~icons/bx/plus-circle'
@@ -56,7 +57,7 @@ const ImportToolbar = ({
   const isRunning = pipeline?.state.current_status === PipelineStatus.RUNNING
 
   const [settings, setSettings] = useLocalStorage<Map<string, StoredFieldSettings>>({
-    key: [LS_PREFIX, 'rng-settings', pipelineRevision.program.program_id, relation.name].join('-'),
+    key: [LS_PREFIX, 'rng-settings', pipelineRevision.program.program_id, quotifyRelationName(relation)].join('-'),
     serialize: value => {
       return JSONbig.stringify(Array.from(value.entries()))
     },

--- a/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
+++ b/web-console/src/lib/components/streaming/import/ImportToolbar.tsx
@@ -10,7 +10,7 @@ import BigNumber from 'bignumber.js'
 import dayjs from 'dayjs'
 import Papa from 'papaparse'
 import { ChangeEvent, Dispatch, MutableRefObject, ReactNode, SetStateAction, useCallback } from 'react'
-import { quotifyRelationName } from 'src/lib/functions/felderaRelation'
+import { getCaseIndependentName } from 'src/lib/functions/felderaRelation'
 import JSONbig from 'true-json-bigint'
 import IconDuplicate from '~icons/bx/duplicate'
 import IconPlusCircle from '~icons/bx/plus-circle'
@@ -57,7 +57,7 @@ const ImportToolbar = ({
   const isRunning = pipeline?.state.current_status === PipelineStatus.RUNNING
 
   const [settings, setSettings] = useLocalStorage<Map<string, StoredFieldSettings>>({
-    key: [LS_PREFIX, 'rng-settings', pipelineRevision.program.program_id, quotifyRelationName(relation)].join('-'),
+    key: [LS_PREFIX, 'rng-settings', pipelineRevision.program.program_id, getCaseIndependentName(relation)].join('-'),
     serialize: value => {
       return JSONbig.stringify(Array.from(value.entries()))
     },

--- a/web-console/src/lib/components/streaming/import/InsertionTable.tsx
+++ b/web-console/src/lib/components/streaming/import/InsertionTable.tsx
@@ -10,7 +10,7 @@ import { useDataGridPresentationLocalStorage } from '$lib/compositions/persisten
 import { getDefaultValue } from '$lib/compositions/streaming/import/useDefaultRows'
 import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQuery'
 import { getValueFormatter, Row } from '$lib/functions/ddl'
-import { caseDependentName, caseDependentNameEq, getCaseIndependentName } from '$lib/functions/felderaRelation'
+import { caseDependentNameEq, getCaseDependentName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ColumnType, Field, PipelineRevision, Relation } from '$lib/services/manager'
 import { LS_PREFIX } from '$lib/types/localStorage'
 import { Pipeline } from '$lib/types/pipeline'
@@ -59,8 +59,8 @@ const useInsertionTable = (props: {
     }
 
     const program = newPipelineRevision.program
-    const tables = program.schema?.inputs.find(caseDependentNameEq(caseDependentName(props.caseIndependentName)))
-    const views = program.schema?.outputs.find(caseDependentNameEq(caseDependentName(props.caseIndependentName)))
+    const tables = program.schema?.inputs.find(caseDependentNameEq(getCaseDependentName(props.caseIndependentName)))
+    const views = program.schema?.outputs.find(caseDependentNameEq(getCaseDependentName(props.caseIndependentName)))
     const relation = tables || views // name is unique in the schema
     if (!relation) {
       return

--- a/web-console/src/lib/components/streaming/import/RngSettingsDialog.tsx
+++ b/web-console/src/lib/components/streaming/import/RngSettingsDialog.tsx
@@ -1,6 +1,7 @@
 // A dialog that displays a random generation settings form for every field in
 // the table.
 
+import { quotifyFieldName } from '$lib/functions/felderaRelation'
 import { ColumnType, Field, Relation } from '$lib/services/manager'
 import { forwardRef, ReactElement, Ref, useState } from 'react'
 import { match, P } from 'ts-pattern'
@@ -96,10 +97,10 @@ const FieldRngSettings = (props: {
 
   return (
     <>
-      <Grid item xs={12} key={`${field.name}-${index}`}>
+      <Grid item xs={12} key={`${quotifyFieldName(field)}-${index}`}>
         <Box sx={{ columnGap: 2, display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
           <Typography sx={{ fontWeight: 600, color: 'text.secondary' }}>
-            {index + 1}. {field.name}:
+            {index + 1}. {quotifyFieldName(field)}:
           </Typography>
           <Typography sx={{ color: 'text.secondary' }}>{displayFieldType(field)}</Typography>
         </Box>
@@ -160,8 +161,8 @@ export const RngSettingsDialog = (props: {
               <FieldRngSettings
                 field={field}
                 index={i}
-                key={`${field.name}-${i}`}
-                fieldSettings={settings.get(field.name)}
+                key={`${quotifyFieldName(field)}-${i}`}
+                fieldSettings={settings.get(quotifyFieldName(field))}
                 setSettings={setSettings}
               />
             ))}

--- a/web-console/src/lib/components/streaming/import/RngSettingsDialog.tsx
+++ b/web-console/src/lib/components/streaming/import/RngSettingsDialog.tsx
@@ -1,7 +1,7 @@
 // A dialog that displays a random generation settings form for every field in
 // the table.
 
-import { quotifyFieldName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ColumnType, Field, Relation } from '$lib/services/manager'
 import { forwardRef, ReactElement, Ref, useState } from 'react'
 import { match, P } from 'ts-pattern'
@@ -97,10 +97,10 @@ const FieldRngSettings = (props: {
 
   return (
     <>
-      <Grid item xs={12} key={`${quotifyFieldName(field)}-${index}`}>
+      <Grid item xs={12} key={`${getCaseIndependentName(field)}-${index}`}>
         <Box sx={{ columnGap: 2, display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
           <Typography sx={{ fontWeight: 600, color: 'text.secondary' }}>
-            {index + 1}. {quotifyFieldName(field)}:
+            {index + 1}. {getCaseIndependentName(field)}:
           </Typography>
           <Typography sx={{ color: 'text.secondary' }}>{displayFieldType(field)}</Typography>
         </Box>
@@ -161,8 +161,8 @@ export const RngSettingsDialog = (props: {
               <FieldRngSettings
                 field={field}
                 index={i}
-                key={`${quotifyFieldName(field)}-${i}`}
-                fieldSettings={settings.get(quotifyFieldName(field))}
+                key={`${getCaseIndependentName(field)}-${i}`}
+                fieldSettings={settings.get(getCaseIndependentName(field))}
                 setSettings={setSettings}
               />
             ))}

--- a/web-console/src/lib/components/streaming/import/randomData/index.tsx
+++ b/web-console/src/lib/components/streaming/import/randomData/index.tsx
@@ -3,7 +3,7 @@
 
 import { useDynamicValidationForm } from '$lib/compositions/streaming/import/useDynamicValidationForm/valibot'
 import { clampToSQL, ColumnTypeJS } from '$lib/functions/ddl'
-import { quotifyFieldName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { Field } from '$lib/services/manager'
 import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
@@ -94,7 +94,7 @@ export const RngFieldSettings = (props: {
       clearErrors()
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.set(quotifyFieldName(field), {
+        newSettings.set(getCaseIndependentName(field), {
           method: method.title,
           config: defaultValues
         })
@@ -137,14 +137,14 @@ export const RngFieldSettings = (props: {
       setParsedExample(clampToSQL(field.columntype)(newExample))
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.set(quotifyFieldName(field), { method: selectedMethod.title, config: myFormData })
+        newSettings.set(getCaseIndependentName(field), { method: selectedMethod.title, config: myFormData })
         return newSettings
       })
     } else {
       setExample(undefined)
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.delete(quotifyFieldName(field))
+        newSettings.delete(getCaseIndependentName(field))
         return newSettings
       })
     }

--- a/web-console/src/lib/components/streaming/import/randomData/index.tsx
+++ b/web-console/src/lib/components/streaming/import/randomData/index.tsx
@@ -3,6 +3,7 @@
 
 import { useDynamicValidationForm } from '$lib/compositions/streaming/import/useDynamicValidationForm/valibot'
 import { clampToSQL, ColumnTypeJS } from '$lib/functions/ddl'
+import { quotifyFieldName } from '$lib/functions/felderaRelation'
 import { Field } from '$lib/services/manager'
 import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
@@ -93,7 +94,7 @@ export const RngFieldSettings = (props: {
       clearErrors()
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.set(field.name, {
+        newSettings.set(quotifyFieldName(field), {
           method: method.title,
           config: defaultValues
         })
@@ -136,14 +137,14 @@ export const RngFieldSettings = (props: {
       setParsedExample(clampToSQL(field.columntype)(newExample))
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.set(field.name, { method: selectedMethod.title, config: myFormData })
+        newSettings.set(quotifyFieldName(field), { method: selectedMethod.title, config: myFormData })
         return newSettings
       })
     } else {
       setExample(undefined)
       setSettings(prev => {
         const newSettings = new Map(prev)
-        newSettings.delete(field.name)
+        newSettings.delete(quotifyFieldName(field))
         return newSettings
       })
     }

--- a/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
@@ -12,7 +12,7 @@ import { useTableUpdater } from '$lib/compositions/streaming/inspection/useTable
 import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQuery'
 import { useAsyncError } from '$lib/functions/common/react'
 import { Row, rowToAnchor } from '$lib/functions/ddl'
-import { caseDependentName, caseDependentNameEq, getCaseIndependentName } from '$lib/functions/felderaRelation'
+import { caseDependentNameEq, getCaseDependentName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { EgressMode, Field, NeighborhoodQuery, OutputQuery, Relation } from '$lib/services/manager'
 import { LS_PREFIX } from '$lib/types/localStorage'
 import { Pipeline } from '$lib/types/pipeline'
@@ -84,8 +84,8 @@ const useInspectionTable = ({ pipeline, caseIndependentName }: InspectionTablePr
 
     const pipelineRevision = pipelineRevisionQuery.data
     const program = pipelineRevision.program
-    const tables = program.schema?.inputs.find(caseDependentNameEq(caseDependentName(caseIndependentName)))
-    const views = program.schema?.outputs.find(caseDependentNameEq(caseDependentName(caseIndependentName)))
+    const tables = program.schema?.inputs.find(caseDependentNameEq(getCaseDependentName(caseIndependentName)))
+    const views = program.schema?.outputs.find(caseDependentNameEq(getCaseDependentName(caseIndependentName)))
     const relation = tables || views // name is unique in the schema
     if (!relation) {
       return

--- a/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionTable.tsx
@@ -12,6 +12,12 @@ import { useTableUpdater } from '$lib/compositions/streaming/inspection/useTable
 import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQuery'
 import { useAsyncError } from '$lib/functions/common/react'
 import { Row, rowToAnchor } from '$lib/functions/ddl'
+import {
+  caseDependentName,
+  caseDependentNameEq,
+  quotifyFieldName,
+  quotifyRelationName
+} from '$lib/functions/felderaRelation'
 import { EgressMode, Field, NeighborhoodQuery, OutputQuery, Relation } from '$lib/services/manager'
 import { LS_PREFIX } from '$lib/types/localStorage'
 import { Pipeline } from '$lib/types/pipeline'
@@ -29,7 +35,7 @@ const FETCH_QUANTILES = 100
 
 export type InspectionTableProps = {
   pipeline: Pipeline
-  name: string
+  quotedRelationName: string
 }
 
 // The number of rows we display in the table.
@@ -52,7 +58,7 @@ const INITIAL_PAGINATION_MODEL: GridPaginationModel = { pageSize: PAGE_SIZE, pag
  * @param param
  * @returns
  */
-const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
+const useInspectionTable = ({ pipeline, quotedRelationName }: InspectionTableProps) => {
   const [relation, setRelation] = useState<Relation | undefined>(undefined)
   const [paginationModel, setPaginationModel] = useState(INITIAL_PAGINATION_MODEL)
   const [neighborhood, setNeighborhood] = useState<NeighborhoodQuery>(DEFAULT_NEIGHBORHOOD)
@@ -71,25 +77,26 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
   // If a revision is loaded, find the requested relation that we want to
   // monitor. We use it to display the table headers etc.
   useEffect(() => {
-    if (!pipelineRevisionQuery.isPending && !pipelineRevisionQuery.isError && pipelineRevisionQuery.data) {
-      setNeighborhood(DEFAULT_NEIGHBORHOOD)
-      setPaginationModel(INITIAL_PAGINATION_MODEL)
-      setQuantiles(undefined)
-      setQuantile(0)
-      setRows([])
-      setLoading(true)
-
-      const pipelineRevision = pipelineRevisionQuery.data
-      const program = pipelineRevision.program
-      const tables = program.schema?.inputs.find(v => v.name === name)
-      const views = program.schema?.outputs.find(v => v.name === name)
-      const relation = tables || views // name is unique in the schema
-      if (!relation) {
-        return
-      }
-      setRelation(relation)
+    if (pipelineRevisionQuery.isPending || pipelineRevisionQuery.isError || !pipelineRevisionQuery.data) {
+      return
     }
-  }, [pipelineRevisionQuery.isPending, pipelineRevisionQuery.isError, pipelineRevisionQuery.data, name])
+    setNeighborhood(DEFAULT_NEIGHBORHOOD)
+    setPaginationModel(INITIAL_PAGINATION_MODEL)
+    setQuantiles(undefined)
+    setQuantile(0)
+    setRows([])
+    setLoading(true)
+
+    const pipelineRevision = pipelineRevisionQuery.data
+    const program = pipelineRevision.program
+    const tables = program.schema?.inputs.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
+    const views = program.schema?.outputs.find(caseDependentNameEq(caseDependentName(quotedRelationName)))
+    const relation = tables || views // name is unique in the schema
+    if (!relation) {
+      return
+    }
+    setRelation(relation)
+  }, [pipelineRevisionQuery.isPending, pipelineRevisionQuery.isError, pipelineRevisionQuery.data, quotedRelationName])
 
   // Request to monitor the changes for the current rows in the table. This is
   // done by opening a stream request to the backend which then sends us the
@@ -103,7 +110,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     updateTable(
       [
         pipeline.descriptor.name,
-        name,
+        quotedRelationName,
         'csv',
         OutputQuery.NEIGHBORHOOD,
         EgressMode.WATCH,
@@ -136,7 +143,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
       // requests and we don't want to exhaust that limit)
       controller.abort()
     }
-  }, [pipeline, name, relation, updateTable, throwError, neighborhood])
+  }, [pipeline, quotedRelationName, relation, updateTable, throwError, neighborhood])
 
   // Load quantiles for the relation we're displaying.
   const quantileLoader = useQuantiles()
@@ -152,7 +159,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
     const controller = new AbortController()
 
     quantileLoader(
-      [pipeline.descriptor.name, name, 'csv', OutputQuery.QUANTILES, EgressMode.SNAPSHOT],
+      [pipeline.descriptor.name, quotedRelationName, 'csv', OutputQuery.QUANTILES, EgressMode.SNAPSHOT],
       setQuantiles,
       relation,
       controller
@@ -177,7 +184,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
       // requests and we don't want to exhaust that limit)
       controller.abort()
     }
-  }, [pipeline, name, relation, quantileLoader, rows, throwError, quantiles])
+  }, [pipeline, quotedRelationName, relation, quantileLoader, rows, throwError, quantiles])
 
   // If the user presses the previous or next button, we update the neighborhood
   // which will trigger update the rows in the table.
@@ -192,7 +199,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
         const minRow = rows.find((row: any) => row.genId < 0)
         if (!minRow) {
           pushMessage({
-            message: `You reached the beginning of the ${relation.name} relation.`,
+            message: `You reached the beginning of the ${quotifyRelationName(relation)} relation.`,
             key: new Date().getTime(),
             color: 'info'
           })
@@ -214,7 +221,7 @@ const useInspectionTable = ({ pipeline, name }: InspectionTableProps) => {
           })
         } else {
           pushMessage({
-            message: `You reached the end of the ${relation.name} relation.`,
+            message: `You reached the end of the ${quotifyRelationName(relation)} relation.`,
             key: new Date().getTime(),
             color: 'info'
           })
@@ -294,14 +301,14 @@ const InspectionTableImpl = ({
 
   const isReadonly =
     !!pipelineRevisionQuery.data &&
-    (pipelineRevisionQuery.data.program.schema?.outputs.some(r => r.name === relation.name) ?? false)
+    (pipelineRevisionQuery.data.program.schema?.outputs.some(caseDependentNameEq(relation)) ?? false)
 
   const defaultColumnVisibility = {
     genId: false,
     rowCount: false
   }
   const gridPersistence = useDataGridPresentationLocalStorage({
-    key: LS_PREFIX + `settings/streaming/inspection/${pipeline.descriptor.name}/${relation.name}`,
+    key: LS_PREFIX + `settings/streaming/inspection/${pipeline.descriptor.name}/${quotifyRelationName(relation)}`,
     defaultColumnVisibility
   })
 
@@ -316,9 +323,9 @@ const InspectionTableImpl = ({
         columns={relation.fields
           .map((col: Field) => {
             return {
-              field: col.name,
-              headerName: col.name,
-              description: col.name,
+              field: quotifyFieldName(col),
+              headerName: quotifyFieldName(col),
+              description: quotifyFieldName(col),
               flex: 1,
               valueGetter: (params: any) => {
                 return params.row.record[col.name]
@@ -363,13 +370,13 @@ const InspectionTableImpl = ({
           toolbar: {
             printOptions: { disableToolbarButton: true },
             csvOptions: {
-              fileName: relation.name,
+              fileName: quotifyRelationName(relation),
               delimiter: ',',
               utf8WithBom: true
             },
             pipelineName: pipeline.descriptor.name,
             status: pipeline.state.current_status,
-            relation: relation.name,
+            relation: relation,
             isReadonly,
             before: [
               !!pause && (

--- a/web-console/src/lib/components/streaming/inspection/InspectionToolbar.tsx
+++ b/web-console/src/lib/components/streaming/inspection/InspectionToolbar.tsx
@@ -1,4 +1,5 @@
 import { useInsertDeleteRows } from '$lib/compositions/streaming/inspection/useDeleteRows'
+import { Relation } from '$lib/services/manager'
 import { PipelineStatus } from '$lib/types/pipeline'
 import { ReactNode, useCallback } from 'react'
 
@@ -19,7 +20,7 @@ export const InspectionToolbar = (
   props: GridToolbarProps & {
     pipelineName: string
     status: PipelineStatus
-    relation: string
+    relation: Relation
     isReadonly: boolean
     before: ReactNode
   }

--- a/web-console/src/lib/components/streaming/inspection/SQLTypeHeader.tsx
+++ b/web-console/src/lib/components/streaming/inspection/SQLTypeHeader.tsx
@@ -1,4 +1,5 @@
 import { nonNull } from '$lib/functions/common/function'
+import { quotifyFieldName } from '$lib/functions/felderaRelation'
 import { Field } from '$lib/services/manager'
 
 import { Typography } from '@mui/material'
@@ -6,7 +7,7 @@ import { Typography } from '@mui/material'
 export const SQLTypeHeader = ({ col }: { col: Field }) => {
   return (
     <span>
-      <Typography component={'span'}>{col.name}</Typography>
+      <Typography component={'span'}>{quotifyFieldName(col)}</Typography>
       <Typography variant='subtitle2' component={'span'} sx={{ pl: 2 }}>
         {col.columntype.type}
         {((p, s) => (p && p > 0 ? '(' + [p, ...(nonNull(s) ? [s] : [])].join(',') + ')' : ''))(

--- a/web-console/src/lib/components/streaming/inspection/SQLTypeHeader.tsx
+++ b/web-console/src/lib/components/streaming/inspection/SQLTypeHeader.tsx
@@ -1,5 +1,5 @@
 import { nonNull } from '$lib/functions/common/function'
-import { quotifyFieldName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { Field } from '$lib/services/manager'
 
 import { Typography } from '@mui/material'
@@ -7,7 +7,7 @@ import { Typography } from '@mui/material'
 export const SQLTypeHeader = ({ col }: { col: Field }) => {
   return (
     <span>
-      <Typography component={'span'}>{quotifyFieldName(col)}</Typography>
+      <Typography component={'span'}>{getCaseIndependentName(col)}</Typography>
       <Typography variant='subtitle2' component={'span'} sx={{ pl: 2 }}>
         {col.columntype.type}
         {((p, s) => (p && p > 0 ? '(' + [p, ...(nonNull(s) ? [s] : [])].join(',') + ')' : ''))(

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -22,7 +22,7 @@ import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQue
 import { humanSize } from '$lib/functions/common/string'
 import { invalidateQuery } from '$lib/functions/common/tanstack'
 import { tuple } from '$lib/functions/common/tuple'
-import { quotifyRelationName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ApiError, AttachedConnector, ConnectorDescr, PipelineRevision, Relation } from '$lib/services/manager'
 import {
   mutationDeletePipeline,
@@ -103,7 +103,7 @@ function getConnectorData(revision: PipelineRevision, direction: InputOrOutput):
 
   return relations.map(relation => {
     const connections = attachedConnectors
-      .filter(ac => ac.relation_name === quotifyRelationName(relation))
+      .filter(ac => ac.relation_name === getCaseIndependentName(relation))
       .map(ac => {
         const connector = connectors.find(c => c.name === ac?.connector_name)
         invariant(connector, 'Attached connector has no connector.') // This can't happen in a revision
@@ -156,7 +156,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
       },
       {
         field: 'config',
-        valueGetter: params => quotifyRelationName(params.row.relation),
+        valueGetter: params => getCaseIndependentName(params.row.relation),
         headerName: direction === 'input' ? 'Table' : 'View',
         flex: 0.6
       },
@@ -168,8 +168,8 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
           if (params.row.connections.length > 0) {
             const records =
               (direction === 'input'
-                ? metrics.input.get(quotifyRelationName(params.row.relation))?.total_records
-                : metrics.output.get(quotifyRelationName(params.row.relation))?.transmitted_records) || 0
+                ? metrics.input.get(getCaseIndependentName(params.row.relation))?.total_records
+                : metrics.output.get(getCaseIndependentName(params.row.relation))?.transmitted_records) || 0
             return format(records > 1000 ? '.3s' : '~s')(records)
           } else {
             // TODO: we need to count records also when relation doesn't have
@@ -185,8 +185,8 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
         renderCell: params => {
           const bytes =
             direction === 'input'
-              ? metrics.input.get(quotifyRelationName(params.row.relation))?.total_bytes
-              : metrics.output.get(quotifyRelationName(params.row.relation))?.transmitted_bytes
+              ? metrics.input.get(getCaseIndependentName(params.row.relation))?.total_bytes
+              : metrics.output.get(getCaseIndependentName(params.row.relation))?.transmitted_bytes
           return humanSize(bytes || 0)
         }
       },
@@ -198,10 +198,10 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
           const errors =
             direction === 'input'
               ? (m => (m ? m.num_parse_errors + m.num_transport_errors : 0))(
-                  metrics.input.get(quotifyRelationName(params.row.relation))
+                  metrics.input.get(getCaseIndependentName(params.row.relation))
                 )
               : (m => (m ? m.num_encode_errors + m.num_transport_errors : 0))(
-                  metrics.output.get(quotifyRelationName(params.row.relation))
+                  metrics.output.get(getCaseIndependentName(params.row.relation))
                 )
           return (
             <Box
@@ -228,7 +228,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
             <Tooltip title={direction === 'input' ? 'Inspect Table' : 'Inspect View'}>
               <IconButton
                 size='small'
-                href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${quotifyRelationName(
+                href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${getCaseIndependentName(
                   params.row.relation
                 )}`}
                 data-testid='button-inspect'
@@ -240,7 +240,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
               <Tooltip title='Import Data'>
                 <IconButton
                   size='small'
-                  href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${quotifyRelationName(
+                  href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${getCaseIndependentName(
                     params.row.relation
                   )}#insert`}
                   data-testid='button-import'
@@ -541,19 +541,18 @@ export default function PipelineTable() {
       return
     }
     setExpandedRows(expandedRows =>
-      (expandedRows.includes(anchorPipelineId) ? expandedRows : [...expandedRows, anchorPipelineId]).filter(
-        row =>
-          data?.find(
-            p =>
-              p.descriptor.pipeline_id === row &&
-              [
-                PipelineStatus.PROVISIONING,
-                PipelineStatus.INITIALIZING,
-                PipelineStatus.PAUSED,
-                PipelineStatus.RUNNING,
-                PipelineStatus.SHUTTING_DOWN
-              ].includes(p.state.current_status)
-          )
+      (expandedRows.includes(anchorPipelineId) ? expandedRows : [...expandedRows, anchorPipelineId]).filter(row =>
+        data?.find(
+          p =>
+            p.descriptor.pipeline_id === row &&
+            [
+              PipelineStatus.PROVISIONING,
+              PipelineStatus.INITIALIZING,
+              PipelineStatus.PAUSED,
+              PipelineStatus.RUNNING,
+              PipelineStatus.SHUTTING_DOWN
+            ].includes(p.state.current_status)
+        )
       )
     )
   }, [anchorPipelineId, setExpandedRows, data])

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -541,18 +541,19 @@ export default function PipelineTable() {
       return
     }
     setExpandedRows(expandedRows =>
-      (expandedRows.includes(anchorPipelineId) ? expandedRows : [...expandedRows, anchorPipelineId]).filter(row =>
-        data?.find(
-          p =>
-            p.descriptor.pipeline_id === row &&
-            [
-              PipelineStatus.PROVISIONING,
-              PipelineStatus.INITIALIZING,
-              PipelineStatus.PAUSED,
-              PipelineStatus.RUNNING,
-              PipelineStatus.SHUTTING_DOWN
-            ].includes(p.state.current_status)
-        )
+      (expandedRows.includes(anchorPipelineId) ? expandedRows : [...expandedRows, anchorPipelineId]).filter(
+        row =>
+          data?.find(
+            p =>
+              p.descriptor.pipeline_id === row &&
+              [
+                PipelineStatus.PROVISIONING,
+                PipelineStatus.INITIALIZING,
+                PipelineStatus.PAUSED,
+                PipelineStatus.RUNNING,
+                PipelineStatus.SHUTTING_DOWN
+              ].includes(p.state.current_status)
+          )
       )
     )
   }, [anchorPipelineId, setExpandedRows, data])

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -22,6 +22,7 @@ import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQue
 import { humanSize } from '$lib/functions/common/string'
 import { invalidateQuery } from '$lib/functions/common/tanstack'
 import { tuple } from '$lib/functions/common/tuple'
+import { quotifyRelationName } from '$lib/functions/felderaRelation'
 import { ApiError, AttachedConnector, ConnectorDescr, PipelineRevision, Relation } from '$lib/services/manager'
 import {
   mutationDeletePipeline,
@@ -102,7 +103,7 @@ function getConnectorData(revision: PipelineRevision, direction: InputOrOutput):
 
   return relations.map(relation => {
     const connections = attachedConnectors
-      .filter(ac => ac.relation_name === relation.name)
+      .filter(ac => ac.relation_name === quotifyRelationName(relation))
       .map(ac => {
         const connector = connectors.find(c => c.name === ac?.connector_name)
         invariant(connector, 'Attached connector has no connector.') // This can't happen in a revision
@@ -155,7 +156,7 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
       },
       {
         field: 'config',
-        valueGetter: params => params.row.relation.name,
+        valueGetter: params => quotifyRelationName(params.row.relation),
         headerName: direction === 'input' ? 'Table' : 'View',
         flex: 0.6
       },
@@ -227,7 +228,9 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
             <Tooltip title={direction === 'input' ? 'Inspect Table' : 'Inspect View'}>
               <IconButton
                 size='small'
-                href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${params.row.relation.name}`}
+                href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${quotifyRelationName(
+                  params.row.relation
+                )}`}
                 data-testid='button-inspect'
               >
                 <IconShow fontSize={20} />
@@ -237,7 +240,9 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
               <Tooltip title='Import Data'>
                 <IconButton
                   size='small'
-                  href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${params.row.relation.name}#insert`}
+                  href={`/streaming/inspection/?pipeline_name=${descriptor.name}&relation=${quotifyRelationName(
+                    params.row.relation
+                  )}#insert`}
                   data-testid='button-import'
                 >
                   <IconUpload fontSize={20} />

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -168,8 +168,8 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
           if (params.row.connections.length > 0) {
             const records =
               (direction === 'input'
-                ? metrics.input.get(params.row.relation.name)?.total_records
-                : metrics.output.get(params.row.relation.name)?.transmitted_records) || 0
+                ? metrics.input.get(quotifyRelationName(params.row.relation))?.total_records
+                : metrics.output.get(quotifyRelationName(params.row.relation))?.transmitted_records) || 0
             return format(records > 1000 ? '.3s' : '~s')(records)
           } else {
             // TODO: we need to count records also when relation doesn't have
@@ -185,8 +185,8 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
         renderCell: params => {
           const bytes =
             direction === 'input'
-              ? metrics.input.get(params.row.relation.name)?.total_bytes
-              : metrics.output.get(params.row.relation.name)?.transmitted_bytes
+              ? metrics.input.get(quotifyRelationName(params.row.relation))?.total_bytes
+              : metrics.output.get(quotifyRelationName(params.row.relation))?.transmitted_bytes
           return humanSize(bytes || 0)
         }
       },
@@ -198,10 +198,10 @@ const DetailPanelContent = (props: { row: Pipeline }) => {
           const errors =
             direction === 'input'
               ? (m => (m ? m.num_parse_errors + m.num_transport_errors : 0))(
-                  metrics.input.get(params.row.relation.name)
+                  metrics.input.get(quotifyRelationName(params.row.relation))
                 )
               : (m => (m ? m.num_encode_errors + m.num_transport_errors : 0))(
-                  metrics.output.get(params.row.relation.name)
+                  metrics.output.get(quotifyRelationName(params.row.relation))
                 )
           return (
             <Box
@@ -473,7 +473,7 @@ export default function PipelineTable() {
     {
       field: 'modification',
       headerName: 'Changes',
-      flex: 1,
+      width: 145,
       renderCell: (params: GridRenderCellParams<Pipeline>) => {
         return <PipelineRevisionStatusChip pipeline={params.row} />
       }

--- a/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
@@ -1,4 +1,5 @@
 import { randomString } from '$lib/functions/common/string'
+import { escapeRelationName, quotifyRelationName } from '$lib/functions/felderaRelation'
 import { AttachedConnector, ProgramSchema } from '$lib/services/manager'
 import { ConnectorDescr } from '$lib/services/manager/models/ConnectorDescr'
 import { useCallback } from 'react'
@@ -13,7 +14,7 @@ export function connectorConnects(schema: ProgramSchema | null | undefined, ac: 
   if (!schema) {
     return false
   }
-  return (ac.is_input ? schema.inputs : schema.outputs).some(view => view.name === ac.relation_name)
+  return (ac.is_input ? schema.inputs : schema.outputs).some(view => ac.relation_name === quotifyRelationName(view))
 }
 
 /**
@@ -24,7 +25,7 @@ export function useAddConnector() {
   const { setNodes, getNodes, getNode, addNodes, addEdges } = useReactFlow()
   const redoLayout = useRedoLayout()
 
-  const addNewConnector = useCallback(
+  const addConnector = useCallback(
     (connector: ConnectorDescr, ac: AttachedConnector) => {
       const newNodeType = ac.is_input ? 'inputNode' : 'outputNode'
       const placeholderId = ac.is_input ? 'inputPlaceholder' : 'outputPlaceholder'
@@ -69,10 +70,9 @@ export function useAddConnector() {
       // Now that we have the node, we need to add a connector if we have one
       const sqlNode = getNode('sql')
       const ourNode = getNode(ac.name)
-      const tableOrView = ac.relation_name
       const sqlPrefix = ac.is_input ? 'table-' : 'view-'
-      const connectorHandle = sqlPrefix + tableOrView
-      const hasAnEdge = ac.relation_name != ''
+      const connectorHandle = sqlPrefix + escapeRelationName(ac.relation_name)
+      const hasAnEdge = ac.relation_name !== ''
 
       if (!(hasAnEdge && sqlNode && ourNode)) {
         return
@@ -102,5 +102,5 @@ export function useAddConnector() {
     [getNode, getNodes, setNodes, addNodes, addEdges, redoLayout]
   )
 
-  return addNewConnector
+  return addConnector
 }

--- a/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
@@ -1,5 +1,5 @@
 import { randomString } from '$lib/functions/common/string'
-import { escapeRelationName, quotifyRelationName } from '$lib/functions/felderaRelation'
+import { escapeRelationName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { AttachedConnector, ProgramSchema } from '$lib/services/manager'
 import { ConnectorDescr } from '$lib/services/manager/models/ConnectorDescr'
 import { useCallback } from 'react'
@@ -14,7 +14,7 @@ export function connectorConnects(schema: ProgramSchema | null | undefined, ac: 
   if (!schema) {
     return false
   }
-  return (ac.is_input ? schema.inputs : schema.outputs).some(view => ac.relation_name === quotifyRelationName(view))
+  return (ac.is_input ? schema.inputs : schema.outputs).some(view => ac.relation_name === getCaseIndependentName(view))
 }
 
 /**

--- a/web-console/src/lib/compositions/streaming/builder/useAttachedPipelineConnectors.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAttachedPipelineConnectors.ts
@@ -1,3 +1,4 @@
+import { unescapeRelationName } from '$lib/functions/felderaRelation'
 import { IONodeData, ProgramNodeData } from '$lib/types/connectors'
 import { useReactFlow } from 'reactflow'
 import invariant from 'tiny-invariant'
@@ -21,7 +22,7 @@ export const useAttachedPipelineConnectors = () => {
 
       ac.relation_name = (handle => {
         invariant(handle, 'Node handle string should be defined')
-        return handle.replace(/^table-|^view-/, '')
+        return unescapeRelationName(handle.replace(/^table-|^view-/, ''))
       })(connectsInput ? edge.targetHandle : edge.sourceHandle)
 
       return ac

--- a/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
@@ -1,9 +1,11 @@
 // Computes the layout of the nodes in the graph.
 
 import { removePrefix } from '$lib/functions/common/string'
+import { ProgramDescr } from '$lib/services/manager'
 import assert from 'assert'
 import { useCallback, useEffect } from 'react'
 import { Edge, getConnectedEdges, Instance, Node, ReactFlowState, useReactFlow, useStore } from 'reactflow'
+import { escapeRelationName, quotifyRelationName } from 'src/lib/functions/felderaRelation'
 
 // How much spacing we put after every input/output node
 const VERTICAL_SPACING = 20
@@ -98,8 +100,9 @@ function layoutNodesFixed(
   const rawInputNodes = nodes.filter(node => node.type === 'inputNode')
   const inputOrder = new Map<string, number>()
   if (programNode[0].data?.program?.schema) {
-    programNode[0].data.program.schema.inputs.forEach((element: { name: string }, index: number) => {
-      inputOrder.set(element.name, index)
+    const schema = programNode[0].data.program.schema as NonNullable<ProgramDescr['schema']>
+    schema.inputs.forEach((relation, index: number) => {
+      inputOrder.set(escapeRelationName(quotifyRelationName(relation)), index)
     })
   }
   const inputNodes = sortInputConnectors(rawInputNodes, getEdges(), inputOrder).concat(

--- a/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
@@ -5,7 +5,7 @@ import { ProgramDescr } from '$lib/services/manager'
 import assert from 'assert'
 import { useCallback, useEffect } from 'react'
 import { Edge, getConnectedEdges, Instance, Node, ReactFlowState, useReactFlow, useStore } from 'reactflow'
-import { escapeRelationName, quotifyRelationName } from 'src/lib/functions/felderaRelation'
+import { escapeRelationName, getCaseIndependentName } from 'src/lib/functions/felderaRelation'
 
 // How much spacing we put after every input/output node
 const VERTICAL_SPACING = 20
@@ -102,7 +102,7 @@ function layoutNodesFixed(
   if (programNode[0].data?.program?.schema) {
     const schema = programNode[0].data.program.schema as NonNullable<ProgramDescr['schema']>
     schema.inputs.forEach((relation, index: number) => {
-      inputOrder.set(escapeRelationName(quotifyRelationName(relation)), index)
+      inputOrder.set(escapeRelationName(getCaseIndependentName(relation)), index)
     })
   }
   const inputNodes = sortInputConnectors(rawInputNodes, getEdges(), inputOrder).concat(

--- a/web-console/src/lib/compositions/streaming/import/useInsertRows.ts
+++ b/web-console/src/lib/compositions/streaming/import/useInsertRows.ts
@@ -2,7 +2,7 @@
 
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
 import { getValueFormatter, Row } from '$lib/functions/ddl'
-import { quotifyRelationName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ApiError, Field, HttpInputOutputService, Relation } from '$lib/services/manager'
 import Papa from 'papaparse'
 import { Dispatch, SetStateAction, useCallback } from 'react'
@@ -27,7 +27,7 @@ function useInsertRows() {
 
   const { mutate: pipelineInsert, isPending: pipelineInsertLoading } = useMutation<string, ApiError, Args>({
     mutationFn: ([pipelineName, relation, force, csvData]) => {
-      return HttpInputOutputService.httpInput(pipelineName, quotifyRelationName(relation), force, 'csv', csvData)
+      return HttpInputOutputService.httpInput(pipelineName, getCaseIndependentName(relation), force, 'csv', csvData)
     }
   })
 

--- a/web-console/src/lib/compositions/streaming/import/useInsertRows.ts
+++ b/web-console/src/lib/compositions/streaming/import/useInsertRows.ts
@@ -2,13 +2,14 @@
 
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
 import { getValueFormatter, Row } from '$lib/functions/ddl'
+import { quotifyRelationName } from '$lib/functions/felderaRelation'
 import { ApiError, Field, HttpInputOutputService, Relation } from '$lib/services/manager'
 import Papa from 'papaparse'
 import { Dispatch, SetStateAction, useCallback } from 'react'
 
 import { useMutation } from '@tanstack/react-query'
 
-type Args = [pipelineName: string, relation: string, force: boolean, csvData: string]
+type Args = [pipelineName: string, relation: Relation, force: boolean, csvData: string]
 
 // We convert fields to a tuple so that we can use it as a line in the CSV we're
 // sending to the server.
@@ -26,7 +27,7 @@ function useInsertRows() {
 
   const { mutate: pipelineInsert, isPending: pipelineInsertLoading } = useMutation<string, ApiError, Args>({
     mutationFn: ([pipelineName, relation, force, csvData]) => {
-      return HttpInputOutputService.httpInput(pipelineName, relation, force, 'csv', csvData)
+      return HttpInputOutputService.httpInput(pipelineName, quotifyRelationName(relation), force, 'csv', csvData)
     }
   })
 
@@ -40,7 +41,7 @@ function useInsertRows() {
     ) => {
       if (!pipelineInsertLoading) {
         const csvData = Papa.unparse(rows.map(row => rowToCsvLine(relation, row)))
-        pipelineInsert([pipelineName, relation.name, force, csvData], {
+        pipelineInsert([pipelineName, relation, force, csvData], {
           onSuccess: () => {
             setRows([])
             pushMessage({ message: `${rows.length} Row(s) inserted`, key: new Date().getTime(), color: 'success' })

--- a/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
+++ b/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
@@ -1,5 +1,6 @@
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
-import { ApiError, HttpInputOutputService } from '$lib/services/manager'
+import { quotifyRelationName } from '$lib/functions/felderaRelation'
+import { ApiError, HttpInputOutputService, Relation } from '$lib/services/manager'
 import { useCallback } from 'react'
 import JSONbig from 'true-json-bigint'
 
@@ -7,7 +8,7 @@ import { useMutation } from '@tanstack/react-query'
 
 type Args = [
   pipelineName: string,
-  relation: string,
+  relation: Relation,
   force: boolean,
   rows: Partial<Record<'insert' | 'delete', Record<string, unknown>>>[],
   isArray?: boolean
@@ -20,7 +21,7 @@ export function useInsertDeleteRows() {
     mutationFn: ([pipelineName, relation, force, rows, isArray]) => {
       return HttpInputOutputService.httpInput(
         pipelineName,
-        relation,
+        quotifyRelationName(relation),
         force,
         'json',
         isArray ? JSONbig.stringify(rows) : rows.map(row => JSONbig.stringify(row)).join(''),

--- a/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
+++ b/web-console/src/lib/compositions/streaming/inspection/useDeleteRows.ts
@@ -1,5 +1,5 @@
 import useStatusNotification from '$lib/components/common/errors/useStatusNotification'
-import { quotifyRelationName } from '$lib/functions/felderaRelation'
+import { getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ApiError, HttpInputOutputService, Relation } from '$lib/services/manager'
 import { useCallback } from 'react'
 import JSONbig from 'true-json-bigint'
@@ -21,7 +21,7 @@ export function useInsertDeleteRows() {
     mutationFn: ([pipelineName, relation, force, rows, isArray]) => {
       return HttpInputOutputService.httpInput(
         pipelineName,
-        quotifyRelationName(relation),
+        getCaseIndependentName(relation),
         force,
         'json',
         isArray ? JSONbig.stringify(rows) : rows.map(row => JSONbig.stringify(row)).join(''),

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -1,5 +1,4 @@
 import { Field, Relation } from '$lib/services/manager'
-import invariant from 'tiny-invariant'
 
 export type CaseDependentName = {
   case_sensitive?: boolean | undefined
@@ -10,11 +9,9 @@ export const quotifyRelationName = (relation: Relation) =>
   relation.case_sensitive ? `"${relation.name}"` : relation.name
 
 export const caseDependentName = (quotedRelationName: string) => {
-  const name = /\"?(\w+)\"?/.exec(quotedRelationName)?.[1]
-  invariant(name, `Invalid relation name parsed: ${name}`)
   return {
-    name,
-    case_sensitive: /\"/.test(quotedRelationName)
+    name: quotedRelationName.replaceAll('"', ''),
+    case_sensitive: quotedRelationName.includes('"')
   }
 }
 

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -1,7 +1,7 @@
 import { Field, Relation } from '$lib/services/manager'
 
 export type CaseDependentName = {
-  case_sensitive?: boolean | undefined
+  case_sensitive?: boolean
   name: string
 }
 

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -7,7 +7,7 @@ export const getCaseIndependentName = (entity: CaseDependentName) =>
   entity.case_sensitive ? `"${entity.name}"` : entity.name
 
 // TODO: update implementation when double quotes become a legal symbol in a name
-export const caseDependentName = (caseIndependentName: string) => {
+export const getCaseDependentName = (caseIndependentName: string) => {
   return {
     name: caseIndependentName.replaceAll('"', ''),
     case_sensitive: caseIndependentName.includes('"')

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -1,0 +1,28 @@
+import { Field, Relation } from '$lib/services/manager'
+import invariant from 'tiny-invariant'
+
+export type CaseDependentName = {
+  case_sensitive?: boolean | undefined
+  name: string
+}
+
+export const quotifyRelationName = (relation: Relation) =>
+  relation.case_sensitive ? `"${relation.name}"` : relation.name
+
+export const caseDependentName = (quotedRelationName: string) => {
+  const name = /\"?(\w+)\"?/.exec(quotedRelationName)?.[1]
+  invariant(name, `Invalid relation name parsed: ${name}`)
+  return {
+    name,
+    case_sensitive: /\"/.test(quotedRelationName)
+  }
+}
+
+export const caseDependentNameEq = (a: CaseDependentName) => (b: CaseDependentName) =>
+  !a.case_sensitive === !b.case_sensitive &&
+  (a.case_sensitive ? a.name === b.name : a.name.toLocaleLowerCase() === b.name.toLocaleLowerCase())
+
+export const quotifyFieldName = (field: Field) => (field.case_sensitive ? `"${field.name}"` : field.name)
+
+export const escapeRelationName = encodeURI
+export const unescapeRelationName = decodeURI

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -6,6 +6,7 @@ export type CaseDependentName = {
 export const getCaseIndependentName = (entity: CaseDependentName) =>
   entity.case_sensitive ? `"${entity.name}"` : entity.name
 
+// TODO: update implementation when double quotes become a legal symbol in a name
 export const caseDependentName = (caseIndependentName: string) => {
   return {
     name: caseIndependentName.replaceAll('"', ''),

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -1,25 +1,21 @@
-import { Field, Relation } from '$lib/services/manager'
-
 export type CaseDependentName = {
   case_sensitive?: boolean
   name: string
 }
 
-export const quotifyRelationName = (relation: Relation) =>
-  relation.case_sensitive ? `"${relation.name}"` : relation.name
+export const getCaseIndependentName = (entity: CaseDependentName) =>
+  entity.case_sensitive ? `"${entity.name}"` : entity.name
 
-export const caseDependentName = (quotedRelationName: string) => {
+export const caseDependentName = (caseIndependentName: string) => {
   return {
-    name: quotedRelationName.replaceAll('"', ''),
-    case_sensitive: quotedRelationName.includes('"')
+    name: caseIndependentName.replaceAll('"', ''),
+    case_sensitive: caseIndependentName.includes('"')
   }
 }
 
 export const caseDependentNameEq = (a: CaseDependentName) => (b: CaseDependentName) =>
   !a.case_sensitive === !b.case_sensitive &&
   (a.case_sensitive ? a.name === b.name : a.name.toLocaleLowerCase() === b.name.toLocaleLowerCase())
-
-export const quotifyFieldName = (field: Field) => (field.case_sensitive ? `"${field.name}"` : field.name)
 
 export const escapeRelationName = encodeURI
 export const unescapeRelationName = decodeURI

--- a/web-console/src/lib/services/manager/models/Field.ts
+++ b/web-console/src/lib/services/manager/models/Field.ts
@@ -11,6 +11,7 @@ import type { ColumnType } from './ColumnType'
  * Matches the Calcite JSON format.
  */
 export type Field = {
+  case_sensitive?: boolean
   columntype: ColumnType
   name: string
 }

--- a/web-console/src/lib/services/manager/models/Relation.ts
+++ b/web-console/src/lib/services/manager/models/Relation.ts
@@ -11,6 +11,7 @@ import type { Field } from './Field'
  * Matches the Calcite JSON format.
  */
 export type Relation = {
+  case_sensitive?: boolean
   fields: Array<Field>
   name: string
 }

--- a/web-console/src/lib/services/pipelineManagerQuery.ts
+++ b/web-console/src/lib/services/pipelineManagerQuery.ts
@@ -478,13 +478,16 @@ export const programQueryCacheUpdate = (
 
   setQueryData(queryClient, PipelineManagerQueryKey.programStatus(programName), updateCache)
 
-  setQueryData(queryClient, PipelineManagerQueryKey.programs(), oldDatas =>
-    oldDatas?.map(oldData => {
-      if (oldData.name !== programName) {
-        return oldData
-      }
-      return updateCache(oldData)
-    })
+  setQueryData(
+    queryClient,
+    PipelineManagerQueryKey.programs(),
+    oldDatas =>
+      oldDatas?.map(oldData => {
+        if (oldData.name !== programName) {
+          return oldData
+        }
+        return updateCache(oldData)
+      })
   )
 }
 
@@ -500,13 +503,16 @@ const pipelineStatusQueryCacheUpdate = (
     }
     return { ...oldData, state: { ...oldData.state, [field]: status } }
   }
-  setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>
-    oldDatas?.map(oldData => {
-      if (oldData.descriptor.name !== pipelineName) {
-        return oldData
-      }
-      return updateCache(oldData)
-    })
+  setQueryData(
+    queryClient,
+    PipelineManagerQueryKey.pipelines(),
+    oldDatas =>
+      oldDatas?.map(oldData => {
+        if (oldData.descriptor.name !== pipelineName) {
+          return oldData
+        }
+        return updateCache(oldData)
+      })
   )
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 }
@@ -536,12 +542,15 @@ export const pipelineQueryCacheUpdate = (
   }
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 
-  setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>
-    oldDatas?.map(oldData => {
-      if (oldData.descriptor.name !== pipelineName) {
-        return oldData
-      }
-      return updateCache(oldData)
-    })
+  setQueryData(
+    queryClient,
+    PipelineManagerQueryKey.pipelines(),
+    oldDatas =>
+      oldDatas?.map(oldData => {
+        if (oldData.descriptor.name !== pipelineName) {
+          return oldData
+        }
+        return updateCache(oldData)
+      })
   )
 }

--- a/web-console/src/lib/services/pipelineManagerQuery.ts
+++ b/web-console/src/lib/services/pipelineManagerQuery.ts
@@ -478,16 +478,13 @@ export const programQueryCacheUpdate = (
 
   setQueryData(queryClient, PipelineManagerQueryKey.programStatus(programName), updateCache)
 
-  setQueryData(
-    queryClient,
-    PipelineManagerQueryKey.programs(),
-    oldDatas =>
-      oldDatas?.map(oldData => {
-        if (oldData.name !== programName) {
-          return oldData
-        }
-        return updateCache(oldData)
-      })
+  setQueryData(queryClient, PipelineManagerQueryKey.programs(), oldDatas =>
+    oldDatas?.map(oldData => {
+      if (oldData.name !== programName) {
+        return oldData
+      }
+      return updateCache(oldData)
+    })
   )
 }
 
@@ -503,16 +500,13 @@ const pipelineStatusQueryCacheUpdate = (
     }
     return { ...oldData, state: { ...oldData.state, [field]: status } }
   }
-  setQueryData(
-    queryClient,
-    PipelineManagerQueryKey.pipelines(),
-    oldDatas =>
-      oldDatas?.map(oldData => {
-        if (oldData.descriptor.name !== pipelineName) {
-          return oldData
-        }
-        return updateCache(oldData)
-      })
+  setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>
+    oldDatas?.map(oldData => {
+      if (oldData.descriptor.name !== pipelineName) {
+        return oldData
+      }
+      return updateCache(oldData)
+    })
   )
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 }
@@ -542,15 +536,12 @@ export const pipelineQueryCacheUpdate = (
   }
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 
-  setQueryData(
-    queryClient,
-    PipelineManagerQueryKey.pipelines(),
-    oldDatas =>
-      oldDatas?.map(oldData => {
-        if (oldData.descriptor.name !== pipelineName) {
-          return oldData
-        }
-        return updateCache(oldData)
-      })
+  setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>
+    oldDatas?.map(oldData => {
+      if (oldData.descriptor.name !== pipelineName) {
+        return oldData
+      }
+      return updateCache(oldData)
+    })
   )
 }

--- a/web-console/tests/e2e/demoAccrual.spec.ts
+++ b/web-console/tests/e2e/demoAccrual.spec.ts
@@ -190,7 +190,7 @@ test('Accrual demo test', async ({ page, request }) => {
     ]) {
       await page.getByTestId('button-expand-relations').click()
       await page.getByTestId('box-relation-options').getByTestId(`button-option-relation-${relation}`).click()
-      await page.getByTestId('box-relation-options').waitFor({state: 'hidden'})
+      await page.getByTestId('box-relation-options').waitFor({ state: 'hidden' })
       await expect(page).toHaveScreenshot(`relation ${relation}.png`)
     }
   })


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Now, whenever a relation or a column is specified in quotes in an SQL program, WebConsole will display it in quotes everywhere, and use quotes when sending the name through the API

I'll update UI test snapshots when PR is greenlit

The changelog should be rebased an updated in the base PR