### PR TITLE
[SQL] Preliminary support for MAP types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [SQL] Preliminary support for MAP-typed values
+  ([#1905](https://github.com/feldera/feldera/pull/1905))
 - [avro] Allow serializing non-nullable SQL columns into nullable Avro columns
   ([#1892](https://github.com/feldera/feldera/pull/1892))
 - [SQL] Support for specifying connector properties in SQL

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -24,8 +24,8 @@ const sidebars = {
         id: 'get-started'
       },
       items: [
-	'docker',
-	'sandbox',
+        'docker',
+        'sandbox',
       ]
     },
     {
@@ -95,15 +95,15 @@ const sidebars = {
               label: "Python SDK",
               href: "pathname:///python/index.html",
             },
-            'api/rest', 
-	    {
-	      type: 'category',
-	      label: 'Connectors',
-	      link: {
-		type: 'doc',
-		id: 'connectors/index'
-	      },
-	      items: [
+            'api/rest',
+            {
+              type: 'category',
+              label: 'Connectors',
+              link: {
+                type: 'doc',
+                id: 'connectors/index'
+              },
+              items: [
               {
                   type: 'category',
                   label: 'Input',
@@ -126,7 +126,7 @@ const sidebars = {
                           type: 'doc',
                           id: 'connectors/sources/delta',
                           label: 'Delta Lake'
-                      },                      
+                      },
                       {
                           type: 'doc',
                           id: 'connectors/sources/kafka',
@@ -169,17 +169,17 @@ const sidebars = {
                       }
                   ]
               }
-	      ]
-	    },
+              ]
+            },
             {
               type: 'category',
-	      label: 'Formats',
-	      items: [
-		'api/json', 
-		'api/parquet', 
+              label: 'Formats',
+              items: [
+                'api/json',
+                'api/parquet',
                 'api/csv',
-	      ],
-	    },
+              ],
+            },
             {
               type: 'category',
               label: 'SQL Reference',
@@ -199,6 +199,7 @@ const sidebars = {
                 'sql/string',
                 'sql/binary',
                 'sql/array',
+                'sql/map',
                 'sql/datetime',
                 'sql/streaming',
                 'sql/udf'

--- a/docs/sql/intro.mdx
+++ b/docs/sql/intro.mdx
@@ -20,7 +20,8 @@ Feldera is used in the following way:
 
 - users define a set of database tables in Feldera. These tables
   become *inputs* for DBSP.
-- users define a set of database views.  The views become *outputs* for DBSP.
+- users define a set of database views.  The views become *outputs* for DBSP
+  (unless they are declared as being `LOCAL`).
   The views can be defined either in Rust, using the DBSP library, or can be
   implemented in standard SQL, and compiled to Rust using the SQL to DBSP
   compiler.
@@ -81,11 +82,11 @@ Differences between DBSP and a database:
 Despite these limitations, DBSP offers a powerful set of features:
 
 - A rich set of data types, including the standard SQL datatypes,
-  dates, times, intervals, arrays
+  dates, times, intervals, arrays, maps, user-defined types
 
 - Arbitrary SQL queries, including the standard relational algebra,
   `GROUP BY`, aggregations, user-defined functions, joins of several
-  flavors, `UNNEST`, and window queries
+  flavors, `UNNEST`, streaming constructs, and window queries
 
 There are many good introductions to SQL on the Internet.  This
 document is not intended as a tutorial, but only as a specification of

--- a/docs/sql/map.md
+++ b/docs/sql/map.md
@@ -1,0 +1,15 @@
+# Operations on Maps
+
+A MAP type can be created using the syntax MAP<type, type>.
+For example `MAP<VARCHAR, INT>` is an map from strings to integers.
+
+## Map literals
+
+Map literals have the syntax `MAP[`key `,` value ( `,` key `,` value )* `]`.
+Here is an example: `SELECT MAP['hi',2]`.
+
+## Predefined functions on map values
+
+| Function                                                             | Description                                                                                                                                                                                                                                                                               | Example                                                             |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| _map_`[`_key_`]`                                                 | Returns the element in the map with the specified key. If there is no such key, the result is `NULL`.                                                                 | `MAP['x', 4, 'y', 3]['x']` => 4                                                |

--- a/docs/sql/types.md
+++ b/docs/sql/types.md
@@ -24,6 +24,7 @@ The compiler supports the following SQL data types:
 | `DATE`                      | A date value.                                                                                                                                                      |                            |
 | `GEOMETRY`                  | A geographic data type (only rudimentary support at this point).                                                                                                   |                            |
 | `ARRAY`                     | An array with element of the specified type. Used as a suffix for another type (e.g., `INT ARRAY`)                                                                 |                            |
+| `MAP`                       | A map with string keys and values of the specified type. Used as a suffix for another type (e.g., `INT MAP`)                                                       |                            |
 
 - For `DECIMAL` types: 23.456 has a precision of 5 and a scale of 3.
   If scale is missing it is assumed to be 0.
@@ -108,6 +109,7 @@ type:
 typeName:
       sqlTypeName
   |   compoundIdentifier
+  |   MAP < type , type >
 
 sqlTypeName:
       char [ precision ] [ charSet ]

--- a/docs/sql/types.md
+++ b/docs/sql/types.md
@@ -24,7 +24,7 @@ The compiler supports the following SQL data types:
 | `DATE`                      | A date value.                                                                                                                                                      |                            |
 | `GEOMETRY`                  | A geographic data type (only rudimentary support at this point).                                                                                                   |                            |
 | `ARRAY`                     | An array with element of the specified type. Used as a suffix for another type (e.g., `INT ARRAY`)                                                                 |                            |
-| `MAP`                       | A map with string keys and values of the specified type. Used as a suffix for another type (e.g., `INT MAP`)                                                       |                            |
+| `MAP`                       | A map with keys and values of specified types. The syntax is `MAP<KEYTYPE, VALUETYPE>`                                                                             |                            |
 
 - For `DECIMAL` types: 23.456 has a precision of 5 and a scale of 3.
   If scale is missing it is assumed to be 0.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
@@ -79,7 +79,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         if (node.is(DBSPDelayOutputOperator.class))
             name = "delay";
         this.stream.append(node.getOutputName())
-                .append(" [ shape=box,label=\"")
+                .append(" [ shape=box style=filled fillcolor=lightgrey label=\"")
                 .append(node.getIdString())
                 .append(" ")
                 .append(name)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -132,6 +132,7 @@ public class RustFileWriter {
                     use ::serde::{Deserialize,Serialize};
                     use compare::{Compare, Extract};
                     use std::{
+                        collections::BTreeMap,
                         convert::identity,
                         ops::Neg,
                         fmt::{Debug, Formatter, Result as FmtResult},

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -38,6 +38,7 @@ import org.dbsp.sqlCompiler.ir.type.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBinary;
@@ -212,8 +213,14 @@ public class TypeCompiler implements ICompilerComponent {
                 case ANY:
                     // Not sure whether this is right
                     return DBSPTypeAny.getDefault();
+                case MAP: {
+                    RelDataType kt = Objects.requireNonNull(dt.getKeyType());
+                    DBSPType keyType = this.convertType(kt, asStruct);
+                    RelDataType vt = Objects.requireNonNull(dt.getValueType());
+                    DBSPType valueType = this.convertType(vt, asStruct);
+                    return new DBSPTypeMap(keyType, valueType, dt.isNullable());
+                }
                 case MULTISET:
-                case MAP:
                 case DISTINCT:
                 case STRUCTURED:
                 case ROW:
@@ -240,13 +247,13 @@ public class TypeCompiler implements ICompilerComponent {
                 case INTERVAL_SECOND:
                     return new DBSPTypeMillisInterval(node, nullable);
                 case GEOMETRY:
-                    return new DBSPTypeGeoPoint(CalciteObject.EMPTY, nullable);
+                    return new DBSPTypeGeoPoint(node, nullable);
                 case TIMESTAMP:
-                    return new DBSPTypeTimestamp(CalciteObject.EMPTY, nullable);
+                    return new DBSPTypeTimestamp(node, nullable);
                 case DATE:
-                    return new DBSPTypeDate(CalciteObject.EMPTY, nullable);
+                    return new DBSPTypeDate(node, nullable);
                 case TIME:
-                    return new DBSPTypeTime(CalciteObject.EMPTY, nullable);
+                    return new DBSPTypeTime(node, nullable);
             }
         }
         throw new UnimplementedException(node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -88,6 +88,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPKeywordLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
@@ -145,6 +146,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeResult;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeSemigroup;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeStream;
@@ -432,6 +434,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
         return this.preorder(node.to(DBSPTypeUser.class));
     }
 
+    public VisitDecision preorder(DBSPTypeMap node) {
+        return this.preorder(node.to(DBSPTypeUser.class));
+    }
+
     public VisitDecision preorder(DBSPTypeResult node) {
         return this.preorder(node.to(DBSPTypeUser.class));
     }
@@ -614,6 +620,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
     }
     
     public VisitDecision preorder(DBSPVecLiteral node) {
+        return this.preorder(node.to(DBSPLiteral.class));
+    }
+
+    public VisitDecision preorder(DBSPMapLiteral node) {
         return this.preorder(node.to(DBSPLiteral.class));
     }
 
@@ -940,6 +950,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
         this.postorder(node.to(DBSPTypeUser.class));
     }
 
+    public void postorder(DBSPTypeMap node) {
+        this.postorder(node.to(DBSPTypeUser.class));
+    }
+
     public void postorder(DBSPTypeResult node) {
         this.postorder(node.to(DBSPTypeUser.class));
     }
@@ -1138,6 +1152,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
     }
 
     public void postorder(DBSPVecLiteral node) {
+        this.postorder(node.to(DBSPLiteral.class));
+    }
+
+    public void postorder(DBSPMapLiteral node) {
         this.postorder(node.to(DBSPLiteral.class));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPMapLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPMapLiteral.java
@@ -132,8 +132,9 @@ public final class DBSPMapLiteral extends DBSPLiteral {
                     .append(this.type)
                     .append(")")
                     .append("null");
-        builder.append("HashMap::from([")
+        builder.append("BTreeMap::from([")
                 .increase();
+        assert this.values != null;
         for (int i = 0; i < keys.size(); i++) {
             builder.append(this.keys.get(i))
                     .append(", ")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPMapLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPMapLiteral.java
@@ -1,0 +1,162 @@
+package org.dbsp.sqlCompiler.ir.expression.literal;
+
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
+import org.dbsp.util.IIndentStream;
+import org.dbsp.util.Linq;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Represents a (constant) map described by its elements. */
+public final class DBSPMapLiteral extends DBSPLiteral {
+    // Both lists must have the same length
+    @Nullable
+    public final List<DBSPExpression> keys;
+    @Nullable
+    public final List<DBSPExpression> values;
+    public final DBSPTypeMap mapType;
+
+    public DBSPMapLiteral(DBSPType keyType, DBSPType valueType, boolean mayBeNull) {
+        super(CalciteObject.EMPTY, new DBSPTypeMap(keyType, valueType, mayBeNull), false);
+        this.keys = new ArrayList<>();
+        this.values = new ArrayList<>();
+        this.mapType = this.getType().to(DBSPTypeMap.class);
+    }
+
+    public static List<DBSPExpression> getKeys(List<DBSPExpression> data) {
+        ArrayList<DBSPExpression> result = new ArrayList<>();
+        for (int i = 0; i < data.size(); i += 2)
+            result.add(data.get(i));
+        return result;
+    }
+
+    public static List<DBSPExpression> getValues(List<DBSPExpression> data) {
+        ArrayList<DBSPExpression> result = new ArrayList<>();
+        for (int i = 1; i < data.size(); i += 2)
+            result.add(data.get(i));
+        return result;
+    }
+
+    public DBSPMapLiteral(DBSPTypeMap mapType, List<DBSPExpression> data) {
+        this(mapType, getKeys(data), getValues(data));
+    }
+
+    public DBSPMapLiteral(DBSPTypeMap mapType, @Nullable List<DBSPExpression> keys, @Nullable List<DBSPExpression> values) {
+        super(CalciteObject.EMPTY, mapType, mapType.mayBeNull);
+        this.mapType = this.getType().to(DBSPTypeMap.class);
+        if (keys == null) {
+            this.keys = null;
+        } else {
+            this.keys = new ArrayList<>();
+            assert values != null;
+            assert keys.size() == values.size();
+            for (DBSPExpression e : keys) {
+                if (!e.getType().sameType(this.getKeyType()))
+                    throw new InternalCompilerError("Not all keys of map have the same type:" +
+                            e.getType() + " vs " + this.getKeyType(), this);
+                this.keys.add(e);
+            }
+        }
+        if (values == null) {
+            this.values = null;
+        } else {
+            this.values = new ArrayList<>();
+            for (DBSPExpression e : values) {
+                if (!e.getType().sameType(this.getValueType()))
+                    throw new InternalCompilerError("Not all values of map have the same type:" +
+                            e.getType() + " vs " + this.getValueType(), this);
+                this.values.add(e);
+            }
+        }
+    }
+
+    public DBSPType getKeyType() {
+        return this.mapType.getKeyType();
+    }
+
+    public DBSPType getValueType() {
+        return this.mapType.getValueType();
+    }
+
+    public int size() {
+        return Objects.requireNonNull(this.keys).size();
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        if (this.keys != null) {
+            assert this.values != null;
+            for (int i = 0; i < this.keys.size(); i++) {
+                DBSPExpression key = this.keys.get(i);
+                key.accept(visitor);
+                DBSPExpression value = this.values.get(i);
+                value.accept(visitor);
+            }
+        }
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public DBSPLiteral getWithNullable(boolean mayBeNull) {
+        return new DBSPMapLiteral(this.getType().setMayBeNull(mayBeNull).to(DBSPTypeMap.class),
+                this.keys, this.values);
+    }
+
+    @Override
+    public boolean sameValue(@Nullable DBSPLiteral o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DBSPMapLiteral that = (DBSPMapLiteral) o;
+        if (!Objects.equals(this.keys, that.keys)) return false;
+        if (!Objects.equals(this.values, that.values)) return false;
+        return mapType.equals(that.mapType);
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        if (this.keys == null)
+            return builder.append("(")
+                    .append(this.type)
+                    .append(")")
+                    .append("null");
+        builder.append("HashMap::from([")
+                .increase();
+        for (int i = 0; i < keys.size(); i++) {
+            builder.append(this.keys.get(i))
+                    .append(", ")
+                    .append(this.values.get(i));
+        }
+        return builder.append("])")
+                .decrease()
+                .newline();
+    }
+
+    @Override
+    public DBSPExpression deepCopy() {
+        return new DBSPMapLiteral(this.mapType,
+                this.keys != null ? Linq.map(this.keys, DBSPExpression::deepCopy) : null,
+                this.values != null ? Linq.map(this.values, DBSPExpression::deepCopy) : null);
+    }
+
+    @Override
+    public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
+        DBSPMapLiteral otherExpression = other.as(DBSPMapLiteral.class);
+        if (otherExpression == null)
+            return false;
+        return context.equivalent(this.keys, otherExpression.keys) &&
+                context.equivalent(this.values, otherExpression.values);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVecLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVecLiteral.java
@@ -65,7 +65,7 @@ public final class DBSPVecLiteral extends DBSPLiteral implements IDBSPContainer 
         if (data != null) {
             for (DBSPExpression e : data) {
                 if (!e.getType().sameType(data.get(0).getType()))
-                    throw new InternalCompilerError("Not all values of set have the same type:" +
+                    throw new InternalCompilerError("Not all values of vector have the same type:" +
                             e.getType() + " vs " + data.get(0).getType(), this);
                 this.add(e);
             }
@@ -78,7 +78,7 @@ public final class DBSPVecLiteral extends DBSPLiteral implements IDBSPContainer 
         this.data = new ArrayList<>();
         for (DBSPExpression e: data) {
             if (!e.getType().sameType(data[0].getType()))
-                throw new InternalCompilerError("Not all values of set have the same type:" +
+                throw new InternalCompilerError("Not all values of vector have the same type:" +
                         e.getType() + " vs " + data[0].getType(), this);
             this.add(e);
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
@@ -48,6 +48,7 @@ public enum DBSPTypeCode {
     STREAM(null, "", ""),
     USER(null, "", ""),
     VEC("ARRAY", "", ""),
+    MAP("MAP", "", "BTreeMap"),
     ZSET("MULTISET", "", "");
 
     @Nullable

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
@@ -1,0 +1,47 @@
+package org.dbsp.sqlCompiler.ir.type.user;
+
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+
+import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.MAP;
+
+/** Represents the type of a Rust Map as a TypeUser. */
+public class DBSPTypeMap extends DBSPTypeUser {
+    public DBSPTypeMap(DBSPType mapKeyType, DBSPType mapValueType, boolean mayBeNull) {
+        super(mapKeyType.getNode(), MAP, "BTreeMap", mayBeNull, mapKeyType, mapValueType);
+    }
+
+    public DBSPType getKeyType() {
+        return this.getTypeArg(0);
+    }
+
+    public DBSPType getValueType() {
+        return this.getTypeArg(1);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        for (DBSPType type: this.typeArgs)
+            type.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean hasCopy() {
+        return false;
+    }
+
+    @Override
+    public DBSPType setMayBeNull(boolean mayBeNull) {
+        if (mayBeNull == this.mayBeNull)
+            return this;
+        return new DBSPTypeMap(this.getKeyType(), this.getValueType(), mayBeNull);
+    }
+
+    // sameType and hashCode inherited from TypeUser.
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -193,7 +193,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                  "connector" : "file",
                  "path" : "/tmp/x"
                }""", str);
-
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ParserTests.java
@@ -158,6 +158,17 @@ public class ParserTests {
     }
 
     @Test
+    public void mapTypeTest() throws SqlParseException {
+        CalciteCompiler calcite = this.getCompiler();
+        String ddl = """
+                CREATE TABLE T (
+                   data     MAP<INT, INT>
+                );""";
+        SqlNode node = calcite.parseStatements(ddl);
+        Assert.assertNotNull(node);
+    }
+
+    @Test
     public void latenessTest() throws SqlParseException {
         CalciteCompiler calcite = this.getCompiler();
         String ddl = """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
@@ -1,0 +1,75 @@
+package org.dbsp.sqlCompiler.compiler.sql.simple;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.sql.BaseSQLTests;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
+import org.dbsp.util.Linq;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+public class MapTests extends BaseSQLTests {
+    public DBSPCompiler compileQuery(String statements, String query) {
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.options.languageOptions.optimizationLevel = 0;
+        compiler.compileStatements(statements);
+        compiler.compileStatement(query);
+        return compiler;
+    }
+
+    void testQuery(String statements, String query, InputOutputChangeStream streams) {
+        query = "CREATE VIEW V AS " + query;
+        DBSPCompiler compiler = this.compileQuery(statements, query);
+        CompilerCircuitStream ccs = new CompilerCircuitStream(compiler, streams);
+        this.addRustTestCase(query, ccs);
+    }
+
+    private void testQuery(String statements, String query) {
+        this.testQuery(statements, query, new InputOutputChangeStream());
+    }
+
+    private void testQuery(String query, DBSPZSetLiteral literal) {
+        this.testQuery("", query,
+                new InputOutputChangeStream().addChange(
+                        new InputOutputChange(new Change(), new Change(literal))));
+    }
+
+    @Test
+    public void mapLiteralTest() {
+        String query = "SELECT MAP['hi',2]";
+        DBSPType str = DBSPTypeString.varchar(false);
+        this.testQuery(query, new DBSPZSetLiteral(
+                new DBSPTupleExpression(new DBSPMapLiteral(
+                        new DBSPTypeMap(
+                                str,
+                                new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false),
+                                false),
+                        Linq.list(new DBSPStringLiteral(CalciteObject.EMPTY, str, "hi", Charset.defaultCharset()),
+                                new DBSPI32Literal(2))))));
+    }
+
+    @Test
+    public void mapIndexTest() {
+        String query = "SELECT MAP['hi',2]['hi'], MAP['hi',2]['x']";
+        this.testQuery(query, new DBSPZSetLiteral(
+                new DBSPTupleExpression(
+                        new DBSPI32Literal(2, true),
+                        new DBSPI32Literal())));
+    }
+}

--- a/sql-to-dbsp-compiler/lib/sqllib/src/array.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/array.rs
@@ -1,7 +1,7 @@
 // Array operations
 
 use crate::{some_function2, some_generic_function2, Weight};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::hash::Hash;
 use std::ops::Index;
 
@@ -445,5 +445,98 @@ where
         accumulator.to_vec()
     } else {
         array_agg(accumulator, value, weight, distinct)
+    }
+}
+
+/////////////////////////////////////////
+
+// 8 versions of map_index, depending on
+// nullability of map
+// nullability of map value
+// nullability of index
+
+pub fn map_index___<I, T>(value: BTreeMap<I, T>, map_index: I) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    value.get(&map_index).cloned()
+}
+
+pub fn map_index___N<I, T>(value: BTreeMap<I, T>, map_index: Option<I>) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    let map_index = map_index?;
+    map_index___(value, map_index)
+}
+
+pub fn map_index__N_<I, T>(value: BTreeMap<I, Option<T>>, map_index: I) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    match value.get(&map_index) {
+        None => None,
+        Some(result) => result.clone(),
+    }
+}
+
+pub fn map_index__N_N<I, T>(value: BTreeMap<I, Option<T>>, map_index: Option<I>) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    let map_index = map_index?;
+    map_index__N_(value, map_index)
+}
+
+pub fn map_index_N__<I, T>(value: Option<BTreeMap<I, T>>, map_index: I) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    match value {
+        None => None,
+        Some(value) => map_index___(value, map_index),
+    }
+}
+
+pub fn map_index_N__N<I, T>(value: Option<BTreeMap<I, T>>, map_index: Option<I>) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    let map_index = map_index?;
+    match value {
+        None => None,
+        Some(value) => map_index___(value, map_index),
+    }
+}
+
+pub fn map_index_N_N_<I, T>(value: Option<BTreeMap<I, Option<T>>>, map_index: I) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    match value {
+        None => None,
+        Some(value) => map_index__N_(value, map_index),
+    }
+}
+
+pub fn map_index_N_N_N<I, T>(
+    value: Option<BTreeMap<I, Option<T>>>,
+    map_index: Option<I>,
+) -> Option<T>
+where
+    I: Ord,
+    T: Clone,
+{
+    let map_index = map_index?;
+    match value {
+        None => None,
+        Some(value) => map_index__N_(value, map_index),
     }
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

MAP types have been on the wishlist for a long time.
They are also an important stepping stone for properly supporting JSON.
JSON objects are really `MAP<VARCHAR, VARIANT>` values.