### PR TITLE
[SQL] Remove unsupported SQL construct (FILTER and OVER) from documentation

### DIFF
--- a/docs/sql/grammar.md
+++ b/docs/sql/grammar.md
@@ -268,11 +268,8 @@ window aggregate.  The grammar for window aggregates is:
 windowedAggregateCall
   : agg '(' [ ALL | DISTINCT ] value [, value ]* ')'
       [ RESPECT NULLS | IGNORE NULLS ]
-      [ WITHIN GROUP '(' ORDER BY orderItem [, orderItem ]* ')' ]
-      [ FILTER '(' WHERE condition ')' ]
       OVER windowSpec
   | agg '(' '*' ')'
-      [ FILTER  '(' WHERE condition ')' ]
       OVER windowSpec
 
 windowSpec


### PR DESCRIPTION
Fixes #1898 (kind of)
