### PR TITLE
py: add Python SDK docs to the website sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -81,6 +81,11 @@ const sidebars = {
       type: 'category',
       label: 'Reference',
       items: [
+            {
+              type: 'link',
+              label: "Python SDK",
+              href: "pathname://python/index.html",
+            },
             'api/rest', 
 	    {
 	      type: 'category',


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

Will have a follow up PR for the website that'll build the docs. 

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
