### PR TITLE
Disable default MUI behavior for editing the cell

### DIFF
--- a/web-console/src/lib/components/streaming/import/InsertionTable.tsx
+++ b/web-console/src/lib/components/streaming/import/InsertionTable.tsx
@@ -86,6 +86,13 @@ export const InsertionTable = ({
           }
         }}
         getRowId={(row: Row) => row.genId}
+        onCellEditStart={(params, event) => {
+          if (params.reason === 'printableKeyDown') {
+            // Prevent editing the field value when pressing printable key after single-clicking on a cell
+            // https://mui.com/x/react-data-grid/events/#disabling-the-default-behavior
+            event.defaultMuiPrevented = true
+          }
+        }}
         columns={[
           ...relation.fields.map((col: Field): GridColDef<Row> => {
             return {


### PR DESCRIPTION
Is this a user-visible change (yes/no): no
The default MUI behavior for "convenient" cell editing was forcing a string value on a strongly-typed numeric column

Fix https://github.com/feldera/feldera/issues/1795 : WebConsole error when adding rows: "e.toFixed is not a function"
