### PR TITLE
Add backpressure mode to HTTP output connector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added backpressure mode to the `/egress` endpoint, which applies
+  backpressure on the pipeline if the HTTP client cannot keep up
+  with the output instead of dropping data.
+  ([#1780](https://github.com/feldera/feldera/pull/1780))
 - `/heap_profile` endpoint that generates the heap profile
   of a pipeline in the pprof format.
   ([#1767](https://github.com/feldera/feldera/pull/1767))

--- a/crates/pipeline_manager/src/api/http_io.rs
+++ b/crates/pipeline_manager/src/api/http_io.rs
@@ -166,6 +166,9 @@ async fn http_input(
         ("mode" = Option<EgressMode>, Query, description = "Output mode. Must be one of 'watch' or 'snapshot'. The default value is 'watch'"),
         ("quantiles" = Option<u32>, Query, description = "For 'quantiles' queries: the number of quantiles to output. The default value is 100."),
         ("array" = Option<bool>, Query, description = "Set to `true` to group updates in this stream into JSON arrays (used in conjunction with `format=json`). The default value is `false`"),
+        ("backpressure" = Option<bool>, Query, description = r#"Apply backpressure on the pipeline when the HTTP client cannot receive data fast enough.
+        When this flag is set to false (the default), the HTTP connector drops data chunks if the client is not keeping up with its output.  This prevents a slow HTTP client from slowing down the entire pipeline.
+        When the flag is set to true, the connector waits for the client to receive each chunk and blocks the pipeline if the client cannot keep up."#)
     ),
     request_body(
         content = Option<NeighborhoodQuery>,

--- a/openapi.json
+++ b/openapi.json
@@ -1390,6 +1390,16 @@
               "type": "boolean",
               "nullable": true
             }
+          },
+          {
+            "name": "backpressure",
+            "in": "query",
+            "description": "Apply backpressure on the pipeline when the HTTP client cannot receive data fast enough.\n        When this flag is set to false (the default), the HTTP connector drops data chunks if the client is not keeping up with its output.  This prevents a slow HTTP client from slowing down the entire pipeline.\n        When the flag is set to true, the connector waits for the client to receive each chunk and blocks the pipeline if the client cannot keep up.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            }
           }
         ],
         "requestBody": {


### PR DESCRIPTION
The HTTP connector was designed for use in the web console where we want to listen to the output of the pipeline without blocking or slowing it down.  It therefore drops outputs on the floor if the client (or the network) are unabel to keep up.  Use cases where we rely on HTTP to receive correct and complete output require a different mode of operation where the connector waits for the client to receive all outputs and applies backpressure on the pipeline if the client cannot keep up.

We introduce the `backpressure` flag that enables this mode. This flag is passed as a parameter to the `/egress` endpoint: `/egress?backpressure=true`.

Is this a user-visible change (yes/no): yes

@abhizer

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
