### PR TITLE
Output buffering mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Output buffering mechanism to consolidate multiple output
+  updates over time.
+  ([#1558](https://github.com/feldera/feldera/pull/1558))
+
 ## [0.12.0] - 2024-03-19
 
 ### Changed

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=$HOME/.rustup
 ENV CARGO_HOME=$HOME/.cargo
 # Adds python and rust binaries to thep path
 ENV PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-ENV RUST_VERSION=1.75.0
+ENV RUST_VERSION=1.76.0
 ENV RUST_BUILD_MODE='' # set to --release for release builds
 
 install-deps:

--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -153,12 +153,12 @@ pub trait DeCollectionHandle: Send {
 
 /// A type-erased batch whose contents can be serialized.
 ///
-/// This is a wrapper around the DBSP `Batch` trait that returns a cursor that
+/// This is a wrapper around the DBSP `BatchReader` trait that returns a cursor that
 /// yields `erased_serde::Serialize` trait objects that can be used to serialize
 /// the contents of the batch without knowing its key and value types.
 // The reason we need the `Sync` trait below is so that we can wrap batches
 // in `Arc` and send the same batch to multiple output endpoint threads.
-pub trait SerBatch: Send + Sync {
+pub trait SerBatchReader: 'static {
     /// Number of keys in the batch.
     fn key_count(&self) -> usize;
 
@@ -175,13 +175,9 @@ pub trait SerBatch: Send + Sync {
         &'a self,
         record_format: RecordFormat,
     ) -> Result<Box<dyn SerCursor + 'a>, ControllerError>;
-
-    fn as_any(self: Arc<Self>) -> Arc<dyn Any + Sync + Send>;
-
-    fn merge(self: Arc<Self>, other: Vec<Arc<dyn SerBatch>>) -> Arc<dyn SerBatch>;
 }
 
-impl Debug for dyn SerBatch {
+impl Debug for dyn SerBatchReader {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut cursor = self
             .cursor(RecordFormat::Json(Default::default()))
@@ -216,6 +212,35 @@ impl Debug for dyn SerBatch {
 
         Ok(())
     }
+}
+
+impl Debug for dyn SerBatch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.as_batch_reader().fmt(f)
+    }
+}
+
+/// A type-erased `Batch`.
+pub trait SerBatch: SerBatchReader + Send + Sync {
+    /// Convert to `Arc<Any>`, which can then be downcast to a reference
+    /// to a concrete batch type.
+    fn as_any(self: Arc<Self>) -> Arc<dyn Any + Sync + Send>;
+
+    /// Merge `self` with all batches in `other`.
+    fn merge(self: Arc<Self>, other: Vec<Arc<dyn SerBatch>>) -> Arc<dyn SerBatch>;
+
+    /// Convert batch into a trace with identical contents.
+    fn into_trace(self: Arc<Self>, persistent_id: &str) -> Box<dyn SerTrace>;
+
+    fn as_batch_reader(&self) -> &dyn SerBatchReader;
+}
+
+/// A type-erased `Trace`.
+pub trait SerTrace: SerBatchReader {
+    /// Insert a batch into the trace.
+    fn insert(&mut self, batch: Arc<dyn SerBatch>);
+
+    fn as_batch_reader(&self) -> &dyn SerBatchReader;
 }
 
 /// Cursor that allows serializing the contents of a type-erased batch.

--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -168,12 +169,16 @@ pub trait SerBatch: Send + Sync {
         self.len() == 0
     }
 
-    /// Create a cursor over the batch that yields record
+    /// Create a cursor over the batch that yields records
     /// formatted using the specified format.
     fn cursor<'a>(
         &'a self,
         record_format: RecordFormat,
     ) -> Result<Box<dyn SerCursor + 'a>, ControllerError>;
+
+    fn as_any(self: Arc<Self>) -> Arc<dyn Any + Sync + Send>;
+
+    fn merge(self: Arc<Self>, other: Vec<Arc<dyn SerBatch>>) -> Arc<dyn SerBatch>;
 }
 
 impl Debug for dyn SerBatch {

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -66,7 +66,9 @@ use std::{
 mod error;
 mod stats;
 
+use crate::catalog::{SerBatchReader, SerTrace};
 pub use error::{ConfigError, ControllerError};
+use pipeline_types::config::OutputBufferConfig;
 pub use pipeline_types::config::{
     ConnectorConfig, FormatConfig, InputEndpointConfig, OutputEndpointConfig, PipelineConfig,
     RuntimeConfig, TransportConfig,
@@ -75,7 +77,7 @@ use pipeline_types::program_schema::canonical_identifier;
 pub use stats::{ControllerStatus, InputEndpointStatus, OutputEndpointStatus};
 
 /// Maximal number of concurrent API connections per circuit
-/// (including both input and output connecions).
+/// (including both input and output connections).
 // TODO: make this configurable.
 pub(crate) const MAX_API_CONNECTIONS: u64 = 100;
 
@@ -548,8 +550,6 @@ impl Controller {
                         for ((_stream, _query), (output_handles, endpoints)) in
                             outputs.iter_by_stream()
                         {
-                            // TODO: add an endpoint config option to consolidate output batches.
-
                             let mut delta_batch = output_handles
                                 .delta
                                 .as_ref()
@@ -825,6 +825,85 @@ impl OutputEndpoints {
                 .map(|(_, endpoints)| endpoints.remove(endpoint_id));
             descr
         })
+    }
+}
+
+/// Buffer used by the output endpoint thread to accumulate outputs.
+struct OutputBuffer {
+    endpoint_name: String,
+
+    buffer: Option<Box<dyn SerTrace>>,
+
+    /// Step number of the last update in the buffer.
+    ///
+    /// The endpoint will wait for this step to commit before sending the buffer
+    /// out.
+    buffered_step: Step,
+
+    /// Time when the first batch was pushed to the buffer.
+    buffer_since: Instant,
+
+    /// Number of input records that will be fully processed after the buffer is flushed.
+    ///
+    /// This is a part of the progress tracking mechanism, which tracks the number of inputs
+    /// to the pipeline that have been processed to completion.  It is currently used
+    /// to determine when the circuit has run to completion.
+    buffered_processed_records: u64,
+}
+
+impl OutputBuffer {
+    /// Create an empty buffer.
+    fn new(endpoint_name: &str) -> Self {
+        Self {
+            endpoint_name: endpoint_name.to_string(),
+            buffer: None,
+            buffered_step: 0,
+            buffer_since: Instant::now(),
+            buffered_processed_records: 0,
+        }
+    }
+
+    /// Insert `batch` into the buffer.
+    fn insert(&mut self, batch: Arc<dyn SerBatch>, step: Step, processed_records: u64) {
+        if let Some(buffer) = &mut self.buffer {
+            buffer.insert(batch);
+        } else {
+            self.buffer = Some(batch.into_trace(&format!("output-buffer-{}", &self.endpoint_name)));
+            self.buffer_since = Instant::now();
+        }
+        self.buffered_step = step;
+        self.buffered_processed_records = processed_records;
+    }
+
+    /// Returns `true` when it is time to flush the buffer either because it's full or
+    /// because the max buffering timeout has expired.
+    fn flush_needed(&self, config: &OutputBufferConfig) -> bool {
+        if let Some(buffer) = &self.buffer {
+            let buffer = buffer.as_ref();
+            if buffer.len() >= config.max_buffer_size_records {
+                return true;
+            }
+
+            if self.buffer_since.elapsed().as_millis() > config.max_buffer_time_millis as u128 {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Time when the oldest data was inserted in the buffer.
+    fn buffer_since(&self) -> Option<Instant> {
+        if self.buffer.is_some() {
+            Some(self.buffer_since)
+        } else {
+            None
+        }
+    }
+
+    /// Return the contents of the buffer leaving it empty.
+    fn take_buffer(&mut self) -> Option<Box<dyn SerTrace>> {
+        self.buffer.take()
     }
 }
 
@@ -1137,11 +1216,14 @@ impl ControllerInner {
         outputs.insert(endpoint_id, handles, endpoint_descr);
 
         let endpoint_name_string = endpoint_name.to_string();
+        let output_buffer_config = endpoint_config.output_buffer_config.clone();
+
         // Thread to run the output pipeline.
         spawn(move || {
             Self::output_thread_func(
                 endpoint_id,
                 endpoint_name_string,
+                output_buffer_config,
                 encoder,
                 parker,
                 queue,
@@ -1165,15 +1247,35 @@ impl ControllerInner {
         last.merge(data)
     }
 
+    fn push_batch_to_encoder(
+        batch: &dyn SerBatchReader,
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        encoder: &mut dyn Encoder,
+        step: Step,
+        controller: &ControllerInner,
+    ) {
+        encoder.consumer().batch_start(step);
+        encoder
+            .encode(batch)
+            .unwrap_or_else(|e| controller.encode_error(endpoint_id, endpoint_name, e));
+        controller.wait_to_commit(step);
+        encoder.consumer().batch_end();
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn output_thread_func(
         endpoint_id: EndpointId,
         endpoint_name: String,
+        output_buffer_config: OutputBufferConfig,
         mut encoder: Box<dyn Encoder>,
         parker: Parker,
         queue: Arc<BatchQueue>,
         disconnect_flag: Arc<AtomicBool>,
         controller: Arc<ControllerInner>,
     ) {
+        let mut output_buffer = OutputBuffer::new(&endpoint_name);
+
         loop {
             if controller.state() == PipelineState::Terminated {
                 return;
@@ -1183,29 +1285,70 @@ impl ControllerInner {
                 return;
             }
 
-            // Dequeue the next output batch and push it to the encoder.
-            if let Some((step, data, processed_records)) = queue.pop() {
-                let num_records = data.iter().map(|b| b.len()).sum();
-                encoder.consumer().batch_start(step);
-                let consolidated = Self::merge_batches(data);
-                encoder
-                    .encode(consolidated.as_ref())
-                    .unwrap_or_else(|e| controller.encode_error(endpoint_id, &endpoint_name, e));
-                controller.wait_to_commit(step);
-                encoder.consumer().batch_end();
-
-                // `num_records` output records have been transmitted --
-                // update output stats, wake up the circuit thread if the
-                // number of queued records drops below high watermark.
-                controller.status.output_batch(
+            if output_buffer.flush_needed(&output_buffer_config) {
+                // One of the triggering conditions for flushing the output buffer is satisfied:
+                // go ahead and flush the buffer; we will check for more messages at the next iteration
+                // of the loop.
+                Self::push_batch_to_encoder(
+                    output_buffer.take_buffer().unwrap().as_batch_reader(),
                     endpoint_id,
-                    processed_records,
-                    num_records,
-                    &controller.circuit_thread_unparker,
+                    &endpoint_name,
+                    encoder.as_mut(),
+                    output_buffer.buffered_step,
+                    &controller,
                 );
+
+                controller
+                    .status
+                    .output_buffered_batches(endpoint_id, output_buffer.buffered_processed_records);
+            } else if let Some((step, data, processed_records)) = queue.pop() {
+                // Dequeue the next output batch. If output buffering is enabled, push it to the
+                // buffer; we will check if the buffer needs to be flushed at the next iteration of
+                // the loop.  If buffering is disabled, push the buffer directly to the encoder.
+
+                let num_records = data.iter().map(|b| b.len()).sum();
+                let consolidated = Self::merge_batches(data);
+
+                // Buffer the new output if buffering is enabled.
+                if output_buffer_config.enable_buffer {
+                    output_buffer.insert(consolidated, step, processed_records);
+                    controller.status.buffer_batch(
+                        endpoint_id,
+                        num_records,
+                        &controller.circuit_thread_unparker,
+                    );
+                } else {
+                    Self::push_batch_to_encoder(
+                        consolidated.as_batch_reader(),
+                        endpoint_id,
+                        &endpoint_name,
+                        encoder.as_mut(),
+                        step,
+                        &controller,
+                    );
+
+                    // `num_records` output records have been transmitted --
+                    // update output stats, wake up the circuit thread if the
+                    // number of queued records drops below high watermark.
+                    controller.status.output_batch(
+                        endpoint_id,
+                        processed_records,
+                        num_records,
+                        &controller.circuit_thread_unparker,
+                    );
+                }
             } else {
                 trace!("Queue is empty -- wait for the circuit thread to wake us up when more data is available");
-                parker.park();
+                if let Some(buffer_since) = output_buffer.buffer_since() {
+                    // Buffering is enabled: wake us up when the buffer timeout has expired.
+                    let timeout = output_buffer_config.max_buffer_time_millis as i128
+                        - buffer_since.elapsed().as_millis() as i128;
+                    if timeout > 0 {
+                        parker.park_timeout(Duration::from_millis(timeout as u64));
+                    }
+                } else {
+                    parker.park();
+                }
             }
         }
     }
@@ -1215,7 +1358,7 @@ impl ControllerInner {
     /// An input step must commit before we can commit any of the output.
     /// Otherwise, if there is a crash, we might have output for which we don't
     /// know the corresponding input, which would break fault tolerance.
-    fn wait_to_commit(self: &Arc<Self>, step: Step) {
+    fn wait_to_commit(&self, step: Step) {
         if !self.status.is_step_committed(step) {
             let mut guard = self.uncommitted_step.lock().unwrap();
             loop {
@@ -1468,14 +1611,14 @@ impl OutputConsumer for OutputProbe {
         })
     }
 
-    fn push_buffer(&mut self, buffer: &[u8]) {
+    fn push_buffer(&mut self, buffer: &[u8], num_records: usize) {
         let num_bytes = buffer.len();
 
         match self.endpoint.push_buffer(buffer) {
             Ok(()) => {
                 self.controller
                     .status
-                    .output_buffer(self.endpoint_id, num_bytes);
+                    .output_buffer(self.endpoint_id, num_bytes, num_records);
             }
             Err(error) => {
                 self.controller.output_transport_error(
@@ -1488,14 +1631,14 @@ impl OutputConsumer for OutputProbe {
         }
     }
 
-    fn push_key(&mut self, key: &[u8], val: &[u8]) {
+    fn push_key(&mut self, key: &[u8], val: &[u8], num_records: usize) {
         let num_bytes = key.len() + val.len();
 
         match self.endpoint.push_key(key, val) {
             Ok(()) => {
                 self.controller
                     .status
-                    .output_buffer(self.endpoint_id, num_bytes);
+                    .output_buffer(self.endpoint_id, num_bytes, num_records);
             }
             Err(error) => {
                 self.controller.output_transport_error(

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -14,7 +14,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::Deserialize;
 use serde_urlencoded::Deserializer as UrlDeserializer;
 use serde_yaml::Value as YamlValue;
-use std::{borrow::Cow, io::Write, mem::take, sync::Arc};
+use std::{borrow::Cow, io::Write, mem::take};
 
 /// JSON format encoder.
 pub struct JsonOutputFormat;
@@ -149,7 +149,7 @@ impl Encoder for JsonEncoder {
         self.output_consumer.as_mut()
     }
 
-    fn encode(&mut self, batches: &[Arc<dyn SerBatch>]) -> AnyResult<()> {
+    fn encode(&mut self, batch: &dyn SerBatch) -> AnyResult<()> {
         let mut buffer = take(&mut self.buffer);
         let mut key_buffer = take(&mut self.key_buffer);
 
@@ -161,199 +161,197 @@ impl Encoder for JsonEncoder {
         };
 
         let mut num_records = 0;
-        for batch in batches.iter() {
-            let mut cursor = CursorWithPolarity::new(
-                batch.cursor(RecordFormat::Json(self.config.json_flavor.clone().unwrap()))?,
-            );
+        let mut cursor = CursorWithPolarity::new(
+            batch.cursor(RecordFormat::Json(self.config.json_flavor.clone().unwrap()))?,
+        );
 
-            while cursor.key_valid() {
-                if !cursor.val_valid() {
-                    cursor.step_key();
-                    continue;
-                }
-                let mut w = cursor.weight();
+        while cursor.key_valid() {
+            if !cursor.val_valid() {
+                cursor.step_key();
+                continue;
+            }
+            let mut w = cursor.weight();
 
-                if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
-                    let mut key_str = String::new();
-                    let _ = cursor.serialize_key(unsafe { key_str.as_mut_vec() });
-                    bail!(
+            if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
+                let mut key_str = String::new();
+                let _ = cursor.serialize_key(unsafe { key_str.as_mut_vec() });
+                bail!(
                         "Unable to output record '{}' with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'.",
                         &key_str
                     );
+            }
+
+            while w != 0 {
+                let prev_len = buffer.len();
+
+                if self.config.array {
+                    if num_records == 0 {
+                        buffer.push(b'[');
+                    } else {
+                        buffer.push(b',');
+                    }
                 }
 
-                while w != 0 {
-                    let prev_len = buffer.len();
-
-                    if self.config.array {
-                        if num_records == 0 {
-                            buffer.push(b'[');
+                // FIXME: an alternative to building JSON manually is to create an
+                // `InsDelUpdate` instance and serialize that, but it would require
+                // packaging the serialized key as `serde_json::RawValue`, which is
+                // not supported by the `RawValue` API.  So we need a custom
+                // implementation of `RawValue`. If we ever decide to build one,
+                // check out the "$serde_json::private::RawValue" magic string in
+                // crate `serde_json`.
+                match self.config.update_format {
+                    JsonUpdateFormat::InsertDelete => {
+                        if w > 0 {
+                            buffer.extend_from_slice(br#"{"insert":"#);
                         } else {
+                            buffer.extend_from_slice(br#"{"delete":"#);
+                        }
+                        cursor.serialize_key(&mut buffer)?;
+                        buffer.push(b'}');
+                    }
+                    JsonUpdateFormat::Snowflake => {
+                        cursor.serialize_key(&mut buffer)?;
+
+                        // Remove the closing brace and add '__action' field.
+                        if buffer.pop() != Some(b'}') {
+                            bail!("Serialized JSON value does not end in '}}'");
+                        }
+                        if buffer.last() != Some(&b'{') {
                             buffer.push(b',');
                         }
+                        let action = if w > 0 { "insert" } else { "delete" };
+                        write!(
+                            buffer,
+                            r#""__action":"{action}","__stream_id":{},"__seq_number":{}}}"#,
+                            self.stream_id, self.seq_number
+                        )?;
                     }
+                    JsonUpdateFormat::Debezium => {
+                        // Crate a Debezium-compliant Kafka message.  The key of the messages
+                        // contains the entire record being inserted or deleted, including its
+                        // schema. The value part of the message is a Debezium change record
+                        // with either 'd'elete of 'c'reate operation. When `op` is
+                        // 'c'reate, only the `after` component (no `before`) containing the
+                        // second copy of the record is present. The value also contains a
+                        // schema for the entire payload.  If `op` is 'd'elete, neither
+                        // `before` nor `after` is present.
+                        //
+                        // This encoding is redundant and expensive, but is necessary due
+                        // to several limitations:
+                        //
+                        // - We do not currently work with schema registries and don't implement
+                        //   any other way to transfer the schema to the consumer.  We assume
+                        //   that the output is consumed by Kafka Connect using the
+                        //   `JsonConverter` class, which requires inline schema.
+                        //
+                        // - Feldera doesn't know which part of the output record forms a key.
+                        //   The list of key fields must be configured in the downstream Kafka
+                        //   Connector. As a result we must include all fields in the key and
+                        //   rely on the connector To extract the actual key.
+                        //
+                        // - The specific connector implementation we currently work with is
+                        //   Debezium JDBC sink, which only supports deletions when the primary
+                        //   key of the table is encoded in the key component of the Kafka
+                        //   message, i.e., it cannot extract it from the value.
+                        //
+                        // This encoding assumes the following Debezium sink connector config:
+                        // ```
+                        // "primary.key.mode": "record_key",
+                        // "delete.enabled": True,
+                        // "primary.key.fields": "<list_of_primary_key_columns>"
+                        // ```
 
-                    // FIXME: an alternative to building JSON manually is to create an
-                    // `InsDelUpdate` instance and serialize that, but it would require
-                    // packaging the serialized key as `serde_json::RawValue`, which is
-                    // not supported by the `RawValue` API.  So we need a custom
-                    // implementation of `RawValue`. If we ever decide to build one,
-                    // check out the "$serde_json::private::RawValue" magic string in
-                    // crate `serde_json`.
-                    match self.config.update_format {
-                        JsonUpdateFormat::InsertDelete => {
-                            if w > 0 {
-                                buffer.extend_from_slice(br#"{"insert":"#);
-                            } else {
-                                buffer.extend_from_slice(br#"{"delete":"#);
-                            }
-                            cursor.serialize_key(&mut buffer)?;
-                            buffer.push(b'}');
+                        // Encode key.
+                        if let Some(key_schema_str) = &self.key_schema_str {
+                            key_buffer.extend_from_slice(br#"{"schema":"#);
+                            key_buffer.extend_from_slice(key_schema_str.as_bytes());
+                            key_buffer.extend_from_slice(br#","payload":"#);
+                        } else {
+                            key_buffer.extend_from_slice(br#"{"payload":"#);
                         }
-                        JsonUpdateFormat::Snowflake => {
-                            cursor.serialize_key(&mut buffer)?;
 
-                            // Remove the closing brace and add '__action' field.
-                            if buffer.pop() != Some(b'}') {
-                                bail!("Serialized JSON value does not end in '}}'");
+                        cursor.serialize_key(&mut key_buffer)?;
+                        key_buffer.extend_from_slice(br#"}"#);
+
+                        // Encode value.
+                        if w > 0 {
+                            if let Some(schema_str) = &self.value_schema_str {
+                                buffer.extend_from_slice(br#"{"schema":"#);
+                                buffer.extend_from_slice(schema_str.as_bytes());
+                                write!(buffer, r#","payload":{{"op":"c","after":"#)?;
+                            } else {
+                                write!(buffer, r#"{{"payload":{{"op":"c","after":"#)?;
                             }
-                            if buffer.last() != Some(&b'{') {
-                                buffer.push(b',');
-                            }
-                            let action = if w > 0 { "insert" } else { "delete" };
+
+                            cursor.serialize_key(&mut buffer)?;
+                            buffer.extend_from_slice(br#"}}"#);
+                        } else if let Some(schema_str) = &self.value_schema_str {
                             write!(
                                 buffer,
-                                r#""__action":"{action}","__stream_id":{},"__seq_number":{}}}"#,
-                                self.stream_id, self.seq_number
+                                r#"{{"schema":{schema_str},"payload":{{"op":"d"}}}}"#
                             )?;
-                        }
-                        JsonUpdateFormat::Debezium => {
-                            // Crate a Debezium-compliant Kafka message.  The key of the messages
-                            // contains the entire record being inserted or deleted, including its
-                            // schema. The value part of the message is a Debezium change record
-                            // with either 'd'elete of 'c'reate operation. When `op` is
-                            // 'c'reate, only the `after` component (no `before`) containing the
-                            // second copy of the record is present. The value also contains a
-                            // schema for the entire payload.  If `op` is 'd'elete, neither
-                            // `before` nor `after` is present.
-                            //
-                            // This encoding is redundant and expensive, but is necessary due
-                            // to several limitations:
-                            //
-                            // - We do not currently work with schema registries and don't implement
-                            //   any other way to transfer the schema to the consumer.  We assume
-                            //   that the output is consumed by Kafka Connect using the
-                            //   `JsonConverter` class, which requires inline schema.
-                            //
-                            // - Feldera doesn't know which part of the output record forms a key.
-                            //   The list of key fields must be configured in the downstream Kafka
-                            //   Connector. As a result we must include all fields in the key and
-                            //   rely on the connector To extract the actual key.
-                            //
-                            // - The specific connector implementation we currently work with is
-                            //   Debezium JDBC sink, which only supports deletions when the primary
-                            //   key of the table is encoded in the key component of the Kafka
-                            //   message, i.e., it cannot extract it from the value.
-                            //
-                            // This encoding assumes the following Debezium sink connector config:
-                            // ```
-                            // "primary.key.mode": "record_key",
-                            // "delete.enabled": True,
-                            // "primary.key.fields": "<list_of_primary_key_columns>"
-                            // ```
-
-                            // Encode key.
-                            if let Some(key_schema_str) = &self.key_schema_str {
-                                key_buffer.extend_from_slice(br#"{"schema":"#);
-                                key_buffer.extend_from_slice(key_schema_str.as_bytes());
-                                key_buffer.extend_from_slice(br#","payload":"#);
-                            } else {
-                                key_buffer.extend_from_slice(br#"{"payload":"#);
-                            }
-
-                            cursor.serialize_key(&mut key_buffer)?;
-                            key_buffer.extend_from_slice(br#"}"#);
-
-                            // Encode value.
-                            if w > 0 {
-                                if let Some(schema_str) = &self.value_schema_str {
-                                    buffer.extend_from_slice(br#"{"schema":"#);
-                                    buffer.extend_from_slice(schema_str.as_bytes());
-                                    write!(buffer, r#","payload":{{"op":"c","after":"#)?;
-                                } else {
-                                    write!(buffer, r#"{{"payload":{{"op":"c","after":"#)?;
-                                }
-
-                                cursor.serialize_key(&mut buffer)?;
-                                buffer.extend_from_slice(br#"}}"#);
-                            } else if let Some(schema_str) = &self.value_schema_str {
-                                write!(
-                                    buffer,
-                                    r#"{{"schema":{schema_str},"payload":{{"op":"d"}}}}"#
-                                )?;
-                            } else {
-                                write!(buffer, r#"{{"payload":{{"op":"d"}}}}"#)?;
-                            }
-                        }
-                        _ => {
-                            // Should never happen.  Unsupported formats are rejected during
-                            // initialization.
-                            bail!(
-                                "Unsupported JSON serialization format: {:?}",
-                                self.config.update_format
-                            )
+                        } else {
+                            write!(buffer, r#"{{"payload":{{"op":"d"}}}}"#)?;
                         }
                     }
+                    _ => {
+                        // Should never happen.  Unsupported formats are rejected during
+                        // initialization.
+                        bail!(
+                            "Unsupported JSON serialization format: {:?}",
+                            self.config.update_format
+                        )
+                    }
+                }
 
-                    // Drop the last encoded record if it exceeds max_buffer_size.
-                    // The record will be included in the next buffer.
-                    let buffer_full = buffer.len() > max_buffer_size;
-                    if buffer_full {
-                        if num_records == 0 {
-                            let record = std::str::from_utf8(&buffer[prev_len..buffer.len()])
-                                .unwrap_or_default();
-                            // We should be able to fit at least one record in the buffer.
-                            bail!("JSON record exceeds maximum buffer size supported by the output transport. Max supported buffer size is {} bytes, but the following record requires {} bytes: '{}'.",
+                // Drop the last encoded record if it exceeds max_buffer_size.
+                // The record will be included in the next buffer.
+                let buffer_full = buffer.len() > max_buffer_size;
+                if buffer_full {
+                    if num_records == 0 {
+                        let record = std::str::from_utf8(&buffer[prev_len..buffer.len()])
+                            .unwrap_or_default();
+                        // We should be able to fit at least one record in the buffer.
+                        bail!("JSON record exceeds maximum buffer size supported by the output transport. Max supported buffer size is {} bytes, but the following record requires {} bytes: '{}'.",
                                   self.max_buffer_size,
                                   buffer.len() - prev_len,
                                   truncate_ellipse(record, MAX_RECORD_LEN_IN_ERRMSG, "..."));
-                        }
-                        buffer.truncate(prev_len);
+                    }
+                    buffer.truncate(prev_len);
+                } else {
+                    if w > 0 {
+                        w -= 1;
                     } else {
-                        if w > 0 {
-                            w -= 1;
-                        } else {
-                            w += 1;
-                        }
-                        num_records += 1;
-                        self.seq_number += 1;
+                        w += 1;
                     }
-                    if !self.config.array {
-                        buffer.push(b'\n');
-                    }
-
-                    if num_records >= self.config.buffer_size_records || buffer_full {
-                        if self.config.array {
-                            buffer.push(b']');
-                        }
-
-                        // println!(
-                        //     "push_buffer: {} bytes",
-                        //     buffer.len() /*std::str::from_utf8(&buffer).unwrap()*/
-                        // );
-                        if !key_buffer.is_empty() {
-                            self.output_consumer.push_key(&key_buffer, &buffer);
-                        } else {
-                            self.output_consumer.push_buffer(&buffer);
-                        }
-                        buffer.clear();
-                        key_buffer.clear();
-                        num_records = 0;
-                    }
+                    num_records += 1;
+                    self.seq_number += 1;
+                }
+                if !self.config.array {
+                    buffer.push(b'\n');
                 }
 
-                cursor.step_key();
+                if num_records >= self.config.buffer_size_records || buffer_full {
+                    if self.config.array {
+                        buffer.push(b']');
+                    }
+
+                    // println!(
+                    //     "push_buffer: {} bytes",
+                    //     buffer.len() /*std::str::from_utf8(&buffer).unwrap()*/
+                    // );
+                    if !key_buffer.is_empty() {
+                        self.output_consumer.push_key(&key_buffer, &buffer);
+                    } else {
+                        self.output_consumer.push_buffer(&buffer);
+                    }
+                    buffer.clear();
+                    key_buffer.clear();
+                    num_records = 0;
+                }
             }
+
+            cursor.step_key();
         }
 
         if num_records > 0 {
@@ -506,7 +504,9 @@ mod test {
                 Arc::new(<SerBatchImpl<_, TestStruct, ()>>::new(zset)) as Arc<dyn SerBatch>
             })
             .collect::<Vec<_>>();
-        encoder.encode(zsets.as_slice()).unwrap();
+        for zset in zsets {
+            encoder.encode(zset.as_ref()).unwrap();
+        }
 
         let seq_number = Rc::new(RefCell::new(0));
         let expected_output = batches
@@ -666,7 +666,7 @@ mod test {
         let zset = OrdZSet::from_keys((), test_data()[0].clone());
 
         let err = encoder
-            .encode(&[Arc::new(<SerBatchImpl<_, TestStruct, ()>>::new(zset)) as Arc<dyn SerBatch>])
+            .encode(&SerBatchImpl::<_, TestStruct, ()>::new(zset) as &dyn SerBatch)
             .unwrap_err();
         assert_eq!(format!("{err}"), "JSON record exceeds maximum buffer size supported by the output transport. Max supported buffer size is 32 bytes, but the following record requires 46 bytes: '{\"delete\":{\"id\":1,\"b\":false,\"i\":10,\"s\":\"bar\"}}'.");
     }

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -14,7 +14,6 @@ use std::{
     collections::BTreeMap,
     error::Error as StdError,
     fmt::{Display, Error as FmtError, Formatter},
-    sync::Arc,
 };
 
 pub(crate) mod csv;
@@ -488,7 +487,7 @@ pub trait Encoder: Send {
 
     /// Encode a batch of updates, push encoded buffers to the consumer
     /// using [`OutputConsumer::push_buffer`].
-    fn encode(&mut self, batches: &[Arc<dyn SerBatch>]) -> AnyResult<()>;
+    fn encode(&mut self, batch: &dyn SerBatch) -> AnyResult<()>;
 }
 
 pub trait OutputConsumer: Send {

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -1,6 +1,6 @@
-use crate::catalog::InputCollectionHandle;
+use crate::catalog::{InputCollectionHandle, SerBatchReader};
 use crate::format::parquet::{ParquetInputFormat, ParquetOutputFormat};
-use crate::{catalog::SerBatch, transport::Step, ControllerError};
+use crate::{transport::Step, ControllerError};
 use actix_web::HttpRequest;
 use anyhow::Result as AnyResult;
 use erased_serde::Serialize as ErasedSerialize;
@@ -487,7 +487,7 @@ pub trait Encoder: Send {
 
     /// Encode a batch of updates, push encoded buffers to the consumer
     /// using [`OutputConsumer::push_buffer`].
-    fn encode(&mut self, batch: &dyn SerBatch) -> AnyResult<()>;
+    fn encode(&mut self, batch: &dyn SerBatchReader) -> AnyResult<()>;
 }
 
 pub trait OutputConsumer: Send {
@@ -496,7 +496,7 @@ pub trait OutputConsumer: Send {
     fn max_buffer_size_bytes(&self) -> usize;
 
     fn batch_start(&mut self, step: Step);
-    fn push_buffer(&mut self, buffer: &[u8]);
-    fn push_key(&mut self, key: &[u8], val: &[u8]);
+    fn push_buffer(&mut self, buffer: &[u8], num_records: usize);
+    fn push_key(&mut self, key: &[u8], val: &[u8], num_records: usize);
     fn batch_end(&mut self);
 }

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -299,7 +299,7 @@ impl Encoder for ParquetEncoder {
         self.output_consumer.as_mut()
     }
 
-    fn encode(&mut self, batches: &[Arc<dyn SerBatch>]) -> AnyResult<()> {
+    fn encode(&mut self, batch: &dyn SerBatch) -> AnyResult<()> {
         let mut buffer = take(&mut self.buffer);
         let props = WriterProperties::builder().build();
         let schema = Arc::new(Schema::new(self.parquet_schema.to_arrow_fields()?));
@@ -307,67 +307,62 @@ impl Encoder for ParquetEncoder {
         let mut builder = ArrowBuilder::new(&fields)?;
 
         let mut num_records = 0;
-        for batch in batches.iter() {
-            let mut cursor = CursorWithPolarity::new(
-                batch.cursor(RecordFormat::Parquet(self.parquet_schema.clone()))?,
-            );
-            while cursor.key_valid() {
-                if !cursor.val_valid() {
-                    cursor.step_key();
-                    continue;
-                }
-                let mut w = cursor.weight();
-                if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
-                    bail!("Unable to output record with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'.");
-                }
-                if w < 0 {
-                    // TODO: we don't support deletes in the parquet format yet.
-                    continue;
-                }
+        let mut cursor = CursorWithPolarity::new(
+            batch.cursor(RecordFormat::Parquet(self.parquet_schema.clone()))?,
+        );
+        while cursor.key_valid() {
+            if !cursor.val_valid() {
+                cursor.step_key();
+                continue;
+            }
+            let mut w = cursor.weight();
+            if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
+                bail!("Unable to output record with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'.");
+            }
+            if w < 0 {
+                // TODO: we don't support deletes in the parquet format yet.
+                continue;
+            }
 
-                while w != 0 {
-                    let prev_len = buffer.len();
-                    cursor.serialize_key_to_arrow(&mut builder)?;
+            while w != 0 {
+                let prev_len = buffer.len();
+                cursor.serialize_key_to_arrow(&mut builder)?;
 
-                    // TODO: buffer.len() is always 0 here atm:
-                    let buffer_full = buffer.len() > self.max_buffer_size;
-                    if buffer_full {
-                        if num_records == 0 {
-                            // We should be able to fit at least one record in the buffer.
-                            bail!("Parquet record exceeds maximum buffer size supported by the output transport. Max supported buffer size is {} bytes, but the record requires {} bytes.",
+                // TODO: buffer.len() is always 0 here atm:
+                let buffer_full = buffer.len() > self.max_buffer_size;
+                if buffer_full {
+                    if num_records == 0 {
+                        // We should be able to fit at least one record in the buffer.
+                        bail!("Parquet record exceeds maximum buffer size supported by the output transport. Max supported buffer size is {} bytes, but the record requires {} bytes.",
                                   self.max_buffer_size,
                                   buffer.len() - prev_len);
-                        }
-                        buffer.truncate(prev_len);
+                    }
+                    buffer.truncate(prev_len);
+                } else {
+                    if w > 0 {
+                        w -= 1;
                     } else {
-                        if w > 0 {
-                            w -= 1;
-                        } else {
-                            w += 1;
-                        }
-                        num_records += 1;
+                        w += 1;
                     }
-
-                    if num_records >= self.config.buffer_size_records || buffer_full {
-                        let buffer_cursor = Cursor::new(&mut buffer);
-                        let mut writer = ArrowWriter::try_new(
-                            buffer_cursor,
-                            schema.clone(),
-                            Some(props.clone()),
-                        )?;
-                        let arrays = builder.build_arrays()?;
-                        let batch = RecordBatch::try_new(schema.clone(), arrays)?;
-                        writer.write(&batch)?;
-                        writer.close()?;
-
-                        self.output_consumer.push_buffer(&buffer);
-                        buffer.clear();
-
-                        num_records = 0;
-                    }
+                    num_records += 1;
                 }
-                cursor.step_key();
+
+                if num_records >= self.config.buffer_size_records || buffer_full {
+                    let buffer_cursor = Cursor::new(&mut buffer);
+                    let mut writer =
+                        ArrowWriter::try_new(buffer_cursor, schema.clone(), Some(props.clone()))?;
+                    let arrays = builder.build_arrays()?;
+                    let batch = RecordBatch::try_new(schema.clone(), arrays)?;
+                    writer.write(&batch)?;
+                    writer.close()?;
+
+                    self.output_consumer.push_buffer(&buffer);
+                    buffer.clear();
+
+                    num_records = 0;
+                }
             }
+            cursor.step_key();
         }
 
         if num_records > 0 {

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -287,8 +287,8 @@ fn parquet_output() {
         vec![Tup2(test_data[0].clone(), 2), Tup2(test_data[1].clone(), 1)],
     );
 
-    let zset = Arc::new(<SerBatchImpl<_, TestStruct, ()>>::new(zset)) as Arc<dyn SerBatch>;
-    encoder.encode(&[zset]).unwrap();
+    let zset = &SerBatchImpl::<_, TestStruct, ()>::new(zset) as &dyn SerBatch;
+    encoder.encode(zset).unwrap();
 
     // Verify output buffer...
     // Construct the expected file manually:

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -19,11 +19,11 @@ use size_of::SizeOf;
 use sqllib::{Date, Time, Timestamp};
 use tempfile::NamedTempFile;
 
+use crate::catalog::SerBatchReader;
 use crate::format::parquet::ParquetEncoder;
 use crate::format::Encoder;
 use crate::static_compile::seroutput::SerBatchImpl;
 use crate::test::{mock_input_pipeline, wait, MockOutputConsumer, DEFAULT_TIMEOUT_MS};
-use crate::SerBatch;
 use pipeline_types::{deserialize_table_record, serialize_table_record};
 
 /// This struct mimics the field naming schema of the compiler.
@@ -287,7 +287,7 @@ fn parquet_output() {
         vec![Tup2(test_data[0].clone(), 2), Tup2(test_data[1].clone(), 1)],
     );
 
-    let zset = &SerBatchImpl::<_, TestStruct, ()>::new(zset) as &dyn SerBatch;
+    let zset = &SerBatchImpl::<_, TestStruct, ()>::new(zset) as &dyn SerBatchReader;
     encoder.encode(zset).unwrap();
 
     // Verify output buffer...

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -22,6 +22,7 @@ use dbsp::circuit::CircuitConfig;
 use dbsp::operator::sample::MAX_QUANTILES;
 use env_logger::Env;
 use log::{debug, error, info, warn};
+use pipeline_types::config::OutputBufferConfig;
 use pipeline_types::{format::json::JsonFlavor, transport::http::EgressMode};
 use pipeline_types::{query::OutputQuery, transport::http::SERVER_PORT_FILE};
 use serde::Deserialize;
@@ -755,6 +756,7 @@ async fn output_endpoint(
     let config = OutputEndpointConfig {
         stream: Cow::from(table_name),
         query: args.query,
+        output_buffer_config: OutputBufferConfig::default(),
         connector_config: ConnectorConfig {
             transport: HttpOutputTransport::config(),
             format: encoder_config_from_http_request(&endpoint_name, &args.format, &req)?,

--- a/crates/adapters/src/server/prometheus.rs
+++ b/crates/adapters/src/server/prometheus.rs
@@ -144,10 +144,10 @@ impl PrometheusMetrics {
             .set(status.metrics.transmitted_records.load(Ordering::Acquire) as i64);
         metrics
             .buffered_records
-            .set(status.metrics.buffered_records.load(Ordering::Acquire) as i64);
+            .set(status.metrics.queued_records.load(Ordering::Acquire) as i64);
         metrics
             .buffered_batches
-            .set(status.metrics.buffered_batches.load(Ordering::Acquire) as i64);
+            .set(status.metrics.queued_batches.load(Ordering::Acquire) as i64);
         metrics
             .num_transport_errors
             .set(status.metrics.num_transport_errors.load(Ordering::Acquire) as i64);

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -1,3 +1,4 @@
+use crate::catalog::{SerBatchReader, SerTrace};
 use crate::{
     catalog::{RecordFormat, SerBatch, SerCollectionHandle, SerCursor},
     ControllerError,
@@ -6,8 +7,8 @@ use anyhow::Result as AnyResult;
 use csv::{Writer as CsvWriter, WriterBuilder as CsvWriterBuilder};
 use dbsp::dynamic::DowncastTrait;
 use dbsp::trace::merge_batches;
-use dbsp::typed_batch::DynBatchReader;
-use dbsp::{trace::Cursor, Batch, BatchReader, OutputHandle};
+use dbsp::typed_batch::{DynBatchReader, DynSpine, DynTrace, Spine, TypedBatch};
+use dbsp::{trace::Cursor, Batch, BatchReader, OutputHandle, Trace};
 use pipeline_types::serde_with_context::{
     SerializationContext, SerializeWithContext, SqlSerdeConfig,
 };
@@ -217,7 +218,7 @@ where
 /// [`SerBatch`] implementation that wraps a `BatchReader`.
 pub struct SerBatchImpl<B, KD, VD>
 where
-    B: Batch + Send,
+    B: BatchReader,
 {
     batch: B,
     phantom: PhantomData<fn() -> (KD, VD)>,
@@ -225,7 +226,7 @@ where
 
 impl<B, KD, VD> Clone for SerBatchImpl<B, KD, VD>
 where
-    B: Batch + Send,
+    B: Batch,
 {
     fn clone(&self) -> Self {
         Self {
@@ -237,7 +238,7 @@ where
 
 impl<B, KD, VD> SerBatchImpl<B, KD, VD>
 where
-    B: Batch + Send,
+    B: BatchReader,
 {
     pub fn new(batch: B) -> Self {
         Self {
@@ -247,9 +248,9 @@ where
     }
 }
 
-impl<B, KD, VD> SerBatch for SerBatchImpl<B, KD, VD>
+impl<B, KD, VD> SerBatchReader for SerBatchImpl<B, KD, VD>
 where
-    B: Batch<Time = ()> + Send + Sync,
+    B: BatchReader<Time = ()>,
     B::R: Into<i64>,
     KD: From<B::Key> + SerializeWithContext<SqlSerdeConfig> + 'static,
     VD: From<B::Val> + SerializeWithContext<SqlSerdeConfig> + 'static,
@@ -297,7 +298,15 @@ where
             )),
         })
     }
+}
 
+impl<B, KD, VD> SerBatch for SerBatchImpl<B, KD, VD>
+where
+    B: Batch<Time = ()> + Send + Sync,
+    B::R: Into<i64>,
+    KD: From<B::Key> + SerializeWithContext<SqlSerdeConfig> + 'static,
+    VD: From<B::Val> + SerializeWithContext<SqlSerdeConfig> + 'static,
+{
     fn as_any(self: Arc<Self>) -> Arc<dyn Any + Sync + Send> {
         self
     }
@@ -322,6 +331,43 @@ where
             typed,
         ))))
     }
+
+    fn into_trace(self: Arc<Self>, persistent_id: &str) -> Box<dyn SerTrace> {
+        let mut spine = TypedBatch::new(DynSpine::<B::Inner>::new(&B::factories(), persistent_id));
+        spine.insert(Arc::unwrap_or_clone(self).batch.into_inner());
+        Box::new(SerBatchImpl::<Spine<B>, KD, VD>::new(spine))
+    }
+
+    fn as_batch_reader(&self) -> &dyn SerBatchReader {
+        self
+    }
+}
+
+impl<T, KD, VD> SerTrace for SerBatchImpl<T, KD, VD>
+where
+    T: Trace<Time = ()>,
+    //TypedBatch<T::Key, T::Val, T::R, <T::InnerTrace as DynTrace>::Batch>: Send + Sync,
+    T::R: Into<i64>,
+    KD: From<T::Key> + SerializeWithContext<SqlSerdeConfig> + 'static,
+    VD: From<T::Val> + SerializeWithContext<SqlSerdeConfig> + 'static,
+{
+    fn insert(&mut self, batch: Arc<dyn SerBatch>) {
+        let batch = Arc::unwrap_or_clone(
+            batch
+                .as_any()
+                .downcast::<SerBatchImpl<
+                    TypedBatch<T::Key, T::Val, T::R, <T::InnerTrace as DynTrace>::Batch>,
+                    KD,
+                    VD,
+                >>()
+                .unwrap(),
+        );
+        self.batch.inner_mut().insert(batch.batch.into_inner());
+    }
+
+    fn as_batch_reader(&self) -> &dyn SerBatchReader {
+        self
+    }
 }
 
 /// [`SerCursor`] implementation that wraps a [`Cursor`].
@@ -339,7 +385,7 @@ where
 impl<'a, Ser, B, KD, VD, C> SerCursorImpl<'a, Ser, B, KD, VD, C>
 where
     Ser: BytesSerializer<C>,
-    B: BatchReader<Time = ()> + Clone,
+    B: BatchReader<Time = ()>,
     B::R: Into<i64>,
     KD: From<B::Key> + SerializeWithContext<C>,
     VD: From<B::Val> + SerializeWithContext<C>,
@@ -354,6 +400,7 @@ where
             val: None,
             phantom: PhantomData,
         };
+        result.skip_zero_keys();
         result.update_key();
         result.update_val();
         result
@@ -372,7 +419,7 @@ where
 
     fn update_val(&mut self) {
         if self.val_valid() {
-            // Safety: `trait BatchReader` guarantees that the inner key type is `B::Key`.
+            // Safety: `trait BatchReader` guarantees that the inner value type is `B::Val`.
             self.val = Some(VD::from(
                 unsafe { self.cursor.val().downcast::<B::Val>() }.clone(),
             ));
@@ -380,12 +427,31 @@ where
             self.val = None;
         }
     }
+
+    fn skip_zero_keys(&mut self) {
+        while self.key_valid() {
+            self.skip_zero_vals();
+            if self.val_valid() {
+                return;
+            }
+            self.step_key()
+        }
+    }
+
+    fn skip_zero_vals(&mut self) {
+        while self.val_valid() {
+            if self.weight() != 0 {
+                return;
+            }
+            self.step_val();
+        }
+    }
 }
 
 impl<'a, Ser, B, KD, VD, C> SerCursor for SerCursorImpl<'a, Ser, B, KD, VD, C>
 where
     Ser: BytesSerializer<C>,
-    B: BatchReader<Time = ()> + Clone,
+    B: BatchReader<Time = ()>,
     B::R: Into<i64>,
     KD: From<B::Key> + SerializeWithContext<C>,
     VD: From<B::Val> + SerializeWithContext<C>,
@@ -424,6 +490,7 @@ where
 
     fn step_key(&mut self) {
         self.cursor.step_key();
+        self.skip_zero_keys();
         self.update_key();
         self.update_val();
     }
@@ -431,12 +498,14 @@ where
     /// Advances the cursor to the next value.
     fn step_val(&mut self) {
         self.cursor.step_val();
+        self.skip_zero_vals();
         self.update_val();
     }
 
     /// Rewinds the cursor to the first key.
     fn rewind_keys(&mut self) {
         self.cursor.rewind_keys();
+        self.skip_zero_keys();
         self.update_key();
         self.update_val();
     }
@@ -444,6 +513,7 @@ where
     /// Rewinds the cursor to the first value for current key.
     fn rewind_vals(&mut self) {
         self.cursor.rewind_vals();
+        self.skip_zero_vals();
         self.update_val();
     }
 }

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -42,10 +42,10 @@ impl OutputConsumer for MockOutputConsumer {
     }
 
     fn batch_start(&mut self, _step: Step) {}
-    fn push_buffer(&mut self, buffer: &[u8]) {
+    fn push_buffer(&mut self, buffer: &[u8], _num_records: usize) {
         self.data.lock().unwrap().extend_from_slice(buffer)
     }
-    fn push_key(&mut self, _key: &[u8], val: &[u8]) {
+    fn push_key(&mut self, _key: &[u8], val: &[u8], _num_records: usize) {
         // TODO: we don't test the contents of keys yet.
         self.data.lock().unwrap().extend_from_slice(val)
     }

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -81,12 +81,12 @@ thread_local! {
 thread_local! {
     // Reference to the `Runtime` that manages this worker thread or `None`
     // if the current thread is not running in a multithreaded runtime.
-    static RUNTIME: RefCell<Option<Runtime>> = RefCell::new(None);
+    static RUNTIME: RefCell<Option<Runtime>> = const { RefCell::new(None) };
 
     // 0-based index of the current worker thread within its runtime.
     // Returns `0` if the current thread in not running in a multithreaded
     // runtime.
-    pub(crate) static WORKER_INDEX: Cell<usize> = Cell::new(0);
+    pub(crate) static WORKER_INDEX: Cell<usize> = const { Cell::new(0) };
 }
 
 pub struct LocalStoreMarker;

--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -105,7 +105,7 @@ pub use operator::{
 pub use trace::{DBData, DBWeight};
 pub use typed_batch::{
     Batch, BatchReader, FileIndexedWSet, FileIndexedZSet, FileKeyBatch, FileValBatch, FileWSet,
-    FileZSet, IndexedZSet, OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, TypedBox, ZSet,
+    FileZSet, IndexedZSet, OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, Trace, TypedBox, ZSet,
 };
 
 #[cfg(doc)]

--- a/crates/dbsp/src/typed_batch.rs
+++ b/crates/dbsp/src/typed_batch.rs
@@ -73,6 +73,8 @@ pub trait BatchReader: 'static {
     /// Extract the dynamically typed batch.
     fn inner(&self) -> &Self::Inner;
 
+    fn inner_mut(&mut self) -> &mut Self::Inner;
+
     /// Drop the statically typed wrapper and return the inner dynamic batch type.  
     fn into_inner(self) -> Self::Inner;
 
@@ -182,6 +184,7 @@ pub struct TypedBatch<K, V, R, B> {
 // bound to DBData and propagate it through all layers, so that `TypedBatch`
 // is truly `Sync`.
 unsafe impl<K, V, R, B> Sync for TypedBatch<K, V, R, B> where B: DynBatch {}
+unsafe impl<K, V, R, B> Send for TypedBatch<K, V, R, B> where B: DynBatch {}
 
 impl<K, V, R, B> Default for TypedBatch<K, V, R, B>
 where
@@ -409,6 +412,10 @@ where
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
+    }
+
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        &mut self.inner
     }
 
     fn into_inner(self) -> Self::Inner {

--- a/crates/dbsp/src/typed_batch.rs
+++ b/crates/dbsp/src/typed_batch.rs
@@ -65,6 +65,11 @@ pub trait BatchReader: 'static {
 
     type Time: Timestamp;
 
+    /// Factories for `Self::Inner`.
+    fn factories() -> <Self::Inner as DynBatchReader>::Factories {
+        BatchReaderFactories::new::<Self::Key, Self::Val, Self::R>()
+    }
+
     /// Extract the dynamically typed batch.
     fn inner(&self) -> &Self::Inner;
 

--- a/crates/pipeline_manager/src/db/pipeline.rs
+++ b/crates/pipeline_manager/src/db/pipeline.rs
@@ -12,7 +12,6 @@ use pipeline_types::{
         ConnectorConfig, InputEndpointConfig, OutputEndpointConfig, PipelineConfig, RuntimeConfig,
     },
     error::ErrorResponse,
-    query::OutputQuery,
 };
 use serde_json::Value;
 use tokio_postgres::Row;
@@ -448,8 +447,9 @@ impl PipelineRevision {
                 stream: Cow::from(ac.relation_name.clone()),
                 // This field gets skipped during serialization/deserialization,
                 // so it doesn't matter what value we use here
-                query: OutputQuery::default(),
+                query: Default::default(),
                 connector_config: connector.unwrap().config.clone(),
+                output_buffer_config: Default::default(),
             };
             expanded_outputs.insert(Cow::from(ac.name.clone()), output_endpoint_config);
         }

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -204,6 +204,8 @@ pub enum Operation {
     Update,
 }
 
+// Rust complains that fields in this enum are never read, even though they are read by `Debug`.
+#[allow(dead_code)]
 #[derive(Debug)]
 enum NotificationError {
     MissingPayloadComponents(String),

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -582,6 +582,7 @@ pub async fn fetch_binary_ref(
                     let path = config.binary_file_path(pipeline_id, program_id, version);
                     let mut file = tokio::fs::File::options()
                         .create(true)
+                        .truncate(true)
                         .write(true)
                         .read(true)
                         .mode(0o760)

--- a/openapi.json
+++ b/openapi.json
@@ -836,10 +836,13 @@
                   "name": "pipeline-67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "outputs": {
                     "Output-To-View": {
+                      "enable_buffer": false,
                       "format": {
                         "config": null,
                         "name": "csv"
                       },
+                      "max_buffer_size_records": 0,
+                      "max_buffer_time_millis": 0,
                       "max_buffered_records": 1000000,
                       "stream": "my_output_view",
                       "transport": {
@@ -3964,6 +3967,9 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/ConnectorConfig"
+          },
+          {
+            "$ref": "#/components/schemas/OutputBufferConfig"
           },
           {
             "type": "object",


### PR DESCRIPTION
Introduces an output buffering mechanism to decouple the rate at which the pipeline
pushes changes to the output transport from the rate of input changes.

By default, output updates produced by the pipeline are pushed directly to
the output transport. Some destinations may prefer to receive updates in fewer
bigger batches. For instance, when writing Parquet files, producing
one bigger file every few minutes is usually better than creating
small files every few milliseconds.

To achieve such input/output decoupling, users can enable output buffering by setting
the `enable_buffer` flag in the output endpoint config to `true`.  When buffering is
enabled, output updates produced by the pipeline are consolidated in an internal buffer
and are pushed to the output transport when one of two conditions is satisfied:

* data has been accumulated in the buffer for longer than a user-defined
  timeout.

* buffer size exceeds a user-defined threshold.

TODO: In the future we may need to allow the user to directly flush the buffer
by performing an API call.

Resolves #1553.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
