### PR TITLE
Remove RwLock in storage cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,6 +3320,7 @@ dependencies = [
  "crc32c",
  "criterion",
  "crossbeam",
+ "crossbeam-skiplist",
  "crossbeam-utils",
  "csv",
  "derive_more",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -75,6 +75,7 @@ sysinfo = "0.30.5"
 libc = "0.2.153"
 static_assertions = "1.1.0"
 lazy_static = "1.4.0"
+crossbeam-skiplist = "0.1"
 
 [dependencies.time]
 version = "0.3.20"


### PR DESCRIPTION
@blp this is a somewhat straight forward translation for more concurrency in the buffer cache removing the RwLock and replacing BTrees/integers with concurrent skip-lists and atomics. There are a few things to double check though given you are more familiar with this code: 

- signature change of `fn get(&self, key: CacheKey) -> Option<&E>` to `fn get(&self, key: CacheKey) -> Option<E>`. I'm not sure if this is bad in practice to clone this on every get and if we need to do something about it (I haven't checked in detail).
- The insert operation on the btree removes the old value whereas in the concurrent skiplist it's two operations (remove, then insert). Does it have any implications on the code? (I didn't think so.)