### PR TITLE
[SQL] Reorganize compilation stages and fix 3 bugs

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
@@ -120,8 +120,6 @@ public class CompilerMain {
         }
     }
 
-    static int schemaCount = 0;
-
     /** Run compiler, return exit code. */
     CompilerMessages run() throws SQLException {
         DBSPCompiler compiler = new DBSPCompiler(this.options);
@@ -151,6 +149,10 @@ public class CompilerMain {
         compiler.compileInput();
         if (compiler.hasErrors())
             return compiler.messages;
+        // The following runs all compilation stages
+        DBSPCircuit dbsp = compiler.getFinalCircuit(this.options.ioOptions.functionName);
+        if (compiler.hasErrors())
+            return compiler.messages;
         if (this.options.ioOptions.emitJsonSchema != null) {
             try {
                 PrintStream outputStream = new PrintStream(
@@ -165,8 +167,6 @@ public class CompilerMain {
             }
         }
 
-        compiler.optimize();
-        DBSPCircuit dbsp = compiler.getFinalCircuit(this.options.ioOptions.functionName);
         String dotFormat = (this.options.ioOptions.emitJpeg ? "jpg"
                             : this.options.ioOptions.emitPng ? "png"
                             : null);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
@@ -36,9 +36,9 @@ public final class DBSPSinkOperator extends DBSPViewBaseOperator {
     public DBSPSinkOperator(CalciteObject node, String viewName, String query,
                             DBSPTypeStruct originalRowType,
                             List<ViewColumnMetadata> metadata,
-                            @Nullable String comment, DBSPOperator input) {
+                            DBSPOperator input) {
         super(node, "inspect", null, viewName, query,
-                originalRowType, metadata, comment, input);
+                originalRowType, metadata, input);
     }
 
     @Override
@@ -55,7 +55,7 @@ public final class DBSPSinkOperator extends DBSPViewBaseOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSinkOperator(
                     this.getNode(), this.viewName, this.query, this.originalRowType,
-                    this.metadata, this.comment, newInputs.get(0));
+                    this.metadata, newInputs.get(0));
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewBaseOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewBaseOperator.java
@@ -22,8 +22,8 @@ public abstract class DBSPViewBaseOperator extends DBSPUnaryOperator {
             CalciteObject node, String operation, @Nullable DBSPExpression function,
             String viewName, String query, DBSPTypeStruct originalRowType,
             List<ViewColumnMetadata> metadata,
-            @Nullable String comment, DBSPOperator input) {
-        super(node, operation, function, input.outputType, input.isMultiset, input, comment);
+            DBSPOperator input) {
+        super(node, operation, function, input.outputType, input.isMultiset, input);
         this.metadata = metadata;
         this.query = query;
         this.viewName = viewName;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
@@ -26,9 +26,9 @@ public final class DBSPViewOperator
             CalciteObject node,
             String viewName, String query, DBSPTypeStruct originalRowType,
             List<ViewColumnMetadata> metadata,
-            @Nullable String comment, DBSPOperator input) {
+            DBSPOperator input) {
         super(node, "map", DBSPClosureExpression.id(), viewName, query,
-                originalRowType, metadata, comment, input);
+                originalRowType, metadata, input);
         assert metadata.size() == originalRowType.fields.size();
     }
 
@@ -49,7 +49,7 @@ public final class DBSPViewOperator
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression ignoredFunction, DBSPType ignoredType) {
         return new DBSPViewOperator(this.getNode(), this.viewName, this.query, this.originalRowType,
-                this.metadata, this.comment, this.input());
+                this.metadata, this.input());
     }
 
     @Override
@@ -57,7 +57,7 @@ public final class DBSPViewOperator
         if (force || this.inputsDiffer(newInputs))
             return new DBSPViewOperator(
                     this.getNode(), this.viewName, this.query, this.originalRowType,
-                    this.metadata, this.comment, newInputs.get(0));
+                    this.metadata, newInputs.get(0));
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -34,6 +34,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.DBSPPartialCircuit;
@@ -50,7 +51,6 @@ import org.dbsp.sqlCompiler.compiler.frontend.CalciteToDBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CustomFunctions;
-import org.dbsp.sqlCompiler.compiler.frontend.parser.SqlCreateLocalView;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateFunctionStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateViewStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.FrontEndStatement;
@@ -127,7 +127,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
     final List<LatenessStatement> lateness = new ArrayList<>();
 
     /** Circuit produced by the compiler. */
-    public @Nullable DBSPCircuit circuit;
+    @Nullable DBSPCircuit circuit;
 
     public DBSPCompiler(CompilerOptions options) {
         this.options = options;
@@ -217,28 +217,47 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         this.frontend.addSchemaSource(name, schema);
     }
 
-    private void compileInternal(String statements, boolean many, @Nullable String comment) {
+    static class SqlStatements {
+        final String statement;
+        final boolean many;
+
+        SqlStatements(String statement, boolean many) {
+            this.statement = statement;
+            this.many = many;
+        }
+    }
+
+    List<SqlStatements> toCompile = new ArrayList<>();
+
+    private void compileInternal(String statements, boolean many) {
         if (this.inputSources != InputSource.File) {
             // If we read from file we already have read the entire data.
             // Otherwise, we append the statements to the sources.
             this.sources.append(statements);
+            this.sources.append("\n");
         }
+        this.toCompile.add(new SqlStatements(statements, many));
+    }
 
+    void runAllCompilerStages() {
         try {
             // Parse using Calcite
-            SqlNodeList parsed;
-            if (many) {
-                if (statements.isEmpty())
+            SqlNodeList parsed = new SqlNodeList(SqlParserPos.ZERO);
+            for (SqlStatements stat: this.toCompile) {
+                if (stat.many) {
+                    if (stat.statement.isEmpty())
+                        continue;
+                    parsed.addAll(this.frontend.parseStatements(stat.statement));
+                } else {
+                    SqlNode node = this.frontend.parse(stat.statement);
+                    List<SqlNode> stmtList = new ArrayList<>();
+                    stmtList.add(node);
+                    parsed.addAll(new SqlNodeList(stmtList, node.getParserPosition()));
+                }
+                if (this.hasErrors())
                     return;
-                parsed = this.frontend.parseStatements(statements);
-            } else {
-                SqlNode node = this.frontend.parse(statements);
-                List<SqlNode> stmtList = new ArrayList<>();
-                stmtList.add(node);
-                parsed = new SqlNodeList(stmtList, node.getParserPosition());
             }
-            if (this.hasErrors())
-                return;
+            this.toCompile.clear();
 
             // Compile first the statements that define functions, types, and lateness
             List<SqlFunction> functions = new ArrayList<>();
@@ -249,7 +268,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                         .newline();
                 SqlKind kind = node.getKind();
                 if (kind == SqlKind.CREATE_TYPE) {
-                    FrontEndStatement fe = this.frontend.compile(node.toString(), node, comment);
+                    FrontEndStatement fe = this.frontend.compile(node.toString(), node);
                     if (fe == null)
                         // error during compilation
                         continue;
@@ -257,14 +276,14 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                     continue;
                 }
                 if (kind == SqlKind.CREATE_FUNCTION) {
-                    FrontEndStatement fe = this.frontend.compile(node.toString(), node, comment);
+                    FrontEndStatement fe = this.frontend.compile(node.toString(), node);
                     if (fe == null)
                         continue;
                     functions.add(fe.to(CreateFunctionStatement.class).function);
                     this.midend.compile(fe);
                 }
                 if (node instanceof SqlLateness) {
-                    FrontEndStatement fe = this.frontend.compile(node.toString(), node, comment);
+                    FrontEndStatement fe = this.frontend.compile(node.toString(), node);
                     if (fe == null)
                         continue;
                     this.lateness.add(fe.to(LatenessStatement.class));
@@ -292,7 +311,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                     continue;
                 if (node instanceof SqlLateness)
                     continue;
-                FrontEndStatement fe = this.frontend.compile(node.toString(), node, comment);
+                FrontEndStatement fe = this.frontend.compile(node.toString(), node);
                 if (fe == null)
                     // error during compilation
                     continue;
@@ -302,6 +321,8 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                 }
                 this.midend.compile(fe);
             }
+
+            this.optimize();
         } catch (SqlParseException e) {
             if (e.getCause() instanceof BaseCompilerException) {
                 // Exceptions we throw in parser validation code are caught
@@ -350,29 +371,21 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         return ios;
     }
 
-    public void compileStatement(String statement, @Nullable String comment) {
-        this.setSource(InputSource.API);
-        this.compileInternal(statement, false, comment);
-    }
-
     public void compileStatements(String program) {
         this.setSource(InputSource.API);
-        this.compileInternal(program, true, null);
+        this.compileInternal(program, true);
     }
 
-    public void optimize() {
+    void optimize() {
         if (this.circuit == null) {
-            this.circuit = this.getFinalCircuit("tmp");
+            this.circuit = this.midend.getFinalCircuit().seal("tmp");
         }
         CircuitOptimizer optimizer = new CircuitOptimizer(this);
         this.circuit = optimizer.optimize(this.circuit);
     }
 
     public void compileStatement(String statement) {
-        Logger.INSTANCE.belowLevel(this, 3)
-                .append("Compiling ")
-                .append(statement);
-        this.compileStatement(statement, null);
+        this.compileInternal(statement, false);
     }
 
     public void setEntireInput(@Nullable String filename, InputStream contents) throws IOException {
@@ -387,7 +400,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         if (this.inputSources == InputSource.None)
             throw new UnsupportedException("compileInput has been called without calling setEntireInput",
                     CalciteObject.EMPTY);
-        this.compileInternal(this.sources.getWholeProgram(), true, null);
+        this.compileInternal(this.sources.getWholeProgram(), true);
     }
 
     public boolean hasErrors() {
@@ -406,10 +419,13 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         }
     }
 
-    /** Get the circuit generated by compiling the statements to far.
+    /** Run all compilation stages.
+     * Get the circuit generated by compiling the statements to far.
      * Start a new circuit.
      * @param name  Name to use for the produced circuit. */
     public DBSPCircuit getFinalCircuit(String name) {
+        this.runAllCompilerStages();
+
         if (this.circuit == null) {
             DBSPPartialCircuit circuit = this.midend.getFinalCircuit();
             this.circuit = circuit.seal(name);
@@ -429,6 +445,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
 
     /** Get the contents of the tables as a result of all the INSERT statements compiled. */
     public TableContents getTableContents() {
+        this.runAllCompilerStages();
         return this.midend.getTableContents();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
@@ -73,6 +73,10 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         this.edgesLabeled = new HashSet<>();
     }
 
+    static String isMultiset(DBSPOperator operator) {
+        return operator.isMultiset ? "" : "*";
+    }
+
     @Override
     public VisitDecision preorder(DBSPSourceBaseOperator node) {
         String name = node.tableName;
@@ -81,6 +85,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         this.stream.append(node.getOutputName())
                 .append(" [ shape=box style=filled fillcolor=lightgrey label=\"")
                 .append(node.getIdString())
+                .append(isMultiset(node))
                 .append(" ")
                 .append(name)
                 .append("\" ]")
@@ -93,6 +98,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         this.stream.append(node.getOutputName())
                 .append(" [ shape=box,label=\"")
                 .append(node.getIdString())
+                .append(isMultiset(node))
                 .append(" ")
                 .append(getFunction(node))
                 .append("\" ]")
@@ -136,6 +142,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         this.stream.append(node.getOutputName())
                 .append(" [ shape=box,label=\"")
                 .append(node.getIdString())
+                .append(isMultiset(node))
                 .append(" ")
                 .append(node.viewName)
                 .append("\"")
@@ -205,6 +212,7 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
                 .append(this.getColor(node))
                 .append(" label=\"")
                 .append(node.getIdString())
+                .append(isMultiset(node))
                 .append(" ")
                 .append(node.operation)
                 .append(node.comment != null ? node.comment : "");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -23,12 +23,14 @@
 
 package org.dbsp.sqlCompiler.compiler.backend.rust;
 
+import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.*;
 import org.dbsp.sqlCompiler.ir.type.*;
 import org.dbsp.sqlCompiler.ir.type.primitive.*;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
+import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -147,7 +149,7 @@ public class RustSqlRuntimeLibrary {
         }
     }
 
-    public FunctionDescription getImplementation(
+    public FunctionDescription getImplementation(CalciteObject node,
             DBSPOpcode opcode, @Nullable DBSPType expectedReturnType,
             DBSPType ltype, @Nullable DBSPType rtype) {
         if (ltype.is(DBSPTypeAny.class) || (rtype != null && rtype.is(DBSPTypeAny.class)))
@@ -164,8 +166,12 @@ public class RustSqlRuntimeLibrary {
             if (opcode == DBSPOpcode.SUB || opcode == DBSPOpcode.ADD) {
                 if (ltype.is(DBSPTypeTimestamp.class) || ltype.is(DBSPTypeDate.class)) {
                     assert expectedReturnType != null;
+                    assert rtype != null;
                     returnType = expectedReturnType;
                     suffixReturn = "_" + returnType.baseTypeWithSuffix();
+                    if (rtype.is(IsNumericType.class))
+                        throw new CompilationError("Cannot apply operation " + Utilities.singleQuote(opcode.toString()) +
+                                " to arguments of type " + ltype.asSqlString() + " and " + rtype.asSqlString(), node);
                 }
             }
         } else if (ltype.is(IsNumericType.class)) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -718,6 +718,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
     @Override
     public VisitDecision preorder(DBSPConditionalAggregateExpression expression) {
         RustSqlRuntimeLibrary.FunctionDescription implementation = RustSqlRuntimeLibrary.INSTANCE.getImplementation(
+                expression.getNode(),
                 expression.opcode, expression.getType(), expression.left.getType(), expression.right.getType());
         this.builder.append(implementation.function);
         if (expression.condition != null)
@@ -794,6 +795,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
             return VisitDecision.STOP;
         }
         RustSqlRuntimeLibrary.FunctionDescription function = RustSqlRuntimeLibrary.INSTANCE.getImplementation(
+                expression.getNode(),
                 expression.operation,
                 expression.getType(),
                 expression.left.getType(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -2125,18 +2125,18 @@ public class CalciteToDBSPCompiler extends RelVisitor
             // Create two operators chained, a ViewOperator and a SinkOperator.
             DBSPViewOperator vo = new DBSPViewOperator(
                     view.getCalciteObject(), view.relationName, view.statement,
-                    struct, additionalMetadata, view.comment, op);
+                    struct, additionalMetadata, op);
             this.circuit.addOperator(vo);
             o = new DBSPSinkOperator(
                     view.getCalciteObject(), view.relationName,
-                    view.statement, struct, additionalMetadata, view.comment, vo);
+                    view.statement, struct, additionalMetadata, vo);
         } else {
             // We may already have a node for this output
             DBSPOperator previous = this.circuit.getView(view.relationName);
             if (previous != null)
                 return previous;
             o = new DBSPViewOperator(view.getCalciteObject(), view.relationName, view.statement,
-                    struct, additionalMetadata, view.comment, op);
+                    struct, additionalMetadata, op);
         }
         this.circuit.addOperator(o);
         return o;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -587,7 +587,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         DBSPType localGroupType = localKeyExpression.getType();
         DBSPTypeIndexedZSet localGroupAndInput = makeIndexedZSet(localGroupType, inputRowType);
         DBSPOperator createIndex = new DBSPMapIndexOperator(
-                node, makeKeys, localGroupAndInput, false, opInput);
+                node, makeKeys, localGroupAndInput, opInput);
         this.circuit.addOperator(createIndex);
         DBSPTypeIndexedZSet aggregateType = makeIndexedZSet(localGroupType, typeFromAggregate);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -396,7 +396,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 right = right.cast(commonBase.setMayBeNull(rightType.mayBeNull));
         }
         // TODO: we don't need the whole function here, just the result type.
-        RustSqlRuntimeLibrary.FunctionDescription function = RustSqlRuntimeLibrary.INSTANCE.getImplementation(
+        RustSqlRuntimeLibrary.FunctionDescription function =
+                RustSqlRuntimeLibrary.INSTANCE.getImplementation(node,
                 opcode, type, left.getType(), right.getType());
         DBSPExpression call = new DBSPBinaryExpression(node, function.returnType, opcode, left, right);
         return call.cast(type);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateFunctionStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateFunctionStatement.java
@@ -8,7 +8,7 @@ public class CreateFunctionStatement extends FrontEndStatement {
     public final ExternalFunction function;
 
     public CreateFunctionStatement(SqlNode node, String statement, ExternalFunction function) {
-        super(node, statement, null);
+        super(node, statement);
         this.function = function;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateRelationStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateRelationStatement.java
@@ -42,10 +42,10 @@ public abstract class CreateRelationStatement
     @Nullable final Map<String, String> connectorProperties;
 
     protected CreateRelationStatement(SqlNode node, String statement, String relationName,
-                                      boolean nameIsQuoted, @Nullable String comment,
+                                      boolean nameIsQuoted,
                                       List<RelColumnMetadata> columns,
                                       @Nullable Map<String, String> connectorProperties) {
-        super(node, statement, comment);
+        super(node, statement);
         this.nameIsQuoted = nameIsQuoted;
         this.relationName = relationName;
         this.columns = columns;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateTableStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateTableStatement.java
@@ -34,9 +34,8 @@ import java.util.Map;
 public class CreateTableStatement extends CreateRelationStatement {
     public CreateTableStatement(SqlNode node, String statement,
                                 String tableName, boolean nameIsQuoted,
-                                @Nullable String comment,
                                 List<RelColumnMetadata> columns,
                                 @Nullable Map<String, String> connectorProperties) {
-        super(node, statement, tableName, nameIsQuoted, comment, columns, connectorProperties);
+        super(node, statement, tableName, nameIsQuoted, columns, connectorProperties);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateTypeStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateTypeStatement.java
@@ -14,7 +14,7 @@ public class CreateTypeStatement extends FrontEndStatement {
 
     public CreateTypeStatement(SqlNode node, String statement,
                                SqlCreateType createType, String typeName, RelDataType relDataType) {
-        super(node, statement, null);
+        super(node, statement);
         this.createType = createType;
         this.typeName = typeName;
         this.relDataType = relDataType;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateViewStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/CreateViewStatement.java
@@ -42,11 +42,11 @@ public class CreateViewStatement extends CreateRelationStatement {
     public final boolean local;
 
     public CreateViewStatement(SqlCreateLocalView node, String statement, String tableName,
-                               boolean nameIsQuoted, @Nullable String comment,
+                               boolean nameIsQuoted,
                                List<RelColumnMetadata> columns, SqlNode query,
                                RelRoot compiled,
                                @Nullable Map<String, String> connectorProperties) {
-        super(node, statement, tableName, nameIsQuoted, comment, columns, connectorProperties);
+        super(node, statement, tableName, nameIsQuoted, columns, connectorProperties);
         this.local = node.isLocal;
         this.query = query;
         this.compiled = compiled;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/DropTableStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/DropTableStatement.java
@@ -31,8 +31,8 @@ public class DropTableStatement extends FrontEndStatement {
     public final String tableName;
 
     public DropTableStatement(SqlNode node, String statement,
-                              String tableName, @Nullable String comment) {
-        super(node, statement, comment);
+                              String tableName) {
+        super(node, statement);
         this.tableName = tableName;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/FrontEndStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/FrontEndStatement.java
@@ -37,13 +37,10 @@ public abstract class FrontEndStatement implements ICastable {
     public final SqlNode node;
     /** Original statement compiled. */
     public final String statement;
-    @Nullable
-    public final String comment;
 
-    protected FrontEndStatement(SqlNode node, String statement, @Nullable String comment) {
+    protected FrontEndStatement(SqlNode node, String statement) {
         this.node = node;
         this.statement = statement;
-        this.comment = comment;
     }
 
     public CalciteObject getCalciteObject() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/LatenessStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/LatenessStatement.java
@@ -12,7 +12,7 @@ public class LatenessStatement extends FrontEndStatement {
     public LatenessStatement(SqlNode node, String statement,
                              SqlIdentifier view, SqlIdentifier column,
                              RexNode value) {
-        super(node, statement, null);
+        super(node, statement);
         this.view = view;
         this.column = column;
         this.value = value;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
@@ -38,9 +38,8 @@ public class TableModifyStatement extends FrontEndStatement {
     /** True for insert, false for remove */
     public final boolean insert;
 
-    public TableModifyStatement(SqlNode node, boolean insert, String statement, String tableName,
-                                SqlNode data, @Nullable String comment) {
-        super(node, statement, comment);
+    public TableModifyStatement(SqlNode node, boolean insert, String statement, String tableName, SqlNode data) {
+        super(node, statement);
         this.insert = insert;
         this.tableName = tableName;
         this.data = data;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -159,7 +159,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)
                 || input != operator.input()) {
             result = new DBSPSinkOperator(operator.getNode(), operator.viewName, operator.query,
-                    originalRowType, operator.metadata, operator.comment, input);
+                    originalRowType, operator.metadata, input);
         }
         this.map(operator, result);
     }
@@ -174,7 +174,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)
                 || input != operator.input()) {
             result = new DBSPViewOperator(operator.getNode(), operator.viewName, operator.query,
-                    originalRowType, operator.metadata, operator.comment, input);
+                    originalRowType, operator.metadata, input);
         }
         this.map(operator, result);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IncrementalizeVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/IncrementalizeVisitor.java
@@ -60,7 +60,7 @@ public class IncrementalizeVisitor extends CircuitCloneVisitor {
         DBSPOperator source = this.mapped(operator.input());
         DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(operator.getNode(), source);
         DBSPSinkOperator sink = new DBSPSinkOperator(operator.getNode(), operator.viewName,
-                operator.query, operator.originalRowType, operator.metadata, operator.comment, diff);
+                operator.query, operator.originalRowType, operator.metadata, diff);
         this.addOperator(diff);
         this.map(operator, sink);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MonotoneAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MonotoneAnalyzer.java
@@ -32,7 +32,7 @@ public class MonotoneAnalyzer implements CircuitTransform, IWritesLogs {
         expanded = monotonicity.apply(expanded);
 
         InsertLimiters limiters = new InsertLimiters(
-                this.reporter, expanded, monotonicity.monotonicity, expander.expansion);
+                this.reporter, expanded, monotonicity.info, expander.expansion);
         // Notice that we apply the limiters to the original circuit, not to the expanded circuit!
         DBSPCircuit result = limiters.apply(circuit);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
@@ -38,13 +38,42 @@ public class OptimizeDistinctVisitor extends CircuitCloneVisitor {
     public void postorder(DBSPStreamDistinctOperator distinct) {
         // distinct (distinct) = distinct
         DBSPOperator input = this.mapped(distinct.input());
-        if (input.is(DBSPStreamDistinctOperator.class)) {
+        if (input.is(DBSPStreamDistinctOperator.class) ||
+            input.is(DBSPDistinctOperator.class) ||
+            !input.isMultiset) {
             this.map(distinct, input, false);
             return;
         }
         if (input.is(DBSPStreamJoinOperator.class) ||
             input.is(DBSPMapOperator.class) ||
             input.is(DBSPSumOperator.class)) {
+            boolean allDistinct = Linq.all(input.inputs, i -> i.is(DBSPStreamDistinctOperator.class));
+            if (allDistinct) {
+                // distinct(map(distinct)) = distinct(map)
+                List<DBSPOperator> newInputs = Linq.map(input.inputs, i -> i.inputs.get(0));
+                DBSPOperator newInput = input.withInputs(newInputs, false);
+                this.addOperator(newInput);
+                DBSPOperator newDistinct = distinct.withInputs(Linq.list(newInput), false);
+                this.map(distinct, newDistinct);
+                return;
+            }
+        }
+        super.postorder(distinct);
+    }
+
+    @Override
+    public void postorder(DBSPDistinctOperator distinct) {
+        // distinct (distinct) = distinct
+        DBSPOperator input = this.mapped(distinct.input());
+        if (input.is(DBSPStreamDistinctOperator.class) ||
+            input.is(DBSPDistinctOperator.class) ||
+            !input.isMultiset) {
+            this.map(distinct, input, false);
+            return;
+        }
+        if (input.is(DBSPStreamJoinOperator.class) ||
+                input.is(DBSPMapOperator.class) ||
+                input.is(DBSPSumOperator.class)) {
             boolean allDistinct = Linq.all(input.inputs, i -> i.is(DBSPStreamDistinctOperator.class));
             if (allDistinct) {
                 // distinct(map(distinct)) = distinct(map)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
@@ -66,7 +66,8 @@ public class OptimizeProjectionVisitor extends CircuitCloneVisitor {
                 source.is(DBSPDifferentiateOperator.class) ||
                 source.is(DBSPDelayOperator.class) ||
                 source.is(DBSPNegateOperator.class) ||
-                source.is(DBSPSumOperator.class) ||
+                // source.is(DBSPSumOperator.class) ||  // swapping with sum is not sound
+                // since it may apply operations like div by 0 to tuples that may never appear
                 source.is(DBSPNoopOperator.class)) {
             // For all such operators we can swap them with the map
             List<DBSPOperator> newSources = new ArrayList<>();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestUtil.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestUtil.java
@@ -30,10 +30,12 @@ public class TestUtil {
 
     /**
      * Check that the messsages contain the specified substring.
-     * @param messages  Compiler messages.
+     * @param compiler  Compiler.
      * @param contents  Substring that we expect to find.
      */
-    public static void assertMessagesContain(CompilerMessages messages, String contents) {
+    public static void assertMessagesContain(DBSPCompiler compiler, String contents) {
+        compiler.runAllCompilerStages();
+        CompilerMessages messages = compiler.messages;
         String text = messages.toString();
         if (text.contains(contents))
             return;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/BaseSQLTests.java
@@ -164,6 +164,7 @@ public class BaseSQLTests {
     public void testNegativeQuery(String query, String messageFragment) {
         DBSPCompiler compiler = this.noThrowCompiler();
         compiler.compileStatement("CREATE VIEW VV AS " + query);
+        compiler.getFinalCircuit("tmp");
         Assert.assertTrue(compiler.messages.exitCode != 0);
         String message = compiler.messages.toString();
         Assert.assertTrue(message.contains(messageFragment));
@@ -247,7 +248,6 @@ public class BaseSQLTests {
     }
 
     public static DBSPCircuit getCircuit(DBSPCompiler compiler) {
-        compiler.optimize();
         String name = "circuit" + testsToRun.size();
         return compiler.getFinalCircuit(name);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -30,7 +30,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 )""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "does not correspond to a column");
+        TestUtil.assertMessagesContain(compiler, "does not correspond to a column");
     }
 
     @Test
@@ -41,7 +41,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 """;
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatements(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Duplicate declaration");
+        TestUtil.assertMessagesContain(compiler, "Duplicate declaration");
     }
 
     @Test
@@ -49,25 +49,25 @@ public class NegativeParserTests extends BaseSQLTests {
         String ddl = "CREATE TABLE T(T INT) WITH ( 5 )";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Error parsing SQL: Encountered \"5\" at");
+        TestUtil.assertMessagesContain(compiler, "Error parsing SQL: Encountered \"5\" at");
 
         // properties need to be SQL strings
         ddl = "CREATE TABLE T(T INT) WITH ( a = b )";
         compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Error parsing SQL: Encountered \"a\" at");
+        TestUtil.assertMessagesContain(compiler, "Error parsing SQL: Encountered \"a\" at");
 
         // properties need to be SQL strings
         ddl = "CREATE TABLE T(T INT) WITH ( NULL = 'NULL' )";
         compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Error parsing SQL: Encountered \"NULL\" at");
+        TestUtil.assertMessagesContain(compiler, "Error parsing SQL: Encountered \"NULL\" at");
 
         // properties cannot be an empty list
         ddl = "CREATE TABLE T(T INT) WITH ( )";
         compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Error parsing SQL: Encountered \")\" at");
+        TestUtil.assertMessagesContain(compiler, "Error parsing SQL: Encountered \")\" at");
     }
 
     @Test
@@ -79,7 +79,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 )""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "in table with another PRIMARY KEY constraint");
+        TestUtil.assertMessagesContain(compiler, "in table with another PRIMARY KEY constraint");
     }
 
     @Test
@@ -90,7 +90,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 );""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Column ID already has a default value");
+        TestUtil.assertMessagesContain(compiler, "Column ID already has a default value");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 "    git_commit_id bigint not null PRIMARY KEY PRIMARY KEY)";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Column GIT_COMMIT_ID already declared a primary key");
+        TestUtil.assertMessagesContain(compiler, "Column GIT_COMMIT_ID already declared a primary key");
     }
 
     @Test
@@ -111,7 +111,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 )""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "already declared as key");
+        TestUtil.assertMessagesContain(compiler, "already declared as key");
     }
 
     @Test
@@ -123,7 +123,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 )""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Error parsing SQL");
+        TestUtil.assertMessagesContain(compiler, "Error parsing SQL");
     }
 
     @Test
@@ -156,7 +156,7 @@ public class NegativeParserTests extends BaseSQLTests {
                     fulfillment
                     on part_order.id = fulfillment.part_order;
                 """);
-        TestUtil.assertMessagesContain(compiler.messages, 
+        TestUtil.assertMessagesContain(compiler,
                 "Window specification must contain an ORDER BY clause");
     }
 
@@ -165,7 +165,7 @@ public class NegativeParserTests extends BaseSQLTests {
         // TODO: this test may become invalid once we add support for ROW types
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatements("CREATE VIEW V AS SELECT ROW(2, 2);\n");
-        TestUtil.assertMessagesContain(compiler.messages, "error: Not yet implemented: ROW");
+        TestUtil.assertMessagesContain(compiler, "error: Not yet implemented: ROW");
     }
 
     @Test
@@ -177,7 +177,7 @@ public class NegativeParserTests extends BaseSQLTests {
                 ", COL1 DOUBLE" +
                 ")";
         compiler.compileStatement(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Column with name 'COL1' already defined");
+        TestUtil.assertMessagesContain(compiler, "Column with name 'COL1' already defined");
     }
 
     @Test
@@ -185,8 +185,9 @@ public class NegativeParserTests extends BaseSQLTests {
         String statement = "CREATE TABLE T(c1 FLOAT)";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatement(statement);
+        getCircuit(compiler);
         Assert.assertTrue(compiler.hasErrors());
-        TestUtil.assertMessagesContain(compiler.messages, "Do not use");
+        TestUtil.assertMessagesContain(compiler, "Do not use");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -134,7 +134,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         String query = "CREATE VIEW V AS SELECT T.COL3 FROM T";
         DBSPCompiler compiler = this.compileDef();
         compiler.compileStatement(query);
-        compiler.optimize();
         // Deterministically name the circuit function.
         DBSPCircuit circuit = compiler.getFinalCircuit("circuit");
         String str = circuit.toString();
@@ -149,7 +148,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                     // CREATE VIEW `V` AS
                     // SELECT `T`.`COL3`
                     // FROM `T`
-                    let stream131: stream<WSet<Tup1<b>>> = stream61;
+                    let stream130: stream<WSet<Tup1<b>>> = stream61;
                 }
                 """;
         Assert.assertEquals(expected, str);
@@ -170,6 +169,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                ) AS SELECT * FROM T;""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatements(ddl);
+        getCircuit(compiler);
         JsonNode meta = compiler.getIOMetadataAsJson();
         JsonNode inputs = meta.get("inputs");
         Assert.assertNotNull(inputs);
@@ -209,8 +209,8 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         DBSPCompiler compiler = this.testCompiler();
         compiler.options.languageOptions.throwOnError = false;
         compiler.compileStatements(ddl);
-        TestUtil.assertMessagesContain(compiler.messages, "Duplicate key");
-        TestUtil.assertMessagesContain(compiler.messages, "Previous declaration");
+        TestUtil.assertMessagesContain(compiler, "Duplicate key");
+        TestUtil.assertMessagesContain(compiler, "Previous declaration");
     }
 
     @Test
@@ -220,7 +220,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         String query = "CREATE VIEW V AS SELECT '1_000'::INT4";
         compiler.compileStatement(query);
         getCircuit(compiler);  // invokes optimizer
-        TestUtil.assertMessagesContain(compiler.messages, "String '1_000' cannot be interpreted as a number");
+        TestUtil.assertMessagesContain(compiler, "String '1_000' cannot be interpreted as a number");
     }
 
     // Test the ability to redirect logging streams.
@@ -648,7 +648,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
             }
         };
         visitor.apply(circuit);
-        TestUtil.assertMessagesContain(compiler.messages, "No view named 'W' found");
+        TestUtil.assertMessagesContain(compiler, "No view named 'W' found");
     }
 
     @Test
@@ -702,7 +702,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         String query = "CREATE VIEW V AS SELECT T.COL1 FROM T";
         compiler.compileStatement(ddl);
         compiler.compileStatements(query);
-        compiler.optimize();
         DBSPCircuit circuit = compiler.getFinalCircuit("circuit");
         DBSPSinkOperator sink = circuit.circuit.getSink("V");
         Assert.assertNotNull(sink);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/SqlIoTest.java
@@ -131,7 +131,6 @@ public abstract class SqlIoTest extends BaseSQLTests {
         compiler.compileStatement("CREATE VIEW VV AS " + query);
         if (!compiler.options.languageOptions.throwOnError)
             compiler.throwIfErrorsOccurred();
-        compiler.optimize();
         InputOutputChange iochange = new InputOutputChange(
                 this.getPreparedInputs(compiler),
                 new Change(expected)
@@ -211,7 +210,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         compiler.options.languageOptions.throwOnError = false;
         this.prepareInputs(compiler);
         compiler.compileStatements(statements);
-        compiler.optimize();
+        getCircuit(compiler);
         Assert.assertTrue(compiler.messages.exitCode != 0);
         String message = compiler.messages.toString();
         boolean contains = message.contains(messageFragment);
@@ -225,11 +224,10 @@ public abstract class SqlIoTest extends BaseSQLTests {
     public void queryFailingInCompilation(String query, String messageFragment, boolean optimize) {
         DBSPCompiler compiler = this.testCompiler(optimize);
         compiler.options.languageOptions.throwOnError = false;
+        compiler.options.languageOptions.optimizationLevel = optimize ? 2 : 0;
         this.prepareInputs(compiler);
         compiler.compileStatement("CREATE VIEW VV AS " + query);
-        if (optimize) {
-            compiler.optimize();
-        }
+        getCircuit(compiler);
         Assert.assertTrue(compiler.messages.exitCode != 0);
         String message = compiler.messages.toString();
         Assert.assertTrue(message.contains(messageFragment));
@@ -245,7 +243,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         compiler.options.languageOptions.throwOnError = false;
         this.prepareInputs(compiler);
         compiler.compileStatement("CREATE VIEW VV AS " + query);
-        compiler.optimize();
+        getCircuit(compiler);
         Assert.assertTrue(compiler.hasWarnings);
         String warnings = compiler.messages.messages.stream().filter(error -> error.warning).toList().toString();
         Assert.assertTrue(warnings.contains(messageFragment));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/StreamingTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/StreamingTest.java
@@ -8,6 +8,8 @@ public class StreamingTest extends SqlIoTest {
     public CompilerOptions testOptions(boolean incremental, boolean optimize) {
         CompilerOptions options = super.testOptions(incremental, optimize);
         options.languageOptions.incrementalize = true;
+        options.languageOptions.outputsAreSets = true;
+        options.languageOptions.throwOnError = false;
         return options;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -714,6 +714,13 @@ public class EndToEndTests extends BaseSQLTests {
     }
 
     @Test
+    public void divTest2() {
+        String query = "SELECT 5 / COUNT(*) - COUNT(*) FROM T";
+        this.testQuery(query, new DBSPZSetLiteral(
+                new DBSPTupleExpression(new DBSPI64Literal(0))));
+    }
+
+    @Test
     public void divZeroTest() {
         String query = "SELECT 1 / 0";
         this.runtimeConstantFail(query, "attempt to divide by zero");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
@@ -26,6 +26,7 @@ package org.dbsp.sqlCompiler.compiler.sql.simple;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.junit.Test;
 
 // Runs the EndToEnd tests but on an input stream with 3 elements each and
 // using an incremental non-optimized circuit.
@@ -72,5 +73,11 @@ public class NaiveIncrementalTests extends EndToEndTests {
                         .addPair(input, new Change(firstOutput))    // Add first input
                         .addPair(new Change(empty), secondOutput)  // Add an empty input
                         .addPair(new Change(input.getSet(0).negate()), thirdOutput));  // Subtract the first input
+    }
+
+    @Test
+    public void divTest2() {
+        // Do not run this test in incremental mode, since it produces
+        // a division by 0 on an empty input.
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegresssionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegresssionTests.java
@@ -6,11 +6,8 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateWith
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.StderrErrorReporter;
 import org.dbsp.sqlCompiler.compiler.TestUtil;
-import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.Passes;
-import org.dbsp.util.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,7 +51,7 @@ public class RegresssionTests extends SqlIoTest {
         DBSPCompiler compiler = this.testCompiler();
         compiler.options.languageOptions.throwOnError = false;
         compiler.compileStatements(sql);
-        TestUtil.assertMessagesContain(compiler.messages, "OVER must be applied to aggregate function");
+        TestUtil.assertMessagesContain(compiler, "OVER must be applied to aggregate function");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -48,7 +48,6 @@ public class Main {
     public static void main(String[] argv) throws IOException, ClassNotFoundException {
         Class.forName("org.hsqldb.jdbcDriver");
         List<String> files = Linq.list(
-                "test/index/aggregates"
                 /*
                 "select1.test"
                 "select2.test",

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -131,7 +131,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
 
     public TableValue[] getInputSets(DBSPCompiler compiler) throws SQLException {
         for (SltSqlStatement statement : this.inputPreparation.statements)
-            compiler.compileStatement(statement.statement, null);
+            compiler.compileStatement(statement.statement);
         TableContents tables = compiler.getTableContents();
         TableValue[] tableValues = new TableValue[tables.tablesCreated.size()];
         for (int i = 0; i < tableValues.length; i++) {
@@ -285,13 +285,12 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                         + dbspQuery + "\n", 2);
         compiler.generateOutputForNextView(false);
         for (SltSqlStatement view: viewPreparation.definitions()) {
-            compiler.compileStatement(view.statement, view.statement);
+            compiler.compileStatement(view.statement);
             compiler.throwIfErrorsOccurred();
         }
         compiler.generateOutputForNextView(true);
-        compiler.compileStatement(dbspQuery, "" /* testQuery.getName() */);
+        compiler.compileStatement(dbspQuery);
         compiler.throwIfErrorsOccurred();
-        compiler.optimize();
         DBSPCircuit dbsp = compiler.getFinalCircuit("gen" + suffix);
         DBSPNode.done();
 
@@ -329,7 +328,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
     void createTables(DBSPCompiler compiler) {
         for (SltSqlStatement statement : this.tablePreparation.statements) {
             String stat = statement.statement;
-            compiler.compileStatement(stat, stat);
+            compiler.compileStatement(stat);
         }
     }
 
@@ -518,14 +517,14 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             if (description.hash == null)
                 throw new RuntimeException("Expected hash to be supplied");
             String hash = isVector ? "hash_vectors" : "hash";
-            list.add(new DBSPLetStatement("_hash",
+            DBSPVariablePath var = new DBSPTypeString(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, false).var();
+            list.add(new DBSPLetStatement(var.variable,
                     new DBSPApplyExpression(hash, new DBSPTypeString(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, false),
                             outputStatement.getVarReference().borrow(),
                             columnTypes,
                             sort)));
             list.add(new DBSPApplyExpression("assert_eq!", new DBSPTypeVoid(),
-                    new DBSPTypeString(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, false).var(),
-                    new DBSPStringLiteral(description.hash)).toStatement());
+                    var, new DBSPStringLiteral(description.hash)).toStatement());
         }
         DBSPExpression body = new DBSPBlockExpression(list, null);
         DBSPFunction function = new DBSPFunction(name, new ArrayList<>(), new DBSPTypeVoid(), body, Linq.list("#[test]"));


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #1963 
Fixes #1964 
Fixes #1965 

The expression `LATENESS VIEW.TIMESTAMPCOL 10`;  is actually incorrect, one cannot subtract an integer from a timestamp.
The compiler will report a (not very good) error for this case.
