### PR TITLE
Improve mysql container health check

### DIFF
--- a/deploy/docker-compose-debezium.yml
+++ b/deploy/docker-compose-debezium.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_USER: mysqluser
       MYSQL_PASSWORD: mysqlpw
     healthcheck:
-      test: ["CMD-SHELL", "mysql -h localhost -u $$MYSQL_USER -p$$MYSQL_PASSWORD -e 'USE inventory;'"]
+      test: ["CMD-SHELL", "mysql -h 127.0.0.1 -u $$MYSQL_USER -p$$MYSQL_PASSWORD -e 'USE inventory;'"]
       interval: 5s
       timeout: 5s
       # MySQL can be _very_ slow to start.


### PR DESCRIPTION
According to [this thread](https://github.com/docker-library/mysql/issues/930), using TCP instead of a local socket for health check should resolve the race.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
