### PR TITLE
Initial support for Avro output format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Initial support for Avro as anoutput format
+  ([#1673](https://github.com/feldera/feldera/pull/1673))
+
 ## [0.14.0] - 2024-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial support for Avro as anoutput format
+- Initial support for Avro as an output format
   ([#1673](https://github.com/feldera/feldera/pull/1673))
 
 ## [0.14.0] - 2024-04-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,6 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
 dependencies = [
- "crc32fast",
  "digest 0.10.7",
  "lazy_static",
  "libflate",
@@ -536,7 +535,6 @@ dependencies = [
  "regex-lite",
  "serde",
  "serde_json",
- "snap",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -311,9 +311,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -349,9 +349,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -368,6 +368,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aes"
@@ -431,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -511,6 +517,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "apache-avro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+dependencies = [
+ "crc32fast",
+ "digest 0.10.7",
+ "lazy_static",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand 0.8.5",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "snap",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "thiserror",
+ "typed-builder",
+ "uuid",
 ]
 
 [[package]]
@@ -822,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
  "event-listener 5.3.0",
@@ -853,11 +884,10 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98c37cf288e302c16ef6c8472aad1e034c6c84ce5ea7b8101c98eb4a802fee"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.2",
@@ -871,7 +901,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel 2.2.1",
  "async-executor",
  "async-io 2.3.2",
  "async-lock 3.3.0",
@@ -912,8 +942,8 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.6.0",
- "rustix 0.38.32",
+ "polling 3.7.0",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -964,26 +994,26 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io 2.3.2",
- "async-lock 2.8.0",
+ "async-lock 3.3.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1031,9 +1061,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1048,9 +1078,9 @@ version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1106,9 +1136,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f7df18977a1ee03650ee4b31b4aefed6d56bac188760b6e37610400fe8d4bb"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1198,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.1.8"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8587ae17c8e967e4b05a62d495be2fb7701bec52a97f7acfe8a29f938384c8"
+checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
@@ -1243,18 +1273,18 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ee6903f9d0197510eb6b44c4d86b493011d08b4992938f7b9be0333b6685aa"
+checksum = "f4963ac9ff2d33a4231b3806c1c69f578f221a9cabb89ad2bde62ce2b442c8a7"
 dependencies = [
- "aws-credential-types 1.1.8",
- "aws-sigv4 1.2.0",
+ "aws-credential-types 1.2.0",
+ "aws-sigv4 1.2.1",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.7",
+ "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
- "aws-types 1.1.9",
+ "aws-types 1.2.0",
  "bytes",
  "fastrand 2.0.2",
  "http 0.2.12",
@@ -1292,24 +1322,24 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644c5939c1b78097d37f3341708978d68490070d4b0f8fa91f0878678c06a7ef"
+checksum = "7f522b68eb0294c59f7beb0defa30e84fed24ebc50ee219e111d6c33eaea96a8"
 dependencies = [
  "ahash 0.8.11",
- "aws-credential-types 1.1.8",
+ "aws-credential-types 1.2.0",
  "aws-runtime",
- "aws-sigv4 1.2.0",
+ "aws-sigv4 1.2.1",
  "aws-smithy-async 1.2.1",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.7",
+ "aws-smithy-http 0.60.8",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
- "aws-smithy-xml 0.60.7",
- "aws-types 1.1.9",
+ "aws-smithy-xml 0.60.8",
+ "aws-types 1.2.0",
  "bytes",
  "fastrand 2.0.2",
  "hex",
@@ -1411,13 +1441,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d6f29688a4be9895c0ba8bef861ad0c0dac5c15e9618b9b7a6c233990fc263"
+checksum = "58b56f1cbe6fd4d0c2573df72868f20ab1c125ca9c9dbce17927a463433a2e57"
 dependencies = [
- "aws-credential-types 1.1.8",
+ "aws-credential-types 1.2.0",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.7",
+ "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
  "bytes",
@@ -1467,7 +1497,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fa43bc04a6b2441968faeab56e68da3812f978a670a5db32accbdcafddd12f"
 dependencies = [
- "aws-smithy-http 0.60.7",
+ "aws-smithy-http 0.60.8",
  "aws-smithy-types 1.1.8",
  "bytes",
  "crc32c",
@@ -1541,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f10fa66956f01540051b0aa7ad54574640f748f9839e843442d99b970d3aff9"
+checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1606,12 +1636,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de34bcfa1fb3c82a80e252a753db34a6658e07f23d3a5b3fc96919518fa7a3f5"
+checksum = "44e7945379821074549168917e89e60630647e186a69243248f08c6d168b975a"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.7",
+ "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
  "bytes",
@@ -1625,7 +1655,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
  "tracing",
 ]
@@ -1697,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872c68cf019c0e4afc5de7753c4f7288ce4b71663212771bf5e4542eb9346ca9"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
 dependencies = [
  "xmlparser",
 ]
@@ -1722,11 +1752,11 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.1.9"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb278e322f16f59630a83b6b2dc992a0b48aa74ed47b4130f193fae0053d713"
+checksum = "5a43b56df2c529fe44cb4d92bd64d0479883fb9608ff62daede4df5405381814"
 dependencies = [
- "aws-credential-types 1.1.8",
+ "aws-credential-types 1.2.0",
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
@@ -1832,7 +1862,7 @@ checksum = "cb515fdd6f8d3a357c8e19b8ec59ef53880807864329b1cb1cba5c53bf76557e"
 dependencies = [
  "either",
  "owo-colors",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1922,7 +1952,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel 2.2.1",
  "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.2",
@@ -1950,9 +1980,9 @@ checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
  "syn_derive",
 ]
 
@@ -2012,7 +2042,7 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2032,9 +2062,9 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2147,7 +2177,7 @@ checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.14.4",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2166,12 +2196,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -2208,7 +2239,7 @@ dependencies = [
  "rkyv",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2221,7 +2252,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2341,7 +2372,7 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2353,9 +2384,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2501,6 +2532,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpp_demangle"
@@ -2773,7 +2813,7 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "strsim 0.10.0",
  "syn 1.0.109",
@@ -2787,7 +2827,7 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "strsim 0.10.0",
  "syn 1.0.109",
@@ -2801,10 +2841,10 @@ checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2837,7 +2877,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2859,6 +2899,12 @@ checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "dashmap"
@@ -3173,12 +3219,13 @@ dependencies = [
  "actix-test",
  "actix-web",
  "anyhow",
+ "apache-avro",
  "arrow",
  "async-stream",
  "async-trait",
  "awc",
  "aws-sdk-s3",
- "aws-types 1.1.9",
+ "aws-types 1.2.0",
  "bstr",
  "bytes",
  "bytestring",
@@ -3201,6 +3248,7 @@ dependencies = [
  "log",
  "mime",
  "mockall",
+ "num-bigint",
  "num-derive 0.3.3",
  "num-traits",
  "once_cell",
@@ -3216,8 +3264,10 @@ dependencies = [
  "regex",
  "reqwest",
  "rkyv",
+ "rust_decimal",
  "rust_decimal_macros",
  "rustls 0.20.9",
+ "schema_registry_converter",
  "serde",
  "serde_arrow",
  "serde_json",
@@ -3468,7 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustc_version",
  "syn 1.0.109",
@@ -3648,16 +3698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "elliptic-curve"
@@ -3702,9 +3752,9 @@ checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3913,7 +3963,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c81935e123ab0741c4c4f0d9b8377e5fb21d3de7e062fa4b1263b1fbcba1ea"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -4097,9 +4147,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4587,7 +4637,7 @@ dependencies = [
  "http 0.2.12",
  "hyper",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -4648,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "ijson"
 version = "0.1.4"
-source = "git+https://github.com/abhizer/ijson.git#539097223774b7520991fc968f1c637f7db782b3"
+source = "git+https://github.com/abhizer/ijson.git#6c9769c780ab533b3fca8f5e2e9204b16af0e6ad"
 dependencies = [
  "dashmap",
  "lazy_static",
@@ -4671,7 +4721,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -4772,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9febecd4aebbe9c7c23c8e536e966805fdf09944c8a915e7991ee51acb67087"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -4832,9 +4882,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -4973,6 +5023,30 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libflate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
+dependencies = [
+ "core2",
+ "hashbrown 0.13.2",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -5258,9 +5332,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5287,9 +5361,9 @@ name = "monoio-macros"
 version = "0.1.0"
 source = "git+https://github.com/gz/monoio.git?rev=9303e02#9303e024249863234be91a31c86ab237c5dc6bfa"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5372,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -5416,7 +5490,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -5427,9 +5501,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5510,7 +5584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -5599,9 +5673,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6001,9 +6075,9 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6173,15 +6247,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.3.9",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6296,12 +6370,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
- "proc-macro2 1.0.79",
- "syn 2.0.58",
+ "proc-macro2 1.0.81",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6340,7 +6414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "version_check",
@@ -6352,7 +6426,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "version_check",
 ]
@@ -6368,9 +6442,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -6408,9 +6482,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6450,7 +6524,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -6491,7 +6565,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
  "tempfile",
 ]
 
@@ -6503,9 +6577,9 @@ checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6566,7 +6640,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -6577,10 +6651,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
 
 [[package]]
 name = "quick-error"
@@ -6622,7 +6702,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
 ]
 
 [[package]]
@@ -6859,11 +6939,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd81f69687fe8a1fa10995108b3ffc7cdbd63e682a4f8fbfd1020130780d7e17"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "refinery-core",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6941,7 +7021,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -7040,10 +7120,16 @@ name = "rkyv_derive"
 version = "0.7.43"
 source = "git+https://github.com/gz/rkyv.git?rev=3d3fd86#3d3fd86d514134af786e38f4094d993cc5b5c198"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlimit"
@@ -7100,7 +7186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustc_version",
  "syn 1.0.109",
@@ -7221,11 +7307,11 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.58",
+ "syn 2.0.60",
  "walkdir",
 ]
 
@@ -7305,9 +7391,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -7343,9 +7429,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -7398,9 +7484,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
@@ -7465,6 +7551,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "schema_registry_converter"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e5a442d604e325eddde3c8108212a4c48463e73daaafa2861a2bc8977414b9"
+dependencies = [
+ "apache-avro",
+ "byteorder",
+ "dashmap",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7550,9 +7651,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -7574,20 +7675,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -7651,9 +7752,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling 0.20.8",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7689,9 +7790,9 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7765,9 +7866,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -7832,7 +7933,7 @@ name = "size-of-derive"
 version = "0.1.2"
 source = "git+https://github.com/gz/size-of.git?rev=3ec40db#3ec40db3d1c8470f22856257542a68ef60c99969"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -7875,7 +7976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -7982,9 +8083,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8068,7 +8169,7 @@ dependencies = [
  "either",
  "heck 0.4.1",
  "once_cell",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "sha2 0.10.8",
  "sqlx-core",
@@ -8162,10 +8263,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8175,10 +8276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8227,18 +8328,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -8250,9 +8351,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8263,9 +8364,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.30.10"
+version = "0.30.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d7c217777061d5a2d652aea771fb9ba98b6dade657204b08c4b9604d11555b"
+checksum = "87341a165d73787554941cd5ef55ad728011566fe714e987d1b976c15dbc3a83"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -8344,7 +8445,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -8357,7 +8458,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.2",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -8376,7 +8477,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -8411,22 +8512,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8540,9 +8641,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8621,7 +8722,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
 ]
 
@@ -8676,7 +8777,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -8712,9 +8813,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -8769,9 +8870,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8822,6 +8923,26 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2 1.0.81",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -8972,10 +9093,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
  "uuid",
 ]
 
@@ -9113,9 +9234,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -9147,9 +9268,9 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9247,11 +9368,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9267,7 +9388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -9276,7 +9397,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -9294,7 +9415,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -9314,17 +9435,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -9335,9 +9457,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9347,9 +9469,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9359,9 +9481,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9371,9 +9499,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9383,9 +9511,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9395,9 +9523,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9407,9 +9535,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -9478,7 +9606,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -9535,9 +9663,9 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -76,6 +76,9 @@ serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arro
 bytes = "1.5.0"
 # `datafusion` must be enabled for the writer to implement the `Invariant` feature.
 deltalake = { version = "0.17.1", features = ["datafusion", "s3", "gcs", "azure"], optional = true }
+apache-avro = { version = "0.16.0", features = ["snappy"] }
+schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"] }
+rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 psutil = "3.2.2"
@@ -100,3 +103,4 @@ rust_decimal_macros = "1.32"
 mockall = "0.12.1"
 pretty_assertions = "1.4.0"
 sqllib = { path = "../../sql-to-dbsp-compiler/lib/sqllib" }
+num-bigint = "0.4.4"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -11,9 +11,10 @@ categories = ["database", "api-bindings", "network-programming"]
 publish = false
 
 [features]
-default = ["with-kafka", "with-deltalake"]
+default = ["with-kafka", "with-deltalake", "with-avro"]
 with-kafka = ["rdkafka"]
 with-deltalake = ["deltalake"]
+with-avro = ["apache-avro", "schema_registry_converter"]
 # Run delta table tests against an S3 bucket.  Requires S3 authentication key
 # to be provided via an environment variable.
 delta-s3-test = []
@@ -76,8 +77,8 @@ serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arro
 bytes = "1.5.0"
 # `datafusion` must be enabled for the writer to implement the `Invariant` feature.
 deltalake = { version = "0.17.1", features = ["datafusion", "s3", "gcs", "azure"], optional = true }
-apache-avro = { version = "0.16.0", features = ["snappy"] }
-schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"] }
+apache-avro = { version = "0.16.0", optional = true }
+schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"], optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{static_compile::DeScalarHandle, ControllerError};
 use anyhow::Result as AnyResult;
+#[cfg(feature = "with-avro")]
 use apache_avro::{types::Value as AvroValue, Schema as AvroSchema};
 use dbsp::{utils::Tup2, InputHandle};
 use pipeline_types::format::json::JsonFlavor;
@@ -28,6 +29,7 @@ pub enum RecordFormat {
     Json(JsonFlavor),
     Csv,
     Parquet(SerdeArrowSchema),
+    #[cfg(feature = "with-avro")]
     Avro,
 }
 
@@ -267,6 +269,7 @@ pub trait SerCursor {
     /// Serialize current key into arrow format. Panics if invalid.
     fn serialize_key_to_arrow(&mut self, dst: &mut ArrowBuilder) -> AnyResult<()>;
 
+    #[cfg(feature = "with-avro")]
     /// Convert current key to an Avro value.
     fn key_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue>;
 
@@ -279,6 +282,7 @@ pub trait SerCursor {
     /// Serialize current value. Panics if invalid.
     fn serialize_val(&mut self, dst: &mut Vec<u8>) -> AnyResult<()>;
 
+    #[cfg(feature = "with-avro")]
     /// Convert current value to Avro.
     fn val_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue>;
 
@@ -375,6 +379,7 @@ impl<'a> SerCursor for CursorWithPolarity<'a> {
         self.cursor.serialize_key(dst)
     }
 
+    #[cfg(feature = "with-avro")]
     fn key_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue> {
         self.cursor.key_to_avro(schema)
     }
@@ -391,6 +396,7 @@ impl<'a> SerCursor for CursorWithPolarity<'a> {
         self.cursor.serialize_val(dst)
     }
 
+    #[cfg(feature = "with-avro")]
     fn val_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue> {
         self.cursor.val_to_avro(schema)
     }

--- a/crates/adapters/src/controller/error.rs
+++ b/crates/adapters/src/controller/error.rs
@@ -109,6 +109,16 @@ pub enum ConfigError {
     OutputFormatNotSpecified {
         endpoint_name: String,
     },
+
+    InvalidEncoderConfig {
+        endpoint_name: String,
+        error: String,
+    },
+
+    InvalidParserConfig {
+        endpoint_name: String,
+        error: String,
+    },
 }
 
 impl StdError for ConfigError {}
@@ -133,6 +143,8 @@ impl DetailedError for ConfigError {
             Self::OutputFormatNotSupported { .. } => Cow::from("OutputFormatNotSupported"),
             Self::InputFormatNotSpecified { .. } => Cow::from("InputFormatNotSpecified"),
             Self::OutputFormatNotSpecified { .. } => Cow::from("OutputFormatNotSpecified"),
+            Self::InvalidEncoderConfig { .. } => Cow::from("InvalidEncoderConfig"),
+            Self::InvalidParserConfig { .. } => Cow::from("InvalidParserConfig"),
         }
     }
 }
@@ -242,6 +254,24 @@ impl Display for ConfigError {
                 write!(
                     f,
                     "Data format is not specified for output endpoint '{endpoint_name}' (set the 'format' field inside connector configuration)"
+                )
+            }
+            Self::InvalidEncoderConfig {
+                endpoint_name,
+                error,
+            } => {
+                write!(
+                    f,
+                    "invalid format configuration for output endpoint '{endpoint_name}': {error}"
+                )
+            }
+            Self::InvalidParserConfig {
+                endpoint_name,
+                error,
+            } => {
+                write!(
+                    f,
+                    "invalid format configuration for input endpoint '{endpoint_name}': {error}"
                 )
             }
         }
@@ -369,6 +399,20 @@ impl ConfigError {
     pub fn output_format_not_specified(endpoint_name: &str) -> Self {
         Self::OutputFormatNotSpecified {
             endpoint_name: endpoint_name.to_owned(),
+        }
+    }
+
+    pub fn invalid_encoder_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::InvalidEncoderConfig {
+            endpoint_name: endpoint_name.to_string(),
+            error: error.to_string(),
+        }
+    }
+
+    pub fn invalid_parser_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::InvalidParserConfig {
+            endpoint_name: endpoint_name.to_string(),
+            error: error.to_string(),
         }
     }
 }
@@ -784,6 +828,18 @@ impl ControllerError {
     pub fn output_format_not_specified(endpoint_name: &str) -> Self {
         Self::Config {
             config_error: ConfigError::output_format_not_specified(endpoint_name),
+        }
+    }
+
+    pub fn invalid_encoder_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::Config {
+            config_error: ConfigError::invalid_encoder_configuration(endpoint_name, error),
+        }
+    }
+
+    pub fn invalid_parser_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::Config {
+            config_error: ConfigError::invalid_parser_configuration(endpoint_name, error),
         }
     }
 

--- a/crates/adapters/src/format/avro/mod.rs
+++ b/crates/adapters/src/format/avro/mod.rs
@@ -1,0 +1,2 @@
+pub mod output;
+pub mod serializer;

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -1,0 +1,394 @@
+use crate::catalog::{CursorWithPolarity, SerBatchReader};
+use crate::format::MAX_DUPLICATES;
+use crate::{ControllerError, Encoder, OutputConsumer, OutputFormat, RecordFormat, SerCursor};
+use actix_web::HttpRequest;
+use anyhow::{anyhow, bail, Result as AnyResult};
+use apache_avro::{to_avro_datum, Schema as AvroSchema};
+use erased_serde::Serialize as ErasedSerialize;
+use log::debug;
+use pipeline_types::format::avro::AvroEncoderConfig;
+use pipeline_types::program_schema::Relation;
+use schema_registry_converter::avro_common::get_supplied_schema;
+use schema_registry_converter::blocking::schema_registry::{post_schema, SrSettings};
+use serde::Deserialize;
+use serde_urlencoded::Deserializer as UrlDeserializer;
+use serde_yaml::Value as YamlValue;
+use std::borrow::Cow;
+use std::str::FromStr;
+use std::time::Duration;
+
+// TODOs:
+// - This connector currently only supports raw Avro format, i.e., deletes cannot be represented.
+//   Add support for other variants such as Debezium that are able to represent deletions.
+// - Support multiple subject name strategies.  Currently, the record name strategy is used
+//   to name the schema in the schema registry
+// - Add options to specify schema by id or subject name and retrieve it from the registry.
+// - Verify that the Avro schema matches table declaration, including nullability of columns
+//   by matching the schema against the SQL relation schema.
+// - Add an option to generate Avro schema from relation schema.
+// - Support complex schemas with cross-references.
+// - Make the serializer less strict, e.g., allow non-nullable columns to be encoded
+//   as nullable columns and smaller int's to be encoded as long's.
+// - The serializer doesn't currently support the Avro `fixed` type.
+// - Add a Kafka end-to-end test to `kafka/test.rs`.  This requires implementing an Avro parser,
+
+/// Avro format encoder.
+pub struct AvroOutputFormat;
+
+impl OutputFormat for AvroOutputFormat {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("avro")
+    }
+
+    fn config_from_http_request(
+        &self,
+        endpoint_name: &str,
+        request: &HttpRequest,
+    ) -> Result<Box<dyn ErasedSerialize>, ControllerError> {
+        let config = AvroEncoderConfig::deserialize(UrlDeserializer::new(form_urlencoded::parse(
+            request.query_string().as_bytes(),
+        )))
+        .map_err(|e| {
+            ControllerError::encoder_config_parse_error(endpoint_name, &e, request.query_string())
+        })?;
+
+        Ok(Box::new(config))
+    }
+
+    fn new_encoder(
+        &self,
+        endpoint_name: &str,
+        config: &YamlValue,
+        _schema: &Relation,
+        consumer: Box<dyn OutputConsumer>,
+    ) -> Result<Box<dyn Encoder>, ControllerError> {
+        let config = AvroEncoderConfig::deserialize(config).map_err(|e| {
+            ControllerError::encoder_config_parse_error(
+                endpoint_name,
+                &e,
+                &serde_yaml::to_string(config).unwrap_or_default(),
+            )
+        })?;
+
+        Ok(Box::new(AvroEncoder::create(
+            endpoint_name,
+            consumer,
+            config,
+        )?))
+    }
+}
+
+struct AvroEncoder {
+    /// Input handle to push serialized data to.
+    output_consumer: Box<dyn OutputConsumer>,
+    schema: AvroSchema,
+    buffer: Vec<u8>,
+}
+
+impl AvroEncoder {
+    fn create(
+        endpoint_name: &str,
+        output_consumer: Box<dyn OutputConsumer>,
+        config: AvroEncoderConfig,
+    ) -> Result<Self, ControllerError> {
+        debug!("Creating Avro encoder; config: {config:#?}");
+
+        let schema_json = serde_json::Value::from_str(&config.schema).map_err(|e| {
+            ControllerError::encoder_config_parse_error(
+                endpoint_name,
+                &format!(
+                    "'schema' string '{}' is not a valid JSON document: {e}",
+                    &config.schema
+                ),
+                &serde_yaml::to_string(&config).unwrap_or_default(),
+            )
+        })?;
+        let schema = AvroSchema::parse(&schema_json).map_err(|e| {
+            ControllerError::encoder_config_parse_error(
+                endpoint_name,
+                &format!("invalid Avro schema: {e}"),
+                &serde_yaml::to_string(&config).unwrap_or_default(),
+            )
+        })?;
+
+        if config.registry_urls.is_empty() {
+            if config.registry_username.is_some() {
+                return Err(ControllerError::invalid_encoder_configuration(
+                    endpoint_name,
+                    "'registry_username' requires 'registry_urls' to be set",
+                ));
+            }
+            if config.registry_authorization_token.is_some() {
+                return Err(ControllerError::invalid_encoder_configuration(
+                    endpoint_name,
+                    "'registry_authorization_token' requires 'registry_urls' to be set",
+                ));
+            }
+            if config.registry_proxy.is_some() {
+                return Err(ControllerError::invalid_encoder_configuration(
+                    endpoint_name,
+                    "'registry_proxy' requires 'registry_urls' to be set",
+                ));
+            }
+            if !config.registry_headers.is_empty() {
+                return Err(ControllerError::invalid_encoder_configuration(
+                    endpoint_name,
+                    "'registry_headers' requires 'registry_urls' to be set",
+                ));
+            }
+        }
+
+        if config.registry_username.is_some() && config.registry_authorization_token.is_some() {
+            return Err(ControllerError::invalid_encoder_configuration(
+                endpoint_name,
+                "'registry_username' and 'registry_authorization_token' options are mutually exclusive"));
+        }
+
+        if config.registry_password.is_some() && config.registry_username.is_none() {
+            return Err(ControllerError::invalid_encoder_configuration(
+                endpoint_name,
+                "'registry_password' option provided without 'registry_username'",
+            ));
+        }
+
+        let sr_settings = if !config.registry_urls.is_empty() {
+            let mut sr_settings_builder = SrSettings::new_builder(config.registry_urls[0].clone());
+            for url in &config.registry_urls[1..] {
+                sr_settings_builder.add_url(url.clone());
+            }
+            if let Some(username) = &config.registry_username {
+                sr_settings_builder
+                    .set_basic_authorization(username, config.registry_password.as_deref());
+            }
+            if let Some(token) = &config.registry_authorization_token {
+                sr_settings_builder.set_token_authorization(token);
+            }
+
+            for (key, val) in config.registry_headers.iter() {
+                sr_settings_builder.add_header(key.as_str(), val.as_str());
+            }
+
+            if let Some(proxy) = &config.registry_proxy {
+                sr_settings_builder.set_proxy(proxy.as_str());
+            }
+
+            if let Some(timeout) = config.registry_timeout_secs {
+                sr_settings_builder.set_timeout(Duration::from_secs(timeout));
+            }
+
+            Some(sr_settings_builder.build().map_err(|e| {
+                ControllerError::invalid_encoder_configuration(
+                    endpoint_name,
+                    &format!("invalid schema registry configuration: {e}"),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let schema_id = if let Some(sr_settings) = &sr_settings {
+            let supplied_schema = get_supplied_schema(&schema);
+            let name = supplied_schema
+                .name
+                .as_ref()
+                .ok_or_else(|| {
+                    ControllerError::invalid_encoder_configuration(
+                        endpoint_name,
+                        "Avro schema must be of type 'record'",
+                    )
+                })?
+                .clone();
+            let registered_schema =
+                post_schema(sr_settings, name, supplied_schema).map_err(|e| {
+                    ControllerError::encode_error(
+                        endpoint_name,
+                        anyhow!("failed to post Avro schema to the schema registry: {e}"),
+                    )
+                })?;
+            debug!(
+                "avro encoder {endpoint_name}: registered new avro schema with id {}",
+                registered_schema.id
+            );
+            registered_schema.id
+        } else {
+            0
+        };
+
+        let mut buffer = vec![0u8; 5];
+        buffer[1..].clone_from_slice(&schema_id.to_be_bytes());
+
+        Ok(Self {
+            output_consumer,
+            schema,
+            buffer,
+        })
+    }
+}
+
+impl Encoder for AvroEncoder {
+    fn consumer(&mut self) -> &mut dyn OutputConsumer {
+        self.output_consumer.as_mut()
+    }
+
+    fn encode(&mut self, batch: &dyn SerBatchReader) -> AnyResult<()> {
+        let mut cursor = CursorWithPolarity::new(batch.cursor(RecordFormat::Avro)?);
+
+        while cursor.key_valid() {
+            if !cursor.val_valid() {
+                cursor.step_key();
+                continue;
+            }
+            let mut w = cursor.weight();
+
+            if w < 0 {
+                // TODO: we currently only support the "plain" Avro flavor that does not
+                // support deletes.  Other formats, e.g., Debezium will allow deletes.
+                cursor.step_key();
+                continue;
+            }
+
+            if !(-MAX_DUPLICATES..=MAX_DUPLICATES).contains(&w) {
+                bail!(
+                        "Unable to output record with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'."
+                    );
+            }
+
+            while w != 0 {
+                let avro_value = cursor
+                    .key_to_avro(&self.schema)
+                    .map_err(|e| anyhow!("error converting record to Avro format: {e}"))?;
+                let mut avro_buffer = to_avro_datum(&self.schema, avro_value)
+                    .map_err(|e| anyhow!("error serializing Avro value: {e}"))?;
+
+                self.buffer.truncate(5);
+                self.buffer.append(&mut avro_buffer);
+                self.output_consumer.push_buffer(&self.buffer, 1);
+
+                if w > 0 {
+                    w -= 1;
+                } else {
+                    w += 1;
+                }
+            }
+            cursor.step_key()
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::format::avro::output::{AvroEncoder, AvroEncoderConfig};
+    use crate::static_compile::seroutput::SerBatchImpl;
+    use crate::test::{generate_test_batches_with_weights, MockOutputConsumer, TestStruct};
+    use crate::{Encoder, SerBatch};
+    use dbsp::utils::Tup2;
+    use dbsp::{DBData, OrdZSet};
+    use log::trace;
+    use pipeline_types::serde_with_context::{SerializeWithContext, SqlSerdeConfig};
+    use proptest::proptest;
+    use serde::Deserialize;
+    use std::sync::Arc;
+
+    fn test_avro<T>(avro_schema: &str, batches: Vec<Vec<Tup2<T, i64>>>)
+    where
+        T: DBData + for<'de> Deserialize<'de> + SerializeWithContext<SqlSerdeConfig>,
+    {
+        let config = AvroEncoderConfig {
+            schema: avro_schema.to_string(),
+            ..Default::default()
+        };
+
+        let consumer = MockOutputConsumer::new();
+        let consumer_data = consumer.data.clone();
+        let mut encoder =
+            AvroEncoder::create("avro_test_endpoint", Box::new(consumer), config).unwrap();
+        let zsets = batches
+            .iter()
+            .map(|batch| {
+                let zset = OrdZSet::from_keys(
+                    (),
+                    batch
+                        .iter()
+                        .map(|Tup2(x, w)| Tup2(x.clone(), *w))
+                        .collect::<Vec<_>>(),
+                );
+                Arc::new(<SerBatchImpl<_, T, ()>>::new(zset)) as Arc<dyn SerBatch>
+            })
+            .collect::<Vec<_>>();
+        for (step, zset) in zsets.iter().enumerate() {
+            encoder.consumer().batch_start(step as u64);
+            encoder.encode(zset.as_batch_reader()).unwrap();
+            encoder.consumer().batch_end();
+        }
+
+        let expected_output = batches
+            .into_iter()
+            .flat_map(|batch| {
+                let zset = OrdZSet::from_keys(
+                    (),
+                    batch
+                        .iter()
+                        .map(|Tup2(x, w)| Tup2(x.clone(), *w))
+                        .collect::<Vec<_>>(),
+                );
+                /*let mut deletes = zset
+                .iter()
+                .flat_map(|(data, (), weight)| {
+                    trace!("data: {data:?}, weight: {weight}");
+                    let range = if weight < 0 { weight..0 } else { 0..0 };
+
+                    range.map(move |_| {
+                        let upd = U::update(
+                            false,
+                            data.clone(),
+                            encoder.stream_id,
+                            *seq_number.borrow(),
+                        );
+                        *seq_number.borrow_mut() += 1;
+                        upd
+                    })
+                })
+                .collect::<Vec<_>>();*/
+                let inserts = zset
+                    .iter()
+                    .flat_map(|(data, (), weight)| {
+                        trace!("data: {data:?}, weight: {weight}");
+                        let range = if weight > 0 { 0..weight } else { 0..0 };
+
+                        range.map(move |_| data.clone())
+                    })
+                    .collect::<Vec<_>>();
+
+                inserts
+            })
+            .collect::<Vec<_>>();
+
+        trace!(
+            "output: {}",
+            std::str::from_utf8(&consumer_data.lock().unwrap().concat()).unwrap()
+        );
+
+        let mut actual_output = Vec::new();
+        for avro_datum in consumer_data.lock().unwrap().iter() {
+            let avro_value =
+                apache_avro::from_avro_datum(&encoder.schema, &mut &avro_datum[5..], None).unwrap();
+            // FIXME: this will use the default `serde::Deserialize` implementation and will only work
+            // for types where it happens to do the right thing. We should use Avro-compatible
+            // deserialization logic instead, when it exists.
+            let val = apache_avro::from_value::<T>(&avro_value).unwrap();
+            actual_output.push(val);
+        }
+
+        assert_eq!(actual_output, expected_output);
+    }
+
+    proptest! {
+        #[test]
+        fn proptest_avro_output(data in generate_test_batches_with_weights(10, 20))
+        {
+            test_avro::<TestStruct>(TestStruct::avro_schema(), data)
+        }
+    }
+}

--- a/crates/adapters/src/format/avro/serializer.rs
+++ b/crates/adapters/src/format/avro/serializer.rs
@@ -1,0 +1,826 @@
+use apache_avro::schema::RecordSchema;
+use apache_avro::{types::Value as AvroValue, Decimal, Schema as AvroSchema};
+use pipeline_types::serde_with_context::serde_config::DecimalFormat;
+use pipeline_types::serde_with_context::{DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat};
+use rust_decimal::Decimal as RustDecimal;
+use serde::ser::{
+    Error as _, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant,
+};
+use serde::{Serialize, Serializer};
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::iter::once;
+use std::mem::take;
+
+/// Serde configuration expected by [`AvroSchemaSerializer`].
+pub fn avro_serde_config() -> SqlSerdeConfig {
+    SqlSerdeConfig::default()
+        .with_timestamp_format(TimestampFormat::MicrosSinceEpoch)
+        .with_time_format(TimeFormat::Micros)
+        .with_date_format(DateFormat::DaysSinceEpoch)
+        .with_decimal_format(DecimalFormat::U128)
+}
+
+#[derive(Debug)]
+pub enum AvroSerializerError {
+    OutOfBounds {
+        value: String,
+        typ: String,
+        schema: AvroSchema,
+    },
+    Incompatible {
+        typ: String,
+        schema: AvroSchema,
+    },
+    MapKeyNotAString {
+        key: Option<String>,
+    },
+    UnknownField {
+        field: String,
+        struct_name: String,
+    },
+    WrongNumberOfFields {
+        typ: String,
+        expected: usize,
+        actual: usize,
+    },
+    Custom {
+        error: String,
+    },
+}
+
+impl AvroSerializerError {
+    fn out_of_bounds<V: Display>(value: &V, typ: &str, schema: &AvroSchema) -> Self {
+        AvroSerializerError::OutOfBounds {
+            value: value.to_string(),
+            typ: typ.to_string(),
+            schema: schema.clone(),
+        }
+    }
+
+    fn incompatible(typ: &str, schema: &AvroSchema) -> Self {
+        AvroSerializerError::Incompatible {
+            typ: typ.to_string(),
+            schema: schema.clone(),
+        }
+    }
+
+    fn map_key_not_a_string(key: Option<String>) -> Self {
+        AvroSerializerError::MapKeyNotAString { key }
+    }
+
+    fn unknown_field(field: &str, struct_name: String) -> Self {
+        AvroSerializerError::UnknownField {
+            field: field.to_string(),
+            struct_name,
+        }
+    }
+    fn wrong_number_of_fields(typ: &str, expected: usize, actual: usize) -> Self {
+        AvroSerializerError::WrongNumberOfFields {
+            typ: typ.to_string(),
+            expected,
+            actual,
+        }
+    }
+}
+
+impl std::error::Error for AvroSerializerError {}
+
+impl Display for AvroSerializerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AvroSerializerError::OutOfBounds { value, typ, schema } => {
+                write!(
+                    f,
+                    "value '{value}' of type '{typ}' is out of bounds of AVRO type {schema:?}"
+                )
+            }
+            AvroSerializerError::Incompatible { typ, schema } => {
+                write!(
+                    f,
+                    "value of type '{typ}' cannot be serialized using AVRO schema {schema:?}"
+                )
+            }
+            AvroSerializerError::MapKeyNotAString { key: Some(key) } => {
+                write!(f, "map key '{key}' is not a string")
+            }
+            AvroSerializerError::MapKeyNotAString { key: None } => {
+                write!(f, "map key is not a string")
+            }
+            AvroSerializerError::UnknownField { field, struct_name } => {
+                write!(
+                    f,
+                    "field '{field}' is not a member of struct '{struct_name}'"
+                )
+            }
+            AvroSerializerError::WrongNumberOfFields {
+                typ,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "wrong number of fields in '{typ}' (expected: {expected}, provided: {actual})"
+                )
+            }
+            AvroSerializerError::Custom { error } => f.write_str(error),
+        }
+    }
+}
+
+impl serde::ser::Error for AvroSerializerError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self::Custom {
+            error: msg.to_string(),
+        }
+    }
+}
+
+pub struct StructSerializer<'a> {
+    schema: &'a RecordSchema,
+    fields: Vec<(String, AvroValue)>,
+}
+
+impl<'a> StructSerializer<'a> {
+    pub fn new(schema: &'a RecordSchema) -> Self {
+        Self {
+            schema,
+            fields: Vec::with_capacity(schema.fields.len()),
+        }
+    }
+}
+
+impl<'a> SerializeStruct for StructSerializer<'a> {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        let field_schema_idx = *self.schema.lookup.get(name).ok_or_else(|| {
+            AvroSerializerError::unknown_field(name, self.schema.name.to_string())
+        })?;
+        self.fields.push((
+            name.to_owned(),
+            value.serialize(AvroSchemaSerializer::new(
+                &self.schema.fields[field_schema_idx].schema,
+            ))?,
+        ));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Record(self.fields))
+    }
+}
+
+pub struct SeqSerializer<'a> {
+    schema: &'a AvroSchema,
+    items: Vec<AvroValue>,
+}
+
+impl<'a> SeqSerializer<'a> {
+    fn new(schema: &'a AvroSchema, len: Option<usize>) -> Self {
+        Self {
+            schema,
+            items: Vec::with_capacity(len.unwrap_or(0)),
+        }
+    }
+}
+
+impl<'a> SerializeSeq for SeqSerializer<'a> {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.items
+            .push(value.serialize(AvroSchemaSerializer::new(self.schema))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Array(self.items))
+    }
+}
+
+pub struct MapSerializer<'a> {
+    schema: &'a AvroSchema,
+    key: String,
+    map: HashMap<String, AvroValue>,
+}
+
+impl<'a> MapSerializer<'a> {
+    fn new(schema: &'a AvroSchema, len: Option<usize>) -> Self {
+        Self {
+            schema,
+            key: String::new(),
+            map: HashMap::with_capacity(len.unwrap_or_default()),
+        }
+    }
+}
+
+impl<'a> SerializeMap for MapSerializer<'a> {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        let key = key
+            .serialize(AvroSchemaSerializer::new(&AvroSchema::String))
+            .map_err(|_| AvroSerializerError::map_key_not_a_string(None))?;
+
+        if let AvroValue::String(key) = key {
+            self.key = key;
+            Ok(())
+        } else {
+            Err(AvroSerializerError::map_key_not_a_string(Some(format!(
+                "{key:?}"
+            ))))
+        }
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        let value = value.serialize(AvroSchemaSerializer::new(self.schema))?;
+        self.map.insert(take(&mut self.key), value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Map(self.map))
+    }
+}
+
+// Never constructed, required by `trait Serializer`.
+pub struct TupleSerializer;
+
+impl SerializeTuple for TupleSerializer {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_element<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        unreachable!()
+    }
+}
+
+// Never constructed, required by `trait Serializer`.
+pub struct TupleStructSerializer;
+
+impl SerializeTupleStruct for TupleStructSerializer {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        unreachable!()
+    }
+}
+
+// Never constructed, required by `trait Serializer`.
+pub struct TupleVariantSerializer;
+
+impl SerializeTupleVariant for TupleVariantSerializer {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_field<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        unreachable!()
+    }
+}
+
+// Never constructed, required by `trait Serializer`.
+pub struct StructVariantSerializer;
+
+impl SerializeStructVariant for StructVariantSerializer {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        _key: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        unreachable!()
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        unreachable!()
+    }
+}
+
+/// Serializer that encodes data into Avro [`Value`](apache_avro::types::Value)s
+/// that match a schema.  This value can then be serialized into a binary representation.
+///
+/// Assumes that the `Serialize` implementation driving this serializer is generated by
+/// the [`serialize_table_record`](pipeline_types::serialize_table_record) macro and configured
+/// using [`avro_serde_config`].
+///
+/// Performs the following transformations on data:
+/// - Converts input timestamps and times in microseconds to microseconds or millisecond,
+///   as required by the Avro schema.
+/// - Converts decimals serialized as `u128` to Avro decimals by adjusting their scale
+///   according to the Avro schema.
+///
+// FIXME: This is not the most efficient implementation. First, it traverses the Avro schema
+// for every value it encodes. This is necessary to correctly encode times and decimals (see
+// above).  The schema will be traversed again when encoding the value into bytes. Second,
+// `Value` is an expensive representation to begin with, as it uses dynamic allocation for
+// strings, arrays, and decimals.
+pub struct AvroSchemaSerializer<'a> {
+    schema: &'a AvroSchema,
+}
+
+impl<'a> AvroSchemaSerializer<'a> {
+    pub fn new(schema: &'a AvroSchema) -> Self {
+        Self { schema }
+    }
+}
+
+impl<'a> Serializer for AvroSchemaSerializer<'a> {
+    type Ok = AvroValue;
+    type Error = AvroSerializerError;
+    type SerializeSeq = SeqSerializer<'a>;
+    type SerializeTuple = TupleSerializer;
+    type SerializeTupleStruct = TupleStructSerializer;
+    type SerializeTupleVariant = TupleVariantSerializer;
+    type SerializeMap = MapSerializer<'a>;
+    type SerializeStruct = StructSerializer<'a>;
+    type SerializeStructVariant = StructVariantSerializer;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Boolean(v))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Int(v as i32))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Int(v as i32))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Date => Ok(AvroValue::Date(v)),
+            _ => Ok(AvroValue::Int(v)),
+        }
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::TimestampMicros => Ok(AvroValue::TimestampMicros(v)),
+            AvroSchema::TimestampMillis => Ok(AvroValue::TimestampMillis(v / 1000)),
+            _ => Ok(AvroValue::Long(v)),
+        }
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Int(v as i32))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Int(v as i32))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Long => Ok(AvroValue::Long(v as i64)),
+            AvroSchema::Int if v <= i32::MAX as u32 => Ok(AvroValue::Int(v as i32)),
+            AvroSchema::Int => Err(AvroSerializerError::out_of_bounds(&v, "u32", self.schema)),
+            _ => Err(AvroSerializerError::incompatible("u32", self.schema)),
+        }
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Long if v < i64::MAX as u64 => Ok(AvroValue::Long(v as i64)),
+            AvroSchema::Long => Err(AvroSerializerError::out_of_bounds(&v, "u64", self.schema)),
+            AvroSchema::TimeMicros => Ok(AvroValue::TimeMicros(v as i64)),
+            AvroSchema::TimeMillis => Ok(AvroValue::TimeMillis((v / 1000) as i32)),
+            _ => Err(AvroSerializerError::incompatible("u64", self.schema)),
+        }
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Decimal(decimal_schema) => {
+                let mut decimal = RustDecimal::deserialize(v.to_be_bytes());
+                decimal.rescale(decimal_schema.scale as u32);
+                if decimal.round_sf(decimal_schema.precision as u32) != Some(decimal) {
+                    return Err(AvroSerializerError::out_of_bounds(
+                        &v,
+                        "decimal",
+                        &AvroSchema::Decimal(decimal_schema.clone()),
+                    ));
+                }
+                Ok(AvroValue::Decimal(Decimal::from(
+                    decimal.mantissa().to_be_bytes(),
+                )))
+            }
+            _ => Err(AvroSerializerError::incompatible("u128", self.schema)),
+        }
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Float => Ok(AvroValue::Float(v)),
+            AvroSchema::Double => Ok(AvroValue::Double(v as f64)),
+            _ => Err(AvroSerializerError::incompatible("f32", self.schema)),
+        }
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Double => Ok(AvroValue::Double(v)),
+            _ => Err(AvroSerializerError::incompatible("f64", self.schema)),
+        }
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(&once(v).collect::<String>())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::String(v.to_owned()))
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Bytes => Ok(AvroValue::Bytes(v.to_vec())),
+            _ => Err(AvroSerializerError::incompatible("byte array", self.schema)),
+        }
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Union(union_schema) => match union_schema.variants() {
+                [AvroSchema::Null, _] => Ok(AvroValue::Union(0, Box::new(AvroValue::Null))),
+                [_, AvroSchema::Null] => Ok(AvroValue::Union(1, Box::new(AvroValue::Null))),
+                _ => Err(AvroSerializerError::incompatible("Option<>", self.schema)),
+            },
+            _ => Err(AvroSerializerError::incompatible("Option<>", self.schema)),
+        }
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        match self.schema {
+            AvroSchema::Union(union_schema) => match union_schema.variants() {
+                [AvroSchema::Null, inner_schema] => {
+                    let serializer = AvroSchemaSerializer::new(inner_schema);
+                    let val = value.serialize(serializer)?;
+                    Ok(AvroValue::Union(1, Box::new(val)))
+                }
+                [inner_schema, AvroSchema::Null] => {
+                    let serializer = AvroSchemaSerializer::new(inner_schema);
+                    let val = value.serialize(serializer)?;
+                    Ok(AvroValue::Union(0, Box::new(val)))
+                }
+                _ => Err(AvroSerializerError::incompatible("Option<>", self.schema)),
+            },
+            _ => Err(AvroSerializerError::incompatible("Option<>", self.schema)),
+        }
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Null)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(AvroValue::Null)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        match self.schema {
+            AvroSchema::Enum(_enum_schema) => {
+                Ok(AvroValue::Enum(variant_index, variant.to_string()))
+            }
+            _ => Err(AvroSerializerError::incompatible(
+                &format!("enum variant '{variant}'"),
+                self.schema,
+            )),
+        }
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(AvroSerializerError::custom(format!("unable to serialize newtype variant '{name}::{variant}': newtype variant serialization is not implemented")))
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        match self.schema {
+            AvroSchema::Array(schema) => Ok(SeqSerializer::new(schema, len)),
+            _ => Err(AvroSerializerError::incompatible("sequence", self.schema)),
+        }
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(AvroSerializerError::custom(format!(
+            "unable to serialize a {len}-tuple: tuple serialization is not implemented"
+        )))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(AvroSerializerError::custom(format!("unable to serialize a tuple struct {name}: tuple struct serialization is not implemented")))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(AvroSerializerError::custom(format!("unable to serialize tuple variant '{name}::{variant}': tuple variant serialization is not implemented")))
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        match self.schema {
+            AvroSchema::Map(schema) => Ok(MapSerializer::new(schema, len)),
+            _ => Err(AvroSerializerError::incompatible("map", self.schema)),
+        }
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        match self.schema {
+            AvroSchema::Record(record_schema) if record_schema.fields.len() == len => {
+                Ok(StructSerializer::new(record_schema))
+            }
+            AvroSchema::Record(record_schema) => Err(AvroSerializerError::wrong_number_of_fields(
+                &format!("struct {name}"),
+                record_schema.fields.len(),
+                len,
+            )),
+            _ => Err(AvroSerializerError::incompatible(
+                &format!("struct {name}"),
+                self.schema,
+            )),
+        }
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(AvroSerializerError::custom(format!("unable to serialize struct variant '{name}::{variant}': struct variant serialization is not implemented")))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::format::avro::serializer::{avro_serde_config, AvroSchemaSerializer};
+    use crate::test::{EmbeddedStruct, TestStruct2};
+    use apache_avro::{
+        from_avro_datum, to_avro_datum, types::Value as AvroValue, Decimal, Schema as AvroSchema,
+    };
+    use dbsp::algebra::{F32, F64};
+    use num_bigint::BigInt;
+    use pipeline_types::{serde_with_context::SerializeWithContext, serialize_table_record};
+    use rust_decimal::Decimal as RustDecimal;
+    use rust_decimal_macros::dec;
+    use serde::Serialize;
+    use sqllib::{Date, Timestamp};
+    use std::str::FromStr;
+
+    #[derive(Serialize)]
+    struct TestStruct1 {
+        id: u32,
+        name: Option<String>,
+        b: Option<bool>,
+    }
+
+    serialize_table_record!(TestStruct1[3] {
+        id["id"]: u32,
+        name["name"]: Option<String>,
+        b["b"]: Option<bool>
+    });
+
+    const SCHEMA1: &'static str = r#"{
+  "type": "record",
+  "name": "Test1",
+  "fields": [
+    { "name": "id", "type": "int" },
+    { "name": "name", "type": ["string", "null"] },
+    { "name": "b", "type": ["boolean", "null"] }
+  ]
+}"#;
+
+    #[derive(Serialize)]
+    struct TestNumeric {
+        float32: F32,
+        float64: F64,
+        dec1: RustDecimal,
+        dec2: RustDecimal,
+        dec3: RustDecimal,
+    }
+
+    serialize_table_record!(TestNumeric[5] {
+        float32["float32"]: F32,
+        float64["float64"]: F64,
+        dec1["dec1"]: RustDecimal,
+        dec2["dec2"]: RustDecimal,
+        dec3["dec3"]: RustDecimal
+    });
+
+    const SCHEMA_NUMERIC: &'static str = r#"{
+  "type": "record",
+  "name": "Numeric",
+  "fields": [
+    { "name": "float32", "type": "float" },
+    { "name": "float64", "type": "double" },
+    { "name": "dec1", "type": {"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2} },
+    { "name": "dec2", "type": {"type": "bytes", "logicalType": "decimal", "precision": 8, "scale": 0} },
+    { "name": "dec3", "type": {"type": "bytes", "logicalType": "decimal", "precision": 6, "scale": 3} }
+  ]
+}"#;
+
+    macro_rules! serializer_test {
+        ($schema: expr, $record: ident, $avro: ident) => {
+            let schema = serde_json::Value::from_str($schema).unwrap();
+            let schema = AvroSchema::parse(&schema).unwrap();
+
+            let serializer = AvroSchemaSerializer::new(&schema);
+            let val = $record
+                .serialize_with_context(serializer, &avro_serde_config())
+                .unwrap();
+            assert_eq!(val, $avro);
+
+            let avro = to_avro_datum(&schema, val.clone()).unwrap();
+            let parsed_val = from_avro_datum::<&[u8]>(&schema, &mut avro.as_ref(), None).unwrap();
+            assert_eq!(val, parsed_val);
+        };
+    }
+
+    #[test]
+    fn test_avro_serializer() {
+        let record1_1: TestStruct1 = TestStruct1 {
+            id: 1,
+            name: Some("foo".to_string()),
+            b: Some(true),
+        };
+
+        let avro1_1: AvroValue = AvroValue::Record(vec![
+            ("id".to_string(), AvroValue::Int(1)),
+            (
+                "name".to_string(),
+                AvroValue::Union(0, Box::new(AvroValue::String("foo".to_string()))),
+            ),
+            (
+                "b".to_string(),
+                AvroValue::Union(0, Box::new(AvroValue::Boolean(true))),
+            ),
+        ]);
+
+        let record1_2: TestStruct1 = TestStruct1 {
+            id: 2,
+            name: None,
+            b: None,
+        };
+
+        let avro1_2: AvroValue = AvroValue::Record(vec![
+            ("id".to_string(), AvroValue::Int(2)),
+            (
+                "name".to_string(),
+                AvroValue::Union(1, Box::new(AvroValue::Null)),
+            ),
+            (
+                "b".to_string(),
+                AvroValue::Union(1, Box::new(AvroValue::Null)),
+            ),
+        ]);
+
+        let record2_1: TestStruct2 = TestStruct2 {
+            field: 1,
+            field_0: Some("foo".to_string()),
+            field_1: false,
+            field_2: Timestamp::new(1713597703),
+            field_3: Date::new(19833),
+            field_5: EmbeddedStruct { field: true },
+        };
+
+        let avro2_1: AvroValue = AvroValue::Record(vec![
+            ("id".to_string(), AvroValue::Long(1)),
+            (
+                "name".to_string(),
+                AvroValue::Union(0, Box::new(AvroValue::String("foo".to_string()))),
+            ),
+            ("b".to_string(), AvroValue::Boolean(false)),
+            ("ts".to_string(), AvroValue::TimestampMicros(1713597703000)),
+            ("dt".to_string(), AvroValue::Date(19833)),
+            (
+                "es".to_string(),
+                AvroValue::Record(vec![("a".to_string(), AvroValue::Boolean(true))]),
+            ),
+        ]);
+
+        let record_numeric_1: TestNumeric = TestNumeric {
+            float32: F32::new(123.45),
+            float64: F64::new(12345E-5),
+            dec1: dec!(12.34),
+            dec2: dec!(1234.56),
+            dec3: dec!(123.12345),
+        };
+
+        let avro_numeric_1: AvroValue = AvroValue::Record(vec![
+            ("float32".to_string(), AvroValue::Float(123.45)),
+            ("float64".to_string(), AvroValue::Double(12345E-5)),
+            (
+                "dec1".to_string(),
+                AvroValue::Decimal(Decimal::from(&BigInt::from(1234).to_signed_bytes_be())),
+            ),
+            (
+                "dec2".to_string(),
+                AvroValue::Decimal(Decimal::from(&BigInt::from(1235).to_signed_bytes_be())),
+            ),
+            (
+                "dec3".to_string(),
+                AvroValue::Decimal(Decimal::from(&BigInt::from(123123).to_signed_bytes_be())),
+            ),
+        ]);
+
+        serializer_test!(SCHEMA1, record1_1, avro1_1);
+        serializer_test!(SCHEMA1, record1_2, avro1_2);
+        serializer_test!(TestStruct2::avro_schema(), record2_1, avro2_1);
+        serializer_test!(SCHEMA_NUMERIC, record_numeric_1, avro_numeric_1);
+    }
+}

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -16,11 +16,13 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
 };
 
+#[cfg(feature = "with-avro")]
 pub(crate) mod avro;
 pub(crate) mod csv;
 mod json;
 pub mod parquet;
 
+#[cfg(feature = "with-avro")]
 use crate::format::avro::output::AvroOutputFormat;
 pub use parquet::relation_to_parquet_schema;
 
@@ -339,6 +341,7 @@ static OUTPUT_FORMATS: Lazy<BTreeMap<&'static str, Box<dyn OutputFormat>>> = Laz
             "parquet",
             Box::new(ParquetOutputFormat) as Box<dyn OutputFormat>,
         ),
+        #[cfg(feature = "with-avro")]
         ("avro", Box::new(AvroOutputFormat) as Box<dyn OutputFormat>),
     ])
 });

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -16,10 +16,12 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
 };
 
+pub(crate) mod avro;
 pub(crate) mod csv;
 mod json;
 pub mod parquet;
 
+use crate::format::avro::output::AvroOutputFormat;
 pub use parquet::relation_to_parquet_schema;
 
 pub use self::csv::{byte_record_deserializer, string_record_deserializer};
@@ -337,6 +339,7 @@ static OUTPUT_FORMATS: Lazy<BTreeMap<&'static str, Box<dyn OutputFormat>>> = Laz
             "parquet",
             Box::new(ParquetOutputFormat) as Box<dyn OutputFormat>,
         ),
+        ("avro", Box::new(AvroOutputFormat) as Box<dyn OutputFormat>),
     ])
 });
 

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -128,7 +128,9 @@ fn parquet_output() {
     );
 
     let zset = &SerBatchImpl::<_, TestStruct2, ()>::new(zset) as &dyn SerBatchReader;
+    encoder.consumer().batch_start(0);
     encoder.encode(zset).unwrap();
+    encoder.consumer().batch_end();
 
     // Verify output buffer...
     // Construct the expected file manually:
@@ -156,9 +158,9 @@ fn parquet_output() {
         .write(&batch)
         .expect("Writing to parquet should succeed");
     writer.close().expect("Closing the writer should succeed");
-    debug_parquet_buffer(buffer.lock().unwrap().clone());
+    debug_parquet_buffer(buffer.lock().unwrap().concat());
 
-    let buffer_copy = buffer.lock().unwrap().clone();
+    let buffer_copy = buffer.lock().unwrap().concat();
 
     assert_eq!(expected_buffer, buffer_copy);
 }

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -192,7 +192,7 @@ where
                     config,
                 )))
             }
-            RecordFormat::Parquet(_) => {
+            RecordFormat::Parquet(_) | RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -298,7 +298,7 @@ where
                     _,
                 >::new(self.handle.clone(), config)))
             }
-            RecordFormat::Parquet(_) => {
+            RecordFormat::Parquet(_) | RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -427,7 +427,7 @@ where
                     ),
                 ))
             }
-            RecordFormat::Parquet(_) => {
+            RecordFormat::Parquet(_) | RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -589,7 +589,7 @@ where
                 self.update_key_func.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
-            RecordFormat::Parquet(_) => {
+            RecordFormat::Parquet(_) | RecordFormat::Avro => {
                 todo!()
             }
         }

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -192,7 +192,11 @@ where
                     config,
                 )))
             }
-            RecordFormat::Parquet(_) | RecordFormat::Avro => {
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
+            #[cfg(feature = "with-avro")]
+            RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -298,7 +302,11 @@ where
                     _,
                 >::new(self.handle.clone(), config)))
             }
-            RecordFormat::Parquet(_) | RecordFormat::Avro => {
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
+            #[cfg(feature = "with-avro")]
+            RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -427,7 +435,11 @@ where
                     ),
                 ))
             }
-            RecordFormat::Parquet(_) | RecordFormat::Avro => {
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
+            #[cfg(feature = "with-avro")]
+            RecordFormat::Avro => {
                 todo!()
             }
         }
@@ -589,7 +601,11 @@ where
                 self.update_key_func.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
-            RecordFormat::Parquet(_) | RecordFormat::Avro => {
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
+            #[cfg(feature = "with-avro")]
+            RecordFormat::Avro => {
                 todo!()
             }
         }

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -1,4 +1,5 @@
 use crate::catalog::{SerBatchReader, SerTrace};
+#[cfg(feature = "with-avro")]
 use crate::format::avro::serializer::{
     avro_serde_config, AvroSchemaSerializer, AvroSerializerError,
 };
@@ -7,7 +8,9 @@ use crate::{
     ControllerError,
 };
 use anyhow::Result as AnyResult;
+#[cfg(feature = "with-avro")]
 use apache_avro::types::Value as AvroValue;
+#[cfg(feature = "with-avro")]
 use apache_avro::Schema as AvroSchema;
 use csv::{Writer as CsvWriter, WriterBuilder as CsvWriterBuilder};
 use dbsp::dynamic::DowncastTrait;
@@ -81,6 +84,7 @@ trait BytesSerializer<C>: Send {
         unimplemented!()
     }
 
+    #[cfg(feature = "with-avro")]
     fn serialize_avro<T>(
         &mut self,
         _val: &T,
@@ -157,10 +161,12 @@ where
     }
 }
 
+#[cfg(feature = "with-avro")]
 pub struct AvroSerializer {
     config: SqlSerdeConfig,
 }
 
+#[cfg(feature = "with-avro")]
 impl AvroSerializer {
     fn create() -> Self {
         Self {
@@ -169,6 +175,7 @@ impl AvroSerializer {
     }
 }
 
+#[cfg(feature = "with-avro")]
 impl BytesSerializer<SqlSerdeConfig> for AvroSerializer {
     fn serialize<T>(&mut self, _val: &T, _buf: &mut Vec<u8>) -> AnyResult<()>
     where
@@ -366,6 +373,7 @@ where
                         .with_timestamp_format(TimestampFormat::MicrosSinceEpoch),
                 ),
             )),
+            #[cfg(feature = "with-avro")]
             RecordFormat::Avro => {
                 Box::new(
                     <SerCursorImpl<'a, AvroSerializer, B, KD, VD, SqlSerdeConfig>>::new(
@@ -551,6 +559,7 @@ where
             .serialize_arrow(self.key.as_ref().unwrap(), dst)
     }
 
+    #[cfg(feature = "with-avro")]
     fn key_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue> {
         Ok(self
             .serializer
@@ -567,6 +576,7 @@ where
         self.serializer.serialize(self.val.as_ref().unwrap(), dst)
     }
 
+    #[cfg(feature = "with-avro")]
     fn val_to_avro(&mut self, schema: &AvroSchema) -> AnyResult<AvroValue> {
         Ok(self
             .serializer

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -95,6 +95,19 @@ impl TestStruct {
             },
         ]
     }
+
+    pub fn avro_schema() -> &'static str {
+        r#"{
+            "type": "record",
+            "name": "TestStruct",
+            "fields": [
+                { "name": "id", "type": "long" },
+                { "name": "b", "type": "boolean" },
+                { "name": "i", "type": ["null", "long"] },
+                { "name": "s", "type": "string" }
+            ]
+        }"#
+    }
 }
 
 deserialize_without_context!(TestStruct);
@@ -202,9 +215,9 @@ pub fn generate_test_batches_with_weights(
 )]
 #[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
 #[archive(compare(PartialEq, PartialOrd))]
-struct EmbeddedStruct {
+pub struct EmbeddedStruct {
     #[serde(rename = "a")]
-    field: bool,
+    pub field: bool,
 }
 
 serialize_table_record!(EmbeddedStruct[1]{
@@ -249,7 +262,7 @@ pub struct TestStruct2 {
     // #[serde(rename = "t")]
     // pub field_4: Time,
     #[serde(rename = "es")]
-    field_5: EmbeddedStruct,
+    pub field_5: EmbeddedStruct,
 }
 
 impl Arbitrary for TestStruct2 {
@@ -324,6 +337,31 @@ impl TestStruct2 {
                 false,
             ),
         ]))
+    }
+
+    pub fn avro_schema() -> &'static str {
+        r#"{
+            "type": "record",
+            "name": "TestStruct2",
+            "fields": [
+                { "name": "id", "type": "long" },
+                { "name": "name", "type": ["string", "null"] },
+                { "name": "b", "type": "boolean" },
+                { "name": "ts", "type": "long", "logicalType": "timestamp-micros" },
+                { "name": "dt", "type": "int", "logicalType": "date" },
+                {
+                    "name": "es",
+                    "type":
+                        {
+                            "type": "record",
+                            "name": "EmbeddedStruct",
+                            "fields": [
+                                { "name": "a", "type": "boolean" }
+                            ]
+                        }
+                }
+            ]
+        }"#
     }
 
     pub fn schema() -> Vec<Field> {

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -138,7 +138,7 @@ where
                 self.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
-            RecordFormat::Parquet(_) => {
+            RecordFormat::Parquet(_) | RecordFormat::Avro => {
                 todo!()
             }
         }

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -138,7 +138,11 @@ where
                 self.clone(),
                 SqlSerdeConfig::from(flavor),
             ))),
-            RecordFormat::Parquet(_) | RecordFormat::Avro => {
+            RecordFormat::Parquet(_) => {
+                todo!()
+            }
+            #[cfg(feature = "with-avro")]
+            RecordFormat::Avro => {
                 todo!()
             }
         }

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -2,7 +2,7 @@ use crate::{transport::Step, OutputConsumer};
 use std::sync::{Arc, Mutex};
 
 pub struct MockOutputConsumer {
-    pub data: Arc<Mutex<Vec<u8>>>,
+    pub data: Arc<Mutex<Vec<Vec<u8>>>>,
     max_buffer_size_bytes: usize,
 }
 
@@ -17,7 +17,7 @@ impl MockOutputConsumer {
         Self::with_max_buffer_size_bytes(usize::MAX)
     }
 
-    pub fn state(&self) -> Vec<u8> {
+    pub fn state(&self) -> Vec<Vec<u8>> {
         self.data.lock().unwrap().clone()
     }
 
@@ -28,7 +28,7 @@ impl MockOutputConsumer {
         }
     }
 
-    pub fn with_buffer(data: Arc<Mutex<Vec<u8>>>) -> Self {
+    pub fn with_buffer(data: Arc<Mutex<Vec<Vec<u8>>>>) -> Self {
         Self {
             data,
             max_buffer_size_bytes: usize::MAX,
@@ -43,11 +43,11 @@ impl OutputConsumer for MockOutputConsumer {
 
     fn batch_start(&mut self, _step: Step) {}
     fn push_buffer(&mut self, buffer: &[u8], _num_records: usize) {
-        self.data.lock().unwrap().extend_from_slice(buffer)
+        self.data.lock().unwrap().push(buffer.to_vec())
     }
     fn push_key(&mut self, _key: &[u8], val: &[u8], _num_records: usize) {
         // TODO: we don't test the contents of keys yet.
-        self.data.lock().unwrap().extend_from_slice(val)
+        self.data.lock().unwrap().push(val.to_vec())
     }
     fn batch_end(&mut self) {}
 }

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -32,8 +32,8 @@ mod mock_output_consumer;
 use crate::catalog::InputCollectionHandle;
 use crate::transport::input_transport_config_to_endpoint;
 pub use data::{
-    generate_test_batch, generate_test_batches, generate_test_batches_with_weights, TestStruct,
-    TestStruct2,
+    generate_test_batch, generate_test_batches, generate_test_batches_with_weights, EmbeddedStruct,
+    TestStruct, TestStruct2,
 };
 use dbsp::circuit::CircuitConfig;
 pub use mock_dezset::{MockDeZSet, MockUpdate};

--- a/crates/pipeline-types/src/format/avro.rs
+++ b/crates/pipeline-types/src/format/avro.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+/// Avro output format configuration.
+#[derive(Serialize, Deserialize, Debug, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AvroEncoderConfig {
+    /// Avro schema used to encode output records.
+    ///
+    /// Specified as a string containing schema definition in JSON format.
+    /// This schema must match precisely the SQL view definition, including
+    /// nullability of columns.
+    pub schema: String,
+    /// List of schema registry URLs. When non-empty, the connector will
+    /// post the schema to the registry and uses the schema id returned
+    /// by the registry .  Otherwise, schema id 0 is used.
+    #[serde(default)]
+    pub registry_urls: Vec<String>,
+    /// Custom headers that will be added to every call to the schema registry.
+    ///
+    /// This option requires `registry_urls` to be set.
+    #[serde(default)]
+    pub registry_headers: HashMap<String, String>,
+    /// Proxy that will be used to access the schema registry.
+    ///
+    /// Requires `registry_urls` to be set.
+    pub registry_proxy: Option<String>,
+    /// Timeout in seconds used to connect to the registry.
+    ///
+    /// Requires `registry_urls` to be set.
+    pub registry_timeout_secs: Option<u64>,
+    /// Username used to authenticate with the registry.
+    ///
+    /// Requires `registry_urls` to be set. This option is mutually exclusive with
+    /// token-based authentication (see `registry_authorization_token`).
+    pub registry_username: Option<String>,
+    /// Password used to authenticate with the registry.
+    ///
+    /// Requires `registry_urls` to be set.
+    pub registry_password: Option<String>,
+    /// Sets used to authenticate with the registry.
+    ///
+    /// Requires `registry_urls` to be set. This option is mutually exclusive with
+    /// password-based authentication (see `registry_username` and `registry_password`).
+    pub registry_authorization_token: Option<String>,
+}

--- a/crates/pipeline-types/src/format/mod.rs
+++ b/crates/pipeline-types/src/format/mod.rs
@@ -1,3 +1,4 @@
+pub mod avro;
 pub mod csv;
 pub mod json;
 pub mod parquet;

--- a/crates/pipeline-types/src/serde_with_context/serde_config.rs
+++ b/crates/pipeline-types/src/serde_with_context/serde_config.rs
@@ -68,7 +68,7 @@ impl Default for TimestampFormat {
     }
 }
 
-// Representation of the SQL `TIMESTAMP` type.
+// Representation of the SQL `DECIMAL` type.
 #[derive(Clone, Debug)]
 pub enum DecimalFormat {
     String,

--- a/crates/pipeline-types/src/serde_with_context/serde_config.rs
+++ b/crates/pipeline-types/src/serde_with_context/serde_config.rs
@@ -68,6 +68,19 @@ impl Default for TimestampFormat {
     }
 }
 
+// Representation of the SQL `TIMESTAMP` type.
+#[derive(Clone, Debug)]
+pub enum DecimalFormat {
+    String,
+    U128,
+}
+
+impl Default for DecimalFormat {
+    fn default() -> Self {
+        Self::String
+    }
+}
+
 /// Deserializer configuration for parsing SQL records.
 #[derive(Clone, Default, Debug)]
 pub struct SqlSerdeConfig {
@@ -77,6 +90,8 @@ pub struct SqlSerdeConfig {
     pub date_format: DateFormat,
     /// `TIMESTAMP` format.
     pub timestamp_format: TimestampFormat,
+    /// `DECIMAL` format.
+    pub decimal_format: DecimalFormat,
 }
 
 impl SqlSerdeConfig {
@@ -96,6 +111,11 @@ impl SqlSerdeConfig {
         self.timestamp_format = timestamp_format;
         self
     }
+
+    pub fn with_decimal_format(mut self, decimal_format: DecimalFormat) -> Self {
+        self.decimal_format = decimal_format;
+        self
+    }
 }
 
 impl From<JsonFlavor> for SqlSerdeConfig {
@@ -106,16 +126,19 @@ impl From<JsonFlavor> for SqlSerdeConfig {
                 time_format: TimeFormat::Millis,
                 date_format: DateFormat::DaysSinceEpoch,
                 timestamp_format: TimestampFormat::MillisSinceEpoch,
+                decimal_format: DecimalFormat::String,
             },
             JsonFlavor::DebeziumMySql => Self {
                 time_format: TimeFormat::Micros,
                 date_format: DateFormat::DaysSinceEpoch,
                 timestamp_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%Z"),
+                decimal_format: DecimalFormat::String,
             },
             JsonFlavor::Snowflake => Self {
                 time_format: TimeFormat::String("%H:%M:%S%.f"),
                 date_format: DateFormat::String("%Y-%m-%d"),
                 timestamp_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%.f%:z"),
+                decimal_format: DecimalFormat::String,
             },
             JsonFlavor::ParquetConverter => Self {
                 time_format: TimeFormat::Nanos,
@@ -126,6 +149,7 @@ impl From<JsonFlavor> for SqlSerdeConfig {
                 // https://docs.rs/parquet/50.0.0/src/parquet/record/api.rs.html#858
                 // the right way is probably to use serde_arrow for deserialization and serialization
                 timestamp_format: TimestampFormat::String("%Y-%m-%d %H:%M:%S %:z"), // 2023-11-04 15:33:47 +00:00
+                decimal_format: DecimalFormat::String,
             },
         }
     }


### PR DESCRIPTION
Avro connector that encodes output updates according to a user-specified Avro schema.  Can optionally post the supplied schema to a schema registry, but does not yet support downloading schema from the registry.

The tricky part of this commit is getting serde to generate precisely the encoding required by the Avro schema, where the same SQL type can be represented in multiple ways. In particular, timestamps can be in microseconds or milliseconds, and decimals are represented as bigints with fixed scale given as part of type definition.  To support this, I implemented a special serializer that traverses the Avro schema in parallel with the serialized object and encodes each field according to its schema.

There are currently several limitations, documented in `avro/output.rs`, including:

- Currently only supports raw Avro format, i.e., deletes cannot be represented.
- Only works with user-provided schemas, no support for downloading the schema from the registry yet.
- Does not support complex schemas with cross-references.

In addition, the connector requires the user to craft an Avro schema that matches the SQL view precisely (or define the view to precisely match an existing schema).  In the future, we may want to simplify this workflow by generating an Avro schema from a view definition.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->

Resolves #1663 