### PR TITLE
docs: improve high-level structure for the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CLI.
   ([#1710](https://github.com/feldera/feldera/pull/1710))
 
+### Changed
+
+- [Docs] Re-organize documentation sections
+  ([#1734](https://github.com/feldera/feldera/pull/1734))
+
 ## [0.15.0] - 2024-04-30
 
 ### Added

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,4 +1,4 @@
-# Docker Compose Install
+# Docker Install
 
 These instructions explain how to run the Feldera Platform on a single machine
 in a configuration suitable for demos, development, and testing.  For production
@@ -51,10 +51,10 @@ You also need `curl` and a web browser such as Chrome or Firefox.
    how to set up the demo's containers:
 
    ```bash
-   curl -O https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml
+   curl -LO https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml
    ```
 
-   You only need to do the first time.
+   You only need to do this the first time.
 
    :::caution
 
@@ -123,7 +123,7 @@ restart it a few different ways:
 ## Troubleshooting
 
 If the demo fails to start after it previously ran successfully, then
-it might not have fully shut down from the previous run.  To ensure
+it might not have fully shut down from the previous run. To ensure
 that it is fully shut down, run the following command, and then try
 starting it again:
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -15,8 +15,33 @@
 const sidebars = {
   docsSidebar: [
     'what-is-feldera',
-    'demo/demo',
-    'tour/tour',
+    {
+      type: 'category',
+      label: 'Get started',
+      items: [
+        'intro',
+        'demo/demo',
+        'tour/tour',
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Deploy',
+      link: { type: 'doc', id: 'cloud/index' },
+      items: [
+        'intro',
+        {
+          type: 'category',
+          label: 'Bring Your Own Cloud',
+          link: { type: 'doc', id: 'cloud/index' },
+          items: [
+            'cloud/assets',
+            'cloud/deployment',
+            'cloud/secret-management'
+          ]
+        },
+      ]
+    },
     {
       type: 'category',
       label: 'Tutorials',
@@ -78,48 +103,46 @@ const sidebars = {
           }
       ]
     },
+    'troubleshooting/index',
     {
       type: 'category',
-      label: 'SQL Reference',
-      link: { type: 'doc', id: 'sql/intro' },
+      label: 'Reference',
       items: [
-        'sql/grammar',
-        'sql/identifiers',
-        'sql/operators',
-        'sql/aggregates',
-        'sql/casts',
-        'sql/types',
-        'sql/boolean',
-        'sql/comparisons',
-        'sql/integer',
-        'sql/float',
-        'sql/decimal',
-        'sql/string',
-        'sql/binary',
-        'sql/array',
-        'sql/datetime',
-        'sql/streaming',
-        'sql/udf'
-      ]
+            {
+              type: 'category',
+              label: 'SQL Reference',
+              link: { type: 'doc', id: 'sql/intro' },
+              items: [
+                'sql/grammar',
+                'sql/identifiers',
+                'sql/operators',
+                'sql/aggregates',
+                'sql/casts',
+                'sql/types',
+                'sql/boolean',
+                'sql/comparisons',
+                'sql/integer',
+                'sql/float',
+                'sql/decimal',
+                'sql/string',
+                'sql/binary',
+                'sql/array',
+                'sql/datetime',
+                'sql/streaming',
+                'sql/udf'
+              ]
+            },
+            'api/rest', 
+            'api/json', 
+            'api/parquet', 
+            'api/csv', 
+            'api/rust']
     },
     {
       type: 'category',
-      label: 'API Reference',
-      items: ['api/rest', 'api/json', 'api/parquet', 'api/csv', 'api/rust']
+      label: 'Learn',
+      items: ['papers', 'videos']
     },
-    {
-      type: 'category',
-      label: 'Bring Your Own Cloud',
-      link: { type: 'doc', id: 'cloud/index' },
-      items: [
-        'cloud/assets',
-        'cloud/deployment',
-        'cloud/secret-management'
-      ]
-    },
-    'intro',
-    'papers',
-    'videos',
     {
       type: 'category',
       label: 'Contributing',

--- a/docs/troubleshooting/index.mdx
+++ b/docs/troubleshooting/index.mdx
@@ -1,0 +1,7 @@
+# Troubleshooting
+
+:::caution Under Construction
+
+This section is under construction.
+
+:::


### PR DESCRIPTION
Signed-off-by: Lalith Suresh <suresh.lalith@gmail.com>

I'm trying to reorganize the top-level structure. Unfortunately the current content 
makes it hard to change a few key things:
* Demo/tour is somewhat redundant with the tutorial. They needn't go into separate sections.
* The Demo/tour is locked to working only with the docker install, which means the docker
  installation instructions should precede it in the "Get started" section.
* Ideally, the deployment form factors should show up one top-level section. The rest of the
  documentation (demos, tutorials etc) should have a context button that switches instructions
  depending on whether the user is running against the Docker or Kubernetes FFs.
* The Reference section could use some groupings (e.g., all formats in one) and a better title.
* The Learn section could use some love. It's pretty dated.

Current structure with this PR:

![image](https://github.com/feldera/feldera/assets/434651/93a2b4c9-f68e-474b-9da9-be65f356c528)

Expanded:
![image](https://github.com/feldera/feldera/assets/434651/8070cffd-d10f-4697-971a-477ccbfe680c)


Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
