### PR TITLE
Delta table input connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [adapters] Delta Lake input adapter.
+  ([#1743](https://github.com/feldera/feldera/pull/1743))
 - [SQL] Support for user-defined functions implemented in SQL
   ([#1714](https://github.com/feldera/feldera/pull/1714))
 - [Kafka] Allow specifying Kafka headers as part of output Kafka connector

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ dependencies = [
  "actix-router",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
+checksum = "9f2776ead772134d55b62dd45e59a79e21612d85d0af729b8b7d3967d601a62a"
 dependencies = [
  "concurrent-queue",
  "event-listener 5.3.0",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
+checksum = "9c90a406b4495d129f00461241616194cb8a032c8d1c53c657f0961d5f8e0498"
 dependencies = [
  "bzip2",
  "flate2",
@@ -903,7 +903,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.2.1",
+ "async-channel 2.3.0",
  "async-executor",
  "async-io 2.3.2",
  "async-lock 3.3.0",
@@ -1065,7 +1065,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1082,7 +1082,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ checksum = "62f7df18977a1ee03650ee4b31b4aefed6d56bac188760b6e37610400fe8d4bb"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1225,22 +1225,22 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaa0be6ee7d90b775ae6ccb6d2ba182b91219ec2001f92338773a094246af1d"
+checksum = "40ddbfb5db93d62521f47b3f223da0884a2f02741ff54cb9cda192a0e73ba08b"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime",
- "aws-sdk-sso 1.23.0",
+ "aws-sdk-sso 1.25.0",
  "aws-sdk-ssooidc",
- "aws-sdk-sts 1.23.0",
+ "aws-sdk-sts 1.25.0",
  "aws-smithy-async 1.2.1",
  "aws-smithy-http 0.60.8",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
- "aws-types 1.2.0",
+ "aws-smithy-types 1.1.9",
+ "aws-types 1.2.1",
  "bytes",
  "fastrand 2.1.0",
  "hex",
@@ -1276,7 +1276,7 @@ checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "zeroize",
 ]
 
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785da4a15e7b166b505fd577e4560c7a7cd8fbdf842eb1336cbcbf8944ce56f1"
+checksum = "75588e7ee5e8496eed939adac2035a6dbab9f7eb2acdd9ab2d31856dab6f3955"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-sigv4 1.2.1",
@@ -1325,8 +1325,8 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
- "aws-types 1.2.0",
+ "aws-smithy-types 1.1.9",
+ "aws-types 1.2.1",
  "bytes",
  "fastrand 2.1.0",
  "http 0.2.12",
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932b8899ac8785b4920098eae75a24d3b881817d6b8e74bd633ee4922fcc890e"
+checksum = "e1da0290e57949a362d3f106285bb539e8a282e6c1b0053f6e02b3fc14f2d730"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime",
@@ -1375,8 +1375,8 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
- "aws-types 1.2.0",
+ "aws-smithy-types 1.1.9",
+ "aws-types 1.2.1",
  "bytes",
  "fastrand 2.1.0",
  "http 0.2.12",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.26.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc5ce518d4b8d16e0408de7bdf1b3097cec61a7daa979750a208f8d9934386d"
+checksum = "966646a69665bb0427460d78747204317f6639bdf5ec61305c4c5195af3dc086"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types 1.2.0",
@@ -1402,9 +1402,9 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.2.0",
+ "aws-types 1.2.1",
  "bytes",
  "fastrand 2.1.0",
  "hex",
@@ -1447,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93157de9fa13c2c9c444cb07a925dbacfea7ef5deb55b578ff3cb6013109fe8e"
+checksum = "fef2d9ca2b43051224ed326ed9960a85e277b7d554a2cd0397e57c0553d86e64"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime",
@@ -1458,8 +1458,8 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
- "aws-types 1.2.0",
+ "aws-smithy-types 1.1.9",
+ "aws-types 1.2.1",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.23.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d969918da100c459a97d00f17d484d7b2fcb276f1eb6d63ef659209355d06188"
+checksum = "c869d1f5c4ee7437b79c3c1664ddbf7a60231e893960cf82b2b299a5ccf2cc5d"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime",
@@ -1480,8 +1480,8 @@ dependencies = [
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
- "aws-types 1.2.0",
+ "aws-smithy-types 1.1.9",
+ "aws-types 1.2.1",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08cc4fc825d57299cb9762990473851614941a3430bb93e43242399983722baf"
+checksum = "9e2b4a632a59e4fab7abf1db0d94a3136ad7871aba46bebd1fdb95c7054afcdb"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-runtime",
@@ -1529,9 +1529,9 @@ dependencies = [
  "aws-smithy-query 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.2.0",
+ "aws-types 1.2.1",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1581,7 +1581,7 @@ dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
@@ -1630,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fa43bc04a6b2441968faeab56e68da3812f978a670a5db32accbdcafddd12f"
 dependencies = [
  "aws-smithy-http 0.60.8",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -1674,7 +1674,7 @@ version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "crc32fast",
 ]
@@ -1709,7 +1709,7 @@ checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1753,7 +1753,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
 ]
 
 [[package]]
@@ -1772,20 +1772,20 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf64e73ef8d4dac6c933230d56d136b75b252edcf82ed36e37d603090cd7348"
+checksum = "c9ac79e9f3a4d576f3cd4a470a0275b138d9e7b11b1cd514a6858ae0a79dd5bb"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "fastrand 2.1.0",
  "h2",
@@ -1804,12 +1804,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c19fdae6e3d5ac9cd01f2d6e6c359c5f5a3e028c2d148a8f5b90bf3399a18a7"
+checksum = "04ec42c2f5c0e7796a2848dde4d9f3bf8ce12ccbb3d5aa40c52fa0cdd61a1c47"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe14dceea1e70101d38fbf2a99e6a34159477c0fb95e68e05c66bd7ae4c3729"
+checksum = "baf98d97bba6ddaba180f1b1147e202d8fe04940403a95a3f826c790f931bbd1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1894,14 +1894,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a43b56df2c529fe44cb4d92bd64d0479883fb9608ff62daede4df5405381814"
+checksum = "a807d90cd50a969b3d95e4e7ad1491fcae13c6e83948d8728363ecc09d66343a"
 dependencies = [
  "aws-credential-types 1.2.0",
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "http 0.2.12",
  "rustc_version",
  "tracing",
@@ -2085,7 +2085,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
- "async-channel 2.2.1",
+ "async-channel 2.3.0",
  "async-lock 3.3.0",
  "async-task",
  "futures-io",
@@ -2113,7 +2113,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
  "syn_derive",
 ]
 
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -2195,7 +2195,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2517,7 +2517,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
  "strsim 0.10.0",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2989,7 +2989,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3398,7 +3398,7 @@ dependencies = [
  "async-trait",
  "awc",
  "aws-sdk-s3",
- "aws-types 1.2.0",
+ "aws-types 1.2.1",
  "bstr",
  "bytes",
  "bytestring",
@@ -3453,6 +3453,7 @@ dependencies = [
  "tempfile",
  "test_bin",
  "tokio",
+ "url",
  "utoipa",
  "uuid",
  "webpki-roots 0.25.4",
@@ -3548,10 +3549,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c15dda219ed925c28e2387712f9a77ed7253a80b53fce59849067bc0918eb2"
 dependencies = [
  "async-trait",
- "aws-config 1.3.0",
+ "aws-config 1.4.0",
  "aws-credential-types 1.2.0",
  "aws-sdk-dynamodb",
- "aws-sdk-sts 1.23.0",
+ "aws-sdk-sts 1.25.0",
  "aws-smithy-runtime-api",
  "backoff",
  "bytes",
@@ -3902,7 +3903,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3958,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -4297,7 +4298,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5056,9 +5057,9 @@ dependencies = [
 
 [[package]]
 name = "krb5-src"
-version = "0.3.2+1.19.2"
+version = "0.3.3+1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cd3b7e7735d48bc3793837041294f2eb747bd0f63bbc081e89972abb9e48fb"
+checksum = "2f5dae230b7334f85b6a968d8b0549c39e3b6ba11e973d62f4c81bb37cdf73af"
 dependencies = [
  "duct",
 ]
@@ -5453,7 +5454,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5482,7 +5483,7 @@ source = "git+https://github.com/gz/monoio.git?rev=9303e02#9303e024249863234be91
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5565,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -5589,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -5621,7 +5622,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5656,11 +5657,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -5788,7 +5788,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -6098,9 +6098,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.2.6",
@@ -6190,7 +6190,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -6284,9 +6284,9 @@ dependencies = [
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
 dependencies = [
  "atomic-waker",
  "fastrand 2.1.0",
@@ -6489,7 +6489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2 1.0.82",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -6598,7 +6598,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -6679,21 +6679,21 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.61",
+ "syn 2.0.63",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+checksum = "9554e3ab233f0a932403704f1a1d08c30d5ccd931adfdfa1e8b5a19b52c1d55a"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7066,7 +7066,7 @@ dependencies = [
  "quote 1.0.36",
  "refinery-core",
  "regex",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7317,9 +7317,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78f46d0066053d16d4ca7b898e9343bc3530f71c61d5ad84cd404ada068745"
+checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -7328,23 +7328,23 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8"
+checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.61",
+ "syn 2.0.63",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581"
+checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
 dependencies = [
  "sha2",
  "walkdir",
@@ -7500,9 +7500,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-fork"
@@ -7533,9 +7533,9 @@ dependencies = [
 
 [[package]]
 name = "sasl2-sys"
-version = "0.1.20+2.1.28"
+version = "0.1.22+2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e645bd98535fc8fd251c43ba7c7c1f9be1e0369c99b6a5ea719052a773e655c"
+checksum = "05f2a7f7efd9fc98b3a9033272df10709f5ee3fa0eabbd61a527a3a1ed6bd3c6"
 dependencies = [
  "cc",
  "duct",
@@ -7641,9 +7641,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "serde_arrow"
 version = "0.11.2"
-source = "git+https://github.com/gz/serde_arrow.git?rev=4ebd888#4ebd8887f9428e813404556253f1a5d2d6a4ea8e"
+source = "git+https://github.com/gz/serde_arrow.git?rev=c9b5cff#c9b5cffbbc7304e0c3c4eb1d2770001bfa05a082"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -7665,20 +7665,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -7744,7 +7744,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7782,7 +7782,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8056,7 +8056,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8237,7 +8237,7 @@ dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
  "rustversion",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8250,7 +8250,7 @@ dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
  "rustversion",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8306,9 +8306,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
@@ -8324,7 +8324,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8498,7 +8498,7 @@ checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8614,7 +8614,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8831,7 +8831,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -8901,7 +8901,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -9055,7 +9055,7 @@ dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
  "regex",
- "syn 2.0.61",
+ "syn 2.0.63",
  "uuid",
 ]
 
@@ -9133,9 +9133,9 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -9195,7 +9195,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -9229,7 +9229,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9608,7 +9608,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.36",
- "syn 2.0.61",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -71,9 +71,8 @@ tempfile = "3.10.0"
 async-trait = "0.1"
 parquet = { version = "51.0.0", features = ["json"] }
 arrow = { version = "51.0.0", features = ["chrono-tz"] }
-#serde_arrow = { version = "0.10.1-rc.1", features = ["arrow-50"] }
-#serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arrow-50"], rev = "2c3a1ad" }
-serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arrow-51"], rev = "4ebd888" }
+serde_arrow = { git = "https://github.com/gz/serde_arrow.git", features = ["arrow-51"], rev = "c9b5cff" }
+# serde_arrow = { path = "../../../serde_arrow/serde_arrow", features = ["arrow-51"] }
 bytes = "1.5.0"
 # `datafusion` must be enabled for the writer to implement the `Invariant` feature.
 deltalake = { version = "0.17.3", features = ["datafusion", "s3", "gcs", "azure"], optional = true }
@@ -81,6 +80,7 @@ apache-avro = { version = "0.16.0", optional = true }
 schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"], optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 metrics-exporter-tcp = { version = "0.9.0" }
+url = "2.5.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 psutil = "3.2.2"

--- a/crates/adapters/src/controller/error.rs
+++ b/crates/adapters/src/controller/error.rs
@@ -119,6 +119,11 @@ pub enum ConfigError {
         endpoint_name: String,
         error: String,
     },
+
+    InvalidTransportConfig {
+        endpoint_name: String,
+        error: String,
+    },
 }
 
 impl StdError for ConfigError {}
@@ -145,6 +150,7 @@ impl DetailedError for ConfigError {
             Self::OutputFormatNotSpecified { .. } => Cow::from("OutputFormatNotSpecified"),
             Self::InvalidEncoderConfig { .. } => Cow::from("InvalidEncoderConfig"),
             Self::InvalidParserConfig { .. } => Cow::from("InvalidParserConfig"),
+            Self::InvalidTransportConfig { .. } => Cow::from("InvalidTransportConfig"),
         }
     }
 }
@@ -272,6 +278,15 @@ impl Display for ConfigError {
                 write!(
                     f,
                     "invalid format configuration for input endpoint '{endpoint_name}': {error}"
+                )
+            }
+            Self::InvalidTransportConfig {
+                endpoint_name,
+                error,
+            } => {
+                write!(
+                    f,
+                    "invalid transport configuration for endpoint '{endpoint_name}': {error}"
                 )
             }
         }
@@ -411,6 +426,13 @@ impl ConfigError {
 
     pub fn invalid_parser_configuration(endpoint_name: &str, error: &str) -> Self {
         Self::InvalidParserConfig {
+            endpoint_name: endpoint_name.to_string(),
+            error: error.to_string(),
+        }
+    }
+
+    pub fn invalid_transport_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::InvalidTransportConfig {
             endpoint_name: endpoint_name.to_string(),
             error: error.to_string(),
         }
@@ -840,6 +862,12 @@ impl ControllerError {
     pub fn invalid_parser_configuration(endpoint_name: &str, error: &str) -> Self {
         Self::Config {
             config_error: ConfigError::invalid_parser_configuration(endpoint_name, error),
+        }
+    }
+
+    pub fn invalid_transport_configuration(endpoint_name: &str, error: &str) -> Self {
+        Self::Config {
+            config_error: ConfigError::invalid_transport_configuration(endpoint_name, error),
         }
     }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -30,7 +30,7 @@
 //! by the circuit, but the counter shows that 10 records are still
 //! pending.
 
-use super::{EndpointId, InputEndpointConfig, OutputEndpointConfig, RuntimeConfig};
+use super::{EndpointId, InputEndpointConfig, OutputEndpointConfig};
 use crate::{
     transport::{AtomicStep, Step},
     PipelineState,
@@ -354,7 +354,6 @@ impl ControllerStatus {
         endpoint_id: EndpointId,
         num_bytes: usize,
         num_records: usize,
-        global_config: &RuntimeConfig,
         circuit_thread_unparker: &Unparker,
         backpressure_thread_unparker: &Unparker,
     ) {
@@ -366,8 +365,8 @@ impl ControllerStatus {
         let old = self.global_metrics.input_batch(num_records);
 
         if old == 0
-            || (old <= global_config.min_batch_size_records
-                && old + num_records > global_config.min_batch_size_records)
+            || (old <= self.pipeline_config.global.min_batch_size_records
+                && old + num_records > self.pipeline_config.global.min_batch_size_records)
         {
             circuit_thread_unparker.unpark();
         }

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -382,11 +382,6 @@ mod test {
             })
             .collect::<Vec<_>>();
 
-        trace!(
-            "output: {}",
-            std::str::from_utf8(&consumer_data.lock().unwrap().concat()).unwrap()
-        );
-
         let mut actual_output = Vec::new();
         for avro_datum in consumer_data.lock().unwrap().iter() {
             let avro_value =

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -46,11 +46,7 @@ pub fn load_parquet_file<T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
 #[test]
 fn rel_to_schema() {
     use super::relation_to_parquet_schema;
-    relation_to_parquet_schema(
-        &Relation::new("TestStruct2", false, TestStruct2::schema()),
-        false,
-    )
-    .expect("Can convert");
+    relation_to_parquet_schema(&TestStruct2::schema(), false).expect("Can convert");
 }
 
 #[test]

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1,0 +1,689 @@
+use crate::catalog::{ArrowStream, InputCollectionHandle};
+use crate::controller::{ControllerInner, EndpointId};
+use crate::integrated::delta_table::{delta_input_serde_config, register_storage_handlers};
+use crate::transport::{InputEndpoint, IntegratedInputEndpoint, Step};
+use crate::{
+    ControllerError, InputConsumer, InputReader, ParseError, PipelineState, RecordFormat,
+    TransportInputEndpoint,
+};
+use anyhow::{anyhow, Result as AnyResult};
+use dbsp::InputHandle;
+use deltalake::datafusion::common::Column;
+use deltalake::datafusion::dataframe::DataFrame;
+use deltalake::datafusion::execution::context::SQLOptions;
+use deltalake::datafusion::prelude::{Expr, ParquetReadOptions, SessionContext};
+use deltalake::datafusion::sql::sqlparser::dialect::GenericDialect;
+use deltalake::datafusion::sql::sqlparser::keywords::Keyword::SQL;
+use deltalake::datafusion::sql::sqlparser::parser::Parser;
+use deltalake::datafusion::sql::sqlparser::test_utils::table;
+use deltalake::delta_datafusion::cdf::FileAction;
+use deltalake::kernel::Action;
+use deltalake::kernel::Error::Parse;
+use deltalake::operations::create::CreateBuilder;
+use deltalake::protocol::SaveMode;
+use deltalake::table::PeekCommit;
+use deltalake::{datafusion, DeltaTable, DeltaTableBuilder, Path};
+use env_logger::builder;
+use futures_util::StreamExt;
+use log::{debug, error, info, trace};
+use pipeline_types::config::{InputEndpointConfig, TransportConfigVariant};
+use pipeline_types::format::json::JsonFlavor;
+use pipeline_types::program_schema::Relation;
+use pipeline_types::transport::delta_table::{DeltaTableIngestMode, DeltaTableReaderConfig};
+use pipeline_types::transport::s3::{ReadStrategy, S3InputConfig};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt::format;
+use std::str::FromStr;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+use tokio::select;
+use tokio::sync::mpsc;
+use tokio::sync::watch::{channel, Receiver, Sender};
+use tokio::time::sleep;
+use url::Url;
+use utoipa::ToSchema;
+
+/// Polling interval when following a delta table.
+const POLL_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Polling delay before retrying an unsuccessful read from a delta log.
+const RETRY_INTERVAL: Duration = Duration::from_millis(2000);
+
+/// Integrated input connector that reads from a delta table.
+pub struct DeltaTableInputEndpoint {
+    inner: Arc<DeltaTableInputEndpointInner>,
+}
+
+impl DeltaTableInputEndpoint {
+    pub fn new(
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        config: &DeltaTableReaderConfig,
+        controller: Weak<ControllerInner>,
+    ) -> Self {
+        register_storage_handlers();
+
+        Self {
+            inner: Arc::new(DeltaTableInputEndpointInner::new(
+                endpoint_id,
+                endpoint_name,
+                config.clone(),
+                controller,
+            )),
+        }
+    }
+}
+
+impl InputEndpoint for DeltaTableInputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}
+impl IntegratedInputEndpoint for DeltaTableInputEndpoint {
+    fn open(
+        &self,
+        input_handle: &InputCollectionHandle,
+        _start_step: Step,
+    ) -> AnyResult<Box<dyn InputReader>> {
+        Ok(Box::new(DeltaTableInputReader::new(
+            &self.inner,
+            input_handle,
+        )?))
+    }
+}
+
+struct DeltaTableInputReader {
+    sender: Sender<PipelineState>,
+}
+
+impl DeltaTableInputReader {
+    fn new(
+        endpoint: &Arc<DeltaTableInputEndpointInner>,
+        input_handle: &InputCollectionHandle,
+    ) -> AnyResult<Self> {
+        let (sender, receiver) = channel(PipelineState::Paused);
+        let endpoint_clone = endpoint.clone();
+        let receiver_clone = receiver.clone();
+
+        // Used to communicate the status of connector initialization.
+        let (init_status_sender, mut init_status_receiver) =
+            mpsc::channel::<Result<(), ControllerError>>(1);
+
+        let input_stream = input_handle
+            .handle
+            .configure_arrow_deserializer(delta_input_serde_config())?;
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("Could not create tokio runtime");
+            rt.block_on(async {
+                let _ = Self::worker_task(
+                    endpoint_clone,
+                    input_stream,
+                    receiver_clone,
+                    init_status_sender,
+                )
+                .await;
+            })
+        });
+
+        init_status_receiver.blocking_recv().ok_or_else(|| {
+            ControllerError::input_transport_error(
+                &endpoint.endpoint_name,
+                true,
+                anyhow!("worker thread terminated unexpectedly during initialization"),
+            )
+        })??;
+
+        Ok(Self { sender })
+    }
+
+    async fn worker_task(
+        endpoint: Arc<DeltaTableInputEndpointInner>,
+        input_stream: Box<dyn ArrowStream>,
+        receiver: Receiver<PipelineState>,
+        init_status_sender: mpsc::Sender<Result<(), ControllerError>>,
+    ) {
+        let mut receiver_clone = receiver.clone();
+        select! {
+            _ = Self::worker_task_inner(endpoint.clone(), input_stream, receiver, init_status_sender) => {
+                debug!("delta_table {}: worker task terminated",
+                    &endpoint.endpoint_name,
+                );
+            }
+            _ = receiver_clone.wait_for(|state| state == &PipelineState::Terminated) => {
+                debug!("delta_table {}: received termination command; worker task canceled",
+                    &endpoint.endpoint_name,
+                );
+            }
+        }
+    }
+
+    async fn worker_task_inner(
+        endpoint: Arc<DeltaTableInputEndpointInner>,
+        mut input_stream: Box<dyn ArrowStream>,
+        mut receiver: Receiver<PipelineState>,
+        init_status_sender: mpsc::Sender<Result<(), ControllerError>>,
+    ) {
+        let table = match endpoint.open_table().await {
+            Err(e) => {
+                let _ = init_status_sender.send(Err(e)).await;
+                return;
+            }
+            Ok(table) => table,
+        };
+
+        let table = Arc::new(table);
+
+        let snapshot_df = match endpoint.prepare_snapshot_query(&table).await {
+            Err(e) => {
+                let _ = init_status_sender.send(Err(e)).await;
+                return;
+            }
+            Ok(snapshot_df) => snapshot_df,
+        };
+
+        // Code before this point is part of endpoint initialization.
+        // After this point, the thread should continue running until it receives a
+        // shutdown command from the controller.
+        let _ = init_status_sender.send(Ok(())).await;
+
+        // Execute the snapshot query; push snapshot data to the circuit.
+        if let Some(snapshot_df) = snapshot_df {
+            info!(
+                "delta_table {}: reading initial snapshot",
+                &endpoint.endpoint_name,
+            );
+
+            endpoint
+                .execute_df(
+                    snapshot_df,
+                    true,
+                    "initial snapshot",
+                    input_stream.as_mut(),
+                    &mut receiver,
+                )
+                .await;
+
+            //let _ = endpoint.datafusion.deregister_table("snapshot");
+            info!(
+                "delta_table {}: finished reading initial snapshot",
+                &endpoint.endpoint_name,
+            );
+        }
+
+        // Start following the table if required by the configuration.
+        if endpoint.config.follow() {
+            let mut version = table.version();
+            loop {
+                wait_running(&mut receiver).await;
+                match table.peek_next_commit(version).await {
+                    Ok(PeekCommit::UpToDate) => sleep(POLL_INTERVAL).await,
+                    Ok(PeekCommit::New(new_version, actions)) => {
+                        version = new_version;
+                        endpoint
+                            .process_log_entry(
+                                &actions,
+                                &table,
+                                input_stream.as_mut(),
+                                &mut receiver,
+                            )
+                            .await;
+                    }
+                    Err(e) => {
+                        if let Some(controller) = endpoint.controller.upgrade() {
+                            controller.input_transport_error(
+                                endpoint.endpoint_id,
+                                &endpoint.endpoint_name,
+                                false,
+                                anyhow!("error reading the next log entry (current table version: {version}): {e}"),
+                            )
+                        }
+                        sleep(RETRY_INTERVAL).await;
+                    }
+                }
+            }
+        } else if let Some(controller) = endpoint.controller.upgrade() {
+            controller.eoi(endpoint.endpoint_id, 0)
+        }
+    }
+}
+
+impl InputReader for DeltaTableInputReader {
+    fn start(&self, _step: Step) -> anyhow::Result<()> {
+        self.sender.send_replace(PipelineState::Running);
+        Ok(())
+    }
+
+    fn pause(&self) -> anyhow::Result<()> {
+        self.sender.send_replace(PipelineState::Paused);
+        Ok(())
+    }
+
+    fn disconnect(&self) {
+        self.sender.send_replace(PipelineState::Terminated);
+    }
+}
+
+impl Drop for DeltaTableInputReader {
+    fn drop(&mut self) {
+        self.disconnect();
+    }
+}
+
+struct DeltaTableInputEndpointInner {
+    endpoint_id: EndpointId,
+    endpoint_name: String,
+    config: DeltaTableReaderConfig,
+    controller: Weak<ControllerInner>,
+    datafusion: SessionContext,
+}
+
+impl DeltaTableInputEndpointInner {
+    fn new(
+        endpoint_id: EndpointId,
+        endpoint_name: &str,
+        config: DeltaTableReaderConfig,
+        controller: Weak<ControllerInner>,
+    ) -> Self {
+        Self {
+            endpoint_id,
+            endpoint_name: endpoint_name.to_string(),
+            config,
+            controller,
+            datafusion: SessionContext::new(),
+        }
+    }
+
+    /// Open existing delta table.  Use version or timestamp specified in the configuration, if any.
+    async fn open_table(&self) -> Result<DeltaTable, ControllerError> {
+        debug!(
+            "delta_table {}: opening delta table '{}'",
+            &self.endpoint_name, &self.config.uri
+        );
+
+        let table_builder = DeltaTableBuilder::from_uri(&self.config.uri)
+            .with_storage_options(self.config.object_store_config.clone());
+
+        let table_builder = match &self.config.mode {
+            DeltaTableIngestMode::Snapshot {
+                snapshot_version: None,
+                snapshot_datetime: None,
+                ..
+            } => table_builder,
+            DeltaTableIngestMode::Snapshot {
+                snapshot_version: Some(version),
+                snapshot_datetime: None,
+                ..
+            } => table_builder.with_version(*version),
+            DeltaTableIngestMode::Snapshot {
+                snapshot_version: None,
+                snapshot_datetime: Some(datetime),
+                ..
+            } => table_builder.with_datestring(datetime).map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("invalid 'snapshot_datetime' format (expected ISO-8601/RFC-3339 timestamp): {e}"),
+                )
+            })?,
+            DeltaTableIngestMode::Snapshot {
+                snapshot_version: Some(_),
+                snapshot_datetime: Some(_),
+                ..
+            } => {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "at most one of 'snapshot_version' and 'snapshot_datetime' options can be specified"));
+            }
+            DeltaTableIngestMode::Follow {
+                start_version: None,
+                start_datetime: None,
+            } |
+            DeltaTableIngestMode::SnapshotAndFollow {
+                start_version: None,
+                start_datetime: None,
+                ..
+            } => table_builder,
+            DeltaTableIngestMode::Follow {
+                start_version: Some(version),
+                start_datetime: None,
+            } |
+            DeltaTableIngestMode::SnapshotAndFollow {
+                start_version: Some(version),
+                start_datetime: None,
+                ..
+            } => table_builder.with_version(*version),
+            DeltaTableIngestMode::Follow {
+                start_version: None,
+                start_datetime: Some(datetime),
+            } |
+            DeltaTableIngestMode::SnapshotAndFollow {
+                start_version: None,
+                start_datetime: Some(datetime),
+                ..
+            } => table_builder.with_datestring(datetime).map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("invalid 'start_datetime' format (expected ISO-8601/RFC-3339 timestamp): {e}"),
+                )
+            })?,
+            DeltaTableIngestMode::Follow {
+                start_version: Some(_),
+                start_datetime: Some(_),
+            } |
+            DeltaTableIngestMode::SnapshotAndFollow {
+                start_version: Some(_),
+                start_datetime: Some(_),
+                ..
+            } => {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "at most one of 'start_version' and 'start_datetime' options can be specified"));
+
+            }
+        };
+
+        let delta_table = table_builder.load().await.map_err(|e| {
+            ControllerError::invalid_transport_configuration(
+                &self.endpoint_name,
+                &format!("error opening delta table '{}': {e}", &self.config.uri),
+            )
+        })?;
+
+        // Register object store with datafusion, so it will recognize individual parquet
+        // file URIs when processing transaction log.  The `object_store_url` function
+        // generates a unique URL, which only makes sense to datafusion.  We must append
+        // the same string to the relative file path we read from the log below to make
+        // sure datafusion links it to this object store.
+        let object_store_url = delta_table.log_store().object_store_url();
+        let url: &Url = object_store_url.as_ref();
+        self.datafusion
+            .runtime_env()
+            .register_object_store(url, delta_table.log_store().object_store());
+
+        debug!(
+            "delta_table {}: opened delta table '{}' (current table version {})",
+            &self.endpoint_name,
+            &self.config.uri,
+            delta_table.version()
+        );
+
+        // TODO: Validate that table schema matches relation schema
+
+        // TODO: Validate that timestamp is a valid column.
+
+        Ok(delta_table)
+    }
+
+    /// Prepare a dataframe to read initial snapshot, if required by endpoint configuration.
+    ///
+    /// This function runs as part of endpoint initialization.  The query will be actually
+    /// executed after initialization. The goal is to catch as many configuration errors as
+    /// possible during initialization.
+    ///
+    // FIXME: we rely on `order by` to order the snapshot by timestamp if requested by
+    // the configuration.  Datafusion implments this by downloading the entire dataset,
+    // storing and sorting it locally.  This is expensive and unnecessary.  A better approach
+    // is to instead read the input table in a series of queries, each returning a time range
+    // equal to the lateness of the timestamp column.  This is how the
+    // [`withEventTimeOrder`](https://docs.databricks.com/en/structured-streaming/delta-lake.html#process-initial-snapshot-without-data-being-dropped)
+    // feature works in Databricks.
+    async fn prepare_snapshot_query(
+        &self,
+        table: &Arc<DeltaTable>,
+    ) -> Result<Option<DataFrame>, ControllerError> {
+        if !self.config.snapshot() {
+            return Ok(None);
+        }
+
+        trace!(
+            "delta_table {}: preparing initial snapshot query",
+            &self.endpoint_name,
+        );
+
+        self.datafusion
+            .register_table("snapshot", table.clone())
+            .map_err(|e| {
+                ControllerError::input_transport_error(
+                    &self.endpoint_name,
+                    true,
+                    anyhow!("failed to register table snapshot with datafusion: {e}"),
+                )
+            })?;
+
+        let mut snapshot_query = "select * from snapshot".to_string();
+
+        if let Some(filter) = self.config.snapshot_filter() {
+            // Parse expression only to validate it.
+            let mut parser = Parser::new(&GenericDialect)
+                .try_with_sql(filter)
+                .map_err(|e| {
+                    ControllerError::invalid_transport_configuration(
+                        &self.endpoint_name,
+                        &format!("error parsing filter expression '{filter}': {e}"),
+                    )
+                })?;
+            parser.parse_expr().map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("invalid filter expression '{filter}': {e}"),
+                )
+            })?;
+
+            snapshot_query = format!("{snapshot_query} where {filter}");
+        }
+
+        if let Some(timestamp_column) = &self.config.timestamp_column {
+            // Parse expression only to validate it.
+            let mut parser = Parser::new(&GenericDialect)
+                .try_with_sql(timestamp_column)
+                .map_err(|e| {
+                    ControllerError::invalid_transport_configuration(
+                        &self.endpoint_name,
+                        &format!("error parsing timestamp expression '{timestamp_column}': {e}"),
+                    )
+                })?;
+            parser.parse_expr().map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("invalid timestamp expression '{timestamp_column}': {e}"),
+                )
+            })?;
+
+            snapshot_query = format!("{snapshot_query} order by {timestamp_column}");
+        }
+
+        let options = SQLOptions::new()
+            .with_allow_ddl(false)
+            .with_allow_dml(false);
+        let snapshot = self
+            .datafusion
+            .sql_with_options(&snapshot_query, options)
+            .await
+            .map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("error compiling snapshot query '{snapshot_query}': {e}"),
+                )
+            })?;
+
+        Ok(Some(snapshot))
+    }
+
+    /// Execute a prepared dataframe and push data from it to the circuit.
+    ///
+    /// * `polarity` - determines whether records in the dataframe should be
+    ///   inserted to or deleted from the table.
+    ///
+    /// * `descr` - dataframe description used to construct error message.
+    ///
+    /// * `input_stream` - handle to push updates to.
+    ///
+    /// * `receiver` - used to block the function until the endpoint is unpaused.
+    async fn execute_df(
+        &self,
+        dataframe: DataFrame,
+        polarity: bool,
+        descr: &str,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) {
+        wait_running(receiver).await;
+
+        let mut stream = match dataframe.execute_stream().await {
+            Err(e) => {
+                if let Some(controller) = self.controller.upgrade() {
+                    controller.input_transport_error(
+                        self.endpoint_id,
+                        &self.endpoint_name,
+                        true,
+                        anyhow!("error retrieving {descr}: {e}"),
+                    )
+                }
+                return;
+            }
+            Ok(stream) => stream,
+        };
+
+        let mut num_batches = 0;
+        while let Some(batch) = stream.next().await {
+            wait_running(receiver).await;
+            let batch = match batch {
+                Ok(batch) => batch,
+                Err(e) => {
+                    if let Some(controller) = self.controller.upgrade() {
+                        controller.input_transport_error(
+                            self.endpoint_id,
+                            &self.endpoint_name,
+                            false,
+                            anyhow!("error retrieving batch {num_batches} of {descr}: {e}"),
+                        )
+                    }
+                    continue;
+                }
+            };
+            // info!("schema: {}", batch.schema());
+            num_batches += 1;
+            let bytes = batch.get_array_memory_size();
+            let rows = batch.num_rows();
+            let result = if polarity {
+                input_stream.insert(&batch)
+            } else {
+                input_stream.delete(&batch)
+            };
+
+            match result {
+                Ok(()) => {
+                    if let Some(controller) = self.controller.upgrade() {
+                        controller.input_batch(self.endpoint_id, bytes, rows)
+                    }
+                }
+                Err(e) => {
+                    if let Some(controller) = self.controller.upgrade() {
+                        controller.parse_error(
+                            self.endpoint_id,
+                            &self.endpoint_name,
+                            ParseError::bin_envelope_error(
+                                format!("error deserializing table records from Parquet data: {e}"),
+                                &[],
+                                None,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply actions from a transaction log entry.
+    ///
+    /// Only `Add` and `Remove` actions are picked up.
+    async fn process_log_entry(
+        &self,
+        actions: &[Action],
+        table: &DeltaTable,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) {
+        // TODO: consider processing all Add actions and all Remove actions in one
+        // go using `ListingTable`, which understands partitioning and can probably
+        // parallelize the load.
+        for action in actions {
+            self.process_action(action, table, input_stream, receiver)
+                .await;
+        }
+    }
+
+    async fn process_action(
+        &self,
+        action: &Action,
+        table: &DeltaTable,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) {
+        match action {
+            Action::Add(add) if add.data_change => {
+                self.add_with_polarity(&add.path, true, table, input_stream, receiver)
+                    .await;
+            }
+            Action::Remove(remove) if remove.data_change => {
+                self.add_with_polarity(&remove.path, false, table, input_stream, receiver)
+                    .await;
+            }
+            _ => (),
+        }
+    }
+
+    async fn add_with_polarity(
+        &self,
+        path: &str,
+        polarity: bool,
+        table: &DeltaTable,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) {
+        // See comment about `object_store_url` above.
+        let full_path = format!("{}{}", table.log_store().object_store_url().as_str(), path);
+        let df = match self
+            .datafusion
+            .read_parquet(full_path, ParquetReadOptions::default())
+            .await
+        {
+            Err(e) => {
+                if let Some(controller) = self.controller.upgrade() {
+                    controller.input_transport_error(
+                        self.endpoint_id,
+                        &self.endpoint_name,
+                        true,
+                        anyhow!("error reading Parquet file '{path}' listed in table log: {e}"),
+                    );
+                }
+                return;
+            }
+            Ok(df) => df,
+        };
+
+        self.execute_df(
+            df,
+            polarity,
+            &format!("file '{path}'"),
+            input_stream,
+            receiver,
+        )
+        .await;
+    }
+}
+
+/// Block until the state is `Running`.
+async fn wait_running(receiver: &mut Receiver<PipelineState>) {
+    // An error indicates that the channel was closed.  It's ok to ignore
+    // the error as this situation will be handled by the top-level select,
+    // which will abort the worker thread.
+    let _ = receiver
+        .wait_for(|state| state == &PipelineState::Running)
+        .await;
+}

--- a/crates/adapters/src/integrated/delta_table/mod.rs
+++ b/crates/adapters/src/integrated/delta_table/mod.rs
@@ -1,3 +1,41 @@
+mod input;
 mod output;
 
+#[cfg(test)]
+mod test;
+
+pub use input::DeltaTableInputEndpoint;
 pub use output::DeltaTableWriter;
+use pipeline_types::serde_with_context::serde_config::DecimalFormat;
+use pipeline_types::serde_with_context::{DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat};
+use std::sync::Once;
+
+static REGISTER_STORAGE_HANDLERS: Once = Once::new();
+
+/// Register url handlers, so URL's like `s3://...` are recognized.
+///
+/// Runs initialization at most once per process.
+pub fn register_storage_handlers() {
+    REGISTER_STORAGE_HANDLERS.call_once(|| {
+        deltalake::aws::register_handlers(None);
+        deltalake::azure::register_handlers(None);
+        deltalake::gcp::register_handlers(None);
+    });
+}
+
+pub fn delta_input_serde_config() -> SqlSerdeConfig {
+    SqlSerdeConfig::default()
+        // Delta standard specifies that the timestamp type uses microseconds.
+        // In reality, delta parquet files can represent timestamps as either
+        // microseconds or nanoseconds.  Other options might be possible.
+        // `serde_arrow` knows the correct type from the Arrow schema, and its
+        // `Deserializer` implementation is nice enough to return the timestamp
+        // formatted as string if the `Deserialize` implementation asks for it
+        // (by calling `deserialize_str`), so we rely on that instead of trying
+        // to deserialize the timestamp as an integer.  A better solution would
+        // require a more flexible SqlSerdeConfig type that would specify a
+        // schema per field.
+        .with_timestamp_format(TimestampFormat::String("%Y-%m-%dT%H:%M:%S%.f%Z"))
+        .with_date_format(DateFormat::DaysSinceEpoch)
+        .with_decimal_format(DecimalFormat::String)
+}

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -1,0 +1,843 @@
+use crate::catalog::InputCollectionHandle;
+use crate::format::parquet::relation_to_arrow_fields;
+use crate::format::parquet::test::load_parquet_file;
+use crate::format::relation_to_parquet_schema;
+use crate::integrated::delta_table::register_storage_handlers;
+use crate::test::{
+    file_to_zset, list_files_recursive, test_circuit, wait, DatabricksPeople, MockDeZSet,
+    MockUpdate, TestStruct2,
+};
+use crate::{Controller, ControllerError, InputFormat};
+use anyhow::anyhow;
+use arrow::datatypes::Schema as ArrowSchema;
+use chrono::{DateTime, NaiveDate};
+use dbsp::typed_batch::TypedBatch;
+use dbsp::utils::Tup2;
+use dbsp::{DBData, OrdZSet, ZSet};
+use deltalake::datafusion::dataframe::DataFrameWriteOptions;
+use deltalake::datafusion::logical_expr::Literal;
+use deltalake::datafusion::prelude::{col, SessionContext};
+use deltalake::datafusion::sql::sqlparser::test_utils::table;
+use deltalake::kernel::{BinaryOperator, DataType, StructField};
+use deltalake::operations::create::CreateBuilder;
+use deltalake::protocol::SaveMode;
+use deltalake::{DeltaOps, DeltaTable, DeltaTableBuilder};
+use env_logger::Env;
+use log::{debug, info, trace};
+use parquet::file::reader::Length;
+use pipeline_types::config::PipelineConfig;
+use pipeline_types::program_schema::{Field, Relation};
+use pipeline_types::serde_with_context::serialize::SerializeWithContextWrapper;
+use pipeline_types::serde_with_context::{
+    DateFormat, DeserializeWithContext, SerializeWithContext, SqlSerdeConfig, TimeFormat,
+    TimestampFormat,
+};
+use pipeline_types::transport::delta_table::DeltaTableIngestMode;
+use proptest::collection::vec;
+use proptest::prelude::{Arbitrary, ProptestConfig, Strategy};
+use proptest::proptest;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
+use serde_arrow::schema::SerdeArrowSchema;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem::forget;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tempfile::{tempdir, NamedTempFile, TempDir};
+use tokio::time::sleep;
+use uuid::Uuid;
+
+fn delta_output_serde_config() -> SqlSerdeConfig {
+    SqlSerdeConfig::default()
+        .with_date_format(DateFormat::String("%Y-%m-%d"))
+        // DeltaLake only supports microsecond-based timestamp encoding, so we just
+        // hardwire that for now.  See also `format/parquet/mod.rs`.
+        .with_timestamp_format(TimestampFormat::MicrosSinceEpoch)
+}
+
+/// Read a snapshot of a delta table with records of type `T` to a temporary JSON file.
+fn delta_table_snapshot_to_json<T>(
+    table_uri: &str,
+    config: &HashMap<String, String>,
+) -> NamedTempFile
+where
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+{
+    let start = Instant::now();
+    let json_file = NamedTempFile::new().unwrap();
+    println!(
+        "delta_table_snapshot_to_json: writing output to {}",
+        json_file.path().display()
+    );
+
+    let mut config = config.clone();
+    config.insert("mode".to_string(), "snapshot".to_string());
+
+    let input_pipeline = delta_table_input_pipeline::<T>(
+        table_uri,
+        &config,
+        &json_file.path().display().to_string(),
+    );
+    input_pipeline.start();
+    wait(|| input_pipeline.status().pipeline_complete(), 400_000).expect("timeout");
+    input_pipeline.stop().unwrap();
+
+    info!("Read delta snapshot in {:?}", start.elapsed());
+
+    json_file
+}
+
+/// Wait until `table` contains exactly `expected_count` records.
+async fn wait_for_count_records(
+    table: &mut Arc<DeltaTable>,
+    expected_count: usize,
+    datafusion: &SessionContext,
+) {
+    let start = Instant::now();
+    loop {
+        // select count() output_table == len().
+        Arc::get_mut(table)
+            .unwrap()
+            .update_incremental(None)
+            .await
+            .unwrap();
+
+        let count = datafusion
+            .read_table(table.clone())
+            .unwrap()
+            .count()
+            .await
+            .unwrap();
+
+        info!("expected output table size: {expected_count}, current size: {count}");
+
+        if count == expected_count {
+            break;
+        }
+
+        if start.elapsed() > Duration::from_millis(20_000) {
+            panic!("timeout");
+        }
+
+        sleep(Duration::from_millis(1_000)).await;
+    }
+}
+
+/// Write `data` to `table`.
+async fn write_data_to_table<T>(
+    table: DeltaTable,
+    arrow_schema: &ArrowSchema,
+    data: &[T],
+) -> DeltaTable
+where
+    T: DBData + SerializeWithContext<SqlSerdeConfig> + Sync,
+{
+    // Convert data to RecordBatch
+    let batch = serde_arrow::to_record_batch(
+        arrow_schema.fields(),
+        &SerializeWithContextWrapper::new(&data.to_vec(), &delta_output_serde_config()),
+    )
+    .unwrap();
+
+    // Write it to the input table.
+    DeltaOps(table)
+        .write(vec![batch])
+        .with_save_mode(SaveMode::Append)
+        .await
+        .unwrap()
+}
+
+async fn create_table(
+    table_uri: &str,
+    storage_options: &HashMap<String, String>,
+    fields: &[StructField],
+) -> DeltaTable {
+    info!("opening or creating delta table '{table_uri}'");
+
+    let table = CreateBuilder::new()
+        .with_location(table_uri)
+        .with_save_mode(SaveMode::Ignore)
+        .with_storage_options(storage_options.clone())
+        .with_columns(fields.to_vec())
+        .await
+        .unwrap();
+    info!("delta table '{table_uri}' successfully created");
+
+    table
+}
+
+/// Build a pipeline that reads from a delta table and writes to a JSON file.
+fn delta_table_input_pipeline<T>(
+    table_uri: &str,
+    config: &HashMap<String, String>,
+    output_file_path: &str,
+) -> Controller
+where
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+{
+    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let mut storage_options = String::new();
+    for (key, val) in config.iter() {
+        storage_options += &format!("                {key}: \"{val}\"\n");
+    }
+
+    // Create controller.
+    let config_str = format!(
+        r#"
+name: test
+workers: 4
+outputs:
+    test_output1:
+        stream: test_output1
+        transport:
+            name: file_output
+            config:
+                path: "{output_file_path}"
+        format:
+            name: json
+            config:
+                update_format: "insert_delete"
+inputs:
+    test_input1:
+        stream: test_input1
+        transport:
+            name: "delta_table_input"
+            config:
+                uri: "{table_uri}"
+{}
+"#,
+        storage_options,
+    );
+
+    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+
+    Controller::with_config(
+        |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
+        &config,
+        Box::new(move |e| panic!("delta_table_input_test: error: {e}")),
+    )
+    .unwrap()
+}
+
+/// Build a pipeline that reads from a delta table and writes to a delta table.
+fn delta_to_delta_pipeline<T>(
+    input_table_uri: &str,
+    input_config: &HashMap<String, String>,
+    output_table_uri: &str,
+    output_config: &HashMap<String, String>,
+    buffer_size: u64,
+    buffer_timeout_ms: u64,
+) -> Controller
+where
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+{
+    info!("creating a pipeline to copy delta table '{input_table_uri}' to '{output_table_uri}'");
+
+    let mut input_storage_options = String::new();
+    for (key, val) in input_config.iter() {
+        input_storage_options += &format!("                {key}: \"{val}\"\n");
+    }
+
+    let mut output_storage_options = String::new();
+    for (key, val) in output_config.iter() {
+        output_storage_options += &format!("                {key}: \"{val}\"\n");
+    }
+
+    // Create controller.
+    let config_str = format!(
+        r#"
+name: test
+workers: 4
+inputs:
+    test_input1:
+        stream: test_input1
+        transport:
+            name: "delta_table_input"
+            config:
+                uri: "{input_table_uri}"
+{}
+outputs:
+    test_output1:
+        stream: test_output1
+        transport:
+            name: "delta_table_output"
+            config:
+                uri: "{output_table_uri}"
+{}
+        enable_output_buffer: true
+        max_output_buffer_size_records: {buffer_size}
+        max_output_buffer_time_millis: {buffer_timeout_ms}
+"#,
+        input_storage_options, output_storage_options,
+    );
+
+    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+
+    Controller::with_config(
+        |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
+        &config,
+        Box::new(move |e| panic!("delta_to_delta pipeline: error: {e}")),
+    )
+    .unwrap()
+}
+
+/// Test function that works for both local FS and remote object stores.
+///
+/// * `verify` - verify the final contents of the delta table is equivalent to
+///   `data`.  Currently only works for tables in the local FS.
+///
+/// TODO: implement verification using the delta table API rather than
+/// by reading parquet files directly.  I guess the best way to do this is
+/// to build an input connector.
+fn delta_table_output_test(
+    data: Vec<TestStruct2>,
+    table_uri: &str,
+    object_store_config: &HashMap<String, String>,
+    verify: bool,
+) {
+    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let buffer_size = 2000;
+
+    let buffer_timeout_ms = 100;
+
+    println!("delta_table_output_test: preparing input file");
+    let mut input_file = NamedTempFile::new().unwrap();
+    for v in data.iter() {
+        let buffer: Vec<u8> = Vec::new();
+        let mut serializer = serde_json::Serializer::new(buffer);
+        v.serialize_with_context(&mut serializer, &SqlSerdeConfig::default())
+            .unwrap();
+        input_file
+            .as_file_mut()
+            .write_all(&serializer.into_inner())
+            .unwrap();
+        input_file.write_all(b"\n").unwrap();
+    }
+
+    let mut storage_options = String::new();
+    for (key, val) in object_store_config.iter() {
+        storage_options += &format!("                {key}: \"{val}\"\n");
+    }
+
+    // Create controller.
+    let config_str = format!(
+        r#"
+name: test
+workers: 4
+inputs:
+    test_input1:
+        stream: test_input1
+        transport:
+            name: file_input
+            config:
+                path: "{}"
+        format:
+            name: json
+            config:
+                update_format: "raw"
+outputs:
+    test_output1:
+        stream: test_output1
+        transport:
+            name: "delta_table_output"
+            config:
+                uri: "{table_uri}"
+{}
+        enable_output_buffer: true
+        max_output_buffer_size_records: {buffer_size}
+        max_output_buffer_time_millis: {buffer_timeout_ms}
+"#,
+        input_file.path().display(),
+        storage_options,
+    );
+
+    println!(
+        "delta_table_output_test: {} records, input file: {}, table uri: {table_uri}",
+        data.len(),
+        input_file.path().display(),
+    );
+    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+
+    let controller = Controller::with_config(
+        |workers| Ok(test_circuit::<TestStruct2>(workers, &TestStruct2::schema())),
+        &config,
+        Box::new(move |e| panic!("delta_table_output_test: error: {e}")),
+    )
+    .unwrap();
+
+    controller.start();
+
+    wait(|| controller.status().pipeline_complete(), 100_000).unwrap();
+
+    if verify {
+        let parquet_files =
+            list_files_recursive(&Path::new(table_uri), OsStr::from_bytes(b"parquet")).unwrap();
+
+        // // Uncomment to inspect the input JSON file.
+        // std::mem::forget(input_file);
+
+        let mut output_records = Vec::with_capacity(data.len());
+        for parquet_file in parquet_files {
+            let mut records: Vec<TestStruct2> = load_parquet_file(&parquet_file);
+            output_records.append(&mut records);
+        }
+
+        output_records.sort();
+
+        assert_eq!(output_records, data);
+    }
+
+    controller.stop().unwrap();
+    println!("delta_table_output_test: success");
+}
+
+/// Read delta table in follow mode, write data to another delta table.
+///
+/// ```text
+/// data --> input table in S3 ---> [pipeline] ---> output table in S3
+/// ```
+///
+/// - When `snapshot` is `false`, runs the connector in `follow` mode,
+///   consuming the dataset in 10 chunks.
+/// - When `snapshot` is `true`, runs the connector in `snapshot_and_follow`
+///   mode.  The dataset is split in halves; the first half is consumed as a
+///   single snapshot and the second half is processed in follow mode.
+async fn test_follow(
+    schema: &[Field],
+    input_table_uri: &str,
+    output_table_uri: &str,
+    storage_options: &HashMap<String, String>,
+    data: Vec<TestStruct2>,
+    snapshot: bool,
+    buffer_size: u64,
+    buffer_timeout_ms: u64,
+) {
+    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
+        .is_test(true)
+        .try_init();
+
+    let datafusion = SessionContext::new();
+
+    // Create arrow schema
+    let arrow_fields = relation_to_arrow_fields(schema, true);
+    info!("arrow_fields: {arrow_fields:?}");
+
+    let arrow_schema = Arc::new(ArrowSchema::new(arrow_fields));
+    info!("arrow_schema: {arrow_schema:?}");
+
+    let mut struct_fields: Vec<_> = vec![];
+
+    for f in arrow_schema.fields.iter() {
+        let data_type = DataType::try_from(f.data_type()).unwrap();
+        struct_fields.push(StructField::new(f.name(), data_type, f.is_nullable()));
+    }
+
+    // Create delta table at `input_table_uri`.
+    let mut input_table = create_table(input_table_uri, storage_options, &struct_fields).await;
+
+    // If `snapshot` is true, write the first half of the dataset as initial snapshot.
+    let split_at = if snapshot {
+        let median = data.len() / 2;
+
+        input_table = write_data_to_table(input_table, &arrow_schema, &data[..median]).await;
+
+        median
+    } else {
+        0
+    };
+
+    // Start parquet-to-parquet pipeline.
+    let mut input_config = storage_options.clone();
+
+    if snapshot {
+        input_config.insert("mode".to_string(), "snapshot_and_follow".to_string());
+    } else {
+        input_config.insert("mode".to_string(), "follow".to_string());
+    }
+    let output_config = storage_options.clone();
+
+    let input_table_uri_clone = input_table_uri.to_string();
+    let output_table_uri_clone = output_table_uri.to_string();
+
+    let pipeline = tokio::task::spawn_blocking(move || {
+        delta_to_delta_pipeline::<TestStruct2>(
+            &input_table_uri_clone,
+            &input_config,
+            &output_table_uri_clone,
+            &output_config,
+            buffer_size,
+            buffer_timeout_ms,
+        )
+    })
+    .await
+    .unwrap();
+
+    pipeline.start();
+
+    // Connect to `output_table_uri`.
+    let mut output_table = Arc::new(
+        DeltaTableBuilder::from_uri(&output_table_uri)
+            .with_storage_options(storage_options.clone())
+            .load()
+            .await
+            .unwrap(),
+    );
+
+    let mut total_count = split_at;
+
+    // Write remaining data in 10 chunks, wait for it to show up in the output table.
+    for chunk in data[split_at..].chunks(std::cmp::max(data[split_at..].len() / 10, 1)) {
+        total_count += chunk.len();
+        input_table = write_data_to_table(input_table, &arrow_schema, chunk).await;
+        wait_for_count_records(&mut output_table, total_count, &datafusion).await;
+    }
+
+    // TODO: this does not currently work because our output delta connector doesn't support
+    // deletions.
+    // // Delete 10% of data, wait for the change to propagate.
+    // for range in 0..10 {
+    //     let cutoff = data.len() as i64 / (10 - range);
+    //     data.retain(|x| x.field > cutoff);
+    //
+    //     // delete from output_table where ... ;
+    //     (input_table, _) = DeltaOps(input_table)
+    //         .delete()
+    //         .with_predicate(col("id").lt_eq(cutoff.lit()))
+    //         .await
+    //         .unwrap();
+    //
+    //     let start = Instant::now();
+    //
+    //     loop {
+    //         sleep(Duration::from_millis(1_000)).await;
+    //
+    //         Arc::get_mut(&mut output_table)
+    //             .unwrap()
+    //             .update_incremental(None)
+    //             .await
+    //             .unwrap();
+    //
+    //         let count = datafusion
+    //             .read_table(output_table.clone())
+    //             .unwrap()
+    //             .count()
+    //             .await
+    //             .unwrap();
+    //
+    //         if count == total_count {
+    //             break;
+    //         }
+    //
+    //         if start.elapsed() > Duration::from_millis(20_000) {
+    //             panic!("timeout");
+    //         }
+    //     }
+    // }
+
+    pipeline.stop().unwrap();
+}
+
+/// Generate up to `max_records` _unique_ records.
+fn data(max_records: usize) -> impl Strategy<Value = Vec<TestStruct2>> {
+    vec(TestStruct2::arbitrary(), 0..max_records).prop_map(|vec| {
+        let mut idx = 0;
+        vec.into_iter()
+            .map(|mut x| {
+                x.field = idx;
+                idx += 1;
+                x
+            })
+            .collect()
+    })
+}
+
+async fn delta_table_follow_file_test_common(snapshot: bool) {
+    // We cannot use proptest macros in `async` context, so generate
+    // some random data manually.
+    let mut runner = TestRunner::default();
+    let data = data(100_000).new_tree(&mut runner).unwrap().current();
+
+    let relation_schema = TestStruct2::schema();
+
+    let input_table_dir = TempDir::new().unwrap();
+    let input_table_uri = input_table_dir.path().display().to_string();
+
+    let output_table_dir = TempDir::new().unwrap();
+    let output_table_uri = output_table_dir.path().display().to_string();
+
+    test_follow(
+        &relation_schema,
+        &input_table_uri,
+        &output_table_uri,
+        &HashMap::new(),
+        data,
+        snapshot,
+        1000,
+        100,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn delta_table_snapshot_and_follow_file_test() {
+    delta_table_follow_file_test_common(true).await
+}
+
+#[tokio::test]
+async fn delta_table_follow_file_test() {
+    delta_table_follow_file_test_common(false).await
+}
+
+#[cfg(feature = "delta-s3-test")]
+async fn delta_table_follow_s3_test_common(snapshot: bool) {
+    register_storage_handlers();
+
+    // We cannot use proptest macros in `async` context, so generate
+    // some random data manually.
+    let mut runner = TestRunner::default();
+    let data = data(100_000).new_tree(&mut runner).unwrap().current();
+
+    let relation_schema = TestStruct2::schema();
+
+    let input_uuid = uuid::Uuid::new_v4();
+    let output_uuid = uuid::Uuid::new_v4();
+
+    let object_store_config = [
+        (
+            "aws_access_key_id".to_string(),
+            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap(),
+        ),
+        (
+            "aws_secret_access_key".to_string(),
+            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap(),
+        ),
+        // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
+        ("aws_region".to_string(), "us-east-2".to_string()),
+        ("AWS_S3_ALLOW_UNSAFE_RENAME".to_string(), "true".to_string()),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+
+    let input_table_uri = format!("s3://feldera-delta-table-test/{input_uuid}/");
+    let output_table_uri = format!("s3://feldera-delta-table-test/{output_uuid}/");
+
+    test_follow(
+        &relation_schema,
+        &input_table_uri,
+        &output_table_uri,
+        &object_store_config,
+        data,
+        snapshot,
+        1000,
+        100,
+    )
+    .await;
+}
+
+#[cfg(feature = "delta-s3-test")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_follow_s3_test() {
+    delta_table_follow_s3_test_common(false).await
+}
+
+#[cfg(feature = "delta-s3-test")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_snapshot_and_follow_s3_test() {
+    delta_table_follow_s3_test_common(true).await
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2))]
+
+    /// ```text
+    /// input.json --> [pipeline1]--->delta_table-->[pipeline2]-->output.json
+    /// ```
+    #[test]
+    fn delta_table_file_output_proptest(data in data(100_000))
+    {
+        let table_dir = TempDir::new().unwrap();
+        let table_uri = table_dir.path().display().to_string();
+        delta_table_output_test(data.clone(), &table_uri, &HashMap::new(), true);
+
+        // // Uncomment to inspect output parquet files produced by the test.
+        // forget(table_dir);
+
+        // Read delta table unordered.
+        let mut json_file = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &HashMap::new());
+
+        let expected_zset = OrdZSet::from_tuples((), data.clone().into_iter().map(|x| Tup2(Tup2(x,()),1)).collect());
+        let zset = file_to_zset::<TestStruct2>(json_file.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_zset);
+
+        // Order delta table by `id` (which should be its natural order).
+        let mut json_file_ordered_by_id = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &HashMap::from([("timestamp_column".to_string(), "id".to_string())]));
+
+        let zset = file_to_zset::<TestStruct2>(json_file_ordered_by_id.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_zset);
+
+        // Order delta table by `timestamp` (which is generated in random order, so this requires actual sorting).
+        let mut json_file_ordered_by_ts = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &HashMap::from([("timestamp_column".to_string(), "ts".to_string())]));
+
+        let zset = file_to_zset::<TestStruct2>(json_file_ordered_by_ts.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_zset);
+
+        // Filter delta table by id
+        let mut json_file_filtered_by_id = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &HashMap::from([("snapshot_filter".to_string(), "id >= 10000 and id <= 20000".to_string())]));
+
+        let expected_filtered_zset = OrdZSet::from_tuples(
+            (),
+            data.clone().into_iter()
+                .filter(|x| x.field >= 10000 && x.field <= 20000)
+                .map(|x| Tup2(Tup2(x,()),1)).collect()
+            );
+
+        let zset = file_to_zset::<TestStruct2>(json_file_filtered_by_id.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_filtered_zset);
+
+        // Filter delta table by timestamp.
+        let mut json_file_filtered_by_ts = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &HashMap::from([("snapshot_filter".to_string(), "ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'".to_string())]));
+
+        let start = NaiveDate::from_ymd_opt(2005, 1, 1)
+                .unwrap()
+                .and_hms_milli_opt(0, 0, 0, 0)
+                .unwrap();
+
+        let end = NaiveDate::from_ymd_opt(2010, 12, 31)
+                .unwrap()
+                .and_hms_milli_opt(23, 59, 59, 0)
+                .unwrap();
+
+        let expected_filtered_zset = OrdZSet::from_tuples(
+            (),
+            data.into_iter()
+                .filter(|x| x.field_2.milliseconds() >= start.timestamp_millis() && x.field_2.milliseconds() <= end.timestamp_millis())
+                .map(|x| Tup2(Tup2(x,()),1)).collect()
+            );
+
+        let zset = file_to_zset::<TestStruct2>(json_file_filtered_by_ts.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_filtered_zset);
+
+
+        // // Uncomment to inspect one of the output json files produced by the test.
+        // forget(json_file_filtered_by_id);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1))]
+
+    /// Write to a Delta table in S3.
+    #[cfg(feature = "delta-s3-test")]
+    #[test]
+    fn delta_table_s3_output_proptest(data in data(100_000))
+    {
+        let uuid = uuid::Uuid::new_v4();
+        let object_store_config = [
+            ("aws_access_key_id".to_string(), std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap()),
+            ("aws_secret_access_key".to_string(), std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap()),
+            // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
+            ("aws_region".to_string(), "us-east-2".to_string()),
+        ]
+            .into_iter()
+            .collect::<HashMap<_,_>>();
+
+        let table_uri = format!("s3://feldera-delta-table-test/{uuid}/");
+        // TODO: enable verification when it's supported for S3.
+        delta_table_output_test(data.clone(), &table_uri, &object_store_config, false);
+        //delta_table_output_test(data.clone(), &table_uri, &object_store_config, false);
+
+        let mut json_file = delta_table_snapshot_to_json::<TestStruct2>(
+            &table_uri,
+            &object_store_config);
+
+        let expected_zset = OrdZSet::from_tuples((), data.into_iter().map(|x| Tup2(Tup2(x,()),1)).collect());
+        let zset = file_to_zset::<TestStruct2>(json_file.as_file_mut(), "json", r#"update_format: "insert_delete""#);
+        assert_eq!(zset, expected_zset);
+    }
+}
+
+/// Read a large (2M records) dataset created in S3 from Databricks.
+/// This dataset was derived from
+/// `/databricks-datasets/learning-spark-v2/people/people-10m.delta`; however the full dataset
+/// is 200MB and can be slow to download, so we cut it down to 2M.
+///
+/// Here is the full notebook used to create it:
+/// ```text
+/// # Load the data from its source.
+/// df = spark.read.load("/databricks-datasets/learning-spark-v2/people/people-10m.delta")
+///
+/// # Write the data to a table.
+/// table_name = "people_2m"
+/// df.limit(2000000).write.saveAsTable(table_name)
+///
+/// # Find location of the delta table in S3.
+/// table_location = spark.sql("DESCRIBE DETAIL people_2m").collect()[0]['location']
+/// print(table_location)
+/// ```
+#[cfg(feature = "delta-s3-test")]
+#[test]
+fn delta_table_s3_people_2m() {
+    let uuid = uuid::Uuid::new_v4();
+    let object_store_config = [
+        (
+            "aws_access_key_id".to_string(),
+            std::env::var("DELTA_TABLE_TEST_AWS_ACCESS_KEY_ID").unwrap(),
+        ),
+        (
+            "aws_secret_access_key".to_string(),
+            std::env::var("DELTA_TABLE_TEST_AWS_SECRET_ACCESS_KEY").unwrap(),
+        ),
+        // AWS region must be specified (see https://github.com/delta-io/delta-rs/issues/1095).
+        ("aws_region".to_string(), "us-west-1".to_string()),
+        // Set long timeout for reading large files from S3.
+        ("timeout".to_string(), "1000 secs".to_string()),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+
+    //let table_uri = "s3://databricks-workspace-stack-d437e-bucket/unity-catalog/5496131495366467/__unitystorage/catalogs/d1e3a643-f243-4798-8554-d32bf5a7205a/tables/cee86cb4-a525-41b9-82fe-616ae62287fc/";
+    let table_uri = "s3://databricks-workspace-stack-d437e-bucket/unity-catalog/5496131495366467/__unitystorage/catalogs/d1e3a643-f243-4798-8554-d32bf5a7205a/tables/90cc5aba-25cd-4ed7-a498-8d08f0ddaa21/";
+    let mut json_file =
+        delta_table_snapshot_to_json::<DatabricksPeople>(table_uri, &object_store_config);
+
+    println!("reading output file");
+    let zset = file_to_zset::<DatabricksPeople>(
+        json_file.as_file_mut(),
+        "json",
+        r#"update_format: "insert_delete""#,
+    );
+
+    assert_eq!(zset.len(), 2_000_000);
+
+    forget(json_file);
+}

--- a/crates/adapters/src/integrated/mod.rs
+++ b/crates/adapters/src/integrated/mod.rs
@@ -3,16 +3,23 @@
 #![allow(unused_variables)]
 
 use crate::controller::{ControllerInner, EndpointId};
-use crate::{ControllerError, Encoder, OutputEndpoint};
-use pipeline_types::config::{OutputEndpointConfig, TransportConfig, TransportConfigVariant};
+use crate::{ControllerError, Encoder, OutputEndpoint, TransportInputEndpoint};
+use pipeline_types::config::{
+    InputEndpointConfig, OutputEndpointConfig, TransportConfig, TransportConfigVariant,
+};
 use pipeline_types::program_schema::Relation;
 use std::sync::Weak;
+
+use crate::transport::IntegratedInputEndpoint;
 
 #[cfg(feature = "with-deltalake")]
 mod delta_table;
 
 #[cfg(feature = "with-deltalake")]
-pub use delta_table::DeltaTableWriter;
+pub use delta_table::{DeltaTableInputEndpoint, DeltaTableWriter};
+
+#[cfg(feature = "with-deltalake")]
+use pipeline_types::config::TransportConfig::DeltaTableInput;
 
 /// An integrated output connector implements both transport endpoint
 /// (`OutputEndpoint`) and `Encoder` traits.  It is used to implement
@@ -44,18 +51,67 @@ pub fn create_integrated_output_endpoint(
     schema: &Relation,
     controller: Weak<ControllerInner>,
 ) -> Result<Box<dyn IntegratedOutputEndpoint>, ControllerError> {
-    match &config.connector_config.transport {
+    let ep = match &config.connector_config.transport {
         #[cfg(feature = "with-deltalake")]
-        TransportConfig::DeltaTableOutput(config) => Ok(Box::new(DeltaTableWriter::new(
+        TransportConfig::DeltaTableOutput(config) => Box::new(DeltaTableWriter::new(
             endpoint_id,
             endpoint_name,
             config,
             schema,
             controller,
-        )?)),
-        transport => Err(ControllerError::unknown_output_transport(
+        )?),
+        transport => {
+            return Err(ControllerError::unknown_output_transport(
+                endpoint_name,
+                &transport.name(),
+            ));
+        }
+    };
+
+    if config.connector_config.format.is_some() {
+        return Err(ControllerError::invalid_parser_configuration(
             endpoint_name,
-            &transport.name(),
-        )),
+            &format!(
+                "{} transport does not allow 'format' specification",
+                config.connector_config.transport.name()
+            ),
+        ));
     }
+
+    Ok(ep)
+}
+
+pub fn create_integrated_input_endpoint(
+    endpoint_id: EndpointId,
+    endpoint_name: &str,
+    config: &InputEndpointConfig,
+    controller: Weak<ControllerInner>,
+) -> Result<Box<dyn IntegratedInputEndpoint>, ControllerError> {
+    let ep = match &config.connector_config.transport {
+        #[cfg(feature = "with-deltalake")]
+        TransportConfig::DeltaTableInput(config) => Box::new(DeltaTableInputEndpoint::new(
+            endpoint_id,
+            endpoint_name,
+            config,
+            controller,
+        )),
+        transport => {
+            return Err(ControllerError::unknown_input_transport(
+                endpoint_name,
+                &transport.name(),
+            ));
+        }
+    };
+
+    if config.connector_config.format.is_some() {
+        return Err(ControllerError::invalid_parser_configuration(
+            endpoint_name,
+            &format!(
+                "{} transport does not allow 'format' specification",
+                config.connector_config.transport.name()
+            ),
+        ));
+    }
+
+    Ok(ep)
 }

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! The transport adapter API consists of the following traits:
 //!
-//! * [`InputEndpoint`] represents a configured data connection, e.g., a file,
+//! * [`TransportInputEndpoint`] represents a configured data connection, e.g., a file,
 //!   an S3 bucket or a Kafka topic.  By providing an [`InputConsumer`], a
 //!   client may open an endpoint and thereby obtain an [`InputReader`].
 //!
@@ -194,4 +194,5 @@ pub use controller::{
 };
 pub use transport::{
     AsyncErrorCallback, InputConsumer, InputEndpoint, InputReader, OutputEndpoint,
+    TransportInputEndpoint,
 };

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -4,9 +4,9 @@ use crate::{
     transport::http::{
         HttpInputEndpoint, HttpInputTransport, HttpOutputEndpoint, HttpOutputTransport,
     },
-    CircuitCatalog, Controller, ControllerError, DbspCircuitHandle, FormatConfig, InputEndpoint,
+    CircuitCatalog, Controller, ControllerError, DbspCircuitHandle, FormatConfig,
     InputEndpointConfig, InputFormat, OutputEndpoint, OutputEndpointConfig, OutputFormat,
-    PipelineConfig,
+    PipelineConfig, TransportInputEndpoint,
 };
 use actix_web::{
     dev::{ServiceFactory, ServiceRequest},
@@ -593,7 +593,7 @@ async fn input_endpoint(
             match controller.add_input_endpoint(
                 &endpoint_name,
                 config,
-                Box::new(endpoint.clone()) as Box<dyn InputEndpoint>,
+                Box::new(endpoint.clone()) as Box<dyn TransportInputEndpoint>,
             ) {
                 Ok(endpoint_id) => endpoint_id,
                 Err(e) => {

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -515,3 +515,158 @@ deserialize_table_record!(TestStruct2["TestStruct", 6] {
     // (r#field_4, "t", false, Time, None),
     (r#field_5, "es", false, EmbeddedStruct, None)
 });
+
+/// Record in the databricks people dataset.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[archive_attr(derive(Clone, Ord, Eq, PartialEq, PartialOrd))]
+#[archive(compare(PartialEq, PartialOrd))]
+pub struct DatabricksPeople {
+    pub id: i32,
+    pub first_name: Option<String>,
+    pub middle_name: Option<String>,
+    pub last_name: Option<String>,
+    pub gender: Option<String>,
+    pub birth_date: Option<Timestamp>,
+    pub ssn: Option<String>,
+    pub salary: Option<i32>,
+}
+
+impl DatabricksPeople {
+    pub fn schema() -> Vec<Field> {
+        vec![
+            Field {
+                name: "id".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Int,
+                    nullable: false,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "firstName".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Varchar,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "middleName".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Varchar,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "lastName".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Varchar,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "gender".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Varchar,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "birthDate".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Timestamp,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "ssn".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Varchar,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+            Field {
+                name: "salary".to_string(),
+                case_sensitive: false,
+                columntype: ColumnType {
+                    typ: SqlType::Int,
+                    nullable: true,
+                    precision: None,
+                    scale: None,
+                    component: None,
+                    fields: None,
+                },
+            },
+        ]
+    }
+}
+
+serialize_table_record!(DatabricksPeople[8]{
+    r#id["id"]: i32,
+    r#first_name["firstname"]: Option<String>,
+    r#middle_name["middlename"]: Option<String>,
+    r#last_name["lastname"]: Option<String>,
+    r#gender["gender"]: Option<String>,
+    r#birth_date["birthdate"]: Option<Timestamp>,
+    r#ssn["ssn"]: Option<String>,
+    r#salary["salary"]: Option<i32>
+});
+
+deserialize_table_record!(DatabricksPeople["DatabricksPeople", 8] {
+    (r#id, "id", false, i32, None),
+    (r#first_name, "firstname", false, Option<String>, Some(None)),
+    (r#middle_name, "middlename", false, Option<String>, Some(None)),
+    (r#last_name, "lastname", false, Option<String>, Some(None)),
+    (r#gender, "gender", false, Option<String>, Some(None)),
+    (r#birth_date, "birthdate", false, Option<Timestamp>, Some(None)),
+    (r#ssn, "ssn", false, Option<String>, Some(None)),
+    (r#salary, "salary", false, Option<i32>, Some(None))
+});

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -1,3 +1,4 @@
+use crate::catalog::ArrowStream;
 use crate::{
     catalog::{DeCollectionStream, RecordFormat},
     static_compile::deinput::{
@@ -146,6 +147,13 @@ where
                 todo!()
             }
         }
+    }
+
+    fn configure_arrow_deserializer(
+        &self,
+        _config: SqlSerdeConfig,
+    ) -> Result<Box<dyn ArrowStream>, ControllerError> {
+        todo!()
     }
 }
 

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -1,4 +1,6 @@
-use super::{InputConsumer, InputEndpoint, InputReader, OutputEndpoint, Step};
+use super::{
+    InputConsumer, InputEndpoint, InputReader, OutputEndpoint, Step, TransportInputEndpoint,
+};
 use crate::PipelineState;
 use anyhow::{bail, Error as AnyError, Result as AnyResult};
 use crossbeam::sync::{Parker, Unparker};
@@ -28,16 +30,18 @@ impl FileInputEndpoint {
 }
 
 impl InputEndpoint for FileInputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}
+
+impl TransportInputEndpoint for FileInputEndpoint {
     fn open(
         &self,
         consumer: Box<dyn InputConsumer>,
         _start_step: Step,
     ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(FileInputReader::new(&self.config, consumer)?))
-    }
-
-    fn is_fault_tolerant(&self) -> bool {
-        false
     }
 }
 

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -1,7 +1,9 @@
+use crate::transport::InputEndpoint;
 use crate::{
     server::{PipelineError, MAX_REPORTED_PARSE_ERRORS},
     transport::{InputReader, Step},
-    ControllerError, InputConsumer, InputEndpoint, ParseError, PipelineState, TransportConfig,
+    ControllerError, InputConsumer, ParseError, PipelineState, TransportConfig,
+    TransportInputEndpoint,
 };
 use actix_web::{web::Payload, HttpResponse};
 use anyhow::{anyhow, Error as AnyError, Result as AnyResult};
@@ -197,6 +199,12 @@ impl HttpInputEndpoint {
 }
 
 impl InputEndpoint for HttpInputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}
+
+impl TransportInputEndpoint for HttpInputEndpoint {
     fn open(
         &self,
         consumer: Box<dyn InputConsumer>,
@@ -204,10 +212,6 @@ impl InputEndpoint for HttpInputEndpoint {
     ) -> AnyResult<Box<dyn InputReader>> {
         *self.inner.consumer.lock().unwrap() = Some(consumer);
         Ok(Box::new(self.clone()))
-    }
-
-    fn is_fault_tolerant(&self) -> bool {
-        false
     }
 }
 

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -1,7 +1,7 @@
 use super::{count_partitions_in_topic, Ctp, DataConsumerContext, ErrorHandler, POLL_TIMEOUT};
 use crate::transport::kafka::ft::check_fatal_errors;
-use crate::transport::{InputReader, Step};
-use crate::{InputConsumer, InputEndpoint};
+use crate::transport::{InputEndpoint, InputReader, Step};
+use crate::{InputConsumer, TransportInputEndpoint};
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
 use crossbeam::sync::{Parker, Unparker};
 use futures::executor::block_on;
@@ -673,6 +673,14 @@ impl InputEndpoint for Endpoint {
         Ok(steps.unwrap())
     }
 
+    fn is_fault_tolerant(&self) -> bool {
+        true
+    }
+
+    fn expire(&self, _step: Step) {}
+}
+
+impl TransportInputEndpoint for Endpoint {
     fn open(
         &self,
         consumer: Box<dyn InputConsumer>,
@@ -680,12 +688,6 @@ impl InputEndpoint for Endpoint {
     ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(Reader::new(&self.0, start_step, consumer)))
     }
-
-    fn is_fault_tolerant(&self) -> bool {
-        true
-    }
-
-    fn expire(&self, _step: Step) {}
 }
 
 struct IndexProducerContext {

--- a/crates/adapters/src/transport/kafka/nonft/input.rs
+++ b/crates/adapters/src/transport/kafka/nonft/input.rs
@@ -1,10 +1,11 @@
+use crate::transport::InputEndpoint;
 use crate::{
     transport::{
         kafka::{rdkafka_loglevel_from, refine_kafka_error, DeferredLogging},
         secret_resolver::MaybeSecret,
         InputReader, Step,
     },
-    InputConsumer, InputEndpoint, PipelineState,
+    InputConsumer, PipelineState, TransportInputEndpoint,
 };
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use crossbeam::queue::ArrayQueue;
@@ -346,16 +347,18 @@ impl KafkaInputReader {
 }
 
 impl InputEndpoint for KafkaInputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}
+
+impl TransportInputEndpoint for KafkaInputEndpoint {
     fn open(
         &self,
         consumer: Box<dyn InputConsumer>,
         _start_step: Step,
     ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(KafkaInputReader::new(&self.config, consumer)?))
-    }
-
-    fn is_fault_tolerant(&self) -> bool {
-        false
     }
 }
 

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -7,10 +7,11 @@ use tokio::sync::{
     watch::{channel, Receiver, Sender},
 };
 
-use crate::{InputConsumer, InputEndpoint, InputReader, PipelineState};
+use crate::{InputConsumer, InputReader, PipelineState, TransportInputEndpoint};
 #[cfg(test)]
 use mockall::automock;
 
+use crate::transport::InputEndpoint;
 use pipeline_types::transport::s3::{AwsCredentials, ConsumeStrategy, ReadStrategy, S3InputConfig};
 
 pub struct S3InputEndpoint {
@@ -29,7 +30,9 @@ impl InputEndpoint for S3InputEndpoint {
     fn is_fault_tolerant(&self) -> bool {
         false
     }
+}
 
+impl TransportInputEndpoint for S3InputEndpoint {
     fn open(
         &self,
         consumer: Box<dyn crate::InputConsumer>,

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -1,4 +1,4 @@
-use super::{InputConsumer, InputEndpoint, InputReader, Step};
+use super::{InputConsumer, InputEndpoint, InputReader, Step, TransportInputEndpoint};
 use crate::PipelineState;
 use actix::System;
 use actix_web::http::header::{ByteRangeSpec, ContentRangeSpec, Range, CONTENT_RANGE};
@@ -28,16 +28,18 @@ impl UrlInputEndpoint {
 }
 
 impl InputEndpoint for UrlInputEndpoint {
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}
+
+impl TransportInputEndpoint for UrlInputEndpoint {
     fn open(
         &self,
         consumer: Box<dyn InputConsumer>,
         _start_step: Step,
     ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(UrlInputReader::new(&self.config, consumer)?))
-    }
-
-    fn is_fault_tolerant(&self) -> bool {
-        false
     }
 }
 

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -12,7 +12,7 @@ use utoipa::ToSchema;
 
 use crate::query::OutputQuery;
 use crate::service::ServiceConfig;
-use crate::transport::delta_table::DeltaTableWriterConfig;
+use crate::transport::delta_table::{DeltaTableReaderConfig, DeltaTableWriterConfig};
 use crate::transport::error::{TransportReplaceError, TransportResolveError};
 use crate::transport::file::{FileInputConfig, FileOutputConfig};
 use crate::transport::kafka::{KafkaInputConfig, KafkaOutputConfig};
@@ -382,6 +382,7 @@ pub enum TransportConfig {
     KafkaOutput(KafkaOutputConfig),
     UrlInput(UrlInputConfig),
     S3Input(S3InputConfig),
+    DeltaTableInput(DeltaTableReaderConfig),
     DeltaTableOutput(DeltaTableWriterConfig),
     /// Direct HTTP input: cannot be instantiated through API
     HttpInput,
@@ -398,6 +399,7 @@ impl TransportConfigVariant for TransportConfig {
             TransportConfig::KafkaOutput(config) => config.name(),
             TransportConfig::UrlInput(config) => config.name(),
             TransportConfig::S3Input(config) => config.name(),
+            TransportConfig::DeltaTableInput(config) => config.name(),
             TransportConfig::DeltaTableOutput(config) => config.name(),
             TransportConfig::HttpInput => "http_input".to_string(),
             TransportConfig::HttpOutput => "http_output".to_string(),
@@ -412,6 +414,7 @@ impl TransportConfigVariant for TransportConfig {
             TransportConfig::KafkaOutput(config) => config.service_names(),
             TransportConfig::UrlInput(config) => config.service_names(),
             TransportConfig::S3Input(config) => config.service_names(),
+            TransportConfig::DeltaTableInput(config) => config.service_names(),
             TransportConfig::DeltaTableOutput(config) => config.service_names(),
             TransportConfig::HttpInput => vec![],
             TransportConfig::HttpOutput => vec![],
@@ -439,6 +442,9 @@ impl TransportConfigVariant for TransportConfig {
                 config.replace_any_service_names(replacement_service_names)?,
             )),
             TransportConfig::S3Input(config) => Ok(TransportConfig::S3Input(
+                config.replace_any_service_names(replacement_service_names)?,
+            )),
+            TransportConfig::DeltaTableInput(config) => Ok(TransportConfig::DeltaTableInput(
                 config.replace_any_service_names(replacement_service_names)?,
             )),
             TransportConfig::DeltaTableOutput(config) => Ok(TransportConfig::DeltaTableOutput(
@@ -478,6 +484,9 @@ impl TransportConfigVariant for TransportConfig {
                 config.resolve_any_services(services)?,
             )),
             TransportConfig::S3Input(config) => Ok(TransportConfig::S3Input(
+                config.resolve_any_services(services)?,
+            )),
+            TransportConfig::DeltaTableInput(config) => Ok(TransportConfig::DeltaTableInput(
                 config.resolve_any_services(services)?,
             )),
             TransportConfig::DeltaTableOutput(config) => Ok(TransportConfig::DeltaTableOutput(

--- a/crates/pipeline-types/src/transport/delta_table.rs
+++ b/crates/pipeline-types/src/transport/delta_table.rs
@@ -16,12 +16,186 @@ pub struct DeltaTableWriterConfig {
     /// * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
     #[serde(flatten)]
     pub object_store_config: HashMap<String, String>,
-    /// A bound on the size in bytes of a single Parquet file.
-    pub max_parquet_file_size: Option<usize>,
 }
 
 impl TransportConfigVariant for DeltaTableWriterConfig {
     fn name(&self) -> String {
         "delta_table_output".to_string()
+    }
+}
+
+/// Delta table read mode.
+///
+/// Three options are available:
+///
+/// * `snapshot` - read a snapshot of the table and stop.
+///
+/// * `follow` - continuously ingest changes to the table, starting from a specified version
+///   or timestamp.
+///
+/// * `snapshot_and_follow` - read a snapshot of the table before switching to continuous ingestion
+///   mode.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+#[serde(tag = "mode")]
+pub enum DeltaTableIngestMode {
+    /// Read a snapshot of the table and stop.
+    #[serde(rename = "snapshot")]
+    Snapshot {
+        /// Optional row filter.
+        ///
+        /// When specified, only rows that satisfy the filter condition are included in the
+        /// snapshot.  The condition must be a valid SQL Boolean expression that can be used in
+        /// the `where` clause of the `select * from snapshot where ...` query.
+        ///
+        /// This option can be used to specify the range of event times to include in the snapshot,
+        /// e.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.
+        snapshot_filter: Option<String>,
+
+        /// Optional table version for the snapshot.
+        ///
+        /// When specified, the connector retrieves the snapshot of the smallest version,
+        /// `v >= snapshot_version` in the transaction log of the table.
+        ///
+        /// Note: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.
+        /// When neither of the two options is specified, the latest committed version of the table
+        /// is used.
+        snapshot_version: Option<i64>,
+
+        /// Optional timestamp for the snapshot.
+        ///
+        /// When specified, the connector computes the snapshot of the smallest version
+        /// created at time `t >= snapshot_datetime` in the transaction log of the table.
+        ///
+        /// Note: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.
+        /// When neither of the two options is specified, the latest committed version of the table
+        /// is used.
+        snapshot_datetime: Option<String>,
+    },
+    /// Follow the changelog of the table, only ingesting changes (new and deleted rows).
+    #[serde(rename = "follow")]
+    Follow {
+        /// Optional table version to start reading from.
+        ///
+        /// When specified, the connector follows the changelog starting from the first version
+        /// `v >= start_version` of the table.
+        ///
+        /// Note: at most one of `start_version` and `start_datetime` options can be specified.
+        /// When neither of the two options is specified, the connector ingests changes that show
+        /// up _after_ the latest committed version of the table.
+        start_version: Option<i64>,
+
+        /// Optional timestamp to start reading from.
+        ///
+        /// When specified, the connector follows the changelog starting from the first version
+        /// of the table created at time `t >= start_datetime`.
+        ///
+        /// Note: at most one of `start_version` and `start_datetime` options can be specified.
+        /// When neither of the two options is specified, the connector ingests changes that show
+        /// up _after_ the latest committed version of the table.
+        start_datetime: Option<String>,
+    },
+
+    /// Take a snapshot of the table before switching to the `follow` mode.
+    #[serde(rename = "snapshot_and_follow")]
+    SnapshotAndFollow {
+        /// Optional row filter.
+        ///
+        /// When specified, only rows that satisfy the filter condition are included in the
+        /// snapshot.  The condition must be a valid SQL Boolean expression that can be used in
+        /// the `where` clause of the `select * from snapshot where ...` query.
+        ///
+        /// This option can be used to specify the range of event times to include in the snapshot,
+        /// e.g.: `ts > '2005-01-01 00:00:00'`.
+        ///
+        /// Note: the filter condition only applies to the initial snapshot of the table, and not
+        /// to the records subsequently ingested in the `follow` mode.
+        snapshot_filter: Option<String>,
+
+        /// Optional table version to start following from.
+        ///
+        /// When specified, the connector retrieves the snapshot of the first version
+        /// `v >= start_version` of the table and starts following transaction log after that.
+        ///
+        /// Note: at most one of `start_version` and `start_datetime` options can be specified.
+        /// When neither of the two options is specified, the connector uses the latest committed
+        /// version.
+        start_version: Option<i64>,
+
+        /// Optional timestamp to start following from.
+        ///
+        /// When specified, the connector retrives the snapshot of the first version
+        /// of the table created at time `t >= start_datetime` and starts following the change
+        /// log after that.
+        ///
+        /// Note: at most one of `start_version` and `start_datetime` options can be specified.
+        /// When neither of the two options is specified, the connector uses the latest committed
+        /// version.
+        start_datetime: Option<String>,
+    },
+}
+
+/// Delta table output connector configuration.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct DeltaTableReaderConfig {
+    /// Table URI.
+    pub uri: String,
+    /// Storage options for configuring backend object store.
+    ///
+    /// For specific options available for different storage backends, see:
+    /// * [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)
+    /// * [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
+    /// * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
+    #[serde(flatten)]
+    pub object_store_config: HashMap<String, String>,
+
+    /// Table column that serves as an event timestamp.
+    ///
+    /// When this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,
+    /// the snapshot of the table will be sorted by the corresponding column.
+    // TODO: The above semantics is expensive and unnecessary.  What is really needed is to maintain
+    // the `LATENESS` guarantee of the column, for which it is sufficient to ingest rows sorted up
+    // to lateness by issuing a series of queries for lateness-width time ranges to the table.
+    pub timestamp_column: Option<String>,
+
+    /// Table read mode.
+    #[serde(flatten)]
+    pub mode: DeltaTableIngestMode,
+}
+
+impl DeltaTableReaderConfig {
+    /// `true` if the configuration requires taking an initial snapshot of the table.
+    pub fn snapshot(&self) -> bool {
+        matches!(
+            &self.mode,
+            DeltaTableIngestMode::Snapshot { .. } | DeltaTableIngestMode::SnapshotAndFollow { .. }
+        )
+    }
+
+    /// `true` if the configuration requires following the transaction log of the table
+    /// (possibly after taking an initial snapshot).s
+    pub fn follow(&self) -> bool {
+        matches!(
+            &self.mode,
+            DeltaTableIngestMode::SnapshotAndFollow { .. } | DeltaTableIngestMode::Follow { .. }
+        )
+    }
+
+    /// Filter expression to use during snapshotting.
+    pub fn snapshot_filter(&self) -> Option<&str> {
+        match &self.mode {
+            DeltaTableIngestMode::Snapshot {
+                snapshot_filter, ..
+            } => snapshot_filter.as_ref().map(AsRef::as_ref),
+            DeltaTableIngestMode::SnapshotAndFollow {
+                snapshot_filter, ..
+            } => snapshot_filter.as_ref().map(AsRef::as_ref),
+            _ => None,
+        }
+    }
+}
+
+impl TransportConfigVariant for DeltaTableReaderConfig {
+    fn name(&self) -> String {
+        "delta_table_input".to_string()
     }
 }

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -213,6 +213,8 @@ request is rejected."
         pipeline_types::transport::s3::ConsumeStrategy,
         pipeline_types::transport::s3::ReadStrategy,
         pipeline_types::transport::s3::S3InputConfig,
+        pipeline_types::transport::delta_table::DeltaTableIngestMode,
+        pipeline_types::transport::delta_table::DeltaTableReaderConfig,
         pipeline_types::transport::delta_table::DeltaTableWriterConfig,
         pipeline_types::format::csv::CsvEncoderConfig,
         pipeline_types::format::csv::CsvParserConfig,

--- a/openapi.json
+++ b/openapi.json
@@ -3380,6 +3380,131 @@
       "CsvParserConfig": {
         "type": "object"
       },
+      "DeltaTableIngestMode": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Read a snapshot of the table and stop.",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "snapshot"
+                ]
+              },
+              "snapshot_datetime": {
+                "type": "string",
+                "description": "Optional timestamp for the snapshot.\n\nWhen specified, the connector computes the snapshot of the smallest version\ncreated at time `t >= snapshot_datetime` in the transaction log of the table.\n\nNote: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
+                "nullable": true
+              },
+              "snapshot_filter": {
+                "type": "string",
+                "description": "Optional row filter.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.",
+                "nullable": true
+              },
+              "snapshot_version": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Optional table version for the snapshot.\n\nWhen specified, the connector retrieves the snapshot of the smallest version,\n`v >= snapshot_version` in the transaction log of the table.\n\nNote: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
+                "nullable": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Follow the changelog of the table, only ingesting changes (new and deleted rows).",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "follow"
+                ]
+              },
+              "start_datetime": {
+                "type": "string",
+                "description": "Optional timestamp to start reading from.\n\nWhen specified, the connector follows the changelog starting from the first version\nof the table created at time `t >= start_datetime`.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector ingests changes that show\nup _after_ the latest committed version of the table.",
+                "nullable": true
+              },
+              "start_version": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Optional table version to start reading from.\n\nWhen specified, the connector follows the changelog starting from the first version\n`v >= start_version` of the table.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector ingests changes that show\nup _after_ the latest committed version of the table.",
+                "nullable": true
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Take a snapshot of the table before switching to the `follow` mode.",
+            "required": [
+              "mode"
+            ],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "snapshot_and_follow"
+                ]
+              },
+              "snapshot_filter": {
+                "type": "string",
+                "description": "Optional row filter.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts > '2005-01-01 00:00:00'`.\n\nNote: the filter condition only applies to the initial snapshot of the table, and not\nto the records subsequently ingested in the `follow` mode.",
+                "nullable": true
+              },
+              "start_datetime": {
+                "type": "string",
+                "description": "Optional timestamp to start following from.\n\nWhen specified, the connector retrives the snapshot of the first version\nof the table created at time `t >= start_datetime` and starts following the change\nlog after that.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector uses the latest committed\nversion.",
+                "nullable": true
+              },
+              "start_version": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Optional table version to start following from.\n\nWhen specified, the connector retrieves the snapshot of the first version\n`v >= start_version` of the table and starts following transaction log after that.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector uses the latest committed\nversion.",
+                "nullable": true
+              }
+            }
+          }
+        ],
+        "description": "Delta table read mode.\n\nThree options are available:\n\n* `snapshot` - read a snapshot of the table and stop.\n\n* `follow` - continuously ingest changes to the table, starting from a specified version\nor timestamp.\n\n* `snapshot_and_follow` - read a snapshot of the table before switching to continuous ingestion\nmode.",
+        "discriminator": {
+          "propertyName": "mode"
+        }
+      },
+      "DeltaTableReaderConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DeltaTableIngestMode"
+          },
+          {
+            "type": "object",
+            "required": [
+              "uri"
+            ],
+            "properties": {
+              "timestamp_column": {
+                "type": "string",
+                "description": "Table column that serves as an event timestamp.\n\nWhen this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,\nthe snapshot of the table will be sorted by the corresponding column.",
+                "nullable": true
+              },
+              "uri": {
+                "type": "string",
+                "description": "Table URI."
+              }
+            },
+            "additionalProperties": {
+              "type": "string",
+              "description": "Storage options for configuring backend object store.\n\nFor specific options available for different storage backends, see:\n* [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)\n* [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)\n* [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)"
+            }
+          }
+        ],
+        "description": "Delta table output connector configuration."
+      },
       "DeltaTableWriterConfig": {
         "type": "object",
         "description": "Delta table output connector configuration.",
@@ -3387,12 +3512,6 @@
           "uri"
         ],
         "properties": {
-          "max_parquet_file_size": {
-            "type": "integer",
-            "description": "A bound on the size in bytes of a single Parquet file.",
-            "nullable": true,
-            "minimum": 0
-          },
           "uri": {
             "type": "string",
             "description": "Table URI."
@@ -5282,6 +5401,24 @@
                 "type": "string",
                 "enum": [
                   "s3_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/DeltaTableReaderConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "delta_table_input"
                 ]
               }
             }


### PR DESCRIPTION
This adapter supports ingesting a delta table in three modes:

- follow - incrementally ingest transaction log starting from a specified (or the latest) version.

- snapshot - read table snapshot, optionally sorted by a timestamp column and optionally filtered by a user-provided predicate, e.g.,  specifying a time range.

- snapshot-and-follow - combines the above two modes.

The connector was tested with local FS and with S3, including with a managed delta table created by databricks in S3.

There are a couple of todos left.  The biggest one is that sorting by timestamp can be very expensive.  A better solution is to implement something like [this](https://docs.databricks.com/en/structured-streaming/delta-lake.html#process-initial-snapshot-without-data-being-dropped).

The second issue is that in follow mode we currently read one file at a time from S3.  We should look into using datafusion's `ListingTable`, which (hopefully) parallelizes the process.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
