### PR TITLE
dbsp_adapters: Change `unreachable` to `warn` for partition queues.

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -249,7 +249,7 @@ impl PollerThread {
                 Ok(Some(_)) => {
                     // All of the subscribed partitions should have be broken
                     // off into `PartitionQueue`s.
-                    unreachable!()
+                    warn!("ignoring message received from consumer despite `split_partition_queue`")
                 }
                 Err(error) => {
                     let fatal = error


### PR DESCRIPTION
The consumer in the kafka FT adapter splits all of its consumers off into separate partition queues, but in testing occasionally some messages show up there anyway.  This commit changes those panics into log messages, in case that actually fixes the problem and so that perhaps we can find out more if not.

See https://github.com/feldera/feldera/issues/1331.

Is this a user-visible change (yes/no): no