### PR TITLE
Enable preserving the page to redirect to after authentication when redirecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebConsole: Make Introduction video inline on jome page, optionally collapsible
 - WebConsole: Show the entire generated API key
 - WebConsole: If AWS Cognito is used as an auth provider, when login is needed a redirect to Cognito Hosted UI happens automatically (#1364)
+- WebConsole: Now user is redirected to the desired page after a successful login
 
 ## [0.9.0] - 2024-02-06
 

--- a/web-console/src/app/(root)/(authenticated)/layout.tsx
+++ b/web-console/src/app/(root)/(authenticated)/layout.tsx
@@ -15,11 +15,11 @@ export default (props: { children: ReactNode }) => {
   })
   const { auth } = useAuth()
   if (auth === 'Unauthenticated') {
-    setRedirectUrl(window.location.pathname + window.location.hash)
+    setRedirectUrl(window.location.pathname + window.location.search + window.location.hash)
     redirect('/login')
   }
   const redirectUrl = window.sessionStorage.getItem(LS_PREFIX + 'redirect')?.slice(1, -1) // Trim quotes of a raw string
-  if (redirectUrl && redirectUrl === window.location.pathname + window.location.hash) {
+  if (redirectUrl && redirectUrl === window.location.pathname + window.location.search + window.location.hash) {
     clearRedirectUrl()
   }
 

--- a/web-console/src/app/(root)/(authenticated)/layout.tsx
+++ b/web-console/src/app/(root)/(authenticated)/layout.tsx
@@ -4,13 +4,23 @@ import { useAuth } from '$lib/compositions/auth/useAuth'
 import * as monaco from 'monaco-editor'
 import { redirect } from 'next/navigation'
 import { ReactNode } from 'react'
+import { LS_PREFIX } from 'src/lib/types/localStorage'
 
+import { useSessionStorage } from '@mantine/hooks'
 import { loader } from '@monaco-editor/react'
 
 export default (props: { children: ReactNode }) => {
+  const [, setRedirectUrl, clearRedirectUrl] = useSessionStorage<string | undefined>({
+    key: LS_PREFIX + 'redirect'
+  })
   const { auth } = useAuth()
   if (auth === 'Unauthenticated') {
+    setRedirectUrl(window.location.pathname + window.location.hash)
     redirect('/login')
+  }
+  const redirectUrl = window.sessionStorage.getItem(LS_PREFIX + 'redirect')?.slice(1, -1) // Trim quotes of a raw string
+  if (redirectUrl && redirectUrl === window.location.pathname + window.location.hash) {
+    clearRedirectUrl()
   }
 
   return props.children

--- a/web-console/src/app/(root)/(blank)/auth/aws/page.tsx
+++ b/web-console/src/app/(root)/(blank)/auth/aws/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuthStore } from '$lib/compositions/auth/useAuth'
 import { useHashPart } from '$lib/compositions/useHashPart'
+import { LS_PREFIX } from '$lib/types/localStorage'
 import { jwtDecode, JwtPayload } from 'jwt-decode'
 import { redirect } from 'next/navigation'
 
@@ -33,6 +34,10 @@ export default () => {
         signOutUrl: logoutUrl
       }
     })
+  }
+  const redirectUrl = window.sessionStorage.getItem(LS_PREFIX + 'redirect')?.slice(1, -1) // Trim quotes of a raw string
+  if (redirectUrl) {
+    return redirect(redirectUrl)
   }
   redirect('/home')
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

I used SessionStorage to temporarily store the page to redirect to.
Tested with my private Cognito user pool

Fix https://github.com/feldera/feldera/issues/1380: Allow an external URL to launch demos directly in the sandbox. ... It should work even through authentication-related redirects.