### PR TITLE
pipeline-manager: SQL MAP type

### DIFF
--- a/crates/adapters/src/format/avro/serializer.rs
+++ b/crates/adapters/src/format/avro/serializer.rs
@@ -708,6 +708,7 @@ mod test {
     use rust_decimal_macros::dec;
     use serde::Serialize;
     use sqllib::{Date, Timestamp};
+    use std::collections::{BTreeMap, HashMap};
     use std::str::FromStr;
 
     #[derive(Serialize)]
@@ -837,6 +838,7 @@ mod test {
             field_2: Timestamp::new(1713597703),
             field_3: Date::new(19833),
             field_5: EmbeddedStruct { field: true },
+            field_6: BTreeMap::from([("foo".to_string(), 1), ("bar".to_string(), 2)]),
         };
 
         let avro2_1: AvroValue = AvroValue::Record(vec![
@@ -851,6 +853,13 @@ mod test {
             (
                 "es".to_string(),
                 AvroValue::Record(vec![("a".to_string(), AvroValue::Boolean(true))]),
+            ),
+            (
+                "m".to_string(),
+                AvroValue::Map(HashMap::from([
+                    ("foo".to_string(), AvroValue::Long(1)),
+                    ("bar".to_string(), AvroValue::Long(2)),
+                ])),
             ),
         ]);
 

--- a/crates/adapters/src/format/json/schema.rs
+++ b/crates/adapters/src/format/json/schema.rs
@@ -236,6 +236,11 @@ mod kafka_connect_json_converter {
                     .map(field_schema)
                     .collect::<Vec<_>>(),
             },
+            SqlType::Map => {
+                panic!(
+                    "SQL MAP type conversion to JSON representation schema is not yet implemented"
+                );
+            }
             SqlType::Interval(_) => RepresentationType::String,
             SqlType::Null => RepresentationType::String,
         }

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -290,7 +290,29 @@ pub fn relation_to_arrow_fields(fields: &[Field], delta_lake: bool) -> Vec<Arrow
                 delta_lake,
             )),
             SqlType::Map => {
-                panic!("SQL MAP type conversion to Parquet data type is not yet implemented");
+                let key_type = c.key.as_ref().unwrap();
+                let val_type = c.value.as_ref().unwrap();
+
+                DataType::Map(
+                    Arc::new(ArrowField::new_struct(
+                        "entries",
+                        [
+                            Arc::new(ArrowField::new(
+                                "keys",
+                                columntype_to_datatype(key_type, delta_lake),
+                                key_type.nullable,
+                            )),
+                            Arc::new(ArrowField::new(
+                                "values",
+                                columntype_to_datatype(val_type, delta_lake),
+                                val_type.nullable,
+                            )),
+                        ]
+                        .as_slice(),
+                        false,
+                    )),
+                    false,
+                )
             }
         }
     }

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -289,6 +289,9 @@ pub fn relation_to_arrow_fields(fields: &[Field], delta_lake: bool) -> Vec<Arrow
                 c.fields.as_ref().unwrap(),
                 delta_lake,
             )),
+            SqlType::Map => {
+                panic!("SQL MAP type conversion to Parquet data type is not yet implemented");
+            }
         }
     }
 

--- a/crates/pipeline-types/src/program_schema.rs
+++ b/crates/pipeline-types/src/program_schema.rs
@@ -252,6 +252,9 @@ pub enum SqlType {
     /// A complex SQL struct type (`CREATE TYPE x ...`).
     #[serde(rename = "STRUCT")]
     Struct,
+    /// SQL `MAP` type.
+    #[serde(rename = "MAP")]
+    Map,
     /// SQL `NULL` type.
     #[serde(rename = "NULL")]
     Null,
@@ -294,6 +297,7 @@ impl<'de> Deserialize<'de> for SqlType {
             "timestamp" => Ok(SqlType::Timestamp),
             "array" => Ok(SqlType::Array),
             "struct" => Ok(SqlType::Struct),
+            "map" => Ok(SqlType::Map),
             "null" => Ok(SqlType::Null),
             _ => Err(serde::de::Error::custom(format!(
                 "Unknown SQL type: {}",
@@ -324,6 +328,7 @@ impl From<SqlType> for &'static str {
             SqlType::Interval(_) => "INTERVAL",
             SqlType::Array => "ARRAY",
             SqlType::Struct => "STRUCT",
+            SqlType::Map => "MAP",
             SqlType::Null => "NULL",
         }
     }

--- a/crates/pipeline-types/src/program_schema.rs
+++ b/crates/pipeline-types/src/program_schema.rs
@@ -132,6 +132,8 @@ impl<'de> Deserialize<'de> for Field {
                     scale: helper.scale,
                     component: helper.component,
                     fields: Some(fields),
+                    key: None,
+                    value: None,
                 }
             } else if let Some(serde_json::Value::Object(obj)) = helper.fields {
                 serde_json::from_value(serde_json::Value::Object(obj))
@@ -144,6 +146,8 @@ impl<'de> Deserialize<'de> for Field {
                     scale: helper.scale,
                     component: helper.component,
                     fields: None,
+                    key: None,
+                    value: None,
                 }
             };
 
@@ -397,6 +401,92 @@ pub struct ColumnType {
     /// ```
     #[cfg_attr(feature = "testing", proptest(value = "Some(Vec::new())"))]
     pub fields: Option<Vec<Field>>,
+    /// Key type; must be set when `type == "MAP"`.
+    #[cfg_attr(feature = "testing", proptest(value = "None"))]
+    pub key: Option<Box<ColumnType>>,
+    /// Value type; must be set when `type == "MAP"`.
+    #[cfg_attr(feature = "testing", proptest(value = "None"))]
+    pub value: Option<Box<ColumnType>>,
+}
+
+impl ColumnType {
+    pub fn boolean(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::Boolean,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
+
+    pub fn tinyint(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::TinyInt,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
+
+    pub fn smallint(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::SmallInt,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
+
+    pub fn int(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::Int,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
+
+    pub fn bigint(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::BigInt,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
+
+    pub fn varchar(nullable: bool) -> Self {
+        ColumnType {
+            typ: SqlType::Varchar,
+            nullable,
+            precision: None,
+            scale: None,
+            component: None,
+            fields: None,
+            key: None,
+            value: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/openapi.json
+++ b/openapi.json
@@ -5411,6 +5411,13 @@
           },
           {
             "type": "string",
+            "description": "SQL `MAP` type.",
+            "enum": [
+              "MAP"
+            ]
+          },
+          {
+            "type": "string",
             "description": "SQL `NULL` type.",
             "enum": [
               "NULL"

--- a/openapi.json
+++ b/openapi.json
@@ -3242,6 +3242,14 @@
             "description": "The fields of the type (if available).\n\nFor example this would specify the fields of a `CREATE TYPE` construct.\n\n```sql\nCREATE TYPE person_typ AS (\nfirstname       VARCHAR(30),\nlastname        VARCHAR(30),\naddress         ADDRESS_TYP\n);\n```\n\nWould lead to the following `fields` value:\n\n```sql\n[\nColumnType { name: \"firstname, ... },\nColumnType { name: \"lastname\", ... },\nColumnType { name: \"address\", fields: [ ... ] }\n]\n```",
             "nullable": true
           },
+          "key": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ColumnType"
+              }
+            ],
+            "nullable": true
+          },
           "nullable": {
             "type": "boolean",
             "description": "Does the type accept NULL values?"
@@ -3260,6 +3268,14 @@
           },
           "type": {
             "$ref": "#/components/schemas/SqlType"
+          },
+          "value": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ColumnType"
+              }
+            ],
+            "nullable": true
           }
         }
       },

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -62,6 +62,15 @@ public class CatalogTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue1941() {
+        String sql = """
+                CREATE TABLE Data (
+                    map MAP<INT, INT>
+                );""";
+        this.compileRustTestCase(sql);
+    }
+
+    @Test
     public void testSanitizeNames() {
         String statements = """
                 create table t1(


### PR DESCRIPTION
**Outstanding tasks/questions:**
- [x] The current MAP type in pipeline-types does not take key / value type arguments inside. Is this needed?
- [x] Adapters crate: JSON and Parquet schema type correspondence
- [x] An error occurs in the compilation of the program itself (see below)

**Error in program:**
```
   Compiling project01904ed3-b496-76d3-8b29-af9a246e9671 v0.1.0 (/home/<user>/.feldera/cargo_workspace/project01904ed3-b496-76d3-8b29-af9a246e9671)
error[E0277]: the trait bound `BTreeMap<i32, i32>: DeserializeWithContext<'_, SqlSerdeConfig>` is not satisfied
   --> project01904ed3-b496-76d3-8b29-af9a246e9671/src/main.rs:116:9
    |
116 | /         deserialize_table_record!(struct_0["t", 1] {
117 | |             (field0, "map", false, Option<BTreeMap<i32, i32>>, Some(None))
118 | |         });
    | |__________^ the trait `DeserializeWithContext<'_, SqlSerdeConfig>` is not implemented for `BTreeMap<i32, i32>`, which is required by `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>: DeserializeSeed<'de>`
    |
    = help: the following other types implement trait `DeserializeWithContext<'de, C>`:
              <bool as DeserializeWithContext<'de, C>>
              <char as DeserializeWithContext<'de, C>>
              <isize as DeserializeWithContext<'de, C>>
              <i8 as DeserializeWithContext<'de, C>>
              <i16 as DeserializeWithContext<'de, C>>
              <i32 as DeserializeWithContext<'de, C>>
              <i64 as DeserializeWithContext<'de, C>>
              <i128 as DeserializeWithContext<'de, C>>
            and 44 others
    = note: required for `std::option::Option<BTreeMap<i32, i32>>` to implement `DeserializeWithContext<'_, SqlSerdeConfig>`
    = note: required for `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>` to implement `DeserializeSeed<'de>`
    = note: this error originates in the macro `deserialize_table_record` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `BTreeMap<i32, i32>: DeserializeWithContext<'_, SqlSerdeConfig>` is not satisfied
    --> project01904ed3-b496-76d3-8b29-af9a246e9671/src/main.rs:116:9
     |
116  | /         deserialize_table_record!(struct_0["t", 1] {
117  | |             (field0, "map", false, Option<BTreeMap<i32, i32>>, Some(None))
118  | |         });
     | |          ^
     | |          |
     | |__________the trait `DeserializeWithContext<'_, SqlSerdeConfig>` is not implemented for `BTreeMap<i32, i32>`, which is required by `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>: DeserializeSeed<'de>`
     |            required by a bound introduced by this call
     |
     = help: the following other types implement trait `DeserializeWithContext<'de, C>`:
               <bool as DeserializeWithContext<'de, C>>
               <char as DeserializeWithContext<'de, C>>
               <isize as DeserializeWithContext<'de, C>>
               <i8 as DeserializeWithContext<'de, C>>
               <i16 as DeserializeWithContext<'de, C>>
               <i32 as DeserializeWithContext<'de, C>>
               <i64 as DeserializeWithContext<'de, C>>
               <i128 as DeserializeWithContext<'de, C>>
             and 44 others
     = note: required for `std::option::Option<BTreeMap<i32, i32>>` to implement `DeserializeWithContext<'_, SqlSerdeConfig>`
     = note: required for `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>` to implement `DeserializeSeed<'de>`
note: required by a bound in `next_value_seed`
    --> /home/<user>/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.203/src/de/mod.rs:1811:12
     |
1809 |     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
     |        --------------- required by a bound in this associated function
1810 |     where
1811 |         V: DeserializeSeed<'de>;
     |            ^^^^^^^^^^^^^^^^^^^^ required by this bound in `MapAccess::next_value_seed`
     = note: this error originates in the macro `deserialize_table_record` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `BTreeMap<i32, i32>: DeserializeWithContext<'_, SqlSerdeConfig>` is not satisfied
    --> project01904ed3-b496-76d3-8b29-af9a246e9671/src/main.rs:116:9
     |
116  | /         deserialize_table_record!(struct_0["t", 1] {
117  | |             (field0, "map", false, Option<BTreeMap<i32, i32>>, Some(None))
118  | |         });
     | |          ^
     | |          |
     | |__________the trait `DeserializeWithContext<'_, SqlSerdeConfig>` is not implemented for `BTreeMap<i32, i32>`, which is required by `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>: DeserializeSeed<'de>`
     |            required by a bound introduced by this call
     |
     = help: the following other types implement trait `DeserializeWithContext<'de, C>`:
               <bool as DeserializeWithContext<'de, C>>
               <char as DeserializeWithContext<'de, C>>
               <isize as DeserializeWithContext<'de, C>>
               <i8 as DeserializeWithContext<'de, C>>
               <i16 as DeserializeWithContext<'de, C>>
               <i32 as DeserializeWithContext<'de, C>>
               <i64 as DeserializeWithContext<'de, C>>
               <i128 as DeserializeWithContext<'de, C>>
             and 44 others
     = note: required for `std::option::Option<BTreeMap<i32, i32>>` to implement `DeserializeWithContext<'_, SqlSerdeConfig>`
     = note: required for `DeserializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>` to implement `DeserializeSeed<'de>`
note: required by a bound in `next_element_seed`
    --> /home/<user>/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.203/src/de/mod.rs:1716:12
     |
1714 |     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
     |        ----------------- required by a bound in this associated function
1715 |     where
1716 |         T: DeserializeSeed<'de>;
     |            ^^^^^^^^^^^^^^^^^^^^ required by this bound in `SeqAccess::next_element_seed`
     = note: this error originates in the macro `deserialize_table_record` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `BTreeMap<i32, i32>: SerializeWithContext<SqlSerdeConfig>` is not satisfied
    --> project01904ed3-b496-76d3-8b29-af9a246e9671/src/main.rs:119:9
     |
119  | /         serialize_table_record!(struct_0[1]{
120  | |             field0["map"]: Option<BTreeMap<i32, i32>>
121  | |         });
     | |          ^
     | |          |
     | |__________the trait `SerializeWithContext<SqlSerdeConfig>` is not implemented for `BTreeMap<i32, i32>`, which is required by `SerializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>: Serialize`
     |            required by a bound introduced by this call
     |
     = help: the following other types implement trait `SerializeWithContext<C>`:
               <bool as SerializeWithContext<C>>
               <char as SerializeWithContext<C>>
               <isize as SerializeWithContext<C>>
               <i8 as SerializeWithContext<C>>
               <i16 as SerializeWithContext<C>>
               <i32 as SerializeWithContext<C>>
               <i64 as SerializeWithContext<C>>
               <i128 as SerializeWithContext<C>>
             and 35 others
     = note: required for `std::option::Option<BTreeMap<i32, i32>>` to implement `SerializeWithContext<SqlSerdeConfig>`
     = note: required for `SerializationContext<'_, SqlSerdeConfig, std::option::Option<BTreeMap<i32, i32>>>` to implement `Serialize`
note: required by a bound in `circuit::{closure#0}::_::_serde::ser::SerializeStruct::serialize_field`
    --> /home/<user>/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.203/src/ser/mod.rs:1860:21
     |
1858 |     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     |        --------------- required by a bound in this associated function
1859 |     where
1860 |         T: ?Sized + Serialize;
     |                     ^^^^^^^^^ required by this bound in `SerializeStruct::serialize_field`
     = note: this error originates in the macro `serialize_table_record` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `project01904ed3-b496-76d3-8b29-af9a246e9671` (bin "project01904ed3-b496-76d3-8b29-af9a246e9671") due to 5 previous errors

exit code: exit status: 101
```

Is this a user-visible change (yes/no): no
