### PR TITLE
[SQL] Support COUNT() with multiple arguments

### DIFF
--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -71,7 +71,7 @@ DECIMAL(10, 4))` if you expect 10-digit results to be possible.
   </tr>
   <tr>
      <td><code>COUNT( [ ALL | DISTINCT ] value [, value ]*)</code></td>
-     <td>Returns the number of input rows for which value is not null (wholly not null if value is composite)</td>
+     <td>Returns the number of input rows for which value is not null.  If the argument contains multiple expressions, it counts only expressions where *all* fields are non-null.</td>
   </tr>
   <tr>
      <td><code>EVERY(condition)</code></td>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -224,10 +224,7 @@ public class AggregateCompiler implements ICompilerComponent {
             argument = one;
         } else {
             DBSPExpression agg = this.getAggregatedValue();
-            if (agg.getType().mayBeNull)
-                argument = ExpressionCompiler.makeIndicator(node, resultType, agg);
-            else
-                argument = one;
+            argument = ExpressionCompiler.makeIndicator(node, resultType, agg);
         }
 
         @Nullable

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RelColumnMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RelColumnMetadata.java
@@ -7,10 +7,8 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 
 import javax.annotation.Nullable;
 
-/**
- * Stores metadata for a column produced by an operator at the level
- * of Calcite Rel objects.
- */
+/** Stores metadata for a column produced by an operator at the level
+ * of Calcite Rel objects. */
 public class RelColumnMetadata {
     public final CalciteObject node;
     /** Column name and type. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
@@ -1,7 +1,5 @@
 package org.dbsp.sqlCompiler.compiler.sql.quidem;
 
-import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
-import org.dbsp.util.Logger;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -745,7 +743,7 @@ public class AggScottTests extends ScottBaseTests {
                 (1 row)""");
     }
 
-    @Test @Ignore("https://github.com/feldera/feldera/issues/1481")
+    @Test
     public void testCompositeCount() {
         this.qs("""
                 -- Composite COUNT and FILTER
@@ -877,11 +875,8 @@ public class AggScottTests extends ScottBaseTests {
     @Test @Ignore("https://github.com/feldera/feldera/issues/1507")
     public void testAvg() {
         this.qs("""
-                -- [CALCITE-280] BigDecimal underflow
-                -- Previously threw "java.lang.ArithmeticException: Non-terminating decimal
-                -- expansion; no exact representable decimal result"
-                select avg(comm) as a, count(comm) as c from --
-                   emp where empno < 7844;
+                select avg(comm) as a, count(comm) as c from
+                emp where empno < 7844;
                 +-------------------+---+
                 | A                 | C |
                 +-------------------+---+
@@ -1128,9 +1123,8 @@ public class AggScottTests extends ScottBaseTests {
                 (6 rows)""");
     }
 
-    @Test @Ignore("https://github.com/feldera/feldera/issues/1539")
+    @Test
     public void testNestedOrderby() {
-        Logger.INSTANCE.setLoggingLevel(CalciteCompiler.class, 2);
         this.qs("""
                 -- Collation of LogicalAggregate ([CALCITE-783] and [CALCITE-822])
                 select  sum(x) as sum_cnt,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
@@ -767,8 +767,6 @@ public class AggScottTests extends ScottBaseTests {
     @Test
     public void testAggregates2() {
         this.qs("""
-                -- [CALCITE-1293] Bad code generated when argument to COUNT(DISTINCT) is a
-                -- GROUP BY column
                 select count(distinct deptno) as cd, count(*) as c
                 from emp
                 group by deptno;
@@ -1130,8 +1128,9 @@ public class AggScottTests extends ScottBaseTests {
                 (6 rows)""");
     }
 
-    @Test @Ignore("TODO: Crashes the compiler")
+    @Test @Ignore("https://github.com/feldera/feldera/issues/1539")
     public void testNestedOrderby() {
+        Logger.INSTANCE.setLoggingLevel(CalciteCompiler.class, 2);
         this.qs("""
                 -- Collation of LogicalAggregate ([CALCITE-783] and [CALCITE-822])
                 select  sum(x) as sum_cnt,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 // https://github.com/apache/calcite/blob/main/core/src/test/resources/sql/agg.iq
 public class AggTests extends PostBaseTests {
-    @Test @Ignore("https://github.com/feldera/feldera/issues/1481")
+    @Test
     public void testCompositeCount() {
         this.qs("""
                 -- composite count
@@ -40,8 +40,8 @@ public class AggTests extends PostBaseTests {
                 | M  | C |
                 +----+---+
                 |  0 | F|
-                | 10 |   |
-                |  0 | M |
+                | 10 |NULL|
+                |  0 | M|
                 +----+---+
                 (3 rows)
                                 


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This was documented, but I never noticed it's supposed to work.
Calcite seems to be the only SQL which supports this esoteric feature.
Fixes #1481
