### PR TITLE
Improve handling of case independent names in Pipeline Builder

### DIFF
--- a/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
+++ b/web-console/src/lib/components/streaming/builder/NodeTypes/SqlNode.tsx
@@ -49,7 +49,7 @@ function SqlTableNode(props: { relation: Relation }) {
       />
       {/* The table- prefix is important for the isValidConnection logic */}
       <Handle
-        id={'table-' + escapeRelationName(getCaseIndependentName(props.relation))}
+        id={'table-' + escapeRelationName(props.relation)}
         type='target'
         position={Position.Left}
         isConnectable={true}
@@ -87,7 +87,7 @@ function SqlViewNode(props: { relation: Relation }) {
       />
       {/* The view- prefix is important for the isValidConnection functions */}
       <Handle
-        id={'view-' + escapeRelationName(getCaseIndependentName(props.relation))}
+        id={'view-' + escapeRelationName(props.relation)}
         type='source'
         position={Position.Right}
         isConnectable={true}

--- a/web-console/src/lib/components/streaming/management/PipelineTable.tsx
+++ b/web-console/src/lib/components/streaming/management/PipelineTable.tsx
@@ -22,7 +22,7 @@ import { usePipelineManagerQuery } from '$lib/compositions/usePipelineManagerQue
 import { humanSize } from '$lib/functions/common/string'
 import { invalidateQuery } from '$lib/functions/common/tanstack'
 import { tuple } from '$lib/functions/common/tuple'
-import { getCaseIndependentName } from '$lib/functions/felderaRelation'
+import { caseDependentNameEq, getCaseDependentName, getCaseIndependentName } from '$lib/functions/felderaRelation'
 import { ApiError, AttachedConnector, ConnectorDescr, PipelineRevision, Relation } from '$lib/services/manager'
 import {
   mutationDeletePipeline,
@@ -103,7 +103,7 @@ function getConnectorData(revision: PipelineRevision, direction: InputOrOutput):
 
   return relations.map(relation => {
     const connections = attachedConnectors
-      .filter(ac => ac.relation_name === getCaseIndependentName(relation))
+      .filter(ac => caseDependentNameEq(getCaseDependentName(ac.relation_name))(relation))
       .map(ac => {
         const connector = connectors.find(c => c.name === ac?.connector_name)
         invariant(connector, 'Attached connector has no connector.') // This can't happen in a revision

--- a/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAddIoNode.ts
@@ -1,5 +1,5 @@
 import { randomString } from '$lib/functions/common/string'
-import { escapeRelationName, getCaseIndependentName } from '$lib/functions/felderaRelation'
+import { caseDependentNameEq, escapeRelationName, getCaseDependentName } from '$lib/functions/felderaRelation'
 import { AttachedConnector, ProgramSchema } from '$lib/services/manager'
 import { ConnectorDescr } from '$lib/services/manager/models/ConnectorDescr'
 import { useCallback } from 'react'
@@ -14,7 +14,8 @@ export function connectorConnects(schema: ProgramSchema | null | undefined, ac: 
   if (!schema) {
     return false
   }
-  return (ac.is_input ? schema.inputs : schema.outputs).some(view => ac.relation_name === getCaseIndependentName(view))
+  const acCaseDependentName = getCaseDependentName(ac.relation_name)
+  return (ac.is_input ? schema.inputs : schema.outputs).some(caseDependentNameEq(acCaseDependentName))
 }
 
 /**
@@ -71,7 +72,7 @@ export function useAddConnector() {
       const sqlNode = getNode('sql')
       const ourNode = getNode(ac.name)
       const sqlPrefix = ac.is_input ? 'table-' : 'view-'
-      const connectorHandle = sqlPrefix + escapeRelationName(ac.relation_name)
+      const connectorHandle = sqlPrefix + escapeRelationName(getCaseDependentName(ac.relation_name))
       const hasAnEdge = ac.relation_name !== ''
 
       if (!(hasAnEdge && sqlNode && ourNode)) {

--- a/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
+++ b/web-console/src/lib/compositions/streaming/builder/useAutoLayout.ts
@@ -5,7 +5,7 @@ import { ProgramDescr } from '$lib/services/manager'
 import assert from 'assert'
 import { useCallback, useEffect } from 'react'
 import { Edge, getConnectedEdges, Instance, Node, ReactFlowState, useReactFlow, useStore } from 'reactflow'
-import { escapeRelationName, getCaseIndependentName } from 'src/lib/functions/felderaRelation'
+import { escapeRelationName } from 'src/lib/functions/felderaRelation'
 
 // How much spacing we put after every input/output node
 const VERTICAL_SPACING = 20
@@ -102,7 +102,7 @@ function layoutNodesFixed(
   if (programNode[0].data?.program?.schema) {
     const schema = programNode[0].data.program.schema as NonNullable<ProgramDescr['schema']>
     schema.inputs.forEach((relation, index: number) => {
-      inputOrder.set(escapeRelationName(getCaseIndependentName(relation)), index)
+      inputOrder.set(escapeRelationName(relation), index)
     })
   }
   const inputNodes = sortInputConnectors(rawInputNodes, getEdges(), inputOrder).concat(

--- a/web-console/src/lib/functions/felderaRelation.ts
+++ b/web-console/src/lib/functions/felderaRelation.ts
@@ -6,11 +6,22 @@ export type CaseDependentName = {
 export const getCaseIndependentName = (entity: CaseDependentName) =>
   entity.case_sensitive ? `"${entity.name}"` : entity.name
 
+const isCaseSensitive = (caseIndependentName: string) => caseIndependentName.includes('"')
+
+/**
+ * Convert case insensitive names to lowercase, leave names in quotes as-is
+ */
+export const normalizeCaseIndependentName = (
+  caseIndependentName: string,
+  caseSensitive = isCaseSensitive(caseIndependentName)
+) => (caseSensitive ? caseIndependentName : caseIndependentName.toLocaleLowerCase())
+
 // TODO: update implementation when double quotes become a legal symbol in a name
 export const getCaseDependentName = (caseIndependentName: string) => {
+  const caseSensitive = isCaseSensitive(caseIndependentName)
   return {
-    name: caseIndependentName.replaceAll('"', ''),
-    case_sensitive: caseIndependentName.includes('"')
+    name: normalizeCaseIndependentName(caseIndependentName.replaceAll('"', ''), caseSensitive),
+    case_sensitive: caseSensitive
   }
 }
 
@@ -18,5 +29,5 @@ export const caseDependentNameEq = (a: CaseDependentName) => (b: CaseDependentNa
   !a.case_sensitive === !b.case_sensitive &&
   (a.case_sensitive ? a.name === b.name : a.name.toLocaleLowerCase() === b.name.toLocaleLowerCase())
 
-export const escapeRelationName = encodeURI
+export const escapeRelationName = (name: CaseDependentName) => encodeURI(getCaseIndependentName(name))
 export const unescapeRelationName = decodeURI


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Without this PR the problem can be observed when setting up SecOps demo and navigating to Pipeline Builder view - connectors are not connected to tables and views.
The bug got exposed up after a PR that makes case insensitive relation names lowercase by default, but the demo wasn't updated to configure lowercase attached_connectors. This configuration was interpreted OK in Pipeline Manager, and WebConsole should match this behavior (match uppercase case-insensitive attached_connector-s to lowercase case-insensitive tables).