### PR TITLE
deploy: Copy `Cargo.lock` into the workspace for precompiling.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -249,6 +249,10 @@ test-python:
     COPY demo/demo_notebooks demo/demo_notebooks
     COPY demo/simple-join demo/simple-join
 
+    # Reuse `Cargo.lock` to ensure consistent crate versions.
+    RUN mkdir -p /working-dir/cargo_workspace
+    COPY Cargo.lock /working-dir/cargo_workspace/Cargo.lock
+
     ENV PGHOST=localhost
     ENV PGUSER=postgres
     ENV PGCLIENTENCODING=UTF8
@@ -283,6 +287,10 @@ build-pipeline-manager-container:
     RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target
     COPY +build-manager/pipeline-manager .
     COPY +build-sql/sql2dbsp-jar-with-dependencies.jar database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target/
+
+    # Reuse `Cargo.lock` to ensure consistent crate versions.
+    RUN mkdir -p .feldera/cargo_workspace
+    COPY --chown=feldera Cargo.lock .feldera/cargo_workspace/Cargo.lock
 
     # Then copy over the crates needed by the sql compiler
     COPY crates/dbsp database-stream-processor/crates/dbsp

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -106,6 +106,11 @@ COPY --from=builder /app/target/release/pipeline-manager pipeline-manager
 # SQL compiler uber jar
 RUN mkdir -p lib/sql-to-dbsp-compiler/SQL-compiler/target
 COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar lib/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
+
+# Reuse `Cargo.lock` to ensure consistent crate versions.
+RUN mkdir -p .feldera/cargo_workspace
+COPY --chown=feldera Cargo.lock .feldera/cargo_workspace/Cargo.lock
+
 # The crates needed for the SQL compiler
 COPY crates/dbsp lib/crates/dbsp
 COPY crates/pipeline-types lib/crates/pipeline-types


### PR DESCRIPTION
Without this, the crate versions used for (pre)compiling in the pipeline manager can be surprising, leading to unexpected build failures.  In particular, we've had some problems with the crates for deltalake in CI, but that's just a symptom of the larger problem.

Is this a user-visible change (yes/no): no