### PR TITLE
Initial support for parquet input/output format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1498](https://github.com/feldera/feldera/pull/1498))
 - SQL: support for ARRAY_DISTINCT function
   ([#1515](https://github.com/feldera/feldera/pull/1515))
-  
+- Added basic support to ingest and export data in the parquet format
+  ([#1510](https://github.com/feldera/feldera/pull/1510))
+
 ## [0.11.0] - 2024-03-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.11",
  "once_cell",
  "version_check",
@@ -564,6 +565,218 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "arrow"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa285343fba4d829d49985bdc541e3789cf6000ed0e84be7c039438df4a4e78c"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753abd0a5290c1bcade7c6623a556f7d1659c5f4148b140b5b63ce7bd1a45705"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono 0.4.35",
+ "half 2.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d390feeb7f21b78ec997a4081a025baef1e2e0d6069e181939b61864c9779609"
+dependencies = [
+ "ahash 0.8.6",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono 0.4.35",
+ "half 2.4.0",
+ "hashbrown 0.14.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69615b061701bcdffbc62756bc7e85c827d5290b472b580c972ebbbf690f5aa4"
+dependencies = [
+ "bytes",
+ "half 2.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e448e5dd2f4113bf5b74a1f26531708f5edcacc77335b7066f9398f4bcf4cdef"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.21.5",
+ "chrono 0.4.35",
+ "half 2.4.0",
+ "lexical-core",
+ "num",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46af72211f0712612f5b18325530b9ad1bfbdc87290d5fbfd32a7da128983781"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono 0.4.35",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d644b91a162f3ad3135ce1184d0a31c28b816a581e08f29e8e9277a574c64e"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half 2.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03dea5e79b48de6c2e04f03f62b0afea7105be7b77d134f6c5414868feefb80d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8950719280397a47d37ac01492e3506a8a724b3fb81001900b866637a829ee0f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono 0.4.35",
+ "half 2.4.0",
+ "indexmap 2.1.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed9630979034077982d8e74a942b7ac228f33dd93a93b615b4d02ad60c260be"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half 2.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007035e17ae09c4e8993e4cb8b5b96edf0afb927cd38e2dff27189b274d83dcf"
+dependencies = [
+ "ahash 0.8.6",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half 2.4.0",
+ "hashbrown 0.14.2",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff3e9c01f7cd169379d269f926892d0e622a704960350d09d331be3ec9e0029"
+
+[[package]]
+name = "arrow-select"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce20973c1912de6514348e064829e50947e35977bb9d7fb637dc99ea9ffd78c"
+dependencies = [
+ "ahash 0.8.6",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f3b37f2aeece31a2636d1b037dabb69ef590e03bdc7eb68519b51ec86932a7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "num",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "ascii_table"
@@ -1191,7 +1404,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.11",
- "http 1.0.0",
+ "http 1.1.0",
  "once_cell",
  "p256",
  "percent-encoding",
@@ -1404,7 +1617,7 @@ dependencies = [
  "aws-smithy-types 1.1.7",
  "bytes",
  "http 0.2.11",
- "http 1.0.0",
+ "http 1.1.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1758,6 +1971,20 @@ name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "byteorder"
@@ -1975,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2012,7 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -2178,6 +2405,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.11",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -2377,6 +2624,12 @@ checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -2599,7 +2852,7 @@ dependencies = [
  "mimalloc-rust-sys",
  "num",
  "once_cell",
- "ordered-float",
+ "ordered-float 3.9.2",
  "ouroboros",
  "paste",
  "petgraph",
@@ -2639,12 +2892,14 @@ dependencies = [
  "actix-test",
  "actix-web",
  "anyhow",
+ "arrow",
  "async-stream",
  "async-trait",
  "awc",
  "aws-sdk-s3",
  "aws-types 1.1.7",
  "bstr",
+ "bytes",
  "bytestring",
  "chrono 0.4.31",
  "circular-queue",
@@ -2667,7 +2922,9 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "once_cell",
+ "parquet",
  "pipeline_types",
+ "pretty_assertions",
  "prometheus",
  "proptest",
  "proptest-derive 0.3.0",
@@ -2681,6 +2938,7 @@ dependencies = [
  "rust_decimal_macros",
  "rustls 0.20.9",
  "serde",
+ "serde_arrow",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
@@ -3142,7 +3400,7 @@ version = "0.1.0"
 dependencies = [
  "async-lock 3.3.0",
  "binrw",
- "chrono 0.4.33",
+ "chrono 0.4.35",
  "clap 4.4.14",
  "crc32c",
  "env_logger 0.10.1",
@@ -3215,6 +3473,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flatbuffers"
+version = "23.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -3560,6 +3828,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -3961,6 +4241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,6 +4386,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -4796,6 +5155,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
@@ -4932,6 +5300,39 @@ dependencies = [
  "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "parquet"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547b92ebf0c1177e3892f44c8f79757ee62e678d564a9834189725f2c5b7a750"
+dependencies = [
+ "ahash 0.8.6",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.21.5",
+ "brotli",
+ "bytes",
+ "chrono 0.4.35",
+ "flate2",
+ "half 2.4.0",
+ "hashbrown 0.14.2",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "serde_json",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd 0.13.0",
 ]
 
 [[package]]
@@ -5106,7 +5507,7 @@ dependencies = [
  "base64 0.21.5",
  "cached 0.43.0",
  "change-detection",
- "chrono 0.4.33",
+ "chrono 0.4.35",
  "clap 4.4.14",
  "colored",
  "deadpool-postgres",
@@ -6479,12 +6880,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+
+[[package]]
 name = "serde"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_arrow"
+version = "0.10.1-rc.1"
+source = "git+https://github.com/gz/serde_arrow.git?rev=7b604f0#7b604f0b792428fe8fa283ea3c2d506c85fb5c16"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "bytemuck",
+ "chrono 0.4.35",
+ "half 2.4.0",
+ "serde",
 ]
 
 [[package]]
@@ -6548,7 +6970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
  "base64 0.21.5",
- "chrono 0.4.33",
+ "chrono 0.4.35",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.1.0",
@@ -6721,7 +7143,7 @@ dependencies = [
  "arcstr",
  "chrono 0.4.31",
  "hashbrown 0.13.2",
- "ordered-float",
+ "ordered-float 3.9.2",
  "rust_decimal",
  "size-of-derive",
  "time",
@@ -6773,6 +7195,12 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -7250,6 +7678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7276,6 +7715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -7585,6 +8033,16 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typedmap"
@@ -8381,6 +8839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8397,6 +8864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -67,6 +67,11 @@ rand = "0.8.5"
 regex = "1.10.2"
 tempfile = "3.10.0"
 async-trait = "0.1"
+parquet = { version = "50.0.0", features = ["json"] }
+arrow = "50.0.0"
+#serde_arrow = { version = "0.10.0", features = ["arrow-50"] }
+serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arrow-50"], rev = "7b604f0" }
+bytes = "1.5.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 psutil = "3.2.2"
@@ -89,3 +94,4 @@ reqwest = { version = "0.11.20", features = ["blocking"] }
 serial_test = "2.0.0"
 rust_decimal_macros = "1.32"
 mockall = "0.12.1"
+pretty_assertions = "1.4.0"

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -570,7 +570,6 @@ impl Controller {
 
                             for (i, endpoint_id) in endpoints.iter().enumerate() {
                                 let endpoint = outputs.lookup_by_id(endpoint_id).unwrap();
-
                                 // If the endpoint has a snapshot stream associated with it,
                                 // then the first output sent to this endpoint must be
                                 // the snapshot.  Subsequent outputs are deltas on top of
@@ -1179,7 +1178,6 @@ impl ControllerInner {
             // Dequeue the next output batch and push it to the encoder.
             if let Some((step, data, processed_records)) = queue.pop() {
                 let num_records = data.iter().map(|b| b.len()).sum();
-
                 encoder.consumer().batch_start(step);
                 encoder
                     .encode(data.as_slice())
@@ -1197,8 +1195,7 @@ impl ControllerInner {
                     &controller.circuit_thread_unparker,
                 );
             } else {
-                // Queue is empty -- wait for the circuit thread to wake us up when
-                // more data is available.
+                trace!("Queue is empty -- wait for the circuit thread to wake us up when more data is available");
                 parker.park();
             }
         }

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -416,8 +416,9 @@ impl ControllerStatus {
         // final number of inputs records when all endpoints are marked as
         // finished.
         let old = self.global_metrics.input_batch(num_records);
-        if old < self.pipeline_config.global.min_batch_size_records
-            && old + num_records >= self.pipeline_config.global.min_batch_size_records
+        if old == 0
+            || old <= self.pipeline_config.global.min_batch_size_records
+                && old + num_records > self.pipeline_config.global.min_batch_size_records
         {
             circuit_thread_unparker.unpark();
         }

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -1,4 +1,5 @@
 use crate::format::json::schema::{build_key_schema, build_value_schema};
+use crate::format::{MAX_DUPLICATES, MAX_RECORD_LEN_IN_ERRMSG};
 use crate::{
     catalog::{CursorWithPolarity, RecordFormat, SerBatch, SerCursor},
     util::truncate_ellipse,
@@ -18,16 +19,6 @@ use std::{borrow::Cow, mem::take, sync::Arc};
 
 /// JSON format encoder.
 pub struct JsonOutputFormat;
-
-/// The largest weight of a record that can be output using
-/// a JSON format without explicit weights.  Such formats require
-/// duplicating the record `w` times, which is expensive for large
-/// weights (and is most likely not what the user intends).
-const MAX_DUPLICATES: i64 = 1_000_000;
-
-/// When including a long JSON record in an error message,
-/// truncate it to `MAX_RECORD_LEN_IN_ERRMSG` bytes.
-static MAX_RECORD_LEN_IN_ERRMSG: usize = 4096;
 
 impl OutputFormat for JsonOutputFormat {
     fn name(&self) -> Cow<'static, str> {

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -1,0 +1,387 @@
+use std::io::Cursor;
+use std::mem::take;
+use std::{borrow::Cow, sync::Arc};
+
+use actix_web::HttpRequest;
+use anyhow::{bail, Result as AnyResult};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use bytes::Bytes;
+use erased_serde::Serialize as ErasedSerialize;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use serde::Deserialize;
+use serde_arrow::schema::SerdeArrowSchema;
+use serde_arrow::ArrowBuilder;
+use serde_urlencoded::Deserializer as UrlDeserializer;
+use serde_yaml::Value as YamlValue;
+
+use crate::catalog::CursorWithPolarity;
+use crate::format::MAX_DUPLICATES;
+use crate::{
+    catalog::{DeCollectionStream, InputCollectionHandle, RecordFormat, SerBatch},
+    format::{Encoder, InputFormat, OutputFormat, ParseError, Parser},
+    ControllerError, OutputConsumer, SerCursor,
+};
+use pipeline_types::format::json::JsonFlavor;
+use pipeline_types::format::parquet::{ParquetEncoderConfig, ParquetParserConfig};
+use pipeline_types::program_schema::{ColumnType, Relation};
+
+#[cfg(test)]
+mod test;
+
+/// CSV format parser.
+pub struct ParquetInputFormat;
+
+impl InputFormat for ParquetInputFormat {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("parquet")
+    }
+
+    /// Create a parser using configuration extracted from an HTTP request.
+    // We could just rely on serde to deserialize the config from the
+    // HTTP query, but a specialized method gives us more flexibility.
+    fn config_from_http_request(
+        &self,
+        _endpoint_name: &str,
+        _request: &HttpRequest,
+    ) -> Result<Box<dyn ErasedSerialize>, ControllerError> {
+        Ok(Box::new(ParquetParserConfig {}))
+    }
+
+    fn new_parser(
+        &self,
+        _endpoint_name: &str,
+        input_stream: &InputCollectionHandle,
+        _config: &YamlValue,
+    ) -> Result<Box<dyn Parser>, ControllerError> {
+        let input_stream = input_stream
+            .handle
+            .configure_deserializer(RecordFormat::Json(JsonFlavor::ParquetConverter))?;
+        Ok(Box::new(ParquetParser::new(input_stream)) as Box<dyn Parser>)
+    }
+}
+
+struct ParquetParser {
+    /// Input handle to push parsed data to.
+    input_stream: Box<dyn DeCollectionStream>,
+    buf: Vec<u8>,
+    last_event_number: u64,
+}
+
+impl ParquetParser {
+    fn new(input_stream: Box<dyn DeCollectionStream>) -> Self {
+        Self {
+            input_stream,
+            buf: Vec::with_capacity(4096),
+            last_event_number: 0,
+        }
+    }
+    fn parse(&mut self) -> (usize, Vec<ParseError>) {
+        if self.buf.is_empty() {
+            return (0, vec![]);
+        }
+
+        let bytes = Bytes::from(take(&mut self.buf));
+        match SerializedFileReader::new(bytes) {
+            Ok(reader) => {
+                let (mut cnt, mut errors) = (0, vec![]);
+                match reader.get_row_iter(None) {
+                    Ok(iter) => {
+                        for maybe_record in iter {
+                            match maybe_record {
+                                Ok(record) => {
+                                    // TODO: this is a temporary solution (parquet->json->feldera) to avoid
+                                    // the overhead of converting the record to JSON we can use serde_arrow
+                                    // as well here.
+                                    let record_json = record.to_json_value().to_string();
+                                    match self.input_stream.insert(record_json.as_bytes()) {
+                                        Ok(_) => cnt += 1,
+                                        Err(e) => {
+                                            errors.push(ParseError::bin_event_error(
+                                                format!(
+                                                    "Error parsing JSON record from parquet file: {}",
+                                                    e
+                                                ),
+                                                self.last_event_number + 1,
+                                                record_json.as_bytes(),
+                                                None,
+                                            ));
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    errors.push(ParseError::bin_event_error(
+                                        format!("Error reading a record from parquet file: {}", e),
+                                        self.last_event_number + 1,
+                                        &[],
+                                        None,
+                                    ));
+                                }
+                            }
+                            self.last_event_number += 1;
+                        }
+                        self.input_stream.flush();
+                        (cnt, errors)
+                    }
+                    Err(e) => (
+                        0,
+                        vec![ParseError::bin_envelope_error(
+                            format!("Unable to iterate over parquet file: {}.", e),
+                            &[],
+                            None,
+                        )],
+                    ),
+                }
+            }
+            Err(e) => (
+                0,
+                vec![ParseError::bin_envelope_error(
+                    format!("Unable to read parquet file: {}.", e),
+                    &[],
+                    Some(Cow::from(
+                        "Make sure the provided file is a valid parquet file.",
+                    )),
+                )],
+            ),
+        }
+    }
+}
+
+impl Parser for ParquetParser {
+    /// In the fragment case, we will wait until eoi() is called to parse any data.
+    ///
+    /// Happens for example with the file connector.
+    fn input_fragment(&mut self, data: &[u8]) -> (usize, Vec<ParseError>) {
+        self.buf.extend_from_slice(data);
+        (0, vec![])
+    }
+
+    /// In the chunk case, we got an entire file in `data` and parse it immediately.
+    fn input_chunk(&mut self, data: &[u8]) -> (usize, Vec<ParseError>) {
+        self.buf.extend_from_slice(data);
+        self.parse()
+    }
+
+    fn eoi(&mut self) -> (usize, Vec<ParseError>) {
+        self.parse()
+    }
+
+    fn fork(&self) -> Box<dyn Parser> {
+        Box::new(Self::new(self.input_stream.fork()))
+    }
+}
+
+/// CSV format encoder.
+pub struct ParquetOutputFormat;
+
+impl OutputFormat for ParquetOutputFormat {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("parquet")
+    }
+
+    fn config_from_http_request(
+        &self,
+        endpoint_name: &str,
+        request: &HttpRequest,
+    ) -> Result<Box<dyn ErasedSerialize>, ControllerError> {
+        Ok(Box::new(
+            ParquetEncoderConfig::deserialize(UrlDeserializer::new(form_urlencoded::parse(
+                request.query_string().as_bytes(),
+            )))
+            .map_err(|e| {
+                ControllerError::encoder_config_parse_error(
+                    endpoint_name,
+                    &e,
+                    request.query_string(),
+                )
+            })?,
+        ))
+    }
+
+    fn new_encoder(
+        &self,
+        endpoint_name: &str,
+        config: &YamlValue,
+        schema: &Relation,
+        consumer: Box<dyn OutputConsumer>,
+    ) -> Result<Box<dyn Encoder>, ControllerError> {
+        let config = ParquetEncoderConfig::deserialize(config).map_err(|e| {
+            ControllerError::encoder_config_parse_error(
+                endpoint_name,
+                &e,
+                &serde_yaml::to_string(&config).unwrap_or_default(),
+            )
+        })?;
+        Ok(Box::new(ParquetEncoder::new(
+            consumer,
+            config,
+            schema.clone(),
+        )?))
+    }
+}
+
+fn relation_to_parquet_schema(relation: &Relation) -> Result<SerdeArrowSchema, ControllerError> {
+    // The type conversion is chosen in accordance with our internal
+    // data types (see sqllib). This may need to be adjusted in the future
+    // or made configurable.
+    fn columntype_to_datatype(c: &ColumnType) -> DataType {
+        match c.typ.to_ascii_lowercase().as_str() {
+            "boolean" => DataType::Boolean,
+            "tinyint" => DataType::Int8,
+            "smallint" => DataType::Int16,
+            "integer" => DataType::Int32,
+            "bigint" | "int64" => DataType::Int64,
+            "float" => DataType::Float32,
+            "double" => DataType::Float64,
+            "decimal" => DataType::Decimal128(
+                c.precision.unwrap_or(0).try_into().unwrap(),
+                c.scale.unwrap_or(0).try_into().unwrap(),
+            ),
+            "char" | "varchar" | "string" | "text" => DataType::LargeUtf8,
+            "time" => DataType::Time64(TimeUnit::Nanosecond),
+            "timestamp" => DataType::Timestamp(TimeUnit::Millisecond, None),
+            "date" => DataType::Date32,
+            "array" => unimplemented!("handle array types"),
+            s => unimplemented!("Encountered unknown type {}", s),
+        }
+    }
+
+    let fields = relation
+        .fields
+        .iter()
+        .map(|f| {
+            Field::new(
+                &f.name,
+                columntype_to_datatype(&f.columntype),
+                f.columntype.nullable,
+            )
+        })
+        .collect::<Vec<Field>>();
+
+    SerdeArrowSchema::from_arrow_fields(&fields).map_err(|e| ControllerError::SchemaParseError {
+        error: format!("Unable to convert schema to parquet/arrow: {e}"),
+    })
+}
+
+struct ParquetEncoder {
+    /// Input handle to push serialized data to.
+    output_consumer: Box<dyn OutputConsumer>,
+    _relation: Relation,
+    parquet_schema: SerdeArrowSchema,
+    config: ParquetEncoderConfig,
+    buffer: Vec<u8>,
+    max_buffer_size: usize,
+}
+
+impl ParquetEncoder {
+    fn new(
+        output_consumer: Box<dyn OutputConsumer>,
+        config: ParquetEncoderConfig,
+        _relation: Relation,
+    ) -> Result<Self, ControllerError> {
+        let max_buffer_size = output_consumer.max_buffer_size_bytes();
+        Ok(Self {
+            output_consumer,
+            config,
+            parquet_schema: relation_to_parquet_schema(&_relation)?,
+            _relation,
+            buffer: Vec::new(),
+            max_buffer_size,
+        })
+    }
+}
+
+impl Encoder for ParquetEncoder {
+    fn consumer(&mut self) -> &mut dyn OutputConsumer {
+        self.output_consumer.as_mut()
+    }
+
+    fn encode(&mut self, batches: &[Arc<dyn SerBatch>]) -> AnyResult<()> {
+        let mut buffer = take(&mut self.buffer);
+        let props = WriterProperties::builder().build();
+        let schema = Arc::new(Schema::new(self.parquet_schema.to_arrow_fields()?));
+        let fields = self.parquet_schema.to_arrow_fields()?;
+        let mut builder = ArrowBuilder::new(&fields)?;
+
+        let mut num_records = 0;
+        for batch in batches.iter() {
+            let mut cursor = CursorWithPolarity::new(
+                batch.cursor(RecordFormat::Parquet(self.parquet_schema.clone()))?,
+            );
+            while cursor.key_valid() {
+                if !cursor.val_valid() {
+                    cursor.step_key();
+                    continue;
+                }
+                let mut w = cursor.weight();
+                if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
+                    bail!("Unable to output record with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'.");
+                }
+                if w < 0 {
+                    // TODO: we don't support deletes in the parquet format yet.
+                    continue;
+                }
+
+                while w != 0 {
+                    let prev_len = buffer.len();
+                    cursor.serialize_key_to_arrow(&mut builder)?;
+
+                    // TODO: buffer.len() is always 0 here atm:
+                    let buffer_full = buffer.len() > self.max_buffer_size;
+                    if buffer_full {
+                        if num_records == 0 {
+                            // We should be able to fit at least one record in the buffer.
+                            bail!("Parquet record exceeds maximum buffer size supported by the output transport. Max supported buffer size is {} bytes, but the record requires {} bytes.",
+                                  self.max_buffer_size,
+                                  buffer.len() - prev_len);
+                        }
+                        buffer.truncate(prev_len);
+                    } else {
+                        if w > 0 {
+                            w -= 1;
+                        } else {
+                            w += 1;
+                        }
+                        num_records += 1;
+                    }
+
+                    if num_records >= self.config.buffer_size_records || buffer_full {
+                        let buffer_cursor = Cursor::new(&mut buffer);
+                        let mut writer = ArrowWriter::try_new(
+                            buffer_cursor,
+                            schema.clone(),
+                            Some(props.clone()),
+                        )?;
+                        let arrays = builder.build_arrays()?;
+                        let batch = RecordBatch::try_new(schema.clone(), arrays)?;
+                        writer.write(&batch)?;
+                        writer.close()?;
+
+                        self.output_consumer.push_buffer(&buffer);
+                        buffer.clear();
+
+                        num_records = 0;
+                    }
+                }
+                cursor.step_key();
+            }
+        }
+
+        if num_records > 0 {
+            let buffer_cursor = Cursor::new(&mut buffer);
+            let mut writer =
+                ArrowWriter::try_new(buffer_cursor, schema.clone(), Some(props.clone()))?;
+            let arrays = builder.build_arrays()?;
+            let batch = RecordBatch::try_new(schema.clone(), arrays)?;
+            writer.write(&batch)?;
+            writer.close()?;
+            self.output_consumer.push_buffer(&buffer);
+            buffer.clear();
+        }
+
+        self.buffer = buffer;
+        Ok(())
+    }
+}

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -1,0 +1,524 @@
+use std::borrow::Cow;
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::Duration;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Date32Array, Int64Array, LargeStringArray, RecordBatch,
+    Time64NanosecondArray, TimestampMillisecondArray,
+};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+use dbsp::trace::Batch;
+use dbsp::OrdZSet;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use pipeline_types::format::parquet::ParquetEncoderConfig;
+use pipeline_types::program_schema::{ColumnType, Field, Relation};
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Deserializer, Serializer};
+use size_of::SizeOf;
+use tempfile::NamedTempFile;
+
+use crate::format::parquet::ParquetEncoder;
+use crate::format::Encoder;
+use crate::static_compile::seroutput::SerBatchImpl;
+use crate::test::{mock_input_pipeline, wait, MockOutputConsumer, DEFAULT_TIMEOUT_MS};
+use crate::{
+    deserialize_table_record, deserialize_without_context, serialize_table_record,
+    serialize_without_context, DateFormat, DeserializeWithContext, SerBatch, SerializeWithContext,
+    SqlSerdeConfig, TimestampFormat,
+};
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+#[serde(transparent)]
+pub struct Timestamp {
+    // since unix epoch
+    milliseconds: i64,
+}
+
+impl Timestamp {
+    fn new(milliseconds: i64) -> Self {
+        Self { milliseconds }
+    }
+
+    fn milliseconds(&self) -> i64 {
+        self.milliseconds
+    }
+}
+
+impl SerializeWithContext<SqlSerdeConfig> for Timestamp {
+    fn serialize_with_context<S>(
+        &self,
+        serializer: S,
+        context: &SqlSerdeConfig,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match context.timestamp_format {
+            TimestampFormat::String(format_string) => {
+                let datetime = DateTime::from_timestamp(
+                    self.milliseconds / 1000,
+                    ((self.milliseconds % 1000) * 1000) as u32,
+                )
+                .expect("Timestamp should be valid");
+                serializer.serialize_str(&datetime.format(format_string).to_string())
+            }
+            TimestampFormat::MillisSinceEpoch => serializer.serialize_i64(self.milliseconds),
+        }
+    }
+}
+
+impl<'de> DeserializeWithContext<'de, SqlSerdeConfig> for Timestamp {
+    fn deserialize_with_context<D>(
+        deserializer: D,
+        config: &'de SqlSerdeConfig,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match config.timestamp_format {
+            TimestampFormat::String(format) => {
+                // `timestamp_str: &'de` doesn't work for JSON, which escapes strings
+                // and can only deserialize into an owned string.
+                let timestamp_str: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
+                let timestamp = NaiveDateTime::parse_from_str(timestamp_str.trim(), format)
+                    .expect("Timestamp should be valid");
+                Ok(Self::new(timestamp.timestamp_millis()))
+            }
+            TimestampFormat::MillisSinceEpoch => {
+                let millis: i64 = Deserialize::deserialize(deserializer)?;
+                Ok(Self::new(millis))
+            }
+        }
+    }
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+#[serde(transparent)]
+pub struct Time {
+    nanoseconds: u64,
+}
+
+impl Time {
+    fn new(nanoseconds: u64) -> Self {
+        Self { nanoseconds }
+    }
+
+    fn nanoseconds(&self) -> u64 {
+        self.nanoseconds
+    }
+}
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+#[serde(transparent)]
+pub struct Date {
+    // since unix epoch
+    days: i32,
+}
+
+impl Date {
+    fn new(days: i32) -> Self {
+        Self { days }
+    }
+
+    fn days(&self) -> i32 {
+        self.days
+    }
+}
+
+impl<'de> DeserializeWithContext<'de, SqlSerdeConfig> for Date {
+    fn deserialize_with_context<D>(
+        deserializer: D,
+        config: &'de SqlSerdeConfig,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match config.date_format {
+            DateFormat::String(format) => {
+                let str: &'de str = Deserialize::deserialize(deserializer)?;
+                let date =
+                    NaiveDate::parse_from_str(str.trim(), format).expect("Date should be valid");
+                Ok(Self::new(
+                    (date.and_time(NaiveTime::default()).timestamp() / 86_400) as i32,
+                ))
+            }
+            DateFormat::DaysSinceEpoch => Ok(Self {
+                days: i32::deserialize(deserializer)?,
+            }),
+        }
+    }
+}
+
+serialize_without_context!(Date);
+serialize_without_context!(Time);
+deserialize_without_context!(Time);
+
+/// This struct mimics the field naming schema of the compiler.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+struct TestStruct {
+    #[serde(rename = "id")]
+    field: i64,
+    #[serde(rename = "name")]
+    field_0: Option<String>,
+    #[serde(rename = "b")]
+    field_1: bool,
+    #[serde(rename = "ts")]
+    field_2: Timestamp,
+    #[serde(rename = "dt")]
+    field_3: Date,
+    #[serde(rename = "t")]
+    field_4: Time,
+}
+
+impl TestStruct {
+    fn data() -> Vec<TestStruct> {
+        vec![
+            TestStruct {
+                field: 1,
+                field_0: Some("test".to_string()),
+                field_1: false,
+                field_2: Timestamp::new(1000),
+                field_3: Date::new(1),
+                field_4: Time::new(1),
+            },
+            TestStruct {
+                field: 2,
+                field_0: None,
+                field_1: true,
+                field_2: Timestamp::new(2000),
+                field_3: Date::new(12),
+                field_4: Time::new(1_000_000_000),
+            },
+        ]
+    }
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            arrow::datatypes::Field::new("id", DataType::Int64, false),
+            arrow::datatypes::Field::new("name", DataType::LargeUtf8, true),
+            arrow::datatypes::Field::new("b", DataType::Boolean, false),
+            arrow::datatypes::Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            arrow::datatypes::Field::new("dt", DataType::Date32, false),
+            arrow::datatypes::Field::new("t", DataType::Time64(TimeUnit::Nanosecond), false),
+        ]))
+    }
+
+    fn relation() -> Relation {
+        Relation::new(
+            "TestStruct",
+            false,
+            vec![
+                Field {
+                    name: "id".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "int64".to_string(),
+                        nullable: false,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+                Field {
+                    name: "name".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "string".to_string(),
+                        nullable: true,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+                Field {
+                    name: "b".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "boolean".to_string(),
+                        nullable: false,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+                Field {
+                    name: "ts".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "timestamp".to_string(),
+                        nullable: false,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+                Field {
+                    name: "dt".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "date".to_string(),
+                        nullable: false,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+                Field {
+                    name: "t".to_string(),
+                    case_sensitive: false,
+                    columntype: ColumnType {
+                        typ: "time".to_string(),
+                        nullable: false,
+                        precision: None,
+                        scale: None,
+                        component: None,
+                    },
+                },
+            ],
+        )
+    }
+
+    fn make_arrow_array(data: &[TestStruct]) -> Vec<ArrayRef> {
+        let row0: Vec<i64> = data.iter().map(|r| r.field).collect();
+        let row1: Vec<Option<String>> = data.iter().map(|r| r.field_0.clone()).collect();
+        let row2: Vec<bool> = data.iter().map(|r| r.field_1).collect();
+        let row3: Vec<i64> = data.iter().map(|r| r.field_2.milliseconds()).collect();
+        let row4: Vec<i32> = data.iter().map(|r| r.field_3.days()).collect();
+        let row5: Vec<i64> = data
+            .iter()
+            .map(|r| r.field_4.nanoseconds() as i64)
+            .collect();
+
+        vec![
+            Arc::new(Int64Array::from(row0)),
+            Arc::new(LargeStringArray::from(row1)),
+            Arc::new(BooleanArray::from(row2)),
+            Arc::new(TimestampMillisecondArray::from(row3)),
+            Arc::new(Date32Array::from(row4)),
+            Arc::new(Time64NanosecondArray::from(row5)),
+        ]
+    }
+}
+
+serialize_table_record!(TestStruct[6]{
+    r#field["id"]: i64,
+    r#field_0["name"]: Option<String>,
+    r#field_1["b"]: bool,
+    r#field_2["ts"]: Timestamp,
+    r#field_3["dt"]: Date,
+    r#field_4["t"]: Time
+});
+
+deserialize_table_record!(TestStruct["TestStruct", 6] {
+    (r#field, "id", false, i64, None),
+    (r#field_0, "name", false, Option<String>, Some(None)),
+    (r#field_1, "b", false, bool, None),
+    (r#field_2, "ts", false, Timestamp, None),
+    (r#field_3, "dt", false, Date, None),
+    (r#field_4, "t", false, Time, None)
+});
+
+#[test]
+fn rel_to_schema() {
+    use super::relation_to_parquet_schema;
+    relation_to_parquet_schema(&TestStruct::relation()).expect("Can convert");
+}
+
+#[test]
+fn parquet_input() {
+    // Prepare input data & pipeline
+    let test_data = TestStruct::data();
+    let temp_file = NamedTempFile::new().unwrap();
+    let config_str = format!(
+        r#"
+stream: test_input
+transport:
+    name: file
+    config:
+        path: {:?}
+        buffer_size_bytes: 5
+format:
+    name: parquet
+"#,
+        temp_file.path().to_str().unwrap()
+    );
+
+    let batch = RecordBatch::try_new(
+        TestStruct::schema(),
+        TestStruct::make_arrow_array(&test_data),
+    )
+    .expect("RecordBatch creation should succeed");
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(&temp_file, TestStruct::schema(), Some(props))
+        .expect("Writer creation should succeed");
+    writer
+        .write(&batch)
+        .expect("Writing to parquet should succeed");
+    writer.close().expect("Closing the writer should succeed");
+
+    // Send the data through the mock pipeline
+    let (endpoint, consumer, zset) =
+        mock_input_pipeline::<TestStruct, TestStruct>(serde_yaml::from_str(&config_str).unwrap())
+            .unwrap();
+    sleep(Duration::from_millis(10));
+    assert!(consumer.state().data.is_empty());
+    assert!(!consumer.state().eoi);
+    endpoint.start(0).unwrap();
+    wait(
+        || zset.state().flushed.len() == test_data.len(),
+        DEFAULT_TIMEOUT_MS,
+    );
+
+    // Make sure the input data matches original test structs
+    for (i, upd) in zset.state().flushed.iter().enumerate() {
+        assert_eq!(upd.unwrap_insert(), &test_data[i]);
+    }
+}
+
+#[test]
+fn parquet_output() {
+    let buffer = Arc::new(Mutex::new(Vec::with_capacity(4096)));
+    let consumer = MockOutputConsumer::with_buffer(buffer.clone());
+    let _consumer_data = consumer.data.clone();
+
+    let config = ParquetEncoderConfig {
+        buffer_size_records: usize::MAX,
+    };
+
+    let test_data = TestStruct::data();
+    let mut encoder = ParquetEncoder::new(Box::new(consumer), config, TestStruct::relation())
+        .expect("Can't create encoder");
+    let zset = OrdZSet::from_keys(
+        (),
+        vec![(test_data[0].clone(), 2), (test_data[1].clone(), 1)],
+    );
+
+    let zset = Arc::new(<SerBatchImpl<_, TestStruct, ()>>::new(zset)) as Arc<dyn SerBatch>;
+    encoder.encode(&[zset]).unwrap();
+
+    // Verify output buffer...
+    // Construct the expected file manually:
+    let test_denorm = vec![
+        test_data[0].clone(),
+        test_data[0].clone(),
+        test_data[1].clone(),
+    ];
+    let batch = RecordBatch::try_new(
+        TestStruct::schema(),
+        TestStruct::make_arrow_array(&test_denorm),
+    )
+    .expect("RecordBatch creation should succeed");
+    let props = WriterProperties::builder().build();
+
+    let mut expected_buffer: Vec<u8> = vec![];
+    let mut expected_buffer_cursor = Cursor::new(&mut expected_buffer);
+    let mut writer = ArrowWriter::try_new(
+        &mut expected_buffer_cursor,
+        TestStruct::schema(),
+        Some(props),
+    )
+    .expect("Writer creation should succeed");
+    writer
+        .write(&batch)
+        .expect("Writing to parquet should succeed");
+    writer.close().expect("Closing the writer should succeed");
+    debug_parquet_buffer(buffer.lock().unwrap().clone());
+
+    let buffer_copy = buffer.lock().unwrap().clone();
+    assert_eq!(expected_buffer, buffer_copy);
+}
+
+fn debug_parquet_buffer(buffer: Vec<u8>) {
+    use bytes::Bytes;
+    use parquet::file::reader::{FileReader, SerializedFileReader};
+
+    let _r = env_logger::try_init();
+    let buffer_copy = Bytes::from(buffer);
+    let reader = SerializedFileReader::new(buffer_copy).expect("Reader creation should succeed");
+    let row_iter = reader
+        .get_row_iter(None)
+        .expect("Row iterator creation should succeed");
+    for maybe_record in row_iter {
+        let record = maybe_record.expect("Record should be read successfully");
+        log::info!("record = {:?}", record.to_string());
+    }
+}

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -193,6 +193,9 @@ where
                     config,
                 )))
             }
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
         }
     }
 }
@@ -298,6 +301,9 @@ where
                     R,
                     _,
                 >::new(self.handle.clone(), config)))
+            }
+            RecordFormat::Parquet(_) => {
+                todo!()
             }
         }
     }
@@ -425,6 +431,9 @@ where
                         SqlSerdeConfig::from(flavor),
                     ),
                 ))
+            }
+            RecordFormat::Parquet(_) => {
+                todo!()
             }
         }
     }
@@ -589,6 +598,9 @@ where
                 self.update_key_func.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
         }
     }
 }

--- a/crates/adapters/src/static_compile/serialize_with_context.rs
+++ b/crates/adapters/src/static_compile/serialize_with_context.rs
@@ -38,7 +38,7 @@ use serde::{
 
 /// Similar to [`Serialize`], but takes an extra `context` argument and
 /// threads it through all nested structures.
-pub trait SerializeWithContext<C>: Sized {
+pub trait SerializeWithContext<C>: Sized + Serialize {
     fn serialize_with_context<S>(&self, serializer: S, context: &C) -> Result<S::Ok, S::Error>
     where
         S: Serializer;
@@ -291,7 +291,7 @@ macro_rules! serialize_struct {
         #[allow(unused_mut)]
         impl<C, $($arg),*> $crate::SerializeWithContext<C> for $struct<$($arg),*>
         where
-            $($arg: $crate::SerializeWithContext<C>),*
+            $($arg: $crate::SerializeWithContext<C> + serde::Serialize),*
             $($($arg : $bound)?),*
         {
             fn serialize_with_context<S>(&self, serializer: S, context: &C) -> Result<S::Ok, S::Error>
@@ -342,10 +342,11 @@ mod test {
     use lazy_static::lazy_static;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
+    use serde::{Deserialize, Serialize};
 
     use crate::{SerializationContext, SerializeWithContext, SqlSerdeConfig};
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
     struct TUPLE0;
     serialize_struct!(TUPLE0()[0] {});
 
@@ -370,7 +371,7 @@ mod test {
         assert_eq!(serialize_json_with_default_context(&TUPLE0).unwrap(), "{}");
     }
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Debug, Eq, PartialEq, Serialize)]
     #[allow(non_snake_case)]
     struct Struct2 {
         #[allow(non_snake_case)]
@@ -419,7 +420,7 @@ mod test {
         );
     }
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Debug, Eq, PartialEq, Serialize)]
     #[allow(non_snake_case)]
     struct UnicodeStruct {
         f1: bool,

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -137,6 +137,9 @@ where
                 self.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
         }
     }
 }

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -17,10 +17,21 @@ impl MockOutputConsumer {
         Self::with_max_buffer_size_bytes(usize::MAX)
     }
 
+    pub fn state(&self) -> Vec<u8> {
+        self.data.lock().unwrap().clone()
+    }
+
     pub fn with_max_buffer_size_bytes(bytes: usize) -> Self {
         Self {
             data: Arc::new(Mutex::new(Vec::new())),
             max_buffer_size_bytes: bytes,
+        }
+    }
+
+    pub fn with_buffer(data: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self {
+            data,
+            max_buffer_size_bytes: usize::MAX,
         }
     }
 }

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -223,6 +223,7 @@ impl OutputEndpoint for FileOutputEndpoint {
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
         self.file.write_all(buffer)?;
+        self.file.sync_all()?;
         Ok(())
     }
 
@@ -251,7 +252,7 @@ mod test {
     use tempfile::NamedTempFile;
 
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
-    struct TestStruct {
+    pub struct TestStruct {
         s: String,
         b: bool,
         i: i64,

--- a/crates/dbsp/src/operator/neighborhood.rs
+++ b/crates/dbsp/src/operator/neighborhood.rs
@@ -10,7 +10,7 @@ use crate::{
     Circuit, DBData, DBWeight, IndexedZSet, NumEntries, OrdIndexedZSet, OrdZSet, RootCircuit,
     Stream,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use size_of::SizeOf;
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -70,7 +70,9 @@ pub type Neighborhood<K, V, R> = OrdZSet<Tup2<i64, Tup2<K, V>>, R>;
 ///
 /// The `anchor` value of `None` is equivalent to specifying the
 /// smallest value of type `K`.
-#[derive(Clone, Debug, Default, Deserialize, PartialOrd, Ord, PartialEq, Eq, Hash, SizeOf)]
+#[derive(
+    Clone, Debug, Default, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq, Hash, SizeOf,
+)]
 pub struct NeighborhoodDescr<K, V> {
     pub anchor: Option<K>,
     #[serde(default)]

--- a/crates/pipeline-types/src/format/json.rs
+++ b/crates/pipeline-types/src/format/json.rs
@@ -140,6 +140,10 @@ pub enum JsonFlavor {
     /// JSON format accepted by the Kafka Connect `JsonConverter` class.
     #[serde(rename = "kafka_connect_json_converter")]
     KafkaConnectJsonConverter,
+    /// Parquet to-json format.
+    /// (For internal use only)
+    #[serde(skip)]
+    ParquetConverter,
 }
 
 const fn default_buffer_size_records() -> usize {

--- a/crates/pipeline-types/src/format/mod.rs
+++ b/crates/pipeline-types/src/format/mod.rs
@@ -1,2 +1,3 @@
 pub mod csv;
 pub mod json;
+pub mod parquet;

--- a/crates/pipeline-types/src/format/parquet.rs
+++ b/crates/pipeline-types/src/format/parquet.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+const fn default_buffer_size_records() -> usize {
+    100_000
+}
+
+/// Configuration for the parquet parser.
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct ParquetParserConfig {}
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct ParquetEncoderConfig {
+    /// Number of records before a new parquet file is written.
+    ///
+    /// The default is 100_000.
+    #[serde(default = "default_buffer_size_records")]
+    pub buffer_size_records: usize,
+}

--- a/crates/pipeline-types/src/transport/file.rs
+++ b/crates/pipeline-types/src/transport/file.rs
@@ -24,7 +24,7 @@ pub struct FileInputConfig {
 }
 
 /// Configuration for writing data to a file with `FileOutputTransport`.
-#[derive(Deserialize, ToSchema)]
+#[derive(Deserialize, Debug, ToSchema)]
 pub struct FileOutputConfig {
     /// File path.
     pub path: String,

--- a/crates/pipeline_manager/src/db/pipeline.rs
+++ b/crates/pipeline_manager/src/db/pipeline.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::{self, Display},
 };
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use deadpool_postgres::Transaction;
 use futures_util::TryFutureExt;
 use pipeline_types::{
@@ -1364,17 +1364,11 @@ fn row_to_pipeline(row: &Row) -> Result<Pipeline, DBError> {
 }
 
 fn convert_bigint_to_time(created_secs: i64) -> Result<DateTime<Utc>, DBError> {
-    let created_naive =
-        NaiveDateTime::from_timestamp_millis(created_secs * 1000).ok_or_else(|| {
-            DBError::invalid_data(format!(
-                "Invalid timestamp in 'pipeline_runtime_state.created' column: {created_secs}"
-            ))
-        })?;
-
-    Ok(DateTime::<Utc>::from_naive_utc_and_offset(
-        created_naive,
-        Utc,
-    ))
+    DateTime::from_timestamp_millis(created_secs * 1000).ok_or_else(|| {
+        DBError::invalid_data(format!(
+            "Invalid timestamp in 'pipeline_runtime_state.created' column: {created_secs}"
+        ))
+    })
 }
 
 fn json_to_attached_connectors(connectors_json: Value) -> Vec<AttachedConnector> {

--- a/docs/api/parquet.md
+++ b/docs/api/parquet.md
@@ -1,0 +1,34 @@
+# Parquet Format
+
+:::caution Under Construction
+
+Note that the Parquet support is currently under development and is missing
+some functionality such as support for arrays and does not propagate information
+about deletes.
+
+Feldera can ingest and output data in the [Parquet format](https://parquet.apache.org/).
+
+- via [`ingress` and `egress` REST endpoints](/docs/tutorials/basics/part2) by specifying `?format=parquet` in the URL
+- as a payload received from or sent to a connector
+
+Here we document the Parquet format and how it interacts with different SQL types.
+
+## Types
+
+The parquet file is expected to be a valid parquet file with a schema. The schema
+(row name and type) must match the table definition in the Feldera pipeline program. We
+use [Arrow](https://arrow.apache.org/) to specify the data-types in parquet. The following table
+shows the mapping between Feldera SQL types
+and [Arrow types](https://docs.rs/arrow/latest/arrow/datatypes/enum.DataType.html).
+
+| Feldera SQL Type                           | Apache Arrow Type                                                                  |
+|--------------------------------------------|------------------------------------------------------------------------------------|
+| `BOOLEAN`                                  | `Boolean`                                                                          |
+| `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT` | `Int8`, `Int16`, `Int32`, `Int64`                                                  |
+| `FLOAT`, `DOUBLE`, `DECIMAL`               | `Float32`, `Float64`, `Decimal`                                                    |
+| `VARCHAR`, `CHAR`, `STRING`                | `LargeUtf8`                                                                        |
+| `TIME`                                     | `DataType::UInt64` (time in nanoseconds)                                           |
+| `TIMESTAMP`                                | `DataType::Timestamp(TimeUnit::Millisecond, None)` (milliseconds since unix epoch) |
+| `DATE`                                     | `DataType::Int32` (days since unix epoch)                                          |
+| `BIGINT ARRAY`                             | TBD                                                                                |
+| `VARCHAR ARRAY ARRAY`                      | TBD                                                                                |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -104,7 +104,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'API Reference',
-      items: ['api/rest', 'api/json', 'api/csv', 'api/rust']
+      items: ['api/rest', 'api/json', 'api/parquet', 'api/csv', 'api/rust']
     },
     {
       type: 'category',

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -1087,7 +1087,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 .increase();
         for (DBSPTypeStruct.Field field: item.type.fields.values()) {
             builder.append("#[serde(rename = \"")
-                    .append(field.name)
+                    .append(Utilities.escape(field.name))
                     .append("\")]\n");
             field.accept(this);
             this.builder.append(",")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -1079,13 +1079,16 @@ public class ToRustInnerVisitor extends InnerVisitor {
 
     @Override
     public VisitDecision preorder(DBSPStructItem item) {
-        this.builder.append("#[derive(Clone, Debug, Eq, PartialEq)]")
+        this.builder.append("#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]")
                 .newline();
         builder.append("struct r#")
                     .append(Objects.requireNonNull(item.type.sanitizedName))
                 .append(" {")
                 .increase();
         for (DBSPTypeStruct.Field field: item.type.fields.values()) {
+            builder.append("#[serde(rename = \"")
+                    .append(field.name)
+                    .append("\")]\n");
             field.accept(this);
             this.builder.append(",")
                     .newline();


### PR DESCRIPTION
Adds pretty basic parquet/arrow support.

- The input/deserialization (for now) is done just by converting to JSON (this is pretty inefficient but doesn't require us to change the API in adapters as we can provide an [u8] buffer)
- The output/serialization is done using serde-arrow and some modifications in the APIs to make it work

Long term think about a better API that works well for column oriented data where parsing/conversion happens in external libraries.

We'll probably need to extend this further to customize the serialization/deserialization.

@mihaibudiu review for the compiler changes, @ryzhyk for the rest

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
