### PR TITLE
First step toward end-to-end test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "num-format",
  "paste",
  "rand 0.8.5",
+ "rdkafka",
  "regex",
  "rkyv",
  "rstest",

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -392,7 +392,8 @@ bar,false,-10
         wait(
             || consumer.state().endpoint_error.is_some(),
             DEFAULT_TIMEOUT_MS,
-        );
+        )
+        .unwrap();
         Ok(())
     }
 

--- a/crates/dbsp/src/utils/tuple/gen.rs
+++ b/crates/dbsp/src/utils/tuple/gen.rs
@@ -305,12 +305,12 @@ macro_rules! declare_tuples {
             */
             impl<$($element: Copy),*> Copy for $tuple_name<$($element),*> {}
 
-            impl<$($element),*> Checkpoint for $tuple_name<$($element),*> {
-                fn checkpoint(&self) -> Result<Vec<u8>, Error> {
+            impl<$($element),*> $crate::circuit::checkpointer::Checkpoint for $tuple_name<$($element),*> {
+                fn checkpoint(&self) -> Result<Vec<u8>, $crate::Error> {
                     todo!()
                 }
 
-                fn restore(&mut self, _data: &[u8]) -> Result<(), Error> {
+                fn restore(&mut self, _data: &[u8]) -> Result<(), $crate::Error> {
                     todo!()
                 }
             }

--- a/crates/dbsp/src/utils/tuple/mod.rs
+++ b/crates/dbsp/src/utils/tuple/mod.rs
@@ -5,8 +5,6 @@
 // This was introduced to resolve issues with auto-derived rkyv trait
 // implementations.
 
-use crate::circuit::checkpointer::Checkpoint;
-use crate::Error;
 use pipeline_types::deserialize_without_context;
 
 pub mod gen;

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["DBSP", "streaming", "analytics", "Nexmark", "benchmark"]
 categories = []
 publish = false
 
+[features]
+with-kafka = ["rdkafka"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -29,6 +32,8 @@ time = { version = "0.3.14", features = ["formatting"] }
 paste = { version = "1.0.9" }
 
 rand = { version = "0.8", features = ["small_rng"] }
+# cmake-build is required on Windows.
+rdkafka = { version = "0.34.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"], optional = true }
 clap = { version = "3.2.8", features = ["derive", "env"] }
 cached = { version = "0.38.0" }
 serde = { version = "1.0", features = ["derive"] }
@@ -59,3 +64,7 @@ harness = false
 [[bench]]
 name = "nexmark-gen"
 harness = false
+
+[[example]]
+name = "generate"
+required-features = ["with-kafka"]

--- a/crates/nexmark/benches/nexmark-gen/main.rs
+++ b/crates/nexmark/benches/nexmark-gen/main.rs
@@ -4,7 +4,7 @@ use rand::rngs::{mock::StepRng, SmallRng};
 
 use dbsp::mimalloc::MiMalloc;
 use dbsp_nexmark::{
-    config::Config as NexmarkConfig,
+    config::GeneratorOptions,
     generator::{config::Config, NexmarkGenerator},
 };
 
@@ -21,9 +21,9 @@ macro_rules! with_rng {
         let rng_name = $rng_name;
         let rng = $rng;
         let config = Config {
-            nexmark_config: NexmarkConfig {
+            options: GeneratorOptions {
                 num_event_generators,
-                ..NexmarkConfig::default()
+                ..GeneratorOptions::default()
             },
             ..Config::default()
         };

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -95,7 +95,7 @@ fn spawn_source_producer(
         .name("benchmark producer".into())
         .spawn(move || {
             let batch_size = nexmark_config.input_batch_size;
-            let mut source = NexmarkSource::new(nexmark_config);
+            let mut source = NexmarkSource::new(nexmark_config.generator_options);
             let mut num_events: u64 = 0;
 
             // Start iterating by loading up the first batch of input ready for processing,
@@ -218,10 +218,13 @@ fn create_ascii_table() -> AsciiTable {
 
 fn run_query(config: &NexmarkConfig, query: Query) -> NexmarkResult {
     let name = format!("{query:?}");
-    println!("Starting {name} bench of {} events...", config.max_events);
+    println!(
+        "Starting {name} bench of {} events...",
+        config.generator_options.max_events
+    );
 
     let num_cores = config.cpu_cores;
-    let expected_num_events = config.max_events;
+    let expected_num_events = config.generator_options.max_events;
     let circuit_config = CircuitConfig {
         min_storage_rows: if config.storage { 0 } else { usize::MAX },
         ..CircuitConfig::with_workers(num_cores)

--- a/crates/nexmark/examples/generate.rs
+++ b/crates/nexmark/examples/generate.rs
@@ -1,0 +1,158 @@
+use clap::Parser;
+use csv::WriterBuilder;
+use dbsp_nexmark::{config::GeneratorOptions, NexmarkSource};
+use env_logger::Env;
+use indicatif::ProgressBar;
+use rdkafka::{
+    config::FromClientConfig,
+    producer::{base_producer::ThreadedProducer, BaseRecord, DefaultProducerContext, Producer},
+    util::Timeout,
+    ClientConfig,
+};
+use serde::Serialize;
+
+/// Accumulates data until it crosses a threshold size and then outputs it to it
+/// to a Kafka topic.
+struct BufferedTopic<'a> {
+    producer: &'a ThreadedProducer<DefaultProducerContext>,
+    topic: String,
+    buffer: Vec<u8>,
+}
+
+/// Maximum size of a record to send to the Kafka broker.  This shouldn't be
+/// increased beyond 1_000_000, which is the default maximum in a couple of
+/// places in the Kafka broker that has to be increased in multiple places (see
+/// https://stackoverflow.com/questions/21020347/how-can-i-send-large-messages-with-kafka-over-15mb).
+const MAX_LEN: usize = 512 * 1024;
+
+impl<'a> BufferedTopic<'a> {
+    /// Creates a new `BufferedTopic` to output to `topic` via `producer`.  The
+    /// buffer is flushed whenever it reaches `MAX_LEN` bytes.
+    pub fn new(producer: &'a ThreadedProducer<DefaultProducerContext>, topic: String) -> Self {
+        Self {
+            producer,
+            topic,
+            buffer: Vec::new(),
+        }
+    }
+
+    /// Writes `record`, flushing automatically if the threshold is reached.
+    pub fn write<S>(&mut self, record: S)
+    where
+        S: Serialize,
+    {
+        let mut writer = WriterBuilder::new()
+            .has_headers(false)
+            .from_writer(Vec::new());
+        writer.serialize(record).unwrap();
+        let s = writer.into_inner().unwrap();
+        if self.buffer.len() + s.len() > MAX_LEN {
+            self.flush();
+        }
+        self.buffer.extend_from_slice(&s[..]);
+    }
+
+    pub fn flush(&mut self) {
+        if !self.buffer.is_empty() {
+            let record: BaseRecord<(), _> = BaseRecord::to(&self.topic).payload(&self.buffer);
+            self.producer.send(record).unwrap();
+            self.buffer.clear();
+        }
+    }
+}
+
+impl<'a> Drop for BufferedTopic<'a> {
+    fn drop(&mut self) {
+        self.flush();
+        self.producer.flush(Timeout::Never).unwrap();
+    }
+}
+
+/// Feeds Nexmark input data into Kafka topics.
+///
+/// This program generates Nexmark events and feeds them into Kafka topics named
+/// `person`, `auction`, and `bid`.  By default, it writes 100,000,000 events,
+/// which can easily be too many, so consider specifying `--max-events`.
+/// Specify `-O bootstrap.servers=<broker>` to use a broker other than
+/// `localhost:9092`.
+///
+/// If the topics that this writes already exist, this will append to them.  To
+/// ensure that the topics contain only the generated output, delete them first,
+/// e.g. with a command like `rpk topic delete person auction bid`.
+///
+/// To verify that the expected number of events was produced, take the sum of
+/// the number of lines in the produced topics, e.g.:
+///
+/// for topic in person bid auction; do rpk topic consume -f '%v' -o :end $topic; done | wc -l
+#[derive(Parser)]
+#[clap(name = "generate")]
+struct Options {
+    #[clap(flatten)]
+    generator_options: GeneratorOptions,
+
+    /// Set a Kafka client option, e.g. `-O key=value`.
+    #[clap(short = 'O')]
+    kafka_options: Vec<String>,
+
+    /// Specify a prefix to add to each of the topic names.
+    #[clap(long, default_value = "")]
+    topic_prefix: String,
+
+    /// Topic for producing person events (plus the prefix).
+    #[clap(long, default_value = "person")]
+    person_topic: String,
+
+    /// Topic for producing auction events (plus the prefix).
+    #[clap(long, default_value = "auction")]
+    auction_topic: String,
+
+    /// Topic for producing bid events (plus the prefix).
+    #[clap(long, default_value = "bid")]
+    bid_topic: String,
+
+    /// Disable progress bar.
+    #[clap(long = "no-progress", default_value_t = true, action = clap::ArgAction::SetFalse)]
+    pub progress: bool,
+}
+
+fn main() {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    let options = Options::parse();
+
+    let progress_bar = if options.progress && options.generator_options.max_events > 0 {
+        ProgressBar::new(options.generator_options.max_events)
+    } else {
+        ProgressBar::hidden()
+    };
+
+    let mut source = NexmarkSource::new(options.generator_options);
+    let mut client_config = ClientConfig::new();
+    client_config.set("bootstrap.servers", "localhost:9092");
+    for option in options.kafka_options {
+        let (key, value) = option
+            .split_once('=')
+            .expect(&format!("{option}: expected '=' in argument"));
+        client_config.set(key, value);
+    }
+    let producer = ThreadedProducer::from_config(&client_config).unwrap();
+    let mut persons = BufferedTopic::new(
+        &producer,
+        format!("{}{}", &options.topic_prefix, &options.person_topic,),
+    );
+    let mut auctions = BufferedTopic::new(
+        &producer,
+        format!("{}{}", &options.topic_prefix, &options.auction_topic,),
+    );
+    let mut bids = BufferedTopic::new(
+        &producer,
+        format!("{}{}", &options.topic_prefix, &options.bid_topic,),
+    );
+    for event in &mut source {
+        match event {
+            dbsp_nexmark::model::Event::Person(person) => persons.write(person),
+            dbsp_nexmark::model::Event::Auction(auction) => auctions.write(auction),
+            dbsp_nexmark::model::Event::Bid(bid) => bids.write(bid),
+        }
+        progress_bar.inc(1);
+    }
+}

--- a/crates/nexmark/src/generator/bids.rs
+++ b/crates/nexmark/src/generator/bids.rs
@@ -52,10 +52,7 @@ impl<R: Rng> NexmarkGenerator<R> {
     }
 
     pub fn next_bid(&mut self, event_id: u64, timestamp: u64) -> Bid {
-        let auction = match self
-            .rng
-            .gen_range(0..self.config.nexmark_config.hot_auction_ratio)
-        {
+        let auction = match self.rng.gen_range(0..self.config.options.hot_auction_ratio) {
             0 => self.next_base0_auction_id(event_id),
             _ => {
                 // Choose the first auction in the batch of last HOT_AUCTION_RATIO auctions.
@@ -64,10 +61,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             }
         } + FIRST_AUCTION_ID;
 
-        let bidder = match self
-            .rng
-            .gen_range(0..self.config.nexmark_config.hot_bidders_ratio)
-        {
+        let bidder = match self.rng.gen_range(0..self.config.options.hot_bidders_ratio) {
             0 => self.next_base0_person_id(event_id),
             _ => {
                 // Choose the second person (so hot bidders and hot sellers don't collide) in
@@ -107,7 +101,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             channel,
             url,
             date_time: timestamp,
-            extra: self.next_extra(current_size, self.config.nexmark_config.avg_bid_byte_size),
+            extra: self.next_extra(current_size, self.config.options.avg_bid_byte_size),
         }
     }
 }

--- a/crates/nexmark/src/generator/mod.rs
+++ b/crates/nexmark/src/generator/mod.rs
@@ -68,9 +68,9 @@ impl<R: Rng> NexmarkGenerator<R> {
             self.wallclock_base_time + event_timestamp - self.config.base_time;
 
         let (auction_proportion, person_proportion, total_proportion) = (
-            self.config.nexmark_config.auction_proportion as u64,
-            self.config.nexmark_config.person_proportion as u64,
-            self.config.nexmark_config.total_proportion() as u64,
+            self.config.options.auction_proportion as u64,
+            self.config.options.person_proportion as u64,
+            self.config.options.total_proportion() as u64,
         );
 
         let rem = new_event_id % total_proportion;
@@ -137,7 +137,7 @@ pub struct NextEvent {
 pub mod tests {
     use super::*;
     use crate::{
-        config::Config as NexmarkConfig,
+        config::GeneratorOptions,
         model::{Auction, Bid, Person},
     };
     use rand::{rngs::mock::StepRng, thread_rng};
@@ -146,9 +146,9 @@ pub mod tests {
     pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
         NexmarkGenerator::new(
             Config {
-                nexmark_config: NexmarkConfig {
+                options: GeneratorOptions {
                     num_event_generators: 1,
-                    ..NexmarkConfig::default()
+                    ..GeneratorOptions::default()
                 },
                 ..Config::default()
             },
@@ -244,9 +244,9 @@ pub mod tests {
         #[case] expected_next_event_ids: Vec<u64>,
     ) {
         let config = Config {
-            nexmark_config: NexmarkConfig {
+            options: GeneratorOptions {
                 num_event_generators,
-                ..NexmarkConfig::default()
+                ..GeneratorOptions::default()
             },
             first_event_id,
             first_event_number,
@@ -266,9 +266,9 @@ pub mod tests {
     fn test_next_event() {
         let mut ng = NexmarkGenerator::new(
             Config {
-                nexmark_config: NexmarkConfig {
+                options: GeneratorOptions {
                     num_event_generators: 1,
-                    ..NexmarkConfig::default()
+                    ..GeneratorOptions::default()
                 },
                 ..Config::default()
             },

--- a/crates/nexmark/src/generator/people.rs
+++ b/crates/nexmark/src/generator/people.rs
@@ -62,10 +62,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             city,
             state,
             date_time: timestamp,
-            extra: self.next_extra(
-                current_size,
-                self.config.nexmark_config.avg_person_byte_size,
-            ),
+            extra: self.next_extra(current_size, self.config.options.avg_person_byte_size),
         }
     }
 
@@ -84,10 +81,7 @@ impl<R: Rng> NexmarkGenerator<R> {
     /// 0".
     pub fn next_base0_person_id(&mut self, event_id: u64) -> u64 {
         let num_people = self.last_base0_person_id(event_id) + 1;
-        let active_people = min(
-            num_people,
-            self.config.nexmark_config.num_active_people as u64,
-        );
+        let active_people = min(num_people, self.config.options.num_active_people as u64);
         let n = self
             .rng
             .gen_range(0..(active_people + nexmark_config::PERSON_ID_LEAD as u64));
@@ -97,16 +91,16 @@ impl<R: Rng> NexmarkGenerator<R> {
     /// Return the last valid person id (ignoring FIRST_PERSON_ID). Will be the
     /// current person id if due to generate a person.
     pub fn last_base0_person_id(&self, event_id: u64) -> u64 {
-        let epoch = event_id / self.config.nexmark_config.total_proportion() as u64;
-        let mut offset = event_id % self.config.nexmark_config.total_proportion() as u64;
+        let epoch = event_id / self.config.options.total_proportion() as u64;
+        let mut offset = event_id % self.config.options.total_proportion() as u64;
 
-        if offset >= self.config.nexmark_config.person_proportion as u64 {
+        if offset >= self.config.options.person_proportion as u64 {
             // About to generate an auction or bid.
             // Go back to the last person generated in this epoch.
-            offset = self.config.nexmark_config.person_proportion as u64 - 1;
+            offset = self.config.options.person_proportion as u64 - 1;
         }
         // About to generate a person.
-        epoch * self.config.nexmark_config.person_proportion as u64 + offset
+        epoch * self.config.options.person_proportion as u64 + offset
     }
 
     // Return a random US state.
@@ -224,7 +218,7 @@ mod tests {
         // which together with the other defaults for person and auction
         // proportion, makes the total 25.
         let mut ng = make_test_generator();
-        ng.config.nexmark_config.bid_proportion = 21;
+        ng.config.options.bid_proportion = 21;
 
         // With the total proportion at 25, there will be a new person
         // at every 25th event.


### PR DESCRIPTION
This adds an example program to the `dbsp_nexmark` crate to generate Nexmark input data into Kafka.

Is this a user-visible change (yes/no): no