### PR TITLE
Unified signatures of rolling aggregate functions.

### DIFF
--- a/crates/dbsp/examples/tutorial/tutorial5.rs
+++ b/crates/dbsp/examples/tutorial/tutorial5.rs
@@ -54,9 +54,11 @@ fn build_circuit(
         })
         .aggregate_linear(|v| *v as i64);
     let moving_averages = monthly_totals
-        .map_index(|(Tup3(l, y, m), v)| (l.clone(), Tup2(*y as u32 * 12 + (*m as u32 - 1), *v)))
-        .as_partitioned_zset()
-        .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))
+        .map_index(|(Tup3(l, y, m), v)| (*y as u32 * 12 + (*m as u32 - 1), Tup2(l.clone(), *v)))
+        .partitioned_rolling_average(
+            |Tup2(l, v)| (l.clone(), *v),
+            RelRange::new(RelOffset::Before(2), RelOffset::Before(0)),
+        )
         .map_index(|(l, Tup2(date, avg))| {
             (Tup3(l.clone(), date / 12, date % 12 + 1), avg.unwrap())
         });

--- a/crates/dbsp/examples/tutorial/tutorial6.rs
+++ b/crates/dbsp/examples/tutorial/tutorial6.rs
@@ -54,15 +54,18 @@ fn build_circuit(
         })
         .aggregate_linear(|v| *v as i64);
     let moving_averages = monthly_totals
-        .map_index(|(Tup3(l, y, m), v)| (l.clone(), Tup2(*y as u32 * 12 + (*m as u32 - 1), *v)))
-        .as_partitioned_zset()
-        .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))
+        .map_index(|(Tup3(l, y, m), v)| (*y as u32 * 12 + (*m as u32 - 1), Tup2(l.clone(), *v)))
+        .partitioned_rolling_average(
+            |Tup2(l, v)| (l.clone(), *v),
+            RelRange::new(RelOffset::Before(2), RelOffset::Before(0)),
+        )
         .map_index(|(l, Tup2(date, avg))| {
             (
                 Tup3(l.clone(), (date / 12) as i32, (date % 12 + 1) as u8),
                 avg.unwrap(),
             )
         });
+
     let joined = monthly_totals.join_index(&moving_averages, |Tup3(l, y, m), cur, avg| {
         Some((Tup3(l.clone(), *y, *m), Tup2(*cur, *avg)))
     });

--- a/crates/dbsp/examples/tutorial/tutorial8.rs
+++ b/crates/dbsp/examples/tutorial/tutorial8.rs
@@ -56,9 +56,9 @@ fn build_circuit(
         })
         .aggregate_linear(|v| *v as i64);
     let running_monthly_totals = monthly_totals
-        .map_index(|(Tup3(l, y, m), v)| (l.clone(), Tup2(*y as u32 * 12 + (*m as u32 - 1), *v)))
-        .as_partitioned_zset()
+        .map_index(|(Tup3(l, y, m), v)| (*y as u32 * 12 + (*m as u32 - 1), Tup2(l.clone(), *v)))
         .partitioned_rolling_aggregate_linear(
+            |Tup2(l, v)| (l.clone(), *v),
             |vaxxed| *vaxxed,
             |total| total,
             RelRange::new(RelOffset::Before(u32::MAX), RelOffset::Before(0)),

--- a/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
@@ -1,12 +1,12 @@
 use crate::{
-    algebra::{HasOne, HasZero, IndexedZSet, ZRingValue},
+    algebra::{HasOne, HasZero, IndexedZSet, UnsignedPrimInt, ZRingValue},
     circuit::{
         operator_traits::{Operator, QuaternaryOperator},
         Scope,
     },
     dynamic::{
-        ClonableTrait, DataTrait, DynDataTyped, DynOpt, DynPair, DynUnit, Erase, Factory,
-        WeightTrait, WithFactory,
+        ClonableTrait, DataTrait, DowncastTrait, DynDataTyped, DynOpt, DynPair, DynUnit, Erase,
+        Factory, WeightTrait, WithFactory,
     },
     operator::{
         dynamic::{
@@ -32,7 +32,7 @@ use crate::{
     Circuit, DBData, DBWeight, DynZWeight, RootCircuit, Stream, ZWeight,
 };
 use dyn_clone::{clone_box, DynClone};
-use num::{Bounded, PrimInt};
+use num::Bounded;
 use std::{
     borrow::Cow,
     marker::PhantomData,
@@ -67,7 +67,7 @@ where
     O: IndexedZSet<Key = B::Key>,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
 {
     input_factories: B::Factories,
@@ -84,7 +84,7 @@ where
     O: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<Out>, Key = B::Key>,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
 {
     pub fn new<KType, VType, AType, OType>() -> Self
@@ -117,8 +117,8 @@ where
 pub struct PartitionedRollingAggregateWithWaterlineFactories<PK, TS, V, Acc, Out, B>
 where
     PK: DataTrait + ?Sized,
-    B: IndexedZSet<Key = DynDataTyped<TS>> + Spillable,
-    TS: DBData + PrimInt,
+    B: IndexedZSet + Spillable,
+    TS: DBData + UnsignedPrimInt + Erase<B::Key>,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -139,15 +139,14 @@ impl<PK, TS, V, Acc, Out, B>
     PartitionedRollingAggregateWithWaterlineFactories<PK, TS, V, Acc, Out, B>
 where
     PK: DataTrait + ?Sized,
-    B: IndexedZSet<Key = DynDataTyped<TS>> + Spillable,
-    TS: DBData + PrimInt,
+    B: IndexedZSet + Spillable,
+    TS: DBData + UnsignedPrimInt + Erase<B::Key>,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
 {
-    pub fn new<KType, VType, PKType, PVType, AType, OType>() -> Self
+    pub fn new<VType, PKType, PVType, AType, OType>() -> Self
     where
-        KType: DBData + Erase<B::Key>,
         VType: DBData + Erase<B::Val>,
         PKType: DBData + Erase<PK>,
         PVType: DBData + Erase<V>,
@@ -155,8 +154,8 @@ where
         OType: DBData + Erase<Out>,
     {
         Self {
-            input_factories: BatchReaderFactories::new::<KType, VType, ZWeight>(),
-            stored_factories: BatchReaderFactories::new::<KType, VType, ZWeight>(),
+            input_factories: BatchReaderFactories::new::<TS, VType, ZWeight>(),
+            stored_factories: BatchReaderFactories::new::<TS, VType, ZWeight>(),
             rolling_aggregate_factories: PartitionedRollingAggregateFactories::new::<
                 PKType,
                 PVType,
@@ -171,7 +170,7 @@ pub struct PartitionedRollingAggregateLinearFactories<TS, V, OV, A, B, O>
 where
     B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable,
     O: IndexedZSet<Key = B::Key>,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
     OV: DataTrait + ?Sized,
     A: WeightTrait + ?Sized,
@@ -187,7 +186,7 @@ where
     B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable,
     O: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<OV>, Key = B::Key>,
     B::Key: DataTrait,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
     OV: DataTrait + ?Sized,
     A: WeightTrait + ?Sized,
@@ -217,7 +216,7 @@ pub struct PartitionedRollingAverageFactories<TS, V, W, B, O>
 where
     B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable,
     O: IndexedZSet<Key = B::Key>,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
     W: WeightTrait + ?Sized,
 {
@@ -230,7 +229,7 @@ impl<TS, V, W, B, O> PartitionedRollingAverageFactories<TS, V, W, B, O>
 where
     B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable,
     O: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<V>, Key = B::Key>,
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
     W: WeightTrait + ?Sized,
 {
@@ -378,15 +377,16 @@ where
         range: RelRange<TS>,
     ) -> OrdPartitionedOverStream<PK, DynDataTyped<TS>, Out>
     where
-        B: IndexedZSet<Key = DynDataTyped<TS>> + Spillable,
+        B: IndexedZSet + Spillable,
         B::Spilled: for<'a> DynFilterMap<
-            DynItemRef<'a> = (&'a DynDataTyped<TS>, &'a <B as BatchReader>::Val),
+            DynItemRef<'a> = (&'a <B as BatchReader>::Key, &'a <B as BatchReader>::Val),
         >,
         B: for<'a> DynFilterMap<
-            DynItemRef<'a> = (&'a DynDataTyped<TS>, &'a <B as BatchReader>::Val),
+            DynItemRef<'a> = (&'a <B as BatchReader>::Key, &'a <B as BatchReader>::Val),
         >,
+        Box<B::Key>: Clone,
         PK: DataTrait + ?Sized,
-        TS: DBData + PrimInt,
+        TS: DBData + UnsignedPrimInt + Erase<B::Key>,
         V: DataTrait + ?Sized,
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
@@ -395,7 +395,7 @@ where
             .region("partitioned_rolling_aggregate_with_waterline", || {
                 // Shift the aggregation window so that its right end is at 0.
                 let shifted_range =
-                    RelRange::new(range.from - range.to, RelOffset::Before(TS::zero()));
+                    RelRange::new(range.from - range.to, RelOffset::Before(HasZero::zero()));
 
                 // Trace bound used inside `partitioned_rolling_aggregate_inner` to
                 // bound its output trace.  This is the same bound we use to construct
@@ -443,7 +443,7 @@ where
                         let (partition_key, ts_val) = res.split_mut();
                         let (res_ts, val) = ts_val.split_mut();
                         partition_func_clone(v, partition_key, val);
-                        ts.clone_to(res_ts);
+                        unsafe { *res_ts.downcast_mut::<TS>() = *ts.downcast::<TS>() };
                     }),
                 );
                 let partitioned_self = self.dyn_map_index(
@@ -452,7 +452,7 @@ where
                         let (partition_key, ts_val) = res.split_mut();
                         let (res_ts, val) = ts_val.split_mut();
                         partition_func(v, partition_key, val);
-                        ts.clone_to(res_ts);
+                        unsafe { *res_ts.downcast_mut::<TS>() = *ts.downcast::<TS>() };
                     }),
                 );
 
@@ -465,49 +465,32 @@ where
                 )
             })
     }
-}
 
-impl<B> Stream<RootCircuit, B> {
-    /// See [`Stream::partitioned_rolling_aggregate`].
-    pub fn dyn_partitioned_rolling_aggregate<TS, V, Acc, Out>(
+    /// Like [`Self::dyn_partitioned_rolling_aggregate`], but can return any
+    /// batch type.
+    pub fn dyn_partitioned_rolling_aggregate<PK, TS, V, Acc, Out>(
         &self,
         factories: &PartitionedRollingAggregateFactories<
             TS,
             V,
             Acc,
             Out,
-            B,
-            OrdPartitionedIndexedZSet<B::Key, DynDataTyped<TS>, DynOpt<Out>>,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, V>,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, DynOpt<Out>>,
         >,
+        partition_func: Box<dyn PartitionFunc<B::Val, PK, V>>,
         aggregator: &dyn DynAggregator<V, (), B::R, Accumulator = Acc, Output = Out>,
         range: RelRange<TS>,
-    ) -> OrdPartitionedOverStream<B::Key, DynDataTyped<TS>, Out>
+    ) -> OrdPartitionedOverStream<PK, DynDataTyped<TS>, Out>
     where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
+        B: IndexedZSet + Spillable,
+        B: for<'a> DynFilterMap<
+            DynItemRef<'a> = (&'a <B as BatchReader>::Key, &'a <B as BatchReader>::Val),
+        >,
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
-        TS: DBData + PrimInt,
-        V: DataTrait + ?Sized,
-    {
-        self.dyn_partitioned_rolling_aggregate_generic::<TS, V, Acc, Out, _>(
-            factories, aggregator, range,
-        )
-    }
-
-    /// Like [`Self::dyn_partitioned_rolling_aggregate`], but can return any
-    /// batch type.
-    pub fn dyn_partitioned_rolling_aggregate_generic<TS, V, Acc, Out, O>(
-        &self,
-        factories: &PartitionedRollingAggregateFactories<TS, V, Acc, Out, B, O>,
-        aggregator: &dyn DynAggregator<V, (), B::R, Accumulator = Acc, Output = Out>,
-        range: RelRange<TS>,
-    ) -> Stream<RootCircuit, O>
-    where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
-        Acc: DataTrait + ?Sized,
-        Out: DataTrait + ?Sized,
-        O: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<Out>, Key = B::Key>,
-        TS: DBData + PrimInt,
+        PK: DataTrait + ?Sized,
+        TS: DBData + UnsignedPrimInt + Erase<B::Key>,
         V: DataTrait + ?Sized,
     {
         // ```
@@ -525,9 +508,19 @@ impl<B> Stream<RootCircuit, B> {
         //                                                                   delayed_trace └────┘
         // ```
         self.circuit().region("partitioned_rolling_aggregate", || {
-            self.dyn_partitioned_rolling_aggregate_inner(
+            let partitioned = self.dyn_map_index(
+                &factories.input_factories,
+                Box::new(move |(ts, v), res| {
+                    let (partition_key, ts_val) = res.split_mut();
+                    let (res_ts, val) = ts_val.split_mut();
+                    partition_func(v, partition_key, val);
+                    unsafe { *res_ts.downcast_mut::<TS>() = *ts.downcast::<TS>() };
+                }),
+            );
+
+            partitioned.dyn_partitioned_rolling_aggregate_inner(
                 factories,
-                self,
+                &partitioned,
                 aggregator,
                 range,
                 TraceBound::new(),
@@ -535,6 +528,93 @@ impl<B> Stream<RootCircuit, B> {
         })
     }
 
+    /// See [`Stream::partitioned_rolling_aggregate_linear`].
+    pub fn dyn_partitioned_rolling_aggregate_linear<PK, TS, V, A, O>(
+        &self,
+        factories: &PartitionedRollingAggregateLinearFactories<
+            TS,
+            V,
+            O,
+            A,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, V>,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, DynOpt<O>>,
+        >,
+        partition_func: Box<dyn PartitionFunc<B::Val, PK, V>>,
+        f: Box<dyn WeighFunc<V, B::R, A>>,
+        output_func: Box<dyn AggOutputFunc<A, O>>,
+        range: RelRange<TS>,
+    ) -> OrdPartitionedOverStream<PK, DynDataTyped<TS>, O>
+    where
+        B: IndexedZSet + Spillable,
+        B: for<'a> DynFilterMap<
+            DynItemRef<'a> = (&'a <B as BatchReader>::Key, &'a <B as BatchReader>::Val),
+        >,
+        PK: DataTrait + ?Sized,
+        TS: DBData + UnsignedPrimInt + Erase<B::Key>,
+        V: DataTrait + ?Sized,
+        A: WeightTrait + ?Sized,
+        O: DataTrait + ?Sized,
+    {
+        let aggregator = LinearAggregator::new(
+            factories.aggregate_factory,
+            factories.opt_accumulator_factory,
+            factories.output_factory,
+            f,
+            output_func,
+        );
+        self.dyn_partitioned_rolling_aggregate::<PK, TS, V, _, _>(
+            &factories.rolling_aggregate_factories,
+            partition_func,
+            &aggregator,
+            range,
+        )
+    }
+
+    pub fn dyn_partitioned_rolling_average<PK, TS, V, W>(
+        &self,
+        factories: &PartitionedRollingAverageFactories<
+            TS,
+            V,
+            W,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, V>,
+            OrdPartitionedIndexedZSet<PK, DynDataTyped<TS>, DynOpt<V>>,
+        >,
+        partition_func: Box<dyn PartitionFunc<B::Val, PK, V>>,
+        f: Box<dyn WeighFunc<V, B::R, W>>,
+        out_func: Box<dyn AggOutputFunc<W, V>>,
+        range: RelRange<TS>,
+    ) -> OrdPartitionedOverStream<PK, DynDataTyped<TS>, V>
+    where
+        B: IndexedZSet + Spillable,
+        B: for<'a> DynFilterMap<
+            DynItemRef<'a> = (&'a <B as BatchReader>::Key, &'a <B as BatchReader>::Val),
+        >,
+        PK: DataTrait + ?Sized,
+        TS: DBData + UnsignedPrimInt + Erase<B::Key>,
+        V: DataTrait + ?Sized,
+        W: WeightTrait + ?Sized,
+    {
+        let weight_factory = factories.weight_factory;
+        self.dyn_partitioned_rolling_aggregate_linear(
+            &factories.aggregate_factories,
+            partition_func,
+            Box::new(move |v: &V, w: &B::R, avg: &mut DynAverage<W, B::R>| {
+                let (sum, count) = avg.split_mut();
+                w.clone_to(count);
+                f(v, w, sum);
+            }),
+            Box::new(move |avg, out| {
+                weight_factory.with(&mut |avg_val| {
+                    avg.compute_avg(avg_val);
+                    out_func(avg_val, out)
+                })
+            }),
+            range,
+        )
+    }
+}
+
+impl<B> Stream<RootCircuit, B> {
     #[doc(hidden)]
     pub fn dyn_partitioned_rolling_aggregate_inner<TS, V, Acc, Out, O>(
         &self,
@@ -549,7 +629,7 @@ impl<B> Stream<RootCircuit, B> {
         O: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<Out>, Key = B::Key>,
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
-        TS: DBData + PrimInt,
+        TS: DBData + UnsignedPrimInt,
         V: DataTrait + ?Sized,
     {
         let circuit = self.circuit();
@@ -594,128 +674,6 @@ impl<B> Stream<RootCircuit, B> {
         feedback.connect(&output);
 
         output
-    }
-
-    /// See [`Stream::partitioned_rolling_aggregate_linear`].
-    pub fn dyn_partitioned_rolling_aggregate_linear<TS, V, A, O>(
-        &self,
-        factories: &PartitionedRollingAggregateLinearFactories<
-            TS,
-            V,
-            O,
-            A,
-            B,
-            OrdPartitionedIndexedZSet<B::Key, DynDataTyped<TS>, DynOpt<O>>,
-        >,
-        f: Box<dyn WeighFunc<V, B::R, A>>,
-        output_func: Box<dyn AggOutputFunc<A, O>>,
-        range: RelRange<TS>,
-    ) -> OrdPartitionedOverStream<B::Key, DynDataTyped<TS>, O>
-    where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
-        A: WeightTrait + ?Sized,
-        TS: DBData + PrimInt,
-        V: DataTrait + ?Sized,
-        O: DataTrait + ?Sized,
-    {
-        let aggregator = LinearAggregator::new(
-            factories.aggregate_factory,
-            factories.opt_accumulator_factory,
-            factories.output_factory,
-            f,
-            output_func,
-        );
-        self.dyn_partitioned_rolling_aggregate_generic::<TS, V, _, _, _>(
-            &factories.rolling_aggregate_factories,
-            &aggregator,
-            range,
-        )
-    }
-
-    /// Like [`Self::dyn_partitioned_rolling_aggregate_linear`], but can return
-    /// any batch type.
-    pub fn dyn_partitioned_rolling_aggregate_linear_generic<TS, V, A, O, Out>(
-        &self,
-        factories: &PartitionedRollingAggregateLinearFactories<TS, V, O, A, B, Out>,
-        f: Box<dyn WeighFunc<V, B::R, A>>,
-        output_func: Box<dyn AggOutputFunc<A, O>>,
-        range: RelRange<TS>,
-    ) -> Stream<RootCircuit, Out>
-    where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
-        A: WeightTrait + ?Sized,
-        TS: DBData + PrimInt,
-        V: DataTrait + ?Sized,
-        O: DataTrait + ?Sized,
-        Out: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<O>, Key = B::Key, R = B::R>,
-    {
-        let aggregator = LinearAggregator::new(
-            factories.aggregate_factory,
-            factories.opt_accumulator_factory,
-            factories.output_factory,
-            f,
-            output_func,
-        );
-        self.dyn_partitioned_rolling_aggregate_generic::<TS, V, _, _, _>(
-            &factories.rolling_aggregate_factories,
-            &aggregator,
-            range,
-        )
-    }
-
-    /// See [`Stream::partitioned_rolling_average`].
-    pub fn dyn_partitioned_rolling_average<TS, V, W>(
-        &self,
-        factories: &PartitionedRollingAverageFactories<
-            TS,
-            V,
-            W,
-            B,
-            OrdPartitionedIndexedZSet<B::Key, DynDataTyped<TS>, DynOpt<V>>,
-        >,
-        f: Box<dyn WeighFunc<V, B::R, W>>,
-        out_func: Box<dyn AggOutputFunc<W, V>>,
-        range: RelRange<TS>,
-    ) -> OrdPartitionedOverStream<B::Key, DynDataTyped<TS>, V>
-    where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
-        W: WeightTrait + ?Sized,
-        TS: DBData + PrimInt,
-        V: DataTrait + ?Sized,
-    {
-        self.dyn_partitioned_rolling_average_generic(factories, f, out_func, range)
-    }
-
-    pub fn dyn_partitioned_rolling_average_generic<TS, V, W, Out>(
-        &self,
-        factories: &PartitionedRollingAverageFactories<TS, V, W, B, Out>,
-        f: Box<dyn WeighFunc<V, B::R, W>>,
-        out_func: Box<dyn AggOutputFunc<W, V>>,
-        range: RelRange<TS>,
-    ) -> Stream<RootCircuit, Out>
-    where
-        B: PartitionedIndexedZSet<DynDataTyped<TS>, V> + Spillable + Send,
-        TS: DBData + PrimInt,
-        V: DataTrait + ?Sized,
-        W: WeightTrait + ?Sized,
-        Out: PartitionedIndexedZSet<DynDataTyped<TS>, DynOpt<V>, Key = B::Key>,
-    {
-        let weight_factory = factories.weight_factory;
-        self.dyn_partitioned_rolling_aggregate_linear_generic(
-            &factories.aggregate_factories,
-            Box::new(move |v: &V, w: &B::R, avg: &mut DynAverage<W, B::R>| {
-                let (sum, count) = avg.split_mut();
-                w.clone_to(count);
-                f(v, w, sum);
-            }),
-            Box::new(move |avg, out| {
-                weight_factory.with(&mut |avg_val| {
-                    avg.compute_avg(avg_val);
-                    out_func(avg_val, out)
-                })
-            }),
-            range,
-        )
     }
 }
 
@@ -765,7 +723,7 @@ where
     fn affected_ranges<R, C>(&self, delta_cursor: &mut C) -> Ranges<TS>
     where
         C: Cursor<DynDataTyped<TS>, V, (), R>,
-        TS: DBData + PrimInt,
+        TS: DBData + UnsignedPrimInt,
         R: ?Sized,
     {
         let mut affected_ranges = Ranges::new();
@@ -806,7 +764,7 @@ where
 impl<TS, V, Acc, Out, B, T, RT, OT, O> QuaternaryOperator<B, T, RT, OT, O>
     for PartitionedRollingAggregate<TS, V, Acc, Out, O>
 where
-    TS: DBData + PrimInt,
+    TS: DBData + UnsignedPrimInt,
     V: DataTrait + ?Sized,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
@@ -949,8 +907,8 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        algebra::DefaultSemigroup,
-        dynamic::{ClonableTrait, DowncastTrait, DynData, DynDataTyped, DynOpt, DynPair, Erase},
+        algebra::{DefaultSemigroup, UnsignedPrimInt},
+        dynamic::{DowncastTrait, DynData, DynDataTyped, DynOpt, DynPair, Erase},
         lean_vec,
         operator::{
             dynamic::{
@@ -967,7 +925,8 @@ mod test {
         trace::{BatchReaderFactories, Cursor},
         typed_batch::{BatchReader, DynBatchReader, DynOrdIndexedZSet, TypedBatch},
         utils::Tup2,
-        DBSPHandle, IndexedZSetHandle, RootCircuit, Runtime, Stream, ZWeight,
+        DBData, DBSPHandle, IndexedZSetHandle, OrdIndexedZSet, RootCircuit, Runtime, Stream,
+        TypedBox, ZWeight,
     };
     use proptest::{collection, prelude::*};
     use size_of::SizeOf;
@@ -987,6 +946,29 @@ mod test {
         >,
     >;
     type OutputStream = Stream<RootCircuit, OutputBatch>;
+
+    impl<PK, TS, V> Stream<RootCircuit, OrdIndexedZSet<PK, Tup2<TS, V>>>
+    where
+        PK: DBData,
+        TS: DBData + UnsignedPrimInt,
+        V: DBData,
+    {
+        pub fn as_partitioned_zset(
+            &self,
+        ) -> Stream<RootCircuit, OrdPartitionedIndexedZSet<PK, TS, DynDataTyped<TS>, V, DynData>>
+        {
+            let factories = BatchReaderFactories::new::<PK, Tup2<TS, V>, ZWeight>();
+
+            self.inner()
+                .dyn_map_index(
+                    &factories,
+                    Box::new(|(k, v), kv| {
+                        kv.from_refs(k, unsafe { v.downcast::<Tup2<TS, V>>().erase() })
+                    }),
+                )
+                .typed()
+        }
+    }
 
     // Reference implementation of `aggregate_range` for testing.
     fn aggregate_range_slow(batch: &DataBatch, partition: u64, range: Range<u64>) -> Option<i64> {
@@ -1058,22 +1040,12 @@ mod test {
             let (input_stream, input_handle) =
                 circuit.add_input_indexed_zset::<u64, Tup2<u64, i64>>();
 
+            let input_by_time =
+                input_stream.map_index(|(partition, Tup2(ts, val))| (*ts, Tup2(*partition, *val)));
+
             let input_stream = input_stream.as_partitioned_zset();
 
-            let input_by_time: Stream<_, TypedBatch<u64,Tup2<u64, i64>, ZWeight, _>> = input_stream
-                .inner()
-                .dyn_map_index::<DynDataTyped<u64>, _>(
-                    &BatchReaderFactories::new::<u64, Tup2<u64, i64>, ZWeight>(),
-                    Box::new(|(partition, ts_val): (&DynData, &DynPair<DynDataTyped<u64>, DynData>), kv: &mut DynPair<DynDataTyped<u64>, DynData>| {
-                        let (k, v) = kv.split_mut();
-                        let (ts, val) = ts_val.split();
-                        ts.clone_to(k);
-                        *v.downcast_mut_checked() = Tup2(*partition.downcast_checked::<u64>(), *val.downcast_checked::<i64>());
-                    }),
-                )
-                .typed();
-
-            let waterline =
+            let waterline: Stream<_, TypedBox<u64, DynDataTyped<u64>>> =
                 input_by_time.waterline_monotonic(|| 0, move |ts| ts.saturating_sub(lateness));
 
             let aggregator = <Fold<i64, i64, DefaultSemigroup<_>, _, _>>::new(
@@ -1084,8 +1056,12 @@ mod test {
             let range_spec = RelRange::new(RelOffset::Before(1000), RelOffset::Before(0));
             let expected_1000_0 =
                 partitioned_rolling_aggregate_slow(&input_stream.inner(), range_spec);
-            let output_1000_0 = input_stream
-                .partitioned_rolling_aggregate(aggregator.clone(), range_spec)
+            let output_1000_0 = input_by_time
+                .partitioned_rolling_aggregate(
+                    |Tup2(partition, val)| (*partition, *val),
+                    aggregator.clone(),
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_1000_0.apply2(&output_1000_0, |expected, actual| {
@@ -1106,8 +1082,13 @@ mod test {
                 assert_eq!(expected, actual)
             });
 
-            let output_1000_0_linear = input_stream
-                .partitioned_rolling_aggregate_linear(|v| *v, |v| v, range_spec)
+            let output_1000_0_linear = input_by_time
+                .partitioned_rolling_aggregate_linear(
+                    |Tup2(partition, val)| (*partition, *val),
+                    |v| *v,
+                    |v| v,
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_1000_0.apply2(&output_1000_0_linear, |expected, actual| {
@@ -1117,8 +1098,11 @@ mod test {
             let range_spec = RelRange::new(RelOffset::Before(500), RelOffset::After(500));
             let expected_500_500 =
                 partitioned_rolling_aggregate_slow(&input_stream.inner(), range_spec);
-            let aggregate_500_500 =
-                input_stream.partitioned_rolling_aggregate(aggregator.clone(), range_spec);
+            let aggregate_500_500 = input_by_time.partitioned_rolling_aggregate(
+                |Tup2(partition, val)| (*partition, *val),
+                aggregator.clone(),
+                range_spec,
+            );
             let output_500_500 = aggregate_500_500.gather(0).integrate();
             expected_500_500.apply2(&output_500_500, |expected, actual| {
                 assert_eq!(expected, actual)
@@ -1151,8 +1135,13 @@ mod test {
                 assert_eq!(expected, actual)
             });
 
-            let output_500_500_linear = input_stream
-                .partitioned_rolling_aggregate_linear(|v| *v, |v| v, range_spec)
+            let output_500_500_linear = input_by_time
+                .partitioned_rolling_aggregate_linear(
+                    |Tup2(partition, val)| (*partition, *val),
+                    |v| *v,
+                    |v| v,
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_500_500.apply2(&output_500_500_linear, |expected, actual| {
@@ -1162,8 +1151,12 @@ mod test {
             let range_spec = RelRange::new(RelOffset::Before(500), RelOffset::Before(100));
             let expected_500_100 =
                 partitioned_rolling_aggregate_slow(&input_stream.inner(), range_spec);
-            let output_500_100 = input_stream
-                .partitioned_rolling_aggregate(aggregator, range_spec)
+            let output_500_100 = input_by_time
+                .partitioned_rolling_aggregate(
+                    |Tup2(partition, val)| (*partition, *val),
+                    aggregator,
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_500_100.apply2(&output_500_100, |expected, actual| {
@@ -1233,22 +1226,25 @@ mod test {
     #[test]
     fn test_partitioned_rolling_aggregate2() {
         let (circuit, (input, expected)) = RootCircuit::build(move |circuit| {
-            let (input, input_handle) = circuit
-                .dyn_add_input_indexed_zset::<DynData/*<u64>*/, DynPair<DynDataTyped<u64>, DynData/*<i64>*/>>(
-                    &AddInputIndexedZSetFactories::new::<u64, Tup2<u64, i64>>(),
-                );
+            let (input_stream, input_handle) =
+                circuit.add_input_indexed_zset::<u64, Tup2<u64, i64>>();
+
             let (expected, expected_handle) =
                 circuit.dyn_add_input_indexed_zset::<DynData/*<u64>*/, DynPair<DynDataTyped<u64>, DynOpt<DynData/*<i64>*/>>>(&AddInputIndexedZSetFactories::new::<u64, Tup2<u64, Option<i64>>>());
 
-            let input = input.typed::<TypedBatch<u64,Tup2<u64,i64>,ZWeight,_>>();
+            let input_by_time =
+                input_stream.map_index(|(partition, Tup2(ts, val))| (*ts, Tup2(*partition, *val)));
 
-            input.inspect(|f| {
+            input_stream.inspect(|f| {
                 for (p, Tup2(ts, v), w) in f.iter() {
                     println!(" input {p} {ts} {v:6} {w:+}");
                 }
             });
             let range_spec = RelRange::new(RelOffset::Before(3), RelOffset::Before(2));
-            let sum = input.partitioned_rolling_aggregate_linear(|&f| f, |x| x, range_spec);
+            let sum = input_by_time.partitioned_rolling_aggregate_linear(
+                |Tup2(partition, val)| (*partition, *val),
+                |&f| f,
+                |x| x, range_spec);
             sum.inspect(|f| {
                 for (p, Tup2(ts, sum), w) in f.iter() {
                     println!("output {p} {ts} {:6} {w:+}", sum.unwrap_or_default());
@@ -1259,18 +1255,15 @@ mod test {
         })
         .unwrap();
 
-        input.dyn_append(
-            &mut Box::new(lean_vec![
-                Tup2(1u64, Tup2(Tup2(0u64, 1i64), 1)),
-                Tup2(1, Tup2(Tup2(1, 10), 1)),
-                Tup2(1, Tup2(Tup2(2, 100), 1)),
-                Tup2(1, Tup2(Tup2(3, 1000), 1)),
-                Tup2(1, Tup2(Tup2(4, 10000), 1)),
-                Tup2(1, Tup2(Tup2(5, 100000), 1)),
-                Tup2(1, Tup2(Tup2(9, 123456), 1)),
-            ])
-            .erase_box(),
-        );
+        input.append(&mut vec![
+            Tup2(1u64, Tup2(Tup2(0u64, 1i64), 1)),
+            Tup2(1, Tup2(Tup2(1, 10), 1)),
+            Tup2(1, Tup2(Tup2(2, 100), 1)),
+            Tup2(1, Tup2(Tup2(3, 1000), 1)),
+            Tup2(1, Tup2(Tup2(4, 10000), 1)),
+            Tup2(1, Tup2(Tup2(5, 100000), 1)),
+            Tup2(1, Tup2(Tup2(9, 123456), 1)),
+        ]);
         expected.dyn_append(
             &mut Box::new(lean_vec![
                 Tup2(1u64, Tup2(Tup2(0u64, None::<i64>), 1)),
@@ -1289,15 +1282,20 @@ mod test {
     #[test]
     fn test_partitioned_rolling_average() {
         let (circuit, (input, expected)) = RootCircuit::build(move |circuit| {
-            let (input_stream, input_handle) = circuit
-                .dyn_add_input_indexed_zset::<DynData/*<u64>*/, DynPair<DynDataTyped<u64>, DynData/*<i64>*/>>(&AddInputIndexedZSetFactories::new::<u64, Tup2<u64, i64>>());
+            let (input_stream, input_handle) =
+                circuit.add_input_indexed_zset::<u64, Tup2<u64, i64>>();
+
             let (expected_stream, expected_handle) =
                 circuit.dyn_add_input_indexed_zset::<DynData/*<u64>*/, DynPair<DynDataTyped<u64>, DynOpt<DynData/*<i64>*/>>>(&AddInputIndexedZSetFactories::new::<u64, Tup2<u64, Option<i64>>>());
 
+            let input_by_time =
+                input_stream.map_index(|(partition, Tup2(ts, val))| (*ts, Tup2(*partition, *val)));
+
             let range_spec = RelRange::new(RelOffset::Before(3), RelOffset::Before(1));
-            input_stream
-                .typed()
-                .partitioned_rolling_average(range_spec)
+            input_by_time
+                .partitioned_rolling_average(
+                    |Tup2(partition, val)| (*partition, *val),
+                    range_spec)
                 .apply2(&expected_stream, |avg: &OrdPartitionedIndexedZSet<u64, u64, _, Option<i64>, _>, expected| assert_eq!(avg.inner(), expected));
             Ok((input_handle, expected_handle))
         })
@@ -1305,17 +1303,14 @@ mod test {
 
         circuit.step().unwrap();
 
-        input.dyn_append(
-            &mut Box::new(lean_vec![
-                Tup2(0u64, Tup2(Tup2(10u64, 10i64), 1)),
-                Tup2(0, Tup2(Tup2(11, 20), 1)),
-                Tup2(0, Tup2(Tup2(12, 30), 1)),
-                Tup2(0, Tup2(Tup2(13, 40), 1)),
-                Tup2(0, Tup2(Tup2(14, 50), 1)),
-                Tup2(0, Tup2(Tup2(15, 60), 1)),
-            ])
-            .erase_box(),
-        );
+        input.append(&mut vec![
+            Tup2(0u64, Tup2(Tup2(10u64, 10i64), 1)),
+            Tup2(0, Tup2(Tup2(11, 20), 1)),
+            Tup2(0, Tup2(Tup2(12, 30), 1)),
+            Tup2(0, Tup2(Tup2(13, 40), 1)),
+            Tup2(0, Tup2(Tup2(14, 50), 1)),
+            Tup2(0, Tup2(Tup2(15, 60), 1)),
+        ]);
         expected.dyn_append(
             &mut Box::new(lean_vec![
                 Tup2(0u64, Tup2(Tup2(10u64, None::<i64>), 1)),
@@ -1333,20 +1328,24 @@ mod test {
     #[test]
     fn test_partitioned_rolling_aggregate() {
         let (circuit, input) = RootCircuit::build(move |circuit| {
-            let (input_stream, input_handle) = circuit
-                .dyn_add_input_indexed_zset::<DynData/*<u64>*/, DynPair<DynDataTyped<u64>, DynData/*<i64>*/>>(
-                    &AddInputIndexedZSetFactories::new::<u64, Tup2<u64, i64>>(),
-                );
-
-            let input_stream = input_stream.typed::<TypedBatch<u64, Tup2<u64, i64>, ZWeight, _>>();
+            let (input_stream, input_handle) =
+                circuit.add_input_indexed_zset::<u64, Tup2<u64, i64>>();
 
             input_stream.inspect(|f| {
                 for (p, Tup2(ts, v), w) in f.iter() {
                     println!(" input {p} {ts} {v:6} {w:+}");
                 }
             });
+            let input_by_time =
+                input_stream.map_index(|(partition, Tup2(ts, val))| (*ts, Tup2(*partition, *val)));
+
             let range_spec = RelRange::new(RelOffset::Before(3), RelOffset::Before(2));
-            let sum = input_stream.partitioned_rolling_aggregate_linear(|&f| f, |x| x, range_spec);
+            let sum = input_by_time.partitioned_rolling_aggregate_linear(
+                |Tup2(partition, val)| (*partition, *val),
+                |&f| f,
+                |x| x,
+                range_spec,
+            );
             sum.inspect(|f| {
                 for (p, Tup2(ts, sum), w) in f.iter() {
                     println!("output {p} {ts} {:6} {w:+}", sum.unwrap_or_default());
@@ -1356,18 +1355,15 @@ mod test {
         })
         .unwrap();
 
-        input.dyn_append(
-            &mut Box::new(lean_vec![
-                Tup2(1u64, Tup2(Tup2(0u64, 1i64), 1)),
-                Tup2(1, Tup2(Tup2(1, 10), 1)),
-                Tup2(1, Tup2(Tup2(2, 100), 1)),
-                Tup2(1, Tup2(Tup2(3, 1000), 1)),
-                Tup2(1, Tup2(Tup2(4, 10000), 1)),
-                Tup2(1, Tup2(Tup2(5, 100000), 1)),
-                Tup2(1, Tup2(Tup2(9, 123456), 1)),
-            ])
-            .erase_box(),
-        );
+        input.append(&mut vec![
+            Tup2(1u64, Tup2(Tup2(0u64, 1i64), 1)),
+            Tup2(1, Tup2(Tup2(1, 10), 1)),
+            Tup2(1, Tup2(Tup2(2, 100), 1)),
+            Tup2(1, Tup2(Tup2(3, 1000), 1)),
+            Tup2(1, Tup2(Tup2(4, 10000), 1)),
+            Tup2(1, Tup2(Tup2(5, 100000), 1)),
+            Tup2(1, Tup2(Tup2(9, 123456), 1)),
+        ]);
         circuit.step().unwrap();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperatorBase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperatorBase.java
@@ -11,10 +11,10 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-/**
- * Base class for operators that perform some form of aggregation.
- */
+/*** Base class for operators that perform some form of aggregation. */
 public abstract class DBSPAggregateOperatorBase extends DBSPUnaryOperator {
+    // Initially 'aggregate' is not null, and 'function' is null.
+    // After lowering these two are swapped.
     @Nullable
     public final DBSPAggregate aggregate;
     public final boolean isLinear;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
@@ -8,10 +8,9 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeIndexedZSet;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeOption;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeStruct;
-import org.dbsp.sqlCompiler.ir.type.DBSPTypeUser;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -96,8 +95,7 @@ public final class DBSPSourceMapOperator extends DBSPSourceTableOperator {
                 keyIndexes++;
             } else {
                 DBSPType fieldType = field.type;
-                DBSPType some = new DBSPTypeUser(
-                        field.getNode(), DBSPTypeCode.USER, "Option", false, fieldType);
+                DBSPType some = new DBSPTypeOption(fieldType);
                 fields.add(new DBSPTypeStruct.Field(
                         field.getNode(), field.name, current, some, field.nameIsQuoted));
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
@@ -212,7 +212,7 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
         DBSPAggregate.Implementation impl = node.getAggregate().combine(this.errorReporter);
         DBSPExpression function = impl.asFold();
         DBSPOperator result = new DBSPWindowAggregateOperator(node.getNode(),
-                function, null, node.window,
+                node.partitioningFunction, function, null, node.window,
                 node.getOutputIndexedZSetType(), node.ascending, node.nullsLast,
                 this.mapped(node.input()));
         this.map(node, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
@@ -213,8 +213,7 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
         DBSPExpression function = impl.asFold();
         DBSPOperator result = new DBSPWindowAggregateOperator(node.getNode(),
                 node.partitioningFunction, function, null, node.window,
-                node.getOutputIndexedZSetType(), node.ascending, node.nullsLast,
-                this.mapped(node.input()));
+                node.getOutputIndexedZSetType(), this.mapped(node.input()));
         this.map(node, result);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -976,8 +976,9 @@ public class ToRustVisitor extends CircuitVisitor {
                 .append(tmp)
                 .append(" = ")
                 .append(operator.input().getOutputName())
-                // FIXME: `as_partitioned_zset()` is a temporary workaround.
-                .append(".as_partitioned_zset().partitioned_rolling_aggregate(");
+                .append(".partitioned_rolling_aggregate(");
+        operator.partitioningFunction.accept(this.innerVisitor);
+        builder.append(", ");
         operator.getFunction().accept(this.innerVisitor);
         builder.append(", ");
         operator.window.accept(this.innerVisitor);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -63,7 +63,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPFieldComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPNoComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedUnwrapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPISizeLiteral;
@@ -75,7 +74,7 @@ import org.dbsp.sqlCompiler.ir.statement.DBSPStructWithHelperItem;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeIndexedZSet;
-import org.dbsp.sqlCompiler.ir.type.DBSPTypeRawTuple;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeOption;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeStream;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
@@ -87,7 +86,6 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.IndentStream;
 import org.dbsp.util.Linq;
-import org.dbsp.util.NameGen;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
@@ -157,7 +155,7 @@ public class ToRustVisitor extends CircuitVisitor {
         for (DBSPTypeStruct.Field field: type.fields.values()) {
             this.builder.append("table.")
                     .append(field.getSanitizedName());
-            if (field.type.mayBeNull || field.type.isOption()) {
+            if (field.type.mayBeNull || field.type.is(DBSPTypeOption.class)) {
                 this.builder.append(".map(|x| x");
             }
             if (field.type.is(DBSPTypeVec.class)) {
@@ -165,7 +163,7 @@ public class ToRustVisitor extends CircuitVisitor {
             } else {
                 this.builder.append(".into()");
             }
-            if (field.type.mayBeNull || field.type.isOption()) {
+            if (field.type.mayBeNull || field.type.is(DBSPTypeOption.class)) {
                 this.builder.append(")");
             }
             this.builder.append(", ");
@@ -197,7 +195,7 @@ public class ToRustVisitor extends CircuitVisitor {
                     .append(field.getSanitizedName())
                     .append(": tuple.")
                     .append(index++);
-            if (field.type.mayBeNull || field.type.isOption()) {
+            if (field.type.mayBeNull || field.type.is(DBSPTypeOption.class)) {
                 this.builder.append(".map(|x| x");
             }
             if (field.type.is(DBSPTypeVec.class)) {
@@ -205,7 +203,7 @@ public class ToRustVisitor extends CircuitVisitor {
             } else {
                 this.builder.append(".into()");
             }
-            if (field.type.mayBeNull || field.type.isOption())  {
+            if (field.type.mayBeNull || field.type.is(DBSPTypeOption.class))  {
                 this.builder.append(")");
             }
             this.builder.append(", ")
@@ -967,16 +965,15 @@ public class ToRustVisitor extends CircuitVisitor {
 
     @Override
     public VisitDecision preorder(DBSPWindowAggregateOperator operator) {
-        // We generate two DBSP operator calls: partitioned_rolling_aggregate
-        // and map_index
-        DBSPType streamType = new DBSPTypeStream(operator.outputType);
-        String tmp = new NameGen("stream").nextName();
         this.writeComments(operator)
                 .append("let ")
-                .append(tmp)
+                .append(operator.getOutputName())
+                // the output type is not correct, so we don't write it
                 .append(" = ")
                 .append(operator.input().getOutputName())
-                .append(".partitioned_rolling_aggregate(");
+                .append(".")
+                .append(operator.operation)
+                .append("(");
         operator.partitioningFunction.accept(this.innerVisitor);
         builder.append(", ");
         operator.getFunction().accept(this.innerVisitor);
@@ -984,30 +981,6 @@ public class ToRustVisitor extends CircuitVisitor {
         operator.window.accept(this.innerVisitor);
         builder.append(");")
                 .newline();
-
-        // TODO: this is ugly https://github.com/feldera/feldera/issues/1733
-        this.builder.append("let ")
-                .append(operator.getOutputName())
-                .append(": ");
-        streamType.accept(this.innerVisitor);
-        DBSPTypeIndexedZSet ix = operator.getOutputIndexedZSetType();
-        // ix has the shape Tup2<Tup2<keyType, timestamp>, aggregate>
-        DBSPType aggregateType = ix.elementType;
-        DBSPTypeTuple key_ts = ix.keyType.to(DBSPTypeTuple.class);
-        assert key_ts.tupFields.length == 2;
-        DBSPType tsType = key_ts.tupFields[1];
-        DBSPVariablePath var = new DBSPVariablePath("ts_agg", new DBSPTypeRawTuple(tsType, aggregateType));
-        DBSPExpression ts = var.field(0);
-        DBSPUnsignedUnwrapExpression unwrap = new DBSPUnsignedUnwrapExpression(
-                operator.getNode(), ts, tsType, operator.ascending, operator.nullsLast);
-
-        builder.append(" = " )
-                .append(tmp)
-                .append(".map_index(|(key, ts_agg)| { ")
-                .append("( Tup2::new(key.clone(), ");
-        // the next generates e.g., UnsignedWrapper::to_signed::<i32, i32, i64, u64>(ts_agg.0)
-        unwrap.accept(this.innerVisitor);
-        builder.append("), ts_agg.1.unwrap_or_default() ) });");
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
@@ -168,10 +168,4 @@ public abstract class DBSPType extends DBSPNode implements IDBSPInnerNode {
     public DBSPExpression none() {
         return DBSPLiteral.none(this);
     }
-
-    /** True if this type is Option of T for some T */
-    public boolean isOption() {
-        return this.is(DBSPTypeUser.class) &&
-                this.to(DBSPTypeUser.class).name.equals("Option");
-    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
@@ -39,6 +39,7 @@ public enum DBSPTypeCode {
     RAW_TUPLE(null, "", ""),
     REF(null, "", ""),
     RESULT(null, "", "Result"),
+    OPTION(null, "", "Option"),
     SEMIGROUP(null, "", ""),
     STREAM(null, "", ""),
     STRUCT("ROW TYPE", "", ""),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeOption.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeOption.java
@@ -1,0 +1,33 @@
+package org.dbsp.sqlCompiler.ir.type;
+
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.NonCoreIR;
+
+import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.OPTION;
+
+/** Represents the type of a Rust Option[T] type as a TypeUser. */
+@NonCoreIR
+public class DBSPTypeOption extends DBSPTypeUser {
+    public DBSPTypeOption(DBSPType resultType) {
+        super(resultType.getNode(), OPTION, "Option", false, resultType);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        for (DBSPType type: this.typeArgs)
+            type.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean hasCopy() {
+        return false;
+    }
+
+    // sameType and hashCode inherited from TypeUser.
+}


### PR DESCRIPTION
All rolling aggregate functions now have a uniform API: they take a Z-set indexed by timestamp and a closure that extracts partition id from the value.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
