### PR TITLE
Increase Kafka initialization timeout to 60 seconds.

### DIFF
--- a/crates/pipeline-types/src/transport/kafka.rs
+++ b/crates/pipeline-types/src/transport/kafka.rs
@@ -184,7 +184,7 @@ const fn default_max_inflight_messages() -> u32 {
 }
 
 const fn default_initialization_timeout_secs() -> u32 {
-    10
+    60
 }
 
 /// Configuration for writing data to a Kafka topic with `OutputTransport`.
@@ -222,7 +222,7 @@ pub struct KafkaOutputConfig {
     /// Maximum timeout in seconds to wait for the endpoint to connect to
     /// a Kafka broker.
     ///
-    /// Defaults to 10.
+    /// Defaults to 60.
     #[serde(default = "default_initialization_timeout_secs")]
     pub initialization_timeout_secs: u32,
 

--- a/openapi.json
+++ b/openapi.json
@@ -3419,7 +3419,7 @@
           "initialization_timeout_secs": {
             "type": "integer",
             "format": "int32",
-            "description": "Maximum timeout in seconds to wait for the endpoint to connect to\na Kafka broker.\n\nDefaults to 10.",
+            "description": "Maximum timeout in seconds to wait for the endpoint to connect to\na Kafka broker.\n\nDefaults to 60.",
             "minimum": 0
           },
           "log_level": {


### PR DESCRIPTION
Some Kafka FT tests fail intermittently in CI with a timeout setting up the initial connection.  It's unclear whether this is because of a real problem or because the broker is running slowly.  Each time it's occurred, the broker has in fact been running slowly (because creating the topic has been retried in each case), but I don't know how to tell whether that's the entire problem.

This tries to solve the problem by increasing the timeout 6x, from 10 seconds to 60 seconds.

See https://github.com/feldera/feldera/issues/1469.

Is this a user-visible change (yes/no): no