### PR TITLE
Lag custom order

### DIFF
--- a/crates/dbsp/src/operator/dynamic/group/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/group/mod.rs
@@ -26,7 +26,7 @@ mod test;
 use dyn_clone::clone_box;
 
 use crate::dynamic::{ClonableTrait, Erase};
-pub use lag::LagFactories;
+pub use lag::{LagCustomOrdFactories, LagFactories};
 pub use topk::{TopKCustomOrdFactories, TopKFactories, TopKRankCustomOrdFactories};
 
 /// Specifies the order in which a group transformer produces output tuples.

--- a/crates/dbsp/src/operator/group/lag.rs
+++ b/crates/dbsp/src/operator/group/lag.rs
@@ -1,9 +1,13 @@
+use crate::dynamic::Erase;
+use crate::operator::dynamic::filter_map::DynFilterMap;
+use crate::operator::dynamic::group::LagCustomOrdFactories;
+use crate::operator::group::custom_ord::WithCustomOrd;
 use crate::{
     dynamic::{DowncastTrait, DynData, DynPair},
     operator::dynamic::group::LagFactories,
     typed_batch::{DynOrdIndexedZSet, IndexedZSet, TypedBatch},
     utils::Tup2,
-    DBData, RootCircuit, Stream, ZWeight,
+    CmpFunc, DBData, OrdIndexedZSet, RootCircuit, Stream, ZWeight,
 };
 
 impl<B> Stream<RootCircuit, B>
@@ -11,13 +15,14 @@ where
     B: IndexedZSet,
     B::InnerBatch: Send,
 {
-    /// Lag operator matches each row in a group with a previous row in the
-    /// same group.
+    /// Lag operator matches each row in a group with a value at the given offset
+    /// in the same group.
     ///
     /// For each key in the input stream, it matches each associated value with
-    /// a previous value (i.e., value with a smaller index according to
-    /// ascending order of values), applies projection function `project` to
-    /// it and outputs the input value along with this projection.
+    /// another value in the same group with a smaller (`offset > 0`) or greater
+    /// (`offset < 0`) index according to ascending order of values), applies
+    /// projection function `project` to it and outputs the input value along
+    /// with this projection.
     ///
     /// # Arguments
     ///
@@ -27,75 +32,93 @@ where
     // must change to take a pair of closures that assemble (V, OV) into an output
     // value and reverse and split it back.
     #[allow(clippy::type_complexity)]
-    pub fn lag<OV, PF>(
+    pub fn lag<VL, PF>(
         &self,
-        offset: usize,
+        offset: isize,
         project: PF,
     ) -> Stream<
         RootCircuit,
         TypedBatch<
             B::Key,
-            Tup2<B::Val, OV>,
+            Tup2<B::Val, VL>,
             ZWeight,
             DynOrdIndexedZSet<B::DynK, DynPair<B::DynV, DynData>>,
         >,
     >
     where
-        OV: DBData,
-        PF: Fn(Option<&B::Val>) -> OV + 'static,
+        VL: DBData,
+        PF: Fn(Option<&B::Val>) -> VL + 'static,
     {
-        let factories = LagFactories::<B::Inner, DynData>::new::<B::Key, B::Val, OV>();
+        let factories = LagFactories::<B::Inner, DynData>::new::<B::Key, B::Val, VL>();
 
         self.inner()
             .dyn_lag(
                 &factories,
                 offset,
                 Box::new(move |v, ov: &mut DynData| unsafe {
-                    *ov.downcast_mut::<OV>() = project(v.map(|v| v.downcast::<B::Val>()))
+                    *ov.downcast_mut::<VL>() = project(v.map(|v| v.downcast::<B::Val>()))
                 }),
             )
             .typed()
     }
+}
 
-    /// Lead operator matches each row in a group with a subsequent row in the
-    /// same group.
-    ///
-    /// For each key in the input stream, matches each associated value with
-    /// a subsequent value (i.e., value with a larger index according to
-    /// ascending order of values), applies projection function `project` to
-    /// it and outputs the input value along with this projection.
+impl<B, K, V> Stream<RootCircuit, B>
+where
+    B: IndexedZSet<Key = K, Val = V, DynK = DynData, DynV = DynData>,
+    B::InnerBatch: Send + for<'a> DynFilterMap<DynItemRef<'a> = (&'a B::DynK, &'a B::DynV)>,
+    K: DBData + Erase<B::DynK>,
+    V: DBData + Erase<B::DynV>,
+{
+    /// Like [`Stream::lag`], but uses a custom ordering of values within the group
+    /// defined by the comparison function `CF`.
     ///
     /// # Arguments
     ///
-    /// * `offset` - offset to the subsequent value.
-    /// * `project` - projection function to apply to the subsequent row. The
-    ///   argument is `None` for out-of-range values.
+    /// * `offset` - offset to the previous or next value.
+    /// * `project` - projection function to apply to the delayed row.
+    /// * `output` - output function that constructs the output value from
+    ///   the value of the current row and the projection of the delayed
+    ///   row.
     #[allow(clippy::type_complexity)]
-    pub fn lead<OV, PF>(
+    pub fn lag_custom_order<VL, OV, PF, CF, OF>(
         &self,
-        offset: usize,
+        offset: isize,
         project: PF,
-    ) -> Stream<
-        RootCircuit,
-        TypedBatch<
-            B::Key,
-            Tup2<B::Val, OV>,
-            ZWeight,
-            DynOrdIndexedZSet<B::DynK, DynPair<B::DynV, DynData>>,
-        >,
-    >
+        output: OF,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<K, OV>>
     where
+        VL: DBData,
         OV: DBData,
-        PF: Fn(Option<&B::Val>) -> OV + 'static,
+        CF: CmpFunc<V>,
+        PF: Fn(Option<&V>) -> VL + 'static,
+        OF: Fn(&V, &VL) -> OV + 'static,
     {
-        let factories = LagFactories::<B::Inner, DynData>::new::<B::Key, B::Val, OV>();
+        let factories = LagCustomOrdFactories::<B::Inner, DynData, DynData, DynData>::new::<
+            K,
+            V,
+            WithCustomOrd<V, CF>,
+            VL,
+            OV,
+        >();
 
         self.inner()
-            .dyn_lead(
+            .dyn_lag_custom_order(
                 &factories,
                 offset,
+                Box::new(move |v1, v2: &mut DynData| unsafe {
+                    *v2.downcast_mut::<WithCustomOrd<V, CF>>() =
+                        WithCustomOrd::new(v1.downcast::<V>().clone())
+                }),
                 Box::new(move |v, ov: &mut DynData| unsafe {
-                    *ov.downcast_mut::<OV>() = project(v.map(|v| v.downcast::<B::Val>()))
+                    *ov.downcast_mut::<VL>() =
+                        project(v.map(|v| &v.downcast::<WithCustomOrd<V, CF>>().val))
+                }),
+                Box::new(move |v2, vl, ov| {
+                    *unsafe { ov.downcast_mut::<OV>() } = output(
+                        &unsafe { &v2.downcast::<WithCustomOrd<V, CF>>() }.val,
+                        unsafe { vl.downcast::<VL>() },
+                    )
                 }),
             )
             .typed()


### PR DESCRIPTION
Adds a version of the `lag` operator where the ordering of elements
within a group is defined by a user-provided function, similar to
`topk_customr_order` and related operators.

Also eliminates the `lead` operator and instead generalizes
`lag` to take a signed offset, with negative offsets corresponding to
`lead`.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
