### PR TITLE
Automatically redirect to AWS Cognito Hosted UI from login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebConsole: Move some footer links to navigation drawer
 - WebConsole: Make Introduction video inline on jome page, optionally collapsible
 - WebConsole: Show the entire generated API key
+- WebConsole: If AWS Cognito is used as an auth provider, when login is needed a redirect to Cognito Hosted UI happens automatically (#1364)
 
 ## [0.9.0] - 2024-02-06
 


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Fix https://github.com/feldera/feldera/issues/1364 : Use a generic login button

![image](https://github.com/feldera/feldera/assets/8537259/f0dad87c-5c17-4982-91ab-459d6df805c3)

This PR makes the UI to redirect to Cognito Hosted UI right away.
Currently there is no UX reason to have a dedicated login page when using AWS Cognito as an auth provider. Hosted UI will already have Feldera branding.
In the future if any additional information should be displayed prior to login it will probably make sense to not display it on a login page, but elsewhere.