### PR TITLE
Switch from crossbeam-channel to std::sync::mpsc::channel.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -591,7 +591,10 @@ where
             local_node_id: self.local_node_id,
             origin_node_id: self.origin_node_id.clone(),
             circuit: self.circuit.clone(),
-            val: std::mem::transmute(self.val.clone()),
+            val: std::mem::transmute::<
+                Rc<UnsafeCell<StreamValue<D>>>,
+                Rc<UnsafeCell<StreamValue<D2>>>,
+            >(self.val.clone()),
         }
     }
 }

--- a/crates/dbsp/src/storage/backend/metrics.rs
+++ b/crates/dbsp/src/storage/backend/metrics.rs
@@ -57,13 +57,6 @@ pub const COMPACTION_DURATION: &str = "file.compaction_duration";
 /// Time a worker was stalled waiting for more merges to complete.
 pub const COMPACTION_STALL_TIME: &str = "file.compaction_stall_time";
 
-/// The queue length of the compaction thread.
-///
-/// If this is always close to the configured limit in `BatchMerger::RX_QUEUE_SIZE`,
-/// it means the compaction thread is not able to keep up with the incoming compaction requests
-/// and the system is under pressure to keep up with the write load.
-pub const COMPACTION_QUEUE_LENGTH: &str = "file.compaction_queue_length";
-
 /// Adds descriptions for the metrics we expose.
 pub(super) fn describe_disk_metrics() {
     // Storage backend metrics.
@@ -105,11 +98,6 @@ pub(super) fn describe_disk_metrics() {
         "Eliminated entries in batches through merging"
     );
     describe_histogram!(COMPACTION_DURATION, Unit::Seconds, "Time to compact batch");
-    describe_histogram!(
-        COMPACTION_QUEUE_LENGTH,
-        Unit::Count,
-        "Length of the compaction queue"
-    );
 
     describe_counter!(
         COMPACTION_STALL_TIME,

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -196,11 +196,11 @@ pub enum StorageError {
 
     /// Unable to receive a message from the thread that does storage compaction.
     #[error("Unable to receive a message from the merge-thread.")]
-    TryRx(#[from] crossbeam::channel::TryRecvError),
+    TryRx(#[from] std::sync::mpsc::TryRecvError),
 
     /// Error when sending a message to the thread that merges batches.
     #[error("Unable to receive a message from the compactor-thread.")]
-    Rx(#[from] crossbeam::channel::RecvError),
+    Rx(#[from] std::sync::mpsc::RecvError),
 
     /// The thread that merges batches exited unexpectedly.
     #[error("Compactor Thread exited unexpectedly.")]

--- a/crates/dbsp/src/trace/layers/layer.rs
+++ b/crates/dbsp/src/trace/layers/layer.rs
@@ -820,7 +820,7 @@ where
                 (source2, lower2, upper2),
                 key_filter,
                 value_filter,
-                usize::max_value(),
+                usize::MAX,
             );
             // TODO: account for filtered out keys.
             effort = (self.vals.keys() - starting_updates) as isize;

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -433,7 +433,7 @@ where
 
     /// Merges `self` with `other` by running merger to completion.
     fn merge(&self, other: &Self) -> Self {
-        let mut fuel = isize::max_value();
+        let mut fuel = isize::MAX;
         let mut merger = Self::Merger::new_merger(self, other);
         merger.work(self, other, &None, &None, &mut fuel);
         merger.done()

--- a/crates/dbsp/src/trace/spine_fueled.rs
+++ b/crates/dbsp/src/trace/spine_fueled.rs
@@ -703,7 +703,7 @@ where
 
     fn consolidate(mut self) -> Option<B> {
         // Merge batches until there is nothing left to merge.
-        let mut fuel = isize::max_value();
+        let mut fuel = isize::MAX;
         while !self.reduced() {
             self.exert(&mut fuel);
         }
@@ -1150,7 +1150,7 @@ where
     fn complete_merges(&mut self) {
         for merge_state in self.merging.iter_mut() {
             if merge_state.is_inprogress() {
-                let mut fuel = isize::max_value();
+                let mut fuel = isize::MAX;
                 merge_state.work(&self.key_filter, &self.value_filter, &mut fuel);
             }
         }
@@ -1346,7 +1346,7 @@ where
         key_filter: &Option<Filter<B::Key>>,
         value_filter: &Option<Filter<B::Val>>,
     ) -> Option<B> {
-        let mut fuel = isize::max_value();
+        let mut fuel = isize::MAX;
         self.work(key_filter, value_filter, &mut fuel);
         if let MergeVariant::Complete(batch) = self {
             batch


### PR DESCRIPTION
The [channel code in std is identical to crossbeam](https://github.com/rust-lang/rust/pull/93563) (taken from on crossbeam-channel) except that https://github.com/rust-lang/rust/issues/107466 is fixed in std but not in crossbeam-channel.

I originally reworked this because the bug in 80ff3ff made me desperate to suspect something is wrong with the channel. While it didn't turn out to be an issue with the channels it's easier to depend on std code instead of a library.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
