### PR TITLE
Fix serde issue with Delta input config.

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3381,129 +3381,55 @@
         "type": "object"
       },
       "DeltaTableIngestMode": {
-        "oneOf": [
-          {
-            "type": "object",
-            "description": "Read a snapshot of the table and stop.",
-            "required": [
-              "mode"
-            ],
-            "properties": {
-              "mode": {
-                "type": "string",
-                "enum": [
-                  "snapshot"
-                ]
-              },
-              "snapshot_datetime": {
-                "type": "string",
-                "description": "Optional timestamp for the snapshot.\n\nWhen specified, the connector computes the snapshot of the smallest version\ncreated at time `t >= snapshot_datetime` in the transaction log of the table.\n\nNote: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
-                "nullable": true
-              },
-              "snapshot_filter": {
-                "type": "string",
-                "description": "Optional row filter.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.",
-                "nullable": true
-              },
-              "snapshot_version": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Optional table version for the snapshot.\n\nWhen specified, the connector retrieves the snapshot of the smallest version,\n`v >= snapshot_version` in the transaction log of the table.\n\nNote: at most one of `snapshot_version` and `snapshot_datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
-                "nullable": true
-              }
-            }
-          },
-          {
-            "type": "object",
-            "description": "Follow the changelog of the table, only ingesting changes (new and deleted rows).",
-            "required": [
-              "mode"
-            ],
-            "properties": {
-              "mode": {
-                "type": "string",
-                "enum": [
-                  "follow"
-                ]
-              },
-              "start_datetime": {
-                "type": "string",
-                "description": "Optional timestamp to start reading from.\n\nWhen specified, the connector follows the changelog starting from the first version\nof the table created at time `t >= start_datetime`.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector ingests changes that show\nup _after_ the latest committed version of the table.",
-                "nullable": true
-              },
-              "start_version": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Optional table version to start reading from.\n\nWhen specified, the connector follows the changelog starting from the first version\n`v >= start_version` of the table.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector ingests changes that show\nup _after_ the latest committed version of the table.",
-                "nullable": true
-              }
-            }
-          },
-          {
-            "type": "object",
-            "description": "Take a snapshot of the table before switching to the `follow` mode.",
-            "required": [
-              "mode"
-            ],
-            "properties": {
-              "mode": {
-                "type": "string",
-                "enum": [
-                  "snapshot_and_follow"
-                ]
-              },
-              "snapshot_filter": {
-                "type": "string",
-                "description": "Optional row filter.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts > '2005-01-01 00:00:00'`.\n\nNote: the filter condition only applies to the initial snapshot of the table, and not\nto the records subsequently ingested in the `follow` mode.",
-                "nullable": true
-              },
-              "start_datetime": {
-                "type": "string",
-                "description": "Optional timestamp to start following from.\n\nWhen specified, the connector retrives the snapshot of the first version\nof the table created at time `t >= start_datetime` and starts following the change\nlog after that.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector uses the latest committed\nversion.",
-                "nullable": true
-              },
-              "start_version": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Optional table version to start following from.\n\nWhen specified, the connector retrieves the snapshot of the first version\n`v >= start_version` of the table and starts following transaction log after that.\n\nNote: at most one of `start_version` and `start_datetime` options can be specified.\nWhen neither of the two options is specified, the connector uses the latest committed\nversion.",
-                "nullable": true
-              }
-            }
-          }
-        ],
+        "type": "string",
         "description": "Delta table read mode.\n\nThree options are available:\n\n* `snapshot` - read a snapshot of the table and stop.\n\n* `follow` - continuously ingest changes to the table, starting from a specified version\nor timestamp.\n\n* `snapshot_and_follow` - read a snapshot of the table before switching to continuous ingestion\nmode.",
-        "discriminator": {
-          "propertyName": "mode"
-        }
+        "enum": [
+          "snapshot",
+          "follow",
+          "snapshot_and_follow"
+        ]
       },
       "DeltaTableReaderConfig": {
-        "allOf": [
-          {
+        "type": "object",
+        "description": "Delta table output connector configuration.",
+        "required": [
+          "uri",
+          "mode"
+        ],
+        "properties": {
+          "datetime": {
+            "type": "string",
+            "description": "Optional timestamp for the snapshot in the ISO-8601/RFC-3339 format.\n\nWhen this option is set, the connector finds and opens the version of the table as of the\nspecified point in time.  In `snapshot` and `snapshot_and_follow` modes, it retrieves the\nsnapshot of this version of the table.  In `follow` and `snapshot_and_follow` modes, it\nfollows transaction log records **after** this version.\n\nNote: at most one of `version` and `datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
+            "nullable": true
+          },
+          "mode": {
             "$ref": "#/components/schemas/DeltaTableIngestMode"
           },
-          {
-            "type": "object",
-            "required": [
-              "uri"
-            ],
-            "properties": {
-              "timestamp_column": {
-                "type": "string",
-                "description": "Table column that serves as an event timestamp.\n\nWhen this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,\nthe snapshot of the table will be sorted by the corresponding column.",
-                "nullable": true
-              },
-              "uri": {
-                "type": "string",
-                "description": "Table URI."
-              }
-            },
-            "additionalProperties": {
-              "type": "string",
-              "description": "Storage options for configuring backend object store.\n\nFor specific options available for different storage backends, see:\n* [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)\n* [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)\n* [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)"
-            }
+          "snapshot_filter": {
+            "type": "string",
+            "description": "Optional row filter.\n\nThis option is only valid when `mode` is set to `snapshot` or `snapshot_and_follow`.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.",
+            "nullable": true
+          },
+          "timestamp_column": {
+            "type": "string",
+            "description": "Table column that serves as an event timestamp.\n\nWhen this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,\nthe snapshot of the table will be sorted by the corresponding column.",
+            "nullable": true
+          },
+          "uri": {
+            "type": "string",
+            "description": "Table URI."
+          },
+          "version": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Optional table version.\n\nWhen this option is set, the connector finds and opens the specified version of the table.\nIn `snapshot` and `snapshot_and_follow` modes, it retrieves the snapshot of this version of\nthe table.  In `follow` and `snapshot_and_follow` modes, it follows transaction log records\n**after** this version.\n\nNote: at most one of `version` and `datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",
+            "nullable": true
           }
-        ],
-        "description": "Delta table output connector configuration."
+        },
+        "additionalProperties": {
+          "type": "string",
+          "description": "Storage options for configuring backend object store.\n\nFor specific options available for different storage backends, see:\n* [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)\n* [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)\n* [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)"
+        }
       },
       "DeltaTableWriterConfig": {
         "type": "object",


### PR DESCRIPTION
The issue is reported [here](https://github.com/feldera/feldera/pull/1764) and is caused by the interaction between two serde `flatten` attributes, one on a HashMap and one on a tagged enum.  As a workaround, I removed the latter embedding its fields directly in the connector config, which actually seems cleaner as well.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
