### PR TITLE
Download CI datasets from github.

### DIFF
--- a/demo/demo_notebooks/fraud_detection.ipynb
+++ b/demo/demo_notebooks/fraud_detection.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cd2b0059",
    "metadata": {
@@ -31,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "bd0696ef",
    "metadata": {},
    "outputs": [],
@@ -51,11 +50,12 @@
     "from collections import Counter\n",
     "from sklearn.utils import shuffle\n",
     "import warnings\n",
+    "import urllib.request\n",
+    "\n",
     "warnings.filterwarnings('ignore')"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3418f8e6",
    "metadata": {},
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "be0a3b00",
    "metadata": {},
    "outputs": [
@@ -73,15 +73,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "env: IN_CI=1\n",
-      "Found dataset /home/leonid/projects/database-stream-processor/demo/demo_notebooks/fraud_data/train_ci.csv\n",
-      "Found dataset /home/leonid/projects/database-stream-processor/demo/demo_notebooks/fraud_data/test_ci.csv\n",
-      "Found dataset /home/leonid/projects/database-stream-processor/demo/demo_notebooks/fraud_data/simulation_ci.csv\n"
+      "Downloading dataset /home/leonid/projects/feldera/demo/demo_notebooks/fraud_data/train_ci.csv\n",
+      "Downloading dataset /home/leonid/projects/feldera/demo/demo_notebooks/fraud_data/test_ci.csv\n",
+      "Downloading dataset /home/leonid/projects/feldera/demo/demo_notebooks/fraud_data/simulation_ci.csv\n"
      ]
     }
    ],
    "source": [
-    "def download_dataset(fileid: str, filepath: str):\n",
+    "def gdown_dataset(fileid: str, filepath: str):\n",
     "    if path.isfile(filepath):\n",
     "        print(\"Found dataset \" + filepath)\n",
     "    else:\n",
@@ -89,24 +88,33 @@
     "        gdown.download(\"https://drive.google.com/uc?id=\" + fileid, filepath + \".tar.gz\", quiet=False)\n",
     "        archive = tarfile.open(filepath + \".tar.gz\")\n",
     "        archive.extractall(path = \"fraud_data\")\n",
-    "    \n",
     "\n",
-    "if 'IN_CI' in os.environ:\n",
+    "def download_dataset(fileurl: str, filepath: str):\n",
+    "    if path.isfile(filepath):\n",
+    "        print(\"Found dataset \" + filepath)\n",
+    "    else:\n",
+    "        print(\"Downloading dataset \" + filepath)\n",
+    "        urllib.request.urlretrieve(fileurl, filepath + \".tar.gz\")\n",
+    "        archive = tarfile.open(filepath + \".tar.gz\")\n",
+    "        archive.extractall(path = \"fraud_data\")\n",
+    "        \n",
+    "\n",
+    "if True:\n",
     "    train_path           = path.abspath(\"fraud_data/train_ci.csv\")\n",
     "    test_path            = path.abspath(\"fraud_data/test_ci.csv\")\n",
     "    simulation_path      = path.abspath(\"fraud_data/simulation_ci.csv\")\n",
     "\n",
-    "    download_dataset(\"1L-61nquAtBWUpwYcyqn31PyfL_IMh5DF\", train_path)\n",
-    "    download_dataset(\"1RUm_24nklQtDPNdPstoviptPvSh22FAj\", test_path)\n",
-    "    download_dataset(\"1n94Tll7yY0jrASh8O1-zYRwkylZNkrvf\", simulation_path)\n",
+    "    download_dataset(\"https://github.com/feldera/ci_datasets/raw/dcfa11a358b9238d84808d5575fb53ae7f3cc0ad/train_ci.csv.tar.gz\", train_path)\n",
+    "    download_dataset(\"https://github.com/feldera/ci_datasets/raw/dcfa11a358b9238d84808d5575fb53ae7f3cc0ad/test_ci.csv.tar.gz\", test_path)\n",
+    "    download_dataset(\"https://github.com/feldera/ci_datasets/raw/dcfa11a358b9238d84808d5575fb53ae7f3cc0ad/simulation_ci.csv.tar.gz\", simulation_path)\n",
     "else:\n",
     "    train_path           = path.abspath(\"fraud_data/train.csv\")\n",
     "    test_path            = path.abspath(\"fraud_data/test.csv\")\n",
     "    simulation_path      = path.abspath(\"fraud_data/simulation_short.csv\")\n",
     "\n",
-    "    download_dataset(\"1pFyoCc1LFnnszA5MknRtoF7saI2GKUyo\", train_path)\n",
-    "    download_dataset(\"1u4yC8ypGmCWUI3LhWIW_bynTEXJEWJhI\", test_path)\n",
-    "    download_dataset(\"1zTPlCFdkl1slvFSQRf4VkqJQx5_-zXNR\", simulation_path)\n",
+    "    gdown_dataset(\"1pFyoCc1LFnnszA5MknRtoF7saI2GKUyo\", train_path)\n",
+    "    gdown_dataset(\"1u4yC8ypGmCWUI3LhWIW_bynTEXJEWJhI\", test_path)\n",
+    "    gdown_dataset(\"1zTPlCFdkl1slvFSQRf4VkqJQx5_-zXNR\", simulation_path)\n",
     "\n",
     "train_outpath        = path.abspath(\"fraud_data/train_output.csv\")\n",
     "test_outpath         = path.abspath(\"fraud_data/test_output.csv\")\n",
@@ -123,7 +131,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "37021d75-be0b-44ab-acc3-887c98af9dba",
    "metadata": {},
@@ -301,7 +308,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3ceee2c1-90af-4823-8521-733287328119",
    "metadata": {},
@@ -332,7 +338,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ee26c169",
    "metadata": {},
@@ -413,7 +418,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ea90ef39",
    "metadata": {},
@@ -504,7 +508,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Google drive is throttling automatic downloads mercilessly, affecting the fraud detection CI job.  These datasets are small enough to store them on github, so we move them there.  As a bonus, we will be able to version them if needed.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
