### PR TITLE
adapters: add an input transport for S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
           snowflake_passphrase: ${{ secrets.snowflake_ci_user_private_key_passphrase }}
           snowflake_password: ${{ secrets.snowflake_ci_user_password }}
 
+      # Ship secrets for the S3 CI account to Earthly.
+      - name: S3 .env
+        run: |
+          echo CI_S3_AWS_ACCESS_KEY="${s3_access_key}" >> deploy/.env && \
+          echo CI_S3_AWS_SECRET="${s3_secret}" >> deploy/.env
+        env:
+          s3_access_key: ${{ secrets.ci_s3_aws_access_key }}
+          s3_secret: ${{ secrets.ci_s3_aws_secret }}
+
       - name: Print ulimit
         run: ulimit -a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1493](https://github.com/feldera/feldera/pull/1493))
 - SQL: support for ARRAY_PREPEND function
   ([#1496](https://github.com/feldera/feldera/pull/1496))
-
+- adapters: add an input connector for Amazon S3 (#1485)
 
 ## [0.11.0] - 2024-03-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.11",
  "httparse",
  "httpdate",
  "itoa",
@@ -136,7 +136,7 @@ dependencies = [
  "awc",
  "bytes",
  "futures-core",
- "http",
+ "http 0.2.11",
  "log",
  "serde",
  "serde_json",
@@ -163,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
 dependencies = [
  "bytestring",
- "http",
+ "http 0.2.11",
  "regex",
  "serde",
  "tracing",
@@ -241,7 +241,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "http",
+ "http 0.2.11",
  "impl-more",
  "openssl",
  "pin-project-lite",
@@ -249,7 +249,7 @@ dependencies = [
  "rustls-webpki",
  "tokio",
  "tokio-openssl",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tracing",
  "webpki-roots 0.22.6",
@@ -908,7 +908,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "itoa",
  "log",
  "mime",
@@ -929,21 +929,21 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.55.3",
  "aws-http",
  "aws-sdk-sso",
  "aws-sdk-sts",
- "aws-smithy-async",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
  "hex",
- "http",
+ "http 0.2.11",
  "hyper",
  "ring 0.16.20",
  "time",
@@ -959,11 +959,23 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-types 0.55.3",
  "fastrand 1.9.0",
  "tokio",
  "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273fa47dafc9ef14c2c074ddddbea4561ff01b7f68d5091c0e9737ced605c01d"
+dependencies = [
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
  "zeroize",
 ]
 
@@ -973,10 +985,10 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
- "http",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "http 0.2.11",
  "regex",
  "tracing",
 ]
@@ -987,12 +999,12 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
- "aws-smithy-types",
- "aws-types",
+ "aws-credential-types 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
- "http",
+ "http 0.2.11",
  "http-body",
  "lazy_static",
  "percent-encoding",
@@ -1001,28 +1013,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e38bab716c8bf07da24be07ecc02e0f5656ce8f30a891322ecdcb202f943b85"
+dependencies = [
+ "aws-credential-types 1.1.7",
+ "aws-sigv4 1.1.7",
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.60.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "aws-types 1.1.7",
+ "bytes",
+ "fastrand 2.0.1",
+ "http 0.2.11",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "aws-sdk-cognitoidentityprovider"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b478b4872923cbfc54cb906fbd01c65eca968cb47bc9325feee771fc1a1c3c82"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.55.3",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
- "http",
+ "http 0.2.11",
  "regex",
  "tokio-stream",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d35d39379445970fc3e4ddf7559fff2c32935ce0b279f9cb27080d6b7c6d94"
+dependencies = [
+ "aws-credential-types 1.1.7",
+ "aws-runtime",
+ "aws-sigv4 1.1.7",
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.60.6",
+ "aws-smithy-json 0.60.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "aws-smithy-xml 0.60.6",
+ "aws-types 1.1.7",
+ "bytes",
+ "http 0.2.11",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1031,19 +1096,19 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.55.3",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower",
- "aws-smithy-json",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
- "http",
+ "http 0.2.11",
  "regex",
  "tokio-stream",
  "tower",
@@ -1056,21 +1121,21 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 0.55.3",
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
- "aws-smithy-async",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-client",
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower",
- "aws-smithy-json",
+ "aws-smithy-json 0.55.3",
  "aws-smithy-query",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
  "bytes",
- "http",
+ "http 0.2.11",
  "regex",
  "tower",
  "tracing",
@@ -1082,11 +1147,11 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
 dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-http",
- "aws-types",
- "http",
+ "aws-credential-types 0.55.3",
+ "aws-sigv4 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-types 0.55.3",
+ "http 0.2.11",
  "tracing",
 ]
 
@@ -1096,17 +1161,46 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.55.3",
  "form_urlencoded",
  "hex",
  "hmac",
- "http",
+ "http 0.2.11",
  "once_cell",
  "percent-encoding",
  "regex",
  "sha2",
  "time",
  "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada00a4645d7d89f296fe0ddbc3fe3554f03035937c849a05d37ddffc1f29a1"
+dependencies = [
+ "aws-credential-types 1.1.7",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.60.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.11",
+ "http 1.0.0",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "ring 0.17.5",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -1122,21 +1216,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-async"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf7f09a27286d84315dfb9346208abb3b0973a692454ae6d0bc8d803fcce3b4"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd4b66f2a8e7c84d7e97bda2666273d41d2a2e25302605bcf906b7b2661ae5e"
+dependencies = [
+ "aws-smithy-http 0.60.6",
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.11",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-client"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-http 0.55.3",
  "aws-smithy-http-tower",
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "fastrand 1.9.0",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
  "rustls 0.20.9",
@@ -1146,16 +1272,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
+dependencies = [
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "bytes",
  "bytes-utils",
  "futures-core",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "once_cell",
@@ -1168,15 +1305,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http"
+version = "0.60.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ca214a6a26f1b7ebd63aa8d4f5e2194095643023f9608edf99a58247b9d80d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-http-tower"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
 dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
  "bytes",
- "http",
+ "http 0.2.11",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -1189,7 +1347,16 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af80ecf3057fb25fe38d1687e94c4601a7817c6a1e87c1b0635f7ecb644ace5"
+dependencies = [
+ "aws-smithy-types 1.1.7",
 ]
 
 [[package]]
@@ -1198,8 +1365,49 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 0.55.3",
  "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb5fca54a532a36ff927fbd7407a7c8eb9c3b4faf72792ba2965ea2cad8ed55"
+dependencies = [
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-http 0.60.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "fastrand 2.0.1",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22389cb6f7cac64f266fb9f137745a9349ced7b47e0d2ba503e9e40ede4f7060"
+dependencies = [
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-types 1.1.7",
+ "bytes",
+ "http 0.2.11",
+ "http 1.0.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1216,10 +1424,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-types"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f081da5481210523d44ffd83d9f0740320050054006c719eae0232d411f024d3"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.11",
+ "http-body",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "aws-smithy-xml"
 version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fccd8f595d0ca839f9f2548e66b99514a85f92feb4c01cf2868d93eb4888a42"
 dependencies = [
  "xmlparser",
 ]
@@ -1230,12 +1470,27 @@ version = "0.55.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
+ "aws-credential-types 0.55.3",
+ "aws-smithy-async 0.55.3",
  "aws-smithy-client",
- "aws-smithy-http",
- "aws-smithy-types",
- "http",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "http 0.2.11",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07c63521aa1ea9a9f92a701f1a08ce3fd20b46c6efc0d5c8947c1fd879e3df1"
+dependencies = [
+ "aws-credential-types 1.1.7",
+ "aws-smithy-async 1.1.7",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types 1.1.7",
+ "http 0.2.11",
  "rustc_version",
  "tracing",
 ]
@@ -1254,6 +1509,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
@@ -1913,6 +2174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,9 +2253,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
 dependencies = [
  "rustc_version",
 ]
@@ -2109,6 +2376,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2351,7 +2640,10 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-stream",
+ "async-trait",
  "awc",
+ "aws-sdk-s3",
+ "aws-types 1.1.7",
  "bstr",
  "bytestring",
  "chrono 0.4.31",
@@ -2371,6 +2663,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
+ "mockall",
  "num-derive 0.3.3",
  "num-traits",
  "once_cell",
@@ -2468,6 +2761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2573,6 +2876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,6 +2910,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "educe"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,6 +2938,26 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2830,6 +3171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +3273,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -3167,6 +3524,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,7 +3545,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -3325,13 +3693,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -3351,7 +3730,7 @@ dependencies = [
  "async-channel 1.9.0",
  "base64 0.13.1",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -3391,7 +3770,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -3410,13 +3789,29 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.11",
+ "hyper",
+ "log",
+ "rustls 0.21.9",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3981,6 +4376,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,6 +4870,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,7 +5090,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline-manager"
-version = "0.11.0"
+version = "0.10.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -4733,6 +5166,16 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.0.1",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -4876,6 +5319,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -5518,6 +5987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5544,7 +6019,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -5575,6 +6050,17 @@ name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
 
 [[package]]
 name = "rgb"
@@ -5947,6 +6433,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6174,6 +6674,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6297,6 +6807,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -6671,6 +7191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "test_bin"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6864,6 +7390,16 @@ dependencies = [
  "rustls 0.20.9",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.9",
+ "tokio",
 ]
 
 [[package]]

--- a/Earthfile
+++ b/Earthfile
@@ -402,6 +402,20 @@ test-snowflake:
         RUN COMPOSE_HTTP_TIMEOUT=120 RUST_LOG=debug,tokio_postgres=info docker-compose --env-file .env -f docker-compose.yml --profile snowflake up --force-recreate --exit-code-from snowflake-demo
     END
 
+test-s3:
+    FROM earthly/dind:alpine
+    COPY deploy/docker-compose.yml .
+    COPY deploy/.env .
+    RUN cat .env
+    ENV FELDERA_VERSION=latest
+    WITH DOCKER --pull postgres \
+                --pull docker.redpanda.com/vectorized/redpanda:v23.2.3 \
+                --load ghcr.io/feldera/pipeline-manager:latest=+build-pipeline-manager-container \
+                --load ghcr.io/feldera/demo-container:latest=+build-demo-container \
+                --load ghcr.io/feldera/kafka-connect:latest=+build-kafka-connect-container
+        RUN COMPOSE_HTTP_TIMEOUT=120 RUST_LOG=debug,tokio_postgres=info docker-compose --env-file .env -f docker-compose.yml --profile s3 up --force-recreate --exit-code-from s3-demo
+    END
+
 # Fetches the test binary from test-manager, and produces a container image out of it
 integration-test-container:
     FROM +install-deps
@@ -506,3 +520,4 @@ all-tests:
     BUILD +test-debezium-mysql
     BUILD +test-debezium-jdbc-sink
     BUILD +test-snowflake
+    BUILD +test-s3

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -35,6 +35,8 @@ form_urlencoded = "1.2.0"
 csv = "1.2.2"
 # cmake-build is required on Windows.
 rdkafka = { version = "0.34.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"], optional = true }
+aws-sdk-s3 = {version = "1.17.0", features = ["behavior-version-latest"] } 
+aws-types = "1.1.7"
 actix = "0.13.1"
 actix-web = { version = "4.4.0", default-features = false, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
 mime = "0.3.16"
@@ -64,6 +66,7 @@ rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf"
 rand = "0.8.5"
 regex = "1.10.2"
 tempfile = "3.10.0"
+async-trait = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 psutil = "3.2.2"
@@ -85,3 +88,4 @@ test_bin = "0.4.0"
 reqwest = { version = "0.11.20", features = ["blocking"] }
 serial_test = "2.0.0"
 rust_decimal_macros = "1.32"
+mockall = "0.12.1"

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -45,6 +45,7 @@ pub mod http;
 
 pub mod url;
 
+mod s3;
 mod secret_resolver;
 
 #[cfg(feature = "with-kafka")]
@@ -55,6 +56,8 @@ pub use url::UrlInputTransport;
 
 #[cfg(feature = "with-kafka")]
 pub use kafka::{KafkaInputTransport, KafkaOutputTransport};
+
+pub use s3::S3InputTransport;
 
 /// Step number for fault-tolerant input and output.
 ///
@@ -83,6 +86,7 @@ static INPUT_TRANSPORT: Lazy<BTreeMap<&'static str, Box<dyn InputTransport>>> = 
             "url",
             Box::new(UrlInputTransport) as Box<dyn InputTransport>,
         ),
+        ("s3", Box::new(S3InputTransport) as Box<dyn InputTransport>),
         #[cfg(feature = "with-kafka")]
         (
             "kafka",

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -1,0 +1,423 @@
+use std::{borrow::Cow, sync::Arc};
+
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
+use serde::Deserialize;
+use tokio::sync::watch::{channel, Receiver, Sender};
+
+use crate::{InputConsumer, InputEndpoint, InputReader, InputTransport, PipelineState};
+#[cfg(test)]
+use mockall::automock;
+
+use pipeline_types::transport::s3::{AwsCredentials, ReadStrategy, S3InputConfig};
+
+pub struct S3InputTransport;
+
+impl InputTransport for S3InputTransport {
+    fn name(&self) -> std::borrow::Cow<'static, str> {
+        Cow::Borrowed("s3")
+    }
+
+    fn new_endpoint(
+        &self,
+        config: &serde_yaml::Value,
+    ) -> anyhow::Result<Box<dyn crate::InputEndpoint>> {
+        let ep = S3InputEndpoint {
+            config: Arc::new(S3InputConfig::deserialize(config)?),
+        };
+        Ok(Box::new(ep))
+    }
+}
+
+struct S3InputEndpoint {
+    config: Arc<S3InputConfig>,
+}
+
+impl InputEndpoint for S3InputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+
+    fn open(
+        &self,
+        consumer: Box<dyn crate::InputConsumer>,
+        _start_step: super::Step,
+    ) -> anyhow::Result<Box<dyn crate::InputReader>> {
+        Ok(Box::new(S3InputReader::new(&self.config, consumer)))
+    }
+}
+
+// This wrapper around the S3 SDK client allows us to
+// mock it for tests (using the mockall crate).
+//
+// See: https://docs.aws.amazon.com/sdk-for-rust/latest/dg/testing.html
+//
+// The automock macro generates a `MockS3Client` that we use during tests.
+struct S3Client {
+    inner: aws_sdk_s3::Client,
+}
+
+#[cfg_attr(test, automock)]
+#[async_trait::async_trait]
+impl S3Api for S3Client {
+    async fn get_object_keys(&self, bucket: &str, prefix: &str) -> anyhow::Result<Vec<String>> {
+        let res: Vec<String> = self
+            .inner
+            .list_objects_v2()
+            .bucket(bucket)
+            .prefix(prefix)
+            .send()
+            .await
+            .map(|output| {
+                output
+                    .contents()
+                    .iter()
+                    .map(|object| {
+                        object
+                            .key()
+                            .expect("Objects should always have a key")
+                            .to_string()
+                    })
+                    .collect()
+            })?;
+        Ok(res)
+    }
+
+    async fn get_object(&self, bucket: &str, key: &str) -> anyhow::Result<GetObjectOutput> {
+        Ok(self
+            .inner
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await?)
+    }
+}
+
+#[async_trait::async_trait]
+trait S3Api: Send {
+    /// Get all object keys inside a bucket
+    async fn get_object_keys(&self, bucket: &str, prefix: &str) -> anyhow::Result<Vec<String>>;
+
+    /// Fetch an object by key within a bucket
+    async fn get_object(&self, bucket: &str, key: &str) -> anyhow::Result<GetObjectOutput>;
+}
+
+struct S3InputReader {
+    sender: Sender<PipelineState>,
+}
+
+impl InputReader for S3InputReader {
+    fn start(&self, _step: super::Step) -> anyhow::Result<()> {
+        self.sender.send_replace(PipelineState::Running);
+        Ok(())
+    }
+
+    fn pause(&self) -> anyhow::Result<()> {
+        self.sender.send_replace(PipelineState::Paused);
+        Ok(())
+    }
+
+    fn disconnect(&self) {
+        self.sender.send_replace(PipelineState::Terminated);
+    }
+}
+
+impl Drop for S3InputReader {
+    fn drop(&mut self) {
+        self.disconnect();
+    }
+}
+
+impl S3InputReader {
+    fn new(config: &Arc<S3InputConfig>, consumer: Box<dyn InputConsumer>) -> S3InputReader {
+        let s3_config = to_s3_config(config);
+        let client = Box::new(S3Client {
+            inner: aws_sdk_s3::Client::from_conf(s3_config),
+        }) as Box<dyn S3Api>;
+        Self::new_inner(config, consumer, client)
+    }
+
+    fn new_inner(
+        config: &Arc<S3InputConfig>,
+        mut consumer: Box<dyn InputConsumer>,
+        s3_client: Box<dyn S3Api>,
+    ) -> S3InputReader {
+        let (sender, receiver) = channel(PipelineState::Paused);
+        let config_clone = config.clone();
+        let receiver_clone = receiver.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Could not create Tokio runtime");
+            rt.block_on(async {
+                let _ =
+                    Self::worker_task(s3_client, config_clone, &mut consumer, receiver_clone).await;
+            })
+        });
+        S3InputReader { sender }
+    }
+
+    async fn worker_task(
+        client: Box<dyn S3Api>,
+        config: Arc<S3InputConfig>,
+        consumer: &mut Box<dyn InputConsumer>,
+        mut receiver: Receiver<PipelineState>,
+    ) -> anyhow::Result<()> {
+        let objects_to_fetch = match &config.read_strategy {
+            ReadStrategy::Prefix { prefix } => {
+                client.get_object_keys(&config.bucket_name, prefix).await?
+            }
+            ReadStrategy::SingleKey { key } => vec![key.clone()],
+        };
+        for key in &objects_to_fetch {
+            let mut object = client.get_object(&config.bucket_name, key).await?;
+            loop {
+                let state = *receiver.borrow();
+                match state {
+                    PipelineState::Paused => {
+                        receiver.changed().await?;
+                    }
+                    PipelineState::Running => {
+                        tokio::select! {
+                            _ = receiver.changed() => (),
+                            result = object.body.next() => {
+                                match result {
+                                    Some(Ok(bytes)) => {
+                                        consumer.input_fragment(&bytes);
+                                    }
+                                    None => break,
+                                    Some(Err(e)) => Err(e)?
+                                }
+                            }
+                        }
+                    }
+                    PipelineState::Terminated => break,
+                };
+            }
+        }
+        Ok(())
+    }
+}
+
+fn to_s3_config(config: &Arc<S3InputConfig>) -> aws_sdk_s3::Config {
+    let config_builder =
+        aws_sdk_s3::Config::builder().region(aws_types::region::Region::new(config.region.clone()));
+    match &config.credentials {
+        AwsCredentials::AccessKey {
+            aws_access_key_id,
+            aws_secret_access_key,
+        } => {
+            let credentials = aws_sdk_s3::config::Credentials::new(
+                aws_access_key_id.clone(),
+                aws_secret_access_key.clone(),
+                None,
+                None,
+                "credential-provider",
+            );
+            config_builder.credentials_provider(credentials).build()
+        }
+        AwsCredentials::NoSignRequest => config_builder.build(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        deserialize_without_context,
+        test::{mock_parser_pipeline, wait, MockDeZSet, MockInputConsumer},
+        transport::s3::{S3InputConfig, S3InputReader},
+    };
+    use aws_sdk_s3::{
+        operation::get_object::GetObjectOutput,
+        primitives::{ByteStream, SdkBody},
+    };
+    use mockall::predicate::eq;
+    use pipeline_types::config::InputEndpointConfig;
+    use serde::{Deserialize, Serialize};
+    use std::{sync::Arc, time::Duration};
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+    struct TestStruct {
+        i: i64,
+    }
+    deserialize_without_context!(TestStruct);
+
+    const MULTI_KEY_CONFIG_STR: &str = r#"
+stream: test_input
+transport:
+    name: s3
+    config:
+        credentials:
+            type: AccessKey
+            aws_access_key_id: FAKE_ACCESS_KEY
+            aws_secret_access_key: FAKE_SECRET
+        bucket_name: test-bucket
+        region: us-west-1
+        read_strategy:
+            type: Prefix
+            prefix: ''
+format:
+    name: csv
+"#;
+
+    const SINGLE_KEY_CONFIG_STR: &str = r#"
+stream: test_input
+transport:
+    name: s3
+    config:
+        credentials:
+            type: AccessKey
+            aws_access_key_id: FAKE_ACCESS_KEY
+            aws_secret_access_key: FAKE_SECRET
+        bucket_name: test-bucket
+        region: us-west-1
+        read_strategy:
+            type: SingleKey
+            key: obj1
+format:
+    name: csv
+"#;
+
+    fn test_setup(
+        config_str: &str,
+        mock: super::MockS3Client,
+    ) -> (
+        Box<dyn crate::InputReader>,
+        MockInputConsumer,
+        MockDeZSet<TestStruct, TestStruct>,
+    ) {
+        let config: InputEndpointConfig = serde_yaml::from_str(&config_str).unwrap();
+        let transport_config: Arc<S3InputConfig> = Arc::new(
+            S3InputConfig::deserialize(config.connector_config.transport.config.clone()).unwrap(),
+        );
+        let (consumer, input_handle) =
+            mock_parser_pipeline::<TestStruct, TestStruct>(&config.connector_config.format)
+                .unwrap();
+        consumer.on_error(Some(Box::new(|_, _| ())));
+        let reader = Box::new(S3InputReader::new_inner(
+            &transport_config,
+            Box::new(consumer.clone()),
+            Box::new(mock),
+        )) as Box<dyn crate::InputReader>;
+        (reader, consumer, input_handle)
+    }
+
+    fn run_test(config_str: &str, mock: super::MockS3Client, test_data: Vec<TestStruct>) {
+        let (reader, consumer, input_handle) = test_setup(config_str, mock);
+        let _ = reader.pause();
+        // No outputs should be produced at this point.
+        assert!(consumer.state().data.is_empty());
+        assert!(!consumer.state().eoi);
+
+        // Unpause the endpoint, wait for the data to appear at the output.
+        reader.start(0).unwrap();
+        wait(|| input_handle.state().flushed.len() == 3, 100);
+
+        assert_eq!(test_data.len(), input_handle.state().flushed.len());
+        for (i, upd) in input_handle.state().flushed.iter().enumerate() {
+            assert_eq!(upd.unwrap_insert(), &test_data[i]);
+        }
+    }
+
+    #[test]
+    fn single_key_read() {
+        let mut mock = super::MockS3Client::default();
+        mock.expect_get_object_keys()
+            .with(eq("test-bucket"), eq(""))
+            .return_once(|_, _| Ok(vec!["obj1".to_string()]));
+        mock.expect_get_object()
+            .with(eq("test-bucket"), eq("obj1"))
+            .return_once(|_, _| {
+                Ok(GetObjectOutput::builder()
+                    .body(ByteStream::from(SdkBody::from("1\n2\n3\n")))
+                    .build())
+            });
+        let test_data: Vec<TestStruct> = (1..4).map(|i| TestStruct { i }).collect();
+        run_test(&SINGLE_KEY_CONFIG_STR, mock, test_data);
+    }
+
+    #[test]
+    fn single_object_with_prefix_read() {
+        let mut mock = super::MockS3Client::default();
+        mock.expect_get_object_keys()
+            .with(eq("test-bucket"), eq(""))
+            .return_once(|_, _| Ok(vec!["obj1".to_string()]));
+        mock.expect_get_object()
+            .with(eq("test-bucket"), eq("obj1"))
+            .return_once(|_, _| {
+                Ok(GetObjectOutput::builder()
+                    .body(ByteStream::from(SdkBody::from("1\n2\n3\n")))
+                    .build())
+            });
+        let test_data: Vec<TestStruct> = (1..4).map(|i| TestStruct { i }).collect();
+        run_test(&MULTI_KEY_CONFIG_STR, mock, test_data);
+    }
+
+    #[test]
+    fn multi_object_read() {
+        let mut mock = super::MockS3Client::default();
+        mock.expect_get_object_keys()
+            .with(eq("test-bucket"), eq(""))
+            .return_once(|_, _| Ok(vec!["obj1".to_string(), "obj2".to_string()]));
+        mock.expect_get_object()
+            .with(eq("test-bucket"), eq("obj1"))
+            .return_once(|_, _| {
+                Ok(GetObjectOutput::builder()
+                    .body(ByteStream::from(SdkBody::from("1\n2\n3\n")))
+                    .build())
+            });
+        mock.expect_get_object()
+            .with(eq("test-bucket"), eq("obj2"))
+            .return_once(|_, _| {
+                Ok(GetObjectOutput::builder()
+                    .body(ByteStream::from(SdkBody::from("4\n5\n6\n")))
+                    .build())
+            });
+        let test_data: Vec<TestStruct> = (1..7).map(|i| TestStruct { i }).collect();
+        run_test(&MULTI_KEY_CONFIG_STR, mock, test_data);
+    }
+
+    #[test]
+    fn multi_object_read_with_pause() {
+        let mut mock = super::MockS3Client::default();
+        // Read 1K objects by prefix, each with 1 row
+        let objs: Vec<String> = (0..1000).map(|i| format!("obj{i}")).collect();
+        for (i, key) in objs.iter().enumerate() {
+            mock.expect_get_object()
+                .with(eq("test-bucket"), eq(key.clone()))
+                .return_once(move |_, _| {
+                    Ok(GetObjectOutput::builder()
+                        .body(ByteStream::from(SdkBody::from(format!("{i}\n"))))
+                        .build())
+                });
+        }
+        mock.expect_get_object_keys()
+            .with(eq("test-bucket"), eq(""))
+            .return_once(|_, _| Ok(objs));
+        let test_data: Vec<TestStruct> = (0..1000).map(|i| TestStruct { i }).collect();
+        let (reader, _, input_handle) = test_setup(MULTI_KEY_CONFIG_STR, mock);
+        reader.start(0).unwrap();
+        // Pause after 50 rows are recorded.
+        wait(|| input_handle.state().flushed.len() > 50, 1000);
+        let _ = reader.pause();
+        // Wait a few milliseconds for the worker to pause and write any WIP object
+        std::thread::sleep(Duration::from_millis(10));
+        let n = input_handle.state().flushed.len();
+        // Wait a few more milliseconds and make sure no more entries were written
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(n, input_handle.state().flushed.len());
+        assert_ne!(input_handle.state().flushed.len(), test_data.len());
+        // Resume to completion
+        reader.start(0).unwrap();
+        wait(
+            || input_handle.state().flushed.len() == test_data.len(),
+            10000,
+        );
+
+        assert_eq!(test_data.len(), input_handle.state().flushed.len());
+        for (i, upd) in input_handle.state().flushed.iter().enumerate() {
+            assert_eq!(upd.unwrap_insert(), &test_data[i]);
+        }
+    }
+}

--- a/crates/pipeline-types/src/transport/mod.rs
+++ b/crates/pipeline-types/src/transport/mod.rs
@@ -1,4 +1,5 @@
 pub mod file;
 pub mod http;
 pub mod kafka;
+pub mod s3;
 pub mod url;

--- a/crates/pipeline-types/src/transport/s3.rs
+++ b/crates/pipeline-types/src/transport/s3.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Configuration for reading data from AWS S3.
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+pub struct S3InputConfig {
+    /// Credentials to authenticate against AWS
+    pub credentials: AwsCredentials,
+    /// AWS region
+    pub region: String,
+    /// S3 bucket name to access
+    pub bucket_name: String,
+    /// Strategy that determines which objects to
+    /// read from the bucket
+    pub read_strategy: ReadStrategy,
+}
+
+/// Configuration to authenticate against AWS
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type")]
+pub enum AwsCredentials {
+    /// Do not sign requests. This is equivalent to
+    /// the `--no-sign-request` flag in the AWS CLI
+    NoSignRequest,
+    /// Authenticate using a long-lived AWS access key and secret
+    AccessKey {
+        aws_access_key_id: String,
+        aws_secret_access_key: String,
+    },
+}
+
+/// Strategy that determines which objects to read from a given bucket
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type")]
+pub enum ReadStrategy {
+    /// Read a single object specified by a key
+    SingleKey { key: String },
+    /// Read all objects whose keys match a prefix
+    Prefix { prefix: String },
+}

--- a/crates/pipeline-types/src/transport/s3.rs
+++ b/crates/pipeline-types/src/transport/s3.rs
@@ -13,6 +13,13 @@ pub struct S3InputConfig {
     /// Strategy that determines which objects to
     /// read from the bucket
     pub read_strategy: ReadStrategy,
+    /// Streaming vs chunked reads
+    #[serde(default = "default_consume_strategy")]
+    pub consume_strategy: ConsumeStrategy,
+}
+
+fn default_consume_strategy() -> ConsumeStrategy {
+    ConsumeStrategy::Fragment
 }
 
 /// Configuration to authenticate against AWS
@@ -37,4 +44,16 @@ pub enum ReadStrategy {
     SingleKey { key: String },
     /// Read all objects whose keys match a prefix
     Prefix { prefix: String },
+}
+
+/// Strategy to feed a fetched object into an InputConsumer.
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type")]
+pub enum ConsumeStrategy {
+    /// Write the object as a series of fragments (see
+    /// InputConsumer::input_fragment).
+    Fragment,
+    /// Write the entire object at once. Appropriate for formats like Parquet
+    /// that cannot be streamed.
+    Object,
 }

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -196,6 +196,7 @@ request is rejected."
         pipeline_types::transport::kafka::KafkaLogLevel,
         pipeline_types::transport::http::Chunk,
         pipeline_types::transport::http::EgressMode,
+        pipeline_types::transport::s3::S3InputConfig,
         pipeline_types::format::csv::CsvEncoderConfig,
         pipeline_types::format::csv::CsvParserConfig,
         pipeline_types::format::json::JsonEncoderConfig,

--- a/demo/project_demo09-S3/program.sql
+++ b/demo/project_demo09-S3/program.sql
@@ -1,0 +1,5 @@
+create table test_table(
+    id integer not null primary key
+);
+
+create view test_view as select * from test_table;

--- a/demo/project_demo09-S3/run.py
+++ b/demo/project_demo09-S3/run.py
@@ -1,0 +1,128 @@
+# Read all objects with the prefix "foo" from an S3 bucket. The S3 bucket is pre-loaded with two objects,
+# foo_1.csv and foo_2.csv, that have values (1, 2, 3) and (4, 5, 6).
+#
+# It expects two environment varaibles CI_S3_AWS_ACCESS_KEY and CI_S3_AWS_SECRET for the test IAM user permissions.
+#
+# To run the demo, start Feldera:
+# > docker compose -f deploy/docker-compose.yml -f deploy/docker-compose-dev.yml --profile s3-demo \
+#       up db pipeline-manager --build --renew-anon-volumes --force-recreate
+#
+# Run this script:
+# > python3 run.py --api-url=http://localhost:8080 --start
+import base64
+import os
+import time
+import datetime
+import requests
+import argparse
+from plumbum.cmd import rpk
+import psycopg
+import json
+import random
+
+# File locations
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+PROGRAM_SQL = os.path.join(SCRIPT_DIR, "program.sql")
+
+DATABASE_NAME = "jdbc_test_db"
+PIPELINE_NAME = "demo-s3"
+FELDERA_CONNECTOR_NAME = "s3-input"
+TABLE_NAME = "test_table"
+VIEW_NAME = "test_view"
+PRIMARY_KEY_COLUMN = "id"
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-url", required=True, help="Feldera API URL (e.g., http://localhost:8080 )")
+    parser.add_argument('--start', action='store_true', default=False, help="Start the Feldera pipeline")
+    args = parser.parse_args()
+    prepare_feldera_pipeline(args.api_url, args.start)
+
+def prepare_feldera_pipeline(api_url, start_pipeline):
+    s3_access_key = os.getenv("CI_S3_AWS_ACCESS_KEY")
+    s3_secret_key = os.getenv("CI_S3_AWS_SECRET")
+    assert s3_access_key is not None and s3_secret_key is not None
+
+    # Create program
+    program_name = "demo-s3-input"
+    program_sql = open(PROGRAM_SQL).read()
+    response = requests.put(f"{api_url}/v0/programs/{program_name}", json={
+        "description": "S3 input connector demo",
+        "code": program_sql
+    })
+    response.raise_for_status()
+    program_version = response.json()["version"]
+
+    # Compile program
+    print(f"Compiling program {program_name} (version: {program_version})...")
+    requests.post(f"{api_url}/v0/programs/{program_name}/compile", json={"version": program_version}).raise_for_status()
+    while True:
+        status = requests.get(f"{api_url}/v0/programs/{program_name}").json()["status"]
+        print(f"Program status: {status}")
+        if status == "Success":
+            break
+        elif status != "Pending" and status != "CompilingRust" and status != "CompilingSql":
+            raise RuntimeError(f"Failed program compilation with status {status}")
+        time.sleep(5)
+
+    # Connectors
+    connectors = []
+    requests.put(f"{api_url}/v0/connectors/{FELDERA_CONNECTOR_NAME}", json={
+        "description": "",
+        "config": {
+            "format": {
+                "name": "csv",
+            },
+            "transport": {
+                "name": "s3",
+                "config": {
+                    "credentials": {
+                        "type": "AccessKey",
+                        "aws_access_key_id": s3_access_key,
+                        "aws_secret_access_key": s3_secret_key,
+                    },
+                    "bucket_name": "feldera-connector-test-bucket",
+                    "region": "us-west-1",
+                    "read_strategy": {
+                        "type": "Prefix",
+                        "prefix": "foo",
+                    }
+                }
+            }
+        }
+    })
+    connectors.append({
+        "connector_name": FELDERA_CONNECTOR_NAME,
+        "is_input": True,
+        "name": FELDERA_CONNECTOR_NAME,
+        "relation_name": TABLE_NAME
+    })
+
+    # Create pipeline
+    requests.put(f"{api_url}/v0/pipelines/{PIPELINE_NAME}", json={
+        "description": "",
+        "config": {
+            "workers": 1,
+        },
+        "program_name": program_name,
+        "connectors": connectors,
+    }).raise_for_status()
+
+    # Start pipeline
+    if start_pipeline:
+        print("(Re)starting pipeline...")
+        requests.post(f"{api_url}/v0/pipelines/{PIPELINE_NAME}/shutdown").raise_for_status()
+        while requests.get(f"{api_url}/v0/pipelines/{PIPELINE_NAME}").json()["state"]["current_status"] != "Shutdown":
+            time.sleep(1)
+        requests.post(f"{api_url}/v0/pipelines/{PIPELINE_NAME}/start").raise_for_status()
+        while requests.get(f"{api_url}/v0/pipelines/{PIPELINE_NAME}").json()["state"]["current_status"] != "Running":
+            time.sleep(1)
+        print("Pipeline (re)started")
+
+        # Wait and then check the output view to see if our results are ready
+        time.sleep(2)
+        response = requests.post(f"{api_url}/v0/pipelines/{PIPELINE_NAME}/egress/{VIEW_NAME}?format=csv&query=quantiles&mode=snapshot")
+        assert response.json()['text_data'] == '1,1\n2,1\n3,1\n4,1\n5,1\n6,1\n'
+
+if __name__ == "__main__":
+    main()

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -160,3 +160,19 @@ services:
       - bash
       - -c
       - "sleep 1 && env && cd demo/project_demo07-SnowflakeSink/ && python3 run.py --api-url http://pipeline-manager:8080"
+
+  s3-demo:
+    profiles: [ "s3" ]
+    depends_on:
+      pipeline-manager:
+        condition: service_healthy
+    image: ghcr.io/feldera/demo-container:${FELDERA_VERSION:-0.10.0}
+    environment:
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
+      - CI_S3_AWS_ACCESS_KEY
+      - CI_S3_AWS_SECRET
+    command:
+      - bash
+      - -c
+      - "sleep 1 && env && cd demo/project_demo09-S3/ && python3 run.py --api-url http://pipeline-manager:8080"

--- a/openapi.json
+++ b/openapi.json
@@ -4234,6 +4234,32 @@
           }
         }
       },
+      "S3InputConfig": {
+        "type": "object",
+        "description": "Configuration for reading data from AWS S3.",
+        "required": [
+          "credentials",
+          "region",
+          "bucket_name",
+          "read_strategy"
+        ],
+        "properties": {
+          "bucket_name": {
+            "type": "string",
+            "description": "S3 bucket name to access"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/AwsCredentials"
+          },
+          "read_strategy": {
+            "$ref": "#/components/schemas/ReadStrategy"
+          },
+          "region": {
+            "type": "string",
+            "description": "AWS region"
+          }
+        }
+      },
       "ServiceConfig": {
         "oneOf": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -4248,6 +4248,9 @@
             "type": "string",
             "description": "S3 bucket name to access"
           },
+          "consume_strategy": {
+            "$ref": "#/components/schemas/ConsumeStrategy"
+          },
           "credentials": {
             "$ref": "#/components/schemas/AwsCredentials"
           },


### PR DESCRIPTION
This adds an `S3InputTransport` that reads objects from AWS S3.

It currently supports two read strategies, one that reads all objects
that match a prefix, and another to read individual objects.

It currently reads in the entire object at once before writing it to the
`InputConsumer`, which is not ideal. An improvement here would be to
perform reads one chunk at a time using the S3 `GetObject` API's `range`
feature.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
