### PR TITLE
[SQL] Re-enable (unsound) rule to push filters into joins

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
@@ -204,9 +204,10 @@ public class CalciteOptimizer implements IWritesLogs {
             HepProgram getProgram(RelNode node) {
                 this.addRules(
                         CoreRules.JOIN_CONDITION_PUSH,
-                        CoreRules.JOIN_PUSH_EXPRESSIONS
-                        // Rule is unsound
-                        // CoreRules.FILTER_INTO_JOIN
+                        CoreRules.JOIN_PUSH_EXPRESSIONS,
+                        // TODO: Rule is unsound
+                        // https://github.com/feldera/feldera/issues/1702
+                        CoreRules.FILTER_INTO_JOIN
                 );
 
                 OuterJoinFinder finder = new OuterJoinFinder();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
@@ -27,8 +27,6 @@ import org.apache.calcite.config.Lex;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTest;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.MonotoneAnalyzer;
-import org.dbsp.util.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -35,13 +35,12 @@ import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
-import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.DBSPFunction;
 import org.dbsp.sqlCompiler.ir.DBSPNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyMethodExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPAsExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPEnumValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -72,7 +71,6 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDouble;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeReal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
 import org.dbsp.sqllogictest.Main;
 import org.dbsp.sqllogictest.SqlTestPrepareInput;
@@ -469,6 +467,8 @@ public class DBSPExecutor extends SqlSltTestExecutor {
         list.add(outputStatement);
         DBSPExpression sort = new DBSPEnumValue("SortOrder", description.getOrder().toString());
 
+        /*
+        This stopped working when transitioning to the untyped runtime.
         if (description.getExpectedOutputSize() >= 0) {
             DBSPExpression count;
             if (isVector) {
@@ -486,6 +486,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                                     new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false)),
                                     new DBSPI32Literal(description.getExpectedOutputSize())).toStatement());
         }
+         */
         if (output != null) {
             if (description.columnTypes != null) {
                 DBSPExpression columnTypes = new DBSPStringLiteral(description.columnTypes);


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes https://github.com/feldera/feldera/issues/1701
But also creates https://github.com/feldera/feldera/issues/1702
