### PR TITLE
Log SQL metrics

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -538,6 +538,7 @@ benchmark:
     END
     SAVE ARTIFACT crates/nexmark/nexmark_results.csv AS LOCAL .
     SAVE ARTIFACT crates/nexmark/sql_nexmark_results.csv AS LOCAL .
+    SAVE ARTIFACT crates/nexmark/sql_nexmark_metrics.csv AS LOCAL .
     SAVE ARTIFACT crates/nexmark/dram_nexmark_results.csv AS LOCAL .
     SAVE ARTIFACT crates/dbsp/galen_results.csv AS LOCAL .
     #SAVE ARTIFACT crates/dbsp/ldbc_results.csv AS LOCAL .

--- a/scripts/bench-publish.bash
+++ b/scripts/bench-publish.bash
@@ -18,6 +18,7 @@ fi
 NEXMARK_CSV_FILE='nexmark_results.csv'
 NEXMARK_DRAM_CSV_FILE='dram_nexmark_results.csv'
 NEXMARK_SQL_CSV_FILE='sql_nexmark_results.csv'
+NEXMARK_SQL_METRICS_CSV_FILE='sql_nexmark_metrics.csv'
 NEXMARK_PERSISTENCE_CSV_FILE='persistence_nexmark_results.csv'
 GALEN_CSV_FILE='galen_results.csv'
 LDBC_CSV_FILE='ldbc_results.csv'
@@ -46,11 +47,12 @@ fi
 
 # Copy nexmark results
 mkdir -p ${DEPLOY_DIR}
-mv ${NEXMARK_CSV_FILE} ${NEXMARK_DRAM_CSV_FILE} ${NEXMARK_SQL_CSV_FILE} ${DEPLOY_DIR}
+mv ${NEXMARK_CSV_FILE} ${NEXMARK_DRAM_CSV_FILE} ${NEXMARK_SQL_CSV_FILE} ${NEXMARK_SQL_METRICS_CSV_FILE} ${DEPLOY_DIR}
 gzip -f ${DEPLOY_DIR}/${NEXMARK_CSV_FILE}
 #gzip -f ${DEPLOY_DIR}/${NEXMARK_PERSISTENCE_CSV_FILE}
 gzip -f ${DEPLOY_DIR}/${NEXMARK_DRAM_CSV_FILE}
 gzip -f ${DEPLOY_DIR}/${NEXMARK_SQL_CSV_FILE}
+gzip -f ${DEPLOY_DIR}/${NEXMARK_SQL_METRICS_CSV_FILE}
 
 # Add galen results to repo
 DEPLOY_DIR="gh-pages/galen/${CI_MACHINE_TYPE}/${PR_COMMIT_SHA}/"

--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -13,6 +13,7 @@ fi
 NEXMARK_CSV_FILE='nexmark_results.csv'
 NEXMARK_DRAM_CSV_FILE='dram_nexmark_results.csv'
 NEXMARK_SQL_CSV_FILE='sql_nexmark_results.csv'
+NEXMARK_SQL_METRICS_CSV_FILE='sql_nexmark_metrics.csv'
 NEXMARK_PERSISTENCE_CSV_FILE='persistence_nexmark_results.csv'
 GALEN_CSV_FILE='galen_results.csv'
 LDBC_CSV_FILE='ldbc_results.csv'
@@ -41,7 +42,7 @@ KAFKA_BROKER=localhost:9092
 rpk topic -X brokers=$KAFKA_BROKER delete bid auction person
 cargo run  -p dbsp_nexmark --example generate --features with-kafka -- --max-events ${MAX_EVENTS} -O bootstrap.servers=$KAFKA_BROKER
 FELDERA_API=http://localhost:8080
-python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API --kafka-broker $KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_CSV_FILE}
+python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API --kafka-broker $KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_CSV_FILE} --csv-metrics crates/nexmark/${NEXMARK_SQL_METRICS_CSV_FILE} --metrics-interval 1
 
 # Run galen benchmark
 cargo bench --bench galen --features="with-csv" -- --workers 10 --csv ${GALEN_CSV_FILE}


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This pull request goes with another one in the benchmarks repository: https://github.com/feldera/benchmarks/pull/4

Changes in this PR:
- add one more statistic to the results of the Nexmark SQL test: peak memory usage. 
- add logging per-run metrics of Nexmark SQL tests to sql_nexmark_metrics.csv. These metrics are: test name, elapsed_seconds, rss_bytes, buffered_input_records, total_input_records, total_processed_records. There are also several disk metrics, for runs using disk storage: total_files_created, total_bytes_written, total_writes_success, buffer_cache_hit, and write_latency_histogram.
- add csv-metrics and metrics-interval args to feldera-sql/run.py to allow controlling metrics csv file location and how often metrics are recorded in that file.

These files are then used by the benchmarks repository to generate new graphs. See that PR for more details. 


