### PR TITLE
dbsp_nexmark: Make storage threshold configurable in nexmark benchmark.

### DIFF
--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -226,7 +226,7 @@ fn run_query(config: &NexmarkConfig, query: Query) -> NexmarkResult {
     let num_cores = config.cpu_cores;
     let expected_num_events = config.generator_options.max_events;
     let circuit_config = CircuitConfig {
-        min_storage_rows: if config.storage { 0 } else { usize::MAX },
+        min_storage_rows: config.min_storage_rows,
         ..CircuitConfig::with_workers(num_cores)
     };
     let (dbsp, input_handle) =

--- a/crates/nexmark/src/config.rs
+++ b/crates/nexmark/src/config.rs
@@ -50,9 +50,12 @@ pub struct Config {
     #[clap(long = "no-progress", default_value_t = true, action = clap::ArgAction::SetFalse)]
     pub progress: bool,
 
-    /// Enable storage.
-    #[clap(long)]
-    pub storage: bool,
+    /// Configure storage. Without this option, data is kept in memory. With
+    /// this option, if `ROWS` is 0 or omitted, all data is written to storage;
+    /// otherwise, data batches are written to storage when they are estimated
+    /// to contain at least `ROWS` rows.
+    #[clap(long="storage", default_value_t = usize::MAX, default_missing_value = "0", hide_default_value(true), value_name("ROWS"))]
+    pub min_storage_rows: usize,
 }
 
 /// Properties of the generated input events.
@@ -147,7 +150,7 @@ impl Default for Config {
             input_batch_size: 40_000,
             output_csv: None,
             progress: true,
-            storage: false,
+            min_storage_rows: usize::MAX,
         }
     }
 }


### PR DESCRIPTION
Before this, running the benchmark without `--storage` ran it entirely in memory, and with `--storage` entirely on disk.  With this commit, `--storage` takes an optional parameter that specifies the minimum (estimated) number of rows before spilling to disk.

Is this a user-visible change (yes/no): no