### PR TITLE
py: function to wait for pipeline to become idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Python] Added support for HTTP GET connector via Python SDK
 - [Python] Add support for Avro format
   ([#1836](https://github.com/feldera/feldera/pull/1836))
+- [Python] Add function to wait for the pipeline to become idle
+  ([#1841](https://github.com/feldera/feldera/pull/1841))
 
 ### Fixed
 

--- a/python/tests/test_wireframes.py
+++ b/python/tests/test_wireframes.py
@@ -198,7 +198,7 @@ class TestWireframes(unittest.TestCase):
 
         out = sql.listen(VIEW_NAME)
         sql.start()
-        time.sleep(10)
+        sql.wait_for_idle()
         sql.shutdown()
         df = out.to_pandas()
         assert df.shape[0] != 0


### PR DESCRIPTION
Adds the function `wait_for_idle()` to the `SQLContext` class.

The goal of the function is to allow the user to wait for the pipeline to become idle (no change in input/processed records and they are equal) for a certain amount of time, thus an indication that the pipeline is done (though, not a guarantee). It should be followed up with checking the input and output records themselves whether they meet expectations.

It might be useful to add a `total_output_records` metric as well here in the future, indicating that the output records have been output to all sinks.

Is this a user-visible change (yes/no): yes