### PR TITLE
[SQL] Add noop implementations of ceil and floor for integer types

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -83,25 +83,15 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
      * The definitions supplied by the user will be copied here. */
     public static final String UDF_FILE_NAME = "udf.rs";
 
-    /**
-     * Where does the compiled program come from?
-     */
+    /** Where does the compiled program come from? */
     public enum InputSource {
-        /**
-         * No data source set yet.
-         */
+        /** No data source set yet. */
         None,
-        /**
-         * Data received from stdin.
-         */
+        /** Data received from stdin. */
         Stdin,
-        /**
-         * Data read from a file.  We read the entire file upfront, and then we compile.
-         */
+        /** Data read from a file.  We read the entire file upfront, and then we compile. */
         File,
-        /**
-         * Data received through API calls (compileStatement/s).
-         */
+        /** Data received through API calls (compileStatement/s). */
         API,
     }
 
@@ -121,9 +111,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     public final TypeCompiler typeCompiler;
     public boolean hasWarnings;
 
-    /**
-     * Circuit produced by the compiler.
-     */
+    /** Circuit produced by the compiler. */
     public @Nullable DBSPCircuit circuit;
 
     public DBSPCompiler(CompilerOptions options) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -1875,4 +1875,124 @@ public class FunctionsTest extends SqlIoTest {
                 """
         );
     }
+
+    @Test
+    public void testCeilInt() {
+        this.qs("""
+                SELECT ceil(2::tinyint);
+                 ceil
+                ------
+                     2
+                (1 row)
+                
+                SELECT ceil(2::smallint);
+                 ceil
+                ------
+                     2
+                (1 row)
+                
+                SELECT ceil(2::int);
+                 ceil
+                ------
+                     2
+                (1 row)
+                
+                SELECT ceil(2::bigint);
+                 ceil
+                ------
+                     2
+                (1 row)
+                
+                SELECT ceil(null::tinyint);
+                 ceil
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT ceil(null::smallint);
+                 ceil
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT ceil(null::int);
+                 ceil
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT ceil(null::bigint);
+                 ceil
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT ceil(null);
+                 ceil
+                ------
+                 NULL
+                (1 row)
+                """
+        );
+    }
+
+    @Test
+    public void testFloorInt() {
+        this.qs("""
+                SELECT floor(2::tinyint);
+                 floor
+                ------
+                     2
+                (1 row)
+                
+                SELECT floor(2::smallint);
+                 floor
+                ------
+                     2
+                (1 row)
+                
+                SELECT floor(2::int);
+                 floor
+                ------
+                     2
+                (1 row)
+                
+                SELECT floor(2::bigint);
+                 floor
+                ------
+                     2
+                (1 row)
+                
+                SELECT floor(null::tinyint);
+                 floor
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT floor(null::smallint);
+                 floor
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT floor(null::int);
+                 floor
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT floor(null::bigint);
+                 floor
+                ------
+                 NULL
+                (1 row)
+                
+                SELECT floor(null);
+                 floor
+                ------
+                 NULL
+                (1 row)
+                """
+        );
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -2,11 +2,6 @@ package org.dbsp.sqlCompiler.compiler.sql.functions;
 
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
-import org.dbsp.sqlCompiler.compiler.sql.simple.Change;
-import org.dbsp.sqlCompiler.compiler.sql.simple.InputOutputChangeStream;
-import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -16,6 +16,7 @@ pub use geopoint::GeoPoint;
 pub use interval::LongInterval;
 pub use interval::ShortInterval;
 use num_traits::Pow;
+use num_traits::PrimInt;
 use num_traits::Zero;
 pub use source::{SourcePosition, SourcePositionRange};
 pub use timestamp::Date;
@@ -549,6 +550,58 @@ macro_rules! some_operator {
             some_existing_operator!($new_func_name, $short_name, $arg_type, $ret_type);
         }
     }
+}
+
+// Macro to create variants for all integer types of a function that takes
+// T: PrimInt, and returns T.
+// Consider you have a function: f<T: PrimInt>(T) -> T
+// Creates f_i8(i8) -> i8 / f_i8N(Option<i8>) -> Option<i8>
+// And similar functions for i16, i32, i64
+#[macro_export]
+macro_rules! for_all_primint_function1 {
+    ($func_name: ident) => {
+        ::paste::paste! {
+            #[inline(always)]
+            pub fn [<$func_name _i8>](arg0: i8) -> i8 {
+                [<$func_name _>](arg0)
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i8N>](arg0: Option<i8>) -> Option<i8> {
+                Some([<$func_name _>](arg0?))
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i16>](arg0: i16) -> i16 {
+                [<$func_name _>](arg0)
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i16N>](arg0: Option<i16>) -> Option<i16> {
+                Some([<$func_name _>](arg0?))
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i32>](arg0: i32) -> i32 {
+                [<$func_name _>](arg0)
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i32N>](arg0: Option<i32>) -> Option<i32> {
+                Some([<$func_name _>](arg0?))
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i64>](arg0: i64) -> i64 {
+                [<$func_name _>](arg0)
+            }
+
+            #[inline(always)]
+            pub fn [<$func_name _i64N>](arg0: Option<i64>) -> Option<i64> {
+                Some([<$func_name _>](arg0?))
+            }
+        }
+    };
 }
 
 #[macro_export]
@@ -1147,6 +1200,13 @@ pub fn floor_decimal(value: Decimal) -> Decimal {
     value.floor()
 }
 
+#[inline(always)]
+pub fn floor_<T: PrimInt>(value: T) -> T {
+    value
+}
+
+for_all_primint_function1!(floor);
+
 some_polymorphic_function1!(floor, f, F32, F32);
 some_polymorphic_function1!(floor, d, F64, F64);
 some_polymorphic_function1!(floor, decimal, Decimal, Decimal);
@@ -1167,6 +1227,13 @@ pub fn ceil_f(value: F32) -> F32 {
 pub fn ceil_decimal(value: Decimal) -> Decimal {
     value.ceil()
 }
+
+#[inline(always)]
+pub fn ceil_<T: PrimInt>(value: T) -> T {
+    value
+}
+
+for_all_primint_function1!(ceil);
 
 some_polymorphic_function1!(ceil, f, F32, F32);
 some_polymorphic_function1!(ceil, d, F64, F64);

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -16,7 +16,6 @@ pub use geopoint::GeoPoint;
 pub use interval::LongInterval;
 pub use interval::ShortInterval;
 use num_traits::Pow;
-use num_traits::PrimInt;
 use num_traits::Zero;
 pub use source::{SourcePosition, SourcePositionRange};
 pub use timestamp::Date;
@@ -550,58 +549,6 @@ macro_rules! some_operator {
             some_existing_operator!($new_func_name, $short_name, $arg_type, $ret_type);
         }
     }
-}
-
-// Macro to create variants for all integer types of a function that takes
-// T: PrimInt, and returns T.
-// Consider you have a function: f<T: PrimInt>(T) -> T
-// Creates f_i8(i8) -> i8 / f_i8N(Option<i8>) -> Option<i8>
-// And similar functions for i16, i32, i64
-#[macro_export]
-macro_rules! for_all_primint_function1 {
-    ($func_name: ident) => {
-        ::paste::paste! {
-            #[inline(always)]
-            pub fn [<$func_name _i8>](arg0: i8) -> i8 {
-                [<$func_name _>](arg0)
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i8N>](arg0: Option<i8>) -> Option<i8> {
-                Some([<$func_name _>](arg0?))
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i16>](arg0: i16) -> i16 {
-                [<$func_name _>](arg0)
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i16N>](arg0: Option<i16>) -> Option<i16> {
-                Some([<$func_name _>](arg0?))
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i32>](arg0: i32) -> i32 {
-                [<$func_name _>](arg0)
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i32N>](arg0: Option<i32>) -> Option<i32> {
-                Some([<$func_name _>](arg0?))
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i64>](arg0: i64) -> i64 {
-                [<$func_name _>](arg0)
-            }
-
-            #[inline(always)]
-            pub fn [<$func_name _i64N>](arg0: Option<i64>) -> Option<i64> {
-                Some([<$func_name _>](arg0?))
-            }
-        }
-    };
 }
 
 #[macro_export]
@@ -1200,13 +1147,6 @@ pub fn floor_decimal(value: Decimal) -> Decimal {
     value.floor()
 }
 
-#[inline(always)]
-pub fn floor_<T: PrimInt>(value: T) -> T {
-    value
-}
-
-for_all_primint_function1!(floor);
-
 some_polymorphic_function1!(floor, f, F32, F32);
 some_polymorphic_function1!(floor, d, F64, F64);
 some_polymorphic_function1!(floor, decimal, Decimal, Decimal);
@@ -1227,13 +1167,6 @@ pub fn ceil_f(value: F32) -> F32 {
 pub fn ceil_decimal(value: Decimal) -> Decimal {
     value.ceil()
 }
-
-#[inline(always)]
-pub fn ceil_<T: PrimInt>(value: T) -> T {
-    value
-}
-
-for_all_primint_function1!(ceil);
 
 some_polymorphic_function1!(ceil, f, F32, F32);
 some_polymorphic_function1!(ceil, d, F64, F64);


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes: https://github.com/feldera/feldera/issues/1565

Don't think we need to add floor and ceil functions in the documentation for integer types.

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
