### PR TITLE
pipeline-manager: integration test: longer compilation timeout

### DIFF
--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -443,7 +443,7 @@ impl TestConfig {
         loop {
             println!("Waiting for compilation");
             std::thread::sleep(time::Duration::from_secs(1));
-            if now.elapsed().as_secs() > 200 {
+            if now.elapsed().as_secs() > 400 {
                 panic!("Compilation timeout");
             }
             let mut resp = self.get(format!("/v0/programs/{program_name}")).await;


### PR DESCRIPTION
Running the integration test occasionally fails due to the compilation timeout being reached.
Increases the timeout from 200s to 400s.

Is this a user-visible change (yes/no): no