### PR TITLE
Watermark

### DIFF
--- a/docs/sql/streaming.md
+++ b/docs/sql/streaming.md
@@ -78,9 +78,6 @@ annotated columns is too late.
 
 ### `WATERMARK` expressions
 
-*This feature is not yet fully implemented.  This documentation is
- only orientative.*
-
 `WATERMARK` is an annotation on the data in a column of a table that
 is relevant for the case of stream processing.  `WATERMARK` is
 described by an expression that evaluates to a constant value.  The

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.circuit.operator;
 
 import org.dbsp.sqlCompiler.compiler.IHasColumnsMetadata;
 import org.dbsp.sqlCompiler.compiler.IHasLateness;
+import org.dbsp.sqlCompiler.compiler.IHasWatermark;
 import org.dbsp.sqlCompiler.compiler.InputTableMetadata;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
@@ -65,6 +66,11 @@ public class DBSPSourceMultisetOperator
 
     @Override
     public Iterable<? extends IHasLateness> getLateness() {
+        return this.metadata.getColumns();
+    }
+
+    @Override
+    public Iterable<? extends IHasWatermark> getWatermarks() {
         return this.metadata.getColumns();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.circuit.operator;
 
 import org.dbsp.sqlCompiler.compiler.IHasColumnsMetadata;
 import org.dbsp.sqlCompiler.compiler.IHasLateness;
+import org.dbsp.sqlCompiler.compiler.IHasWatermark;
 import org.dbsp.sqlCompiler.compiler.ViewColumnMetadata;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
@@ -63,5 +64,11 @@ public class DBSPViewOperator
     @Override
     public Iterable<? extends IHasLateness> getLateness() {
         return this.metadata;
+    }
+
+    @Override
+    public Iterable<? extends IHasWatermark> getWatermarks() {
+        // Currently no watermark information in views
+        return Linq.list();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWaterlineOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWaterlineOperator.java
@@ -16,9 +16,9 @@ public class DBSPWaterlineOperator extends DBSPUnaryOperator {
     /** Initial value of waterline */
     public final DBSPExpression init;
 
-    public DBSPWaterlineOperator(CalciteObject node, DBSPExpression init, DBSPClosureExpression function, DBSPType
-            outputType, DBSPOperator input) {
-        super(node, "waterline_monotonic", function, outputType, false, input);
+    public DBSPWaterlineOperator(CalciteObject node, DBSPExpression init,
+                                 DBSPClosureExpression function, DBSPOperator input) {
+        super(node, "waterline_monotonic", function, function.getResultType(), false, input);
         this.init = init;
     }
 
@@ -26,14 +26,14 @@ public class DBSPWaterlineOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPWaterlineOperator(this.getNode(), this.init,
                 Objects.requireNonNull(expression).to(DBSPClosureExpression.class),
-                this.outputType, this.input());
+                this.input());
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPWaterlineOperator(this.getNode(), this.init,
-                    this.getFunction().to(DBSPClosureExpression.class), this.outputType, newInputs.get(0));
+                    this.getFunction().to(DBSPClosureExpression.class), newInputs.get(0));
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IHasColumnsMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IHasColumnsMetadata.java
@@ -2,4 +2,5 @@ package org.dbsp.sqlCompiler.compiler;
 
 public interface IHasColumnsMetadata {
     Iterable<? extends IHasLateness> getLateness();
+    Iterable<? extends IHasWatermark> getWatermarks();
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IHasWatermark.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IHasWatermark.java
@@ -1,0 +1,12 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.util.IHasName;
+
+import javax.annotation.Nullable;
+
+/** Interface implemented by objects may have watermark information */
+public interface IHasWatermark extends IHasCalciteObject, IHasName {
+    @Nullable
+    DBSPExpression getWatermark();
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/InputColumnMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/InputColumnMetadata.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 
 /** Metadata describing an input table column. */
 public class InputColumnMetadata
-        implements IHasLateness, IHasName, IHasSourcePositionRange, IHasType {
+        implements IHasLateness, IHasWatermark, IHasName, IHasSourcePositionRange, IHasType {
     public final CalciteObject node;
     /** Column name. */
     public final String name;
@@ -62,5 +62,11 @@ public class InputColumnMetadata
     @Override
     public SourcePositionRange getPositionRange() {
         return this.getNode().getPositionRange();
+    }
+
+    @Nullable
+    @Override
+    public DBSPExpression getWatermark() {
+        return this.watermark;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -42,6 +42,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.InputColumnMetadata;
@@ -659,6 +660,21 @@ public class ToRustVisitor extends CircuitVisitor {
                 .append(", ");
         operator.getFunction().accept(this.innerVisitor);
         this.builder.append(");");
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPWindowOperator operator) {
+        this.writeComments(operator)
+                .append("let ")
+                .append(operator.getOutputName())
+                .append(" = ")
+                .append(operator.inputs.get(0).getOutputName())
+                .append(".")
+                .append(operator.operation)
+                .append("(&")
+                .append(operator.inputs.get(1).getOutputName())
+                .append(");");
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -48,6 +48,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.IRTransform;
 import org.dbsp.sqlCompiler.ir.DBSPAggregate;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPItem;
@@ -305,7 +306,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         if (!outputType.sameType(operator.outputType)
                 || input != operator.input()
                 || function != operator.getFunction()) {
-            result = new DBSPIndexOperator(operator.getNode(), function,
+            result = new DBSPIndexOperator(operator.getNode(), function.to(DBSPClosureExpression.class),
                     outputType.to(DBSPTypeIndexedZSet.class), operator.isMultiset, input);
         }
         this.map(operator, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeUser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeUser.java
@@ -26,6 +26,10 @@ package org.dbsp.sqlCompiler.ir.type;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPConstructorExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
+import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.util.IIndentStream;
 
 import java.util.Arrays;
@@ -94,5 +98,27 @@ public class DBSPTypeUser extends DBSPType {
         if (this.mayBeNull)
             builder.append("?");
         return builder;
+    }
+
+    /** Generate a constructor for this type with the signature:
+     * (Self)::method(arguments)
+     * @param method     Method to invoke on this type
+     * @param arguments  Arguments to pass to constructor
+     * @return           An expression which invokes the constructor
+     */
+    public DBSPExpression constructor(String method, DBSPExpression... arguments) {
+        return new DBSPConstructorExpression(
+                new DBSPPathExpression(this, new DBSPPath(this.name, method)),
+                this,
+                arguments);
+    }
+
+    /** Generate a constructor for this type with the signature:
+     * (Self)::new(arguments)
+     * @param arguments  Arguments to pass to constructor
+     * @return           An expression which invokes the constructor
+     */
+    public DBSPExpression constructor(DBSPExpression... arguments) {
+        return this.constructor("new", arguments);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -135,7 +135,8 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         // Deterministically name the circuit function.
         DBSPCircuit circuit = compiler.getFinalCircuit("circuit");
         String str = circuit.toString();
-        String expected = """
+        String expected;
+        expected = """
                 Circuit circuit {
                     // DBSPSourceMultisetOperator 39
                     // CREATE TABLE `T` (`COL1` INTEGER NOT NULL, `COL2` DOUBLE NOT NULL, `COL3` BOOLEAN NOT NULL, `COL4` VARCHAR NOT NULL, `COL5` INTEGER, `COL6` DOUBLE)
@@ -145,7 +146,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                     // CREATE VIEW `V` AS
                     // SELECT `T`.`COL3`
                     // FROM `T`
-                    let stream126: stream<WSet<Tup1<b>>> = stream61;
+                    let stream128: stream<WSet<Tup1<b>>> = stream61;
                 }
                 """;
         Assert.assertEquals(expected, str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresWindowTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresWindowTests.java
@@ -80,7 +80,7 @@ public class PostgresWindowTests extends SqlIoTest {
                   9 |   8 |
                  10 |   9 |
                 (10 rows)
-                                
+                
                 SELECT lag(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1 WHERE unique2 < 10;
                  lag | ten | four
                 -----+-----+------
@@ -95,7 +95,7 @@ public class PostgresWindowTests extends SqlIoTest {
                      |   1 |    3
                    1 |   3 |    3
                 (10 rows)
-                                
+                
                 SELECT lag(ten, four) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1
                 WHERE unique2 < 10;
                  lag | ten | four
@@ -111,7 +111,7 @@ public class PostgresWindowTests extends SqlIoTest {
                      |   1 |    3
                      |   3 |    3
                 (10 rows)
-                                
+                
                 SELECT lag(ten, four, 0) OVER (PARTITION BY four ORDER BY ten), ten, four
                 FROM tenk1
                 WHERE unique2 < 10;
@@ -128,7 +128,7 @@ public class PostgresWindowTests extends SqlIoTest {
                    0 |   1 |    3
                    0 |   3 |    3
                 (10 rows)
-                                
+                
                 SELECT lag(ten, four, 0.7) OVER (PARTITION BY four ORDER BY ten), ten, four
                 FROM tenk1
                 WHERE unique2 < 10 ORDER BY four, ten;
@@ -145,7 +145,7 @@ public class PostgresWindowTests extends SqlIoTest {
                  0.7 |   1 |    3
                  0.7 |   3 |    3
                 (10 rows)
-                                
+                
                 SELECT lead(ten) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1
                 WHERE unique2 < 10;
                  lead | ten | four
@@ -161,9 +161,9 @@ public class PostgresWindowTests extends SqlIoTest {
                     3 |   1 |    3
                       |   3 |    3
                 (10 rows)
-                                
+                
                 SELECT lead(ten * 2, 1) OVER (PARTITION BY four ORDER BY ten), ten, four
-                FROM tenk1 
+                FROM tenk1
                 WHERE unique2 < 10;
                  lead | ten | four
                 ------+-----+------
@@ -178,8 +178,8 @@ public class PostgresWindowTests extends SqlIoTest {
                     6 |   1 |    3
                       |   3 |    3
                 (10 rows)
-                                
-                SELECT lead(ten * 2, 1, -1) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1 
+                
+                SELECT lead(ten * 2, 1, -1) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1
                 WHERE unique2 < 10;
                  lead | ten | four
                 ------+-----+------
@@ -194,8 +194,8 @@ public class PostgresWindowTests extends SqlIoTest {
                     6 |   1 |    3
                    -1 |   3 |    3
                 (10 rows)
-                                
-                SELECT lead(ten * 2, 1, -1.4) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1 
+                
+                SELECT lead(ten * 2, 1, -1.4) OVER (PARTITION BY four ORDER BY ten), ten, four FROM tenk1
                 WHERE unique2 < 10 ORDER BY four, ten;
                  lead | ten | four
                 ------+-----+------


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

(However, I cannot modify the CHANGELOG until the new release.)

This implements the WATERMARK annotation on an input table column.
This uses the DBSP window operator, which unfortunately requires a single column, so we only support 1 column per input table. The implementation uses a waterline operator, and a window operator.

