### PR TITLE
Avro: Serialize non-nullable fields as nullable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [SQL] Support for ARRAY_AGG aggregation function.
+- [avro] Allow serializing non-nullable SQL columns into nullable Avro columns
+  ([#1892](https://github.com/feldera/feldera/pull/1892))
+- [SQL] Support for `ARRAY_AGG` aggregation function.
 - [SQL] Support for hopping windows using table functions
   ([#1855](https://github.com/feldera/feldera/pull/1855))
 - API: Support skipping the serialization of schema ID in Avro format.


### PR DESCRIPTION
When serializing Avro data, the Rust type must generally match the Avro schema precisely.  One situation where we can relax this requirement is when serializing a non-optional field into an Avro union type.  This is important in practice, as we don't control the nullability of columns in views.

This commit should enable this behavior.  It introduces some additional performance overhead due to having to check the schema when serializing every field.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
