### PR TITLE
dbsp: New FallbackKeyBatch and FallbackValBatch types.

### DIFF
--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -104,9 +104,9 @@ pub use operator::{
 };
 pub use trace::{DBData, DBWeight};
 pub use typed_batch::{
-    Batch, BatchReader, FallbackWSet, FallbackZSet, FileIndexedWSet, FileIndexedZSet, FileKeyBatch,
-    FileValBatch, FileWSet, FileZSet, IndexedZSet, OrdIndexedWSet, OrdIndexedZSet, OrdWSet,
-    OrdZSet, Trace, TypedBox, ZSet,
+    Batch, BatchReader, FallbackKeyBatch, FallbackValBatch, FallbackWSet, FallbackZSet,
+    FileIndexedWSet, FileIndexedZSet, FileKeyBatch, FileValBatch, FileWSet, FileZSet, IndexedZSet,
+    OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, Trace, TypedBox, ZSet,
 };
 
 #[cfg(doc)]

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -238,7 +238,7 @@ pub type FileKeySpine<B, C> = Spine<
     >,
 >;
 
-/// An on-stroage [`Spine`] of `C`'s default batch type, with key, value, and
+/// An on-storage [`Spine`] of `C`'s default batch type, with key, value, and
 /// weight types taken from `B`.
 pub type FileValSpine<B, C> = Spine<
     <<C as WithClock>::Time as Timestamp>::FileValBatch<

--- a/crates/dbsp/src/time/mod.rs
+++ b/crates/dbsp/src/time/mod.rs
@@ -66,8 +66,8 @@ use crate::{
     algebra::{Lattice, PartialOrder},
     dynamic::{DataTrait, WeightTrait},
     trace::{
-        Batch, FallbackIndexedWSet, FallbackWSet, FileKeyBatch, FileValBatch, OrdIndexedWSet,
-        OrdKeyBatch, OrdValBatch, OrdWSet,
+        Batch, FallbackIndexedWSet, FallbackKeyBatch, FallbackValBatch, FallbackWSet,
+        OrdIndexedWSet, OrdKeyBatch, OrdValBatch, OrdWSet,
     },
     DBData, Scope,
 };
@@ -234,8 +234,9 @@ impl Timestamp for UnitTimestamp {
     type MemKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = OrdKeyBatch<K, Self, R>;
 
     type FileValBatch<K: DataTrait + ?Sized, V: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
-        FileValBatch<K, V, Self, R>;
-    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FileKeyBatch<K, Self, R>;
+        FallbackValBatch<K, V, Self, R>;
+    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
+        FallbackKeyBatch<K, Self, R>;
     fn minimum() -> Self {
         UnitTimestamp
     }
@@ -285,8 +286,9 @@ impl Timestamp for u32 {
     type MemKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = OrdKeyBatch<K, Self, R>;
 
     type FileValBatch<K: DataTrait + ?Sized, V: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
-        FileValBatch<K, V, Self, R>;
-    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FileKeyBatch<K, Self, R>;
+        FallbackValBatch<K, V, Self, R>;
+    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
+        FallbackKeyBatch<K, Self, R>;
 
     fn minimum() -> Self {
         0

--- a/crates/dbsp/src/time/nested_ts32.rs
+++ b/crates/dbsp/src/time/nested_ts32.rs
@@ -1,8 +1,8 @@
 use crate::{
     algebra::{Lattice, PartialOrder},
     dynamic::{DataTrait, WeightTrait},
-    time::{FileValBatch, Product, Timestamp},
-    trace::{FileKeyBatch, OrdKeyBatch, OrdValBatch},
+    time::{Product, Timestamp},
+    trace::{FallbackKeyBatch, FallbackValBatch, OrdKeyBatch, OrdValBatch},
     Scope,
 };
 use rkyv::{Archive, Deserialize, Serialize};
@@ -111,8 +111,9 @@ impl Timestamp for NestedTimestamp32 {
     type MemKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = OrdKeyBatch<K, Self, R>;
 
     type FileValBatch<K: DataTrait + ?Sized, V: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
-        FileValBatch<K, V, Self, R>;
-    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FileKeyBatch<K, Self, R>;
+        FallbackValBatch<K, V, Self, R>;
+    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
+        FallbackKeyBatch<K, Self, R>;
 
     fn minimum() -> Self {
         Self::new(false, 0)

--- a/crates/dbsp/src/time/product.rs
+++ b/crates/dbsp/src/time/product.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{Lattice, PartialOrder},
     dynamic::{DataTrait, WeightTrait},
     time::Timestamp,
-    trace::{FileKeyBatch, FileValBatch, OrdKeyBatch, OrdValBatch},
+    trace::{FallbackKeyBatch, FallbackValBatch, OrdKeyBatch, OrdValBatch},
     Scope,
 };
 use rkyv::{Archive, Deserialize, Serialize};
@@ -93,8 +93,9 @@ where
     type MemKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = OrdKeyBatch<K, Self, R>;
 
     type FileValBatch<K: DataTrait + ?Sized, V: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
-        FileValBatch<K, V, Self, R>;
-    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> = FileKeyBatch<K, Self, R>;
+        FallbackValBatch<K, V, Self, R>;
+    type FileKeyBatch<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> =
+        FallbackKeyBatch<K, Self, R>;
 
     fn minimum() -> Self {
         Self::new(TOuter::minimum(), TInner::minimum())

--- a/crates/dbsp/src/trace/cursor/mod.rs
+++ b/crates/dbsp/src/trace/cursor/mod.rs
@@ -74,6 +74,14 @@ enum Direction {
 ///
 /// Every key in a nonempty collection has at least one value.
 ///
+/// # Visiting time-diff pairs within a value
+///
+/// Time-diff pairs are most often visited using [`map_times`] and related
+/// methods, which take a closure that is applied to each of the pairs. For
+/// cases where there is known to be only one pair, [`weight`] is
+/// appropriate. In special cases, the [`TimeDiffCursor`] trait allows iterating
+/// through all of the pairs.
+///
 /// # Example
 ///
 /// The following is typical code for iterating through all of the key-value
@@ -102,6 +110,8 @@ enum Direction {
 /// [`seek_val_reverse`]: `Self::seek_val_reverse`
 /// [`rewind_vals`]: `Self::rewind_vals`
 /// [`fast_forward_vals`]: `Self::fast_forward_vals`
+/// [`map_times`]: Self::map_times
+/// [`weight`]: Self::weight
 pub trait Cursor<K: ?Sized, V: ?Sized, T, R: ?Sized> {
     /*fn key_vtable(&self) -> &'static VTable<K>;
     fn val_vtable(&self) -> &'static VTable<V>;*/
@@ -454,6 +464,79 @@ where
 
     fn fast_forward_vals(&mut self) {
         self.0.fast_forward_vals()
+    }
+}
+
+/// Visits the `(time, diff)` pairs at a [`Cursor`]'s `(key, value)` position.
+///
+/// Obtained via [`HasTimeDiffCursor`].
+///
+/// Within time-diff pairs, the times may not be ordered or unique and, in
+/// particular, [`CursorList`](`cursor_list::CursorList`) cursors can contain
+/// out-of-order and duplicate timestamps.  Because duplicate times are
+/// possible, it's possible to have multiple diffs even when `T = ()`.
+///
+/// That said, most specific kinds of batches do guarantee unique and ordered
+/// time-diff pairs, including [`OrdWSet`](crate::trace::ord::OrdWSet),
+/// [`OrdIndexedWSet`](crate::trace::ord::OrdIndexedWSet), and similar `WSet`
+/// and `ZSet` types and indexed versions.
+pub trait TimeDiffCursor<'a, T, R>
+where
+    R: ?Sized,
+{
+    /// Returns the current time-diff pair, if there is one, or `None` if the
+    /// cursor has been exhausted.
+    fn current<'b>(&'b mut self, tmp: &'b mut R) -> Option<(&T, &R)>;
+
+    /// Advances to the next time-diff pair.
+    fn step(&mut self);
+}
+
+/// Obtains a [`TimeDiffCursor`] for a [`Cursor`]'s current position.
+///
+/// Not every cursor type implements this trait.  It's usually better to use
+/// [`Cursor::map_times`] and related functions, which are always available.
+pub trait HasTimeDiffCursor<K, V, T, R>: Cursor<K, V, T, R>
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized,
+{
+    /// The `(time, diff)` cursor type for the [`Cursor`].
+    type TimeDiffCursor<'a>: TimeDiffCursor<'a, T, R>
+    where
+        Self: 'a;
+
+    /// Returns the [`TimeDiffCursor`] for this cursor's key-value position.  If
+    /// the current key or value is not valid, the returned cursor will have
+    /// length 0.
+    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_>;
+}
+
+/// An implementation of [`TimeDiffCursor`] for simple cases.
+pub struct SingletonTimeDiffCursor<'a, R>(Option<&'a R>)
+where
+    R: ?Sized;
+
+impl<'a, R> SingletonTimeDiffCursor<'a, R>
+where
+    R: ?Sized,
+{
+    pub fn new(diff: Option<&'a R>) -> Self {
+        Self(diff)
+    }
+}
+
+impl<'a, R> TimeDiffCursor<'a, (), R> for SingletonTimeDiffCursor<'a, R>
+where
+    R: ?Sized,
+{
+    fn current(&mut self, _tmp: &mut R) -> Option<(&(), &R)> {
+        self.0.map(|diff| (&(), diff))
+    }
+
+    fn step(&mut self) {
+        self.0 = None;
     }
 }
 

--- a/crates/dbsp/src/trace/cursor/mod.rs
+++ b/crates/dbsp/src/trace/cursor/mod.rs
@@ -7,11 +7,14 @@ pub mod cursor_list;
 pub mod cursor_pair;
 mod reverse;
 
+use std::fmt::Debug;
+
 pub use cursor_empty::CursorEmpty;
 pub use cursor_group::CursorGroup;
 pub use cursor_list::CursorList;
 pub use cursor_pair::CursorPair;
 pub use reverse::ReverseKeyCursor;
+use size_of::SizeOf;
 
 use crate::dynamic::Factory;
 
@@ -294,6 +297,163 @@ pub trait Cursor<K: ?Sized, V: ?Sized, T, R: ?Sized> {
                 self.fast_forward_vals();
             }
         }
+    }
+}
+
+/// A cursor that can be cloned as a `dyn Cursor` when it is inside a [`Box`].
+///
+/// Rust doesn't have a built-in way to clone boxed trait objects.  This
+/// provides such a way for boxed [`Cursor`]s.
+pub trait ClonableCursor<'s, K, V, T, R>: Cursor<K, V, T, R> + Debug
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized,
+{
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, T, R> + 's>;
+}
+
+impl<'s, K, V, T, R, C> ClonableCursor<'s, K, V, T, R> for C
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized,
+    C: Cursor<K, V, T, R> + Debug + Clone + 's,
+{
+    fn clone_boxed(&self) -> Box<dyn ClonableCursor<'s, K, V, T, R> + 's> {
+        Box::new(self.clone())
+    }
+}
+
+/// A wrapper around a `dyn Cursor` to allow choice of implementations at runtime.
+#[derive(Debug, SizeOf)]
+pub struct DelegatingCursor<'s, K, V, T, R>(pub Box<dyn ClonableCursor<'s, K, V, T, R> + 's>)
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized;
+
+impl<'s, K, V, T, R> Clone for DelegatingCursor<'s, K, V, T, R>
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone_boxed())
+    }
+}
+
+impl<'s, K, V, T, R> Cursor<K, V, T, R> for DelegatingCursor<'s, K, V, T, R>
+where
+    K: ?Sized,
+    V: ?Sized,
+    R: ?Sized,
+{
+    fn weight_factory(&self) -> &'static dyn Factory<R> {
+        self.0.weight_factory()
+    }
+
+    fn key(&self) -> &K {
+        self.0.key()
+    }
+
+    fn val(&self) -> &V {
+        self.0.val()
+    }
+
+    fn map_times(&mut self, logic: &mut dyn FnMut(&T, &R)) {
+        self.0.map_times(logic)
+    }
+
+    fn map_times_through(&mut self, upper: &T, logic: &mut dyn FnMut(&T, &R)) {
+        self.0.map_times_through(upper, logic)
+    }
+
+    fn map_values(&mut self, logic: &mut dyn FnMut(&V, &R))
+    where
+        T: PartialEq<()>,
+    {
+        self.0.map_values(logic)
+    }
+
+    fn weight(&mut self) -> &R
+    where
+        T: PartialEq<()>,
+    {
+        self.0.weight()
+    }
+
+    fn key_valid(&self) -> bool {
+        self.0.key_valid()
+    }
+
+    fn val_valid(&self) -> bool {
+        self.0.val_valid()
+    }
+
+    fn step_key(&mut self) {
+        self.0.step_key()
+    }
+
+    fn step_key_reverse(&mut self) {
+        self.0.step_key_reverse()
+    }
+
+    fn seek_key(&mut self, key: &K) {
+        self.0.seek_key(key)
+    }
+
+    fn seek_key_with(&mut self, predicate: &dyn Fn(&K) -> bool) {
+        self.0.seek_key_with(predicate)
+    }
+
+    fn seek_key_with_reverse(&mut self, predicate: &dyn Fn(&K) -> bool) {
+        self.0.seek_key_with_reverse(predicate)
+    }
+
+    fn seek_key_reverse(&mut self, key: &K) {
+        self.0.seek_key_reverse(key)
+    }
+
+    fn step_val(&mut self) {
+        self.0.step_val()
+    }
+
+    fn seek_val(&mut self, val: &V) {
+        self.0.seek_val(val)
+    }
+
+    fn seek_val_with(&mut self, predicate: &dyn Fn(&V) -> bool) {
+        self.0.seek_val_with(predicate)
+    }
+
+    fn rewind_keys(&mut self) {
+        self.0.rewind_keys()
+    }
+
+    fn fast_forward_keys(&mut self) {
+        self.0.fast_forward_keys()
+    }
+
+    fn rewind_vals(&mut self) {
+        self.0.rewind_vals()
+    }
+
+    fn step_val_reverse(&mut self) {
+        self.0.step_val_reverse()
+    }
+
+    fn seek_val_reverse(&mut self, val: &V) {
+        self.0.seek_val_reverse(val)
+    }
+
+    fn seek_val_with_reverse(&mut self, predicate: &dyn Fn(&V) -> bool) {
+        self.0.seek_val_with_reverse(predicate)
+    }
+
+    fn fast_forward_vals(&mut self) {
+        self.0.fast_forward_vals()
     }
 }
 

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -30,7 +30,7 @@
 //! Traces keep track of the lower and upper bounds among their tuples' times.
 //! If the trace contains incomparable times, then it will have multiple lower
 //! and upper bounds, one for each category of incomparable time, in an
-//! [`Antichain`](crate::time::Antichain).
+//! [`Antichain`].
 
 use crate::dynamic::ClonableTrait;
 pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -52,15 +52,12 @@ pub use spine_fueled::Spine;
 pub mod test;
 
 pub use ord::{
-    FallbackIndexedWSet, FallbackIndexedWSetFactories, FallbackWSet, FallbackWSetFactories,
-};
-pub use ord::{
+    FallbackIndexedWSet, FallbackIndexedWSetFactories, FallbackKeyBatch, FallbackKeyBatchFactories,
+    FallbackValBatch, FallbackValBatchFactories, FallbackWSet, FallbackWSetFactories,
     FileIndexedWSet, FileIndexedWSetFactories, FileKeyBatch, FileKeyBatchFactories, FileValBatch,
-    FileValBatchFactories, FileWSet, FileWSetFactories,
-};
-pub use ord::{
-    OrdIndexedWSet, OrdIndexedWSetFactories, OrdKeyBatch, OrdKeyBatchFactories, OrdValBatch,
-    OrdValBatchFactories, OrdWSet, OrdWSetFactories,
+    FileValBatchFactories, FileWSet, FileWSetFactories, OrdIndexedWSet, OrdIndexedWSetFactories,
+    OrdKeyBatch, OrdKeyBatchFactories, OrdValBatch, OrdValBatchFactories, OrdWSet,
+    OrdWSetFactories,
 };
 
 use rkyv::{archived_root, Deserialize, Infallible};

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -11,6 +11,7 @@ use crate::{
             file::indexed_wset_batch::{
                 FileIndexedWSetBuilder, FileIndexedWSetCursor, FileIndexedWSetMerger,
             },
+            filter,
             merge_batcher::MergeBatcher,
             vec::indexed_wset_batch::{
                 OrdIndexedWSetMerger, VecIndexedWSetBuilder, VecIndexedWSetCursor,
@@ -1128,13 +1129,6 @@ where
             *fuel -= 1;
         }
     }
-}
-
-fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
-where
-    T: ?Sized,
-{
-    f.as_ref().map_or(true, |f| f(t))
 }
 
 impl<K, V, R, O> SizeOf for GenericMerger<K, V, R, O>

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -1,0 +1,595 @@
+use crate::{
+    dynamic::{DataTrait, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait},
+    time::AntichainRef,
+    trace::{
+        cursor::DelegatingCursor,
+        ord::{
+            file::key_batch::{FileKeyBuilder, FileKeyMerger},
+            merge_batcher::MergeBatcher,
+            vec::key_batch::{OrdKeyBuilder, OrdKeyMerger},
+            FileKeyBatch, OrdKeyBatch,
+        },
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, FileKeyBatchFactories,
+        Filter, Merger, OrdKeyBatchFactories, WeightedItem,
+    },
+    DBData, DBWeight, NumEntries, Runtime, Timestamp,
+};
+use rand::Rng;
+use rkyv::{ser::Serializer, Archive, Archived, Deserialize, Fallible, Serialize};
+use size_of::SizeOf;
+use std::{
+    fmt::{self, Debug},
+    path::PathBuf,
+};
+
+use super::utils::GenericMerger;
+
+pub struct FallbackKeyBatchFactories<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    file: FileKeyBatchFactories<K, T, R>,
+    vec: OrdKeyBatchFactories<K, T, R>,
+}
+
+impl<K, T, R> Clone for FallbackKeyBatchFactories<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self {
+            file: self.file.clone(),
+            vec: self.vec.clone(),
+        }
+    }
+}
+
+impl<K, T, R> BatchReaderFactories<K, DynUnit, T, R> for FallbackKeyBatchFactories<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn new<KType, VType, RType>() -> Self
+    where
+        KType: DBData + Erase<K>,
+        VType: DBData + Erase<DynUnit>,
+        RType: DBWeight + Erase<R>,
+    {
+        Self {
+            file: FileKeyBatchFactories::new::<KType, VType, RType>(),
+            vec: OrdKeyBatchFactories::new::<KType, VType, RType>(),
+        }
+    }
+
+    fn key_factory(&self) -> &'static dyn Factory<K> {
+        self.file.key_factory()
+    }
+
+    fn keys_factory(&self) -> &'static dyn Factory<DynVec<K>> {
+        self.file.keys_factory()
+    }
+
+    fn val_factory(&self) -> &'static dyn Factory<DynUnit> {
+        self.file.val_factory()
+    }
+
+    fn weight_factory(&self) -> &'static dyn Factory<R> {
+        self.file.weight_factory()
+    }
+}
+
+impl<K, T, R> BatchFactories<K, DynUnit, T, R> for FallbackKeyBatchFactories<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, DynUnit>> {
+        self.file.item_factory()
+    }
+
+    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, DynUnit, R>> {
+        self.file.weighted_item_factory()
+    }
+
+    fn weighted_items_factory(
+        &self,
+    ) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, DynUnit>, R>> {
+        self.file.weighted_items_factory()
+    }
+}
+
+/// A batch of keys with weights and times.
+///
+/// Each tuple in `FallbackKeyBatch<K, T, R>` has key type `K`, value type `()`,
+/// weight type `R`, and time type `R`.
+pub struct FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackKeyBatchFactories<K, T, R>,
+    inner: Inner<K, T, R>,
+}
+
+enum Inner<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    Vec(OrdKeyBatch<K, T, R>),
+    File(FileKeyBatch<K, T, R>),
+}
+
+impl<K, T, R> Inner<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn as_file(&self) -> Option<&FileKeyBatch<K, T, R>> {
+        match self {
+            Inner::Vec(_vec) => None,
+            Inner::File(file) => Some(file),
+        }
+    }
+    fn as_vec(&self) -> Option<&OrdKeyBatch<K, T, R>> {
+        match self {
+            Inner::Vec(vec) => Some(vec),
+            Inner::File(_file) => None,
+        }
+    }
+}
+
+impl<K, T, R> Debug for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.inner {
+            Inner::Vec(vec) => vec.fmt(f),
+            Inner::File(file) => file.fmt(f),
+        }
+    }
+}
+
+impl<K, T, R> Clone for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self {
+            factories: self.factories.clone(),
+            inner: match &self.inner {
+                Inner::Vec(vec) => Inner::Vec(vec.clone()),
+                Inner::File(file) => Inner::File(file.clone()),
+            },
+        }
+    }
+}
+
+impl<K, T, R> NumEntries for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    const CONST_NUM_ENTRIES: Option<usize> = None;
+
+    fn num_entries_shallow(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.num_entries_shallow(),
+            Inner::File(file) => file.num_entries_shallow(),
+        }
+    }
+
+    fn num_entries_deep(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.num_entries_deep(),
+            Inner::File(file) => file.num_entries_deep(),
+        }
+    }
+}
+
+impl<K, T, R> BatchReader for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Factories = FallbackKeyBatchFactories<K, T, R>;
+    type Key = K;
+    type Val = DynUnit;
+    type Time = T;
+    type R = R;
+    type Cursor<'s> = DelegatingCursor<'s, K, DynUnit, T, R>;
+
+    fn factories(&self) -> Self::Factories {
+        self.factories.clone()
+    }
+
+    fn cursor(&self) -> Self::Cursor<'_> {
+        DelegatingCursor(match &self.inner {
+            Inner::Vec(vec) => Box::new(vec.cursor()),
+            Inner::File(file) => Box::new(file.cursor()),
+        })
+    }
+
+    #[inline]
+    fn key_count(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.key_count(),
+            Inner::File(file) => file.key_count(),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.len(),
+            Inner::File(file) => file.len(),
+        }
+    }
+
+    fn lower(&self) -> AntichainRef<'_, T> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.lower(),
+            Inner::File(file) => file.lower(),
+        }
+    }
+
+    fn upper(&self) -> AntichainRef<'_, T> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.upper(),
+            Inner::File(file) => file.upper(),
+        }
+    }
+
+    fn truncate_keys_below(&mut self, lower_bound: &Self::Key) {
+        match &mut self.inner {
+            Inner::Vec(vec) => vec.truncate_keys_below(lower_bound),
+            Inner::File(file) => file.truncate_keys_below(lower_bound),
+        }
+    }
+
+    fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, output: &mut DynVec<Self::Key>)
+    where
+        Self::Time: PartialEq<()>,
+        RG: Rng,
+    {
+        match &self.inner {
+            Inner::Vec(vec) => vec.sample_keys(rng, sample_size, output),
+            Inner::File(file) => file.sample_keys(rng, sample_size, output),
+        }
+    }
+}
+
+impl<K, T, R> Batch for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Batcher = MergeBatcher<Self>;
+    type Builder = FallbackKeyBuilder<K, T, R>;
+    type Merger = FallbackKeyMerger<K, T, R>;
+
+    fn begin_merge(&self, other: &Self) -> Self::Merger {
+        Self::Merger::new_merger(self, other)
+    }
+
+    fn recede_to(&mut self, frontier: &T) {
+        match &mut self.inner {
+            Inner::Vec(vec) => vec.recede_to(frontier),
+            Inner::File(file) => file.recede_to(frontier),
+        }
+    }
+
+    fn persistent_id(&self) -> Option<PathBuf> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.persistent_id(),
+            Inner::File(file) => file.persistent_id(),
+        }
+    }
+}
+
+/// State for an in-progress merge.
+pub struct FallbackKeyMerger<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackKeyBatchFactories<K, T, R>,
+    inner: MergerInner<K, T, R>,
+}
+
+enum MergerInner<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    AllFile(FileKeyMerger<K, T, R>),
+    AllVec(OrdKeyMerger<K, T, R>),
+    ToVec(GenericMerger<K, DynUnit, T, R, OrdKeyBatch<K, T, R>>),
+    ToFile(GenericMerger<K, DynUnit, T, R, FileKeyBatch<K, T, R>>),
+}
+
+impl<K, T, R> Merger<K, DynUnit, T, R, FallbackKeyBatch<K, T, R>> for FallbackKeyMerger<K, T, R>
+where
+    Self: SizeOf,
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn new_merger(batch1: &FallbackKeyBatch<K, T, R>, batch2: &FallbackKeyBatch<K, T, R>) -> Self {
+        FallbackKeyMerger {
+            factories: batch1.factories.clone(),
+            inner: if batch1.len() + batch2.len() < Runtime::min_storage_rows() {
+                match (&batch1.inner, &batch2.inner) {
+                    (Inner::Vec(vec1), Inner::Vec(vec2)) => {
+                        MergerInner::AllVec(OrdKeyMerger::new_merger(vec1, vec2))
+                    }
+                    _ => MergerInner::ToVec(GenericMerger::new(
+                        &batch1.factories.vec,
+                        batch1,
+                        batch2,
+                    )),
+                }
+            } else {
+                match (&batch1.inner, &batch2.inner) {
+                    (Inner::File(file1), Inner::File(file2)) => {
+                        MergerInner::AllFile(FileKeyMerger::new_merger(file1, file2))
+                    }
+                    _ => MergerInner::ToFile(GenericMerger::new(
+                        &batch1.factories.file,
+                        batch1,
+                        batch2,
+                    )),
+                }
+            },
+        }
+    }
+
+    fn done(self) -> FallbackKeyBatch<K, T, R> {
+        FallbackKeyBatch {
+            factories: self.factories.clone(),
+            inner: match self.inner {
+                MergerInner::AllFile(merger) => Inner::File(merger.done()),
+                MergerInner::AllVec(merger) => Inner::Vec(merger.done()),
+                MergerInner::ToVec(merger) => Inner::Vec(merger.done()),
+                MergerInner::ToFile(merger) => Inner::File(merger.done()),
+            },
+        }
+    }
+
+    fn work(
+        &mut self,
+        source1: &FallbackKeyBatch<K, T, R>,
+        source2: &FallbackKeyBatch<K, T, R>,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<DynUnit>>,
+        fuel: &mut isize,
+    ) {
+        match &mut self.inner {
+            MergerInner::AllFile(merger) => merger.work(
+                source1.inner.as_file().unwrap(),
+                source2.inner.as_file().unwrap(),
+                key_filter,
+                value_filter,
+                fuel,
+            ),
+            MergerInner::AllVec(merger) => merger.work(
+                source1.inner.as_vec().unwrap(),
+                source2.inner.as_vec().unwrap(),
+                key_filter,
+                value_filter,
+                fuel,
+            ),
+            MergerInner::ToVec(merger) => match (&source1.inner, &source2.inner) {
+                (Inner::File(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::File(a), Inner::Vec(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::Vec(b)) => merger.work(a, b, key_filter, value_filter, fuel),
+            },
+            MergerInner::ToFile(merger) => match (&source1.inner, &source2.inner) {
+                (Inner::File(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::File(a), Inner::Vec(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::Vec(b)) => merger.work(a, b, key_filter, value_filter, fuel),
+            },
+        }
+    }
+}
+
+impl<K, T, R> SizeOf for FallbackKeyMerger<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        match &self.inner {
+            MergerInner::AllFile(file) => file.size_of_children(context),
+            MergerInner::AllVec(vec) => vec.size_of_children(context),
+            MergerInner::ToFile(merger) => merger.size_of_children(context),
+            MergerInner::ToVec(merger) => merger.size_of_children(context),
+        }
+    }
+}
+
+/// A builder for creating layers from unsorted update tuples.
+pub struct FallbackKeyBuilder<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackKeyBatchFactories<K, T, R>,
+    inner: BuilderInner<K, T, R>,
+}
+
+enum BuilderInner<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    File(FileKeyBuilder<K, T, R>),
+    Vec(OrdKeyBuilder<K, T, R>),
+}
+
+impl<K, T, R> Builder<FallbackKeyBatch<K, T, R>> for FallbackKeyBuilder<K, T, R>
+where
+    Self: SizeOf,
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    #[inline]
+    fn new_builder(factories: &FallbackKeyBatchFactories<K, T, R>, time: T) -> Self {
+        Self::with_capacity(factories, time, 0)
+    }
+
+    #[inline]
+    fn with_capacity(
+        factories: &FallbackKeyBatchFactories<K, T, R>,
+        time: T,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            factories: factories.clone(),
+            inner: if capacity < Runtime::min_storage_rows() {
+                BuilderInner::Vec(OrdKeyBuilder::with_capacity(&factories.vec, time, capacity))
+            } else {
+                BuilderInner::File(FileKeyBuilder::with_capacity(
+                    &factories.file,
+                    time,
+                    capacity,
+                ))
+            },
+        }
+    }
+
+    #[inline]
+    fn reserve(&mut self, _additional: usize) {}
+
+    #[inline]
+    fn push(&mut self, item: &mut DynPair<DynPair<K, DynUnit>, R>) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push(item),
+            BuilderInner::Vec(vec) => vec.push(item),
+        }
+    }
+
+    #[inline]
+    fn push_refs(&mut self, key: &K, val: &DynUnit, weight: &R) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push_refs(key, val, weight),
+            BuilderInner::Vec(vec) => vec.push_refs(key, val, weight),
+        }
+    }
+
+    #[inline]
+    fn push_vals(&mut self, key: &mut K, val: &mut DynUnit, weight: &mut R) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push_vals(key, val, weight),
+            BuilderInner::Vec(vec) => vec.push_vals(key, val, weight),
+        }
+    }
+
+    #[inline(never)]
+    fn done(self) -> FallbackKeyBatch<K, T, R> {
+        FallbackKeyBatch {
+            factories: self.factories,
+            inner: match self.inner {
+                BuilderInner::File(file) => Inner::File(file.done()),
+                BuilderInner::Vec(vec) => Inner::Vec(vec.done()),
+            },
+        }
+    }
+}
+
+impl<K, T, R> SizeOf for FallbackKeyBuilder<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, _context: &mut size_of::Context) {
+        // XXX
+    }
+}
+
+impl<K, T, R> SizeOf for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, _context: &mut size_of::Context) {
+        // XXX
+    }
+}
+
+impl<K, T, R> Archive for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Archived = ();
+    type Resolver = ();
+
+    unsafe fn resolve(&self, _pos: usize, _resolver: Self::Resolver, _out: *mut Self::Archived) {
+        unimplemented!();
+    }
+}
+
+impl<K, T, R, S> Serialize<S> for FallbackKeyBatch<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    S: Serializer + ?Sized,
+{
+    fn serialize(&self, _serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        unimplemented!();
+    }
+}
+
+impl<K, T, R, D> Deserialize<FallbackKeyBatch<K, T, R>, D> for Archived<FallbackKeyBatch<K, T, R>>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    D: Fallible,
+{
+    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackKeyBatch<K, T, R>, D::Error> {
+        unimplemented!();
+    }
+}

--- a/crates/dbsp/src/trace/ord/fallback/mod.rs
+++ b/crates/dbsp/src/trace/ord/fallback/mod.rs
@@ -3,5 +3,7 @@
 #![allow(clippy::large_enum_variant)]
 
 pub mod indexed_wset;
+pub mod key_batch;
 mod utils;
+pub mod val_batch;
 pub mod wset;

--- a/crates/dbsp/src/trace/ord/fallback/mod.rs
+++ b/crates/dbsp/src/trace/ord/fallback/mod.rs
@@ -1,4 +1,7 @@
 //! Batch implementations that fall back from memory to disk.
 
+#![allow(clippy::large_enum_variant)]
+
 pub mod indexed_wset;
+mod utils;
 pub mod wset;

--- a/crates/dbsp/src/trace/ord/fallback/utils.rs
+++ b/crates/dbsp/src/trace/ord/fallback/utils.rs
@@ -1,0 +1,332 @@
+use std::cmp::Ordering;
+
+use dyn_clone::clone_box;
+use size_of::SizeOf;
+
+use crate::{
+    dynamic::{DataTrait, WeightTrait},
+    time::Antichain,
+    trace::{
+        cursor::{HasTimeDiffCursor, TimeDiffCursor},
+        ord::filter,
+        Batch, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, TimedBuilder,
+    },
+    Timestamp,
+};
+
+/// The row position of a [`Cursor`], regardless of the underlying type of the
+/// cursor.
+///
+/// [`GenericMerger`] uses this to save and restore positions in the batches
+/// it's merging, since it can't keep a cursor around from one run to another
+/// because of lifetime issues.
+enum Position<K>
+where
+    K: DataTrait + ?Sized,
+{
+    Start,
+    At(Box<K>),
+    End,
+}
+
+impl<K> Position<K>
+where
+    K: DataTrait + ?Sized,
+{
+    fn to_cursor<'s, B>(&self, source: &'s B) -> B::Cursor<'s>
+    where
+        B: BatchReader<Key = K>,
+    {
+        let mut cursor = source.cursor();
+        match self {
+            Position::Start => (),
+            Position::At(key) => cursor.seek_key(key.as_ref()),
+            Position::End => {
+                cursor.fast_forward_keys();
+                cursor.step_key()
+            }
+        }
+        cursor
+    }
+
+    fn from_cursor<C, V, T, R>(cursor: &C) -> Position<K>
+    where
+        C: Cursor<K, V, T, R>,
+        V: DataTrait + ?Sized,
+        T: Timestamp,
+        R: ?Sized,
+    {
+        if cursor.key_valid() {
+            Self::At(clone_box(cursor.key()))
+        } else {
+            Self::End
+        }
+    }
+}
+
+pub(super) struct GenericMerger<K, V, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = T>,
+    O::Builder: TimedBuilder<O>,
+{
+    builder: O::Builder,
+    lower: Antichain<T>,
+    upper: Antichain<T>,
+    pos1: Position<K>,
+    pos2: Position<K>,
+}
+
+impl<K, V, T, R, O> GenericMerger<K, V, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = T>,
+    O::Builder: TimedBuilder<O>,
+{
+    pub fn new<A, B>(factories: &O::Factories, batch1: &A, batch2: &B) -> Self
+    where
+        A: BatchReader<Time = T>,
+        B: BatchReader<Time = T>,
+    {
+        Self {
+            builder: O::Builder::new_builder(factories, T::default()),
+            lower: batch1.lower().meet(batch2.lower()),
+            upper: batch1.upper().join(batch2.upper()),
+            pos1: Position::Start,
+            pos2: Position::Start,
+        }
+    }
+
+    pub fn work<'s, A, B>(
+        &mut self,
+        source1: &'s A,
+        source2: &'s B,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        A: BatchReader<Key = K, Val = V, R = R, Time = T>,
+        B: BatchReader<Key = K, Val = V, R = R, Time = T>,
+        A::Cursor<'s>: HasTimeDiffCursor<K, V, T, R>,
+        B::Cursor<'s>: HasTimeDiffCursor<K, V, T, R>,
+    {
+        let mut cursor1 = self.pos1.to_cursor(source1);
+        let mut cursor2 = self.pos2.to_cursor(source2);
+        source1.factories().weight_factory().with(&mut |diff1| {
+            source1.factories().weight_factory().with(&mut |diff2| {
+                source1.factories().weight_factory().with(&mut |sum| {
+                    while cursor1.key_valid() && cursor2.key_valid() && *fuel > 0 {
+                        match cursor1.key().cmp(cursor2.key()) {
+                            Ordering::Less => self.copy_values_if(
+                                diff1,
+                                &mut cursor1,
+                                key_filter,
+                                value_filter,
+                                fuel,
+                            ),
+                            Ordering::Equal => self.merge_values_if(
+                                &mut cursor1,
+                                &mut cursor2,
+                                diff1,
+                                diff2,
+                                sum,
+                                key_filter,
+                                value_filter,
+                                fuel,
+                            ),
+                            Ordering::Greater => self.copy_values_if(
+                                diff1,
+                                &mut cursor2,
+                                key_filter,
+                                value_filter,
+                                fuel,
+                            ),
+                        }
+                    }
+
+                    while cursor1.key_valid() && *fuel > 0 {
+                        self.copy_values_if(diff1, &mut cursor1, key_filter, value_filter, fuel);
+                    }
+                    while cursor2.key_valid() && *fuel > 0 {
+                        self.copy_values_if(diff1, &mut cursor2, key_filter, value_filter, fuel);
+                    }
+                })
+            })
+        });
+        self.pos1 = Position::from_cursor(&cursor1);
+        self.pos2 = Position::from_cursor(&cursor2);
+    }
+
+    pub fn done(self) -> O {
+        self.builder.done_with_bounds(self.lower, self.upper)
+    }
+
+    fn copy_values_if<C>(
+        &mut self,
+        tmp: &mut R,
+        cursor: &mut C,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        C: HasTimeDiffCursor<K, V, T, R>,
+    {
+        if filter(key_filter, cursor.key()) {
+            while cursor.val_valid() {
+                self.copy_time_diffs_if(cursor, tmp, value_filter, fuel);
+            }
+        }
+        *fuel -= 1;
+        cursor.step_key();
+    }
+
+    fn copy_time_diffs_if<C>(
+        &mut self,
+        cursor: &mut C,
+        tmp: &mut R,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        C: HasTimeDiffCursor<K, V, T, R>,
+    {
+        if filter(value_filter, cursor.val()) {
+            let mut tdc = cursor.time_diff_cursor();
+            while let Some((time, diff)) = tdc.current(tmp) {
+                self.builder
+                    .push_time(cursor.key(), cursor.val(), time, diff);
+                tdc.step();
+                *fuel -= 1;
+            }
+        }
+        *fuel -= 1;
+        cursor.step_val();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn merge_values_if<C1, C2>(
+        &mut self,
+        cursor1: &mut C1,
+        cursor2: &mut C2,
+        tmp1: &mut R,
+        tmp2: &mut R,
+        sum: &mut R,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        C1: HasTimeDiffCursor<K, V, T, R>,
+        C2: HasTimeDiffCursor<K, V, T, R>,
+    {
+        if filter(key_filter, cursor1.key()) {
+            while cursor1.val_valid() && cursor2.val_valid() {
+                match cursor1.val().cmp(cursor2.val()) {
+                    Ordering::Less => self.copy_time_diffs_if(cursor1, tmp1, value_filter, fuel),
+                    Ordering::Equal => self.merge_time_diffs_if(
+                        cursor1,
+                        cursor2,
+                        tmp1,
+                        tmp2,
+                        sum,
+                        value_filter,
+                        fuel,
+                    ),
+                    Ordering::Greater => self.copy_time_diffs_if(cursor2, tmp1, value_filter, fuel),
+                }
+                while cursor1.val_valid() {
+                    self.copy_time_diffs_if(cursor1, tmp1, value_filter, fuel);
+                }
+                while cursor2.val_valid() {
+                    self.copy_time_diffs_if(cursor2, tmp2, value_filter, fuel);
+                }
+            }
+        }
+        *fuel -= 1;
+        cursor1.step_key();
+        cursor2.step_key();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn merge_time_diffs_if<C1, C2>(
+        &mut self,
+        cursor1: &mut C1,
+        cursor2: &mut C2,
+        tmp1: &mut R,
+        tmp2: &mut R,
+        sum: &mut R,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) where
+        C1: HasTimeDiffCursor<K, V, T, R>,
+        C2: HasTimeDiffCursor<K, V, T, R>,
+    {
+        if filter(value_filter, cursor1.val()) {
+            let mut tdc1 = cursor1.time_diff_cursor();
+            let mut tdc2 = cursor2.time_diff_cursor();
+
+            loop {
+                let Some((time1, diff1)) = tdc1.current(tmp1) else {
+                    break;
+                };
+                let Some((time2, diff2)) = tdc2.current(tmp2) else {
+                    break;
+                };
+
+                match time1.cmp(time2) {
+                    Ordering::Less => {
+                        self.builder
+                            .push_time(cursor1.key(), cursor1.val(), time1, diff1);
+                        tdc1.step();
+                    }
+                    Ordering::Equal => {
+                        diff1.add(diff2, sum);
+                        if !sum.is_zero() {
+                            self.builder
+                                .push_time(cursor1.key(), cursor1.val(), time1, sum);
+                        }
+                    }
+                    Ordering::Greater => {
+                        self.builder
+                            .push_time(cursor2.key(), cursor2.val(), time2, diff2);
+                        tdc2.step();
+                    }
+                }
+                *fuel -= 1;
+            }
+            while let Some((time1, diff1)) = tdc1.current(tmp1) {
+                self.builder
+                    .push_time(cursor1.key(), cursor1.val(), time1, diff1);
+                tdc1.step();
+                *fuel -= 1;
+            }
+            while let Some((time2, diff2)) = tdc2.current(tmp2) {
+                self.builder
+                    .push_time(cursor2.key(), cursor2.val(), time2, diff2);
+                tdc2.step();
+                *fuel -= 1;
+            }
+        }
+        *fuel -= 1;
+        cursor1.step_val();
+        cursor2.step_val();
+    }
+}
+
+impl<K, V, T, R, O> SizeOf for GenericMerger<K, V, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    O: Batch + BatchReader<Key = K, Val = V, R = R, Time = T>,
+    O::Builder: TimedBuilder<O>,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        self.builder.size_of_children(context)
+    }
+}

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -1,0 +1,608 @@
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+
+use crate::trace::cursor::DelegatingCursor;
+use crate::trace::ord::file::val_batch::FileValBuilder;
+use crate::trace::ord::vec::val_batch::OrdValBuilder;
+use crate::{
+    dynamic::{DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait},
+    time::AntichainRef,
+    trace::{
+        ord::{
+            file::val_batch::FileValMerger, merge_batcher::MergeBatcher,
+            vec::val_batch::OrdValMerger,
+        },
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, FileValBatch,
+        FileValBatchFactories, Filter, Merger, OrdValBatch, OrdValBatchFactories, WeightedItem,
+    },
+    DBData, DBWeight, NumEntries, Runtime, Timestamp,
+};
+use rand::Rng;
+use rkyv::{ser::Serializer, Archive, Archived, Deserialize, Fallible, Serialize};
+use size_of::SizeOf;
+
+use super::utils::GenericMerger;
+
+pub struct FallbackValBatchFactories<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    file: FileValBatchFactories<K, V, T, R>,
+    vec: OrdValBatchFactories<K, V, T, R>,
+}
+
+impl<K, V, T, R> Clone for FallbackValBatchFactories<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self {
+            file: self.file.clone(),
+            vec: self.vec.clone(),
+        }
+    }
+}
+
+impl<K, V, T, R> BatchReaderFactories<K, V, T, R> for FallbackValBatchFactories<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn new<KType, VType, RType>() -> Self
+    where
+        KType: DBData + Erase<K>,
+        VType: DBData + Erase<V>,
+        RType: DBWeight + Erase<R>,
+    {
+        Self {
+            file: FileValBatchFactories::new::<KType, VType, RType>(),
+            vec: OrdValBatchFactories::new::<KType, VType, RType>(),
+        }
+    }
+
+    fn key_factory(&self) -> &'static dyn Factory<K> {
+        self.file.key_factory()
+    }
+
+    fn keys_factory(&self) -> &'static dyn Factory<DynVec<K>> {
+        self.file.keys_factory()
+    }
+
+    fn val_factory(&self) -> &'static dyn Factory<V> {
+        self.file.val_factory()
+    }
+
+    fn weight_factory(&self) -> &'static dyn Factory<R> {
+        self.file.weight_factory()
+    }
+}
+
+impl<K, V, T, R> BatchFactories<K, V, T, R> for FallbackValBatchFactories<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn item_factory(&self) -> &'static dyn Factory<DynPair<K, V>> {
+        self.file.item_factory()
+    }
+
+    fn weighted_item_factory(&self) -> &'static dyn Factory<WeightedItem<K, V, R>> {
+        self.file.weighted_item_factory()
+    }
+
+    fn weighted_items_factory(&self) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>> {
+        self.file.weighted_items_factory()
+    }
+}
+
+/// An immutable collection of update tuples, from a contiguous interval of
+/// logical times.
+pub struct FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackValBatchFactories<K, V, T, R>,
+    inner: Inner<K, V, T, R>,
+}
+
+enum Inner<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    Vec(OrdValBatch<K, V, T, R>),
+    File(FileValBatch<K, V, T, R>),
+}
+
+impl<K, V, T, R> Inner<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn as_file(&self) -> Option<&FileValBatch<K, V, T, R>> {
+        match self {
+            Inner::Vec(_vec) => None,
+            Inner::File(file) => Some(file),
+        }
+    }
+
+    fn as_vec(&self) -> Option<&OrdValBatch<K, V, T, R>> {
+        match self {
+            Inner::Vec(vec) => Some(vec),
+            Inner::File(_file) => None,
+        }
+    }
+}
+
+impl<K, V, T, R> Clone for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self {
+            factories: self.factories.clone(),
+            inner: match &self.inner {
+                Inner::Vec(vec) => Inner::Vec(vec.clone()),
+                Inner::File(file) => Inner::File(file.clone()),
+            },
+        }
+    }
+}
+
+impl<K, V, T, R> NumEntries for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    const CONST_NUM_ENTRIES: Option<usize> = None;
+
+    #[inline]
+    fn num_entries_shallow(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.num_entries_shallow(),
+            Inner::File(file) => file.num_entries_shallow(),
+        }
+    }
+
+    #[inline]
+    fn num_entries_deep(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.num_entries_deep(),
+            Inner::File(file) => file.num_entries_deep(),
+        }
+    }
+}
+
+impl<K, V, T, R> Display for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match &self.inner {
+            Inner::Vec(vec) => Display::fmt(vec, f),
+            Inner::File(file) => Display::fmt(file, f),
+        }
+    }
+}
+
+impl<K, V, T, R> BatchReader for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Factories = FallbackValBatchFactories<K, V, T, R>;
+    type Key = K;
+    type Val = V;
+    type Time = T;
+    type R = R;
+
+    type Cursor<'s> = DelegatingCursor<'s, K, V, T, R>;
+
+    fn factories(&self) -> Self::Factories {
+        self.factories.clone()
+    }
+
+    fn cursor(&self) -> Self::Cursor<'_> {
+        DelegatingCursor(match &self.inner {
+            Inner::Vec(vec) => Box::new(vec.cursor()),
+            Inner::File(file) => Box::new(file.cursor()),
+        })
+    }
+
+    fn key_count(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.key_count(),
+            Inner::File(file) => file.key_count(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match &self.inner {
+            Inner::Vec(vec) => vec.len(),
+            Inner::File(file) => file.len(),
+        }
+    }
+
+    fn lower(&self) -> AntichainRef<'_, T> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.lower(),
+            Inner::File(file) => file.lower(),
+        }
+    }
+
+    fn upper(&self) -> AntichainRef<'_, T> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.upper(),
+            Inner::File(file) => file.upper(),
+        }
+    }
+
+    fn truncate_keys_below(&mut self, lower_bound: &Self::Key) {
+        match &mut self.inner {
+            Inner::Vec(vec) => vec.truncate_keys_below(lower_bound),
+            Inner::File(file) => file.truncate_keys_below(lower_bound),
+        }
+    }
+
+    fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, output: &mut DynVec<Self::Key>)
+    where
+        RG: Rng,
+        T: PartialEq<()>,
+    {
+        match &self.inner {
+            Inner::Vec(vec) => vec.sample_keys(rng, sample_size, output),
+            Inner::File(file) => file.sample_keys(rng, sample_size, output),
+        }
+    }
+}
+
+impl<K, V, T, R> Batch for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Batcher = MergeBatcher<Self>;
+    type Builder = FallbackValBuilder<K, V, T, R>;
+    type Merger = FallbackValMerger<K, V, T, R>;
+
+    fn begin_merge(&self, other: &Self) -> Self::Merger {
+        FallbackValMerger::new_merger(self, other)
+    }
+
+    fn recede_to(&mut self, frontier: &T) {
+        match &mut self.inner {
+            Inner::Vec(vec) => vec.recede_to(frontier),
+            Inner::File(file) => file.recede_to(frontier),
+        }
+    }
+
+    fn persistent_id(&self) -> Option<PathBuf> {
+        match &self.inner {
+            Inner::Vec(vec) => vec.persistent_id(),
+            Inner::File(file) => file.persistent_id(),
+        }
+    }
+}
+
+/// State for an in-progress merge.
+pub struct FallbackValMerger<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackValBatchFactories<K, V, T, R>,
+    inner: MergerInner<K, V, T, R>,
+}
+
+enum MergerInner<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    AllFile(FileValMerger<K, V, T, R>),
+    AllVec(OrdValMerger<K, V, T, R>),
+    ToVec(GenericMerger<K, V, T, R, OrdValBatch<K, V, T, R>>),
+    ToFile(GenericMerger<K, V, T, R, FileValBatch<K, V, T, R>>),
+}
+
+impl<K, V, T, R> Merger<K, V, T, R, FallbackValBatch<K, V, T, R>> for FallbackValMerger<K, V, T, R>
+where
+    Self: SizeOf,
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn new_merger(
+        batch1: &FallbackValBatch<K, V, T, R>,
+        batch2: &FallbackValBatch<K, V, T, R>,
+    ) -> Self {
+        FallbackValMerger {
+            factories: batch1.factories.clone(),
+            inner: if batch1.len() + batch2.len() < Runtime::min_storage_rows() {
+                match (&batch1.inner, &batch2.inner) {
+                    (Inner::Vec(vec1), Inner::Vec(vec2)) => {
+                        MergerInner::AllVec(OrdValMerger::new_merger(vec1, vec2))
+                    }
+                    _ => MergerInner::ToVec(GenericMerger::new(
+                        &batch1.factories.vec,
+                        batch1,
+                        batch2,
+                    )),
+                }
+            } else {
+                match (&batch1.inner, &batch2.inner) {
+                    (Inner::File(file1), Inner::File(file2)) => {
+                        MergerInner::AllFile(FileValMerger::new_merger(file1, file2))
+                    }
+                    _ => MergerInner::ToFile(GenericMerger::new(
+                        &batch1.factories.file,
+                        batch1,
+                        batch2,
+                    )),
+                }
+            },
+        }
+    }
+
+    fn done(self) -> FallbackValBatch<K, V, T, R> {
+        FallbackValBatch {
+            factories: self.factories.clone(),
+            inner: match self.inner {
+                MergerInner::AllFile(merger) => Inner::File(merger.done()),
+                MergerInner::AllVec(merger) => Inner::Vec(merger.done()),
+                MergerInner::ToVec(merger) => Inner::Vec(merger.done()),
+                MergerInner::ToFile(merger) => Inner::File(merger.done()),
+            },
+        }
+    }
+
+    fn work(
+        &mut self,
+        source1: &FallbackValBatch<K, V, T, R>,
+        source2: &FallbackValBatch<K, V, T, R>,
+        key_filter: &Option<Filter<K>>,
+        value_filter: &Option<Filter<V>>,
+        fuel: &mut isize,
+    ) {
+        match &mut self.inner {
+            MergerInner::AllFile(merger) => merger.work(
+                source1.inner.as_file().unwrap(),
+                source2.inner.as_file().unwrap(),
+                key_filter,
+                value_filter,
+                fuel,
+            ),
+            MergerInner::AllVec(merger) => merger.work(
+                source1.inner.as_vec().unwrap(),
+                source2.inner.as_vec().unwrap(),
+                key_filter,
+                value_filter,
+                fuel,
+            ),
+            MergerInner::ToVec(merger) => match (&source1.inner, &source2.inner) {
+                (Inner::File(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::File(a), Inner::Vec(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::Vec(b)) => merger.work(a, b, key_filter, value_filter, fuel),
+            },
+            MergerInner::ToFile(merger) => match (&source1.inner, &source2.inner) {
+                (Inner::File(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::File(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::File(a), Inner::Vec(b)) => {
+                    merger.work(a, b, key_filter, value_filter, fuel)
+                }
+                (Inner::Vec(a), Inner::Vec(b)) => merger.work(a, b, key_filter, value_filter, fuel),
+            },
+        }
+    }
+}
+
+impl<K, V, T, R> SizeOf for FallbackValMerger<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, _context: &mut size_of::Context) {
+        // XXX
+    }
+}
+
+/// A builder for creating layers from unsorted update tuples.
+pub struct FallbackValBuilder<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    factories: FallbackValBatchFactories<K, V, T, R>,
+    inner: BuilderInner<K, V, T, R>,
+}
+
+enum BuilderInner<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    File(FileValBuilder<K, V, T, R>),
+    Vec(OrdValBuilder<K, V, T, R>),
+}
+
+impl<K, V, T, R> Builder<FallbackValBatch<K, V, T, R>> for FallbackValBuilder<K, V, T, R>
+where
+    Self: SizeOf,
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn new_builder(factories: &FallbackValBatchFactories<K, V, T, R>, time: T) -> Self {
+        Self::with_capacity(factories, time, 0)
+    }
+
+    fn with_capacity(
+        factories: &FallbackValBatchFactories<K, V, T, R>,
+        time: T,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            factories: factories.clone(),
+            inner: if capacity < Runtime::min_storage_rows() {
+                BuilderInner::Vec(OrdValBuilder::with_capacity(&factories.vec, time, capacity))
+            } else {
+                BuilderInner::File(FileValBuilder::with_capacity(
+                    &factories.file,
+                    time,
+                    capacity,
+                ))
+            },
+        }
+    }
+
+    fn reserve(&mut self, _additional: usize) {}
+
+    fn push(&mut self, item: &mut DynPair<DynPair<K, V>, R>) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push(item),
+            BuilderInner::Vec(vec) => vec.push(item),
+        }
+    }
+
+    fn push_refs(&mut self, key: &K, val: &V, weight: &R) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push_refs(key, val, weight),
+            BuilderInner::Vec(vec) => vec.push_refs(key, val, weight),
+        }
+    }
+
+    fn push_vals(&mut self, key: &mut K, val: &mut V, weight: &mut R) {
+        match &mut self.inner {
+            BuilderInner::File(file) => file.push_vals(key, val, weight),
+            BuilderInner::Vec(vec) => vec.push_vals(key, val, weight),
+        }
+    }
+
+    fn done(self) -> FallbackValBatch<K, V, T, R> {
+        FallbackValBatch {
+            factories: self.factories,
+            inner: match self.inner {
+                BuilderInner::File(file) => Inner::File(file.done()),
+                BuilderInner::Vec(vec) => Inner::Vec(vec.done()),
+            },
+        }
+    }
+}
+
+impl<K, V, T, R> SizeOf for FallbackValBuilder<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, _context: &mut size_of::Context) {
+        // XXX
+    }
+}
+
+impl<K, V, T, R> SizeOf for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, _context: &mut size_of::Context) {
+        // XXX
+    }
+}
+
+impl<K, V, T, R> Archive for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    type Archived = ();
+    type Resolver = ();
+
+    unsafe fn resolve(&self, _pos: usize, _resolver: Self::Resolver, _out: *mut Self::Archived) {
+        unimplemented!();
+    }
+}
+
+impl<K, V, T, R, S> Serialize<S> for FallbackValBatch<K, V, T, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    S: Serializer + ?Sized,
+{
+    fn serialize(&self, _serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        unimplemented!();
+    }
+}
+
+impl<K, V, T, R, D> Deserialize<FallbackValBatch<K, V, T, R>, D>
+    for Archived<FallbackValBatch<K, V, T, R>>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    D: Fallible,
+{
+    fn deserialize(&self, _deserializer: &mut D) -> Result<FallbackValBatch<K, V, T, R>, D::Error> {
+        unimplemented!();
+    }
+}

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -8,6 +8,7 @@ use crate::{
     trace::{
         ord::{
             file::wset_batch::{FileWSetBuilder, FileWSetCursor, FileWSetMerger},
+            filter,
             merge_batcher::MergeBatcher,
             vec::wset_batch::{VecWSetBuilder, VecWSetCursor, VecWSetMerger},
         },
@@ -982,13 +983,6 @@ where
         *fuel -= 1;
         cursor.step_key();
     }
-}
-
-fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
-where
-    T: ?Sized,
-{
-    f.as_ref().map_or(true, |f| f(t))
 }
 
 impl<K, R, O> SizeOf for GenericMerger<K, R, O>

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -14,8 +14,9 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
-        ord::merge_batcher::MergeBatcher, Batch, BatchFactories, BatchReader, BatchReaderFactories,
-        Builder, Cursor, Filter, Merger, WeightedItem,
+        ord::{filter, merge_batcher::MergeBatcher},
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
+        WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -668,13 +669,6 @@ where
         self.lower1 = cursor1.key_cursor.absolute_position() as usize;
         self.lower2 = cursor2.key_cursor.absolute_position() as usize;
     }
-}
-
-fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
-where
-    T: ?Sized,
-{
-    f.as_ref().map_or(true, |f| f(t))
 }
 
 impl<K, V, R> SizeOf for FileIndexedWSetMerger<K, V, R>

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
+        cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
         WeightedItem,
@@ -895,6 +896,21 @@ where
 
     fn fast_forward_vals(&mut self) {
         self.move_val(|val_cursor| val_cursor.move_last());
+    }
+}
+
+impl<'s, K, V, R> HasTimeDiffCursor<K, V, (), R> for FileIndexedWSetCursor<'s, K, V, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    type TimeDiffCursor<'a> = SingletonTimeDiffCursor<'a, R>
+    where
+        Self: 'a;
+
+    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_> {
+        SingletonTimeDiffCursor::new(self.val_valid().then(|| self.diff.as_ref()))
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -12,12 +12,12 @@ use crate::{
             Factories as FileFactories,
         },
     },
-    time::AntichainRef,
+    time::{Antichain, AntichainRef},
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
-        WeightedItem,
+        TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -996,6 +996,25 @@ where
             file: self.writer.into_reader().unwrap(),
             lower_bound: 0,
         }
+    }
+}
+
+impl<K, V, R> TimedBuilder<FileIndexedWSet<K, V, R>> for FileIndexedWSetBuilder<K, V, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    fn push_time(&mut self, key: &K, val: &V, _time: &(), weight: &R) {
+        self.push_refs(key, val, weight);
+    }
+
+    fn done_with_bounds(
+        self,
+        _lower: Antichain<()>,
+        _upper: Antichain<()>,
+    ) -> FileIndexedWSet<K, V, R> {
+        self.done()
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -16,7 +16,7 @@ use crate::{
         cursor::{HasTimeDiffCursor, TimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
-        WeightedItem,
+        TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime, Timestamp,
@@ -848,6 +848,52 @@ where
     key: Box<DynOpt<K>>,
 }
 
+impl<K, T, R> TimedBuilder<FileKeyBatch<K, T, R>> for FileKeyBuilder<K, T, R>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+{
+    /// Pushes a tuple including `time` into the builder.
+    ///
+    /// A caller that uses this must finalize the batch with
+    /// [`Self::done_with_bounds`], supplying correct upper and lower bounds, to
+    /// ensure that the final batch's invariants are correct.
+    #[inline]
+    fn push_time(&mut self, key: &K, _val: &DynUnit, time: &T, weight: &R) {
+        if let Some(cur_key) = self.key.get() {
+            if cur_key != key {
+                self.writer.write0((cur_key, ().erase())).unwrap();
+                self.key.from_ref(key);
+            }
+        } else {
+            self.key.from_ref(key);
+        }
+        self.writer.write1((time, weight)).unwrap();
+    }
+
+    /// Finalizes a batch with lower bound `lower` and upper bound `upper`.
+    /// This is only necessary if `push_time()` was used; otherwise, use
+    /// [`Self::done`] instead.
+    #[inline(never)]
+    fn done_with_bounds(
+        mut self,
+        lower: Antichain<T>,
+        upper: Antichain<T>,
+    ) -> FileKeyBatch<K, T, R> {
+        if let Some(key) = self.key.get() {
+            self.writer.write0((key, ().erase())).unwrap();
+        }
+        FileKeyBatch {
+            factories: self.factories,
+            file: self.writer.into_reader().unwrap(),
+            lower,
+            upper,
+            lower_bound: 0,
+        }
+    }
+}
+
 impl<K, T, R> Builder<FileKeyBatch<K, T, R>> for FileKeyBuilder<K, T, R>
 where
     Self: SizeOf,
@@ -892,15 +938,8 @@ where
 
     #[inline]
     fn push_refs(&mut self, key: &K, _val: &DynUnit, weight: &R) {
-        if let Some(cur_key) = self.key.get() {
-            if cur_key != key {
-                self.writer.write0((cur_key, ().erase())).unwrap();
-                self.key.from_ref(key);
-            }
-        } else {
-            self.key.from_ref(key);
-        }
-        self.writer.write1((&self.time, weight)).unwrap();
+        let time = self.time.clone();
+        self.push_time(key, &(), &time, weight);
     }
 
     fn push_vals(&mut self, key: &mut K, val: &mut DynUnit, weight: &mut R) {
@@ -908,24 +947,15 @@ where
     }
 
     #[inline(never)]
-    fn done(mut self) -> FileKeyBatch<K, T, R> {
+    fn done(self) -> FileKeyBatch<K, T, R> {
+        let lower = Antichain::from_elem(self.time.clone());
         let time_next = self.time.advance(0);
         let upper = if time_next <= self.time {
             Antichain::new()
         } else {
             Antichain::from_elem(time_next)
         };
-
-        if let Some(key) = self.key.get() {
-            self.writer.write0((key, ().erase())).unwrap();
-        }
-        FileKeyBatch {
-            factories: self.factories,
-            file: self.writer.into_reader().unwrap(),
-            lower: Antichain::from_elem(self.time),
-            upper,
-            lower_bound: 0,
-        }
+        self.done_with_bounds(lower, upper)
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -13,8 +13,9 @@ use crate::{
     },
     time::{Antichain, AntichainRef},
     trace::{
-        ord::merge_batcher::MergeBatcher, Batch, BatchFactories, BatchReader, BatchReaderFactories,
-        Builder, Cursor, Filter, Merger, WeightedItem,
+        ord::{filter, merge_batcher::MergeBatcher},
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
+        WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime, Timestamp,
@@ -541,13 +542,6 @@ where
         self.lower1 = cursor1.cursor.absolute_position() as usize;
         self.lower2 = cursor2.cursor.absolute_position() as usize;
     }
-}
-
-fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
-where
-    T: ?Sized,
-{
-    f.as_ref().map_or(true, |f| f(t))
 }
 
 impl<K, T, R> SizeOf for FileKeyMerger<K, T, R>

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -14,8 +14,9 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
-        ord::merge_batcher::MergeBatcher, Batch, BatchFactories, BatchReader, BatchReaderFactories,
-        Builder, Cursor, Deserializer, Filter, Merger, Serializer, WeightedItem,
+        ord::{filter, merge_batcher::MergeBatcher},
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
+        Filter, Merger, Serializer, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -582,13 +583,6 @@ where
         self.lower1 = cursor1.cursor.absolute_position() as usize;
         self.lower2 = cursor2.cursor.absolute_position() as usize;
     }
-}
-
-fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
-where
-    T: ?Sized,
-{
-    f.as_ref().map_or(true, |f| f(t))
 }
 
 type RawCursor<'s, K, R> = FileCursor<'s, Backend, K, R, (), (&'static K, &'static R, ())>;

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -12,12 +12,12 @@ use crate::{
             Factories as FileFactories,
         },
     },
-    time::AntichainRef,
+    time::{Antichain, AntichainRef},
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, WeightedItem,
+        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -846,6 +846,20 @@ where
 
     fn push_vals(&mut self, key: &mut K, _val: &mut DynUnit, weight: &mut R) {
         self.push_refs(key, &(), weight)
+    }
+}
+
+impl<K, R> TimedBuilder<FileWSet<K, R>> for FileWSetBuilder<K, R>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    fn push_time(&mut self, key: &K, val: &DynUnit, _time: &(), weight: &R) {
+        self.push_refs(key, val, weight);
+    }
+
+    fn done_with_bounds(self, _lower: Antichain<()>, _upper: Antichain<()>) -> FileWSet<K, R> {
+        self.done()
     }
 }
 

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
+        cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
         Filter, Merger, Serializer, WeightedItem,
@@ -764,6 +765,20 @@ where
         if self.valid {
             logic(&(), self.diff.as_ref())
         }
+    }
+}
+
+impl<'s, K, R> HasTimeDiffCursor<K, DynUnit, (), R> for FileWSetCursor<'s, K, R>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    type TimeDiffCursor<'a> = SingletonTimeDiffCursor<'a, R>
+    where
+        Self: 'a;
+
+    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_> {
+        SingletonTimeDiffCursor::new(self.val_valid().then(|| self.diff.as_ref()))
     }
 }
 

--- a/crates/dbsp/src/trace/ord/mod.rs
+++ b/crates/dbsp/src/trace/ord/mod.rs
@@ -5,6 +5,8 @@ pub mod vec;
 
 pub use fallback::{
     indexed_wset::{FallbackIndexedWSet, FallbackIndexedWSetFactories},
+    key_batch::{FallbackKeyBatch, FallbackKeyBatchFactories},
+    val_batch::{FallbackValBatch, FallbackValBatchFactories},
     wset::{FallbackWSet, FallbackWSetFactories},
 };
 pub use file::{

--- a/crates/dbsp/src/trace/ord/mod.rs
+++ b/crates/dbsp/src/trace/ord/mod.rs
@@ -17,3 +17,12 @@ pub use vec::{
     VecValBatch as OrdValBatch, VecValBatchFactories as OrdValBatchFactories, VecWSet as OrdWSet,
     VecWSetFactories as OrdWSetFactories,
 };
+
+use super::Filter;
+
+fn filter<T>(f: &Option<Filter<T>>, t: &T) -> bool
+where
+    T: ?Sized,
+{
+    f.as_ref().map_or(true, |f| f(t))
+}

--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -4,7 +4,7 @@ use crate::{
         DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, LeanVec, WeightTrait,
         WeightTraitTyped, WithFactory,
     },
-    time::AntichainRef,
+    time::{Antichain, AntichainRef},
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         layers::{
@@ -12,7 +12,7 @@ use crate::{
             LeafBuilder, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
         },
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, WeightedItem,
+        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries,
@@ -884,6 +884,25 @@ where
             layer: self.builder.done(),
             factories: self.factories,
         }
+    }
+}
+
+impl<K, V, R> TimedBuilder<VecIndexedWSet<K, V, R>> for VecIndexedWSetBuilder<K, V, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    fn push_time(&mut self, key: &K, val: &V, _time: &(), weight: &R) {
+        self.push_refs(key, val, weight);
+    }
+
+    fn done_with_bounds(
+        self,
+        _lower: Antichain<()>,
+        _upper: Antichain<()>,
+    ) -> VecIndexedWSet<K, V, R> {
+        self.done()
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
+        cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         layers::{
             Builder as _, Cursor as _, Layer, LayerBuilder, LayerCursor, LayerFactories, Leaf,
             LeafBuilder, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
@@ -791,6 +792,21 @@ where
 
     fn fast_forward_vals(&mut self) {
         self.cursor.child.fast_forward();
+    }
+}
+
+impl<'s, K, V, R> HasTimeDiffCursor<K, V, (), R> for VecIndexedWSetCursor<'s, K, V, R>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    type TimeDiffCursor<'a> = SingletonTimeDiffCursor<'a, R>
+    where
+        Self: 'a;
+
+    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_> {
+        SingletonTimeDiffCursor::new(self.val_valid().then(|| self.cursor.child.current_diff()))
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -11,7 +11,7 @@ use crate::{
             LeafBuilder, LeafCursor, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
         },
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, WeightedItem,
+        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::{ConsolidatePairedSlices, Tup2},
     DBData, DBWeight, NumEntries, Timestamp,
@@ -737,6 +737,37 @@ where
     factories: VecKeyBatchFactories<K, T, R>,
 }
 
+impl<K, T, R, O> TimedBuilder<VecKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    T: Timestamp,
+    R: WeightTrait + ?Sized,
+    O: OrdOffset,
+{
+    /// Pushes a tuple including `time` into the builder.
+    ///
+    /// A caller that uses this must finalize the batch with
+    /// [`Self::done_with_bounds`], supplying correct upper and lower bounds, to
+    /// ensure that the final batch's invariants are correct.
+    #[inline]
+    fn push_time(&mut self, key: &K, _val: &DynUnit, time: &T, weight: &R) {
+        self.builder.push_refs((key, (time, weight)));
+    }
+
+    /// Finalizes a batch with lower bound `lower` and upper bound `upper`.
+    /// This is only necessary if `push_time()` was used; otherwise, use
+    /// [`Self::done`] instead.
+    #[inline(never)]
+    fn done_with_bounds(self, lower: Antichain<T>, upper: Antichain<T>) -> VecKeyBatch<K, T, R, O> {
+        VecKeyBatch {
+            layer: self.builder.done(),
+            lower,
+            upper,
+            factories: self.factories,
+        }
+    }
+}
+
 impl<K, T, R, O> Builder<VecKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
 where
     K: DataTrait + ?Sized,
@@ -792,19 +823,14 @@ where
 
     #[inline(never)]
     fn done(self) -> VecKeyBatch<K, T, R, O> {
+        let lower = Antichain::from_elem(self.time.clone());
         let time_next = self.time.advance(0);
         let upper = if time_next <= self.time {
             Antichain::new()
         } else {
             Antichain::from_elem(time_next)
         };
-
-        VecKeyBatch {
-            layer: self.builder.done(),
-            lower: Antichain::from_elem(self.time),
-            upper,
-            factories: self.factories,
-        }
+        Self::done_with_bounds(self, lower, upper)
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/wset_batch.rs
@@ -4,7 +4,7 @@ use crate::{
         DataTrait, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory, LeanVec,
         WeightTrait, WeightTraitTyped, WithFactory,
     },
-    time::AntichainRef,
+    time::{Antichain, AntichainRef},
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         layers::{
@@ -13,7 +13,7 @@ use crate::{
         },
         ord::merge_batcher::MergeBatcher,
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, WeightedItem,
+        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries,
@@ -687,6 +687,20 @@ where
             layer: self.builder.done(),
             factories: self.factories,
         }
+    }
+}
+
+impl<K, R> TimedBuilder<VecWSet<K, R>> for VecWSetBuilder<K, R>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    fn push_time(&mut self, key: &K, val: &DynUnit, _time: &(), weight: &R) {
+        self.push_refs(key, val, weight);
+    }
+
+    fn done_with_bounds(self, _lower: Antichain<()>, _upper: Antichain<()>) -> VecWSet<K, R> {
+        self.done()
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/wset_batch.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
+        cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         layers::{
             Builder as _, Cursor as _, Leaf, LeafBuilder, LeafCursor, LeafFactories, MergeBuilder,
             Trie, TupleBuilder,
@@ -604,6 +605,20 @@ impl<'s, K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Cursor<K, DynUnit, (), 
 
     fn fast_forward_vals(&mut self) {
         self.valid = true;
+    }
+}
+
+impl<'s, K, R> HasTimeDiffCursor<K, DynUnit, (), R> for VecWSetCursor<'s, K, R>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    type TimeDiffCursor<'a> = SingletonTimeDiffCursor<'a, R>
+    where
+        Self: 'a;
+
+    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_> {
+        SingletonTimeDiffCursor::new(self.val_valid().then(|| self.cursor.current_diff()))
     }
 }
 

--- a/crates/dbsp/src/typed_batch.rs
+++ b/crates/dbsp/src/typed_batch.rs
@@ -11,7 +11,8 @@ pub use crate::{
     },
     trace::{
         Batch as DynBatch, BatchReader as DynBatchReader,
-        FallbackIndexedWSet as DynFallbackIndexedWSet, FallbackWSet as DynFallbackWSet,
+        FallbackIndexedWSet as DynFallbackIndexedWSet, FallbackKeyBatch as DynFallbackKeyBatch,
+        FallbackValBatch as DynFallbackValBatch, FallbackWSet as DynFallbackWSet,
         FileIndexedWSet as DynFileIndexedWSet, FileKeyBatch as DynFileKeyBatch,
         FileValBatch as DynFileValBatch, FileWSet as DynFileWSet,
         OrdIndexedWSet as DynOrdIndexedWSet, OrdKeyBatch as DynOrdKeyBatch,
@@ -505,6 +506,10 @@ pub type FallbackIndexedWSet<K, V, R, DynR> =
     TypedBatch<K, V, R, DynFallbackIndexedWSet<DynData, DynData, DynR>>;
 pub type FallbackIndexedZSet<K, V> =
     TypedBatch<K, V, ZWeight, DynFallbackIndexedWSet<DynData, DynData, DynZWeight>>;
+pub type FallbackKeyBatch<K, T, R, DynR> =
+    TypedBatch<K, (), R, DynFallbackKeyBatch<DynData, T, DynR>>;
+pub type FallbackValBatch<K, V, T, R, DynR> =
+    TypedBatch<K, V, R, DynFallbackValBatch<DynData, DynData, T, DynR>>;
 
 pub type Spine<B> = TypedBatch<
     <B as BatchReader>::Key,


### PR DESCRIPTION
The individual commits in this series are meaningful and it's worth looking at
them individually.

These complete the set of batch types that choose between memory or
storage implementations at creation time.  These fix the runtime for
the `galen` benchmark, which regressed when storage was introduced because
it uses valbatches.

Is this a user-visible change (yes/no): no