### PR TITLE
dbsp: Fix hidden dependency on vec-based batches in input_upsert.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/input_upsert.rs
+++ b/crates/dbsp/src/operator/dynamic/input_upsert.rs
@@ -389,6 +389,7 @@ where
                     }
                     key_updates.consolidate();
                     builder.extend(key_updates.dyn_iter_mut());
+                    key_updates.truncate(0);
                 }
 
                 skip_key = false;


### PR DESCRIPTION
The vec-based batches set keys, values, and weights to their default values when their builders accept tuples via `Builder::push` or `Builder::push_vals`, which take mutable references.  The code for `input_upsert` accumulates updates to keys in a `key_updates` vector, and then adds them to a builder via `extend`, which internally uses `Builder::push` and thus clears all the updates that were added to have weight 0.

Before this commit, that code didn't later clear the `key_updates` vector, which meant that anything added later was appended to a bunch of zeroed tuples.  This was benign because, the next time `key_updates` was used, it was first consolidated, which meant that all the zero-weight tuples were dropped.

This failed with the file-based batches, which don't have any special optimizations for mutable references and thus don't zero anything, which meant that nothing in `key_updates` ever got cleared.  This commit fixes the problem by properly clearing `key_updates` to empty after using it.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
