### PR TITLE
[SQL] Preliminary support for WATERMARK annotations

### DIFF
--- a/docs/sql/grammar.md
+++ b/docs/sql/grammar.md
@@ -55,6 +55,7 @@ columnConstraint
   :   PRIMARY KEY
   |   FOREIGN KEY REFERENCES identifier '(' identifier ')'
   |   LATENESS expression
+  |   WATERMARK expression
   |   DEFAULT expression
 
 parensColumnList
@@ -288,3 +289,7 @@ on aggregation](aggregates.md#window-aggregate-functions).
 ### LATENESS
 
 See [Streaming SQL Extensions](streaming.md#lateness-expressions)
+
+### WATERMARKS
+
+See [Streaming SQL Extensions](streaming.md#watermark-expressions)

--- a/docs/sql/streaming.md
+++ b/docs/sql/streaming.md
@@ -3,7 +3,7 @@
 In order to implement features that are supported by streaming
 engines, we offer a few extensions to standard SQL.
 
-### LATENESS expressions
+### `LATENESS` expressions
 
 `LATENESS` is a property of the data in a column of a table or a view
 that is relevant for the case of stream processing.  `LATENESS` is
@@ -76,3 +76,36 @@ A table or view can have any number of columns annotated with
 lateness.  An inserted row is considered "too late" if any of its
 annotated columns is too late.
 
+### `WATERMARK` expressions
+
+*This feature is not yet fully implemented.  This documentation is
+ only orientative.*
+
+`WATERMARK` is an annotation on the data in a column of a table that
+is relevant for the case of stream processing.  `WATERMARK` is
+described by an expression that evaluates to a constant value.  The
+expression must have a type that can be subtracted from the column
+type.  For example, a column of type `TIMESTAMP` may have a watermark
+specified as an `INTERVAL` type.
+
+To specify `WATERMARK` for a table column, the column declaration can
+be annotated in the `CREATE TABLE` statement.  For example:
+
+```sql
+CREATE TABLE order_pickup (
+   when TIMESTAMP NOT NULL WATERMARK INTERVAL '1:00' HOURS TO MINUTES,
+   location VARCHAR
+);
+```
+
+The effect of the `WATERMARK` is to delay the processing of the input
+rows until they are less likely to arrive out of order with respect to
+other rows.  More precisely, the system maintains the largest value
+encountered so far in any input row for the columns that have a
+watermark.  Given a `WATERMARK` annotation with value W, an input row
+with a value X for a watermarked column will be "held up" until an
+input row with a value X + W has been received.  The program will
+behave as if the row with value X has only just been received.
+
+If a table has multiple columns annotated with `WATERMARK` values, a
+row is released only when *all* the delays have been exceeded.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -26,6 +26,7 @@ data: {
       "DISCARD"
       "IF"
       "LATENESS"
+      "WATERMARK"
       "PLANS"
       "REMOVE"
       "SEED"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
@@ -45,7 +45,7 @@ void ExtendedTableElement(List<SqlNode> list) :
         {
             strategy = nullable ? ColumnStrategy.NULLABLE : ColumnStrategy.NOT_NULLABLE;
             column = new SqlExtendedColumnDeclaration(s.add(id).end(this), id,
-                            type.withNullable(nullable), null, strategy, null, null, false, null);
+                            type.withNullable(nullable), null, strategy, null, null, false, null, null);
         }
         ( column = ColumnAttribute(column) )*
         {
@@ -76,6 +76,7 @@ SqlExtendedColumnDeclaration ColumnAttribute(SqlExtendedColumnDeclaration column
     SqlIdentifier foreignKeyTable = null;
     SqlIdentifier foreignKeyColumn = null;
     SqlNode lateness = null;
+    SqlNode watermark = null;
     SqlNode e;
     Span s;
 }
@@ -90,6 +91,10 @@ SqlExtendedColumnDeclaration ColumnAttribute(SqlExtendedColumnDeclaration column
         |
             <LATENESS> lateness = Expression(ExprContext.ACCEPT_NON_QUERY) {
                return column.setLatenes(lateness);
+            }
+        |
+            <WATERMARK> watermark = Expression(ExprContext.ACCEPT_NON_QUERY) {
+               return column.setWatermark(watermark);
             }
         |
             <DEFAULT_> e = Expression(ExprContext.ACCEPT_SUB_QUERY) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
@@ -1,0 +1,51 @@
+package org.dbsp.sqlCompiler.circuit.operator;
+
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * The DBSPWindow operator corresponds to a DBSP window() call.
+ * The left input is a stream of IndexedZSets, while the
+ * right input is a stream of scalar pairs.  The keys of
+ * elements in the left input are compared with the two scalars
+ * in the pair; when they fall between the two limits,
+ * they are emitted to the output ZSet. */
+public class DBSPWindowOperator extends DBSPOperator {
+    public DBSPWindowOperator(
+            CalciteObject node, DBSPOperator data, DBSPOperator control) {
+        super(node, "window", null, data.getType(), data.isMultiset);
+        this.addInput(data);
+        this.addInput(control);
+        // Check that the left input and output are indexed ZSets
+        this.getOutputIndexedZSetType();
+    }
+
+    @Override
+    public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
+        return this;
+    }
+
+    @Override
+    public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
+        assert newInputs.size() == 2: "Expected 2 inputs, got " + newInputs.size();
+        if (force || this.inputsDiffer(newInputs))
+            return new DBSPWindowOperator(
+                    this.getNode(), newInputs.get(0), newInputs.get(1));
+        return this;
+    }
+
+    @Override
+    public void accept(CircuitVisitor visitor) {
+        visitor.push(this);
+        VisitDecision decision = visitor.preorder(this);
+        if (!decision.stop())
+            visitor.postorder(this);
+        visitor.pop(this);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/InputColumnMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/InputColumnMetadata.java
@@ -22,17 +22,22 @@ public class InputColumnMetadata
     /** Lateness, if declared.  Should be a constant expression. */
     @Nullable
     public final DBSPExpression lateness;
+    /** Watermark, if declared.  Should be a constant expression. */
+    @Nullable
+    public final DBSPExpression watermark;
     /** Default value, if declared.  Should be a constant expression */
     @Nullable
     public final DBSPExpression defaultValue;
 
     public InputColumnMetadata(CalciteObject node, String name, DBSPType type, boolean isPrimaryKey,
-                               @Nullable DBSPExpression lateness, @Nullable DBSPExpression defaultValue) {
+                               @Nullable DBSPExpression lateness, @Nullable DBSPExpression watermark,
+                               @Nullable DBSPExpression defaultValue) {
         this.node = node;
         this.name = name;
         this.type = type;
         this.isPrimaryKey = isPrimaryKey;
         this.lateness = lateness;
+        this.watermark = watermark;
         this.defaultValue = defaultValue;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -1702,11 +1702,20 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 lateness = null;
             }
         }
+        DBSPExpression watermark = null;
+        if (metadata.watermark != null) {
+            watermark = expressionCompiler.compile(metadata.watermark);
+            if (!watermark.getType().is(IHasZero.class)) {
+                this.compiler.reportError(watermark.getSourcePosition(), "Illegal expression",
+                        "Illegal expression for watermark value");
+                watermark = null;
+            }
+        }
         DBSPExpression defaultValue = null;
         if (metadata.defaultValue != null)
             defaultValue = expressionCompiler.compile(metadata.defaultValue).cast(type);
         return new InputColumnMetadata(metadata.getNode(), metadata.getName(), type,
-                metadata.isPrimaryKey, lateness, defaultValue);
+                metadata.isPrimaryKey, lateness, watermark, defaultValue);
     }
 
     DBSPNode compileCreateView(CreateViewStatement view) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/AvroSchemaWrapper.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/AvroSchemaWrapper.java
@@ -48,7 +48,7 @@ public class AvroSchemaWrapper implements IHasSchema {
     public List<RelColumnMetadata> getColumns() {
         RelDataType rowType = this.convertRecord(this.schema);
         return Linq.map(rowType.getFieldList(), f -> new RelColumnMetadata(
-                CalciteObject.EMPTY, f, false, false, null, null));
+                CalciteObject.EMPTY, f, false, false, null, null, null));
     }
 
     private RelDataType convertRecord(Schema recordSchema) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -37,8 +37,6 @@ import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
-import org.apache.calcite.rel.hint.HintPredicates;
-import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -511,6 +509,7 @@ public class CalciteCompiler implements IWritesLogs {
             SqlDataTypeSpec typeSpec;
             boolean isPrimaryKey = false;
             RexNode lateness = null;
+            RexNode watermark = null;
             RexNode defaultValue = null;
             if (col instanceof SqlColumnDeclaration) {
                 SqlColumnDeclaration cd = (SqlColumnDeclaration) col;
@@ -535,6 +534,8 @@ public class CalciteCompiler implements IWritesLogs {
                 SqlToRelConverter converter = this.getConverter();
                 if (cd.lateness != null)
                     lateness = converter.convertExpression(cd.lateness);
+                if (cd.watermark != null)
+                    watermark = converter.convertExpression(cd.watermark);
                 if (cd.defaultValue != null) {
                     // workaround for https://issues.apache.org/jira/browse/CALCITE-6129
                     if (cd.defaultValue instanceof SqlLiteral) {
@@ -570,7 +571,7 @@ public class CalciteCompiler implements IWritesLogs {
                     name.getSimple(), index++, type);
             RelColumnMetadata meta = new RelColumnMetadata(
                     CalciteObject.create(col), field, isPrimaryKey, Utilities.identifierIsQuoted(name),
-                    lateness, defaultValue);
+                    lateness, watermark, defaultValue);
             result.add(meta);
         }
 
@@ -636,7 +637,7 @@ public class CalciteCompiler implements IWritesLogs {
                 colByName.put(specifiedName, field);
             }
             RelColumnMetadata meta = new RelColumnMetadata(node,
-                    field, false, nameIsQuoted, null, null);
+                    field, false, nameIsQuoted, null, null, null);
             columns.add(meta);
             index++;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RelColumnMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/RelColumnMetadata.java
@@ -18,6 +18,9 @@ public class RelColumnMetadata {
     /** Lateness, if declared. */
     @Nullable
     public final RexNode lateness;
+    /** Lateness, if declared. */
+    @Nullable
+    public final RexNode watermark;
     /** Default value, if declared */
     @Nullable
     public final RexNode defaultValue;
@@ -27,22 +30,24 @@ public class RelColumnMetadata {
     @Override
     public String toString() {
         return "RelColumnMetadata{" +
-                "field=" + field +
-                ", isPrimaryKey=" + isPrimaryKey +
-                ", lateness=" + lateness +
-                ", defaultValue=" + defaultValue +
-                ", nameIsQuoted=" + nameIsQuoted +
+                "field=" + this.field +
+                ", isPrimaryKey=" + this.isPrimaryKey +
+                ", lateness=" + this.lateness +
+                ", watermark=" + this.watermark +
+                ", defaultValue=" + this.defaultValue +
+                ", nameIsQuoted=" + this.nameIsQuoted +
                 '}';
     }
 
     public RelColumnMetadata(
             CalciteObject node, RelDataTypeField field, boolean isPrimaryKey, boolean nameIsQuoted,
-            @Nullable RexNode lateness, @Nullable RexNode defaultValue) {
+            @Nullable RexNode lateness, @Nullable RexNode watermark, @Nullable RexNode defaultValue) {
         this.node = node;
         this.isPrimaryKey = isPrimaryKey;
         this.nameIsQuoted = nameIsQuoted;
         this.field = field;
         this.lateness = lateness;
+        this.watermark = watermark;
         this.defaultValue = defaultValue;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlExtendedColumnDeclaration.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlExtendedColumnDeclaration.java
@@ -31,13 +31,14 @@ public class SqlExtendedColumnDeclaration extends SqlCall {
     // These can be mutated
     public boolean primaryKey;
     public @Nullable SqlNode lateness;
+    public @Nullable SqlNode watermark;
     public @Nullable SqlNode defaultValue;
 
     public SqlExtendedColumnDeclaration(
             SqlParserPos pos, SqlIdentifier name, SqlDataTypeSpec dataType,
             @Nullable SqlNode expression, ColumnStrategy strategy,
             @Nullable SqlIdentifier foreignKeyTable, @Nullable SqlIdentifier foreignKeyColumn,
-            boolean primaryKey, @Nullable SqlNode lateness) {
+            boolean primaryKey, @Nullable SqlNode lateness, @Nullable SqlNode watermark) {
         super(pos);
         this.name = name;
         this.dataType = dataType;
@@ -52,6 +53,7 @@ public class SqlExtendedColumnDeclaration extends SqlCall {
             this.foreignKeyColumns.add(foreignKeyColumn);
         this.primaryKey = primaryKey;
         this.lateness = lateness;
+        this.watermark = watermark;
     }
 
     public SqlExtendedColumnDeclaration setPrimaryKey(SqlParserPos pos) {
@@ -81,9 +83,18 @@ public class SqlExtendedColumnDeclaration extends SqlCall {
     public SqlExtendedColumnDeclaration setLatenes(SqlNode lateness) {
         if (this.lateness != null) {
             throw new CompilationError("Column " + this.name +
-                    " already declared a foreign key", CalciteObject.create(lateness));
+                    " already has lateness", CalciteObject.create(lateness));
         }
         this.lateness = lateness;
+        return this;
+    }
+
+    public SqlExtendedColumnDeclaration setWatermark(SqlNode watermark) {
+        if (this.watermark != null) {
+            throw new CompilationError("Column " + this.name +
+                    " already has a watermark", CalciteObject.create(watermark));
+        }
+        this.watermark = watermark;
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/HasSchema.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/HasSchema.java
@@ -23,11 +23,8 @@ public class HasSchema implements IHasSchema {
         for (RelDataTypeField field: rowType.getFieldList()) {
             RelColumnMetadata meta = new RelColumnMetadata(
                     CalciteObject.create(field.getType()),
-                    field,
-                    false,
-            true,
-                    null,
-                    null);
+                    field, false, true,
+                    null, null, null);
             this.columns.add(meta);
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -338,6 +338,9 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs {
     public void postorder(DBSPControlledFilterOperator operator) { this.replace(operator); }
 
     @Override
+    public void postorder(DBSPWindowOperator operator) { this.replace(operator); }
+
+    @Override
     public void postorder(DBSPIntegrateTraceRetainKeysOperator operator) { this.replace(operator); }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -42,6 +42,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.IRTransform;
@@ -253,6 +254,15 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                     outputType.to(DBSPTypeZSet.class), function, operator.isMultiset,
                     sources.get(0), sources.get(1));
         }
+        this.map(operator, result);
+    }
+
+    @Override
+    public void postorder(DBSPWindowOperator operator) {
+        List<DBSPOperator> sources = Linq.map(operator.inputs, this::mapped);
+        DBSPOperator result = operator;
+        if (Linq.different(sources, operator.inputs))
+            result = new DBSPWindowOperator(operator.getNode(), sources.get(0), sources.get(1));
         this.map(operator, result);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -286,6 +286,10 @@ public abstract class CircuitVisitor
         return this.preorder(node.to(DBSPUnaryOperator.class));
     }
 
+    public VisitDecision preorder(DBSPWindowOperator node) {
+        return this.preorder(node.to(DBSPOperator.class));
+    }
+
     public VisitDecision preorder(DBSPControlledFilterOperator node) {
         return this.preorder(node.to(DBSPOperator.class));
     }
@@ -476,6 +480,10 @@ public abstract class CircuitVisitor
 
     public void postorder(DBSPApplyOperator node) {
         this.postorder(node.to(DBSPUnaryOperator.class));
+    }
+
+    public void postorder(DBSPWindowOperator node) {
+        this.postorder(node.to(DBSPOperator.class));
     }
 
     public void postorder(DBSPControlledFilterOperator node) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
@@ -32,6 +32,7 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.StderrErrorReporter;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlExtendedColumnDeclaration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -104,6 +105,24 @@ public class ParserTests {
         Assert.assertTrue(node instanceof SqlCreateTable);
         SqlCreateTable create = (SqlCreateTable) node;
         Assert.assertNotNull(create.columnList);
+        SqlExtendedColumnDeclaration decl = (SqlExtendedColumnDeclaration) create.columnList.get(0);
+        Assert.assertNotNull(decl.lateness);
+    }
+
+    @Test
+    public void watermarkTest() throws SqlParseException {
+        CalciteCompiler calcite = this.getCompiler();
+        String ddl = """
+                CREATE TABLE st(
+                   ts       TIMESTAMP WATERMARK INTERVAL '5:00' HOURS TO MINUTES,
+                   name     VARCHAR)""";
+        SqlNode node = calcite.parse(ddl);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node instanceof SqlCreateTable);
+        SqlCreateTable create = (SqlCreateTable) node;
+        Assert.assertNotNull(create.columnList);
+        SqlExtendedColumnDeclaration decl = (SqlExtendedColumnDeclaration) create.columnList.get(0);
+        Assert.assertNotNull(decl.watermark);
     }
 
     @Test


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This PR introduces front-end support for WATERMARK annotations on table columns. 
Right now the compiler does not use this information at all, so I am claiming this is not a user-visible change yet.
The documentation is marked as such.
Fixes #1678 
Requires #1680
