### PR TITLE
Earthfile: Build `dbsp` and `nexmark` benchmarks even without running…

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -129,8 +129,9 @@ build-webui:
 
 build-dbsp:
     FROM +rust-sources
-    DO rust+CARGO --args="build --package dbsp"
+    DO rust+CARGO --args="build --package dbsp --benches"
     DO rust+CARGO --args="build --package pipeline_types"
+    DO rust+CARGO --args="build --package dbsp_nexmark --benches"
 
 build-sql:
     FROM +build-dbsp


### PR DESCRIPTION
… them.

We have different CI workflows for building and for running benchmarks. Before this commit, the build workflow didn't build the benchmarks, which meant that they could fail to compile in the benchmark runs.  This commit makes the build workflow build the benchmarks too.

Is this a user-visible change (yes/no): no