### PR TITLE
py: Enforce optimized build.

### DIFF
--- a/python/feldera/rest/client.py
+++ b/python/feldera/rest/client.py
@@ -86,6 +86,7 @@ class Client:
         body = {
             "code": program.code,
             "description": program.description or "",
+            "config": { "profile": "optimized" }
         }
 
         resp = self.http.put(


### PR DESCRIPTION
Unoptimized builds were introduced for use with the sandbox, so we can speed up compilation for severely rate limited demo pipelines, where performance is not needed.  In most other cases, optimized builds are a better default, and now that we can override this setting per-program, we can make sure that pipelines created via the Python SDK are optimized.  For now I hardwired the optimized mode.  It's easy enough to add an option to choose a different build profile if we have a use case for that.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
