### PR TITLE
Avoid head-of-line blocking in async spine.

### DIFF
--- a/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
@@ -404,7 +404,7 @@ impl Inner {
     ) -> Result<Arc<FBuf>, StorageError> {
         let end_offset = offset + block.len() as u64;
 
-        let fm = self.files.get_mut(&fd.0).unwrap();
+        let fm = self.files.get_mut(&fd.0).expect("File state for writing should exist. Accidentally shared a mutable file across threads?");
         fm.error()?;
         fm.size = fm.size.max(end_offset);
 

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -10,7 +10,6 @@ use std::{
     mem::{replace, take},
     ops::Range,
     path::PathBuf,
-    rc::Rc,
 };
 
 use binrw::{
@@ -194,7 +193,7 @@ where
 }
 
 struct ColumnWriter {
-    parameters: Rc<Parameters>,
+    parameters: Arc<Parameters>,
     column_index: usize,
     rows: Range<u64>,
     data_block: DataBlockBuilder,
@@ -203,7 +202,7 @@ struct ColumnWriter {
 }
 
 impl ColumnWriter {
-    fn new(factories: &AnyFactories, parameters: &Rc<Parameters>, column_index: usize) -> Self {
+    fn new(factories: &AnyFactories, parameters: &Arc<Parameters>, column_index: usize) -> Self {
         ColumnWriter {
             parameters: parameters.clone(),
             column_index,
@@ -377,7 +376,7 @@ impl StrideBuilder {
 }
 
 struct DataBlockBuilder {
-    parameters: Rc<Parameters>,
+    parameters: Arc<Parameters>,
     raw: FBuf,
     value_offsets: Vec<usize>,
     value_offset_stride: StrideBuilder,
@@ -399,7 +398,7 @@ struct DataBlock<K: ?Sized> {
 }
 
 impl DataBlockBuilder {
-    fn new(factories: &AnyFactories, parameters: &Rc<Parameters>) -> Self {
+    fn new(factories: &AnyFactories, parameters: &Arc<Parameters>) -> Self {
         let mut raw = FBuf::with_capacity(parameters.min_data_block);
         raw.resize(DataBlockHeader::LEN, 0);
         Self {
@@ -611,7 +610,7 @@ impl ContiguousRanges {
 }
 
 struct IndexBlockBuilder {
-    parameters: Rc<Parameters>,
+    parameters: Arc<Parameters>,
     column_index: usize,
     raw: FBuf,
     entries: Vec<IndexEntry>,
@@ -681,7 +680,7 @@ where
 impl IndexBlockBuilder {
     fn new(
         factories: &AnyFactories,
-        parameters: &Rc<Parameters>,
+        parameters: &Arc<Parameters>,
         column_index: usize,
         child_type: NodeType,
     ) -> Self {
@@ -921,7 +920,7 @@ impl Writer {
     ) -> Result<Self, StorageError> {
         assert_eq!(factories.len(), n_columns);
 
-        let parameters = Rc::new(parameters);
+        let parameters = Arc::new(parameters);
         let cws = factories
             .iter()
             .enumerate()

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -451,7 +451,7 @@ where
     type Builder: Builder<Self>;
 
     /// A type used to progressively merge batches.
-    type Merger: Merger<Self::Key, Self::Val, Self::Time, Self::R, Self>;
+    type Merger: Merger<Self::Key, Self::Val, Self::Time, Self::R, Self> + Send + Sync;
 
     /// Assemble an unordered vector of weighted items into a batch.
     #[allow(clippy::type_complexity)]

--- a/crates/dbsp/src/trace/spine_async/merger.rs
+++ b/crates/dbsp/src/trace/spine_async/merger.rs
@@ -2,14 +2,23 @@
 
 use crate::storage::backend::metrics::COMPACTION_QUEUE_LENGTH;
 use crate::storage::backend::StorageError as Error;
-use crate::trace::spine_async::BatchIdent;
+use crate::trace::spine_async::{BatchIdent, MAX_LEVELS};
 use crate::trace::Batch;
 use crate::Runtime;
+use crossbeam::channel::internal::SelectHandle;
 use crossbeam::channel::{Receiver, RecvError};
 use metrics::gauge;
 
 pub(crate) enum BackgroundOperation {
-    Merge(Box<dyn FnMut(isize) -> bool + Send>),
+    /// This is a closure that will be called by the compactor thread which ultimately
+    /// merges batches inside of it.
+    ///
+    /// The `isize` argument is the fuel that the closure can use to perform its work.
+    /// If the fuel is exhausted (e.g., 0 after the call it means the merge was not
+    /// completed and the closure should be called again.
+    /// If the fuel is non-zero, it means the merge has completed and the closure
+    /// should not be called again/can be disposed.
+    Merge(Box<dyn FnMut(&mut isize) + Send>),
 }
 
 pub(super) enum MergeResult<B>
@@ -23,33 +32,30 @@ pub(crate) struct BatchMerger {
     /// A handle to receive merge operations on the merger thread.
     receiver: Receiver<BackgroundOperation>,
     /// In progress merges.
-    _in_progress: Vec<Box<dyn FnMut(isize) -> bool + Send>>,
+    in_progress: Vec<Box<dyn FnMut(&mut isize) + Send>>,
 }
 
 impl BatchMerger {
     /// Size of the incoming merge queue.
     pub(crate) const RX_QUEUE_SIZE: usize = 128;
     /// How many concurrent merges we allow.
-    const CONCURRENT_MERGES: usize = 1;
+    const CONCURRENT_MERGES: usize = MAX_LEVELS;
 
     pub(crate) fn new(receiver: Receiver<BackgroundOperation>) -> Self {
         Self {
             receiver,
-            _in_progress: Vec::with_capacity(Self::CONCURRENT_MERGES),
+            in_progress: Vec::with_capacity(Self::CONCURRENT_MERGES),
         }
     }
 
     pub(crate) fn run(&mut self) {
         let label = vec![("compactor", Runtime::background_index().to_string())];
         while !Runtime::kill_in_progress() {
-            let op: Result<BackgroundOperation, RecvError> = self.receiver.recv();
             gauge!(COMPACTION_QUEUE_LENGTH, &label).set(self.receiver.len() as f64);
-
+            let op: Result<BackgroundOperation, RecvError> = self.receiver.recv();
             match op {
-                Ok(BackgroundOperation::Merge(mut merge_fun)) => {
-                    let fuel = isize::MAX;
-                    let r = merge_fun(fuel);
-                    assert!(r); // for now, we expect the merge_fun to complete the merge in one invocation
+                Ok(BackgroundOperation::Merge(merge_fun)) => {
+                    self.in_progress.push(merge_fun);
                 }
                 Err(e) => {
                     // We dropped all references to the recv channel, this means
@@ -58,6 +64,18 @@ impl BatchMerger {
                         "exiting compactor thread due to rx error on channel: {:?}",
                         e
                     );
+                    return;
+                }
+            }
+
+            while !self.in_progress.is_empty() {
+                self.in_progress.retain_mut(|f| {
+                    let mut fuel = 100_000isize; // Chosen arbitrarily. Might need some tuning.
+                    f(&mut fuel);
+                    fuel == 0
+                });
+
+                if self.in_progress.len() < Self::CONCURRENT_MERGES && self.receiver.is_ready() {
                     break;
                 }
             }

--- a/crates/dbsp/src/trace/test/mod.rs
+++ b/crates/dbsp/src/trace/test/mod.rs
@@ -402,6 +402,7 @@ proptest! {
             trace.insert(batch);
             trace.retain_keys(Box::new(move |x| *x.downcast_checked::<i32>() >= ((i * 20) as i32)));
 
+            trace.complete_merges();
             // FIXME: Change to 20000 after changing vtable types to pointers.
             assert!(trace.size_of().total_bytes() < /*20000*/ 180000);
         }
@@ -422,6 +423,7 @@ proptest! {
 
             trace.insert(batch);
             trace.retain_values(Box::new(move |x| *x.downcast_checked::<i32>() >= ((i * 20) as i32)));
+            trace.complete_merges();
             // FIXME: Change to 20000 after changing vtable types to pointers.
             assert!(trace.size_of().total_bytes() < /*20000*/180000);
         }

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -233,7 +233,7 @@ fn create_ascii_table(config: &NexmarkConfig) -> AsciiTable {
             "Cache Hit Rate",
             "Cpcts",
             "Cpct Saving",
-            "Cpct Stall [s]",
+            "Cpct Stall",
         ]);
         max_width += 50;
     }
@@ -505,7 +505,7 @@ fn main() -> Result<()> {
                 ),
                 format!("{}", diff.total_compactions),
                 format!("{}", diff.compaction_savings),
-                format!("{}", diff.compaction_stall_time / 1000),
+                format!("{} s", diff.compaction_stall_time / 1000),
             ])
         }
         row


### PR DESCRIPTION
This means we work on multiple merges simultaneously. We can re-use the fuel approach to do that. But we need to make sure we can call the work-closure multiple times to continue merging. This involved being able to share Batch::Merger across threads too (if there is a better way instead of having the Send+Sync bound there I'd be happy to avoid that).