### PR TITLE
[SQL] Support for VALUES with ARRAY constructors

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -1,10 +1,44 @@
 package org.dbsp.sqlCompiler.compiler.sql.functions;
 
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class FunctionsTest extends SqlIoTest {
+    @Override
+    public void prepareData(DBSPCompiler compiler) {
+        String ddl = "CREATE TABLE ARR_TABLE (VALS INTEGER ARRAY NOT NULL,ID INTEGER NOT NULL)";
+        String insert = """
+                INSERT INTO ARR_TABLE VALUES(ARRAY [1, 2, 3], 6);
+                INSERT INTO ARR_TABLE VALUES(ARRAY [1, 2, 3], 7);
+                """;
+        compiler.compileStatement(ddl);
+        compiler.compileStatements(insert);
+    }
+
+    @Test
+    public void testUnnest() {
+        this.q("""
+                select * from arr_table;
+                  vals   | id
+                ---------+----
+                 {1,2,3} |  6
+                 {1,2,3} |  7"""
+        );
+        this.q("""
+                SELECT VAL FROM ARR_TABLE, UNNEST(VALS) AS VAL;
+                 val
+                -----
+                 1
+                 2
+                 3
+                 1
+                 2
+                 3"""
+        );
+    }
+
     @Test
     public void testLeft() {
         this.q("""


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1430

This will compile correctly a statement like `INSERT INTO ARR_TABLE VALUES(ARRAY [1, 2, 3], 6);` into a Z-set value.
Note that INSERT statements are not allowed for user programs, they are currently only used for testing.
This will not handle something like 
```
INSERT INTO ARR_TABLE VALUES
                (ARRAY [1, 2, 3], 6),
                (ARRAY [1, 2, 3], 7)
```

But that can be decomposed into two INSERT statements.
If we really want that, it could be implemented with a bit more effort.
This should make it easier to write tests for array functions.