### PR TITLE
Implement correct semantics for `lag`.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/group/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/group/mod.rs
@@ -421,7 +421,7 @@ where
                 // println!("val: {val:?}, w: {w:?}");
                 builder.push_vals(&mut key2, val, w);
             };
-            // Output callaback that pushes to an intermediate buffer.
+            // Output callback that pushes to an intermediate buffer.
             let mut cb_desc = |val: &mut OB::Val, w: &mut B::R| {
                 //println!("val: {val:?}, w: {w:?}");
                 let (kv, weight) = tuple.split_mut();
@@ -513,7 +513,7 @@ where
                 // Unordered transformer: sort the buffer before pushing tuples
                 // to `builder`.
                 Monotonicity::Unordered => {
-                    self.buffer.sort();
+                    self.buffer.consolidate();
                     for tuple in self.buffer.dyn_iter_mut() {
                         builder.push(tuple)
                     }

--- a/crates/dbsp/src/operator/group/lag.rs
+++ b/crates/dbsp/src/operator/group/lag.rs
@@ -21,9 +21,13 @@ where
     ///
     /// For each key in the input stream, it matches each associated value with
     /// another value in the same group with a smaller (`offset > 0`) or greater
-    /// (`offset < 0`) index according to ascending order of values), applies
+    /// (`offset < 0`) index according to ascending order of values, applies
     /// projection function `project` to it and outputs the input value along
     /// with this projection.
+    ///
+    /// The offset it computed as if each value occurred as many times as its
+    /// weight.  Values with negative weights are ignored; hence the output Z-set
+    /// will only contain positive weights.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
`lag` originally behaved as if all copies of a record occupied the same index in the list of values.  Apparently, SQL requires different semantics, with each copy occupying a separate slot.  This patch implements the new semantics.  Along the way I dropped the optimization that made sure that the operator output sorted tuples, since it was getting too complicated to maintain.

Addresses #1545 (that test now passes).

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
