### PR TITLE
gitignore: Add `.cargo/config.toml`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ playwright-snapshots/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Local cargo configuration.
+/.cargo/config.toml


### PR DESCRIPTION
This allows a developer to add a local `.cargo/config.toml` without it showing up in `git status` as uncommitted.

Is this a user-visible change (yes/no): no