### PR TITLE
Run rust tests separately

### DIFF
--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -28,7 +28,11 @@ if [ "$SMOKE" != "" ]; then
   EVENT_RATE=10000000
   MAX_EVENTS=1000000
 fi
-cargo bench --bench nexmark -- --first-event-rate=${EVENT_RATE} --max-events=${MAX_EVENTS} --cpu-cores ${CORES}  --num-event-generators ${GENERATORS} --source-buffer-size 10000 --input-batch-size 40000 --csv ${NEXMARK_CSV_FILE}
+
+FILES=( "q0" "q1" "q2" "q3" "q4" "q5" "q6" "q7" "q8" "q9" "q12" "q13" "q14" "q15" "q16" "q17" "q18" "q19" "q20" "q21" "q22" )
+for FILE in "${FILES[@]}"
+  do cargo bench --bench nexmark -- --first-event-rate=${EVENT_RATE} --max-events=${MAX_EVENTS} --cpu-cores ${CORES}  --num-event-generators ${GENERATORS} --source-buffer-size 10000 --input-batch-size 40000 --csv ${NEXMARK_CSV_FILE} --query $FILE
+done
 
 # Run nexmark SQL benchmark
 # This test requires a running instance of redpanda and pipeline-manager.


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Rust nexmark tests are now run in separate cargo invocations so that memory statistics for each test can be more accurately measured.

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
