### PR TITLE
[SQL] Use join_flatmap when possible

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFlatmapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFlatmapOperator.java
@@ -1,0 +1,52 @@
+package org.dbsp.sqlCompiler.circuit.operator;
+
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/** We use join_flatmap to implement a join followed by a filter.
+ * The function returns None for dropping a value, and Some(result)
+ * for keeping a result. */
+public final class DBSPJoinFlatmapOperator extends DBSPOperator {
+    public DBSPJoinFlatmapOperator(
+            CalciteObject node, DBSPTypeZSet outputType,
+            DBSPExpression function, boolean isMultiset,
+            DBSPOperator left, DBSPOperator right) {
+        super(node, "join_flatmap", function, outputType, isMultiset);
+        this.addInput(left);
+        this.addInput(right);
+    }
+
+    @Override
+    public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
+        return new DBSPJoinFlatmapOperator(
+                this.getNode(), outputType.to(DBSPTypeZSet.class),
+                Objects.requireNonNull(expression),
+                this.isMultiset, this.inputs.get(0), this.inputs.get(1));
+    }
+
+    @Override
+    public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
+        if (force || this.inputsDiffer(newInputs))
+            return new DBSPJoinFlatmapOperator(
+                    this.getNode(), this.getOutputZSetType(),
+                    this.getFunction(), this.isMultiset, newInputs.get(0), newInputs.get(1));
+        return this;
+    }
+
+    @Override
+    public void accept(CircuitVisitor visitor) {
+        visitor.push(this);
+        VisitDecision decision = visitor.preorder(this);
+        if (!decision.stop())
+            visitor.postorder(this);
+        visitor.pop(this);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -313,6 +313,11 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs {
     }
 
     @Override
+    public void postorder(DBSPJoinFlatmapOperator operator) {
+        this.replace(operator);
+    }
+
+    @Override
     public void postorder(DBSPDistinctOperator operator) {
         this.replace(operator);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -69,6 +69,7 @@ public class CircuitOptimizer implements ICompilerComponent {
             }
             passes.add(new DeadCode(reporter, true, false));
             passes.add(new MonotoneAnalyzer(reporter));
+            passes.add(new FilterJoin(reporter));
             passes.add(new OptimizeProjections(reporter));
             passes.add(new DeadCode(reporter, true, false));
             passes.add(new Simplify(reporter).circuitRewriter());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -268,6 +268,10 @@ public abstract class CircuitVisitor
         return this.preorder(node.to(DBSPOperator.class));
     }
 
+    public VisitDecision preorder(DBSPJoinFlatmapOperator node) {
+        return this.preorder(node.to(DBSPOperator.class));
+    }
+
     public VisitDecision preorder(DBSPPrimitiveAggregateOperator node) {
         return this.preorder(node.to(DBSPOperator.class));
     }
@@ -339,6 +343,10 @@ public abstract class CircuitVisitor
     }
 
     public void postorder(DBSPJoinOperator node) {
+        this.postorder(node.to(DBSPOperator.class));
+    }
+
+    public void postorder(DBSPJoinFlatmapOperator node) {
         this.postorder(node.to(DBSPOperator.class));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoin.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoin.java
@@ -1,0 +1,48 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFlatmapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.BetaReduction;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
+import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
+import org.dbsp.util.Linq;
+
+import java.util.List;
+
+/** Combine a Join followed by a filter into a JoinFlatmap. */
+public class FilterJoin extends CircuitCloneVisitor {
+    public FilterJoin(IErrorReporter reporter) {
+        super(reporter, false);
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator operator) {
+        DBSPOperator source = this.mapped(operator.input());
+        if (source.is(DBSPJoinOperator.class)) {
+            DBSPClosureExpression expression = source.getFunction().to(DBSPClosureExpression.class);
+            DBSPClosureExpression filter = operator.getFunction().to(DBSPClosureExpression.class);
+            DBSPLetStatement let = new DBSPLetStatement("tmp", expression.body);
+            DBSPExpression cond = filter.call(let.getVarReference().borrow());
+            DBSPIfExpression ifexp = new DBSPIfExpression(
+                    source.getNode(),
+                    cond,
+                    let.getVarReference().some(),
+                    let.getVarReference().getType().setMayBeNull(true).none());
+            DBSPBlockExpression block = new DBSPBlockExpression(Linq.list(let), ifexp);
+            DBSPClosureExpression newFunction = block.closure(expression.parameters);
+            newFunction = new BetaReduction(this.errorReporter).apply(newFunction).to(DBSPClosureExpression.class);
+            DBSPOperator result =
+                    new DBSPJoinFlatmapOperator(source.getNode(), source.getOutputZSetType(),
+                            newFunction, source.isMultiset, source.inputs.get(0), source.inputs.get(1));
+            this.map(operator, result);
+            return;
+        }
+        super.postorder(operator);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
@@ -139,6 +139,8 @@ public final class DBSPTupleExpression extends DBSPBaseTupleExpression {
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
+        if (this.isNull)
+            return builder.append("None");
         return builder.append(DBSPTypeCode.TUPLE.rustName)
                 .append(this.fields.length)
                 .append("::new(")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -55,7 +55,7 @@ public abstract class DBSPLiteral extends DBSPExpression {
     /** Represents a "null" value of the specified type. */
     public static DBSPExpression none(DBSPType type) {
         if (!type.mayBeNull)
-            throw new RuntimeException(type.toString() + " cannot represent NULL");
+            throw new RuntimeException(type + " cannot represent NULL");
         if (type.is(DBSPTypeInteger.class)) {
             DBSPTypeInteger it = type.to(DBSPTypeInteger.class);
             if (!it.signed)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -146,7 +146,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                     // CREATE VIEW `V` AS
                     // SELECT `T`.`COL3`
                     // FROM `T`
-                    let stream129: stream<WSet<Tup1<b>>> = stream61;
+                    let stream130: stream<WSet<Tup1<b>>> = stream61;
                 }
                 """;
         Assert.assertEquals(expected, str);


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Join followed by a filter will be implemented using join_flatmap.

I expect this will help a lot Q9 from nexmark.
