### PR TITLE
Fix warnings for upgrade to Rust 1.78.

### DIFF
--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -3,7 +3,6 @@ use crate::{
     transport::{InputReader, Step},
     ControllerError, InputConsumer, InputEndpoint, ParseError, PipelineState, TransportConfig,
 };
-use actix::Message;
 use actix_web::{web::Payload, HttpResponse};
 use anyhow::{anyhow, Error as AnyError, Result as AnyResult};
 use circular_queue::CircularQueue;
@@ -79,10 +78,6 @@ impl HttpInputEndpointInner {
         }
     }
 }
-
-#[derive(Message)]
-#[rtype(result = "()")]
-struct EndpointStateNotification;
 
 /// Input endpoint that streams input data via HTTP.
 #[derive(Clone)]

--- a/crates/dbsp/src/dynamic/factory.rs
+++ b/crates/dbsp/src/dynamic/factory.rs
@@ -65,10 +65,6 @@ where
     }
 }
 
-pub trait AnyFactory {
-    fn downcast<Trait: ArchiveTrait + ?Sized>(&self) -> Option<&dyn Factory<Trait>>;
-}
-
 impl<T, Trait> WithFactory<T> for Trait
 where
     Trait: ArchiveTrait + ?Sized + 'static,

--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -68,7 +68,7 @@ pub mod dynamic;
 mod error;
 mod hash;
 mod num_entries;
-mod ref_pair;
+//mod ref_pair;
 
 pub mod typed_batch;
 

--- a/crates/dbsp/src/operator/dynamic/aggregate/aggregator.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/aggregator.rs
@@ -11,9 +11,6 @@ use crate::{
     DBData, DBWeight,
 };
 
-pub trait AggInitFunc<V: ?Sized, A: ?Sized>: Fn(&V, &mut A) + DynClone {}
-impl<V: ?Sized, A: ?Sized, F> AggInitFunc<V, A> for F where F: Fn(&V, &mut A) + Clone {}
-
 pub trait AggOutputFunc<A: ?Sized, O: ?Sized>: Fn(&mut A, &mut O) + DynClone {}
 impl<A: ?Sized, O: ?Sized, F> AggOutputFunc<A, O> for F where F: Fn(&mut A, &mut O) + Clone {}
 

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/mod.rs
@@ -282,6 +282,7 @@ where
 
     /// Produce a semi-human-readable representation of the tree for debugging
     /// purposes.
+    #[allow(unused)]
     fn format_tree<W>(&mut self, writer: &mut W) -> Result<(), fmt::Error>
     where
         W: Write,
@@ -306,6 +307,7 @@ where
 
     /// Self-diagnostics: validate that `self` points to a well-formed
     /// radix-tree whose contents is equivalent to `contents`.
+    #[allow(unused)]
     fn validate(&mut self, contents: &BTreeMap<TS, Box<A>>, combine: &dyn Fn(&mut A, &A)) {
         let mut contents_clone = BTreeMap::new();
 

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -137,6 +137,7 @@ pub type OrdPartitionedTreeAggregateFactories<TS, V, Z, Acc> = PartitionedTreeAg
 >;
 
 /// Cursor over partitioned radix tree.
+#[allow(unused)]
 pub trait PartitionedRadixTreeCursor<PK, TS, A>:
     Cursor<PK, DynPair<DynPrefix<TS>, DynTreeNode<TS, A>>, (), DynZWeight> + Sized
 where

--- a/crates/dbsp/src/utils/consolidation/utils.rs
+++ b/crates/dbsp/src/utils/consolidation/utils.rs
@@ -423,6 +423,7 @@ pub(super) trait Payload<'a> {
 
     unsafe fn copy_payload(src: Self::Ptr, dest: Self::Ptr, count: usize);
 
+    #[allow(dead_code)]
     unsafe fn copy_payload_nonoverlapping(src: Self::Ptr, dest: Self::Ptr, count: usize);
 
     unsafe fn drop_payload_in_place(payload: Self::Ptr);
@@ -539,10 +540,12 @@ where
 pub(super) trait PayloadLen: Copy + 'static {
     fn equal_to(&self, len: usize) -> bool;
 
+    #[allow(dead_code)]
     fn is_empty(&self) -> bool {
         self.equal_to(0)
     }
 
+    #[allow(dead_code)]
     fn from_usize(len: usize) -> Self;
 }
 
@@ -579,10 +582,12 @@ where
 }
 
 pub(super) trait PayloadPtr: Copy {
+    #[allow(dead_code)]
     unsafe fn offset(self, count: isize) -> Self;
 
     unsafe fn add(self, count: usize) -> Self;
 
+    #[allow(dead_code)]
     unsafe fn sub(self, count: usize) -> Self;
 }
 

--- a/crates/pipeline_manager/src/db/pipeline.rs
+++ b/crates/pipeline_manager/src/db/pipeline.rs
@@ -1221,6 +1221,7 @@ pub(crate) async fn set_pipeline_desired_status(
 }
 
 /// Returns true if the connector of a given name is an input connector.
+#[allow(dead_code)]
 pub(crate) async fn attached_connector_is_input(
     db: &ProjectDB,
     tenant_id: TenantId,

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -34,6 +34,7 @@ pub(crate) trait Storage {
     /// # Note
     /// This should be called after the SQL compilation succeeded, e.g., in the
     /// same transaction that sets status to  [`ProgramStatus::CompilingRust`].
+    #[allow(dead_code)]
     async fn set_program_schema(
         &self,
         tenant_id: TenantId,
@@ -62,6 +63,7 @@ pub(crate) trait Storage {
     /// database matches `expected_version`. Setting the status to
     /// `ProgramStatus::Pending` resets the schema and is used to queue the
     /// program for compilation.
+    #[allow(dead_code)]
     async fn set_program_status_guarded(
         &self,
         tenant_id: TenantId,
@@ -199,6 +201,7 @@ pub(crate) trait Storage {
     ) -> Result<Version, DBError>;
 
     /// Get input/output status for an attached connector.
+    #[allow(dead_code)]
     async fn attached_connector_is_input(
         &self,
         tenant_id: TenantId,


### PR DESCRIPTION
I guess it's better at finding code that isn't used.

Is this a user-visible change (yes/no): no