### PR TITLE
Fix obscure crash when displaying a number

### DIFF
--- a/web-console/src/lib/components/input/BigNumberInput.tsx
+++ b/web-console/src/lib/components/input/BigNumberInput.tsx
@@ -81,7 +81,7 @@ export const BigNumberInput = (
       return { valid: value }
     },
     valueToText: (valid: BigNumber | null) => {
-      return valid === null ? null : valid.toFixed()
+      return valid === null ? null : valid?.toFixed() ?? ''
     }
   }
   const valueObj = 'value' in props ? ({ value: props.value } as { value?: BigNumber | null }) : {}


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

![image](https://github.com/feldera/feldera/assets/8537259/9ebe06f7-1c7b-4dcf-aa1f-4492a6df6e4a)
