### PR TITLE
Support for Kafka message headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Kafka] Allow specifying Kafka headers as part of output Kafka connector
+  config
+  ([#1718](https://github.com/feldera/feldera/pull/1718))
 - [SQL] Support for `LEAD`/`LAG` window aggregates
   ([#1706](https://github.com/feldera/feldera/pull/1706))
 - [SQL] Support for `WATERMARK` table column annotations

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -935,7 +935,7 @@ mod test_with_kafka {
         ]);
 
         // Create buffer consumer
-        let buffer_consumer = BufferConsumer::new("test_server_output_topic", "csv", "");
+        let buffer_consumer = BufferConsumer::new("test_server_output_topic", "csv", "", None);
 
         // Config string
         let config_str = r#"

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -197,7 +197,7 @@ outputs:
         .unwrap();
     assert!(controller.is_fault_tolerant());
 
-    let buffer_consumer = BufferConsumer::new(&output_topic, format, format_config);
+    let buffer_consumer = BufferConsumer::new(&output_topic, format, format_config, None);
 
     info!("{test_name}: Sending inputs");
     let producer = TestProducer::new();

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::Error as AnyError;
-use pipeline_types::transport::kafka::KafkaLogLevel;
+use parquet::data_type::AsBytes;
+use pipeline_types::transport::kafka::{KafkaHeader, KafkaLogLevel};
+use rdkafka::message::{Header, OwnedHeaders};
 use rdkafka::{
     client::{Client as KafkaClient, ClientContext},
     config::RDKafkaLogLevel,
@@ -165,4 +167,17 @@ impl DeferredLogging {
             }
         }
     }
+}
+
+pub fn build_headers(headers: &Vec<KafkaHeader>) -> OwnedHeaders {
+    let mut result = OwnedHeaders::new_with_capacity(headers.len());
+
+    for header in headers {
+        result = result.insert(Header {
+            key: &header.key,
+            value: header.value.as_ref().map(|val| val.0.as_bytes()),
+        });
+    }
+
+    result
 }

--- a/crates/pipeline-types/src/serde_with_context/serialize.rs
+++ b/crates/pipeline-types/src/serde_with_context/serialize.rs
@@ -364,8 +364,6 @@ macro_rules! serialize_table_record {
 #[cfg(test)]
 mod test {
     use lazy_static::lazy_static;
-    use rust_decimal::Decimal;
-    use rust_decimal_macros::dec;
     use serde::{Deserialize, Serialize};
 
     use crate::serde_with_context::{SerializationContext, SerializeWithContext, SqlSerdeConfig};
@@ -402,13 +400,10 @@ mod test {
         cc_num: u64,
         #[allow(non_snake_case)]
         first: Option<String>,
-        #[allow(non_snake_case)]
-        dec: Decimal,
     }
     serialize_struct!(Struct2()[3] {
         cc_num["cc_num"]: u64,
-        first["FIRST"]: Option<String>,
-        dec["DEC"]: Decimal
+        first["FIRST"]: Option<String>
     });
 
     #[test]
@@ -417,30 +412,27 @@ mod test {
             serialize_json_with_default_context(&Struct2 {
                 cc_num: 100,
                 first: None,
-                dec: dec!(0.123),
             })
             .unwrap(),
-            r#"{"cc_num":100,"FIRST":null,"DEC":"0.123"}"#
+            r#"{"cc_num":100,"FIRST":null}"#
         );
 
         assert_eq!(
             serialize_json_with_default_context(&Struct2 {
                 cc_num: 100,
                 first: None,
-                dec: dec!(-1.40),
             })
             .unwrap(),
-            r#"{"cc_num":100,"FIRST":null,"DEC":"-1.40"}"#
+            r#"{"cc_num":100,"FIRST":null}"#
         );
 
         assert_eq!(
             serialize_json_with_default_context(&Struct2 {
                 cc_num: 100,
                 first: Some("foo".to_string()),
-                dec: dec!(1e20),
             })
             .unwrap(),
-            r#"{"cc_num":100,"FIRST":"foo","DEC":"100000000000000000000"}"#
+            r#"{"cc_num":100,"FIRST":"foo"}"#
         );
     }
 

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -200,6 +200,8 @@ request is rejected."
         pipeline_types::transport::url::UrlInputConfig,
         pipeline_types::transport::kafka::KafkaInputConfig,
         pipeline_types::transport::kafka::KafkaInputFtConfig,
+        pipeline_types::transport::kafka::KafkaHeader,
+        pipeline_types::transport::kafka::KafkaHeaderValue,
         pipeline_types::transport::kafka::KafkaOutputConfig,
         pipeline_types::transport::kafka::KafkaOutputFtConfig,
         pipeline_types::transport::kafka::KafkaLogLevel,

--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -257,7 +257,7 @@ impl CompilationProfile {
         match self {
             CompilationProfile::Dev => "debug",
             CompilationProfile::Unoptimized => "unoptimized",
-            CompilationProfile::Optimized => "release",
+            CompilationProfile::Optimized => "optimized",
         }
     }
 }

--- a/demo/project_demo00-SecOps/run.py
+++ b/demo/project_demo00-SecOps/run.py
@@ -36,7 +36,6 @@ def main():
 
 
 def prepare_feldera(api_url, pipeline_to_redpanda_server, pipeline_to_schema_registry):
-
     # Create program
     program_name = "demo-sec-ops-program"
     program_sql = open(PROJECT_SQL).read()
@@ -62,7 +61,7 @@ def prepare_feldera(api_url, pipeline_to_redpanda_server, pipeline_to_schema_reg
     # Connectors
     connectors = []
     for (connector_name, stream, topic_topics, is_input) in [
-        ("secops_pipeline", 'PIPELINE',  ["secops_pipeline"], True),
+        ("secops_pipeline", 'PIPELINE', ["secops_pipeline"], True),
         ("secops_pipeline_sources", 'PIPELINE_SOURCES', ["secops_pipeline_sources"], True),
         ("secops_artifact", 'ARTIFACT', ["secops_artifact"], True),
         ("secops_vulnerability", 'VULNERABILITY', ["secops_vulnerability"], True),
@@ -135,7 +134,9 @@ def prepare_feldera(api_url, pipeline_to_redpanda_server, pipeline_to_schema_reg
                 "name": "kafka_output",
                 "config": {
                     "bootstrap.servers": pipeline_to_redpanda_server,
-                    "topic": "secops_vulnerability_stats_avro"
+                    "topic": "secops_vulnerability_stats_avro",
+                    "headers": [{"key": "header1", "value": "this is a string"},
+                                {"key": "header2", "value": list(b'byte array')}]
                 }
             }
         }
@@ -146,7 +147,6 @@ def prepare_feldera(api_url, pipeline_to_redpanda_server, pipeline_to_schema_reg
         "name": "secops_vulnerability_stats_avro",
         "relation_name": "k8scluster_vulnerability_stats"
     })
-
 
     # Create pipeline
     pipeline_name = "demo-sec-ops-pipeline"

--- a/openapi.json
+++ b/openapi.json
@@ -856,6 +856,7 @@
                       "transport": {
                         "config": {
                           "fault_tolerance": null,
+                          "headers": [],
                           "initialization_timeout_secs": 60,
                           "kafka_service": null,
                           "log_level": null,
@@ -3635,6 +3636,31 @@
           "raw"
         ]
       },
+      "KafkaHeader": {
+        "type": "object",
+        "description": "Kafka message header.",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KafkaHeaderValue"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "KafkaHeaderValue": {
+        "type": "string",
+        "format": "binary",
+        "description": "Kafka header value encoded as a UTF-8 string or a byte array."
+      },
       "KafkaInputConfig": {
         "type": "object",
         "description": "Configuration for reading data from Kafka topics with `InputTransport`.",
@@ -3754,6 +3780,13 @@
               }
             ],
             "nullable": true
+          },
+          "headers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KafkaHeader"
+            },
+            "description": "Kafka headers to be added to each message produced by this connector."
           },
           "initialization_timeout_secs": {
             "type": "integer",


### PR DESCRIPTION
Added `headers` field to Kafka output connector config to specify a list
of headers to be added to each message.

Kafka headers are a list of key-value pairs.  Keys are strings.  The
same key can occur multiple times, therefore the ordering is important.
The value component of the header is an optional byte array.  For
convenience, we allow specifying it as an actual array of bytes in JSON
(`[1,2,3,4,5]`) or as a UTF8-encoded string ("foobar").  Here is an
example Kafka connector config with headers that I added to the SecOps
demo:

```
"config": {
    "format": {
        "name": "avro",
        "config": {
            "schema": schema,
            "registry_urls": [pipeline_to_schema_registry],
        }
    },
    "transport": {
        "name": "kafka_output",
        "config": {
            "bootstrap.servers": pipeline_to_redpanda_server,
            "topic": "secops_vulnerability_stats_avro",
            "headers": [{"key": "header1", "value": "this is a string"},
                        {"key": "header2", "value": list(b'byte array')}]
        }
    }
}
```

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
