### PR TITLE
Integration test logging

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -460,7 +460,12 @@ integration-tests:
                 --compose docker-compose.yml \
                 --service pipeline-manager \
                 --load itest:latest=+integration-test-container
-        RUN sleep 15 && docker run --env-file .env --network default_default itest:latest
+        # Output pipeline manager logs if tests fail. Without this we don't have
+        # a way to see what went wrong in the manager.
+        RUN sleep 15 && docker run --env-file .env --network default_default itest:latest; \
+            status=$?; \
+            [ $status -ne 0 ] && docker logs default-pipeline-manager-1; \
+            exit $status
     END
 
 ui-playwright-container:

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -934,7 +934,7 @@ inherits = "release"
     }
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 enum Stage {
     Sql,
     Rust,
@@ -1086,6 +1086,10 @@ impl CompilationJob {
         let exit_status = self.compiler_process.wait().await.map_err(|e| {
             ManagerError::io_error("waiting for the compiler process".to_string(), e)
         })?;
+        debug!(
+            "{:?} compiler terminated with exit status {exit_status:?}",
+            self.stage
+        );
         Ok(exit_status)
         // doesn't update status
     }


### PR DESCRIPTION
We run the pipeline manager inside docker when running integration tests
in CI.  As a result, we do not get to see its logs, which makes it hard
to debug CI errors.  This commit adds a `docker logs` command to the CI
job to output pipeline manager logs on error.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
