### PR TITLE
Fix UI regressions

### DIFF
--- a/web-console/src/app/(spa)/(root)/(authenticated)/(app)/services/list/page.tsx
+++ b/web-console/src/app/(spa)/(root)/(authenticated)/(app)/services/list/page.tsx
@@ -21,6 +21,7 @@ import { ServiceType } from '$lib/types/xgressServices'
 import { ServiceProps } from '$lib/types/xgressServices/ServiceDialog'
 import { useEffect } from 'react'
 import invariant from 'tiny-invariant'
+import JSONbig from 'true-json-bigint'
 import { match, P } from 'ts-pattern'
 
 import { Box, Button, Card, Chip, IconButton } from '@mui/material'
@@ -32,7 +33,7 @@ const getServiceConfigThumb = ({ config }: ServiceDescr) => {
     const suffix = config.kafka.bootstrap_servers.length > 1 ? ', ...' : ''
     return config.kafka.bootstrap_servers[0] + suffix
   }
-  invariant(false, 'getServiceThumb: Unexpected service config type: ' + JSON.stringify(config))
+  invariant(false, 'getServiceThumb: Unexpected service config type: ' + JSONbig.stringify(config))
 }
 const ServiceActions = ({ row: service }: { row: ServiceDescr }) => {
   const { showDeleteDialog } = useDeleteDialog()

--- a/web-console/src/app/(spa)/(root)/(authenticated)/(app)/streaming/builder/page.tsx
+++ b/web-console/src/app/(spa)/(root)/(authenticated)/(app)/streaming/builder/page.tsx
@@ -407,7 +407,10 @@ export default () => {
     initialData: defaultPipelineData,
     refetchOnWindowFocus: false
   })
-  const pipeline = pipelineQuery.data?.descriptor
+  // Sometimes a temporary state exists where query cache for a pipeline is undefined
+  // (usually collision between optimistic cache update and a premature fetch elsewhere)
+  // for these cases we use constant default data, which is fine for a temporary state
+  const pipeline = pipelineQuery.data?.descriptor ?? defaultPipelineData.descriptor
   invariant(pipeline, 'Pipeline should be initialized with a default value')
 
   useEffect(() => {

--- a/web-console/src/lib/components/analytics/TableSqlPrograms.tsx
+++ b/web-console/src/lib/components/analytics/TableSqlPrograms.tsx
@@ -148,7 +148,7 @@ export const TableSqlPrograms = () => {
       editable: true
     },
     {
-      flex: 0.15,
+      width: 145,
       field: 'status',
       headerName: 'Status',
       display: 'flex',
@@ -156,7 +156,7 @@ export const TableSqlPrograms = () => {
         const { tooltip, ...statusChipProps } = getStatusChipProps(params.row.status)
         return (
           <Tooltip title={tooltip}>
-            <CustomChip rounded size='small' skin='light' {...statusChipProps} sx={{ width: 120 }} />
+            <CustomChip rounded size='small' skin='light' {...statusChipProps} sx={{ width: 125 }} />
           </Tooltip>
         )
       }

--- a/web-console/src/lib/components/connectors/dialogs/DebeziumInputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/DebeziumInputConnector.tsx
@@ -112,7 +112,8 @@ export const DebeziumInputConnectorDialog = (props: ConnectorDialogProps) => {
   )
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, transport, format }: FieldErrors<DebeziumInputSchema>) => {
+  const handleErrors = (errors: FieldErrors<DebeziumInputSchema>) => {
+    const { name, description, transport, format } = errors
     if (!props.show) {
       return
     }
@@ -129,6 +130,8 @@ export const DebeziumInputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('authTab')
     } else if (format?.format_name || format?.update_format) {
       setActiveTab('formatTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
   const [editorDirty, setEditorDirty] = useState<'dirty' | 'clean' | 'error'>('clean')

--- a/web-console/src/lib/components/connectors/dialogs/DeltaLakeInputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/DeltaLakeInputConnector.tsx
@@ -118,6 +118,8 @@ export const DeltaLakeInputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('optionsTab')
       return
     }
+
+    throw new Error(JSONbig.stringify(errors))
   }
 
   return (

--- a/web-console/src/lib/components/connectors/dialogs/DeltaLakeOutputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/DeltaLakeOutputConnector.tsx
@@ -87,7 +87,8 @@ export const DeltaLakeOutputConnectorDialog = (props: ConnectorDialogProps) => {
     handleClose
   )
 
-  const handleErrors = ({ name, description, transport }: FieldErrors<DeltaLakeOutputSchema>) => {
+  const handleErrors = (errors: FieldErrors<DeltaLakeOutputSchema>) => {
+    const { name, description, transport } = errors
     if (!props.show) {
       return
     }
@@ -99,6 +100,7 @@ export const DeltaLakeOutputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('optionsTab')
       return
     }
+    throw new Error(JSONbig.stringify(errors))
   }
 
   return (

--- a/web-console/src/lib/components/connectors/dialogs/DeltaLakeOutputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/DeltaLakeOutputConnector.tsx
@@ -100,6 +100,10 @@ export const DeltaLakeOutputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('optionsTab')
       return
     }
+    if (errors.max_output_buffer_time_millis || errors.max_output_buffer_size_records) {
+      setActiveTab('bufferTab')
+      return
+    }
     throw new Error(JSONbig.stringify(errors))
   }
 

--- a/web-console/src/lib/components/connectors/dialogs/KafkaInputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/KafkaInputConnector.tsx
@@ -25,62 +25,59 @@ import { Direction } from '$lib/types/connectors'
 import { ConnectorDialogProps } from '$lib/types/connectors/ConnectorDialogProps'
 import { useEffect, useState } from 'react'
 import { FieldErrors } from 'react-hook-form'
-import { outputBufferConfigSchema, outputBufferConfigValidation } from 'src/lib/functions/connectors/outputBuffer'
+import { outputBufferConfigSchema } from 'src/lib/functions/connectors/outputBuffer'
 import JSONbig from 'true-json-bigint'
 import * as va from 'valibot'
 
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import Box from '@mui/material/Box'
 
-const schema = va.merge(
-  [
-    va.object({
-      name: va.nonOptional(va.string([va.minLength(1, 'Specify connector name')])),
-      description: va.optional(va.string(), ''),
-      transport: va.intersect([
-        va.object(
-          {
-            bootstrap_servers: va.optional(
-              va.array(va.string([va.minLength(1, 'Specify at least one server')]), [
-                va.minLength(1, 'Specify at least one server')
-              ])
-            ),
-            auto_offset_reset: va.optional(
-              va.picklist([
-                'smallest',
-                'earliest',
-                'beginning',
-                'largest',
-                'latest',
-                'end',
-                'error',
-                'Invalid enum value'
-              ]),
-              'earliest'
-            ),
-            group_id: va.optional(va.string([va.minLength(1, 'group.id should not be empty')])),
-            topics: va.nonOptional(
-              va.array(va.string([va.minLength(1, 'Topic name should not be empty')]), [
-                va.minLength(1, 'Provide at least one topic')
-              ])
-            ),
-            preset_service: va.optional(va.string([va.toCustom(s => (s === '' ? undefined! : s))]))
-          },
-          // Allow configurations options not mentioned in the schema
-          va.union([va.string(), va.number(), va.boolean(), va.array(va.string()), va.any()])
-        ),
-        authParamsSchema
-      ]),
-      format: va.object({
-        format_name: va.nonOptional(va.picklist(['json', 'csv'])),
-        update_format: va.optional(va.picklist(['raw', 'insert_delete']), 'raw'),
-        json_array: va.nonOptional(va.boolean())
-      })
-    }),
-    outputBufferConfigSchema
-  ],
-  [outputBufferConfigValidation()]
-)
+const schema = va.merge([
+  va.object({
+    name: va.nonOptional(va.string([va.minLength(1, 'Specify connector name')])),
+    description: va.optional(va.string(), ''),
+    transport: va.intersect([
+      va.object(
+        {
+          bootstrap_servers: va.optional(
+            va.array(va.string([va.minLength(1, 'Specify at least one server')]), [
+              va.minLength(1, 'Specify at least one server')
+            ])
+          ),
+          auto_offset_reset: va.optional(
+            va.picklist([
+              'smallest',
+              'earliest',
+              'beginning',
+              'largest',
+              'latest',
+              'end',
+              'error',
+              'Invalid enum value'
+            ]),
+            'earliest'
+          ),
+          group_id: va.optional(va.string([va.minLength(1, 'group.id should not be empty')])),
+          topics: va.nonOptional(
+            va.array(va.string([va.minLength(1, 'Topic name should not be empty')]), [
+              va.minLength(1, 'Provide at least one topic')
+            ])
+          ),
+          preset_service: va.optional(va.string([va.toCustom(s => (s === '' ? undefined! : s))]))
+        },
+        // Allow configurations options not mentioned in the schema
+        va.union([va.string(), va.number(), va.boolean(), va.array(va.string()), va.any()])
+      ),
+      authParamsSchema
+    ]),
+    format: va.object({
+      format_name: va.nonOptional(va.picklist(['json', 'csv'])),
+      update_format: va.optional(va.picklist(['raw', 'insert_delete']), 'raw'),
+      json_array: va.nonOptional(va.boolean())
+    })
+  }),
+  outputBufferConfigSchema
+])
 export type KafkaInputSchema = va.Input<typeof schema>
 
 export const KafkaInputConnectorDialog = (props: ConnectorDialogProps) => {
@@ -124,7 +121,8 @@ export const KafkaInputConnectorDialog = (props: ConnectorDialogProps) => {
   )
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, transport, format }: FieldErrors<KafkaInputSchema>) => {
+  const handleErrors = (errors: FieldErrors<KafkaInputSchema>) => {
+    const { name, description, transport, format } = errors
     if (!props.show) {
       return
     }
@@ -141,6 +139,8 @@ export const KafkaInputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('authTab')
     } else if (format?.format_name || format?.json_array || format?.update_format) {
       setActiveTab('formatTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
 

--- a/web-console/src/lib/components/connectors/dialogs/KafkaOutputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/KafkaOutputConnector.tsx
@@ -106,7 +106,8 @@ export const KafkaOutputConnectorDialog = (props: ConnectorDialogProps) => {
   )
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, transport, format }: FieldErrors<KafkaOutputSchema>) => {
+  const handleErrors = (errors: FieldErrors<KafkaOutputSchema>) => {
+    const { name, description, transport, format } = errors
     if (!props.show) {
       return
     }
@@ -118,6 +119,8 @@ export const KafkaOutputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('authTab')
     } else if (format?.format_name || format?.json_array) {
       setActiveTab('formatTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
 

--- a/web-console/src/lib/components/connectors/dialogs/KafkaOutputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/KafkaOutputConnector.tsx
@@ -119,6 +119,8 @@ export const KafkaOutputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('authTab')
     } else if (format?.format_name || format?.json_array) {
       setActiveTab('formatTab')
+    } else if (errors.max_output_buffer_time_millis || errors.max_output_buffer_size_records) {
+      setActiveTab('bufferTab')
     } else {
       throw new Error(JSONbig.stringify(errors))
     }

--- a/web-console/src/lib/components/connectors/dialogs/SnowflakeOutputConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/SnowflakeOutputConnector.tsx
@@ -98,7 +98,8 @@ export const SnowflakeOutputConnectorDialog = (props: ConnectorDialogProps) => {
   )
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, transport, format }: FieldErrors<SnowflakeOutputSchema>) => {
+  const handleErrors = (errors: FieldErrors<SnowflakeOutputSchema>) => {
+    const { name, description, transport, format } = errors
     if (!props.show) {
       return
     }
@@ -110,6 +111,8 @@ export const SnowflakeOutputConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('authTab')
     } else if (format?.format_name) {
       setActiveTab('formatTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
 

--- a/web-console/src/lib/components/connectors/dialogs/UrlConnector.tsx
+++ b/web-console/src/lib/components/connectors/dialogs/UrlConnector.tsx
@@ -27,6 +27,7 @@ import Typography from '@mui/material/Typography'
 
 import { TabGenericInputFormatDetails } from './tabs/generic/TabGenericInputFormatDetails'
 import Transition from './tabs/Transition'
+import JSONbig from 'true-json-bigint'
 
 const schema = va.object({
   name: va.nonOptional(va.string([va.minLength(1, 'Specify connector name')])),
@@ -102,7 +103,8 @@ export const UrlConnectorDialog = (props: ConnectorDialogProps) => {
   const onSubmit = useConnectorRequest(props.connector, prepareData, props.onSuccess, handleClose)
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, transport, format }: FieldErrors<UrlSchema>) => {
+  const handleErrors = (errors: FieldErrors<UrlSchema>) => {
+    const { name, description, transport, format } = errors
     if (!props.show) {
       return
     }
@@ -110,6 +112,8 @@ export const UrlConnectorDialog = (props: ConnectorDialogProps) => {
       setActiveTab('detailsTab')
     } else if (format?.format_name || format?.json_array || format?.update_format) {
       setActiveTab('formatTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
   const tabFooter = <TabFooter submitButton={props.submitButton} {...{ activeTab, setActiveTab, tabs }} />

--- a/web-console/src/lib/components/services/dialogs/KafkaService.tsx
+++ b/web-console/src/lib/components/services/dialogs/KafkaService.tsx
@@ -87,7 +87,8 @@ export const KafkaServiceDialog = (props: ServiceDialogProps) => {
       }
 
   // If there is an error, switch to the earliest tab with an error
-  const handleErrors = ({ name, description, config }: FieldErrors<KafkaServiceSchema>) => {
+  const handleErrors = (errors: FieldErrors<KafkaServiceSchema>) => {
+    const { name, description, config } = errors
     if (!props.show) {
       return
     }
@@ -97,6 +98,8 @@ export const KafkaServiceDialog = (props: ServiceDialogProps) => {
       setActiveTab('authTab')
     } else if (config) {
       setActiveTab('configTab')
+    } else {
+      throw new Error(JSONbig.stringify(errors))
     }
   }
 

--- a/web-console/src/lib/components/streaming/builder/NoSchemaDialog.tsx
+++ b/web-console/src/lib/components/streaming/builder/NoSchemaDialog.tsx
@@ -7,6 +7,7 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
+import { Box, IconButton } from '@mui/material'
 
 const MissingSchemaDialog = (props: {
   open: boolean
@@ -26,12 +27,21 @@ const MissingSchemaDialog = (props: {
       aria-labelledby='alert-dialog-title'
       aria-describedby='alert-dialog-description'
       onClose={(event, reason) => {
-        if (reason !== 'backdropClick') {
-          handleClose()
+        if (reason === 'backdropClick') {
+          return props.setOpen(false)
         }
+        handleClose()
       }}
     >
-      <DialogTitle>Missing Schema?</DialogTitle>
+      <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+        <DialogTitle>Missing Schema?</DialogTitle>
+        <Box>
+          <IconButton onClick={() => props.setOpen(false)}>
+            <i className='bx bx-x'></i>
+          </IconButton>
+        </Box>
+      </Box>
+
       <DialogContent>
         <DialogContentText>
           We didn't find the schema for the program of the config you are trying to load. Either the program has not

--- a/web-console/src/lib/components/streaming/management/RevisionStatus.tsx
+++ b/web-console/src/lib/components/streaming/management/RevisionStatus.tsx
@@ -18,6 +18,7 @@ import {
   useRef,
   useState
 } from 'react'
+import JSONbig from 'true-json-bigint'
 
 import { ThemeColor } from '@core/layouts/types'
 import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react'
@@ -257,8 +258,8 @@ export const PipelineRevisionStatusChip = (props: { pipeline: Pipeline }) => {
       !curPipelineConfigQuery.isError
     ) {
       const configDiffResult = diffLines(
-        JSON.stringify(pipelineRevisionQuery.data.config, null, 2),
-        JSON.stringify(curPipelineConfigQuery.data, null, 2)
+        JSONbig.stringify(pipelineRevisionQuery.data.config, null, 2),
+        JSONbig.stringify(curPipelineConfigQuery.data, null, 2)
       ).filter(line => line.added || line.removed)
 
       // Distinguish the case where the program is not set in the pipeline
@@ -298,8 +299,8 @@ export const PipelineRevisionStatusChip = (props: { pipeline: Pipeline }) => {
         show={show}
         setShow={setShow}
         diffCount={diffCount}
-        origConfig={JSON.stringify(pipelineRevisionQuery.data?.config || '', null, 2)}
-        newConfig={JSON.stringify(curPipelineConfigQuery.data || '', null, 2)}
+        origConfig={JSONbig.stringify(pipelineRevisionQuery.data?.config || '', null, 2)}
+        newConfig={JSONbig.stringify(curPipelineConfigQuery.data || '', null, 2)}
         origProgram={pipelineRevisionQuery.data?.program.code || ''}
         newProgram={curProgramQuery.data?.code || ''}
         validationError={validationError}

--- a/web-console/src/lib/compositions/streaming/inspection/useQuantiles.ts
+++ b/web-console/src/lib/compositions/streaming/inspection/useQuantiles.ts
@@ -11,6 +11,7 @@ import { Chunk, HttpInputOutputService, OpenAPI, Relation } from '$lib/services/
 import { getHeaders } from '$lib/services/manager/core/request'
 import { Arguments } from '$lib/types/common/function'
 import { Dispatch, SetStateAction, useCallback, useMemo } from 'react'
+import JSONbig from 'true-json-bigint'
 
 function useQuantiles() {
   const utf8Decoder = useMemo(() => new TextDecoder('utf-8'), [])
@@ -57,7 +58,7 @@ function useQuantiles() {
 
       try {
         for await (const line of readLineFromStream(response)) {
-          const obj: Chunk = JSON.parse(line)
+          const obj: Chunk = JSONbig.parse(line)
           if (!obj.json_data) {
             continue
           }

--- a/web-console/src/lib/functions/connectors/outputBuffer.ts
+++ b/web-console/src/lib/functions/connectors/outputBuffer.ts
@@ -21,11 +21,16 @@ export const outputBufferConfigSchema = va.object({
 })
 
 export const outputBufferConfigValidation = <
-  T extends { max_output_buffer_time_millis?: BigNumber; max_output_buffer_size_records?: BigNumber }
+  T extends {
+    enable_output_buffer?: boolean
+    max_output_buffer_time_millis?: BigNumber
+    max_output_buffer_size_records?: BigNumber
+  }
 >() =>
   va.forward<T>(
     va.custom(
-      input => !!input.max_output_buffer_time_millis || !!input.max_output_buffer_size_records,
+      input =>
+        !input.enable_output_buffer || !!input.max_output_buffer_time_millis || !!input.max_output_buffer_size_records,
       'Specify either max_output_buffer_time_millis or max_output_buffer_size_records'
     ),
     ['max_output_buffer_time_millis'] as va.PathList<T>

--- a/web-console/src/lib/services/manager/core/request.ts
+++ b/web-console/src/lib/services/manager/core/request.ts
@@ -1,14 +1,16 @@
 /* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
+import JSONbig from 'true-json-bigint'
+
 /* eslint-disable */
 import { ApiError } from './ApiError'
+import { CancelablePromise } from './CancelablePromise'
+
 import type { ApiRequestOptions } from './ApiRequestOptions'
 import type { ApiResult } from './ApiResult'
-import { CancelablePromise } from './CancelablePromise'
 import type { OnCancel } from './CancelablePromise'
 import type { OpenAPIConfig } from './OpenAPI'
-
 export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
   return value !== undefined && value !== null
 }
@@ -108,7 +110,7 @@ export const getFormData = (options: ApiRequestOptions): FormData | undefined =>
       if (isString(value) || isBlob(value)) {
         formData.append(key, value)
       } else {
-        formData.append(key, JSON.stringify(value))
+        formData.append(key, JSONbig.stringify(value))
       }
     }
 
@@ -185,11 +187,11 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 export const getRequestBody = (options: ApiRequestOptions): any => {
   if (options.body !== undefined) {
     if (options.mediaType?.includes('/json')) {
-      return JSON.stringify(options.body)
+      return JSONbig.stringify(options.body)
     } else if (isString(options.body) || isBlob(options.body) || isFormData(options.body)) {
       return options.body
     } else {
-      return JSON.stringify(options.body)
+      return JSONbig.stringify(options.body)
     }
   }
   return undefined
@@ -240,7 +242,7 @@ export const getResponseBody = async (response: Response): Promise<any> => {
         const jsonTypes = ['application/json', 'application/problem+json']
         const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type))
         if (isJSON) {
-          return await response.json()
+          return JSONbig.parse(await response.text())
         } else {
           return await response.text()
         }
@@ -274,7 +276,7 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
     const errorStatusText = result.statusText ?? 'unknown'
     const errorBody = (() => {
       try {
-        return JSON.stringify(result.body, null, 2)
+        return JSONbig.stringify(result.body, null, 2)
       } catch (e) {
         return undefined
       }

--- a/web-console/src/lib/services/pipelineManagerQuery.ts
+++ b/web-console/src/lib/services/pipelineManagerQuery.ts
@@ -41,7 +41,8 @@ import {
   UpdateProgramRequest,
   UpdateProgramResponse,
   UpdateServiceRequest,
-  UpdateServiceResponse
+  UpdateServiceResponse,
+  Pipeline as RawPipeline
 } from '$lib/services/manager'
 import { Arguments } from '$lib/types/common/function'
 import { ControllerStatus, Pipeline, PipelineStatus } from '$lib/types/pipeline'
@@ -63,6 +64,11 @@ const toClientPipelineStatus = (status: RawPipelineStatus) => {
     .with(RawPipelineStatus.FAILED, () => PipelineStatus.FAILED)
     .exhaustive()
 }
+
+const toClientPipeline = (p: RawPipeline) => ({
+  ...p,
+  state: { ...p.state, current_status: toClientPipelineStatus(p.state.current_status) }
+})
 
 /**
  * Consolidate local STARTING | PAUSING | SHUTTING_DOWN status with remote PROVISIONING status
@@ -122,13 +128,7 @@ const PipelineManagerApi = {
   programs: () => ProgramsService.getPrograms(),
   programCode: (programName: string) => ProgramsService.getProgram(programName, true),
   programStatus: (programName: string) => ProgramsService.getProgram(programName, false),
-  pipelines: () =>
-    PipelinesService.listPipelines().then(ps =>
-      ps.map(p => ({
-        ...p,
-        state: { ...p.state, current_status: toClientPipelineStatus(p.state.current_status) }
-      }))
-    ),
+  pipelines: () => PipelinesService.listPipelines().then(ps => ps.map(toClientPipeline)),
   pipelineStatus: compose(PipelinesService.getPipeline, p =>
     p.then(p => ({ ...p, state: { ...p.state, current_status: toClientPipelineStatus(p.state.current_status) } }))
   ),
@@ -617,6 +617,7 @@ export const pipelineQueryCacheUpdate = (
       }
     } satisfies Pipeline
   }
+  console.log('pipelineQueryCacheUpdate', pipelineName, newData)
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 
   setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>

--- a/web-console/src/lib/services/pipelineManagerQuery.ts
+++ b/web-console/src/lib/services/pipelineManagerQuery.ts
@@ -617,7 +617,7 @@ export const pipelineQueryCacheUpdate = (
       }
     } satisfies Pipeline
   }
-  console.log('pipelineQueryCacheUpdate', pipelineName, newData)
+
   setQueryData(queryClient, PipelineManagerQueryKey.pipelineStatus(pipelineName), updateCache)
 
   setQueryData(queryClient, PipelineManagerQueryKey.pipelines(), oldDatas =>


### PR DESCRIPTION
Is this a user-visible change (yes/no): no (intra-sprint regressions and improvements)

Fix https://github.com/feldera/feldera/issues/1931 : Output buffer attributes required even when the output buffer is disabled
Fix https://github.com/feldera/feldera/issues/1932 : Output buffer size gets serialized as string instead of int
Fix https://github.com/feldera/feldera/issues/1933 : Kafka input connector creation dialog: CREATE button doesn't work
Fix https://github.com/feldera/feldera/issues/1936 : UI truncates fields even if there is room to display them entirely
Fix https://github.com/feldera/feldera/issues/1938 : "Application error" during pipeline creation
Add output buffer config validation to Snowflake Output
Add an error popup when validation error during connector creation cannot be handled