### PR TITLE
Per-thread Storage cache.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,6 +3361,7 @@ dependencies = [
  "tempfile",
  "textwrap 0.15.2",
  "thiserror",
+ "thread_local",
  "time",
  "tokio",
  "typedmap",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -75,6 +75,7 @@ sysinfo = "0.30.5"
 libc = "0.2.153"
 static_assertions = "1.1.0"
 lazy_static = "1.4.0"
+thread_local = "1.1.8"
 
 [dependencies.time]
 version = "0.3.20"


### PR DESCRIPTION
I  ran the persistence demo a few more times with the per-thread-cache approach and runtime seems to vary enough so that I can say it probably doesn't differ much from the concurrent cache (where it takes ~341 seconds).

```
Running the training pipeline. Point your browser to http://localhost:8080/streaming/management/ to monitor the status of the pipeline.
Training time = 409.233
 ✘ gz@gz-desktop-pro  ~/workspace/dbsp/demo/project_demo10-FraudDetectionDeltaLake   per-thread-cache ±  python3 run.py

Running the training pipeline. Point your browser to http://localhost:8080/streaming/management/ to monitor the status of the pipeline.
Training time = 361.326

 ✘ gz@gz-desktop-pro  ~/workspace/dbsp/demo/project_demo10-FraudDetectionDeltaLake   per-thread-cache ±  python3 run.py

Running the training pipeline. Point your browser to http://localhost:8080/streaming/management/ to monitor the status of the pipeline.
Training time = 355.901
```

the plus side is that this approach is much simpler so we can go with that for now until we really need a concurrent one