### PR TITLE
docker: release docker-compose file using Github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,6 +278,8 @@ it into main, and create a new release from Github. Create a new tag from
 within the `release` page on Github. Follow the versioning format of `vX.Y.Z`
 when creating the new tag. Add the CHANGELOG entry to the release description.
 
+Add `deploy/docker-compose.yml` as an asset for the release.
+
 ### Phase 2: post-release commit
 
 Once the release is out, keep an eye on the CI on the main branch. It should

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Next, run the following command to download a Docker Compose file, and use it to
 a Feldera Platform deployment suitable for demos, development and testing:
 
 ```text
-curl https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | docker compose -f - --profile demo up
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+docker compose -f - --profile demo up
 ```
 
 It can take some time for the container images to be downloaded. About ten seconds after that, the Feldera

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,7 @@ First, install [Docker compose](https://docs.docker.com/compose/install/).
 Next, to bring up a local Feldera Platform instance run the following:
 
 ```
-curl https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | docker compose -f - up
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | docker compose -f - up
 ```
 
 This will bring up a DBSP and Postgres container.

--- a/docs/tutorials/basics/part3.md
+++ b/docs/tutorials/basics/part3.md
@@ -109,7 +109,7 @@ the Redpanda container should already be running.  Otherwise, you can start it
 using the following command:
 
 ```bash
-curl https://raw.githubusercontent.com/feldera/dbsp/main/deploy/docker-compose.yml | docker compose -f - up redpanda
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | docker compose -f - up redpanda
 ```
 
 Next, you will need to install `rpk`, the Redpanda CLI, by following the instructions on

--- a/docs/tutorials/rest_api/index.md
+++ b/docs/tutorials/rest_api/index.md
@@ -39,7 +39,7 @@ language (e.g., in Python using the `requests` module).
    to interact with. If you do not have one already, you can start one locally using
    [**docker**](https://docs.docker.com/engine/install/):
    ```
-   curl https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
+   curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
    docker compose -f - up
    ```
    (leave it running in a separate terminal while going through this tutorial)
@@ -610,7 +610,7 @@ them running in the background. In this case, you can also explicitly
 shut them down using `docker compose down`:
 
 ```
-curl https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
 docker compose -f - down
 ```
 


### PR DESCRIPTION
This sets us up to release the docker-compose file as an asset every release. I've edited the previous release. it fixes a common issue we have in that we expect users to use stable container images with `docker-compose.yml` files from main. It's not very robust when introducing changes.

This way, we always have a stable docker-compose file we can reference in our documentation.

Signed-off-by: Lalith Suresh <lalith@feldera.com>

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
