### PR TITLE
benchmark: API key and Kafka option arguments

### DIFF
--- a/benchmark/feldera-sql/README.md
+++ b/benchmark/feldera-sql/README.md
@@ -98,5 +98,5 @@ This step has the following sub-steps:
 To run the benchmark itself, run:
 
 ```
-python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API --kafka-broker $KAFKA_FROM_FELDERA
+python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API -O bootstrap.servers=$KAFKA_FROM_FELDERA
 ```

--- a/benchmark/run-nexmark.sh
+++ b/benchmark/run-nexmark.sh
@@ -473,7 +473,7 @@ case $runner:$language in
 	CARGO=$(find_program cargo)
 	run_log feldera-sql/run.py \
 	    --api-url="$api_url" \
-	    --kafka-broker="${kafka_from_feldera:-${kafka_broker}}" \
+	    -O bootstrap.servers="${kafka_from_feldera:-${kafka_broker}}" \
 	    --cores $cores \
 	    --input-topic-suffix "-$events" \
 	    --csv results.csv \

--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -48,12 +48,12 @@ KAFKA_BROKER=localhost:9092
 rpk topic -X brokers=$KAFKA_BROKER delete bid auction person
 cargo run  -p dbsp_nexmark --example generate --features with-kafka -- --max-events ${MAX_EVENTS} -O bootstrap.servers=$KAFKA_BROKER
 FELDERA_API=http://localhost:8080
-python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API --kafka-broker $KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_CSV_FILE} --csv-metrics crates/nexmark/${NEXMARK_SQL_METRICS_CSV_FILE} --metrics-interval 1
+python3 benchmark/feldera-sql/run.py --api-url $FELDERA_API -O bootstrap.servers=$KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_CSV_FILE} --csv-metrics crates/nexmark/${NEXMARK_SQL_METRICS_CSV_FILE} --metrics-interval 1
 
 rpk topic -X brokers=$KAFKA_BROKER delete bid auction person
 cargo run  -p dbsp_nexmark --example generate --features with-kafka -- --max-events ${MAX_EVENTS} -O bootstrap.servers=$KAFKA_BROKER
 FELDERA_API=http://localhost:8080
-python3 benchmark/feldera-sql/run.py --storage --api-url $FELDERA_API --kafka-broker $KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_STORAGE_CSV_FILE} --csv-metrics crates/nexmark/${NEXMARK_SQL_STORAGE_METRICS_CSV_FILE} --metrics-interval 1
+python3 benchmark/feldera-sql/run.py --storage --api-url $FELDERA_API -O bootstrap.servers=$KAFKA_BROKER --csv crates/nexmark/${NEXMARK_SQL_STORAGE_CSV_FILE} --csv-metrics crates/nexmark/${NEXMARK_SQL_STORAGE_METRICS_CSV_FILE} --metrics-interval 1
 
 # Run galen benchmark
 cargo bench --bench galen -- --workers 10 --csv ${GALEN_CSV_FILE}


### PR DESCRIPTION
Changes to the end-to-end SQL benchmark run script:
- Argument to supply additional Kafka options such as for SSL and SASL configuration
- Argument to supply API key which is included as an HTTP header with each request
- Specify optimized compilation profile
- Comments for configuring pipeline resources

Is this a user-visible change (yes/no): no