### PR TITLE
Delta out: `truncate` and `error_if_exists` modes.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=$HOME/.rustup
 ENV CARGO_HOME=$HOME/.cargo
 # Adds python and rust binaries to thep path
 ENV PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-ENV RUST_VERSION=1.76.0
+ENV RUST_VERSION=1.78.0
 ENV RUST_BUILD_MODE='' # set to --release for release builds
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -362,6 +362,7 @@ outputs:
             name: "delta_table_output"
             config:
                 uri: "{table_uri}"
+                mode: "truncate"
 {}
         enable_output_buffer: true
         max_output_buffer_size_records: {buffer_size}

--- a/crates/pipeline-types/src/transport/delta_table.rs
+++ b/crates/pipeline-types/src/transport/delta_table.rs
@@ -3,11 +3,35 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
 
+/// Delta table write mode.
+///
+/// Determines how the Delta table connector handles an existing table at the target location.
+#[derive(Default, Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub enum DeltaTableWriteMode {
+    /// New updates will be appended to the existing table at the target location.
+    #[default]
+    #[serde(rename = "append")]
+    Append,
+
+    /// Existing table at the specified location will get truncated.
+    ///
+    /// The connector truncates the table by outputing delete actions for all
+    /// files in the latest snapshot of the table.
+    #[serde(rename = "truncate")]
+    Truncate,
+
+    /// If a table exists at the specified location, the operation must fail.
+    #[serde(rename = "error_if_exists")]
+    ErrorIfExists,
+}
+
 /// Delta table output connector configuration.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub struct DeltaTableWriterConfig {
     /// Table URI.
     pub uri: String,
+    #[serde(default)]
+    pub mode: DeltaTableWriteMode,
     /// Storage options for configuring backend object store.
     ///
     /// For specific options available for different storage backends, see:

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -217,6 +217,7 @@ request is rejected."
         pipeline_types::transport::s3::S3InputConfig,
         pipeline_types::transport::delta_table::DeltaTableIngestMode,
         pipeline_types::transport::delta_table::DeltaTableReaderConfig,
+        pipeline_types::transport::delta_table::DeltaTableWriteMode,
         pipeline_types::transport::delta_table::DeltaTableWriterConfig,
         pipeline_types::format::csv::CsvEncoderConfig,
         pipeline_types::format::csv::CsvParserConfig,

--- a/openapi.json
+++ b/openapi.json
@@ -3586,6 +3586,15 @@
           "description": "Storage options for configuring backend object store.\n\nFor specific options available for different storage backends, see:\n* [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)\n* [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)\n* [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)"
         }
       },
+      "DeltaTableWriteMode": {
+        "type": "string",
+        "description": "Delta table write mode.\n\nDetermines how the Delta table connector handles an existing table at the target location.",
+        "enum": [
+          "append",
+          "truncate",
+          "error_if_exists"
+        ]
+      },
       "DeltaTableWriterConfig": {
         "type": "object",
         "description": "Delta table output connector configuration.",
@@ -3593,6 +3602,9 @@
           "uri"
         ],
         "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/DeltaTableWriteMode"
+          },
           "uri": {
             "type": "string",
             "description": "Table URI."


### PR DESCRIPTION
The Delta output connector defaulted to appending new data to an existing table if one exists at the target location.  This commit adds two additional modes:

- error_if_exists - fail if there exists a table at the target location.
- truncate - truncate all existing contents of the table before adding new updates to it.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->

@Karakatiza666 , can we include this new option to the webconsole PR for delta connectors. It's a drop-down list with three options: `append`/`truncate`/`error_if_exists`. The default is `append`.