### PR TITLE
py: run spwaned listeners as daemons

### DIFF
--- a/python/feldera/_callback_runner.py
+++ b/python/feldera/_callback_runner.py
@@ -23,6 +23,7 @@ class CallbackRunner(Thread):
             queue: Optional[Queue],
     ):
         super().__init__()
+        self.daemon = True
         self.client: FelderaClient = client
         self.pipeline_name: str = pipeline_name
         self.view_name: str = view_name

--- a/python/tests/test_wireframes.py
+++ b/python/tests/test_wireframes.py
@@ -119,6 +119,18 @@ class TestWireframes(unittest.TestCase):
         with self.assertRaises(ValueError):
             sql.connect_source_pandas(TBL_NAME, df)
 
+    def test_sql_error(self):
+        sql = SQLContext('sql_error', TEST_CLIENT).get_or_create()
+        TBL_NAME = "student"
+        df = pd.DataFrame([(1, "a"), (2, "b"), (3, "c")], columns=["id", "name"])
+        sql.register_table(TBL_NAME, SQLSchema({"id": "INT", "name": "STRING"}))
+        sql.register_view("s", f"SELECT FROM blah")
+        sql.connect_source_pandas(TBL_NAME, df)
+        _ = sql.listen("s")
+
+        with self.assertRaises(Exception):
+            sql.run_to_completion()
+
     def test_kafka(self):
         from kafka import KafkaProducer
         from kafka.admin import KafkaAdminClient, NewTopic


### PR DESCRIPTION
The CallbackRunner, which runs in a separate thread now runs as a daemon. This means that the spawned thread will stop executing when the main thread ends.

Fixes: #1831 

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
