### PR TITLE
[SQL] Add source code snippet to json error description

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
@@ -73,7 +73,7 @@ public class CompilerMessages {
             output.append(contents.getFragment(this.range));
         }
 
-        public JsonNode toJson(ObjectMapper mapper) {
+        public JsonNode toJson(SourceFileContents contents, ObjectMapper mapper) {
             ObjectNode result = mapper.createObjectNode();
             result.put("startLineNumber", this.range.start.line);
             result.put("startColumn", this.range.start.column);
@@ -82,6 +82,8 @@ public class CompilerMessages {
             result.put("warning", this.warning);
             result.put("errorType", this.errorType);
             result.put("message", this.message);
+            String snippet = contents.getFragment(this.range);
+            result.put("snippet", snippet);
             return result;
         }
 
@@ -166,7 +168,7 @@ public class CompilerMessages {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         if (this.compiler.options.ioOptions.emitJsonErrors) {
-            JsonNode node = this.toJson();
+            JsonNode node = this.toJson(this.compiler.sources);
             builder.append(node.toPrettyString());
         } else {
             for (Error message: this.messages) {
@@ -182,11 +184,11 @@ public class CompilerMessages {
         return this.messages.isEmpty();
     }
 
-    public JsonNode toJson() {
+    public JsonNode toJson(SourceFileContents contents) {
         ObjectMapper mapper = new ObjectMapper();
         ArrayNode result = mapper.createArrayNode();
         for (Error message: this.messages) {
-            JsonNode node = message.toJson(mapper);
+            JsonNode node = message.toJson(contents, mapper);
             result.add(node);
         }
         return result;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -935,6 +935,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.readTree(json);
         Assert.assertNotNull(jsonNode);
+        Assert.assertNotNull(jsonNode.get(0).get("snippet").asText());
     }
 
     @Test


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1842 

Now the JSON object returned will also contain a source code snippet if applicable, under the field "snippet":

```
{
  "startLineNumber" : 1,
  "startColumn" : 32,
  "endLineNumber" : 1,
  "endColumn" : 32,
  "warning" : false,
  "errorType" : "Error in SQL statement",
  "message" : "Object 'T' not found",
  "snippet" : "    1|CREATE VIEW V AS SELECT * FROM T\n                                     ^\n"
}
```
