### PR TITLE
pipeline-manager: program compilation profile with default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1734](https://github.com/feldera/feldera/pull/1734))
 - [Docs] Expand connectors documentation
   ([#1746](https://github.com/feldera/feldera/pull/1746))
+- [pipeline-manager] Program compilation profile is optional and is no
+  longer treated as a hint. Compiler compilation profile is now a default.
+  ([#1777](https://github.com/feldera/feldera/pull/1777))
 
 ## [0.15.0] - 2024-04-30
 

--- a/crates/pipeline_manager/migrations/V15__program_compilation_profile_nullable.sql
+++ b/crates/pipeline_manager/migrations/V15__program_compilation_profile_nullable.sql
@@ -1,0 +1,3 @@
+-- The program compilation profile can now also not be specified,
+-- in which case the compiler default compilation profile is used.
+ALTER TABLE program ALTER COLUMN compilation_profile DROP NOT NULL;

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -201,7 +201,7 @@ async fn program_creation() {
             "program desc",
             "ignored",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -217,7 +217,7 @@ async fn program_creation() {
         schema: None,
         code: None,
         config: ProgramConfig {
-            profile: CompilationProfile::Unoptimized,
+            profile: Some(CompilationProfile::Unoptimized),
         },
     };
     let actual = rows.get(0).unwrap();
@@ -234,7 +234,7 @@ async fn program_creation() {
         schema: None,
         code: Some("ignored".to_string()),
         config: ProgramConfig {
-            profile: CompilationProfile::Unoptimized,
+            profile: Some(CompilationProfile::Unoptimized),
         },
     };
     let actual = rows.get(0).unwrap();
@@ -251,7 +251,7 @@ async fn program_creation() {
         schema: None,
         code: None,
         config: ProgramConfig {
-            profile: CompilationProfile::Unoptimized,
+            profile: Some(CompilationProfile::Unoptimized),
         },
     };
     let (_, actual) = rows.get(0).unwrap();
@@ -272,7 +272,7 @@ async fn duplicate_program() {
             "program desc",
             "ignored",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -286,7 +286,7 @@ async fn duplicate_program() {
             "program desc",
             "ignored",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -309,7 +309,7 @@ async fn program_code() {
             "program desc",
             "create table t1(c1 integer);",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -341,7 +341,7 @@ async fn update_program() {
             "program desc",
             "create table t1(c1 integer);",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -406,7 +406,7 @@ async fn program_queries() {
             "program desc",
             "create table t1(c1 integer);",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -494,7 +494,7 @@ async fn project_pending() {
             "project desc",
             "ignored",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -509,7 +509,7 @@ async fn project_pending() {
             "project desc",
             "ignored",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -547,7 +547,7 @@ async fn update_status() {
             "program desc",
             "create table t1(c1 integer);",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -788,7 +788,7 @@ async fn versioning_no_change_no_connectors() {
             "",
             "",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -845,7 +845,7 @@ async fn versioning() {
             "program desc",
             "only schema matters--this isn't compiled",
             &ProgramConfig {
-                profile: CompilationProfile::Unoptimized,
+                profile: Some(CompilationProfile::Unoptimized),
             },
             None,
         )
@@ -1340,23 +1340,31 @@ pub(crate) fn option_runtime_config() -> impl Strategy<Value = Option<RuntimeCon
 
 /// Generate different program configurations
 pub(crate) fn program_config() -> impl Strategy<Value = ProgramConfig> {
-    any::<(bool,)>().prop_map(|config| ProgramConfig {
+    any::<(bool, bool)>().prop_map(|config| ProgramConfig {
         profile: if config.0 {
-            CompilationProfile::Unoptimized
+            None
         } else {
-            CompilationProfile::Optimized
+            if config.1 {
+                Some(CompilationProfile::Unoptimized)
+            } else {
+                Some(CompilationProfile::Optimized)
+            }
         },
     })
 }
 
 /// Generate different program configurations
 pub(crate) fn option_program_config() -> impl Strategy<Value = Option<ProgramConfig>> {
-    any::<Option<(bool,)>>().prop_map(|c| {
+    any::<Option<(bool, bool)>>().prop_map(|c| {
         c.map(|config| ProgramConfig {
             profile: if config.0 {
-                CompilationProfile::Unoptimized
+                None
             } else {
-                CompilationProfile::Optimized
+                if config.1 {
+                    Some(CompilationProfile::Unoptimized)
+                } else {
+                    Some(CompilationProfile::Optimized)
+                }
             },
         })
     })

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -267,7 +267,7 @@ mod test {
                     "program desc",
                     "ignored",
                     &ProgramConfig {
-                        profile: CompilationProfile::Unoptimized,
+                        profile: Some(CompilationProfile::Unoptimized),
                     },
                     None,
                 )
@@ -392,7 +392,7 @@ mod test {
                 "program desc",
                 "ignored",
                 &ProgramConfig {
-                    profile: CompilationProfile::Unoptimized,
+                    profile: Some(CompilationProfile::Unoptimized),
                 },
                 None,
             )

--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -117,7 +117,7 @@ async fn initialize_local_pipeline_manager_instance() -> TempDir {
         compiler_working_directory: workdir.to_owned(),
         sql_compiler_home: "../../sql-to-dbsp-compiler".to_owned(),
         dbsp_override_path: "../../".to_owned(),
-        compilation_profile: Some(crate::config::CompilationProfile::Unoptimized),
+        compilation_profile: crate::config::CompilationProfile::Unoptimized,
         precompile: true,
         binary_ref_host: "127.0.0.1".to_string(),
         binary_ref_port: 9090,

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -744,7 +744,7 @@ mod test {
                 "program desc",
                 "ignored",
                 &ProgramConfig {
-                    profile: CompilationProfile::Unoptimized,
+                    profile: Some(CompilationProfile::Unoptimized),
                 },
                 None,
             )

--- a/openapi.json
+++ b/openapi.json
@@ -3253,7 +3253,7 @@
       },
       "CompilationProfile": {
         "type": "string",
-        "description": "Argument to `cargo build --profile <>` passed to the rust compiler\n\nNote that this is a hint to the backend, and can be overriden by\nthe Feldera instance depending on the administrator configuration.",
+        "description": "Enumeration of possible compilation profiles that can be passed to the Rust compiler\nas an argument via `cargo build --profile <>`. A compilation profile affects among\nother things the compilation speed (how long till the program is ready to be run)\nand runtime speed (the performance while running).",
         "enum": [
           "dev",
           "unoptimized",
@@ -4581,12 +4581,14 @@
       "ProgramConfig": {
         "type": "object",
         "description": "Program configuration.",
-        "required": [
-          "profile"
-        ],
         "properties": {
           "profile": {
-            "$ref": "#/components/schemas/CompilationProfile"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompilationProfile"
+              }
+            ],
+            "nullable": true
           }
         }
       },

--- a/web-console/README.md
+++ b/web-console/README.md
@@ -72,7 +72,6 @@ If you change the API, execute the following steps to update the bindings:
 ```bash
 yarn build-openapi
 yarn generate-openapi
-patch -p2 < openapi-fixes.patch
 ```
 
 Note sometimes strange caching errors may warrant deleting `node_modules` after

--- a/web-console/openapi-fixes.patch
+++ b/web-console/openapi-fixes.patch
@@ -1,9 +1,7 @@
-This patch fixes bugs in output from `yarn generate-openapi && yarn format`.
-
-diff --git b/web-console/src/lib/services/manager/models/ColumnType.ts a/web-console/src/lib/services/manager/models/ColumnType.ts
+diff --git a/web-console/src/lib/services/manager/models/ColumnType.ts b/web-console/src/lib/services/manager/models/ColumnType.ts
 index 8484d2bea..953d53760 100644
---- b/web-console/src/lib/services/manager/models/ColumnType.ts
-+++ a/web-console/src/lib/services/manager/models/ColumnType.ts
+--- a/web-console/src/lib/services/manager/models/ColumnType.ts
++++ b/web-console/src/lib/services/manager/models/ColumnType.ts
 @@ -57,5 +57,5 @@ export type ColumnType = {
     * - `DECIMAL(1,2)` sets scale to `2`.
     */
@@ -11,19 +9,24 @@ index 8484d2bea..953d53760 100644
 -  type?: SqlType
 +  type: SqlType
  }
-diff --git b/web-console/src/lib/services/manager/models/TransportConfig.ts a/web-console/src/lib/services/manager/models/TransportConfig.ts
-index 1adc4562e..c826d84c8 100644
---- b/web-console/src/lib/services/manager/models/TransportConfig.ts
-+++ a/web-console/src/lib/services/manager/models/TransportConfig.ts
-@@ -9,6 +9,7 @@ import type { KafkaInputConfig } from './KafkaInputConfig'
- import type { KafkaOutputConfig } from './KafkaOutputConfig'
- import type { S3InputConfig } from './S3InputConfig'
- import type { UrlInputConfig } from './UrlInputConfig'
-+
- /**
-  * Transport-specific endpoint configuration passed to
-  * `crate::OutputTransport::new_endpoint`
-@@ -17,37 +18,42 @@ import type { UrlInputConfig } from './UrlInputConfig'
+diff --git a/web-console/src/lib/services/manager/models/ConnectorConfig.ts b/web-console/src/lib/services/manager/models/ConnectorConfig.ts
+index 1e6fdd524..9c994ea19 100644
+--- a/web-console/src/lib/services/manager/models/ConnectorConfig.ts
++++ b/web-console/src/lib/services/manager/models/ConnectorConfig.ts
+@@ -9,7 +9,7 @@ import type { TransportConfig } from './TransportConfig'
+  * A data connector's configuration
+  */
+ export type ConnectorConfig = OutputBufferConfig & {
+-  format?: FormatConfig | null
++  format: FormatConfig
+   /**
+    * Backpressure threshold.
+    *
+diff --git a/web-console/src/lib/services/manager/models/TransportConfig.ts b/web-console/src/lib/services/manager/models/TransportConfig.ts
+index a44285d34..774e36089 100644
+--- a/web-console/src/lib/services/manager/models/TransportConfig.ts
++++ b/web-console/src/lib/services/manager/models/TransportConfig.ts
+@@ -18,41 +18,47 @@ import type { UrlInputConfig } from './UrlInputConfig'
  export type TransportConfig =
    | {
        config: FileInputConfig
@@ -56,6 +59,11 @@ index 1adc4562e..c826d84c8 100644
 +      name: TransportConfig.name.S3_INPUT
      }
    | {
+       config: DeltaTableReaderConfig
+-      name: TransportConfig.name
++      name: TransportConfig.name.DELTA_TABLE_INPUT
+     }
+   | {
        config: DeltaTableWriterConfig
 -      name: TransportConfig.name
 -    }
@@ -72,21 +80,9 @@ index 1adc4562e..c826d84c8 100644
 +    KAFKA_OUTPUT = 'kafka_output',
 +    URL_INPUT = 'url_input',
 +    S3_INPUT = 's3_input',
++    DELTA_TABLE_INPUT = 'delta_table_input',
 +    DELTA_TABLE_OUTPUT = 'delta_table_output',
 +    HTTP_INPUT = 'http_input',
 +    HTTP_OUTPUT = 'http_output'
    }
  }
-diff --git b/web-console/src/lib/services/manager/models/ConnectorConfig.ts a/web-console/src/lib/services/manager/models/ConnectorConfig.ts
-index 1e6fdd524..9c994ea19 100644
---- b/web-console/src/lib/services/manager/models/ConnectorConfig.ts
-+++ a/web-console/src/lib/services/manager/models/ConnectorConfig.ts
-@@ -9,7 +9,7 @@ import type { TransportConfig } from './TransportConfig'
-  * A data connector's configuration
-  */
- export type ConnectorConfig = OutputBufferConfig & {
--  format?: FormatConfig | null
-+  format: FormatConfig
-   /**
-    * Backpressure threshold.
-    *

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --max-warnings 0 --fix \"src/**/*.{js,jsx,ts,tsx}\"",
     "format": "prettier --write \"{src,tests}/**/*.{js,jsx,ts,tsx}\"",
     "format-check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
-    "generate-openapi": "openapi --input ../openapi.json --output ./src/lib/services/manager && yarn format",
+    "generate-openapi": "openapi --input ../openapi.json --output ./src/lib/services/manager && yarn format && patch -p2 < openapi-fixes.patch",
     "build-openapi": "cd .. && cargo run --bin pipeline-manager -- --dump-openapi",
     "test": "PLAYWRIGHT_API_ORIGIN=http://localhost:8080/ PLAYWRIGHT_APP_ORIGIN=http://localhost:8080/ DISPLAY= yarn playwright test",
     "test-ui": "PLAYWRIGHT_API_ORIGIN=http://localhost:8080/ PLAYWRIGHT_APP_ORIGIN=http://localhost:8080/ DISPLAY= yarn playwright test --ui-host=0.0.0.0",

--- a/web-console/src/lib/components/layouts/analytics/editor.tsx
+++ b/web-console/src/lib/components/layouts/analytics/editor.tsx
@@ -163,7 +163,7 @@ const useCreateProgramEffect = (
     if (!program.name || program.program_id) {
       return
     }
-    return createProgram({ ...program, code: program.code ?? '' })
+    return createProgram({ ...program, config: undefined, code: program.code ?? '' })
   }, SAVE_DELAY)
   useEffect(() => createProgramDebounced(), [program, createProgramDebounced])
 }

--- a/web-console/src/lib/services/manager/core/OpenAPI.ts
+++ b/web-console/src/lib/services/manager/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
   BASE: '',
-  VERSION: '0.15.0',
+  VERSION: '0.16.0',
   WITH_CREDENTIALS: false,
   CREDENTIALS: 'include',
   TOKEN: undefined,

--- a/web-console/src/lib/services/manager/index.ts
+++ b/web-console/src/lib/services/manager/index.ts
@@ -33,6 +33,8 @@ export type { CreateOrReplaceServiceResponse } from './models/CreateOrReplaceSer
 export type { CreateServiceProbeResponse } from './models/CreateServiceProbeResponse'
 export type { CsvEncoderConfig } from './models/CsvEncoderConfig'
 export type { CsvParserConfig } from './models/CsvParserConfig'
+export { DeltaTableIngestMode } from './models/DeltaTableIngestMode'
+export type { DeltaTableReaderConfig } from './models/DeltaTableReaderConfig'
 export type { DeltaTableWriterConfig } from './models/DeltaTableWriterConfig'
 export { EgressMode } from './models/EgressMode'
 export type { ErrorResponse } from './models/ErrorResponse'

--- a/web-console/src/lib/services/manager/models/CompilationProfile.ts
+++ b/web-console/src/lib/services/manager/models/CompilationProfile.ts
@@ -3,10 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
- * Argument to `cargo build --profile <>` passed to the rust compiler
- *
- * Note that this is a hint to the backend, and can be overriden by
- * the Feldera instance depending on the administrator configuration.
+ * Enumeration of possible compilation profiles that can be passed to the Rust compiler
+ * as an argument via `cargo build --profile <>`. A compilation profile affects among
+ * other things the compilation speed (how long till the program is ready to be run)
+ * and runtime speed (the performance while running).
  */
 export enum CompilationProfile {
   DEV = 'dev',

--- a/web-console/src/lib/services/manager/models/DeltaTableIngestMode.ts
+++ b/web-console/src/lib/services/manager/models/DeltaTableIngestMode.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Delta table read mode.
+ *
+ * Three options are available:
+ *
+ * * `snapshot` - read a snapshot of the table and stop.
+ *
+ * * `follow` - continuously ingest changes to the table, starting from a specified version
+ * or timestamp.
+ *
+ * * `snapshot_and_follow` - read a snapshot of the table before switching to continuous ingestion
+ * mode.
+ */
+export enum DeltaTableIngestMode {
+  SNAPSHOT = 'snapshot',
+  FOLLOW = 'follow',
+  SNAPSHOT_AND_FOLLOW = 'snapshot_and_follow'
+}

--- a/web-console/src/lib/services/manager/models/DeltaTableReaderConfig.ts
+++ b/web-console/src/lib/services/manager/models/DeltaTableReaderConfig.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * Delta table output connector configuration.
+ */
+export type DeltaTableReaderConfig = Record<string, string>

--- a/web-console/src/lib/services/manager/models/ProgramConfig.ts
+++ b/web-console/src/lib/services/manager/models/ProgramConfig.ts
@@ -7,5 +7,5 @@ import type { CompilationProfile } from './CompilationProfile'
  * Program configuration.
  */
 export type ProgramConfig = {
-  profile: CompilationProfile
+  profile?: CompilationProfile | null
 }

--- a/web-console/src/lib/services/manager/models/TransportConfig.ts
+++ b/web-console/src/lib/services/manager/models/TransportConfig.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { DeltaTableReaderConfig } from './DeltaTableReaderConfig'
 import type { DeltaTableWriterConfig } from './DeltaTableWriterConfig'
 import type { FileInputConfig } from './FileInputConfig'
 import type { FileOutputConfig } from './FileOutputConfig'
@@ -9,7 +10,6 @@ import type { KafkaInputConfig } from './KafkaInputConfig'
 import type { KafkaOutputConfig } from './KafkaOutputConfig'
 import type { S3InputConfig } from './S3InputConfig'
 import type { UrlInputConfig } from './UrlInputConfig'
-
 /**
  * Transport-specific endpoint configuration passed to
  * `crate::OutputTransport::new_endpoint`
@@ -41,6 +41,10 @@ export type TransportConfig =
       name: TransportConfig.name.S3_INPUT
     }
   | {
+      config: DeltaTableReaderConfig
+      name: TransportConfig.name.DELTA_TABLE_INPUT
+    }
+  | {
       config: DeltaTableWriterConfig
       name: TransportConfig.name.DELTA_TABLE_OUTPUT
     }
@@ -52,6 +56,7 @@ export namespace TransportConfig {
     KAFKA_OUTPUT = 'kafka_output',
     URL_INPUT = 'url_input',
     S3_INPUT = 's3_input',
+    DELTA_TABLE_INPUT = 'delta_table_input',
     DELTA_TABLE_OUTPUT = 'delta_table_output',
     HTTP_INPUT = 'http_input',
     HTTP_OUTPUT = 'http_output'

--- a/web-console/src/lib/services/manager/services/PipelinesService.ts
+++ b/web-console/src/lib/services/manager/services/PipelinesService.ts
@@ -178,6 +178,44 @@ export class PipelinesService {
     })
   }
   /**
+   * Initiate profile dump.
+   * @param pipelineName Unique pipeline name
+   * @returns any Profile dump initiated.
+   * @throws ApiError
+   */
+  public static dumpProfile(pipelineName: string): CancelablePromise<Record<string, any>> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/v0/pipelines/{pipeline_name}/dump_profile',
+      path: {
+        pipeline_name: pipelineName
+      },
+      errors: {
+        400: `Specified pipeline id is not a valid uuid.`,
+        404: `Specified pipeline id does not exist.`
+      }
+    })
+  }
+  /**
+   * Retrieve heap profile of the pipeline.
+   * @param pipelineName Unique pipeline name
+   * @returns binary Pipeline's heap usage profile as a gzipped protobuf that can be inspected by the pprof tool.
+   * @throws ApiError
+   */
+  public static heapProfile(pipelineName: string): CancelablePromise<Blob> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/v0/pipelines/{pipeline_name}/heap_profile',
+      path: {
+        pipeline_name: pipelineName
+      },
+      errors: {
+        400: `Specified pipeline id is not a valid uuid.`,
+        404: `Specified pipeline id does not exist.`
+      }
+    })
+  }
+  /**
    * Retrieve pipeline metrics and performance counters.
    * @param pipelineName Unique pipeline name
    * @returns any Pipeline metrics retrieved successfully.


### PR DESCRIPTION
The program compilation profile is used if specified, and if not, the compiler default compilation profile is used. This removes the previous hint mechanism.

You can check it works by editing in a demo (for example, `demo/steady/demo.py`):
```python
response = requests.put(f"{api_url}/v0/programs/{program_name}", headers=headers, json={
    "description": "",
    "code": program_sql,
    "profile": "optimized"
})
```
(EDIT: removed the surrounding `"program": { ...}` as it is now flattened)

... and then running it:
```
python3 demo.py --api-url http://localhost:8080 --target-rate-per-second 1
```

... you'll then see in the pipeline-manager log:
```
INFO [manager] Compiling Rust for program 00000000-0000-0000-0000-000000000000 with profile optimized
```

Is this a user-visible change (yes/no): yes