### PR TITLE
Strongly typed connector transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1524](https://github.com/feldera/feldera/pull/1524))
 - WebConsole: Support NULL values on Data Inspection and Insertion page (#1392)
 
+### Changed
+
+- pipeline-manager: connector transport configuration in the API is now
+  strongly typed, and the transport names have the `_input` and `_output`
+  suffix added ([#1532](https://github.com/feldera/feldera/pull/1532))
+
 ## [0.12.0] - 2024-03-19
 
 ### Changed

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -227,7 +227,7 @@ fn parquet_input() {
         r#"
 stream: test_input
 transport:
-    name: file
+    name: file_input
     config:
         path: {:?}
         buffer_size_bytes: 5

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -78,9 +78,6 @@
 //!
 //! The transport adapter API consists of the following traits:
 //!
-//! * [`InputTransport`] is a factory trait that creates [`InputEndpoint`]
-//!   instances from configurations.
-//!
 //! * [`InputEndpoint`] represents a configured data connection, e.g., a file,
 //!   an S3 bucket or a Kafka topic.  By providing an [`InputConsumer`], a
 //!   client may open an endpoint and thereby obtain an [`InputReader`].
@@ -92,9 +89,6 @@
 //! * [`InputConsumer`] is provided by the client, not the API.  An
 //!   [`InputReader`] with new data or status information provides it by calling
 //!   the consumer's methods.
-//!
-//! * [`OutputTransport`] is a factory trait that creates [`OutputEndpoint`]
-//!   instances.
 //!
 //! * [`OutputEndpoint`] represents an individual outgoing data connection,
 //!   e.g., a file, an S3 bucket or a Kafka topic.
@@ -196,6 +190,5 @@ pub use controller::{
     InputEndpointConfig, OutputEndpointConfig, PipelineConfig, RuntimeConfig, TransportConfig,
 };
 pub use transport::{
-    AsyncErrorCallback, FileInputTransport, InputConsumer, InputEndpoint, InputReader,
-    InputTransport, OutputEndpoint, OutputTransport,
+    AsyncErrorCallback, InputConsumer, InputEndpoint, InputReader, OutputEndpoint,
 };

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -936,7 +936,7 @@ inputs:
     test_input1:
         stream: test_input1
         transport:
-            name: kafka
+            name: kafka_input
             config:
                 auto.offset.reset: "earliest"
                 topics: [test_server_input_topic]
@@ -947,7 +947,7 @@ outputs:
     test_output2:
         stream: test_output1
         transport:
-            name: kafka
+            name: kafka_output
             config:
                 topic: test_server_output_topic
                 max_inflight_messages: 0

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     controller::InputEndpointConfig, transport::InputReader, Catalog, CircuitCatalog,
-    DbspCircuitHandle, FormatConfig, InputTransport,
+    DbspCircuitHandle, FormatConfig,
 };
 use anyhow::Result as AnyResult;
 use dbsp::Runtime;
@@ -25,6 +25,7 @@ mod mock_input_consumer;
 mod mock_output_consumer;
 
 use crate::catalog::InputCollectionHandle;
+use crate::transport::input_transport_config_to_endpoint;
 pub use data::{
     generate_test_batch, generate_test_batches, generate_test_batches_with_weights,
     test_struct_schema, TestStruct,
@@ -118,9 +119,8 @@ where
 {
     let (consumer, input_handle) = mock_parser_pipeline(&config.connector_config.format)?;
 
-    let transport =
-        <dyn InputTransport>::get_transport(&config.connector_config.transport.name).unwrap();
-    let endpoint = transport.new_endpoint(&config.connector_config.transport.config)?;
+    let endpoint =
+        input_transport_config_to_endpoint(config.connector_config.transport.clone())?.unwrap();
 
     let reader = endpoint.open(Box::new(consumer.clone()), 0)?;
 

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -11,9 +11,7 @@ use futures_util::StreamExt;
 use log::debug;
 use num_traits::FromPrimitive;
 use serde::Deserialize;
-use serde_yaml::Value as YamlValue;
 use std::{
-    borrow::Cow,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, Mutex,
@@ -53,10 +51,7 @@ impl HttpInputTransport {
     // }
 
     pub(crate) fn config() -> TransportConfig {
-        TransportConfig {
-            name: Cow::from("api"),
-            config: YamlValue::Null,
-        }
+        TransportConfig::HttpInput
     }
 }
 

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -7,9 +7,7 @@ use log::debug;
 use log::error;
 use serde::{ser::SerializeStruct, Serializer};
 use serde_json::value::RawValue;
-use serde_yaml::Value as YamlValue;
 use std::{
-    borrow::Cow,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -40,10 +38,7 @@ pub(crate) struct HttpOutputTransport;
 
 impl HttpOutputTransport {
     pub(crate) fn config() -> TransportConfig {
-        TransportConfig {
-            name: Cow::from("api"),
-            config: YamlValue::Null,
-        }
+        TransportConfig::HttpOutput
     }
 
     pub(crate) fn default_format() -> String {

--- a/crates/adapters/src/transport/kafka/nonft/test.rs
+++ b/crates/adapters/src/transport/kafka/nonft/test.rs
@@ -89,7 +89,7 @@ outputs:
     test_output:
         stream: test_output1
         transport:
-            name: kafka
+            name: kafka_output
             config:
                 bootstrap.servers: localhost:11111
                 topic: end_to_end_test_output_topic
@@ -141,7 +141,7 @@ inputs:
     test_input1:
         stream: test_input1
         transport:
-            name: kafka
+            name: kafka_input
             config:
                 auto.offset.reset: "earliest"
                 group.instance.id: "{test_name}"
@@ -153,7 +153,7 @@ outputs:
     test_output2:
         stream: test_output1
         transport:
-            name: kafka
+            name: kafka_output
             config:
                 topic: {output_topic}
                 max_inflight_messages: 0
@@ -222,7 +222,7 @@ fn test_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str) {
         r#"
 stream: test_input
 transport:
-    name: kafka
+    name: kafka_input
     config:
         bootstrap.servers: localhost:11111
         auto.offset.reset: "earliest"
@@ -244,7 +244,7 @@ format:
     let config_str = r#"
 stream: test_input
 transport:
-    name: kafka
+    name: kafka_input
     config:
         auto.offset.reset: "earliest"
         topics: [input_test_topic1, this_topic_does_not_exist]
@@ -266,7 +266,7 @@ format:
         r#"
 stream: test_input
 transport:
-    name: kafka
+    name: kafka_input
     config:
         auto.offset.reset: "earliest"
         topics: [{topic1}, {topic2}]
@@ -372,7 +372,7 @@ inputs:
     test_input1:
         stream: test_input1
         transport:
-            name: kafka
+            name: kafka_input
             config:
                 auto.offset.reset: "earliest"
                 group.instance.id: "buffer_test"
@@ -384,7 +384,7 @@ outputs:
     test_output2:
         stream: test_output1
         transport:
-            name: kafka
+            name: kafka_output
             config:
                 topic: {output_topic}
                 max_inflight_messages: 0

--- a/crates/pipeline-types/src/transport/file.rs
+++ b/crates/pipeline-types/src/transport/file.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Configuration for reading data from a file with `FileInputTransport`
-#[derive(Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct FileInputConfig {
     /// File path.
     pub path: String,
@@ -24,7 +24,7 @@ pub struct FileInputConfig {
 }
 
 /// Configuration for writing data to a file with `FileOutputTransport`.
-#[derive(Deserialize, Debug, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct FileOutputConfig {
     /// File path.
     pub path: String,

--- a/crates/pipeline-types/src/transport/kafka.rs
+++ b/crates/pipeline-types/src/transport/kafka.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use anyhow::{Error as AnyError, Result as AnyResult};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Configuration for reading data from Kafka topics with `InputTransport`.
-#[derive(Deserialize, Debug, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct KafkaInputConfig {
     /// Options passed directly to `rdkafka`.
     ///
@@ -42,7 +42,7 @@ pub struct KafkaInputConfig {
 }
 
 /// Fault tolerance configuration for Kafka input connector.
-#[derive(Deserialize, Clone, Debug, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct KafkaInputFtConfig {
     /// Options passed to `rdkafka` for consumers only, as documented at
     /// [`librdkafka`
@@ -86,7 +86,7 @@ pub struct KafkaInputFtConfig {
 }
 
 /// Kafka logging levels.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ToSchema)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, ToSchema)]
 pub enum KafkaLogLevel {
     #[serde(rename = "emerg")]
     Emerg,
@@ -188,7 +188,7 @@ const fn default_initialization_timeout_secs() -> u32 {
 }
 
 /// Configuration for writing data to a Kafka topic with `OutputTransport`.
-#[derive(Deserialize, Debug, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct KafkaOutputConfig {
     /// Options passed directly to `rdkafka`.
     ///
@@ -232,7 +232,7 @@ pub struct KafkaOutputConfig {
 }
 
 /// Fault tolerance configuration for Kafka output connector.
-#[derive(Deserialize, Clone, Debug, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct KafkaOutputFtConfig {
     /// Options passed to `rdkafka` for consumers only, as documented at
     /// [`librdkafka`

--- a/crates/pipeline-types/src/transport/s3.rs
+++ b/crates/pipeline-types/src/transport/s3.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Configuration for reading data from AWS S3.
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct S3InputConfig {
     /// Credentials to authenticate against AWS
     pub credentials: AwsCredentials,
@@ -23,7 +23,7 @@ fn default_consume_strategy() -> ConsumeStrategy {
 }
 
 /// Configuration to authenticate against AWS
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(tag = "type")]
 pub enum AwsCredentials {
     /// Do not sign requests. This is equivalent to
@@ -37,7 +37,7 @@ pub enum AwsCredentials {
 }
 
 /// Strategy that determines which objects to read from a given bucket
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(tag = "type")]
 pub enum ReadStrategy {
     /// Read a single object specified by a key
@@ -47,7 +47,7 @@ pub enum ReadStrategy {
 }
 
 /// Strategy to feed a fetched object into an InputConsumer.
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 #[serde(tag = "type")]
 pub enum ConsumeStrategy {
     /// Write the object as a series of fragments (see

--- a/crates/pipeline-types/src/transport/url.rs
+++ b/crates/pipeline-types/src/transport/url.rs
@@ -1,9 +1,9 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Configuration for reading data from an HTTP or HTTPS URL with
 /// `UrlInputTransport`.
-#[derive(Clone, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct UrlInputConfig {
     /// URL.
     pub path: String,

--- a/crates/pipeline_manager/migrations/V13__connector_transport_name.sql
+++ b/crates/pipeline_manager/migrations/V13__connector_transport_name.sql
@@ -1,0 +1,64 @@
+-- The connector configuration transport name has been changed to
+-- include the _input and _output postfix. Below, the name is changed
+-- with the input/output being inferred from either their attachment
+-- or the fields being present inside the YAML.
+
+-- url -> url_input
+UPDATE connector
+SET config = REPLACE(config, 'name: url', 'name: url_input')
+WHERE config LIKE '%name: url%';
+
+-- s3 -> s3_input
+UPDATE connector
+SET config = REPLACE(config, 'name: s3', 'name: s3_input')
+    WHERE config LIKE '%name: s3%';
+
+-- file (input) -> file_input
+UPDATE connector
+SET config = REPLACE(config, 'name: file', 'name: file_input')
+WHERE config LIKE '%name: file%'
+      AND id IN (
+          SELECT ac.connector_id
+          FROM attached_connector AS ac
+          WHERE ac.is_input = TRUE
+      );
+
+-- file (output) -> file_output
+UPDATE connector
+SET config = REPLACE(config, 'name: file', 'name: file_output')
+WHERE config LIKE '%name: file%'
+      AND config NOT LIKE '%name: file_input%' -- Exclude any previous file_input matches
+      AND id IN (
+          SELECT ac.connector_id
+          FROM attached_connector AS ac
+          WHERE ac.is_input = FALSE
+      );
+
+-- kafka (input) -> kafka_input
+UPDATE connector
+SET config = REPLACE(config, 'name: kafka', 'name: kafka_input')
+WHERE config LIKE '%name: kafka%'
+      AND (
+          config LIKE '%topics:%'
+          OR
+          id IN (
+              SELECT ac.connector_id
+              FROM attached_connector AS ac
+              WHERE ac.is_input = TRUE
+          )
+      );
+
+-- kafka (output) -> kafka_output
+UPDATE connector
+SET config = REPLACE(config, 'name: kafka', 'name: kafka_output')
+WHERE config LIKE '%name: kafka%'
+      AND config NOT LIKE '%name: kafka_input%' -- Exclude any previous kafka_input matches
+      AND (
+          config LIKE '%topic:%'
+          OR
+          id IN (
+              SELECT ac.connector_id
+              FROM attached_connector AS ac
+              WHERE ac.is_input = FALSE
+          )
+      );

--- a/crates/pipeline_manager/src/api/examples.rs
+++ b/crates/pipeline_manager/src/api/examples.rs
@@ -138,7 +138,7 @@ pub(crate) fn pipeline_config() -> PipelineConfig {
         config: ConnectorConfig::from_yaml_str(
             r#"
 transport:
-    name: kafka
+    name: kafka_input
     config:
         auto.offset.reset: "earliest"
         group.instance.id: "group0"
@@ -160,11 +160,9 @@ format:
         config: ConnectorConfig::from_yaml_str(
             r#"
 transport:
-    name: kafka
+    name: kafka_output
     config:
-        auto.offset.reset: "earliest"
-        group.instance.id: "group0"
-        topics: [test_input2]
+        topic: test_output1
 format:
     name: csv"#,
         ),

--- a/crates/pipeline_manager/src/db/error.rs
+++ b/crates/pipeline_manager/src/db/error.rs
@@ -73,6 +73,9 @@ pub enum DBError {
     UnknownConnectorName {
         connector_name: String,
     },
+    InvalidConnectorTransport {
+        reason: String,
+    },
     UnknownService {
         service_id: ServiceId,
     },
@@ -426,6 +429,9 @@ impl Display for DBError {
             DBError::UnknownConnectorName { connector_name } => {
                 write!(f, "Unknown connector name '{connector_name}'")
             }
+            DBError::InvalidConnectorTransport { reason } => {
+                write!(f, "Invalid connector transport: '{reason}'")
+            }
             DBError::UnknownService { service_id } => {
                 write!(f, "Unknown service id '{service_id}'")
             }
@@ -529,6 +535,7 @@ impl DetailedError for DBError {
             Self::UnknownPipelineName { .. } => Cow::from("UnknownPipelineName"),
             Self::UnknownConnector { .. } => Cow::from("UnknownConnector"),
             Self::UnknownConnectorName { .. } => Cow::from("UnknownConnectorName"),
+            Self::InvalidConnectorTransport { .. } => Cow::from("InvalidConnectorTransport"),
             Self::UnknownService { .. } => Cow::from("UnknownService"),
             Self::UnknownServiceName { .. } => Cow::from("UnknownServiceName"),
             Self::UnknownServiceProbe { .. } => Cow::from("UnknownServiceProbe"),
@@ -588,6 +595,7 @@ impl ResponseError for DBError {
             Self::UnknownPipelineName { .. } => StatusCode::NOT_FOUND,
             Self::UnknownConnector { .. } => StatusCode::NOT_FOUND,
             Self::UnknownConnectorName { .. } => StatusCode::NOT_FOUND,
+            Self::InvalidConnectorTransport { .. } => StatusCode::BAD_REQUEST,
             Self::UnknownService { .. } => StatusCode::NOT_FOUND,
             Self::UnknownServiceName { .. } => StatusCode::NOT_FOUND,
             Self::UnknownServiceProbe { .. } => StatusCode::NOT_FOUND,

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -177,7 +177,7 @@ pub fn test_connector_config() -> ConnectorConfig {
     ConnectorConfig::from_yaml_str(
         r#"
 transport:
-    name: kafka
+    name: kafka_input
     config:
         auto.offset.reset: "earliest"
         group.instance.id: "group0"
@@ -1192,7 +1192,7 @@ pub(crate) fn limited_connector() -> impl Strategy<Value = ConnectorConfig> {
             format!(
                 "
                 transport:
-                    name: kafka
+                    name: kafka_input
                     config:
                         auto.offset.reset: \"earliest\"
                         group.instance.id: \"group0\"
@@ -1214,7 +1214,7 @@ pub(crate) fn limited_option_connector() -> impl Strategy<Value = Option<Connect
                 format!(
                     "
                 transport:
-                    name: kafka
+                    name: kafka_input
                     config:
                         auto.offset.reset: \"earliest\"
                         group.instance.id: \"group0\"

--- a/demo/demo_notebooks/fraud_detection.ipynb
+++ b/demo/demo_notebooks/fraud_detection.ipynb
@@ -227,7 +227,7 @@
     "            \"description\": \"\",\n",
     "            \"config\": {\n",
     "               \"format\": { \"name\": \"csv\", \"config\": {} },\n",
-    "               \"transport\": { \"name\": \"url\", \"config\": { \"path\": url, } }\n",
+    "               \"transport\": { \"name\": \"url_input\", \"config\": { \"path\": url, } }\n",
     "            }\n",
     "        })\n",
     "        connectors.append({ \"connector_name\": connector_name, \"is_input\": is_input, \"name\": connector_name, \"relation_name\": stream })\n",

--- a/demo/demos/accrual.json
+++ b/demo/demos/accrual.json
@@ -19,7 +19,7 @@
             "description": "Accrual customers input connector",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "redpanda:9092",
                   "auto.offset.reset": "earliest",

--- a/demo/demos/product-availability/demo.json
+++ b/demo/demos/product-availability/demo.json
@@ -21,7 +21,7 @@
             "description": "Kafka input connector for the warehouse table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -51,7 +51,7 @@
             "description": "Kafka input connector for the product table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -81,7 +81,7 @@
             "description": "Kafka input connector for the storage table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",

--- a/demo/demos/product-availability/demo.template.json
+++ b/demo/demos/product-availability/demo.template.json
@@ -21,7 +21,7 @@
             "description": "Kafka input connector for the warehouse table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -51,7 +51,7 @@
             "description": "Kafka input connector for the product table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -81,7 +81,7 @@
             "description": "Kafka input connector for the storage table of the Product Availability demo.",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:product-availability-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",

--- a/demo/demos/productitems-continuous/demo.json
+++ b/demo/demos/productitems-continuous/demo.json
@@ -21,7 +21,7 @@
             "description": "ProductItems Kafka input connector for product table",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:productitems-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -51,7 +51,7 @@
             "description": "ProductItems Kafka input connector for item table",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:productitems-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",

--- a/demo/demos/productitems-continuous/demo.template.json
+++ b/demo/demos/productitems-continuous/demo.template.json
@@ -21,7 +21,7 @@
             "description": "ProductItems Kafka input connector for product table",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:productitems-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",
@@ -51,7 +51,7 @@
             "description": "ProductItems Kafka input connector for item table",
             "config": {
               "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                   "bootstrap.servers": "${secret:productitems-bootstrap-servers}",
                   "security.protocol": "SASL_PLAINTEXT",

--- a/demo/hello-world/run.py
+++ b/demo/hello-world/run.py
@@ -62,7 +62,7 @@ def main():
             "description": "",
             "config": {
                 "transport": {
-                    "name": "file",
+                    "name": "file_" + ("input" if is_input else "output"),
                     "config": {
                         "path": filepath,
                     }

--- a/demo/project_demo00-SecOps/run.py
+++ b/demo/project_demo00-SecOps/run.py
@@ -67,7 +67,7 @@ def prepare_feldera(api_url):
                     }
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_" + ("input" if is_input else "output"),
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic_topics

--- a/demo/project_demo01-TimeSeriesEnrich/run.py
+++ b/demo/project_demo01-TimeSeriesEnrich/run.py
@@ -98,7 +98,7 @@ def prepare_feldera(api_url, start_pipeline):
                     "config": {}
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_" + ("input" if is_input else "output"),
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic_topics

--- a/demo/project_demo02-FraudDetection/run.py
+++ b/demo/project_demo02-FraudDetection/run.py
@@ -96,7 +96,7 @@ def prepare_feldera(api_url, start_pipeline):
                     "config": {}
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_" + ("input" if is_input else "output"),
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic_topics

--- a/demo/project_demo03-GreenTrip/run.py
+++ b/demo/project_demo03-GreenTrip/run.py
@@ -85,7 +85,7 @@ def prepare_feldera(api_url, start_pipeline):
                     "config": {}
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_" + ("input" if is_input else "output"),
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic_topics

--- a/demo/project_demo04-SimpleSelect/run.py
+++ b/demo/project_demo04-SimpleSelect/run.py
@@ -78,7 +78,7 @@ def prepare_feldera(api_url, start_pipeline):
                     "config": {}
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_" + ("input" if is_input else "output"),
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic_topics

--- a/demo/project_demo05-DebeziumMySQL/run.py
+++ b/demo/project_demo05-DebeziumMySQL/run.py
@@ -155,7 +155,7 @@ def prepare_feldera_pipeline(api_url, start_pipeline):
                     }
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_input",
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "auto.offset.reset": "earliest",

--- a/demo/project_demo06-SupplyChainTutorial/run.py
+++ b/demo/project_demo06-SupplyChainTutorial/run.py
@@ -62,7 +62,7 @@ def main():
                 }
             },
             "transport": {
-                "name": "url",
+                "name": "url_input",
                 "config": {
                     "path": "https://feldera-basics-tutorial.s3.amazonaws.com/part.json"
                 }
@@ -76,7 +76,7 @@ def main():
                 }
             },
             "transport": {
-                "name": "url",
+                "name": "url_input",
                 "config": {
                     "path": "https://feldera-basics-tutorial.s3.amazonaws.com/vendor.json"
                 }
@@ -90,7 +90,7 @@ def main():
                 }
             },
             "transport": {
-                "name": "url",
+                "name": "url_input",
                 "config": {
                     "path": "https://feldera-basics-tutorial.s3.amazonaws.com/price.json"
                 }
@@ -104,7 +104,7 @@ def main():
                 }
             },
             "transport": {
-                "name": "kafka",
+                "name": "kafka_input",
                 "config": {
                     "topics": ["price"],
                     "bootstrap.servers": pipeline_to_redpanda_server,
@@ -121,7 +121,7 @@ def main():
                 }
             },
             "transport": {
-                "name": "kafka",
+                "name": "kafka_output",
                 "config": {
                     "topic": "preferred_vendor",
                     "bootstrap.servers": pipeline_to_redpanda_server,

--- a/demo/project_demo07-SnowflakeSink/run.py
+++ b/demo/project_demo07-SnowflakeSink/run.py
@@ -201,7 +201,7 @@ def prepare_feldera(api_url):
                     }
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_output",
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic

--- a/demo/project_demo08-DebeziumJDBC/run.py
+++ b/demo/project_demo08-DebeziumJDBC/run.py
@@ -203,7 +203,7 @@ def prepare_feldera_pipeline(api_url, start_pipeline):
                     }
                 },
                 "transport": {
-                    "name": "kafka",
+                    "name": "kafka_output",
                     "config": {
                         "bootstrap.servers": pipeline_to_redpanda_server,
                         "topic": topic

--- a/demo/project_demo09-S3/run.py
+++ b/demo/project_demo09-S3/run.py
@@ -74,7 +74,7 @@ def prepare_feldera_pipeline(api_url, start_pipeline):
                 "name": "csv",
             },
             "transport": {
-                "name": "s3",
+                "name": "s3_input",
                 "config": {
                     "credentials": {
                         "type": "AccessKey",

--- a/demo/simple-join/run.py
+++ b/demo/simple-join/run.py
@@ -129,7 +129,7 @@ def main():
                 "description": "",
                 "config": {
                     "transport": {
-                        "name": "file",
+                        "name": "file_" + ("input" if is_input else "output"),
                         "config": {
                             "path": filepath,
                         }

--- a/docs/api/json.md
+++ b/docs/api/json.md
@@ -273,7 +273,7 @@ the connector configuration:
 ```json
 {
     "transport": {
-        "name": "url",
+        "name": "url_input",
         "config": {
             "path":"https://feldera-basics-tutorial.s3.amazonaws.com/part.json"
         }

--- a/docs/tutorials/rest_api/index.md
+++ b/docs/tutorials/rest_api/index.md
@@ -225,7 +225,7 @@ we will define an HTTP source for each of the tables:
     "description": "Connector for part",
     "config": {
         "transport": {
-            "name": "url",
+            "name": "url_input",
             "config": {
                 "path": "https://feldera-basics-tutorial.s3.amazonaws.com/part.json"
             }
@@ -246,7 +246,7 @@ we will define an HTTP source for each of the tables:
     "description": "Connector for vendor",
     "config": {
         "transport": {
-            "name": "url",
+            "name": "url_input",
             "config": {
                 "path": "https://feldera-basics-tutorial.s3.amazonaws.com/vendor.json"
             }
@@ -267,7 +267,7 @@ we will define an HTTP source for each of the tables:
     "description": "Connector for price",
     "config": {
         "transport": {
-            "name": "url",
+            "name": "url_input",
             "config": {
                 "path": "https://feldera-basics-tutorial.s3.amazonaws.com/price.json"
             }

--- a/openapi.json
+++ b/openapi.json
@@ -822,12 +822,15 @@
                       "transport": {
                         "config": {
                           "auto.offset.reset": "earliest",
+                          "fault_tolerance": null,
                           "group.instance.id": "group0",
+                          "group_join_timeout_secs": 10,
+                          "log_level": null,
                           "topics": [
                             "test_input1"
                           ]
                         },
-                        "name": "kafka"
+                        "name": "kafka_input"
                       }
                     }
                   },
@@ -847,13 +850,13 @@
                       "stream": "my_output_view",
                       "transport": {
                         "config": {
-                          "auto.offset.reset": "earliest",
-                          "group.instance.id": "group0",
-                          "topics": [
-                            "test_input2"
-                          ]
+                          "fault_tolerance": null,
+                          "initialization_timeout_secs": 60,
+                          "log_level": null,
+                          "max_inflight_messages": 1000,
+                          "topic": "test_output1"
                         },
-                        "name": "kafka"
+                        "name": "kafka_output"
                       }
                     }
                   },
@@ -4881,20 +4884,147 @@
         "format": "uuid"
       },
       "TransportConfig": {
-        "type": "object",
-        "description": "Transport endpoint configuration.",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "config": {
+        "oneOf": [
+          {
             "type": "object",
-            "description": "Transport-specific endpoint configuration passed to\n`crate::OutputTransport::new_endpoint`\nand `crate::InputTransport::new_endpoint`."
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/FileInputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "file_input"
+                ]
+              }
+            }
           },
-          "name": {
-            "type": "string",
-            "description": "Data transport name, e.g., `file`, `kafka`, `kinesis`"
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/FileOutputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "file_output"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/KafkaInputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "kafka_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/KafkaOutputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "kafka_output"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/UrlInputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "url_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/S3InputConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "s3_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "http_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "http_output"
+                ]
+              }
+            }
           }
+        ],
+        "description": "Transport-specific endpoint configuration passed to\n`crate::OutputTransport::new_endpoint`\nand `crate::InputTransport::new_endpoint`.",
+        "discriminator": {
+          "propertyName": "name"
         }
       },
       "UpdateConnectorRequest": {

--- a/web-console/src/lib/components/services/dialogs/KafkaService.tsx
+++ b/web-console/src/lib/components/services/dialogs/KafkaService.tsx
@@ -397,7 +397,7 @@ const TabKafkaConfig = (props: { disabled?: boolean }) => {
                         <SwitchElement key={field} name={'config.' + field} label={''}></SwitchElement>
                       </Box>
                     ))
-                    .with('list', () => (
+                    .with('list', 'array', () => (
                       <TextFieldElement
                         key={field}
                         multiline

--- a/web-console/src/lib/functions/connectors.ts
+++ b/web-console/src/lib/functions/connectors.ts
@@ -12,7 +12,7 @@ import KafkaLogo from '$public/images/vendors/kafka-logo-black.svg'
 import SnowflakeLogo from '$public/images/vendors/snowflake-logo.svg'
 import { fromKafkaConfig } from 'src/lib/functions/kafka/librdkafkaOptions'
 import invariant from 'tiny-invariant'
-import { match, P } from 'ts-pattern'
+import { match } from 'ts-pattern'
 import iconBoilingFlask from '~icons/generic/boiling-flask'
 import iconHttpGet from '~icons/tabler/http-get'
 import iconKafka from '~icons/vendors/apache-kafka-icon'
@@ -24,25 +24,19 @@ import { SVGImport } from '../types/imports'
 // Determine the type of a connector from its config entries.
 export const connectorDescrToType = (config: ConnectorDescr['config']): ConnectorType => {
   return match(config)
-    .with(
-      { transport: { name: 'kafka', config: { topics: P._ } }, format: { config: { update_format: 'debezium' } } },
-      () => {
-        return ConnectorType.DEBEZIUM_IN
-      }
-    )
-    .with(
-      { transport: { name: 'kafka', config: { topic: P._ } }, format: { config: { update_format: 'snowflake' } } },
-      () => {
-        return ConnectorType.SNOWFLAKE_OUT
-      }
-    )
-    .with({ transport: { name: 'kafka', config: { topics: P._ } } }, () => {
+    .with({ transport: { name: 'kafka_input' }, format: { config: { update_format: 'debezium' } } }, () => {
+      return ConnectorType.DEBEZIUM_IN
+    })
+    .with({ transport: { name: 'kafka_output' }, format: { config: { update_format: 'snowflake' } } }, () => {
+      return ConnectorType.SNOWFLAKE_OUT
+    })
+    .with({ transport: { name: 'kafka_input' } }, () => {
       return ConnectorType.KAFKA_IN
     })
-    .with({ transport: { name: 'kafka', config: { topic: P._ } } }, () => {
+    .with({ transport: { name: 'kafka_output' } }, () => {
       return ConnectorType.KAFKA_OUT
     })
-    .with({ transport: { name: 'url' } }, () => {
+    .with({ transport: { name: 'url_input' } }, () => {
       return ConnectorType.URL
     })
     .otherwise(() => {
@@ -207,19 +201,19 @@ export const connectorTypeToDirection = (status: ConnectorType) =>
 export const connectorTransportName = (status: ConnectorType) =>
   match(status)
     .with(ConnectorType.KAFKA_IN, () => {
-      return 'kafka'
+      return 'kafka_input'
     })
     .with(ConnectorType.KAFKA_OUT, () => {
-      return 'kafka'
+      return 'kafka_output'
     })
     .with(ConnectorType.DEBEZIUM_IN, () => {
-      return 'kafka'
+      return 'kafka_input'
     })
     .with(ConnectorType.SNOWFLAKE_OUT, () => {
-      return 'kafka'
+      return 'kafka_output'
     })
     .with(ConnectorType.URL, () => {
-      return 'url'
+      return 'url_input'
     })
     .with(ConnectorType.UNKNOWN, () => {
       return ''


### PR DESCRIPTION
**What is changed in this PR?**

The resolution of a connector transport configuration is moved from the adapters crate (where it used a static dynamic mapping from name to resolver) to the pipeline-types crate, which is used for direct deserialization at the API level.

- The change is not backwards-compatible, in that each connector transport config is now explicitly `_input` or `_output`, e.g., this means the following example for a Kafka input connector...
  ```
  "config": {
      "transport": {
          "name": "kafka",
          "config": {
             ... (unchanged)
          }
      }
      "format": {
          ... (unchanged)
      }
  }
  ```

   ... becomes ...

   ```
  "config": {
      "transport": {
          "name": "kafka_input",
          "config": {
             ... (unchanged)
          }
      }
      "format": {
          ... (unchanged)
      }
  }
   ```

**Why the change?**

- OpenAPI documentation now includes connector transports
- Config is no longer a plain `YamlValue`: deserialization at the API-level will catch when incorrectly structured configs are passed. Note that this will not catch e.g., incorrect semantic values for fields besides type, or fields that are not present (as serde ignores these by default).
- Future integration with services will be less complicated if the types are known

**What remains?**

- [x] The web-console needs to use the updated `_input` and `_output` names in its connector config specification.

**Notes**
- The enumeration also include `HttpInput` and `HttpOutput`, though they will return `unknown_input/output_transport` at the adapters crate. This could be further improved, though the only proper way is to disassociate API types fully from adapter types, in which the former can be transformed into the latter. A quick fix would be to test for these at the API level, and return a database error if they are attempted to be created. 

**Future work**

- The same can be done for format configuration in a future PR, but wanted to keep them separate
- When a connector is attached, the `is_input` field can be made redundant

Is this a user-visible change (yes/no): yes