### PR TITLE
[Python SDK] use iter_lines to read HTTP response.

### DIFF
--- a/python/feldera/rest/client.py
+++ b/python/feldera/rest/client.py
@@ -485,17 +485,10 @@ class Client:
 
         end = time.time() + timeout if timeout else None
 
-        old_chunk = b""
-
-        for chunk in resp.iter_content(chunk_size=None):
+        # Using the default chunk size below makes `iter_lines` extremely
+        # inefficient when dealing with long lines.
+        for chunk in resp.iter_lines(chunk_size=50000000):
             if end and time.time() > end:
                 break
             if chunk:
-                try:
-                    chunk = old_chunk + chunk
-                    valid_json = json.loads(chunk)
-                    old_chunk = b""
-                    yield valid_json
-                except json.decoder.JSONDecodeError:
-                    old_chunk += chunk
-                    continue
+                yield json.loads(chunk)


### PR DESCRIPTION
Use `iter_lines` to read HTTP response line-by-line.  This way we don't need to worry about incomplete chunks.  The previous implementation also ran out of memory on large outputs.  I did not figure out what was going on exactly, but it used up 20GB of RAM while parsing a few thousand records.  This implementation does not seem to have that problem.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
