### PR TITLE
dbsp: Fix excessive storage files using nonzero storage size threshold.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -440,7 +440,8 @@ impl Controller {
     {
         let mut start: Option<Instant> = None;
         let min_storage_rows = if controller.status.pipeline_config.global.storage {
-            0
+            // This reduces the files stored on disk to a reasonable number.
+            1_000_000
         } else {
             usize::MAX
         };


### PR DESCRIPTION
Without this, feeding just a few records to, say, the SecOps demo produces several hundred files on disk.  With this, no files are written.

Addresses https://github.com/feldera/feldera/issues/1712.

Is this a user-visible change (yes/no): no