### PR TITLE
Make profiles more readable.

### DIFF
--- a/crates/dbsp/src/monitor/circuit_graph.rs
+++ b/crates/dbsp/src/monitor/circuit_graph.rs
@@ -390,14 +390,15 @@ impl CircuitGraph {
         for (from_id, to) in self.edges.iter() {
             let from_node = self.node_ref(from_id).unwrap();
 
-            for (to_id, kind) in to.iter() {
+            for (to_id, _kind) in to.iter() {
                 let to_node = self.node_ref(to_id).unwrap();
                 let to_id = match to_node.kind {
                     NodeKind::StrictInput { output } => to_id.parent_id().unwrap().child(output),
                     _ => to_id.clone(),
                 };
 
-                if kind.is_stream() {
+                // Don't draw self-loops on strict operators.
+                if from_id != &to_id {
                     edges.push(VisEdge::new(
                         Node::node_identifier(from_id),
                         from_node.is_circuit(),


### PR DESCRIPTION
This tiny change improves the readability of circuit graphs generated by DBSP (which we use to debug and profile circuits).  Previously, there was no edge between the two halves of the Exchange operator.  As a result, multithreaded circuits ended up being partitioned into multiple fragments.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
