### PR TITLE
Handle negative fuel in merger.rs.

### DIFF
--- a/crates/dbsp/src/trace/spine_async/merger.rs
+++ b/crates/dbsp/src/trace/spine_async/merger.rs
@@ -72,7 +72,7 @@ impl BatchMerger {
                 self.in_progress.retain_mut(|f| {
                     let mut fuel = 100_000isize; // Chosen arbitrarily. Might need some tuning.
                     f(&mut fuel);
-                    fuel == 0
+                    fuel <= 0
                 });
 
                 if self.in_progress.len() < Self::CONCURRENT_MERGES && self.receiver.is_ready() {


### PR DESCRIPTION
`BatchMerger::run` assumed that when all fuel is used up by the work function, the remaining value is exactly 0.  This may not be the case for an imperfect merger that uses more fuel than available and returns a negative value.  This may cause partially merged batches to be removed from the queue without sending an acknowledgement message.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
