### PR TITLE
Commit API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,6 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
-  # It's really `--all-features`, but not adding `persistence`, we expect the
-  # persistence feature to go away again in the future (but if we add it
-  # unconditionally it changes the code that's run significantly)
-  ALMOST_ALL_FEATURES: --features "with-serde with-csv pg-embed"
 
 jobs:
   pre_job:
@@ -125,4 +121,4 @@ jobs:
           RUSTRDOCFLAGS: "-D warnings --cfg docsrs"
         with:
           command: doc
-          args: --workspace ${{ env.ALMOST_ALL_FEATURES }}
+          args: --workspace --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,6 +3100,8 @@ dependencies = [
  "serde",
  "serde_json",
  "size-of",
+ "static_assertions",
+ "sysinfo",
  "tar",
  "tarpc",
  "tempfile",
@@ -5163,6 +5165,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -7858,6 +7869,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sysinfo"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d7c217777061d5a2d652aea771fb9ba98b6dade657204b08c4b9604d11555b"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8806,6 +8832,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-core"

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -64,6 +64,7 @@ use std::{
     thread::{spawn, JoinHandle},
     time::{Duration, Instant},
 };
+use uuid::Uuid;
 
 mod error;
 mod stats;
@@ -442,6 +443,7 @@ impl Controller {
             layout: Layout::new_solo(controller.status.pipeline_config.global.workers as usize),
             storage: controller.status.pipeline_config.storage_location.clone(),
             min_storage_rows: usize::MAX,
+            init_checkpoint: Uuid::nil(),
         };
         let mut circuit = match circuit_factory(config) {
             Ok((circuit, catalog)) => {

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -23,7 +23,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["with-serde"]
 with-serde = []
 with-csv = ["csv"]
-persistence2 = []
 
 [dependencies]
 num = "0.4.0"
@@ -47,7 +46,7 @@ rand = "0.8.5"
 # Revert after https://github.com/paupino/rust-decimal/pull/637 is merged:
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 # Go back to rkyv repo once https://github.com/rkyv/rkyv/pull/462 is merged:
-rkyv = { git = "https://github.com/gz/rkyv.git", rev = "3d3fd86", default-features = false, features = ["std", "size_64", "extra_traits"] }
+rkyv = { git = "https://github.com/gz/rkyv.git", rev = "3d3fd86", default-features = false, features = ["std", "size_64", "extra_traits", "validation", "uuid"] }
 # Once chrono is released with `849932` chrono version needs to be updated in size-of crate:
 size-of = { git = "https://github.com/gz/size-of.git", rev = "3ec40db", features = ["hashbrown", "time-std", "xxhash-xxh3", "arcstr", "chrono", "ordered-float"] }
 tarpc = { version = "0.33.0", features = ["full"] }
@@ -76,15 +75,17 @@ rlimit = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 ptr_meta = "0.2.0"
 pipeline_types = { path = "../pipeline-types" }
-io-uring = "0.6.3"
+sysinfo = "0.30.5"
+libc = "0.2.153"
+static_assertions = "1.1.0"
 
 [dependencies.time]
 version = "0.3.20"
 features = ["formatting", "macros", "serde", "serde-human-readable"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2.150"
 nix = { version = "0.27.1", features = ["uio"] }
+io-uring = "0.6.3"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/dbsp/benches/path.rs
+++ b/crates/dbsp/benches/path.rs
@@ -127,7 +127,8 @@ fn main() {
         //fs::write("path.dot", graph.to_dot()).unwrap();
 
         circuit.step().unwrap();
-    });
+    })
+    .expect("runtime initialization should succeed");
 
     hruntime.join().unwrap();
 }

--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -1,0 +1,308 @@
+//! Logic to manage persistent checkpoints for a circuit.
+
+use std::collections::{HashSet, VecDeque};
+use std::fs;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use rkyv::{Archive, Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::Error;
+
+/// Holds meta-data about a checkpoint that was taken for persistent storage
+/// and recovery of a circuit's state.
+#[derive(Debug, Clone, Serialize, Deserialize, Archive)]
+pub struct CheckpointMetadata {
+    /// A unique identifier for the given checkpoint.
+    ///
+    /// This is used to identify the checkpoint in the file-system hierarchy.
+    pub uuid: Uuid,
+    /// An optional name for the checkpoint.
+    pub identifier: Option<String>,
+    /// Fingerprint of the circuit at the time of the checkpoint.
+    pub fingerprint: u64,
+    /// Which `step` the circuit was at when the checkpoint was created.
+    pub step_id: u64,
+}
+
+impl CheckpointMetadata {
+    pub fn new(uuid: Uuid, identifier: Option<String>, fingerprint: u64, step_id: u64) -> Self {
+        CheckpointMetadata {
+            uuid,
+            identifier,
+            fingerprint,
+            step_id,
+        }
+    }
+}
+
+/// A "checkpointer" is responsible for the creation, and removal of
+/// checkpoints for a circuit.
+///
+/// It handles list of available checkpoints, and the files associated
+/// with each checkpoint.
+#[derive(Debug)]
+pub(crate) struct Checkpointer {
+    storage_path: PathBuf,
+    checkpoint_list: VecDeque<CheckpointMetadata>,
+}
+
+impl Checkpointer {
+    /// We keep at least this many checkpoints around.
+    pub(super) const MIN_CHECKPOINT_THRESHOLD: usize = 2;
+    /// Name of the checkpoint list file.
+    ///
+    /// File will be stored inside the runtime storage directory with this
+    /// name.
+    const CHECKPOINT_FILE_NAME: &'static str = "checkpoints.feldera";
+    /// A slice of all file-extension the system can create.
+    const DBSP_FILE_EXTENSION: &'static [&'static str] = &["mut", "feldera"];
+
+    pub fn new(storage_path: PathBuf) -> Self {
+        let checkpoint_list =
+            Self::try_read_checkpoints_from_file(&storage_path).unwrap_or_else(|_| {
+                panic!(
+                    "The checkpoint file in '{}' should be valid",
+                    storage_path.display()
+                )
+            });
+
+        Checkpointer {
+            storage_path,
+            checkpoint_list,
+        }
+    }
+
+    /// Remove unexpected/leftover files from a previous run in the storage
+    /// directory.
+    pub(super) fn gc_startup(&self) -> Result<(), Error> {
+        if self.checkpoint_list.is_empty() {
+            // This is a safety measure we take to ensure that we don't
+            // accidentally remove files just in case we fail to read the checkpoint
+            // file. We don't remove anything.
+            return Ok(());
+        }
+
+        // Collect all directories and files still referenced by a checkpoint
+        let mut in_use_paths: HashSet<PathBuf> = HashSet::new();
+        in_use_paths.insert(self.storage_path.join(Checkpointer::CHECKPOINT_FILE_NAME));
+        for cpm in self.checkpoint_list.iter() {
+            in_use_paths.insert(self.storage_path.join(cpm.uuid.to_string()));
+            let batches = self
+                .gather_batches_for_checkpoint(cpm)
+                .expect("Batches for a checkpoint should be discoverable");
+            for batch in batches {
+                in_use_paths.insert(self.storage_path.join(batch));
+            }
+        }
+
+        // Collect everything found in the storage directory
+        let mut all_paths: HashSet<PathBuf> = HashSet::new();
+        let files = fs::read_dir(&self.storage_path)?;
+        for file in files {
+            let file = file?;
+            let path = file.path();
+            all_paths.insert(path);
+        }
+
+        // Remove everything that is not referenced by a checkpoint
+        let to_remove = all_paths.difference(&in_use_paths);
+        for path in to_remove {
+            if Checkpointer::DBSP_FILE_EXTENSION.contains(
+                &path
+                    .extension()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default(),
+            ) || path.is_dir()
+            {
+                if path.is_dir() {
+                    log::debug!("Removing unused directory '{}'", path.display());
+                    fs::remove_dir_all(path)?;
+                } else {
+                    match fs::remove_file(path) {
+                        Ok(_) => {
+                            log::debug!("Removed unused file '{}'", path.display());
+                        }
+                        Err(e) => {
+                            log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", path.display(), e);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn create_checkpoint_dir(&self, uuid: Uuid) -> Result<(), Error> {
+        let checkpoint_dir = self.storage_path.join(uuid.to_string());
+        create_dir_all(checkpoint_dir)?;
+        Ok(())
+    }
+
+    pub(super) fn commit(
+        &mut self,
+        uuid: Uuid,
+        identifier: Option<String>,
+        fingerprint: u64,
+        step_id: u64,
+    ) -> Result<CheckpointMetadata, Error> {
+        let md = CheckpointMetadata {
+            uuid,
+            identifier,
+            fingerprint,
+            step_id,
+        };
+        self.checkpoint_list.push_back(md.clone());
+        self.update_checkpoint_file()?;
+        Ok(md)
+    }
+
+    /// List all currently available checkpoints.
+    pub(super) fn list_checkpoints(&mut self) -> Result<Vec<CheckpointMetadata>, Error> {
+        Ok(self.checkpoint_list.clone().into())
+    }
+
+    fn try_read_checkpoints_from_file<P: AsRef<Path>>(
+        storage_path: P,
+    ) -> Result<VecDeque<CheckpointMetadata>, Error> {
+        let checkpoint_file_path = storage_path
+            .as_ref()
+            .to_path_buf()
+            .join(Self::CHECKPOINT_FILE_NAME);
+        if !checkpoint_file_path.exists() {
+            return Ok(VecDeque::new());
+        }
+        let content = fs::read(checkpoint_file_path)?;
+        let archived = unsafe { rkyv::archived_root::<VecDeque<CheckpointMetadata>>(&content) };
+        let checkpoint_list: VecDeque<CheckpointMetadata> =
+            archived.deserialize(&mut rkyv::Infallible).unwrap();
+        Ok(checkpoint_list)
+    }
+
+    pub(super) fn gather_batches_for_checkpoint(
+        &self,
+        cpm: &CheckpointMetadata,
+    ) -> Result<HashSet<String>, Error> {
+        assert_ne!(cpm.uuid, Uuid::nil());
+        let checkpoint_dir = self.storage_path.join(cpm.uuid.to_string());
+        assert!(
+            checkpoint_dir.exists(),
+            "Checkpoint directory does not exist"
+        );
+
+        let mut batch_files_in_commit: HashSet<String> = HashSet::new();
+        let files = fs::read_dir(&checkpoint_dir)?;
+        for file in files {
+            let file = file?;
+            let path = file.path();
+            let file_name = path.file_name().unwrap().to_string_lossy();
+
+            if file_name.starts_with("pspine-batches") {
+                let content = fs::read(file.path())?;
+                let archived = rkyv::check_archived_root::<Vec<String>>(&content).unwrap();
+                for batch in archived.iter() {
+                    let batch_path = self.storage_path.join(batch.to_string());
+                    if batch_path.exists() {
+                        batch_files_in_commit.insert(batch.to_string());
+                    }
+                }
+            }
+        }
+
+        Ok(batch_files_in_commit)
+    }
+
+    fn update_checkpoint_file(&self) -> Result<(), Error> {
+        let checkpoint_file =
+            self.storage_path
+                .join(format!("{}{}", Self::CHECKPOINT_FILE_NAME, ".mut"));
+
+        // write checkpoint list to a file:
+        let as_bytes = crate::storage::file::to_bytes(&self.checkpoint_list)
+            .expect("failed to serialize checkpoint-list data");
+        let mut f = File::create(&checkpoint_file)?;
+        f.write_all(as_bytes.as_slice())?;
+        f.sync_all()?;
+        fs::rename(&checkpoint_file, checkpoint_file.with_extension(""))?;
+
+        Ok(())
+    }
+
+    /// Removes all the files in `files` from the storage base directory.
+    fn remove_batch_files<P: AsRef<Path>>(&self, files: &Vec<P>) -> Result<(), Error> {
+        for file in files {
+            assert!(file.as_ref().is_file());
+            assert!(
+                file.as_ref().starts_with(&self.storage_path),
+                "File {} is not in the storage directory",
+                file.as_ref().display()
+            );
+            match fs::remove_file(file) {
+                Ok(_) => {
+                    log::debug!("Removed file {}", file.as_ref().display());
+                }
+                Err(e) => {
+                    log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", file.as_ref().display(), e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Removes all meta-data files associated with the checkpoint given by
+    /// `cpm` by removing the folder associated with the checkpoint.
+    fn remove_checkpoint_dir(&self, cpm: &CheckpointMetadata) -> Result<(), Error> {
+        assert_ne!(cpm.uuid, Uuid::nil());
+        let checkpoint_dir = self.storage_path.join(cpm.uuid.to_string());
+        if !checkpoint_dir.exists() {
+            log::warn!(
+                "Tried to remove a checkpoint directory '{}' that doesn't exist.",
+                checkpoint_dir.display()
+            );
+            return Ok(());
+        }
+        fs::remove_dir_all(checkpoint_dir)?;
+        Ok(())
+    }
+
+    /// Remove the oldest checkpoint from the list.
+    ///
+    /// # Returns
+    /// - Metadata of the removed checkpoint, if there are more than
+    ///   `MIN_CHECKPOINT_THRESHOLD`
+    /// - None otherwise.
+    pub fn gc_checkpoint(&mut self) -> Result<Option<CheckpointMetadata>, Error> {
+        // Ensures that we can unwrap the call to pop_front, and front later:
+        static_assertions::const_assert!(Checkpointer::MIN_CHECKPOINT_THRESHOLD >= 2);
+        if self.checkpoint_list.len() > Self::MIN_CHECKPOINT_THRESHOLD {
+            let cp_to_remove = self.checkpoint_list.pop_front().unwrap();
+            let next_in_line = self.checkpoint_list.front().unwrap();
+
+            // Update the checkpoint list file, we do this first intentionally, in case
+            // later operations fail we don't want the checkpoint list to
+            // contain a checkpoint that only has part of the files.
+            //
+            // If any of the later operations fail, restarting the circuit will try
+            // to remove the checkpoint files again (see also [`Self::gc_startup`]).
+            self.update_checkpoint_file()?;
+
+            let potentially_remove = self.gather_batches_for_checkpoint(&cp_to_remove)?;
+            let need_to_keep = self.gather_batches_for_checkpoint(next_in_line)?;
+            let to_remove = potentially_remove
+                .difference(&need_to_keep)
+                .map(PathBuf::from)
+                .collect::<Vec<_>>();
+
+            self.remove_batch_files(&to_remove)?;
+            self.remove_checkpoint_dir(&cp_to_remove)?;
+
+            Ok(Some(cp_to_remove))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/dbsp/src/circuit/fingerprinter.rs
+++ b/crates/dbsp/src/circuit/fingerprinter.rs
@@ -1,0 +1,35 @@
+//! Fingerprinter for circuits.
+//!
+//! Based on the FNV-1a hash function.
+//! `std::hash::DefaultHasher` is not used because it is not stable beyond the
+//! current rust release.
+
+pub struct Fingerprinter {
+    // The fingerprint of the circuit.
+    hash: u64,
+}
+
+impl Default for Fingerprinter {
+    fn default() -> Self {
+        Self {
+            hash: Self::FNV_OFFSET_BASIS,
+        }
+    }
+}
+
+impl Fingerprinter {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    pub fn hash(&mut self, key: &str) -> u64 {
+        for byte in key.bytes() {
+            self.hash ^= byte as u64;
+            self.hash = self.hash.wrapping_mul(Fingerprinter::FNV_PRIME);
+        }
+        self.hash
+    }
+
+    pub fn finish(self) -> u64 {
+        self.hash
+    }
+}

--- a/crates/dbsp/src/circuit/mod.rs
+++ b/crates/dbsp/src/circuit/mod.rs
@@ -22,7 +22,9 @@ pub(crate) mod runtime;
 #[macro_use]
 pub mod metadata;
 pub mod cache;
+mod checkpointer;
 pub mod circuit_builder;
+mod fingerprinter;
 pub mod operator_traits;
 pub mod schedule;
 pub mod trace;

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -9,6 +9,7 @@ use crate::circuit::{
 };
 use crate::Error;
 use std::borrow::Cow;
+use uuid::Uuid;
 
 /// Minimal requirements for values exchanged by operators.
 pub trait Data: Clone + 'static {}
@@ -199,7 +200,7 @@ pub trait Operator: 'static {
     /// Instructors operator to checkpoint its state to persistent storage.
     ///
     /// In most cases (except for traces) this method is a no-op.
-    fn commit(&self, _cid: u64) -> Result<(), Error> {
+    fn commit(&self, _cid: Uuid) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/crates/dbsp/src/dynamic/mod.rs
+++ b/crates/dbsp/src/dynamic/mod.rs
@@ -127,7 +127,7 @@ mod lean_vec;
 mod option;
 pub mod pair;
 mod pairs;
-mod rkyv;
+pub(crate) mod rkyv;
 mod set;
 mod vec;
 mod weight;

--- a/crates/dbsp/src/monitor/mod.rs
+++ b/crates/dbsp/src/monitor/mod.rs
@@ -395,7 +395,6 @@ impl TraceMonitorInternal {
     }
 
     fn scheduler_event(&mut self, event: &SchedulerEvent) -> Result<(), TraceError> {
-        // eprintln!("scheduler event: {}", event);
         if !self.running() {
             return Err(TraceError::InvalidEvent(Cow::from(
                 "scheduler event received after circuit execution has terminated",

--- a/crates/dbsp/src/operator/communication/exchange.rs
+++ b/crates/dbsp/src/operator/communication/exchange.rs
@@ -763,7 +763,7 @@ where
 ///     for _ in 1..ROUNDS {
 ///         circuit.step();
 ///     }
-/// });
+/// }).expect("failed to start runtime");
 ///
 /// hruntime.join().unwrap();
 /// # }
@@ -1089,7 +1089,8 @@ mod tests {
 
                 assert_eq!(input_data, output_data);
             }
-        });
+        })
+        .expect("failed to start runtime");
 
         hruntime.join().unwrap();
     }
@@ -1157,7 +1158,8 @@ mod tests {
                 for _ in 1..ROUNDS {
                     circuit.step().unwrap();
                 }
-            });
+            })
+            .expect("failed to start runtime");
 
             hruntime.join().unwrap();
         }

--- a/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
@@ -1141,7 +1141,6 @@ mod test {
 
     proptest! {
         #[test]
-        #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_aggregate_test_st(inputs in test_input()) {
             let iterations = inputs.len();
             let circuit = RootCircuit::build(|circuit| aggregate_test_circuit(circuit, inputs)).unwrap().0;
@@ -1152,7 +1151,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_aggregate_test_mt(inputs in test_input(), log_workers in (1..=4)) {
             let workers = 1usize << log_workers;
             let iterations = inputs.len();

--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -294,7 +294,8 @@ mod tests {
             for _ in 0..3 {
                 circuit.step().unwrap();
             }
-        });
+        })
+        .expect("failed to run runtime");
 
         hruntime.join().unwrap();
     }

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -855,7 +855,8 @@ mod test {
     fn do_distinct_inc_test_mt(workers: usize) {
         let hruntime = Runtime::run(workers, || {
             distinct_inc_test();
-        });
+        })
+        .expect("Runtime successful");
 
         hruntime.join().unwrap();
     }

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1366,7 +1366,8 @@ mod test {
     fn do_join_test_mt(workers: usize) {
         let hruntime = Runtime::run(workers, || {
             join_test();
-        });
+        })
+        .expect("failed to run test");
 
         hruntime.join().unwrap();
     }

--- a/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
@@ -1429,7 +1429,6 @@ mod test {
         #![proptest_config(ProptestConfig::with_cases(5))]
 
         #[test]
-        #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_rolling_aggregate_quasi_monotone(trace in input_trace_quasi_monotone(5, 10_000, 2_000, 20, 200)) {
             // 10_000 is an empirically established bound: without GC this test needs >10KB.
             let (mut circuit, input) = partition_rolling_aggregate_circuit(10000, Some(30_000));
@@ -1445,7 +1444,6 @@ mod test {
 
     proptest! {
         #[test]
-        #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_over_range_sparse(trace in input_trace(5, 1_000_000, 10, 10)) {
             let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 
@@ -1458,7 +1456,6 @@ mod test {
         }
 
         #[test]
-        #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_over_range_dense(trace in input_trace(5, 500, 25, 10)) {
             let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 

--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -29,7 +29,7 @@ pub struct Profiler {
 }
 
 /// Runtime profile of an individual DBSP worker thread.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct WorkerProfile {
     metadata: HashMap<GlobalNodeId, OperatorMeta>,
 }

--- a/crates/dbsp/src/storage/backend/memory_impl.rs
+++ b/crates/dbsp/src/storage/backend/memory_impl.rs
@@ -99,12 +99,27 @@ impl Storage for MemoryBackend {
         Ok(FileHandle(file_counter))
     }
 
+    fn open(&self, name: &Path) -> Result<ImmutableFileHandle, StorageError> {
+        let files = self.files.read().unwrap();
+        let file_id = files
+            .iter()
+            .find(|(_, fm)| fm.name == name)
+            .map(|(id, _)| *id)
+            .ok_or(StorageError::StdIo(IoError::from(ErrorKind::NotFound)))?;
+
+        Ok(ImmutableFileHandle(file_id))
+    }
+
     fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
         self.delete_inner(fd.0)
     }
 
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
         self.delete_inner(fd.0)
+    }
+
+    fn base(&self) -> &Path {
+        todo!()
     }
 
     fn write_block(

--- a/crates/dbsp/src/storage/backend/tests.rs
+++ b/crates/dbsp/src/storage/backend/tests.rs
@@ -107,7 +107,6 @@ impl<const ALLOW_OVERWRITE: bool> Clone for InMemoryBackend<ALLOW_OVERWRITE> {
         }
     }
 }
-
 fn insert_slice_at_offset(
     vec: &Vec<Option<u8>>,
     offset: usize,
@@ -145,6 +144,10 @@ impl<const ALLOW_OVERWRITE: bool> Storage for InMemoryBackend<ALLOW_OVERWRITE> {
         Ok(FileHandle(file_counter))
     }
 
+    fn open(&self, _name: &Path) -> Result<ImmutableFileHandle, StorageError> {
+        unimplemented!()
+    }
+
     fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
         self.immutable_files.borrow_mut().remove(&fd.0);
         Ok(())
@@ -153,6 +156,10 @@ impl<const ALLOW_OVERWRITE: bool> Storage for InMemoryBackend<ALLOW_OVERWRITE> {
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
         self.files.borrow_mut().remove(&fd.0);
         Ok(())
+    }
+
+    fn base(&self) -> &Path {
+        Path::new("")
     }
 
     fn write_block(

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -281,6 +281,9 @@ where
     fn create_named(&self, name: &Path) -> Result<FileHandle, StorageError> {
         self.backend.create_named(name)
     }
+    fn open(&self, name: &Path) -> Result<ImmutableFileHandle, StorageError> {
+        self.backend.open(name)
+    }
     fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
         self.inner.borrow_mut().delete_file((&fd).into());
         self.backend.delete(fd)
@@ -288,6 +291,15 @@ where
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
         self.inner.borrow_mut().delete_file((&fd).into());
         self.backend.delete_mut(fd)
+    }
+
+    fn evict(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
+        self.inner.borrow_mut().delete_file((&fd).into());
+        Ok(())
+    }
+
+    fn base(&self) -> &Path {
+        self.backend.base()
     }
 
     fn write_block(

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -13,6 +13,7 @@ use std::{
 use crc32c::crc32c;
 use metrics::counter;
 
+use crate::storage::file::reader::{CorruptionError, Error};
 use crate::{
     storage::backend::{
         metrics::{BUFFER_CACHE_HIT, BUFFER_CACHE_MISS},
@@ -20,8 +21,6 @@ use crate::{
     },
     storage::buffer_cache::FBuf,
 };
-
-use crate::storage::file::reader::{CorruptionError, Error};
 
 /// A key for the block cache.
 ///

--- a/crates/dbsp/src/storage/dirlock/mod.rs
+++ b/crates/dbsp/src/storage/dirlock/mod.rs
@@ -1,0 +1,169 @@
+//! A simple PID-based locking mechanism.
+//!
+//! Makes sure we don't accidentally run multiple instances of the program
+//! using the same data directory.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Error as IoError, ErrorKind, Read, Write};
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use sysinfo::{Pid, System};
+
+use crate::storage::backend::StorageError;
+
+#[cfg(test)]
+mod test;
+
+/// Check whether a process exists, used to determine whether a pid file is
+/// stale.
+fn process_exists(pid: u32) -> bool {
+    let s = System::new_all();
+    s.process(Pid::from(pid as usize)).is_some()
+}
+
+/// An instance of a PID file.
+///
+/// The PID file is removed from the FS when the instance is dropped.
+#[derive(Debug)]
+pub struct LockedDirectory {
+    base: PathBuf,
+    pid: Pid,
+}
+
+impl Drop for LockedDirectory {
+    fn drop(&mut self) {
+        let pid_file = self.base.join(LockedDirectory::LOCKFILE_NAME);
+        if pid_file.exists() {
+            log::trace!("Removing pidfile: {}", pid_file.display());
+            std::fs::remove_file(&pid_file).unwrap();
+        }
+    }
+}
+
+/// A guard that holds an exclusive lock on a file.
+///
+/// The lock is dropped once the guard is dropped.
+/// This avoids concurrency issues when two pipelines are started at the same
+/// time.
+struct FlockGuard(File);
+
+impl FlockGuard {
+    fn new(file: File) -> Result<FlockGuard, IoError> {
+        #[cfg(unix)]
+        {
+            let r = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if r != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(FlockGuard(file))
+    }
+}
+
+impl Drop for FlockGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            unsafe {
+                libc::flock(self.0.as_raw_fd(), libc::LOCK_UN);
+            }
+        }
+    }
+}
+
+impl LockedDirectory {
+    const LOCKFILE_NAME: &'static str = "feldera.pidlock";
+
+    fn with_pid<P: AsRef<Path>>(base_path: P, pid: Pid) -> Result<LockedDirectory, StorageError> {
+        let pid_str = pid.to_string();
+        let pid_file = base_path.as_ref().join(LockedDirectory::LOCKFILE_NAME);
+
+        let mut guard = if pid_file.exists() {
+            // we set create(true) for both branches, to avoid concurrency issues when two
+            // pipelines are started at the same time.
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&pid_file)?;
+            let mut guard = FlockGuard::new(file).map_err(|e: IoError| {
+                if e.kind() == ErrorKind::WouldBlock {
+                    StorageError::StorageLocked(0, pid_file.clone())
+                } else {
+                    e.into()
+                }
+            })?;
+
+            // From here on we have a lock on the file:
+            let mut contents = String::new();
+            guard.0.read_to_string(&mut contents)?;
+
+            let old_pid = contents.trim().parse::<u32>();
+            if let Ok(old_pid) = old_pid {
+                if process_exists(old_pid) {
+                    return Err(StorageError::StorageLocked(old_pid, pid_file));
+                } else if old_pid == pid.as_u32() {
+                    // The pidfile is ours, just leave it as is.
+                } else {
+                    // The process doesn't exist, so we can safely overwrite the pidfile.
+                    log::debug!("Found stale pidfile: {}", pid_file.display());
+                }
+            } else {
+                // If the pidfile is corrupt, we won't take ownership of the storage dir until
+                // the user fixes it.
+                log::error!(
+                    "Invalid pidfile contents: '{}' in {}, pipeline refused to take ownership of storage dir.",
+                    contents,
+                    pid_file.display(),
+                );
+                return Err(StorageError::StorageLocked(0, pid_file));
+            }
+
+            guard
+        } else {
+            FlockGuard::new(
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&pid_file)?,
+            )?
+        };
+        guard.0.write_all(pid_str.as_bytes())?;
+
+        Ok(LockedDirectory {
+            base: base_path.as_ref().into(),
+            pid,
+        })
+    }
+
+    /// Attempts to create a new pidfile in the `base_path` directory,
+    /// returning an error if the file was already created by a different
+    /// process (and that process is still alive).
+    ///
+    /// # Arguments
+    /// - `base_path`: The directory in which to create the pidfile. It must
+    ///   already exist.
+    ///
+    /// # Panics
+    /// - If the current process's PID cannot be determined.
+    pub fn new<P: AsRef<Path>>(base_path: P) -> Result<LockedDirectory, StorageError> {
+        let pid = sysinfo::get_current_pid().expect("failed to get current pid");
+        if !base_path.as_ref().exists() {
+            return Err(StorageError::StorageLocationNotFound);
+        }
+        Self::with_pid(base_path, pid)
+    }
+
+    /// Returns the PID of the process that created the pidfile.
+    pub fn pid(&self) -> Pid {
+        self.pid
+    }
+
+    /// Returns the path to the directory in which the pidfile was created.
+    pub fn base(&self) -> &Path {
+        self.base.as_path()
+    }
+}

--- a/crates/dbsp/src/storage/dirlock/test.rs
+++ b/crates/dbsp/src/storage/dirlock/test.rs
@@ -1,0 +1,37 @@
+use super::LockedDirectory;
+use crate::storage::backend::StorageError::StorageLocked;
+use std::fs::File;
+use std::io::Read;
+use sysinfo::Pid;
+
+#[test]
+fn test_pidlock_lifecycle() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let pidfile = LockedDirectory::new(temp_dir.path()).unwrap();
+    let pidfile_path = temp_dir.path().join(LockedDirectory::LOCKFILE_NAME);
+    assert!(pidfile_path.exists());
+
+    let mut file = File::open(&pidfile_path).unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, format!("{}", std::process::id()));
+
+    drop(pidfile);
+    assert!(!pidfile_path.exists());
+}
+
+#[test]
+fn test_pidlock_locks() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let pidfile = LockedDirectory::new(temp_dir.path()).unwrap();
+    let r = LockedDirectory::with_pid(temp_dir.path(), Pid::from(0));
+    assert_eq!(
+        r.unwrap_err(),
+        StorageLocked(
+            std::process::id(),
+            temp_dir.path().join(LockedDirectory::LOCKFILE_NAME)
+        )
+    );
+    drop(pidfile);
+    LockedDirectory::with_pid(temp_dir.path(), Pid::from(0)).expect("other PID can take over");
+}

--- a/crates/dbsp/src/storage/file/mod.rs
+++ b/crates/dbsp/src/storage/file/mod.rs
@@ -146,7 +146,7 @@ where
     /// are unknown.
     ///
     /// See documentation of [`AnyFactories`].
-    fn any_factories(&self) -> AnyFactories {
+    pub(crate) fn any_factories(&self) -> AnyFactories {
         AnyFactories {
             key_factory: Arc::new(self.key_factory),
             item_factory: Arc::new(self.item_factory),

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -1224,7 +1224,6 @@ where
         let storage = self.storage().clone();
         let any_factories0 = self.factories0.any_factories();
         let any_factories1 = self.factories1.any_factories();
-
         let (file_handle, path) = self.close()?;
         Reader::new(
             &[&any_factories0, &any_factories1],

--- a/crates/dbsp/src/storage/mod.rs
+++ b/crates/dbsp/src/storage/mod.rs
@@ -5,6 +5,7 @@
 //! buffering, and an upper layer, [mod@file], that implements data access.
 pub mod backend;
 pub mod buffer_cache;
+pub mod dirlock;
 pub mod file;
 #[cfg(test)]
 mod test;

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -3,6 +3,7 @@ use crate::{
     dynamic::{
         DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait, WeightTraitTyped,
     },
+    storage::file::reader::Error as ReaderError,
     time::AntichainRef,
     trace::{
         layers::OrdOffset,
@@ -25,6 +26,7 @@ use dyn_clone::clone_box;
 use rand::Rng;
 use rkyv::{ser::Serializer, Archive, Archived, Deserialize, Fallible, Serialize};
 use size_of::SizeOf;
+use std::path::Path;
 use std::{
     cmp::Ordering,
     fmt::{self, Debug},
@@ -416,6 +418,13 @@ where
             Inner::Vec(vec) => vec.persistent_id(),
             Inner::File(file) => file.persistent_id(),
         }
+    }
+
+    fn from_path(factories: &Self::Factories, path: &Path) -> Result<Self, ReaderError> {
+        Ok(FallbackIndexedWSet {
+            factories: factories.clone(),
+            inner: Inner::File(FileIndexedWSet::from_path(&factories.file, path)?),
+        })
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -26,7 +26,7 @@ use size_of::SizeOf;
 use std::{
     cmp::{min, Ordering},
     fmt::{self, Debug},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 pub struct FileKeyBatchFactories<K, T, R>
@@ -323,6 +323,20 @@ where
 
     fn persistent_id(&self) -> Option<PathBuf> {
         Some(self.file.path())
+    }
+
+    fn from_path(factories: &Self::Factories, path: &Path) -> Result<Self, ReaderError> {
+        let any_factory0 = factories.factories0.any_factories();
+        let any_factory1 = factories.factories1.any_factories();
+        let file = Reader::open(&[&any_factory0, &any_factory1], &Runtime::storage(), path)?;
+
+        Ok(Self {
+            factories: factories.clone(),
+            file,
+            lower_bound: 0,
+            lower: Antichain::new(),
+            upper: Antichain::new(),
+        })
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -25,11 +25,11 @@ use rand::{seq::index::sample, Rng};
 use rkyv::{Archive, Deserialize, Serialize};
 use size_of::SizeOf;
 use std::{
-    cmp::min,
+    cmp::{min, Ordering},
     fmt::{self, Debug},
     ops::{Add, AddAssign, Neg},
+    path::{Path, PathBuf},
 };
-use std::{cmp::Ordering, path::PathBuf};
 
 pub struct FileWSetFactories<K, R>
 where
@@ -452,6 +452,17 @@ where
 
     fn persistent_id(&self) -> Option<PathBuf> {
         Some(self.file.path())
+    }
+
+    fn from_path(factories: &Self::Factories, path: &Path) -> Result<Self, ReaderError> {
+        let any_factory0 = factories.file_factories.any_factories();
+        let file = Reader::open(&[&any_factory0], &Runtime::storage(), path)?;
+
+        Ok(Self {
+            factories: factories.clone(),
+            file,
+            lower_bound: 0,
+        })
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -18,6 +18,7 @@ use crate::{
 use rand::Rng;
 use rkyv::{Archive, Deserialize, Serialize};
 use size_of::SizeOf;
+use std::path::PathBuf;
 use std::{
     fmt::{self, Debug, Display},
     ops::DerefMut,
@@ -328,6 +329,10 @@ where
     type Batcher = MergeBatcher<Self>;
     type Builder = OrdKeyBuilder<K, T, R, O>;
     type Merger = OrdKeyMerger<K, T, R, O>;
+
+    fn persistent_id(&self) -> Option<PathBuf> {
+        unimplemented!()
+    }
 
     /*fn from_keys(time: Self::Time, keys: Vec<(Self::Key, Self::R)>) -> Self {
         Self::from_tuples(time, keys)

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -19,6 +19,7 @@ use crate::{
 use rand::Rng;
 use rkyv::{Archive, Deserialize, Serialize};
 use size_of::SizeOf;
+use std::path::PathBuf;
 use std::{
     fmt::{self, Debug, Display, Formatter},
     ops::DerefMut,
@@ -398,6 +399,10 @@ where
     type Batcher = MergeBatcher<Self>;
     type Builder = OrdValBuilder<K, V, T, R, O>;
     type Merger = OrdValMerger<K, V, T, R, O>;
+
+    fn persistent_id(&self) -> Option<PathBuf> {
+        unimplemented!()
+    }
 
     /*fn from_keys(time: Self::Time, keys: Vec<(Self::Key, Self::R)>) -> Self
     where

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -14,7 +14,7 @@ use crate::{
         Merger, Trace,
     },
     utils::VecExt,
-    DBData, DBWeight, NumEntries, Timestamp,
+    DBData, DBWeight, Error, NumEntries, Timestamp,
 };
 use dyn_clone::clone_box;
 use rand::{seq::IteratorRandom, thread_rng, Rng, SeedableRng};
@@ -27,6 +27,7 @@ use std::{
     fmt::{self, Debug},
     marker::PhantomData,
 };
+use uuid::Uuid;
 
 pub struct TestBatchFactories<K, V, T, R>
 where
@@ -1253,6 +1254,14 @@ where
         }
     }
 
+    fn from_commit_id<S: AsRef<str>>(
+        _factories: &Self::Factories,
+        _cid: Uuid,
+        _persistent_id: S,
+    ) -> Self {
+        todo!()
+    }
+
     fn recede_to(&mut self, frontier: &Self::Time) {
         Batch::recede_to(self, frontier);
     }
@@ -1303,6 +1312,10 @@ where
 
     fn value_filter(&self) -> &Option<Filter<Self::Val>> {
         &self.value_filter
+    }
+
+    fn commit(&self, _cid: Uuid) -> Result<(), Error> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
This adds a checkpointing API to the circuit runtime to take checkpoints and resume a circuit from a previously recorded checkpoint.

The way it works is every circuit has a FIFO queue of checkpoints.
There are two operations, to create a checkpoint and to delete the earliest checkpoint.
Each checkpoint consists of remembering the batch-files for every spine. This is done by creating a set of meta-data files in a checkpoint specific directory.
Removing a checkpoint then consists of garbage collecting the set of batch-files no longer used by any (still valid, in-use) checkpoints.
    
 It also includes some additional features for robustness:    
 - Adds a functionality for a circuit to lock the storage directory.
 - Adds a functionality to "fingerprint" a circuit and reject resuming
      in case the circuit has changed.

