### PR TITLE
[SQL] Prevent SQRT(negative value) in STDDEV due to unstable FP computations

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -594,8 +594,12 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression div = ExpressionCompiler.makeBinaryExpression(
                 node, this.resultType, DBSPOpcode.DIV_NULL,
                 sub, denom).cast(sqrtType);
+        // Prevent sqrt from negative values if computations are unstable
+        DBSPExpression max = ExpressionCompiler.makeBinaryExpression(
+                node, sqrtType, DBSPOpcode.MAX,
+                div, sqrtType.to(IsNumericType.class).getZero());
         DBSPExpression sqrt = ExpressionCompiler.compilePolymorphicFunction(
-                "sqrt", node, sqrtType, Linq.list(div), 1);
+                "sqrt", node, sqrtType, Linq.list(max), 1);
         sqrt = sqrt.cast(this.resultType);
         DBSPClosureExpression post = new DBSPClosureExpression(node, sqrt, a.asParameter());
         DBSPExpression postZero = DBSPLiteral.none(this.nullableResultType);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
@@ -165,6 +165,16 @@ public class AggTests extends PostBaseTests {
     }
 
     @Test
+    public void issue1901() {
+        this.qs("""
+                select stddev(value) FROM (VALUES (.1e0), (.1e0), (.1e0)) t1(value) WHERE true;
+                result
+                ------
+                 0e0
+                (1 row)""");
+    }
+
+    @Test
     public void stddevTests() {
         this.qs("""
                 -- Our own test, for denominator of 0 in SAMP

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -6,7 +6,7 @@ use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ToPrimitive};
 
 use crate::{
     for_all_compare, for_all_int_compare, for_all_int_operator, for_all_numeric_compare,
-    some_existing_operator, some_operator,
+    for_all_numeric_operator, some_existing_operator, some_operator,
 };
 
 use rust_decimal::Decimal;
@@ -301,3 +301,23 @@ where
     let right = right?;
     div_null__(left, right)
 }
+
+#[inline(always)]
+fn max<T>(left: T, right: T) -> T
+where
+    T: Ord,
+{
+    left.max(right)
+}
+
+for_all_numeric_operator!(max);
+
+#[inline(always)]
+fn min<T>(left: T, right: T) -> T
+where
+    T: Ord,
+{
+    left.min(right)
+}
+
+for_all_numeric_operator!(min);


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1904
