### PR TITLE
connectors: delta table: remove field flattening and internal tagging

### DIFF
--- a/crates/pipeline-types/src/transport/delta_table.rs
+++ b/crates/pipeline-types/src/transport/delta_table.rs
@@ -14,7 +14,6 @@ pub struct DeltaTableWriterConfig {
     /// * [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)
     /// * [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
     /// * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
-    #[serde(flatten)]
     pub object_store_config: HashMap<String, String>,
 }
 
@@ -36,7 +35,6 @@ impl TransportConfigVariant for DeltaTableWriterConfig {
 /// * `snapshot_and_follow` - read a snapshot of the table before switching to continuous ingestion
 ///   mode.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
-#[serde(tag = "mode")]
 pub enum DeltaTableIngestMode {
     /// Read a snapshot of the table and stop.
     #[serde(rename = "snapshot")]
@@ -145,7 +143,6 @@ pub struct DeltaTableReaderConfig {
     /// * [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)
     /// * [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
     /// * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
-    #[serde(flatten)]
     pub object_store_config: HashMap<String, String>,
 
     /// Table column that serves as an event timestamp.
@@ -158,7 +155,6 @@ pub struct DeltaTableReaderConfig {
     pub timestamp_column: Option<String>,
 
     /// Table read mode.
-    #[serde(flatten)]
     pub mode: DeltaTableIngestMode,
 }
 


### PR DESCRIPTION
Serialization/deserialization of `DeltaTableReaderConfig` currently is confused about the flattened HashMap and ingest mode. For example, if you run:

```
curl -X 'PUT' 'http://localhost:8080/v0/connectors/delta_table_input_connector' -d '{
  "description": "Some description",
  "config": {
    "transport": {
        "name": "delta_table_input",
        "config": {
            "uri": "protocol:/path/to/somewhere",
            "customoption1": "val1",
            "customoption2": "val2",
            "customoption3": "val3",
            "customoption4": "val4",
            "customoption5": "val5",
            "mode": "follow"
        }
    }
  }
}' -H 'Content-Type: application/json'
```

... it will return successfully, but then if you do:

```
curl -X 'GET' 'http://localhost:8080/v0/connectors'
```

Deserialization from the database will not work, it will have serialized it internally in confusion to (note the double 'mode' -- it is also not possible to give `start_version: 67` because it is an integer not a string):

```
transport:
  name: delta_table_input
  config:
    uri: protocol:/path/to/somewhere
    mode: follow
    customoption5: val5
    customoption2: val2
    customoption3: val3
    customoption1: val1
    customoption4: val4
    timestamp_column: null
    mode: follow
    start_version: null
    start_datetime: null
```

This PR makes the delta table connector configurations without field flattening and internal tagging, such that the API is unambiguous. New usage is:

```
curl -X 'PUT' 'http://localhost:8080/v0/connectors/delta_table_input_connector' -d '{
  "description": "Some description",
  "config": {
    "transport": {
        "name": "delta_table_input",
        "config": {
            "uri": "protocol:/path/to/somewhere",
            "object_store_config": {
                "customoption1": "val1",
                "customoption2": "val2",
                "customoption3": "val3",
                "customoption4": "val4",
                "customoption5": "val5"
            },
            "mode": {
                "follow": {
                    "start_version": 67,
                    "start_datetime": "something"
                }
            }
        }
    }
  }
}' -H 'Content-Type: application/json'
```

Is this a user-visible change (yes/no): yes