### PR TITLE
dbsp: Rename `*ZSet` to `*WSet` in file-based and fallback implementa…

### DIFF
--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -104,9 +104,9 @@ pub use operator::{
 };
 pub use trace::{DBData, DBWeight};
 pub use typed_batch::{
-    Batch, BatchReader, FallbackZSet, FileIndexedWSet, FileIndexedZSet, FileKeyBatch, FileValBatch,
-    FileWSet, FileZSet, IndexedZSet, OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, Trace,
-    TypedBox, ZSet,
+    Batch, BatchReader, FallbackWSet, FallbackZSet, FileIndexedWSet, FileIndexedZSet, FileKeyBatch,
+    FileValBatch, FileWSet, FileZSet, IndexedZSet, OrdIndexedWSet, OrdIndexedZSet, OrdWSet,
+    OrdZSet, Trace, TypedBox, ZSet,
 };
 
 #[cfg(doc)]

--- a/crates/dbsp/src/operator/dynamic/filter_map.rs
+++ b/crates/dbsp/src/operator/dynamic/filter_map.rs
@@ -1,7 +1,7 @@
 //! Filter and transform data record-by-record.
 
-use crate::trace::ord::fallback::indexed_zset::FallbackIndexedZSet;
-use crate::trace::ord::fallback::zset::FallbackZSet;
+use crate::trace::ord::fallback::indexed_wset::FallbackIndexedWSet;
+use crate::trace::ord::fallback::wset::FallbackWSet;
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
@@ -115,7 +115,7 @@ impl<C: Circuit, B: DynFilterMap> Stream<C, B> {
     }
 }
 
-// This impl for VecZSet is identical to the one for FallbackZSet below.  There
+// This impl for VecZSet is identical to the one for FallbackWSet below.  There
 // doesn't seem to be a good way to avoid the code duplication short of a macro.
 impl<K, R> DynFilterMap for OrdWSet<K, R>
 where
@@ -233,7 +233,7 @@ where
     }
 }
 
-impl<K, R> DynFilterMap for FallbackZSet<K, R>
+impl<K, R> DynFilterMap for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -290,7 +290,7 @@ where
     }
 }
 
-impl<K, V, R> DynFilterMap for FallbackIndexedZSet<K, V, R>
+impl<K, V, R> DynFilterMap for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,

--- a/crates/dbsp/src/operator/dynamic/group/topk.rs
+++ b/crates/dbsp/src/operator/dynamic/group/topk.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     dynamic::{DataTrait, DynUnit, Erase, Factory, WeightTrait},
     trace::{
-        ord::fallback::indexed_zset::FallbackIndexedZSetFactories, BatchReader,
+        ord::fallback::indexed_wset::FallbackIndexedWSetFactories, BatchReader,
         BatchReaderFactories, OrdIndexedWSetFactories, Spillable,
     },
     DBData, DBWeight, DynZWeight, RootCircuit, Stream, ZWeight,
@@ -48,7 +48,7 @@ where
     R: WeightTrait + ?Sized,
 {
     input_factories: OrdIndexedWSetFactories<K, V, R>,
-    stored_factories: FallbackIndexedZSetFactories<K, V2, R>,
+    stored_factories: FallbackIndexedWSetFactories<K, V2, R>,
     inner_factories: OrdIndexedWSetFactories<K, V2, R>,
 }
 
@@ -81,7 +81,7 @@ where
     OV: DataTrait + ?Sized,
 {
     inner_factories: OrdIndexedZSetFactories<K, V2>,
-    stored_factories: FallbackIndexedZSetFactories<K, V2, DynZWeight>,
+    stored_factories: FallbackIndexedWSetFactories<K, V2, DynZWeight>,
     output_factories: OrdIndexedZSetFactories<K, OV>,
 }
 

--- a/crates/dbsp/src/operator/dynamic/neighborhood.rs
+++ b/crates/dbsp/src/operator/dynamic/neighborhood.rs
@@ -7,7 +7,7 @@ use crate::{
     declare_trait_object,
     dynamic::{Data, DataTrait, DynDataTyped, DynPair, Erase},
     trace::{
-        ord::fallback::indexed_zset::{FallbackIndexedZSet, FallbackIndexedZSetFactories},
+        ord::fallback::indexed_wset::{FallbackIndexedWSet, FallbackIndexedWSetFactories},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Spillable,
         Spine,
     },
@@ -187,7 +187,7 @@ pub type NeighborhoodDescrStream<K, V> =
 pub struct NeighborhoodFactories<B: IndexedZSetReader + Spillable> {
     input_factories: <B::Spilled as BatchReader>::Factories,
     local_factories: OrdIndexedZSetFactories<B::Key, B::Val>,
-    stored_factories: FallbackIndexedZSetFactories<B::Key, B::Val, DynZWeight>,
+    stored_factories: FallbackIndexedWSetFactories<B::Key, B::Val, DynZWeight>,
     output_factories: <DynNeighborhood<B::Key, B::Val> as BatchReader>::Factories,
 }
 
@@ -285,7 +285,7 @@ where
             // the final neighborhood.
             // TODO: use different workers for different collections.
             let output = self.circuit().add_binary_operator(
-                NeighborhoodNumbered::<Spine<FallbackIndexedZSet<B::Key, B::Val, DynZWeight>>>::new(
+                NeighborhoodNumbered::<Spine<FallbackIndexedWSet<B::Key, B::Val, DynZWeight>>>::new(
                     &factories.output_factories,
                 ),
                 &local_output

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -17,7 +17,7 @@ use crate::{
         trace::{TraceBounds, TraceFeedback},
     },
     trace::{
-        cursor::CursorEmpty, ord::fallback::indexed_zset::FallbackIndexedZSet, BatchReader,
+        cursor::CursorEmpty, ord::fallback::indexed_wset::FallbackIndexedWSet, BatchReader,
         BatchReaderFactories, Builder, Cursor, Spillable, Spine,
     },
     utils::Tup2,
@@ -58,7 +58,7 @@ pub type OrdPartitionedRadixTree<PK, TS, A> =
     OrdIndexedZSet<PK, DynPair<DynPrefix<TS>, DynTreeNode<TS, A>>>;
 
 pub type FilePartitionedRadixTree<PK, TS, A> =
-    FallbackIndexedZSet<PK, DynPair<DynPrefix<TS>, DynTreeNode<TS, A>>, DynZWeight>;
+    FallbackIndexedWSet<PK, DynPair<DynPrefix<TS>, DynTreeNode<TS, A>>, DynZWeight>;
 
 pub type FilePartitionedRadixTreeFactories<PK, TS, A> =
     <FilePartitionedRadixTree<PK, TS, A> as BatchReader>::Factories;

--- a/crates/dbsp/src/operator/filter_map.rs
+++ b/crates/dbsp/src/operator/filter_map.rs
@@ -2,7 +2,7 @@ use crate::{
     dynamic::{DataTrait, Erase, WeightTrait},
     trace::BatchReaderFactories,
     typed_batch::{
-        Batch, BatchReader, DynFallbackIndexedZSet, DynFallbackZSet, DynOrdIndexedWSet, DynOrdWSet,
+        Batch, BatchReader, DynFallbackIndexedWSet, DynFallbackWSet, DynOrdIndexedWSet, DynOrdWSet,
         OrdIndexedWSet, OrdWSet, TypedBatch,
     },
     Circuit, DBData, DBWeight, Stream,
@@ -293,7 +293,7 @@ where
     }
 }
 
-impl<K, DynK, R, DynR> FilterMap for TypedBatch<K, (), R, DynFallbackZSet<DynK, DynR>>
+impl<K, DynK, R, DynR> FilterMap for TypedBatch<K, (), R, DynFallbackWSet<DynK, DynR>>
 where
     K: DBData + Erase<DynK>,
     DynK: DataTrait + ?Sized,
@@ -361,7 +361,7 @@ where
 }
 
 impl<K, DynK, V, DynV, R, DynR> FilterMap
-    for TypedBatch<K, V, R, DynFallbackIndexedZSet<DynK, DynV, DynR>>
+    for TypedBatch<K, V, R, DynFallbackIndexedWSet<DynK, DynV, DynR>>
 where
     K: DBData + Erase<DynK>,
     DynK: DataTrait + ?Sized,

--- a/crates/dbsp/src/time/mod.rs
+++ b/crates/dbsp/src/time/mod.rs
@@ -66,7 +66,7 @@ use crate::{
     algebra::{Lattice, PartialOrder},
     dynamic::{DataTrait, WeightTrait},
     trace::{
-        Batch, FallbackIndexedZSet, FallbackZSet, FileKeyBatch, FileValBatch, OrdIndexedWSet,
+        Batch, FallbackIndexedWSet, FallbackWSet, FileKeyBatch, FileValBatch, OrdIndexedWSet,
         OrdKeyBatch, OrdValBatch, OrdWSet,
     },
     DBData, Scope,
@@ -264,8 +264,8 @@ impl Timestamp for () {
     type MemKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = OrdWSet<K, R>;
 
     type FileValBatch<K: DataTrait + ?Sized, V: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
-        FallbackIndexedZSet<K, V, R>;
-    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FallbackZSet<K, R>;
+        FallbackIndexedWSet<K, V, R>;
+    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FallbackWSet<K, R>;
 
     fn minimum() -> Self {}
     fn advance(&self, _scope: Scope) -> Self {}

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -48,11 +48,11 @@ pub mod spine_fueled;
 pub mod test;
 
 pub use ord::{
-    FallbackIndexedZSet, FallbackIndexedZSetFactories, FallbackZSet, FallbackZSetFactories,
+    FallbackIndexedWSet, FallbackIndexedWSetFactories, FallbackWSet, FallbackWSetFactories,
 };
 pub use ord::{
-    FileIndexedZSet, FileIndexedZSetFactories, FileKeyBatch, FileKeyBatchFactories, FileValBatch,
-    FileValBatchFactories, FileZSet, FileZSetFactories,
+    FileIndexedWSet, FileIndexedWSetFactories, FileKeyBatch, FileKeyBatchFactories, FileValBatch,
+    FileValBatchFactories, FileWSet, FileWSetFactories,
 };
 pub use ord::{
     OrdIndexedWSet, OrdIndexedWSetFactories, OrdKeyBatch, OrdKeyBatchFactories, OrdValBatch,
@@ -378,7 +378,7 @@ where
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Spilled = FallbackIndexedZSet<K, V, R>;
+    type Spilled = FallbackIndexedWSet<K, V, R>;
 }
 
 impl<K, R> Spillable for OrdWSet<K, R>
@@ -386,7 +386,7 @@ where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Spilled = FallbackZSet<K, R>;
+    type Spilled = FallbackWSet<K, R>;
 }
 
 pub trait Stored: BatchReader<Time = ()> {
@@ -400,7 +400,7 @@ pub trait Stored: BatchReader<Time = ()> {
     }
 }
 
-impl<K, V, R> Stored for FallbackIndexedZSet<K, V, R>
+impl<K, V, R> Stored for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -409,7 +409,7 @@ where
     type Unspilled = OrdIndexedWSet<K, V, R>;
 }
 
-impl<K, R> Stored for FallbackZSet<K, R>
+impl<K, R> Stored for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -1,18 +1,23 @@
 use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef, ZRingValue},
     dynamic::{
-        DataTrait, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait,
-        WeightTraitTyped,
+        DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait, WeightTraitTyped,
     },
     time::AntichainRef,
     trace::{
+        layers::OrdOffset,
         ord::{
-            file::zset_batch::{FileZSetBuilder, FileZSetCursor, FileZSetMerger},
+            file::indexed_wset_batch::{
+                FileIndexedWSetBuilder, FileIndexedWSetCursor, FileIndexedWSetMerger,
+            },
             merge_batcher::MergeBatcher,
-            vec::wset_batch::{VecWSetBuilder, VecWSetCursor, VecWSetMerger},
+            vec::indexed_wset_batch::{
+                OrdIndexedWSetMerger, VecIndexedWSetBuilder, VecIndexedWSetCursor,
+            },
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, FileZSet,
-        FileZSetFactories, Filter, Merger, OrdWSet, OrdWSetFactories, WeightedItem,
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, FileIndexedWSet,
+        FileIndexedWSetFactories, Filter, Merger, OrdIndexedWSet, OrdIndexedWSetFactories,
+        WeightedItem,
     },
     DBData, DBWeight, NumEntries, Runtime,
 };
@@ -27,18 +32,20 @@ use std::{
 };
 use std::{ops::Neg, path::PathBuf};
 
-pub struct FallbackZSetFactories<K, R>
+pub struct FallbackIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    file: FileZSetFactories<K, R>,
-    vec: OrdWSetFactories<K, R>,
+    file: FileIndexedWSetFactories<K, V, R>,
+    vec: OrdIndexedWSetFactories<K, V, R>,
 }
 
-impl<K, R> Clone for FallbackZSetFactories<K, R>
+impl<K, V, R> Clone for FallbackIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -49,20 +56,21 @@ where
     }
 }
 
-impl<K, R> BatchReaderFactories<K, DynUnit, (), R> for FallbackZSetFactories<K, R>
+impl<K, V, R> BatchReaderFactories<K, V, (), R> for FallbackIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn new<KType, VType, RType>() -> Self
     where
         KType: DBData + Erase<K>,
-        VType: DBData + Erase<DynUnit>,
+        VType: DBData + Erase<V>,
         RType: DBWeight + Erase<R>,
     {
         Self {
-            file: FileZSetFactories::new::<KType, VType, RType>(),
-            vec: OrdWSetFactories::new::<KType, VType, RType>(),
+            file: FileIndexedWSetFactories::new::<KType, VType, RType>(),
+            vec: OrdIndexedWSetFactories::new::<KType, VType, RType>(),
         }
     }
 
@@ -74,7 +82,7 @@ where
         self.file.keys_factory()
     }
 
-    fn val_factory(&self) -> &'static dyn Factory<DynUnit> {
+    fn val_factory(&self) -> &'static dyn Factory<V> {
         self.file.val_factory()
     }
 
@@ -83,57 +91,59 @@ where
     }
 }
 
-impl<K, R> BatchFactories<K, DynUnit, (), R> for FallbackZSetFactories<K, R>
+impl<K, V, R> BatchFactories<K, V, (), R> for FallbackIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, DynUnit>> {
+    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, V>> {
         self.file.item_factory()
     }
 
-    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, DynUnit, R>> {
+    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, V, R>> {
         self.file.weighted_item_factory()
     }
 
-    fn weighted_items_factory(
-        &self,
-    ) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, DynUnit>, R>> {
+    fn weighted_items_factory(&self) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>> {
         self.file.weighted_items_factory()
     }
 }
 
-pub struct FallbackZSet<K, R>
+pub struct FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackZSetFactories<K, R>,
-    inner: Inner<K, R>,
+    factories: FallbackIndexedWSetFactories<K, V, R>,
+    inner: Inner<K, V, R>,
 }
 
 #[allow(clippy::large_enum_variant)]
-enum Inner<K, R>
+enum Inner<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    Vec(OrdWSet<K, R>),
-    File(FileZSet<K, R>),
+    Vec(OrdIndexedWSet<K, V, R>),
+    File(FileIndexedWSet<K, V, R>),
 }
 
-impl<K, R> Inner<K, R>
+impl<K, V, R> Inner<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn as_file(&self) -> Option<&FileZSet<K, R>> {
+    fn as_file(&self) -> Option<&FileIndexedWSet<K, V, R>> {
         match self {
             Inner::Vec(_vec) => None,
             Inner::File(file) => Some(file),
         }
     }
-    fn as_vec(&self) -> Option<&OrdWSet<K, R>> {
+    fn as_vec(&self) -> Option<&OrdIndexedWSet<K, V, R>> {
         match self {
             Inner::Vec(vec) => Some(vec),
             Inner::File(_file) => None,
@@ -141,9 +151,10 @@ where
     }
 }
 
-impl<K, R> Debug for FallbackZSet<K, R>
+impl<K, V, R> Debug for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -154,9 +165,10 @@ where
     }
 }
 
-impl<K, R> Clone for FallbackZSet<K, R>
+impl<K, V, R> Clone for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -173,11 +185,12 @@ where
 // This is `#[cfg(test)]` only because it would be surprisingly expensive in
 // production.
 #[cfg(test)]
-impl<Other, K, R> PartialEq<Other> for FallbackZSet<K, R>
+impl<Other, K, V, R> PartialEq<Other> for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    Other: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+    Other: BatchReader<Key = K, Val = V, R = R, Time = ()>,
 {
     fn eq(&self, other: &Other) -> bool {
         use crate::trace::eq_batch;
@@ -186,16 +199,18 @@ where
 }
 
 #[cfg(test)]
-impl<K, R> Eq for FallbackZSet<K, R>
+impl<K, V, R> Eq for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
 }
 
-impl<K, R> NumEntries for FallbackZSet<K, R>
+impl<K, V, R> NumEntries for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     const CONST_NUM_ENTRIES: Option<usize> = None;
@@ -215,9 +230,10 @@ where
     }
 }
 
-impl<K, R> NegByRef for FallbackZSet<K, R>
+impl<K, V, R> NegByRef for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
     R::Type: DBWeight + ZRingValue + NegByRef + Erase<R>,
 {
@@ -233,9 +249,10 @@ where
     }
 }
 
-impl<K, R> Neg for FallbackZSet<K, R>
+impl<K, V, R> Neg for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
     R::Type: DBWeight + ZRingValue + NegByRef + Erase<R>,
 {
@@ -247,9 +264,10 @@ where
     }
 }
 
-impl<K, R> Add<Self> for FallbackZSet<K, R>
+impl<K, V, R> Add<Self> for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Output = Self;
@@ -266,9 +284,10 @@ where
     }
 }
 
-impl<K, R> AddAssign<Self> for FallbackZSet<K, R>
+impl<K, V, R> AddAssign<Self> for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -279,9 +298,10 @@ where
     }
 }
 
-impl<K, R> AddAssignByRef for FallbackZSet<K, R>
+impl<K, V, R> AddAssignByRef for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -292,9 +312,10 @@ where
     }
 }
 
-impl<K, R> AddByRef for FallbackZSet<K, R>
+impl<K, V, R> AddByRef for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -303,17 +324,20 @@ where
     }
 }
 
-impl<K, R> BatchReader for FallbackZSet<K, R>
+impl<K, V, R> BatchReader for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Factories = FallbackZSetFactories<K, R>;
+    type Factories = FallbackIndexedWSetFactories<K, V, R>;
     type Key = K;
-    type Val = DynUnit;
+    type Val = V;
     type Time = ();
     type R = R;
-    type Cursor<'s> = FallbackZSetCursor<'s, K, R>;
+    type Cursor<'s> = FallbackIndexedWSetCursor<'s, K, V, R>
+    where
+        V: 's;
 
     fn factories(&self) -> Self::Factories {
         self.factories.clone()
@@ -321,7 +345,7 @@ where
 
     #[inline]
     fn cursor(&self) -> Self::Cursor<'_> {
-        FallbackZSetCursor::new(self)
+        FallbackIndexedWSetCursor::new(self)
     }
 
     #[inline]
@@ -368,17 +392,18 @@ where
     }
 }
 
-impl<K, R> Batch for FallbackZSet<K, R>
+impl<K, V, R> Batch for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Batcher = MergeBatcher<Self>;
-    type Builder = FallbackZSetBuilder<K, R>;
-    type Merger = FallbackZSetMerger<K, R>;
+    type Builder = FallbackIndexedWSetBuilder<K, V, R>;
+    type Merger = FallbackIndexedWSetMerger<K, V, R>;
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FallbackZSetMerger::new_merger(self, other)
+        FallbackIndexedWSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -386,7 +411,7 @@ where
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
         Self {
             factories: factories.clone(),
-            inner: Inner::Vec(OrdWSet::dyn_empty(&factories.vec, time)),
+            inner: Inner::Vec(OrdIndexedWSet::dyn_empty(&factories.vec, time)),
         }
     }
     fn persistent_id(&self) -> Option<PathBuf> {
@@ -398,47 +423,54 @@ where
 }
 
 /// State for an in-progress merge.
-pub struct FallbackZSetMerger<K, R>
+pub struct FallbackIndexedWSetMerger<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackZSetFactories<K, R>,
-    inner: MergerInner<K, R>,
+    factories: FallbackIndexedWSetFactories<K, V, R>,
+    inner: MergerInner<K, V, R>,
 }
 
-enum MergerInner<K, R>
+enum MergerInner<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    AllFile(FileZSetMerger<K, R>),
-    AllVec(VecWSetMerger<K, R>),
-    ToVec(GenericMerger<K, R, OrdWSet<K, R>>),
-    ToFile(GenericMerger<K, R, FileZSet<K, R>>),
+    AllFile(FileIndexedWSetMerger<K, V, R>),
+    AllVec(OrdIndexedWSetMerger<K, V, R>),
+    ToVec(GenericMerger<K, V, R, OrdIndexedWSet<K, V, R>>),
+    ToFile(GenericMerger<K, V, R, FileIndexedWSet<K, V, R>>),
 }
 
-impl<K, R> Merger<K, DynUnit, (), R, FallbackZSet<K, R>> for FallbackZSetMerger<K, R>
+impl<K, V, R> Merger<K, V, (), R, FallbackIndexedWSet<K, V, R>>
+    for FallbackIndexedWSetMerger<K, V, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_merger(batch1: &FallbackZSet<K, R>, batch2: &FallbackZSet<K, R>) -> Self {
+    fn new_merger(
+        batch1: &FallbackIndexedWSet<K, V, R>,
+        batch2: &FallbackIndexedWSet<K, V, R>,
+    ) -> Self {
         Self {
             factories: batch1.factories.clone(),
             inner: if batch1.len() + batch2.len() <= Runtime::max_memory_rows() {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::Vec(vec1), Inner::Vec(vec2)) => {
-                        MergerInner::AllVec(VecWSetMerger::new_merger(vec1, vec2))
+                        MergerInner::AllVec(OrdIndexedWSetMerger::new_merger(vec1, vec2))
                     }
                     _ => MergerInner::ToVec(GenericMerger::new(&batch1.factories.vec)),
                 }
             } else {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::File(file1), Inner::File(file2)) => {
-                        MergerInner::AllFile(FileZSetMerger::new_merger(file1, file2))
+                        MergerInner::AllFile(FileIndexedWSetMerger::new_merger(file1, file2))
                     }
                     _ => MergerInner::ToFile(GenericMerger::new(&batch1.factories.file)),
                 }
@@ -447,8 +479,8 @@ where
     }
 
     #[inline]
-    fn done(self) -> FallbackZSet<K, R> {
-        FallbackZSet {
+    fn done(self) -> FallbackIndexedWSet<K, V, R> {
+        FallbackIndexedWSet {
             factories: self.factories,
             inner: match self.inner {
                 MergerInner::AllFile(merger) => Inner::File(merger.done()),
@@ -461,10 +493,10 @@ where
 
     fn work(
         &mut self,
-        source1: &FallbackZSet<K, R>,
-        source2: &FallbackZSet<K, R>,
+        source1: &FallbackIndexedWSet<K, V, R>,
+        source2: &FallbackIndexedWSet<K, V, R>,
         key_filter: &Option<Filter<K>>,
-        value_filter: &Option<Filter<DynUnit>>,
+        value_filter: &Option<Filter<V>>,
         fuel: &mut isize,
     ) {
         match &mut self.inner {
@@ -510,9 +542,10 @@ where
     }
 }
 
-impl<K, R> SizeOf for FallbackZSetMerger<K, R>
+impl<K, V, R> SizeOf for FallbackIndexedWSetMerger<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -525,34 +558,38 @@ where
     }
 }
 
-trait ClonableCursor<'s, K, R>: Cursor<K, DynUnit, (), R> + Debug
+trait ClonableCursor<'s, K, V, R>: Cursor<K, V, (), R> + Debug
 where
     K: ?Sized,
+    V: ?Sized,
     R: ?Sized,
 {
-    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, R> + 's>;
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, R> + 's>;
 }
 
-impl<'s, K, R, C> ClonableCursor<'s, K, R> for C
+impl<'s, K, V, R, C> ClonableCursor<'s, K, V, R> for C
 where
     K: ?Sized,
+    V: ?Sized,
     R: ?Sized,
-    C: Cursor<K, DynUnit, (), R> + Debug + Clone + 's,
+    C: Cursor<K, V, (), R> + Debug + Clone + 's,
 {
-    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, R> + 's> {
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, R> + 's> {
         Box::new(self.clone())
     }
 }
 /// A cursor for navigating a single layer.
 #[derive(Debug, SizeOf)]
-pub struct FallbackZSetCursor<'s, K, R>(Box<dyn ClonableCursor<'s, K, R> + 's>)
+pub struct FallbackIndexedWSetCursor<'s, K, V, R>(Box<dyn ClonableCursor<'s, K, V, R> + 's>)
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized;
 
-impl<'s, K, R> Clone for FallbackZSetCursor<'s, K, R>
+impl<'s, K, V, R> Clone for FallbackIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -560,22 +597,24 @@ where
     }
 }
 
-impl<'s, K, R> FallbackZSetCursor<'s, K, R>
+impl<'s, K, V, R> FallbackIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn new(zset: &'s FallbackZSet<K, R>) -> Self {
-        Self(match &zset.inner {
+    fn new(wset: &'s FallbackIndexedWSet<K, V, R>) -> Self {
+        Self(match &wset.inner {
             Inner::Vec(vec) => Box::new(vec.cursor()),
             Inner::File(file) => Box::new(file.cursor()),
         })
     }
 }
 
-impl<'s, K, R> Cursor<K, DynUnit, (), R> for FallbackZSetCursor<'s, K, R>
+impl<'s, K, V, R> Cursor<K, V, (), R> for FallbackIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn weight_factory(&self) -> &'static dyn Factory<R> {
@@ -586,7 +625,7 @@ where
         self.0.key()
     }
 
-    fn val(&self) -> &DynUnit {
+    fn val(&self) -> &V {
         self.0.val()
     }
 
@@ -598,7 +637,7 @@ where
         self.0.map_times_through(upper, logic)
     }
 
-    fn map_values(&mut self, logic: &mut dyn FnMut(&DynUnit, &R)) {
+    fn map_values(&mut self, logic: &mut dyn FnMut(&V, &R)) {
         self.0.map_values(logic)
     }
 
@@ -642,11 +681,11 @@ where
         self.0.step_val()
     }
 
-    fn seek_val(&mut self, val: &DynUnit) {
+    fn seek_val(&mut self, val: &V) {
         self.0.seek_val(val)
     }
 
-    fn seek_val_with(&mut self, predicate: &dyn Fn(&DynUnit) -> bool) {
+    fn seek_val_with(&mut self, predicate: &dyn Fn(&V) -> bool) {
         self.0.seek_val_with(predicate)
     }
 
@@ -666,11 +705,11 @@ where
         self.0.step_val_reverse()
     }
 
-    fn seek_val_reverse(&mut self, val: &DynUnit) {
+    fn seek_val_reverse(&mut self, val: &V) {
         self.0.seek_val_reverse(val)
     }
 
-    fn seek_val_with_reverse(&mut self, predicate: &dyn Fn(&DynUnit) -> bool) {
+    fn seek_val_with_reverse(&mut self, predicate: &dyn Fn(&V) -> bool) {
         self.0.seek_val_with_reverse(predicate)
     }
 
@@ -680,48 +719,55 @@ where
 }
 
 /// A builder for batches from ordered update tuples.
-pub struct FallbackZSetBuilder<K, R>
+pub struct FallbackIndexedWSetBuilder<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackZSetFactories<K, R>,
-    inner: BuilderInner<K, R>,
+    factories: FallbackIndexedWSetFactories<K, V, R>,
+    inner: BuilderInner<K, V, R>,
 }
 
 #[allow(clippy::large_enum_variant)]
-enum BuilderInner<K, R>
+enum BuilderInner<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    File(FileZSetBuilder<K, R>),
-    Vec(VecWSetBuilder<K, R>),
+    File(FileIndexedWSetBuilder<K, V, R>),
+    Vec(VecIndexedWSetBuilder<K, V, R, usize>),
 }
 
-impl<K, R> Builder<FallbackZSet<K, R>> for FallbackZSetBuilder<K, R>
+impl<K, V, R> Builder<FallbackIndexedWSet<K, V, R>> for FallbackIndexedWSetBuilder<K, V, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_builder(factories: &FallbackZSetFactories<K, R>, time: ()) -> Self {
+    fn new_builder(factories: &FallbackIndexedWSetFactories<K, V, R>, time: ()) -> Self {
         Self::with_capacity(factories, time, 0)
     }
 
     #[inline]
-    fn with_capacity(factories: &FallbackZSetFactories<K, R>, time: (), capacity: usize) -> Self {
+    fn with_capacity(
+        factories: &FallbackIndexedWSetFactories<K, V, R>,
+        time: (),
+        capacity: usize,
+    ) -> Self {
         Self {
             factories: factories.clone(),
             inner: if capacity <= Runtime::max_memory_rows() {
-                BuilderInner::Vec(VecWSetBuilder::with_capacity(
+                BuilderInner::Vec(VecIndexedWSetBuilder::with_capacity(
                     &factories.vec,
                     time,
                     capacity,
                 ))
             } else {
-                BuilderInner::File(FileZSetBuilder::with_capacity(
+                BuilderInner::File(FileIndexedWSetBuilder::with_capacity(
                     &factories.file,
                     time,
                     capacity,
@@ -734,7 +780,7 @@ where
     fn reserve(&mut self, _additional: usize) {}
 
     #[inline]
-    fn push(&mut self, item: &mut DynPair<DynPair<K, DynUnit>, R>) {
+    fn push(&mut self, item: &mut DynPair<DynPair<K, V>, R>) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push(item),
             BuilderInner::Vec(vec) => vec.push(item),
@@ -742,7 +788,7 @@ where
     }
 
     #[inline]
-    fn push_refs(&mut self, key: &K, val: &DynUnit, weight: &R) {
+    fn push_refs(&mut self, key: &K, val: &V, weight: &R) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push_refs(key, val, weight),
             BuilderInner::Vec(vec) => vec.push_refs(key, val, weight),
@@ -750,7 +796,7 @@ where
     }
 
     #[inline]
-    fn push_vals(&mut self, key: &mut K, val: &mut DynUnit, weight: &mut R) {
+    fn push_vals(&mut self, key: &mut K, val: &mut V, weight: &mut R) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push_vals(key, val, weight),
             BuilderInner::Vec(vec) => vec.push_vals(key, val, weight),
@@ -758,8 +804,8 @@ where
     }
 
     #[inline(never)]
-    fn done(self) -> FallbackZSet<K, R> {
-        FallbackZSet {
+    fn done(self) -> FallbackIndexedWSet<K, V, R> {
+        FallbackIndexedWSet {
             factories: self.factories,
             inner: match self.inner {
                 BuilderInner::File(file) => Inner::File(file.done()),
@@ -769,9 +815,10 @@ where
     }
 }
 
-impl<K, R> SizeOf for FallbackZSetBuilder<K, R>
+impl<K, V, R> SizeOf for FallbackIndexedWSetBuilder<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -782,9 +829,10 @@ where
     }
 }
 
-impl<K, R> SizeOf for FallbackZSet<K, R>
+impl<K, V, R> SizeOf for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -795,9 +843,10 @@ where
     }
 }
 
-impl<K, R> Archive for FallbackZSet<K, R>
+impl<K, V, R> Archive for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Archived = ();
@@ -808,9 +857,10 @@ where
     }
 }
 
-impl<K, R, S> Serialize<S> for FallbackZSet<K, R>
+impl<K, V, R, S> Serialize<S> for FallbackIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
     S: Serializer + ?Sized,
 {
@@ -819,13 +869,15 @@ where
     }
 }
 
-impl<K, R, D> Deserialize<FallbackZSet<K, R>, D> for Archived<FallbackZSet<K, R>>
+impl<K, V, R, D> Deserialize<FallbackIndexedWSet<K, V, R>, D>
+    for Archived<FallbackIndexedWSet<K, V, R>>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
     D: Fallible,
 {
-    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackZSet<K, R>, D::Error> {
+    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackIndexedWSet<K, V, R>, D::Error> {
         unimplemented!();
     }
 }
@@ -859,9 +911,10 @@ where
         cursor
     }
 
-    fn from_cursor<C, R>(cursor: &C) -> Position<K>
+    fn from_cursor<C, V, R>(cursor: &C) -> Position<K>
     where
-        C: Cursor<K, DynUnit, (), R>,
+        C: Cursor<K, V, (), R>,
+        V: ?Sized,
         R: ?Sized,
     {
         if cursor.key_valid() {
@@ -872,38 +925,43 @@ where
     }
 }
 
-struct GenericMerger<K, R, O>
+struct GenericMerger<K, V, R, O>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
 {
     builder: O::Builder,
     pos1: Position<K>,
     pos2: Position<K>,
 }
 
-trait CursorWeightRef<K, T, R>: Cursor<K, DynUnit, T, R>
+trait CursorWeightRef<K, V, T, R>: Cursor<K, V, T, R>
 where
     K: ?Sized,
+    V: ?Sized,
     R: ?Sized,
 {
     fn weight_ref(&self) -> &R;
 }
 
-impl<'s, K, R> CursorWeightRef<K, (), R> for VecWSetCursor<'s, K, R>
+impl<'s, K, V, R, O> CursorWeightRef<K, V, (), R> for VecIndexedWSetCursor<'s, K, V, R, O>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
+    O: OrdOffset,
 {
     fn weight_ref(&self) -> &R {
-        self.cursor.current_diff()
+        self.cursor.child.current_diff()
     }
 }
 
-impl<'s, K, R> CursorWeightRef<K, (), R> for FileZSetCursor<'s, K, R>
+impl<'s, K, V, R> CursorWeightRef<K, V, (), R> for FileIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn weight_ref(&self) -> &R {
@@ -911,11 +969,12 @@ where
     }
 }
 
-impl<K, R, O> GenericMerger<K, R, O>
+impl<K, V, R, O> GenericMerger<K, V, R, O>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
 {
     fn new(factories: &O::Factories) -> Self {
         Self {
@@ -930,41 +989,49 @@ where
         source1: &'s A,
         source2: &'s B,
         key_filter: &Option<Filter<K>>,
-        value_filter: &Option<Filter<DynUnit>>,
+        value_filter: &Option<Filter<V>>,
         fuel: &mut isize,
     ) where
-        A: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
-        B: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
-        A::Cursor<'s>: CursorWeightRef<K, (), R>,
-        B::Cursor<'s>: CursorWeightRef<K, (), R>,
+        A: BatchReader<Key = K, Val = V, R = R, Time = ()>,
+        B: BatchReader<Key = K, Val = V, R = R, Time = ()>,
+        A::Cursor<'s>: CursorWeightRef<K, V, (), R>,
+        B::Cursor<'s>: CursorWeightRef<K, V, (), R>,
     {
-        if !filter(value_filter, &()) {
-            return;
-        }
-
         let mut cursor1 = self.pos1.cursor(source1);
         let mut cursor2 = self.pos2.cursor(source2);
+        let mut diff = source1.factories().weight_factory().default_box();
         while cursor1.key_valid() && cursor2.key_valid() && *fuel > 0 {
             match cursor1.key().cmp(cursor2.key()) {
                 Ordering::Less => {
-                    self.copy_value_if(&mut cursor1, key_filter, fuel);
+                    self.copy_values_if(&mut cursor1, key_filter, value_filter, fuel);
                 }
                 Ordering::Equal => {
-                    self.copy_value_if(&mut cursor1, key_filter, fuel);
+                    if filter(key_filter, cursor1.key()) {
+                        self.merge_values(
+                            &mut cursor1,
+                            &mut cursor2,
+                            value_filter,
+                            diff.as_mut(),
+                            fuel,
+                        );
+                    } else {
+                        *fuel -= 1;
+                    }
+                    cursor1.step_key();
                     cursor2.step_key();
-                    *fuel -= 1;
                 }
+
                 Ordering::Greater => {
-                    self.copy_value_if(&mut cursor2, key_filter, fuel);
+                    self.copy_values_if(&mut cursor2, key_filter, value_filter, fuel);
                 }
             }
         }
 
         while cursor1.key_valid() && *fuel > 0 {
-            self.copy_value_if(&mut cursor1, key_filter, fuel);
+            self.copy_values_if(&mut cursor1, key_filter, value_filter, fuel);
         }
         while cursor2.key_valid() && *fuel > 0 {
-            self.copy_value_if(&mut cursor2, key_filter, fuel);
+            self.copy_values_if(&mut cursor2, key_filter, value_filter, fuel);
         }
         self.pos1 = Position::from_cursor(&cursor1);
         self.pos2 = Position::from_cursor(&cursor2);
@@ -974,16 +1041,86 @@ where
         self.builder.done()
     }
 
-    fn copy_value_if<C>(&mut self, cursor: &mut C, key_filter: &Option<Filter<K>>, fuel: &mut isize)
-    where
-        C: CursorWeightRef<K, (), R>,
+    fn copy_values_if<C>(
+        &mut self,
+        cursor: &mut C,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        C: CursorWeightRef<K, V, (), R>,
     {
         if filter(key_filter, cursor.key()) {
-            self.builder
-                .push_refs(cursor.key(), &(), cursor.weight_ref());
+            while cursor.val_valid() {
+                if filter(value_filter, cursor.val()) {
+                    self.builder
+                        .push_refs(cursor.key(), cursor.val(), cursor.weight_ref());
+                }
+                cursor.step_val();
+                *fuel -= 1;
+            }
+        } else {
+            *fuel -= 1;
         }
-        *fuel -= 1;
         cursor.step_key();
+    }
+
+    fn copy_value<C>(&mut self, cursor: &mut C, value_filter: &Option<Filter<V>>)
+    where
+        C: CursorWeightRef<K, V, (), R>,
+    {
+        if filter(value_filter, cursor.val()) {
+            self.builder
+                .push_refs(cursor.key(), cursor.val(), cursor.weight_ref());
+        }
+        cursor.step_val();
+    }
+
+    fn merge_values<C1, C2>(
+        &mut self,
+        cursor1: &mut C1,
+        cursor2: &mut C2,
+        value_filter: &Option<Filter<V>>,
+        sum: &mut R,
+        fuel: &mut isize,
+    ) where
+        C1: CursorWeightRef<K, V, (), R>,
+        C2: CursorWeightRef<K, V, (), R>,
+    {
+        while cursor1.val_valid() && cursor2.val_valid() {
+            let value1 = cursor1.val();
+            let value2 = cursor2.val();
+            let cmp = value1.cmp(value2);
+            match cmp {
+                Ordering::Less => {
+                    self.copy_value(cursor1, value_filter);
+                }
+                Ordering::Equal => {
+                    if filter(value_filter, value1) {
+                        cursor1.weight_ref().add(cursor2.weight_ref(), sum);
+                        if !sum.is_zero() {
+                            self.builder.push_refs(cursor1.key(), cursor1.val(), sum);
+                        }
+                    }
+                    cursor1.step_val();
+                    cursor2.step_val();
+                }
+
+                Ordering::Greater => {
+                    self.copy_value(cursor2, value_filter);
+                }
+            }
+            *fuel -= 1;
+        }
+
+        while cursor1.val_valid() {
+            self.copy_value(cursor1, value_filter);
+            *fuel -= 1;
+        }
+        while cursor2.val_valid() {
+            self.copy_value(cursor2, value_filter);
+            *fuel -= 1;
+        }
     }
 }
 
@@ -994,11 +1131,12 @@ where
     f.as_ref().map_or(true, |f| f(t))
 }
 
-impl<K, R, O> SizeOf for GenericMerger<K, R, O>
+impl<K, V, R, O> SizeOf for GenericMerger<K, V, R, O>
 where
     K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
         self.builder.size_of_children(context)

--- a/crates/dbsp/src/trace/ord/fallback/mod.rs
+++ b/crates/dbsp/src/trace/ord/fallback/mod.rs
@@ -1,4 +1,4 @@
 //! Batch implementations that fall back from memory to disk.
 
-pub mod indexed_zset;
-pub mod zset;
+pub mod indexed_wset;
+pub mod wset;

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -1,23 +1,18 @@
 use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef, ZRingValue},
     dynamic::{
-        DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait, WeightTraitTyped,
+        DataTrait, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait,
+        WeightTraitTyped,
     },
     time::AntichainRef,
     trace::{
-        layers::OrdOffset,
         ord::{
-            file::indexed_zset_batch::{
-                FileIndexedZSetBuilder, FileIndexedZSetCursor, FileIndexedZSetMerger,
-            },
+            file::wset_batch::{FileWSetBuilder, FileWSetCursor, FileWSetMerger},
             merge_batcher::MergeBatcher,
-            vec::indexed_wset_batch::{
-                OrdIndexedWSetMerger, VecIndexedWSetBuilder, VecIndexedWSetCursor,
-            },
+            vec::wset_batch::{VecWSetBuilder, VecWSetCursor, VecWSetMerger},
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, FileIndexedZSet,
-        FileIndexedZSetFactories, Filter, Merger, OrdIndexedWSet, OrdIndexedWSetFactories,
-        WeightedItem,
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, FileWSet,
+        FileWSetFactories, Filter, Merger, OrdWSet, OrdWSetFactories, WeightedItem,
     },
     DBData, DBWeight, NumEntries, Runtime,
 };
@@ -32,20 +27,18 @@ use std::{
 };
 use std::{ops::Neg, path::PathBuf};
 
-pub struct FallbackIndexedZSetFactories<K, V, R>
+pub struct FallbackWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    file: FileIndexedZSetFactories<K, V, R>,
-    vec: OrdIndexedWSetFactories<K, V, R>,
+    file: FileWSetFactories<K, R>,
+    vec: OrdWSetFactories<K, R>,
 }
 
-impl<K, V, R> Clone for FallbackIndexedZSetFactories<K, V, R>
+impl<K, R> Clone for FallbackWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -56,21 +49,20 @@ where
     }
 }
 
-impl<K, V, R> BatchReaderFactories<K, V, (), R> for FallbackIndexedZSetFactories<K, V, R>
+impl<K, R> BatchReaderFactories<K, DynUnit, (), R> for FallbackWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn new<KType, VType, RType>() -> Self
     where
         KType: DBData + Erase<K>,
-        VType: DBData + Erase<V>,
+        VType: DBData + Erase<DynUnit>,
         RType: DBWeight + Erase<R>,
     {
         Self {
-            file: FileIndexedZSetFactories::new::<KType, VType, RType>(),
-            vec: OrdIndexedWSetFactories::new::<KType, VType, RType>(),
+            file: FileWSetFactories::new::<KType, VType, RType>(),
+            vec: OrdWSetFactories::new::<KType, VType, RType>(),
         }
     }
 
@@ -82,7 +74,7 @@ where
         self.file.keys_factory()
     }
 
-    fn val_factory(&self) -> &'static dyn Factory<V> {
+    fn val_factory(&self) -> &'static dyn Factory<DynUnit> {
         self.file.val_factory()
     }
 
@@ -91,59 +83,57 @@ where
     }
 }
 
-impl<K, V, R> BatchFactories<K, V, (), R> for FallbackIndexedZSetFactories<K, V, R>
+impl<K, R> BatchFactories<K, DynUnit, (), R> for FallbackWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, V>> {
+    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, DynUnit>> {
         self.file.item_factory()
     }
 
-    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, V, R>> {
+    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, DynUnit, R>> {
         self.file.weighted_item_factory()
     }
 
-    fn weighted_items_factory(&self) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>> {
+    fn weighted_items_factory(
+        &self,
+    ) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, DynUnit>, R>> {
         self.file.weighted_items_factory()
     }
 }
 
-pub struct FallbackIndexedZSet<K, V, R>
+pub struct FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackIndexedZSetFactories<K, V, R>,
-    inner: Inner<K, V, R>,
+    factories: FallbackWSetFactories<K, R>,
+    inner: Inner<K, R>,
 }
 
 #[allow(clippy::large_enum_variant)]
-enum Inner<K, V, R>
+enum Inner<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    Vec(OrdIndexedWSet<K, V, R>),
-    File(FileIndexedZSet<K, V, R>),
+    Vec(OrdWSet<K, R>),
+    File(FileWSet<K, R>),
 }
 
-impl<K, V, R> Inner<K, V, R>
+impl<K, R> Inner<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn as_file(&self) -> Option<&FileIndexedZSet<K, V, R>> {
+    fn as_file(&self) -> Option<&FileWSet<K, R>> {
         match self {
             Inner::Vec(_vec) => None,
             Inner::File(file) => Some(file),
         }
     }
-    fn as_vec(&self) -> Option<&OrdIndexedWSet<K, V, R>> {
+    fn as_vec(&self) -> Option<&OrdWSet<K, R>> {
         match self {
             Inner::Vec(vec) => Some(vec),
             Inner::File(_file) => None,
@@ -151,10 +141,9 @@ where
     }
 }
 
-impl<K, V, R> Debug for FallbackIndexedZSet<K, V, R>
+impl<K, R> Debug for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -165,10 +154,9 @@ where
     }
 }
 
-impl<K, V, R> Clone for FallbackIndexedZSet<K, V, R>
+impl<K, R> Clone for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -185,12 +173,11 @@ where
 // This is `#[cfg(test)]` only because it would be surprisingly expensive in
 // production.
 #[cfg(test)]
-impl<Other, K, V, R> PartialEq<Other> for FallbackIndexedZSet<K, V, R>
+impl<Other, K, R> PartialEq<Other> for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    Other: BatchReader<Key = K, Val = V, R = R, Time = ()>,
+    Other: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
 {
     fn eq(&self, other: &Other) -> bool {
         use crate::trace::eq_batch;
@@ -199,18 +186,16 @@ where
 }
 
 #[cfg(test)]
-impl<K, V, R> Eq for FallbackIndexedZSet<K, V, R>
+impl<K, R> Eq for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
 }
 
-impl<K, V, R> NumEntries for FallbackIndexedZSet<K, V, R>
+impl<K, R> NumEntries for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     const CONST_NUM_ENTRIES: Option<usize> = None;
@@ -230,10 +215,9 @@ where
     }
 }
 
-impl<K, V, R> NegByRef for FallbackIndexedZSet<K, V, R>
+impl<K, R> NegByRef for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
     R::Type: DBWeight + ZRingValue + NegByRef + Erase<R>,
 {
@@ -249,10 +233,9 @@ where
     }
 }
 
-impl<K, V, R> Neg for FallbackIndexedZSet<K, V, R>
+impl<K, R> Neg for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
     R::Type: DBWeight + ZRingValue + NegByRef + Erase<R>,
 {
@@ -264,10 +247,9 @@ where
     }
 }
 
-impl<K, V, R> Add<Self> for FallbackIndexedZSet<K, V, R>
+impl<K, R> Add<Self> for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Output = Self;
@@ -284,10 +266,9 @@ where
     }
 }
 
-impl<K, V, R> AddAssign<Self> for FallbackIndexedZSet<K, V, R>
+impl<K, R> AddAssign<Self> for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -298,10 +279,9 @@ where
     }
 }
 
-impl<K, V, R> AddAssignByRef for FallbackIndexedZSet<K, V, R>
+impl<K, R> AddAssignByRef for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -312,10 +292,9 @@ where
     }
 }
 
-impl<K, V, R> AddByRef for FallbackIndexedZSet<K, V, R>
+impl<K, R> AddByRef for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
@@ -324,20 +303,17 @@ where
     }
 }
 
-impl<K, V, R> BatchReader for FallbackIndexedZSet<K, V, R>
+impl<K, R> BatchReader for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Factories = FallbackIndexedZSetFactories<K, V, R>;
+    type Factories = FallbackWSetFactories<K, R>;
     type Key = K;
-    type Val = V;
+    type Val = DynUnit;
     type Time = ();
     type R = R;
-    type Cursor<'s> = FallbackIndexedZSetCursor<'s, K, V, R>
-    where
-        V: 's;
+    type Cursor<'s> = FallbackWSetCursor<'s, K, R>;
 
     fn factories(&self) -> Self::Factories {
         self.factories.clone()
@@ -345,7 +321,7 @@ where
 
     #[inline]
     fn cursor(&self) -> Self::Cursor<'_> {
-        FallbackIndexedZSetCursor::new(self)
+        FallbackWSetCursor::new(self)
     }
 
     #[inline]
@@ -392,18 +368,17 @@ where
     }
 }
 
-impl<K, V, R> Batch for FallbackIndexedZSet<K, V, R>
+impl<K, R> Batch for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Batcher = MergeBatcher<Self>;
-    type Builder = FallbackIndexedZSetBuilder<K, V, R>;
-    type Merger = FallbackIndexedZSetMerger<K, V, R>;
+    type Builder = FallbackWSetBuilder<K, R>;
+    type Merger = FallbackWSetMerger<K, R>;
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FallbackIndexedZSetMerger::new_merger(self, other)
+        FallbackWSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -411,7 +386,7 @@ where
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
         Self {
             factories: factories.clone(),
-            inner: Inner::Vec(OrdIndexedWSet::dyn_empty(&factories.vec, time)),
+            inner: Inner::Vec(OrdWSet::dyn_empty(&factories.vec, time)),
         }
     }
     fn persistent_id(&self) -> Option<PathBuf> {
@@ -423,54 +398,47 @@ where
 }
 
 /// State for an in-progress merge.
-pub struct FallbackIndexedZSetMerger<K, V, R>
+pub struct FallbackWSetMerger<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackIndexedZSetFactories<K, V, R>,
-    inner: MergerInner<K, V, R>,
+    factories: FallbackWSetFactories<K, R>,
+    inner: MergerInner<K, R>,
 }
 
-enum MergerInner<K, V, R>
+enum MergerInner<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    AllFile(FileIndexedZSetMerger<K, V, R>),
-    AllVec(OrdIndexedWSetMerger<K, V, R>),
-    ToVec(GenericMerger<K, V, R, OrdIndexedWSet<K, V, R>>),
-    ToFile(GenericMerger<K, V, R, FileIndexedZSet<K, V, R>>),
+    AllFile(FileWSetMerger<K, R>),
+    AllVec(VecWSetMerger<K, R>),
+    ToVec(GenericMerger<K, R, OrdWSet<K, R>>),
+    ToFile(GenericMerger<K, R, FileWSet<K, R>>),
 }
 
-impl<K, V, R> Merger<K, V, (), R, FallbackIndexedZSet<K, V, R>>
-    for FallbackIndexedZSetMerger<K, V, R>
+impl<K, R> Merger<K, DynUnit, (), R, FallbackWSet<K, R>> for FallbackWSetMerger<K, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_merger(
-        batch1: &FallbackIndexedZSet<K, V, R>,
-        batch2: &FallbackIndexedZSet<K, V, R>,
-    ) -> Self {
+    fn new_merger(batch1: &FallbackWSet<K, R>, batch2: &FallbackWSet<K, R>) -> Self {
         Self {
             factories: batch1.factories.clone(),
             inner: if batch1.len() + batch2.len() <= Runtime::max_memory_rows() {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::Vec(vec1), Inner::Vec(vec2)) => {
-                        MergerInner::AllVec(OrdIndexedWSetMerger::new_merger(vec1, vec2))
+                        MergerInner::AllVec(VecWSetMerger::new_merger(vec1, vec2))
                     }
                     _ => MergerInner::ToVec(GenericMerger::new(&batch1.factories.vec)),
                 }
             } else {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::File(file1), Inner::File(file2)) => {
-                        MergerInner::AllFile(FileIndexedZSetMerger::new_merger(file1, file2))
+                        MergerInner::AllFile(FileWSetMerger::new_merger(file1, file2))
                     }
                     _ => MergerInner::ToFile(GenericMerger::new(&batch1.factories.file)),
                 }
@@ -479,8 +447,8 @@ where
     }
 
     #[inline]
-    fn done(self) -> FallbackIndexedZSet<K, V, R> {
-        FallbackIndexedZSet {
+    fn done(self) -> FallbackWSet<K, R> {
+        FallbackWSet {
             factories: self.factories,
             inner: match self.inner {
                 MergerInner::AllFile(merger) => Inner::File(merger.done()),
@@ -493,10 +461,10 @@ where
 
     fn work(
         &mut self,
-        source1: &FallbackIndexedZSet<K, V, R>,
-        source2: &FallbackIndexedZSet<K, V, R>,
+        source1: &FallbackWSet<K, R>,
+        source2: &FallbackWSet<K, R>,
         key_filter: &Option<Filter<K>>,
-        value_filter: &Option<Filter<V>>,
+        value_filter: &Option<Filter<DynUnit>>,
         fuel: &mut isize,
     ) {
         match &mut self.inner {
@@ -542,10 +510,9 @@ where
     }
 }
 
-impl<K, V, R> SizeOf for FallbackIndexedZSetMerger<K, V, R>
+impl<K, R> SizeOf for FallbackWSetMerger<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -558,38 +525,34 @@ where
     }
 }
 
-trait ClonableCursor<'s, K, V, R>: Cursor<K, V, (), R> + Debug
+trait ClonableCursor<'s, K, R>: Cursor<K, DynUnit, (), R> + Debug
 where
     K: ?Sized,
-    V: ?Sized,
     R: ?Sized,
 {
-    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, R> + 's>;
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, R> + 's>;
 }
 
-impl<'s, K, V, R, C> ClonableCursor<'s, K, V, R> for C
+impl<'s, K, R, C> ClonableCursor<'s, K, R> for C
 where
     K: ?Sized,
-    V: ?Sized,
     R: ?Sized,
-    C: Cursor<K, V, (), R> + Debug + Clone + 's,
+    C: Cursor<K, DynUnit, (), R> + Debug + Clone + 's,
 {
-    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, R> + 's> {
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, R> + 's> {
         Box::new(self.clone())
     }
 }
 /// A cursor for navigating a single layer.
 #[derive(Debug, SizeOf)]
-pub struct FallbackIndexedZSetCursor<'s, K, V, R>(Box<dyn ClonableCursor<'s, K, V, R> + 's>)
+pub struct FallbackWSetCursor<'s, K, R>(Box<dyn ClonableCursor<'s, K, R> + 's>)
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized;
 
-impl<'s, K, V, R> Clone for FallbackIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, R> Clone for FallbackWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
@@ -597,13 +560,12 @@ where
     }
 }
 
-impl<'s, K, V, R> FallbackIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, R> FallbackWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn new(zset: &'s FallbackIndexedZSet<K, V, R>) -> Self {
+    fn new(zset: &'s FallbackWSet<K, R>) -> Self {
         Self(match &zset.inner {
             Inner::Vec(vec) => Box::new(vec.cursor()),
             Inner::File(file) => Box::new(file.cursor()),
@@ -611,10 +573,9 @@ where
     }
 }
 
-impl<'s, K, V, R> Cursor<K, V, (), R> for FallbackIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, R> Cursor<K, DynUnit, (), R> for FallbackWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn weight_factory(&self) -> &'static dyn Factory<R> {
@@ -625,7 +586,7 @@ where
         self.0.key()
     }
 
-    fn val(&self) -> &V {
+    fn val(&self) -> &DynUnit {
         self.0.val()
     }
 
@@ -637,7 +598,7 @@ where
         self.0.map_times_through(upper, logic)
     }
 
-    fn map_values(&mut self, logic: &mut dyn FnMut(&V, &R)) {
+    fn map_values(&mut self, logic: &mut dyn FnMut(&DynUnit, &R)) {
         self.0.map_values(logic)
     }
 
@@ -681,11 +642,11 @@ where
         self.0.step_val()
     }
 
-    fn seek_val(&mut self, val: &V) {
+    fn seek_val(&mut self, val: &DynUnit) {
         self.0.seek_val(val)
     }
 
-    fn seek_val_with(&mut self, predicate: &dyn Fn(&V) -> bool) {
+    fn seek_val_with(&mut self, predicate: &dyn Fn(&DynUnit) -> bool) {
         self.0.seek_val_with(predicate)
     }
 
@@ -705,11 +666,11 @@ where
         self.0.step_val_reverse()
     }
 
-    fn seek_val_reverse(&mut self, val: &V) {
+    fn seek_val_reverse(&mut self, val: &DynUnit) {
         self.0.seek_val_reverse(val)
     }
 
-    fn seek_val_with_reverse(&mut self, predicate: &dyn Fn(&V) -> bool) {
+    fn seek_val_with_reverse(&mut self, predicate: &dyn Fn(&DynUnit) -> bool) {
         self.0.seek_val_with_reverse(predicate)
     }
 
@@ -719,55 +680,48 @@ where
 }
 
 /// A builder for batches from ordered update tuples.
-pub struct FallbackIndexedZSetBuilder<K, V, R>
+pub struct FallbackWSetBuilder<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FallbackIndexedZSetFactories<K, V, R>,
-    inner: BuilderInner<K, V, R>,
+    factories: FallbackWSetFactories<K, R>,
+    inner: BuilderInner<K, R>,
 }
 
 #[allow(clippy::large_enum_variant)]
-enum BuilderInner<K, V, R>
+enum BuilderInner<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    File(FileIndexedZSetBuilder<K, V, R>),
-    Vec(VecIndexedWSetBuilder<K, V, R, usize>),
+    File(FileWSetBuilder<K, R>),
+    Vec(VecWSetBuilder<K, R>),
 }
 
-impl<K, V, R> Builder<FallbackIndexedZSet<K, V, R>> for FallbackIndexedZSetBuilder<K, V, R>
+impl<K, R> Builder<FallbackWSet<K, R>> for FallbackWSetBuilder<K, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_builder(factories: &FallbackIndexedZSetFactories<K, V, R>, time: ()) -> Self {
+    fn new_builder(factories: &FallbackWSetFactories<K, R>, time: ()) -> Self {
         Self::with_capacity(factories, time, 0)
     }
 
     #[inline]
-    fn with_capacity(
-        factories: &FallbackIndexedZSetFactories<K, V, R>,
-        time: (),
-        capacity: usize,
-    ) -> Self {
+    fn with_capacity(factories: &FallbackWSetFactories<K, R>, time: (), capacity: usize) -> Self {
         Self {
             factories: factories.clone(),
             inner: if capacity <= Runtime::max_memory_rows() {
-                BuilderInner::Vec(VecIndexedWSetBuilder::with_capacity(
+                BuilderInner::Vec(VecWSetBuilder::with_capacity(
                     &factories.vec,
                     time,
                     capacity,
                 ))
             } else {
-                BuilderInner::File(FileIndexedZSetBuilder::with_capacity(
+                BuilderInner::File(FileWSetBuilder::with_capacity(
                     &factories.file,
                     time,
                     capacity,
@@ -780,7 +734,7 @@ where
     fn reserve(&mut self, _additional: usize) {}
 
     #[inline]
-    fn push(&mut self, item: &mut DynPair<DynPair<K, V>, R>) {
+    fn push(&mut self, item: &mut DynPair<DynPair<K, DynUnit>, R>) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push(item),
             BuilderInner::Vec(vec) => vec.push(item),
@@ -788,7 +742,7 @@ where
     }
 
     #[inline]
-    fn push_refs(&mut self, key: &K, val: &V, weight: &R) {
+    fn push_refs(&mut self, key: &K, val: &DynUnit, weight: &R) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push_refs(key, val, weight),
             BuilderInner::Vec(vec) => vec.push_refs(key, val, weight),
@@ -796,7 +750,7 @@ where
     }
 
     #[inline]
-    fn push_vals(&mut self, key: &mut K, val: &mut V, weight: &mut R) {
+    fn push_vals(&mut self, key: &mut K, val: &mut DynUnit, weight: &mut R) {
         match &mut self.inner {
             BuilderInner::File(file) => file.push_vals(key, val, weight),
             BuilderInner::Vec(vec) => vec.push_vals(key, val, weight),
@@ -804,8 +758,8 @@ where
     }
 
     #[inline(never)]
-    fn done(self) -> FallbackIndexedZSet<K, V, R> {
-        FallbackIndexedZSet {
+    fn done(self) -> FallbackWSet<K, R> {
+        FallbackWSet {
             factories: self.factories,
             inner: match self.inner {
                 BuilderInner::File(file) => Inner::File(file.done()),
@@ -815,10 +769,9 @@ where
     }
 }
 
-impl<K, V, R> SizeOf for FallbackIndexedZSetBuilder<K, V, R>
+impl<K, R> SizeOf for FallbackWSetBuilder<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -829,10 +782,9 @@ where
     }
 }
 
-impl<K, V, R> SizeOf for FallbackIndexedZSet<K, V, R>
+impl<K, R> SizeOf for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
@@ -843,10 +795,9 @@ where
     }
 }
 
-impl<K, V, R> Archive for FallbackIndexedZSet<K, V, R>
+impl<K, R> Archive for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Archived = ();
@@ -857,10 +808,9 @@ where
     }
 }
 
-impl<K, V, R, S> Serialize<S> for FallbackIndexedZSet<K, V, R>
+impl<K, R, S> Serialize<S> for FallbackWSet<K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
     S: Serializer + ?Sized,
 {
@@ -869,15 +819,13 @@ where
     }
 }
 
-impl<K, V, R, D> Deserialize<FallbackIndexedZSet<K, V, R>, D>
-    for Archived<FallbackIndexedZSet<K, V, R>>
+impl<K, R, D> Deserialize<FallbackWSet<K, R>, D> for Archived<FallbackWSet<K, R>>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
     D: Fallible,
 {
-    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackIndexedZSet<K, V, R>, D::Error> {
+    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackWSet<K, R>, D::Error> {
         unimplemented!();
     }
 }
@@ -911,10 +859,9 @@ where
         cursor
     }
 
-    fn from_cursor<C, V, R>(cursor: &C) -> Position<K>
+    fn from_cursor<C, R>(cursor: &C) -> Position<K>
     where
-        C: Cursor<K, V, (), R>,
-        V: ?Sized,
+        C: Cursor<K, DynUnit, (), R>,
         R: ?Sized,
     {
         if cursor.key_valid() {
@@ -925,43 +872,38 @@ where
     }
 }
 
-struct GenericMerger<K, V, R, O>
+struct GenericMerger<K, R, O>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
 {
     builder: O::Builder,
     pos1: Position<K>,
     pos2: Position<K>,
 }
 
-trait CursorWeightRef<K, V, T, R>: Cursor<K, V, T, R>
+trait CursorWeightRef<K, T, R>: Cursor<K, DynUnit, T, R>
 where
     K: ?Sized,
-    V: ?Sized,
     R: ?Sized,
 {
     fn weight_ref(&self) -> &R;
 }
 
-impl<'s, K, V, R, O> CursorWeightRef<K, V, (), R> for VecIndexedWSetCursor<'s, K, V, R, O>
+impl<'s, K, R> CursorWeightRef<K, (), R> for VecWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: OrdOffset,
 {
     fn weight_ref(&self) -> &R {
-        self.cursor.child.current_diff()
+        self.cursor.current_diff()
     }
 }
 
-impl<'s, K, V, R> CursorWeightRef<K, V, (), R> for FileIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, R> CursorWeightRef<K, (), R> for FileWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn weight_ref(&self) -> &R {
@@ -969,12 +911,11 @@ where
     }
 }
 
-impl<K, V, R, O> GenericMerger<K, V, R, O>
+impl<K, R, O> GenericMerger<K, R, O>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
 {
     fn new(factories: &O::Factories) -> Self {
         Self {
@@ -989,49 +930,41 @@ where
         source1: &'s A,
         source2: &'s B,
         key_filter: &Option<Filter<K>>,
-        value_filter: &Option<Filter<V>>,
+        value_filter: &Option<Filter<DynUnit>>,
         fuel: &mut isize,
     ) where
-        A: BatchReader<Key = K, Val = V, R = R, Time = ()>,
-        B: BatchReader<Key = K, Val = V, R = R, Time = ()>,
-        A::Cursor<'s>: CursorWeightRef<K, V, (), R>,
-        B::Cursor<'s>: CursorWeightRef<K, V, (), R>,
+        A: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+        B: BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
+        A::Cursor<'s>: CursorWeightRef<K, (), R>,
+        B::Cursor<'s>: CursorWeightRef<K, (), R>,
     {
+        if !filter(value_filter, &()) {
+            return;
+        }
+
         let mut cursor1 = self.pos1.cursor(source1);
         let mut cursor2 = self.pos2.cursor(source2);
-        let mut diff = source1.factories().weight_factory().default_box();
         while cursor1.key_valid() && cursor2.key_valid() && *fuel > 0 {
             match cursor1.key().cmp(cursor2.key()) {
                 Ordering::Less => {
-                    self.copy_values_if(&mut cursor1, key_filter, value_filter, fuel);
+                    self.copy_value_if(&mut cursor1, key_filter, fuel);
                 }
                 Ordering::Equal => {
-                    if filter(key_filter, cursor1.key()) {
-                        self.merge_values(
-                            &mut cursor1,
-                            &mut cursor2,
-                            value_filter,
-                            diff.as_mut(),
-                            fuel,
-                        );
-                    } else {
-                        *fuel -= 1;
-                    }
-                    cursor1.step_key();
+                    self.copy_value_if(&mut cursor1, key_filter, fuel);
                     cursor2.step_key();
+                    *fuel -= 1;
                 }
-
                 Ordering::Greater => {
-                    self.copy_values_if(&mut cursor2, key_filter, value_filter, fuel);
+                    self.copy_value_if(&mut cursor2, key_filter, fuel);
                 }
             }
         }
 
         while cursor1.key_valid() && *fuel > 0 {
-            self.copy_values_if(&mut cursor1, key_filter, value_filter, fuel);
+            self.copy_value_if(&mut cursor1, key_filter, fuel);
         }
         while cursor2.key_valid() && *fuel > 0 {
-            self.copy_values_if(&mut cursor2, key_filter, value_filter, fuel);
+            self.copy_value_if(&mut cursor2, key_filter, fuel);
         }
         self.pos1 = Position::from_cursor(&cursor1);
         self.pos2 = Position::from_cursor(&cursor2);
@@ -1041,86 +974,16 @@ where
         self.builder.done()
     }
 
-    fn copy_values_if<C>(
-        &mut self,
-        cursor: &mut C,
-        key_filter: &Option<Filter<K>>,
-        value_filter: &Option<Filter<V>>,
-        fuel: &mut isize,
-    ) where
-        C: CursorWeightRef<K, V, (), R>,
+    fn copy_value_if<C>(&mut self, cursor: &mut C, key_filter: &Option<Filter<K>>, fuel: &mut isize)
+    where
+        C: CursorWeightRef<K, (), R>,
     {
         if filter(key_filter, cursor.key()) {
-            while cursor.val_valid() {
-                if filter(value_filter, cursor.val()) {
-                    self.builder
-                        .push_refs(cursor.key(), cursor.val(), cursor.weight_ref());
-                }
-                cursor.step_val();
-                *fuel -= 1;
-            }
-        } else {
-            *fuel -= 1;
-        }
-        cursor.step_key();
-    }
-
-    fn copy_value<C>(&mut self, cursor: &mut C, value_filter: &Option<Filter<V>>)
-    where
-        C: CursorWeightRef<K, V, (), R>,
-    {
-        if filter(value_filter, cursor.val()) {
             self.builder
-                .push_refs(cursor.key(), cursor.val(), cursor.weight_ref());
+                .push_refs(cursor.key(), &(), cursor.weight_ref());
         }
-        cursor.step_val();
-    }
-
-    fn merge_values<C1, C2>(
-        &mut self,
-        cursor1: &mut C1,
-        cursor2: &mut C2,
-        value_filter: &Option<Filter<V>>,
-        sum: &mut R,
-        fuel: &mut isize,
-    ) where
-        C1: CursorWeightRef<K, V, (), R>,
-        C2: CursorWeightRef<K, V, (), R>,
-    {
-        while cursor1.val_valid() && cursor2.val_valid() {
-            let value1 = cursor1.val();
-            let value2 = cursor2.val();
-            let cmp = value1.cmp(value2);
-            match cmp {
-                Ordering::Less => {
-                    self.copy_value(cursor1, value_filter);
-                }
-                Ordering::Equal => {
-                    if filter(value_filter, value1) {
-                        cursor1.weight_ref().add(cursor2.weight_ref(), sum);
-                        if !sum.is_zero() {
-                            self.builder.push_refs(cursor1.key(), cursor1.val(), sum);
-                        }
-                    }
-                    cursor1.step_val();
-                    cursor2.step_val();
-                }
-
-                Ordering::Greater => {
-                    self.copy_value(cursor2, value_filter);
-                }
-            }
-            *fuel -= 1;
-        }
-
-        while cursor1.val_valid() {
-            self.copy_value(cursor1, value_filter);
-            *fuel -= 1;
-        }
-        while cursor2.val_valid() {
-            self.copy_value(cursor2, value_filter);
-            *fuel -= 1;
-        }
+        *fuel -= 1;
+        cursor.step_key();
     }
 }
 
@@ -1131,12 +994,11 @@ where
     f.as_ref().map_or(true, |f| f(t))
 }
 
-impl<K, V, R, O> SizeOf for GenericMerger<K, V, R, O>
+impl<K, R, O> SizeOf for GenericMerger<K, R, O>
 where
     K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
-    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = ()>,
+    O: Batch + BatchReader<Key = K, Val = DynUnit, R = R, Time = ()>,
 {
     fn size_of_children(&self, context: &mut size_of::Context) {
         self.builder.size_of_children(context)

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -31,7 +31,7 @@ use std::{
     ops::{Add, AddAssign},
 };
 
-pub struct FileIndexedZSetFactories<K, V, R>
+pub struct FileIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -49,7 +49,7 @@ where
     weighted_items_factory: &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>>,
 }
 
-impl<K, V, R> Clone for FileIndexedZSetFactories<K, V, R>
+impl<K, V, R> Clone for FileIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -71,7 +71,7 @@ where
     }
 }
 
-impl<K, V, R> BatchReaderFactories<K, V, (), R> for FileIndexedZSetFactories<K, V, R>
+impl<K, V, R> BatchReaderFactories<K, V, (), R> for FileIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -115,7 +115,7 @@ where
     }
 }
 
-impl<K, V, R> BatchFactories<K, V, (), R> for FileIndexedZSetFactories<K, V, R>
+impl<K, V, R> BatchFactories<K, V, (), R> for FileIndexedWSetFactories<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -136,21 +136,21 @@ where
 
 /// A batch of key-value weighted tuples without timing information.
 ///
-/// Each tuple in `FileIndexedZSet<K, V, R>` has key type `K`, value type `V`,
+/// Each tuple in `FileIndexedWSet<K, V, R>` has key type `K`, value type `V`,
 /// weight type `R`, and time `()`.
-pub struct FileIndexedZSet<K, V, R>
+pub struct FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileIndexedZSetFactories<K, V, R>,
+    factories: FileIndexedWSetFactories<K, V, R>,
     #[allow(clippy::type_complexity)]
     file: Reader<Backend, (&'static K, &'static DynUnit, (&'static V, &'static R, ()))>,
     lower_bound: usize,
 }
 
-impl<K, V, R> Debug for FileIndexedZSet<K, V, R>
+impl<K, V, R> Debug for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -159,7 +159,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "FileIndexedZSet {{ lower_bound: {}, data: ",
+            "FileIndexedWSet {{ lower_bound: {}, data: ",
             self.lower_bound
         )?;
         let mut cursor = self.cursor();
@@ -189,7 +189,7 @@ where
     }
 }
 
-impl<K, V, R> Clone for FileIndexedZSet<K, V, R>
+impl<K, V, R> Clone for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -207,7 +207,7 @@ where
 // This is `#[cfg(test)]` only because it would be surprisingly expensive in
 // production.
 #[cfg(test)]
-impl<Other, K, V, R> PartialEq<Other> for FileIndexedZSet<K, V, R>
+impl<Other, K, V, R> PartialEq<Other> for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -221,7 +221,7 @@ where
 }
 
 #[cfg(test)]
-impl<K, V, R> Eq for FileIndexedZSet<K, V, R>
+impl<K, V, R> Eq for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -229,7 +229,7 @@ where
 {
 }
 
-impl<K, V, R> NumEntries for FileIndexedZSet<K, V, R>
+impl<K, V, R> NumEntries for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -246,7 +246,7 @@ where
     }
 }
 
-impl<K, V, R> NegByRef for FileIndexedZSet<K, V, R>
+impl<K, V, R> NegByRef for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -281,7 +281,7 @@ where
     }
 }
 
-impl<K, V, R> Neg for FileIndexedZSet<K, V, R>
+impl<K, V, R> Neg for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -296,7 +296,7 @@ where
     }
 }
 
-impl<K, V, R> Add<Self> for FileIndexedZSet<K, V, R>
+impl<K, V, R> Add<Self> for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -316,7 +316,7 @@ where
     }
 }
 
-impl<K, V, R> AddAssign<Self> for FileIndexedZSet<K, V, R>
+impl<K, V, R> AddAssign<Self> for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -330,7 +330,7 @@ where
     }
 }
 
-impl<K, V, R> AddAssignByRef for FileIndexedZSet<K, V, R>
+impl<K, V, R> AddAssignByRef for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -344,7 +344,7 @@ where
     }
 }
 
-impl<K, V, R> AddByRef for FileIndexedZSet<K, V, R>
+impl<K, V, R> AddByRef for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -356,18 +356,18 @@ where
     }
 }
 
-impl<K, V, R> BatchReader for FileIndexedZSet<K, V, R>
+impl<K, V, R> BatchReader for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Factories = FileIndexedZSetFactories<K, V, R>;
+    type Factories = FileIndexedWSetFactories<K, V, R>;
     type Key = K;
     type Val = V;
     type Time = ();
     type R = R;
-    type Cursor<'s> = FileIndexedZSetCursor<'s, K, V, R>
+    type Cursor<'s> = FileIndexedWSetCursor<'s, K, V, R>
     where
         V: 's;
 
@@ -377,7 +377,7 @@ where
 
     #[inline]
     fn cursor(&self) -> Self::Cursor<'_> {
-        FileIndexedZSetCursor::new(self)
+        FileIndexedWSetCursor::new(self)
     }
 
     #[inline]
@@ -436,18 +436,18 @@ where
     }
 }
 
-impl<K, V, R> Batch for FileIndexedZSet<K, V, R>
+impl<K, V, R> Batch for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Batcher = MergeBatcher<Self>;
-    type Builder = FileIndexedZSetBuilder<K, V, R>;
-    type Merger = FileIndexedZSetMerger<K, V, R>;
+    type Builder = FileIndexedWSetBuilder<K, V, R>;
+    type Merger = FileIndexedWSetMerger<K, V, R>;
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FileIndexedZSetMerger::new_merger(self, other)
+        FileIndexedWSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -465,13 +465,13 @@ where
 }
 
 /// State for an in-progress merge.
-pub struct FileIndexedZSetMerger<K, V, R>
+pub struct FileIndexedWSetMerger<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileIndexedZSetFactories<K, V, R>,
+    factories: FileIndexedWSetFactories<K, V, R>,
 
     // Position in first batch.
     lower1: usize,
@@ -482,7 +482,7 @@ where
     writer: Writer2<Backend, K, DynUnit, V, R>,
 }
 
-impl<K, V, R> FileIndexedZSetMerger<K, V, R>
+impl<K, V, R> FileIndexedWSetMerger<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -490,7 +490,7 @@ where
 {
     fn copy_values_if(
         &mut self,
-        cursor: &mut FileIndexedZSetCursor<K, V, R>,
+        cursor: &mut FileIndexedWSetCursor<K, V, R>,
         key_filter: &Option<Filter<K>>,
         value_filter: &Option<Filter<V>>,
         fuel: &mut isize,
@@ -520,7 +520,7 @@ where
 
     fn copy_value(
         &mut self,
-        cursor: &mut FileIndexedZSetCursor<K, V, R>,
+        cursor: &mut FileIndexedWSetCursor<K, V, R>,
         value_filter: &Option<Filter<V>>,
     ) -> u64 {
         let retval = if filter(value_filter, cursor.val.as_ref()) {
@@ -537,8 +537,8 @@ where
 
     fn merge_values<'a>(
         &mut self,
-        cursor1: &mut FileIndexedZSetCursor<'a, K, V, R>,
-        cursor2: &mut FileIndexedZSetCursor<'a, K, V, R>,
+        cursor1: &mut FileIndexedWSetCursor<'a, K, V, R>,
+        cursor2: &mut FileIndexedWSetCursor<'a, K, V, R>,
         value_filter: &Option<Filter<V>>,
     ) -> bool {
         let mut n = 0;
@@ -580,7 +580,7 @@ where
     }
 }
 
-impl<K, V, R> Merger<K, V, (), R, FileIndexedZSet<K, V, R>> for FileIndexedZSetMerger<K, V, R>
+impl<K, V, R> Merger<K, V, (), R, FileIndexedWSet<K, V, R>> for FileIndexedWSetMerger<K, V, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
@@ -588,7 +588,7 @@ where
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_merger(batch1: &FileIndexedZSet<K, V, R>, batch2: &FileIndexedZSet<K, V, R>) -> Self {
+    fn new_merger(batch1: &FileIndexedWSet<K, V, R>, batch2: &FileIndexedWSet<K, V, R>) -> Self {
         Self {
             factories: batch1.factories.clone(),
             lower1: batch1.lower_bound,
@@ -604,8 +604,8 @@ where
     }
 
     #[inline]
-    fn done(self) -> FileIndexedZSet<K, V, R> {
-        FileIndexedZSet {
+    fn done(self) -> FileIndexedWSet<K, V, R> {
+        FileIndexedWSet {
             factories: self.factories.clone(),
             file: self.writer.into_reader().unwrap(),
             lower_bound: 0,
@@ -614,14 +614,14 @@ where
 
     fn work(
         &mut self,
-        source1: &FileIndexedZSet<K, V, R>,
-        source2: &FileIndexedZSet<K, V, R>,
+        source1: &FileIndexedWSet<K, V, R>,
+        source2: &FileIndexedWSet<K, V, R>,
         key_filter: &Option<Filter<K>>,
         value_filter: &Option<Filter<V>>,
         fuel: &mut isize,
     ) {
-        let mut cursor1 = FileIndexedZSetCursor::new_from(source1, self.lower1);
-        let mut cursor2 = FileIndexedZSetCursor::new_from(source2, self.lower2);
+        let mut cursor1 = FileIndexedWSetCursor::new_from(source1, self.lower1);
+        let mut cursor2 = FileIndexedWSetCursor::new_from(source2, self.lower2);
         while cursor1.key_valid() && cursor2.key_valid() && *fuel > 0 {
             match cursor1.key.as_ref().cmp(cursor2.key.as_ref()) {
                 Ordering::Less => {
@@ -666,7 +666,7 @@ where
     f.as_ref().map_or(true, |f| f(t))
 }
 
-impl<K, V, R> SizeOf for FileIndexedZSetMerger<K, V, R>
+impl<K, V, R> SizeOf for FileIndexedWSetMerger<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -691,13 +691,13 @@ type ValCursor<'s, K, V, R> =
 
 /// A cursor for navigating a single layer.
 #[derive(Debug, SizeOf)]
-pub struct FileIndexedZSetCursor<'s, K, V, R>
+pub struct FileIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    zset: &'s FileIndexedZSet<K, V, R>,
+    wset: &'s FileIndexedWSet<K, V, R>,
 
     key_cursor: KeyCursor<'s, K, V, R>,
     key: Box<K>,
@@ -707,7 +707,7 @@ where
     pub(crate) diff: Box<R>,
 }
 
-impl<'s, K, V, R> Clone for FileIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, V, R> Clone for FileIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -715,7 +715,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            zset: self.zset,
+            wset: self.wset,
             key_cursor: self.key_cursor.clone(),
             key: clone_box(&self.key),
             val_cursor: self.val_cursor.clone(),
@@ -725,28 +725,28 @@ where
     }
 }
 
-impl<'s, K, V, R> FileIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, V, R> FileIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    pub fn new_from(zset: &'s FileIndexedZSet<K, V, R>, lower_bound: usize) -> Self {
-        let key_cursor = zset
+    pub fn new_from(wset: &'s FileIndexedWSet<K, V, R>, lower_bound: usize) -> Self {
+        let key_cursor = wset
             .file
             .rows()
             .subset(lower_bound as u64..)
             .first()
             .unwrap();
-        let mut key = zset.factories.key_factory.default_box();
+        let mut key = wset.factories.key_factory.default_box();
         unsafe { key_cursor.key(&mut key) };
 
         let val_cursor = key_cursor.next_column().unwrap().first().unwrap();
-        let mut val = zset.factories.val_factory.default_box();
-        let mut diff = zset.factories.weight_factory.default_box();
+        let mut val = wset.factories.val_factory.default_box();
+        let mut diff = wset.factories.weight_factory.default_box();
         unsafe { val_cursor.item((&mut val, &mut diff)) };
         Self {
-            zset,
+            wset,
             key_cursor,
             key,
             val_cursor,
@@ -755,8 +755,8 @@ where
         }
     }
 
-    pub fn new(zset: &'s FileIndexedZSet<K, V, R>) -> Self {
-        Self::new_from(zset, zset.lower_bound)
+    pub fn new(wset: &'s FileIndexedWSet<K, V, R>) -> Self {
+        Self::new_from(wset, wset.lower_bound)
     }
 
     fn move_key<F>(&mut self, op: F)
@@ -778,14 +778,14 @@ where
     }
 }
 
-impl<'s, K, V, R> Cursor<K, V, (), R> for FileIndexedZSetCursor<'s, K, V, R>
+impl<'s, K, V, R> Cursor<K, V, (), R> for FileIndexedWSetCursor<'s, K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn weight_factory(&self) -> &'static dyn Factory<R> {
-        self.zset.factories.weight_factory
+        self.wset.factories.weight_factory
     }
 
     fn key(&self) -> &K {
@@ -894,18 +894,18 @@ where
 }
 
 /// A builder for batches from ordered update tuples.
-pub struct FileIndexedZSetBuilder<K, V, R>
+pub struct FileIndexedWSetBuilder<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileIndexedZSetFactories<K, V, R>,
+    factories: FileIndexedWSetFactories<K, V, R>,
     writer: Writer2<Backend, K, DynUnit, V, R>,
     key: Box<DynOpt<K>>,
 }
 
-impl<K, V, R> Builder<FileIndexedZSet<K, V, R>> for FileIndexedZSetBuilder<K, V, R>
+impl<K, V, R> Builder<FileIndexedWSet<K, V, R>> for FileIndexedWSetBuilder<K, V, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
@@ -913,7 +913,7 @@ where
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_builder(factories: &FileIndexedZSetFactories<K, V, R>, _time: ()) -> Self {
+    fn new_builder(factories: &FileIndexedWSetFactories<K, V, R>, _time: ()) -> Self {
         Self {
             factories: factories.clone(),
             writer: Writer2::new(
@@ -929,7 +929,7 @@ where
 
     #[inline]
     fn with_capacity(
-        factories: &FileIndexedZSetFactories<K, V, R>,
+        factories: &FileIndexedWSetFactories<K, V, R>,
         time: (),
         _capacity: usize,
     ) -> Self {
@@ -966,11 +966,11 @@ where
     }
 
     #[inline(never)]
-    fn done(mut self) -> FileIndexedZSet<K, V, R> {
+    fn done(mut self) -> FileIndexedWSet<K, V, R> {
         if let Some(key) = self.key.get() {
             self.writer.write0((key, ().erase())).unwrap();
         }
-        FileIndexedZSet {
+        FileIndexedWSet {
             factories: self.factories,
             file: self.writer.into_reader().unwrap(),
             lower_bound: 0,
@@ -978,7 +978,7 @@ where
     }
 }
 
-impl<K, V, R> SizeOf for FileIndexedZSetBuilder<K, V, R>
+impl<K, V, R> SizeOf for FileIndexedWSetBuilder<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -989,7 +989,7 @@ where
     }
 }
 
-impl<K, V, R> SizeOf for FileIndexedZSet<K, V, R>
+impl<K, V, R> SizeOf for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -1000,7 +1000,7 @@ where
     }
 }
 
-impl<K, V, R> Archive for FileIndexedZSet<K, V, R>
+impl<K, V, R> Archive for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -1014,7 +1014,7 @@ where
     }
 }
 
-impl<K, V, R, S> Serialize<S> for FileIndexedZSet<K, V, R>
+impl<K, V, R, S> Serialize<S> for FileIndexedWSet<K, V, R>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -1026,14 +1026,14 @@ where
     }
 }
 
-impl<K, V, R, D> Deserialize<FileIndexedZSet<K, V, R>, D> for Archived<FileIndexedZSet<K, V, R>>
+impl<K, V, R, D> Deserialize<FileIndexedWSet<K, V, R>, D> for Archived<FileIndexedWSet<K, V, R>>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
     D: Fallible,
 {
-    fn deserialize(&self, _deserializer: &mut D) -> Result<FileIndexedZSet<K, V, R>, D::Error> {
+    fn deserialize(&self, _deserializer: &mut D) -> Result<FileIndexedWSet<K, V, R>, D::Error> {
         unimplemented!();
     }
 }

--- a/crates/dbsp/src/trace/ord/file/mod.rs
+++ b/crates/dbsp/src/trace/ord/file/mod.rs
@@ -1,11 +1,11 @@
 //! Trace and batch implementations based on files.
 
-pub mod indexed_zset_batch;
+pub mod indexed_wset_batch;
 pub mod key_batch;
 pub mod val_batch;
-pub mod zset_batch;
+pub mod wset_batch;
 
-pub use indexed_zset_batch::{FileIndexedZSet, FileIndexedZSetFactories};
+pub use indexed_wset_batch::{FileIndexedWSet, FileIndexedWSetFactories};
 pub use key_batch::{FileKeyBatch, FileKeyBatchFactories};
 pub use val_batch::{FileValBatch, FileValBatchFactories};
-pub use zset_batch::{FileZSet, FileZSetFactories};
+pub use wset_batch::{FileWSet, FileWSetFactories};

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use std::{cmp::Ordering, path::PathBuf};
 
-pub struct FileZSetFactories<K, R>
+pub struct FileWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -45,7 +45,7 @@ where
     weighted_items_factory: &'static dyn Factory<DynWeightedPairs<DynPair<K, DynUnit>, R>>,
 }
 
-impl<K, R> Clone for FileZSetFactories<K, R>
+impl<K, R> Clone for FileWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -63,7 +63,7 @@ where
     }
 }
 
-impl<K, R> BatchReaderFactories<K, DynUnit, (), R> for FileZSetFactories<K, R>
+impl<K, R> BatchReaderFactories<K, DynUnit, (), R> for FileWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<K, R> BatchFactories<K, DynUnit, (), R> for FileZSetFactories<K, R>
+impl<K, R> BatchFactories<K, DynUnit, (), R> for FileWSetFactories<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -126,25 +126,25 @@ where
 
 /// A batch of weighted tuples without values or times.
 ///
-/// Each tuple in `FileZSet<K, R>` has key type `K`, value type `()`, weight
+/// Each tuple in `FileWSet<K, R>` has key type `K`, value type `()`, weight
 /// type `R`, and time type `()`.
-pub struct FileZSet<K, R>
+pub struct FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileZSetFactories<K, R>,
+    factories: FileWSetFactories<K, R>,
     file: Reader<Backend, (&'static K, &'static R, ())>,
     lower_bound: usize,
 }
 
-impl<K, R> Debug for FileZSet<K, R>
+impl<K, R> Debug for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "FileZSet {{ lower_bound: {}, data: ", self.lower_bound)?;
+        write!(f, "FileWSet {{ lower_bound: {}, data: ", self.lower_bound)?;
         let mut cursor = self.cursor();
         let mut n_keys = 0;
         while cursor.key_valid() {
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<K, R> Clone for FileZSet<K, R>
+impl<K, R> Clone for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -175,7 +175,7 @@ where
     }
 }
 
-impl<K, R> FileZSet<K, R>
+impl<K, R> FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -193,7 +193,7 @@ where
 
 // This is `#[cfg(test)]` only because it would be surprisingly expensive in
 // production.
-impl<Other, K, R> PartialEq<Other> for FileZSet<K, R>
+impl<Other, K, R> PartialEq<Other> for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -205,14 +205,14 @@ where
     }
 }
 
-impl<K, R> Eq for FileZSet<K, R>
+impl<K, R> Eq for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
 }
 
-impl<K, R> NumEntries for FileZSet<K, R>
+impl<K, R> NumEntries for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -228,7 +228,7 @@ where
     }
 }
 
-impl<K, R> NegByRef for FileZSet<K, R>
+impl<K, R> NegByRef for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
@@ -256,7 +256,7 @@ where
     }
 }
 
-impl<K, R> Neg for FileZSet<K, R>
+impl<K, R> Neg for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTraitTyped + ?Sized,
@@ -270,7 +270,7 @@ where
 }
 
 // TODO: by-value merge
-impl<K, R> Add<Self> for FileZSet<K, R>
+impl<K, R> Add<Self> for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -288,7 +288,7 @@ where
     }
 }
 
-impl<K, R> AddAssign<Self> for FileZSet<K, R>
+impl<K, R> AddAssign<Self> for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -300,7 +300,7 @@ where
     }
 }
 
-impl<K, R> AddAssignByRef for FileZSet<K, R>
+impl<K, R> AddAssignByRef for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -312,7 +312,7 @@ where
     }
 }
 
-impl<K, R> AddByRef for FileZSet<K, R>
+impl<K, R> AddByRef for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -322,18 +322,18 @@ where
     }
 }
 
-impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Deserialize<FileZSet<K, R>, Deserializer>
+impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Deserialize<FileWSet<K, R>, Deserializer>
     for ()
 {
     fn deserialize(
         &self,
         _deserializer: &mut Deserializer,
-    ) -> Result<FileZSet<K, R>, <Deserializer as rkyv::Fallible>::Error> {
+    ) -> Result<FileWSet<K, R>, <Deserializer as rkyv::Fallible>::Error> {
         todo!()
     }
 }
 
-impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Archive for FileZSet<K, R> {
+impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Archive for FileWSet<K, R> {
     type Archived = ();
     type Resolver = ();
 
@@ -341,7 +341,7 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Archive for FileZSet<K, R> 
         todo!()
     }
 }
-impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Serialize<Serializer> for FileZSet<K, R> {
+impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Serialize<Serializer> for FileWSet<K, R> {
     fn serialize(
         &self,
         _serializer: &mut Serializer,
@@ -350,17 +350,17 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Serialize<Serializer> for F
     }
 }
 
-impl<K, R> BatchReader for FileZSet<K, R>
+impl<K, R> BatchReader for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    type Factories = FileZSetFactories<K, R>;
+    type Factories = FileWSetFactories<K, R>;
     type Key = K;
     type Val = DynUnit;
     type Time = ();
     type R = R;
-    type Cursor<'s> = FileZSetCursor<'s, K, R>;
+    type Cursor<'s> = FileWSetCursor<'s, K, R>;
 
     fn factories(&self) -> Self::Factories {
         self.factories.clone()
@@ -368,7 +368,7 @@ where
 
     #[inline]
     fn cursor(&self) -> Self::Cursor<'_> {
-        FileZSetCursor::new(self)
+        FileWSetCursor::new(self)
     }
 
     #[inline]
@@ -427,17 +427,17 @@ where
     }
 }
 
-impl<K, R> Batch for FileZSet<K, R>
+impl<K, R> Batch for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     type Batcher = MergeBatcher<Self>;
-    type Builder = FileZSetBuilder<K, R>;
-    type Merger = FileZSetMerger<K, R>;
+    type Builder = FileWSetBuilder<K, R>;
+    type Merger = FileWSetMerger<K, R>;
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FileZSetMerger::new_merger(self, other)
+        FileWSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -456,12 +456,12 @@ where
 }
 
 /// State for an in-progress merge.
-pub struct FileZSetMerger<K, R>
+pub struct FileWSetMerger<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileZSetFactories<K, R>,
+    factories: FileWSetFactories<K, R>,
 
     // Position in first batch.
     lower1: usize,
@@ -472,13 +472,13 @@ where
     writer: Writer1<Backend, K, R>,
 }
 
-impl<K, R> Merger<K, DynUnit, (), R, FileZSet<K, R>> for FileZSetMerger<K, R>
+impl<K, R> Merger<K, DynUnit, (), R, FileWSet<K, R>> for FileWSetMerger<K, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn new_merger(batch1: &FileZSet<K, R>, batch2: &FileZSet<K, R>) -> Self {
+    fn new_merger(batch1: &FileWSet<K, R>, batch2: &FileWSet<K, R>) -> Self {
         Self {
             factories: batch1.factories.clone(),
             lower1: batch1.lower_bound,
@@ -492,8 +492,8 @@ where
         }
     }
 
-    fn done(self) -> FileZSet<K, R> {
-        FileZSet {
+    fn done(self) -> FileWSet<K, R> {
+        FileWSet {
             factories: self.factories.clone(),
             file: self.writer.into_reader().unwrap(),
             lower_bound: 0,
@@ -502,8 +502,8 @@ where
 
     fn work(
         &mut self,
-        source1: &FileZSet<K, R>,
-        source2: &FileZSet<K, R>,
+        source1: &FileWSet<K, R>,
+        source2: &FileWSet<K, R>,
         key_filter: &Option<Filter<K>>,
         value_filter: &Option<Filter<DynUnit>>,
         fuel: &mut isize,
@@ -512,8 +512,8 @@ where
             return;
         }
 
-        let mut cursor1 = FileZSetCursor::new_from(source1, self.lower1);
-        let mut cursor2 = FileZSetCursor::new_from(source2, self.lower2);
+        let mut cursor1 = FileWSetCursor::new_from(source1, self.lower1);
+        let mut cursor2 = FileWSetCursor::new_from(source2, self.lower2);
         let mut sum = self.factories.weight_factory.default_box();
         while cursor1.key_valid() && cursor2.key_valid() && *fuel > 0 {
             match cursor1.key.as_ref().cmp(cursor2.key.as_ref()) {
@@ -584,26 +584,26 @@ type RawCursor<'s, K, R> = FileCursor<'s, Backend, K, R, (), (&'static K, &'stat
 
 /// A cursor for navigating a single layer.
 #[derive(Debug, SizeOf)]
-pub struct FileZSetCursor<'s, K, R>
+pub struct FileWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    zset: &'s FileZSet<K, R>,
+    wset: &'s FileWSet<K, R>,
     cursor: RawCursor<'s, K, R>,
     key: Box<K>,
     pub(crate) diff: Box<R>,
     valid: bool,
 }
 
-impl<'s, K, R> Clone for FileZSetCursor<'s, K, R>
+impl<'s, K, R> Clone for FileWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     fn clone(&self) -> Self {
         Self {
-            zset: self.zset,
+            wset: self.wset,
             cursor: self.cursor.clone(),
             key: clone_box(&self.key),
             diff: clone_box(&self.diff),
@@ -612,24 +612,24 @@ where
     }
 }
 
-impl<'s, K, R> FileZSetCursor<'s, K, R>
+impl<'s, K, R> FileWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn new_from(zset: &'s FileZSet<K, R>, lower_bound: usize) -> Self {
-        let cursor = zset
+    fn new_from(wset: &'s FileWSet<K, R>, lower_bound: usize) -> Self {
+        let cursor = wset
             .file
             .rows()
             .subset(lower_bound as u64..)
             .first()
             .unwrap();
-        let mut key = zset.factories.key_factory.default_box();
-        let mut diff = zset.factories.weight_factory.default_box();
+        let mut key = wset.factories.key_factory.default_box();
+        let mut diff = wset.factories.weight_factory.default_box();
         let valid = unsafe { cursor.item((&mut key, &mut diff)) }.is_some();
 
         Self {
-            zset,
+            wset,
             cursor,
             key,
             diff,
@@ -637,8 +637,8 @@ where
         }
     }
 
-    fn new(zset: &'s FileZSet<K, R>) -> Self {
-        Self::new_from(zset, zset.lower_bound)
+    fn new(wset: &'s FileWSet<K, R>) -> Self {
+        Self::new_from(wset, wset.lower_bound)
     }
 
     fn move_key<F>(&mut self, op: F)
@@ -650,7 +650,7 @@ where
     }
 }
 
-impl<'s, K, R> Cursor<K, DynUnit, (), R> for FileZSetCursor<'s, K, R>
+impl<'s, K, R> Cursor<K, DynUnit, (), R> for FileWSetCursor<'s, K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -752,7 +752,7 @@ where
     }
 
     fn weight_factory(&self) -> &'static dyn Factory<R> {
-        self.zset.factories.weight_factory
+        self.wset.factories.weight_factory
     }
 
     fn map_values(&mut self, logic: &mut dyn FnMut(&DynUnit, &R)) {
@@ -763,23 +763,23 @@ where
 }
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct FileZSetBuilder<K, R>
+pub struct FileWSetBuilder<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    factories: FileZSetFactories<K, R>,
+    factories: FileWSetFactories<K, R>,
     writer: Writer1<Backend, K, R>,
 }
 
-impl<K, R> Builder<FileZSet<K, R>> for FileZSetBuilder<K, R>
+impl<K, R> Builder<FileWSet<K, R>> for FileWSetBuilder<K, R>
 where
     Self: SizeOf,
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_builder(factories: &<FileZSet<K, R> as BatchReader>::Factories, _time: ()) -> Self {
+    fn new_builder(factories: &<FileWSet<K, R> as BatchReader>::Factories, _time: ()) -> Self {
         Self {
             factories: factories.clone(),
             writer: Writer1::new(
@@ -793,7 +793,7 @@ where
 
     #[inline]
     fn with_capacity(
-        factories: &<FileZSet<K, R> as BatchReader>::Factories,
+        factories: &<FileWSet<K, R> as BatchReader>::Factories,
         time: (),
         _capacity: usize,
     ) -> Self {
@@ -812,8 +812,8 @@ where
     }
 
     #[inline(never)]
-    fn done(self) -> FileZSet<K, R> {
-        FileZSet {
+    fn done(self) -> FileWSet<K, R> {
+        FileWSet {
             factories: self.factories,
             file: self.writer.into_reader().unwrap(),
             lower_bound: 0,
@@ -829,7 +829,7 @@ where
     }
 }
 
-impl<K, R> SizeOf for FileZSetBuilder<K, R>
+impl<K, R> SizeOf for FileWSetBuilder<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -839,7 +839,7 @@ where
     }
 }
 
-impl<K, R> SizeOf for FileZSetMerger<K, R>
+impl<K, R> SizeOf for FileWSetMerger<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
@@ -849,7 +849,7 @@ where
     }
 }
 
-impl<K, R> SizeOf for FileZSet<K, R>
+impl<K, R> SizeOf for FileWSet<K, R>
 where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,

--- a/crates/dbsp/src/trace/ord/mod.rs
+++ b/crates/dbsp/src/trace/ord/mod.rs
@@ -4,12 +4,12 @@ pub mod merge_batcher;
 pub mod vec;
 
 pub use fallback::{
-    indexed_zset::{FallbackIndexedZSet, FallbackIndexedZSetFactories},
-    zset::{FallbackZSet, FallbackZSetFactories},
+    indexed_wset::{FallbackIndexedWSet, FallbackIndexedWSetFactories},
+    wset::{FallbackWSet, FallbackWSetFactories},
 };
 pub use file::{
-    FileIndexedZSet, FileIndexedZSetFactories, FileKeyBatch, FileKeyBatchFactories, FileValBatch,
-    FileValBatchFactories, FileZSet, FileZSetFactories,
+    FileIndexedWSet, FileIndexedWSetFactories, FileKeyBatch, FileKeyBatchFactories, FileValBatch,
+    FileValBatchFactories, FileWSet, FileWSetFactories,
 };
 pub use vec::{
     VecIndexedWSet as OrdIndexedWSet, VecIndexedWSetFactories as OrdIndexedWSetFactories,

--- a/crates/dbsp/src/trace/ord/vec/mod.rs
+++ b/crates/dbsp/src/trace/ord/vec/mod.rs
@@ -10,7 +10,7 @@
 //!   `key` and `val` are ordered and whose timestamp type is `()`.
 //!   Semantically, such collections store `(key, val, weight)` tuples without
 //!   timing information, and implement the indexed ZSet abstraction of DBSP.
-//! * `OrdZSet`:  Collections whose data have the form `key` where `key` is
+//! * `OrdWSet`:  Collections whose data have the form `key` where `key` is
 //!   ordered and whose timestamp type is `()`.  Semantically, such collections
 //!   store `(key, weight)` tuples without timing information, and implement the
 //!   ZSet abstraction of DBSP.
@@ -19,7 +19,7 @@
 //! representation and should consume fewer resources (computation and memory)
 //! when it applies.
 //!
-//! Likewise, `OrdIndexedWSet` and `OrdZSet` are less general than `OrdVal` and
+//! Likewise, `OrdIndexedWSet` and `OrdWSet` are less general than `OrdVal` and
 //! `OrdKey` respectively, but are more light-weight.
 
 pub mod indexed_wset_batch;

--- a/crates/dbsp/src/trace/test/mod.rs
+++ b/crates/dbsp/src/trace/test/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     trace::{
         cursor::CursorPair,
         ord::{
-            FallbackIndexedZSet, FallbackIndexedZSetFactories, FallbackZSet, FallbackZSetFactories,
+            FallbackIndexedWSet, FallbackIndexedWSetFactories, FallbackWSet, FallbackWSetFactories,
             FileKeyBatch, FileKeyBatchFactories, FileValBatch, FileValBatchFactories, OrdKeyBatch,
             OrdKeyBatchFactories, OrdValBatch, OrdValBatchFactories,
         },
@@ -437,9 +437,9 @@ proptest! {
 
     #[test]
     fn test_file_zset_spine(batches in kr_batches(50, 2, 50, 10), seed in 0..u64::max_value()) {
-        let factories = <FallbackZSetFactories<DynI32, DynZWeight>>::new::<i32, (), ZWeight>();
+        let factories = <FallbackWSetFactories<DynI32, DynZWeight>>::new::<i32, (), ZWeight>();
 
-        test_zset_spine::<FallbackZSet<DynI32, DynZWeight>>(&factories, batches, seed)
+        test_zset_spine::<FallbackWSet<DynI32, DynZWeight>>(&factories, batches, seed)
     }
 
     #[test]
@@ -450,8 +450,8 @@ proptest! {
 
     #[test]
     fn test_file_indexed_zset_spine(batches in kvr_batches(100, 5, 2, 200, 10), seed in 0..u64::max_value()) {
-        let factories = <FallbackIndexedZSetFactories<DynI32, DynI32, DynZWeight>>::new::<i32, i32, ZWeight>();
-        test_indexed_zset_spine::<FallbackIndexedZSet<DynI32, DynI32, DynZWeight>>(&factories, batches, seed)
+        let factories = <FallbackIndexedWSetFactories<DynI32, DynI32, DynZWeight>>::new::<i32, i32, ZWeight>();
+        test_indexed_zset_spine::<FallbackIndexedWSet<DynI32, DynI32, DynZWeight>>(&factories, batches, seed)
     }
 
 

--- a/crates/dbsp/src/typed_batch.rs
+++ b/crates/dbsp/src/typed_batch.rs
@@ -11,9 +11,9 @@ pub use crate::{
     },
     trace::{
         Batch as DynBatch, BatchReader as DynBatchReader,
-        FallbackIndexedZSet as DynFallbackIndexedZSet, FallbackZSet as DynFallbackZSet,
-        FileIndexedZSet as DynFileIndexedZSet, FileKeyBatch as DynFileKeyBatch,
-        FileValBatch as DynFileValBatch, FileZSet as DynFileZSet,
+        FallbackIndexedWSet as DynFallbackIndexedWSet, FallbackWSet as DynFallbackWSet,
+        FileIndexedWSet as DynFileIndexedWSet, FileKeyBatch as DynFileKeyBatch,
+        FileValBatch as DynFileValBatch, FileWSet as DynFileWSet,
         OrdIndexedWSet as DynOrdIndexedWSet, OrdKeyBatch as DynOrdKeyBatch,
         OrdValBatch as DynOrdValBatch, OrdWSet as DynOrdWSet, Spillable as DynSpillable,
         Spine as DynSpine, Stored as DynStored, Trace as DynTrace,
@@ -489,22 +489,22 @@ pub type OrdKeyBatch<K, T, R, DynR> = TypedBatch<K, (), R, DynOrdKeyBatch<DynDat
 pub type OrdValBatch<K, V, T, R, DynR> =
     TypedBatch<K, V, R, DynOrdValBatch<DynData, DynData, T, DynR>>;
 
-pub type FileWSet<K, R, DynR> = TypedBatch<K, (), R, DynFileZSet<DynData, DynR>>;
-pub type FileZSet<K> = TypedBatch<K, (), ZWeight, DynFileZSet<DynData, DynZWeight>>;
+pub type FileWSet<K, R, DynR> = TypedBatch<K, (), R, DynFileWSet<DynData, DynR>>;
+pub type FileZSet<K> = TypedBatch<K, (), ZWeight, DynFileWSet<DynData, DynZWeight>>;
 pub type FileIndexedWSet<K, V, R, DynR> =
-    TypedBatch<K, V, R, DynFileIndexedZSet<DynData, DynData, DynR>>;
+    TypedBatch<K, V, R, DynFileIndexedWSet<DynData, DynData, DynR>>;
 pub type FileIndexedZSet<K, V> =
-    TypedBatch<K, V, ZWeight, DynFileIndexedZSet<DynData, DynData, DynZWeight>>;
+    TypedBatch<K, V, ZWeight, DynFileIndexedWSet<DynData, DynData, DynZWeight>>;
 pub type FileKeyBatch<K, T, R, DynR> = TypedBatch<K, (), R, DynFileKeyBatch<DynData, T, DynR>>;
 pub type FileValBatch<K, V, T, R, DynR> =
     TypedBatch<K, V, R, DynFileValBatch<DynData, DynData, T, DynR>>;
 
-pub type FallbackWSet<K, R, DynR> = TypedBatch<K, (), R, DynFallbackZSet<DynData, DynR>>;
-pub type FallbackZSet<K> = TypedBatch<K, (), ZWeight, DynFallbackZSet<DynData, DynZWeight>>;
+pub type FallbackWSet<K, R, DynR> = TypedBatch<K, (), R, DynFallbackWSet<DynData, DynR>>;
+pub type FallbackZSet<K> = TypedBatch<K, (), ZWeight, DynFallbackWSet<DynData, DynZWeight>>;
 pub type FallbackIndexedWSet<K, V, R, DynR> =
-    TypedBatch<K, V, R, DynFallbackIndexedZSet<DynData, DynData, DynR>>;
+    TypedBatch<K, V, R, DynFallbackIndexedWSet<DynData, DynData, DynR>>;
 pub type FallbackIndexedZSet<K, V> =
-    TypedBatch<K, V, ZWeight, DynFallbackIndexedZSet<DynData, DynData, DynZWeight>>;
+    TypedBatch<K, V, ZWeight, DynFallbackIndexedWSet<DynData, DynData, DynZWeight>>;
 
 pub type Spine<B> = TypedBatch<
     <B as BatchReader>::Key,


### PR DESCRIPTION
…tions.

The vector-based implementations of ZSets were renamed to WSets some time ago.  This renames the other implementations to match.

Is this a user-visible change (yes/no): no