### PR TITLE
py: properly serialize DataFrames with Timestamp columns

### DIFF
--- a/crates/pipeline-types/src/format/json.rs
+++ b/crates/pipeline-types/src/format/json.rs
@@ -140,6 +140,8 @@ pub enum JsonFlavor {
     /// JSON format accepted by the Kafka Connect `JsonConverter` class.
     #[serde(rename = "kafka_connect_json_converter")]
     KafkaConnectJsonConverter,
+    #[serde(rename = "pandas")]
+    Pandas,
     /// Parquet to-json format.
     /// (For internal use only)
     #[serde(skip)]

--- a/crates/pipeline-types/src/serde_with_context/serde_config.rs
+++ b/crates/pipeline-types/src/serde_with_context/serde_config.rs
@@ -140,6 +140,12 @@ impl From<JsonFlavor> for SqlSerdeConfig {
                 timestamp_format: TimestampFormat::String("%Y-%m-%dT%H:%M:%S%.f%:z"),
                 decimal_format: DecimalFormat::String,
             },
+            JsonFlavor::Pandas => Self {
+                time_format: TimeFormat::String("%H:%M:%S%.f"),
+                date_format: DateFormat::String("%Y-%m-%d"),
+                timestamp_format: TimestampFormat::MillisSinceEpoch,
+                decimal_format: DecimalFormat::String,
+            },
             JsonFlavor::ParquetConverter => Self {
                 time_format: TimeFormat::Nanos,
                 date_format: DateFormat::String("%Y-%m-%d"),

--- a/openapi.json
+++ b/openapi.json
@@ -3790,7 +3790,8 @@
           "default",
           "debezium_mysql",
           "snowflake",
-          "kafka_connect_json_converter"
+          "kafka_connect_json_converter",
+          "pandas"
         ]
       },
       "JsonParserConfig": {

--- a/python/README.md
+++ b/python/README.md
@@ -33,3 +33,11 @@ make html
 ```
 
 To clean the build, run `make clean`.
+
+## Testing
+
+
+```bash
+cd python
+python3 -m unittest
+```

--- a/python/feldera/_helpers.py
+++ b/python/feldera/_helpers.py
@@ -32,3 +32,12 @@ def validate_connector_input_format(fmt: Format):
 
     if isinstance(fmt, JSONFormat) and fmt.config.get("update_format") is None:
         raise ValueError("update_format not set in the format config; consider using: .with_update_format()")
+
+
+def chunk_dataframe(df, chunk_size=1000):
+    """
+    Yield successive n-sized chunks from the given dataframe.
+    """
+
+    for i in range(0, len(df), chunk_size):
+        yield df.iloc[i:i + chunk_size]

--- a/python/feldera/output_handler.py
+++ b/python/feldera/output_handler.py
@@ -39,4 +39,7 @@ class OutputHandler:
         """
 
         self.handler.join()
+
+        if len(self.buffer) == 0:
+            return pd.DataFrame()
         return pd.concat(self.buffer, ignore_index=True)

--- a/python/feldera/output_handler.py
+++ b/python/feldera/output_handler.py
@@ -20,7 +20,8 @@ class OutputHandler:
 
         # the callback that is passed to the `CallbackRunner`
         def callback(df: pd.DataFrame, _: int):
-            self.buffer.append(df)
+            if not df.empty:
+                self.buffer.append(df)
 
         # sets up the callback runner
         self.handler = CallbackRunner(self.client, self.pipeline_name, self.view_name, callback, queue)
@@ -38,4 +39,4 @@ class OutputHandler:
         """
 
         self.handler.join()
-        return pd.concat(self.buffer)
+        return pd.concat(self.buffer, ignore_index=True)

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -32,7 +32,7 @@ class HttpRequests:
             content_type: str = "application/json",
             params: Optional[Mapping[str, Any]] = None,
             stream: bool = False,
-            dont_serialize: bool = False,
+            serialize: bool = True,
     ) -> Any:
         """
         :param http_method: The HTTP method to use. Takes the equivalent `requests.*` module. (Example: `requests.get`)
@@ -41,7 +41,7 @@ class HttpRequests:
         :param content_type: The value for `Content-Type` HTTP header. "application/json" by default.
         :param params: The query parameters part of this request.
         :param stream: True if the response is expected to be a HTTP stream.
-        :param dont_serialize: True if the body is already serialized.
+        :param serialize: True if the body needs to be serialized to JSON.
         """
         self.headers["Content-Type"] = content_type
 
@@ -77,7 +77,7 @@ class HttpRequests:
                     request_path,
                     timeout=timeout,
                     headers=headers,
-                    data=json_serialize(body) if not dont_serialize else body,
+                    data=json_serialize(body) if serialize else body,
                     params=params,
                     stream=stream,
                 )
@@ -108,7 +108,7 @@ class HttpRequests:
             content_type: Optional[str] = "application/json",
             params: Optional[Mapping[str, Any]] = None,
             stream: bool = False,
-            dont_serialize: bool = False,
+            serialize: bool = True,
     ) -> Any:
         return self.send_request(
             requests.post,
@@ -116,7 +116,7 @@ class HttpRequests:
             body,
             content_type,
             params, stream=stream,
-            dont_serialize=dont_serialize
+            serialize=serialize
         )
 
     def patch(

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -9,6 +9,10 @@ import requests
 from typing import Callable, Optional, Any, Union, Mapping, Sequence, List
 
 
+def json_serialize(body: Any) -> str:
+    return json.dumps(body) if body else "" if body == "" else "null"
+
+
 class HttpRequests:
     def __init__(self, config: Config) -> None:
         self.config = config
@@ -28,6 +32,7 @@ class HttpRequests:
             content_type: str = "application/json",
             params: Optional[Mapping[str, Any]] = None,
             stream: bool = False,
+            dont_serialize: bool = False,
     ) -> Any:
         """
         :param http_method: The HTTP method to use. Takes the equivalent `requests.*` module. (Example: `requests.get`)
@@ -36,6 +41,7 @@ class HttpRequests:
         :param content_type: The value for `Content-Type` HTTP header. "application/json" by default.
         :param params: The query parameters part of this request.
         :param stream: True if the response is expected to be a HTTP stream.
+        :param dont_serialize: True if the body is already serialized.
         """
         self.headers["Content-Type"] = content_type
 
@@ -71,7 +77,7 @@ class HttpRequests:
                     request_path,
                     timeout=timeout,
                     headers=headers,
-                    data=json.dumps(body) if body else "" if body == "" else "null",
+                    data=json_serialize(body) if not dont_serialize else body,
                     params=params,
                     stream=stream,
                 )
@@ -102,8 +108,16 @@ class HttpRequests:
             content_type: Optional[str] = "application/json",
             params: Optional[Mapping[str, Any]] = None,
             stream: bool = False,
+            dont_serialize: bool = False,
     ) -> Any:
-        return self.send_request(requests.post, path, body, content_type, params, stream=stream)
+        return self.send_request(
+            requests.post,
+            path,
+            body,
+            content_type,
+            params, stream=stream,
+            dont_serialize=dont_serialize
+        )
 
     def patch(
             self,

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -381,6 +381,7 @@ class FelderaClient:
             array: bool = False,
             force: bool = False,
             update_format: str = "raw",
+            json_flavor: str = None,
             dont_serialize: bool = False,
     ):
         """
@@ -395,7 +396,8 @@ class FelderaClient:
         :param force: If True, the data will be inserted even if the pipeline is paused
         :param update_format: JSON data change event format, used in conjunction with the "json" format,
             the default value is "insert_delete", other supported formats: "weighted", "debezium", "snowflake", "raw"
-
+        :param json_flavor: JSON encoding used for individual table records, the default value is "default", other supported encodings:
+            "debezium_mysql", "snowflake", "kafka_connect_json_converter", "pandas"
         :param data: The data to insert
         :param dont_serialize: If True, the data will not be serialized to JSON. Use if the data is already serialized.
         """
@@ -405,6 +407,9 @@ class FelderaClient:
 
         if update_format not in ["insert_delete", "weighted", "debezium", "snowflake", "raw"]:
             raise ValueError("update_format must be one of 'insert_delete', 'weighted', 'debezium', 'snowflake', 'raw'")
+
+        if json_flavor is not None and json_flavor not in ["default", "debezium_mysql", "snowflake", "kafka_connect_json_converter", "pandas"]:
+            raise ValueError("json_flavor must be one of 'default', 'debezium_mysql', 'snowflake', 'kafka_connect_json_converter', 'pandas'")
 
         # python sends `True` which isn't accepted by the backend
         array = _prepare_boolean_input(array)
@@ -418,6 +423,9 @@ class FelderaClient:
         if format == "json":
             params["array"] = array
             params["update_format"] = update_format
+
+        if json_flavor is not None:
+            params["json_flavor"] = json_flavor
 
         content_type = "application/json"
 

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -32,12 +32,18 @@ class FelderaClient:
         """
         :param url: The url to Feldera API (ex: https://try.feldera.com)
         :param api_key: The optional API key for Feldera
-        :param timeout: (optional) The amount of time in seconds that the cient will wait for a response beforing timing
+        :param timeout: (optional) The amount of time in seconds that the client will wait for a response before timing
             out.
         """
 
         self.config = Config(url, api_key, timeout)
         self.http = HttpRequests(self.config)
+
+        try:
+            self.programs()
+        except Exception as e:
+            logging.error(f"Failed to connect to Feldera API: {e}")
+            raise e
 
     def programs(self) -> list[Program]:
         """
@@ -382,7 +388,7 @@ class FelderaClient:
             force: bool = False,
             update_format: str = "raw",
             json_flavor: str = None,
-            dont_serialize: bool = False,
+            serialize: bool = True,
     ):
         """
         Insert data into a pipeline
@@ -399,7 +405,7 @@ class FelderaClient:
         :param json_flavor: JSON encoding used for individual table records, the default value is "default", other supported encodings:
             "debezium_mysql", "snowflake", "kafka_connect_json_converter", "pandas"
         :param data: The data to insert
-        :param dont_serialize: If True, the data will not be serialized to JSON. Use if the data is already serialized.
+        :param serialize: If True, the data will be serialized to JSON. True by default
         """
 
         if format not in ["json", "csv"]:
@@ -438,7 +444,7 @@ class FelderaClient:
             params=params,
             content_type=content_type,
             body=data,
-            dont_serialize=dont_serialize,
+            serialize=serialize,
         )
 
     def listen_to_pipeline(

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -381,6 +381,7 @@ class FelderaClient:
             array: bool = False,
             force: bool = False,
             update_format: str = "raw",
+            dont_serialize: bool = False,
     ):
         """
         Insert data into a pipeline
@@ -396,6 +397,7 @@ class FelderaClient:
             the default value is "insert_delete", other supported formats: "weighted", "debezium", "snowflake", "raw"
 
         :param data: The data to insert
+        :param dont_serialize: If True, the data will not be serialized to JSON. Use if the data is already serialized.
         """
 
         if format not in ["json", "csv"]:
@@ -428,6 +430,7 @@ class FelderaClient:
             params=params,
             content_type=content_type,
             body=data,
+            dont_serialize=dont_serialize,
         )
 
     def listen_to_pipeline(

--- a/python/feldera/sql_context.py
+++ b/python/feldera/sql_context.py
@@ -180,9 +180,9 @@ class SQLContext:
                         tbl_name,
                         "json",
                         datum.to_json(orient='records', date_format='epoch'),
-                        json_flavor = 'pandas',
+                        json_flavor='pandas',
                         array=True,
-                        dont_serialize=True
+                        serialize=False
                     )
 
         self.http_input_buffer.clear()

--- a/python/feldera/sql_context.py
+++ b/python/feldera/sql_context.py
@@ -179,7 +179,8 @@ class SQLContext:
                         self.pipeline_name,
                         tbl_name,
                         "json",
-                        datum.to_json(orient='records', date_format="iso"),
+                        datum.to_json(orient='records', date_format='epoch'),
+                        json_flavor = 'pandas',
                         array=True,
                         dont_serialize=True
                     )

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -135,18 +135,18 @@ class TestPipeline(unittest.TestCase):
         name = str(uuid.uuid4())
         self.test_create_pipeline(name, False)
 
-        TEST_CLIENT.start_pipeline(name)
+        TEST_CLIENT.pause_pipeline(name)
 
         t1 = threading.Thread(target=self.__listener, args=(name,))
         t1.start()
 
+        TEST_CLIENT.start_pipeline(name)
         TEST_CLIENT.push_to_pipeline(name, "tbl", "csv", data)
 
         t1.join()
 
         assert self.result
 
-        TEST_CLIENT.pause_pipeline(name)
         TEST_CLIENT.shutdown_pipeline(name)
         TEST_CLIENT.delete_pipeline(name)
 

--- a/python/tests/test_wireframes.py
+++ b/python/tests/test_wireframes.py
@@ -331,7 +331,7 @@ class TestWireframes(unittest.TestCase):
         VIEW_NAME = "s"
 
         # backend doesn't support TIMESTAMP of format: "2024-06-06T18:06:28.443"
-        sql.register_table(TBL_NAME, SQLSchema({"id": "INT", "name": "STRING", "birthdate": "STRING"}))
+        sql.register_table(TBL_NAME, SQLSchema({"id": "INT", "name": "STRING", "birthdate": "TIMESTAMP"}))
 
         sql.register_view(VIEW_NAME, f"SELECT * FROM {TBL_NAME}")
 


### PR DESCRIPTION
Fixes: #1840

Also does the following things:

* chunk dataframes into smaller groups of 1000 rows per request while ingesting data
* avoids adding empty dataframes to output buffer
* ignores the index while concatenating output dataframes

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
