### PR TITLE
pipeline_manager: `--demos` takes an HTTPS URL.

### DIFF
--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -172,7 +172,7 @@ pub struct ApiServerConfig {
     /// can use this option to set up environment-specific demos for users
     /// (e.g., ones that connect to an internal data source).
     #[serde(default)]
-    #[arg(long)]
+    #[arg(long, value_name = "HTTPS_URL")]
     pub demos: Vec<String>,
 }
 


### PR DESCRIPTION
Is this a user-visible change (yes/no): no