### PR TITLE
[SQL] Added REMOVE statement to create negative Z-sets

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -16,6 +16,7 @@ data: {
       "org.apache.calcite.sql.ddl.SqlCreateType"
       "org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlExtendedColumnDeclaration"
       "org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlCreateFunctionDeclaration"
+      "org.dbsp.sqlCompiler.compiler.frontend.statements.SqlRemove"
     ]
 
     # List of new keywords. Example: "DATABASES", "TABLES". If the keyword is
@@ -25,6 +26,7 @@ data: {
       "IF"
       "LATENESS"
       "PLANS"
+      "REMOVE"
       "SEED"
       "SEMI"
       "SEQUENCES"
@@ -884,6 +886,7 @@ data: {
     # List of methods for parsing custom SQL statements.
     # Return type of method implementation should be 'SqlNode'.
     statementParserMethods: [
+        "RemoveStatement()"
     ]
 
     # List of methods for parsing custom literals.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
@@ -152,6 +152,40 @@ void AttributeDef(List<SqlNode> list) :
     }
 }
 
+/** REMOVE FROM TABLE */
+SqlNode RemoveStatement() :
+{
+    final SqlIdentifier tableName;
+    SqlNode tableRef;
+    SqlNode source;
+    final SqlNodeList columnList;
+    final Span s;
+    final Pair<SqlNodeList, SqlNodeList> p;
+}
+{
+    <REMOVE>
+    { s = span(); }
+    <FROM> tableName = CompoundTableIdentifier()
+    { tableRef = tableName; }
+    (
+            LOOKAHEAD(2)
+            p = ParenthesizedCompoundIdentifierList() {
+                if (p.right.size() > 0) {
+                    tableRef = extend(tableRef, p.right);
+                }
+                if (p.left.size() > 0) {
+                    columnList = p.left;
+                } else {
+                    columnList = null;
+                }
+            }
+        |   { columnList = null; }
+    )
+    source = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
+        return new SqlRemove(s.end(source), tableRef, source, columnList);
+    }
+}
+
 SqlCreateFunctionDeclaration SqlCreateFunction(Span s, boolean replace) :
 {
     final boolean ifNotExists;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -103,6 +103,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateTableStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateViewStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.DropTableStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.FrontEndStatement;
+import org.dbsp.sqlCompiler.compiler.frontend.statements.SqlRemove;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.TableModifyStatement;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.util.IWritesLogs;
@@ -874,7 +875,19 @@ public class CalciteCompiler implements IWritesLogs {
                 if (!(table instanceof SqlIdentifier))
                     throw new UnimplementedException(CalciteObject.create(table));
                 SqlIdentifier id = (SqlIdentifier) table;
-                TableModifyStatement stat = new TableModifyStatement(node, sqlStatement, id.toString(), insert.getSource(), comment);
+                TableModifyStatement stat = new TableModifyStatement(node, true, sqlStatement, id.toString(), insert.getSource(), comment);
+                RelRoot values = converter.convertQuery(stat.data, true, true);
+                values = values.withRel(this.optimize(values.rel));
+                stat.setTranslation(values.rel);
+                return stat;
+            } else if (node instanceof SqlRemove) {
+                SqlToRelConverter converter = this.getConverter();
+                SqlRemove insert = (SqlRemove) node;
+                SqlNode table = insert.getTargetTable();
+                if (!(table instanceof SqlIdentifier))
+                    throw new UnimplementedException(CalciteObject.create(table));
+                SqlIdentifier id = (SqlIdentifier) table;
+                TableModifyStatement stat = new TableModifyStatement(node, false, sqlStatement, id.toString(), insert.getSource(), comment);
                 RelRoot values = converter.convertQuery(stat.data, true, true);
                 values = values.withRel(this.optimize(values.rel));
                 stat.setTranslation(values.rel);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/SqlRemove.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/SqlRemove.java
@@ -1,0 +1,122 @@
+package org.dbsp.sqlCompiler.compiler.frontend.statements;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
+
+import java.util.List;
+
+/** This implements our own extension of SQL DML statement.
+ * The REMOVE statement is almost like an INSERT statement,
+ * but the effect is to remove a value from a table.
+ * Unlike DELETE, the values are not specified by a query. */
+public class SqlRemove extends SqlCall {
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("REMOVE", SqlKind.DELETE) {
+                @SuppressWarnings("argument.type.incompatible")
+                @Override public SqlCall createCall(@Nullable SqlLiteral functionQualifier,
+                                                    SqlParserPos pos,
+                                                    @Nullable SqlNode... operands) {
+                    return new SqlRemove(
+                            pos,
+                            operands[0],
+                            operands[1],
+                            (SqlNodeList) operands[2]);
+                }
+            };
+
+    SqlNode targetTable;
+    SqlNode source;
+    @Nullable SqlNodeList columnList;
+
+    public SqlRemove(SqlParserPos pos,
+                     SqlNode targetTable,
+                     SqlNode source,
+                     @Nullable SqlNodeList columnList) {
+        super(pos);
+        this.targetTable = targetTable;
+        this.source = source;
+        this.columnList = columnList;
+    }
+
+    @Override public SqlKind getKind() {
+        return SqlKind.DELETE;
+    }
+
+    @Override public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @SuppressWarnings("nullness")
+    @Override public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(targetTable, source);
+    }
+
+    @SuppressWarnings("assignment.type.incompatible")
+    @Override public void setOperand(int i, @Nullable SqlNode operand) {
+        switch (i) {
+            case 0:
+                assert operand instanceof SqlIdentifier;
+                this.targetTable = operand;
+                break;
+            case 1:
+                this.source = operand;
+                break;
+            case 3:
+                this.columnList = (SqlNodeList) operand;
+                break;
+            default:
+                throw new AssertionError(i);
+        }
+    }
+
+    /** Return the identifier for the target table of the removal. */
+    public SqlNode getTargetTable() {
+        return targetTable;
+    }
+
+    /** Returns the source expression for the data to be removed. */
+    public SqlNode getSource() {
+        return source;
+    }
+
+    public void setSource(SqlSelect source) {
+        this.source = source;
+    }
+
+    @Pure
+    public @Nullable SqlNodeList getTargetColumnList() {
+        return this.columnList;
+    }
+
+    @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.startList(SqlWriter.FrameTypeEnum.SELECT);
+        writer.sep("REMOVE FROM");
+        final int opLeft = getOperator().getLeftPrec();
+        final int opRight = getOperator().getRightPrec();
+        this.targetTable.unparse(writer, opLeft, opRight);
+        if (this.columnList != null) {
+            this.columnList.unparse(writer, opLeft, opRight);
+        }
+        writer.newlineAndIndent();
+        this.source.unparse(writer, 0, 0);
+    }
+
+    @Override public void validate(SqlValidator validator, SqlValidatorScope scope) {
+        // validator.validateInsert(this);
+        // TODO
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
@@ -30,17 +30,20 @@ import javax.annotation.Nullable;
 
 /**
  * Describes a SQL statements that modifies a table
- * (e.g., an INSERT statement).
+ * (e.g., an INSERT or REMOVE statement).
  */
 public class TableModifyStatement extends FrontEndStatement {
     public final String tableName;
     public final SqlNode data;
     @Nullable
     public RelNode rel;
+    /** True for insert, false for remove */
+    public final boolean insert;
 
-    public TableModifyStatement(SqlNode node, String statement, String tableName,
+    public TableModifyStatement(SqlNode node, boolean insert, String statement, String tableName,
                                 SqlNode data, @Nullable String comment) {
         super(node, statement, comment);
+        this.insert = insert;
         this.tableName = tableName;
         this.data = data;
         this.rel = null;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
@@ -75,16 +75,16 @@ public class BaseSQLTests {
         }
 
         public void showErrors() {
-            compiler.messages.show(System.err);
-            compiler.messages.clear();
+            this.compiler.messages.show(System.err);
+            this.compiler.messages.clear();
         }
 
         /** Compiles a SQL script composed of INSERT statements.
          * into a Change. */
-        public Change toChange(DBSPCompiler compiler, String script) {
-            compiler.clearTables();
-            compiler.compileStatements(script);
-            TableContents tableContents = compiler.getTableContents();
+        public Change toChange(String script) {
+            this.compiler.clearTables();
+            this.compiler.compileStatements(script);
+            TableContents tableContents = this.compiler.getTableContents();
             return new Change(tableContents);
         }
 
@@ -95,7 +95,7 @@ public class BaseSQLTests {
          *                 column that contains weights.
          */
         public void step(String script, String expected) {
-            Change input = this.toChange(compiler, script);
+            Change input = this.toChange(script);
             DBSPType outputType = circuit.getSingleOutputType();
             Change output = TableParser.parseChangeTable(expected, outputType);
             stream.addPair(input, output);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
@@ -105,10 +105,19 @@ public class ParserTests {
     }
 
     @Test
-    public void SourceNameTest() throws SqlParseException {
+    public void sourceNameTest() throws SqlParseException {
         // Tests that a table can be named 'source'.
         CalciteCompiler calcite = this.getCompiler();
         String ddl = "CREATE TABLE SOURCE (COL INT)";
+        SqlNode node = calcite.parse(ddl);
+        Assert.assertNotNull(node);
+    }
+
+    @Test
+    public void removeTest() throws SqlParseException {
+        // Tests the newly added REMOVE statement
+        CalciteCompiler calcite = this.getCompiler();
+        String ddl = "REMOVE FROM SOURCE VALUES(1, 2, 3)";
         SqlNode node = calcite.parse(ddl);
         Assert.assertNotNull(node);
     }


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1456 

This introduces a REMOVE statement in SQL, which is the exact counterpart of the INSERT statement. It supports pretty much the same forms as INSERT. The result of executing INSERT is to obtain a positive Z-set, whereas executing a REMOVE generates a negative Z-set. 

Both INSERT and REMOVE are used for writing nicer tests. Here is a fragment of an example of a Java test built using the new syntax:

```java
@Test
    public void blogTest() {
        String statements = """
                CREATE TABLE CUSTOMER(name VARCHAR NOT NULL, zipcode INT NOT NULL);                               
                CREATE VIEW DENSITY AS
                SELECT zipcode, COUNT(name)
                FROM CUSTOMER
                GROUP BY zipcode
                """;
        DBSPCompiler compiler = this.testCompiler();
        compiler.compileStatements(statements);
        Assert.assertFalse(compiler.hasErrors());
        CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
        ccs.step("",
                """
                 zipcode | count | weight
                --------------------------""");
        ccs.step("""
                 INSERT INTO customer VALUES('Bob', 1000);
                 INSERT INTO customer VALUES('Pam', 2000);
                 INSERT INTO customer VALUES('Sue', 3000);
                 INSERT INTO customer VALUES('Mike', 1000);""",
                """
                 zipcode | count | weight
                --------------------------
                 1000    | 2     | 1
                 2000    | 1     | 1
                 3000    | 1     | 1""");
        ccs.step("""
                REMOVE FROM customer VALUES('Bob', 1000);
                INSERT INTO customer VALUES('Bob', 2000);""",
                """
                 zipcode | count | weight
                --------------------------
                 1000    | 2     | -1
                 2000    | 1     | -1
                 2000    | 2     | 1
                 1000    | 1     | 1""");
```

Currently we do not expose DML statements to users, but some day we might. At that point this will become a user-visible change.

