### PR TITLE
dbsp: Change `max_memory_rows` to `min_storage_rows`.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -441,7 +441,7 @@ impl Controller {
         let config = CircuitConfig {
             layout: Layout::new_solo(controller.status.pipeline_config.global.workers as usize),
             storage: controller.status.pipeline_config.storage_location.clone(),
-            max_memory_rows: usize::MAX,
+            min_storage_rows: usize::MAX,
         };
         let mut circuit = match circuit_factory(config) {
             Ok((circuit, catalog)) => {

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -216,11 +216,11 @@ pub struct CircuitConfig {
     /// bigger than more or for fault tolerance.
     pub storage: Option<String>,
 
-    /// Maximum number of rows of any given persistent trace to keep in memory
-    /// before spilling it to storage. If this is 0, then all traces will be
-    /// stored on disk; if it is `usize::MAX`, then all traces will be kept in
-    /// memory; and intermediate values specify a threshold.
-    pub max_memory_rows: usize,
+    /// Minimum number of rows in a persistent trace to spill it to storage. If
+    /// this is 0, then all traces will be stored on disk; if it is
+    /// `usize::MAX`, then all traces will be kept in memory; and intermediate
+    /// values specify a threshold.
+    pub min_storage_rows: usize,
 }
 
 impl CircuitConfig {
@@ -228,7 +228,7 @@ impl CircuitConfig {
         Self {
             layout: Layout::new_solo(n),
             storage: None,
-            max_memory_rows: usize::MAX,
+            min_storage_rows: usize::MAX,
         }
     }
 }
@@ -242,8 +242,8 @@ impl IntoCircuitConfig for CircuitConfig {
         self.storage.clone()
     }
 
-    fn max_memory_rows(&self) -> usize {
-        self.max_memory_rows
+    fn min_storage_rows(&self) -> usize {
+        self.min_storage_rows
     }
 }
 
@@ -256,7 +256,7 @@ pub trait IntoCircuitConfig {
         None
     }
 
-    fn max_memory_rows(&self) -> usize {
+    fn min_storage_rows(&self) -> usize {
         usize::MAX
     }
 }

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -409,10 +409,7 @@ where
     fn recede_to(&mut self, _frontier: &()) {}
 
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
-        Self {
-            factories: factories.clone(),
-            inner: Inner::Vec(OrdIndexedWSet::dyn_empty(&factories.vec, time)),
-        }
+        Self::Builder::new_builder(factories, time).done()
     }
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -460,7 +460,7 @@ where
     ) -> Self {
         Self {
             factories: batch1.factories.clone(),
-            inner: if batch1.len() + batch2.len() <= Runtime::max_memory_rows() {
+            inner: if batch1.len() + batch2.len() < Runtime::min_storage_rows() {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::Vec(vec1), Inner::Vec(vec2)) => {
                         MergerInner::AllVec(OrdIndexedWSetMerger::new_merger(vec1, vec2))
@@ -760,7 +760,7 @@ where
     ) -> Self {
         Self {
             factories: factories.clone(),
-            inner: if capacity <= Runtime::max_memory_rows() {
+            inner: if capacity < Runtime::min_storage_rows() {
                 BuilderInner::Vec(VecIndexedWSetBuilder::with_capacity(
                     &factories.vec,
                     time,

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -428,7 +428,7 @@ where
     fn new_merger(batch1: &FallbackWSet<K, R>, batch2: &FallbackWSet<K, R>) -> Self {
         Self {
             factories: batch1.factories.clone(),
-            inner: if batch1.len() + batch2.len() <= Runtime::max_memory_rows() {
+            inner: if batch1.len() + batch2.len() < Runtime::min_storage_rows() {
                 match (&batch1.inner, &batch2.inner) {
                     (Inner::Vec(vec1), Inner::Vec(vec2)) => {
                         MergerInner::AllVec(VecWSetMerger::new_merger(vec1, vec2))
@@ -714,7 +714,7 @@ where
     fn with_capacity(factories: &FallbackWSetFactories<K, R>, time: (), capacity: usize) -> Self {
         Self {
             factories: factories.clone(),
-            inner: if capacity <= Runtime::max_memory_rows() {
+            inner: if capacity < Runtime::min_storage_rows() {
                 BuilderInner::Vec(VecWSetBuilder::with_capacity(
                     &factories.vec,
                     time,

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -384,10 +384,7 @@ where
     fn recede_to(&mut self, _frontier: &()) {}
 
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
-        Self {
-            factories: factories.clone(),
-            inner: Inner::Vec(OrdWSet::dyn_empty(&factories.vec, time)),
-        }
+        Self::Builder::new_builder(factories, time).done()
     }
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -31,10 +31,9 @@ const fn default_workers() -> u16 {
     1
 }
 
-/// Default maximum on the number of rows that a trace can hold before it is
-/// spilled to disk.  This default value means that traces will always be kept
-/// in memory.
-const fn default_max_memory_rows() -> usize {
+/// Default minimum on the number of rows in a trace to spill it to disk.  This
+/// default value means that traces will always be kept in memory.
+const fn default_min_storage_rows() -> usize {
     usize::MAX
 }
 
@@ -64,9 +63,9 @@ pub struct PipelineConfig {
     /// before spilling it to storage. If this is 0, then all traces will be
     /// stored on disk; if it is `usize::MAX`, then all traces will be kept in
     /// memory; and intermediate values specify a threshold.
-    #[serde(default = "default_max_memory_rows")]
-    #[schema(default = "default_max_memory_rows")]
-    pub max_memory_rows: usize,
+    #[serde(default = "default_min_storage_rows")]
+    #[schema(default = "default_min_storage_rows")]
+    pub min_storage_rows: usize,
 
     /// Input endpoint configuration.
     pub inputs: BTreeMap<Cow<'static, str>, InputEndpointConfig>,

--- a/crates/pipeline_manager/src/db/pipeline.rs
+++ b/crates/pipeline_manager/src/db/pipeline.rs
@@ -513,7 +513,7 @@ impl PipelineRevision {
             name: Some(format!("pipeline-{pipeline_id}")),
             global: pipeline.config.clone(),
             storage_location: None,
-            max_memory_rows: usize::MAX,
+            min_storage_rows: usize::MAX,
             inputs: expanded_inputs,
             outputs: expanded_outputs,
         };

--- a/openapi.json
+++ b/openapi.json
@@ -840,8 +840,8 @@
                     }
                   },
                   "max_buffering_delay_usecs": 0,
-                  "max_memory_rows": 18446744073709551615,
                   "min_batch_size_records": 0,
+                  "min_storage_rows": 18446744073709551615,
                   "name": "pipeline-67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "outputs": {
                     "Output-To-View": {
@@ -4160,10 +4160,10 @@
                   "$ref": "#/components/schemas/InputEndpointConfig"
                 }
               },
-              "max_memory_rows": {
+              "min_storage_rows": {
                 "type": "integer",
                 "description": "Maximum number of rows of any given persistent trace to keep in memory\nbefore spilling it to storage. If this is 0, then all traces will be\nstored on disk; if it is `usize::MAX`, then all traces will be kept in\nmemory; and intermediate values specify a threshold.",
-                "default": "default_max_memory_rows",
+                "default": "default_min_storage_rows",
                 "minimum": 0
               },
               "name": {

--- a/web-console/src/lib/services/manager/models/PipelineConfig.ts
+++ b/web-console/src/lib/services/manager/models/PipelineConfig.ts
@@ -48,7 +48,7 @@ export type PipelineConfig = {
    * stored on disk; if it is `usize::MAX`, then all traces will be kept in
    * memory; and intermediate values specify a threshold.
    */
-  max_memory_rows?: number
+  min_storage_rows?: number
   /**
    * Pipeline name
    */


### PR DESCRIPTION
With this, even empty batches get written to storage if `min_storage_rows` is 0.  This consistency is helpful for checkpointing because every batch that could be stored will be, even if it is empty.

Thanks to @gz for reporting this.

Is this a user-visible change (yes/no): no