### PR TITLE
Earthfile: Properly save playwright artifacts.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -475,8 +475,8 @@ ui-playwright-tests:
                 && exit $exit_code
         END
     FINALLY
-        SAVE ARTIFACT --if-exists playwright-report.zip AS LOCAL ./playwright-artifacts/
-        SAVE ARTIFACT --if-exists test-results.zip      AS LOCAL ./playwright-artifacts/
+        SAVE ARTIFACT --if-exists /dbsp/playwright-report.zip AS LOCAL ./playwright-artifacts/
+        SAVE ARTIFACT --if-exists /dbsp/test-results.zip      AS LOCAL ./playwright-artifacts/
     END
 
 benchmark:


### PR DESCRIPTION
This produced artifacs for me with `earthly -i -P +ui-playwright-tests`, but the original script did not.  I think that the likely reason is that ui-playwright-tests starts with `FROM +ui-playwright-container` and the latter target changes the workdir.

Is this a user-visible change (yes/no): no