### PR TITLE
dbsp: Avoid panicking within a panic handler.

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -274,8 +274,10 @@ fn panic_hook(panic_info: &PanicInfo<'_>, default_panic_hook: &dyn Fn(&PanicInfo
     default_panic_hook(panic_info);
 
     RUNTIME.with(|runtime| {
-        if let Some(runtime) = runtime.borrow().clone() {
-            runtime.panic(panic_info)
+        if let Ok(runtime) = runtime.try_borrow() {
+            if let Some(runtime) = runtime.as_ref() {
+                runtime.panic(panic_info);
+            }
         }
     })
 }


### PR DESCRIPTION
I've managed to write code with bugs such that the `runtime.borrow()` in the `panic_hook` triggered a nested panic because the runtime was already borrowed.  This avoids the problem.  This seems better than having my tests hard-abort without useful debug output.

Is this a user-visible change (yes/no): no