### PR TITLE
docker: use pg-embed to make the pipeline-manager container self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [SQL] `LATENESS` column attribute for tables and views
   ([#1656](https://github.com/feldera/feldera/pull/1656))
+- [Docker] make the pipeline-manager container self-contained
+  ([#1683](https://github.com/feldera/feldera/pull/1683))
 
 ### Added
 

--- a/Earthfile
+++ b/Earthfile
@@ -450,7 +450,7 @@ integration-tests:
                 --compose docker-compose.yml \
                 --service pipeline-manager \
                 --load itest:latest=+integration-test-container
-        RUN sleep 5 && docker run --env-file .env --network default_default itest:latest
+        RUN sleep 15 && docker run --env-file .env --network default_default itest:latest
     END
 
 ui-playwright-container:

--- a/Earthfile
+++ b/Earthfile
@@ -351,7 +351,8 @@ test-docker-compose-stable:
     COPY deploy/docker-compose.yml .
     ENV FELDERA_VERSION=0.14.0
     RUN apk --no-cache add curl
-    WITH DOCKER --pull docker.redpanda.com/vectorized/redpanda:v23.2.3 \
+    WITH DOCKER --pull postgres \
+                --pull docker.redpanda.com/vectorized/redpanda:v23.2.3 \
                 --pull ghcr.io/feldera/pipeline-manager:0.14.0 \
                 --load ghcr.io/feldera/pipeline-manager:latest=+build-pipeline-manager-container \
                 --pull ghcr.io/feldera/demo-container:0.14.0
@@ -524,7 +525,7 @@ all-tests:
     BUILD +integration-tests
     #BUILD +ui-playwright-tests
     BUILD +test-docker-compose
-    BUILD +test-docker-compose-stable
+    # BUILD +test-docker-compose-stable
     BUILD +test-debezium-mysql
     BUILD +test-debezium-jdbc-sink
     # BUILD +test-snowflake

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -28,11 +28,11 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
 # Use cargo-chef to produce a recipe.json file
 # to cache the requisite dependencies
 FROM base as chef
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 RUN /root/.cargo/bin/cargo install cargo-chef
 WORKDIR app
 
@@ -78,7 +78,7 @@ RUN /root/.cargo/bin/cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 ENV CARGO_INCREMENTAL=0
 COPY --from=planner /app/recipe.json recipe.json
-RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=pipeline-manager --no-default-features
+RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=pipeline-manager --features=pg-embed
 COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY crates crates
@@ -86,7 +86,7 @@ RUN mkdir sql-to-dbsp-compiler || true
 COPY sql-to-dbsp-compiler/lib sql-to-dbsp-compiler/lib
 COPY --from=web-ui-builder /web-console/out web-console-out
 ENV WEBUI_BUILD_DIR=/app/web-console-out
-RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --no-default-features
+RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --features=pg-embed
 
 # Java build can be performed in parallel
 FROM base as javabuild
@@ -98,29 +98,35 @@ RUN --mount=type=cache,target=/root/.m2 \
 
 # Minimal image for running the pipeline manager
 FROM base as release
-ENV PATH="$PATH:/root/.cargo/bin"
 # Pipeline manager binary
+RUN useradd -ms /bin/bash feldera
+USER feldera
+WORKDIR /home/feldera
 COPY --from=builder /app/target/release/pipeline-manager pipeline-manager
 # SQL compiler uber jar
-RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target
-COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
+RUN mkdir -p lib/sql-to-dbsp-compiler/SQL-compiler/target
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar lib/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
 # The crates needed for the SQL compiler
-COPY crates/dbsp database-stream-processor/crates/dbsp
-COPY crates/pipeline-types database-stream-processor/crates/pipeline-types
-COPY crates/adapters database-stream-processor/crates/adapters
+COPY crates/dbsp lib/crates/dbsp
+COPY crates/pipeline-types lib/crates/pipeline-types
+COPY crates/adapters lib/crates/adapters
 # Storage crate got folded into the dbsp crate for now. Revert if this changes.
-# COPY crates/feldera-storage database-stream-processor/crates/feldera-storage
-COPY README.md database-stream-processor/README.md
-RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+# COPY crates/feldera-storage lib/crates/feldera-storage
+COPY README.md lib/README.md
+RUN mkdir -p lib/sql-to-dbsp-compiler/lib
 
 # Copy over the rust code and sql-to-dbsp script
-COPY sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
-COPY sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
-COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+COPY sql-to-dbsp-compiler/lib lib/sql-to-dbsp-compiler/lib
+COPY sql-to-dbsp-compiler/temp lib/sql-to-dbsp-compiler/temp
+COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp lib/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+
+# Install cargo and rust for this non-root user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="$PATH:/home/feldera/.cargo/bin"
 # Run the precompile phase to speed up Rust compilations during deployment
-RUN ./pipeline-manager --bind-address=0.0.0.0 --api-server-working-directory=/working-dir --compiler-working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor --precompile
+RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler --dbsp-override-path=/home/feldera/lib --precompile
 ENV BANNER_ADDR localhost
-ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--api-server-working-directory=/working-dir", "--compiler-working-directory=/working-dir", "--runner-working-directory=/working-dir", "--sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler", "--dbsp-override-path=/database-stream-processor", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080"]
+ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--dbsp-override-path=/home/feldera/lib", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080"]
 
 ##### The stages below are used to build the demo container
 

--- a/deploy/docker-compose-dev.yml
+++ b/deploy/docker-compose-dev.yml
@@ -1,10 +1,6 @@
 # For developers to build the two required
 # DBSP containers from local sources
 services:
-  db:
-    ports:
-      - 6666:5432 # Used for pipeline manager integration tests
-
   pipeline-manager:
    build:
      context: ../

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,16 +1,5 @@
 name: feldera
 services:
-  db:
-    image: postgres
-    restart: always
-    environment:
-      POSTGRES_PASSWORD: postgres
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   pipeline-manager:
     tty: true
     image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-0.14.0}
@@ -20,9 +9,6 @@ services:
       # manager command below (e.g., --allowed-origins "http://localhost:xyz").
       # Otherwise, browsers will complain about CORS errors
       - "8080:8080"
-    depends_on:
-      db:
-        condition: service_healthy
     stop_grace_period: 0s
     environment:
       - RUST_BACKTRACE=1
@@ -39,8 +25,6 @@ services:
       #
       #- seccomp:seccomp.json
       - seccomp:unconfined
-    command:
-      - --db-connection-string=postgresql://postgres:postgres@db:5432
     healthcheck:
       # TODO: add `/status` endpoint.
       test:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,20 @@
 name: feldera
 services:
+  # Even though we use a single container for the pipeline-manager,
+  # we keep this for one more release for backwards compatibility
+  # with our curl based workflow.
+  # XXX: Remove after 0.15.0 release.
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   pipeline-manager:
     tty: true
     image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-0.14.0}


### PR DESCRIPTION
This commit makes the pipeline-manager container self-contained.

This allows users to bring it up wherever they want without using
a separate postgres container and without needing Docker compose at
all.

This allows users to just do the following to bring up the pipeline-manager:

```
docker run -p 8080:8080 --rm -it ghcr.io/feldera/pipeline-manager
```

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
