### PR TITLE
PR 1639 postfix.

### DIFF
--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -518,6 +518,10 @@ inherits = "release"
             );
         let p = &config.dbsp_override_path;
         project_toml_code = project_toml_code
+            .replace(
+                "dbsp_adapters = { path = \"../../crates/adapters\", default-features = false }",
+                "dbsp_adapters = { path = \"../../crates/adapters\" }",
+            )
             .replace("../../crates", &format!("{p}/crates"))
             .replace("../lib", &format!("{}", config.sql_lib_path().display()));
         debug!("TOML:\n{project_toml_code}");

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 paste = { version = "1.0.12" }
 derive_more = { version = "0.99.17", features = ["add", "not", "from"] }
 dbsp = { path = "../../crates/dbsp", features = ["with-serde"] }
-dbsp_adapters = { path = "../../crates/adapters", default-features=false }
+dbsp_adapters = { path = "../../crates/adapters", default-features = false }
 pipeline_types = { path = "../../crates/pipeline-types" }
 sqllib = { path = "../lib/sqllib" }
 json = { path = "../lib/json" }


### PR DESCRIPTION
Re-enable default features of the `adapters` crate when using it to build a Feldera pipeline.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
