### PR TITLE
Expose dbsp metrics in pipeline metrics endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [SQL] Added `MATERIALIZED` views
   ([#1959](https://github.com/feldera/feldera/pull/1959))
 - [WebConsole] Drop Data Services functionality (#1945)
+- Pipeline manager metrics endpoint now includes metrics of all
+  running pipelines ([#1969](https://github.com/feldera/feldera/pull/1969)).
 
 ## [0.19.0] - 2024-06-25
 
@@ -75,7 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1767](https://github.com/feldera/feldera/pull/1767))
 - Python SDK for Feldera
   ([#1745](https://github.com/feldera/feldera/pull/1745))
-
 
 ## [0.16.0] - 2024-05-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2225,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.68",
+ "which",
+]
+
+[[package]]
 name = "binrw"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2768,17 @@ checksum = "1d34327ead1c743a10db339de35fb58957564b99d248a67985c55638b22c59b5"
 dependencies = [
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3728,9 +3798,9 @@ dependencies = [
  "futures-util",
  "jemalloc_pprof",
  "lazy_static",
- "metrics 0.22.3",
- "metrics-exporter-tcp",
- "metrics-util",
+ "metrics 0.23.0",
+ "metrics-exporter-prometheus",
+ "metrics-util 0.17.0",
  "mime",
  "mockall",
  "num-bigint",
@@ -3786,7 +3856,7 @@ dependencies = [
  "hdrhist",
  "indicatif",
  "metrics 0.22.3",
- "metrics-util",
+ "metrics-util 0.16.3",
  "mimalloc-rust-sys",
  "num-format",
  "paste",
@@ -4227,6 +4297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,6 +4675,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -5166,6 +5248,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -5214,6 +5297,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
+ "log",
  "rustls 0.23.10",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
@@ -5607,6 +5691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,6 +5788,16 @@ dependencies = [
  "core2",
  "hashbrown 0.14.5",
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -5883,19 +5983,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-exporter-tcp"
-version = "0.9.0"
+name = "metrics-exporter-prometheus"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62a4304fc3e0fe66e94c6f577fc8f594ee72f9231de206f69d28ea8b35ec545"
+checksum = "bf0af7a0d7ced10c0151f870e5e3f3f8bc9ffc5992d32873566ca1f9169ae776"
 dependencies = [
- "bytes",
- "crossbeam-channel",
- "home",
- "metrics 0.22.3",
- "mio",
- "prost 0.12.6",
- "prost-build",
- "prost-types",
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics 0.23.0",
+ "metrics-util 0.17.0",
+ "quanta",
+ "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -5911,6 +6015,25 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "metrics 0.22.3",
+ "num_cpus",
+ "ordered-float 4.2.0",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "metrics 0.23.0",
  "num_cpus",
  "ordered-float 4.2.0",
  "quanta",
@@ -5972,6 +6095,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
 name = "mockall"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5997,12 +6126,6 @@ dependencies = [
  "quote 1.0.36",
  "syn 2.0.68",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
@@ -7267,27 +7390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.6",
- "prost-types",
- "regex",
- "syn 2.0.68",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7311,15 +7413,6 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.68",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
 ]
 
 [[package]]
@@ -8210,6 +8303,8 @@ version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
@@ -8284,6 +8379,7 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -8626,6 +8722,12 @@ checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
  "dirs 5.0.1",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -10142,6 +10244,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.34",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10479,6 +10593,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,12 +4279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "duct"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,13 +6943,13 @@ dependencies = [
  "futures-util",
  "jsonwebtoken",
  "log",
- "once_cell",
+ "metrics 0.23.0",
+ "metrics-exporter-prometheus",
  "openssl",
  "pg-client-config",
  "pg-embed",
  "pipeline_types",
  "pretty_assertions",
- "prometheus-client",
  "proptest",
  "proptest-derive 0.3.0",
  "rand 0.8.5",
@@ -7293,29 +7287,6 @@ dependencies = [
  "parking_lot 0.12.3",
  "protobuf",
  "thiserror",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.3",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.68",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -78,10 +78,10 @@ deltalake = { version = "=0.18.1", features = ["datafusion", "s3", "gcs", "azure
 apache-avro = { version = "0.16.0", optional = true }
 schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"], optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
-metrics-exporter-tcp = { version = "0.9.0" }
 url = "2.5.0"
-metrics-util = "0.16.3"
-metrics = "0.22.3"
+metrics = "0.23"
+metrics-util = "0.17"
+metrics-exporter-prometheus = "0.15.1"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -7,6 +7,7 @@ use anyhow::Error as AnyError;
 use crossbeam::channel::{bounded, Receiver, Select, Sender, TryRecvError};
 use hashbrown::HashMap;
 use itertools::Either;
+use metrics::counter;
 pub use pipeline_types::config::{StorageCacheConfig, StorageConfig};
 use std::{
     collections::HashSet,
@@ -602,6 +603,7 @@ impl DBSPHandle {
 
     /// Evaluate the circuit for one clock cycle.
     pub fn step(&mut self) -> Result<(), DBSPError> {
+        counter!("feldera.dbsp.step").increment(1);
         self.step_id += 1;
         self.broadcast_command(Command::Step, |_, _| {})
     }

--- a/crates/dbsp/src/circuit/metrics.rs
+++ b/crates/dbsp/src/circuit/metrics.rs
@@ -58,7 +58,7 @@ pub const COMPACTION_DURATION: &str = "file.compaction_duration";
 pub const COMPACTION_STALL_TIME: &str = "file.compaction_stall_time";
 
 /// Adds descriptions for the metrics we expose.
-pub(super) fn describe_disk_metrics() {
+pub(crate) fn describe_metrics() {
     // Storage backend metrics.
     describe_counter!(FILES_CREATED, "total number of files created");
     describe_counter!(FILES_DELETED, "total number of files deleted");

--- a/crates/dbsp/src/circuit/mod.rs
+++ b/crates/dbsp/src/circuit/mod.rs
@@ -25,6 +25,7 @@ pub mod cache;
 pub mod checkpointer;
 pub mod circuit_builder;
 mod fingerprinter;
+pub mod metrics;
 pub mod operator_traits;
 pub mod schedule;
 pub mod trace;

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -2,6 +2,7 @@
 //! fashion.
 
 use crate::circuit::checkpointer::Checkpointer;
+use crate::circuit::metrics::describe_metrics;
 use crate::error::Error as DBSPError;
 use crate::trace::spine_async::merger::{BackgroundOperation, BatchMerger};
 use crate::{
@@ -430,6 +431,7 @@ impl Runtime {
             },
         );
         let storage = storage?;
+        describe_metrics();
 
         let runtime = Self(Arc::new(RuntimeInner::new(
             config,

--- a/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
@@ -17,18 +17,17 @@ use libc::{c_void, iovec};
 use metrics::{counter, histogram};
 use pipeline_types::config::StorageCacheConfig;
 
+use crate::circuit::metrics::{
+    FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS, READ_LATENCY, TOTAL_BYTES_READ,
+    TOTAL_BYTES_WRITTEN, WRITES_SUCCESS, WRITE_LATENCY,
+};
 use crate::storage::backend::{
-    metrics::{
-        FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS, READ_LATENCY, TOTAL_BYTES_READ,
-        TOTAL_BYTES_WRITTEN, WRITES_SUCCESS, WRITE_LATENCY,
-    },
     AtomicIncrementOnlyI64, FileHandle, ImmutableFile, ImmutableFileHandle, ImmutableFiles,
     Storage, IMMUTABLE_FILE_METADATA, NEXT_FILE_HANDLE,
 };
 use crate::storage::buffer_cache::FBuf;
 use crate::storage::init;
 
-use super::metrics::describe_disk_metrics;
 use super::{StorageCacheFlags, StorageError};
 
 #[cfg(test)]
@@ -533,7 +532,6 @@ impl IoUringBackend {
         immutable_files: Arc<ImmutableFiles>,
     ) -> Result<Self, IoError> {
         init();
-        describe_disk_metrics();
         Ok(Self {
             base: base.as_ref().to_path_buf(),
             cache,

--- a/crates/dbsp/src/storage/backend/memory_impl.rs
+++ b/crates/dbsp/src/storage/backend/memory_impl.rs
@@ -11,15 +11,12 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use crate::storage::{backend::NEXT_FILE_HANDLE, buffer_cache::FBuf};
-
-use super::{
-    metrics::{
-        describe_disk_metrics, FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS,
-        TOTAL_BYTES_READ, TOTAL_BYTES_WRITTEN, WRITES_SUCCESS,
-    },
-    AtomicIncrementOnlyI64, FileHandle, ImmutableFileHandle, Storage, StorageError,
+use super::{AtomicIncrementOnlyI64, FileHandle, ImmutableFileHandle, Storage, StorageError};
+use crate::circuit::metrics::{
+    FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS, TOTAL_BYTES_READ,
+    TOTAL_BYTES_WRITTEN, WRITES_SUCCESS,
 };
+use crate::storage::{backend::NEXT_FILE_HANDLE, buffer_cache::FBuf};
 
 /// Meta-data we keep per file we created.
 #[derive(Default)]
@@ -45,7 +42,6 @@ impl MemoryBackend {
     ///   Note that in case we use a global buffer cache, this counter should be
     ///   shared among all instances of the backend.
     pub fn new(next_file_id: Arc<AtomicIncrementOnlyI64>) -> Self {
-        describe_disk_metrics();
         Self {
             files: RwLock::new(HashMap::new()),
             next_file_id,

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -29,8 +29,6 @@ use uuid::Uuid;
 
 use crate::storage::buffer_cache::FBuf;
 
-pub mod metrics;
-
 #[cfg(target_os = "linux")]
 pub mod io_uring_impl;
 pub mod memory_impl;

--- a/crates/dbsp/src/storage/backend/posixio_impl.rs
+++ b/crates/dbsp/src/storage/backend/posixio_impl.rs
@@ -16,18 +16,16 @@ use std::{
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-use crate::storage::{backend::NEXT_FILE_HANDLE, buffer_cache::FBuf, init};
-
 use super::{
-    append_to_path,
-    metrics::{
-        describe_disk_metrics, FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS,
-        READ_LATENCY, TOTAL_BYTES_READ, TOTAL_BYTES_WRITTEN, WRITES_SUCCESS, WRITE_LATENCY,
-    },
-    tempdir_for_thread, AtomicIncrementOnlyI64, FileHandle, ImmutableFile, ImmutableFileHandle,
-    ImmutableFiles, Storage, StorageCacheFlags, StorageError, IMMUTABLE_FILE_METADATA,
-    MUTABLE_EXTENSION,
+    append_to_path, tempdir_for_thread, AtomicIncrementOnlyI64, FileHandle, ImmutableFile,
+    ImmutableFileHandle, ImmutableFiles, Storage, StorageCacheFlags, StorageError,
+    IMMUTABLE_FILE_METADATA, MUTABLE_EXTENSION,
 };
+use crate::circuit::metrics::{
+    FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS, READ_LATENCY, TOTAL_BYTES_READ,
+    TOTAL_BYTES_WRITTEN, WRITES_SUCCESS, WRITE_LATENCY,
+};
+use crate::storage::{backend::NEXT_FILE_HANDLE, buffer_cache::FBuf, init};
 
 /// Meta-data we keep per file we created.
 struct FileMetaData {
@@ -115,7 +113,6 @@ impl PosixBackend {
         immutable_files: Arc<ImmutableFiles>,
     ) -> Self {
         init();
-        describe_disk_metrics();
         Self {
             base: base.as_ref().to_path_buf(),
             files: RefCell::new(HashMap::new()),

--- a/crates/dbsp/src/storage/bin/bench.rs
+++ b/crates/dbsp/src/storage/bin/bench.rs
@@ -389,12 +389,6 @@ fn main() {
         create_dir_all(&args.path).expect("failed to create directory");
     }
 
-    #[cfg(feature = "metrics-exporter-tcp")]
-    {
-        let builder = metrics_exporter_tcp::TcpBuilder::new();
-        builder.install().expect("failed to install TCP exporter");
-    }
-
     let br = match args.backend {
         Backend::Posix => posixio_main(args.clone()),
         Backend::IoUring => io_uring_main(args.clone()),

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -14,13 +14,11 @@ use std::{
 use crc32c::crc32c;
 use metrics::counter;
 
+use crate::circuit::metrics::{BUFFER_CACHE_HIT, BUFFER_CACHE_MISS};
 use crate::storage::backend::Backend;
 use crate::storage::file::reader::{CorruptionError, Error};
 use crate::{
-    storage::backend::{
-        metrics::{BUFFER_CACHE_HIT, BUFFER_CACHE_MISS},
-        FileHandle, ImmutableFileHandle, Storage, StorageError,
-    },
+    storage::backend::{FileHandle, ImmutableFileHandle, Storage, StorageError},
     storage::buffer_cache::FBuf,
     Runtime,
 };

--- a/crates/dbsp/src/trace/spine_async/mod.rs
+++ b/crates/dbsp/src/trace/spine_async/mod.rs
@@ -7,11 +7,11 @@ use crate::{
     Error, NumEntries, Runtime,
 };
 
-use crate::dynamic::{ClonableTrait, DeserializableDyn};
-use crate::storage::backend::metrics::{
+use crate::circuit::metrics::{
     COMPACTION_DURATION, COMPACTION_SIZE, COMPACTION_SIZE_SAVINGS, COMPACTION_STALL_TIME,
     TOTAL_COMPACTIONS,
 };
+use crate::dynamic::{ClonableTrait, DeserializableDyn};
 use crate::storage::backend::StorageError;
 use crate::storage::file::to_bytes;
 use crate::storage::{checkpoint_path, write_commit_metadata};

--- a/crates/dbsp/src/trace/spine_fueled.rs
+++ b/crates/dbsp/src/trace/spine_fueled.rs
@@ -94,8 +94,8 @@ use crate::{
     Error, NumEntries,
 };
 
+use crate::circuit::metrics::{COMPACTION_DURATION, COMPACTION_SIZE, TOTAL_COMPACTIONS};
 use crate::dynamic::{ClonableTrait, DeserializableDyn};
-use crate::storage::backend::metrics::{COMPACTION_DURATION, COMPACTION_SIZE, TOTAL_COMPACTIONS};
 use crate::storage::file::to_bytes;
 use crate::storage::{checkpoint_path, write_commit_metadata};
 use metrics::{counter, histogram};

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -5,12 +5,12 @@
 use anyhow::{anyhow, Result};
 use ascii_table::AsciiTable;
 use clap::Parser;
-use dbsp::circuit::{CircuitConfig, StorageCacheConfig, StorageConfig};
-use dbsp::storage::backend::metrics::{
+use dbsp::circuit::metrics::{
     BUFFER_CACHE_HIT, BUFFER_CACHE_MISS, COMPACTION_SIZE_SAVINGS, COMPACTION_STALL_TIME,
     FILES_CREATED, READS_SUCCESS, TOTAL_BYTES_READ, TOTAL_BYTES_WRITTEN, TOTAL_COMPACTIONS,
     WRITES_SUCCESS,
 };
+use dbsp::circuit::{CircuitConfig, StorageCacheConfig, StorageConfig};
 use dbsp::storage::backend::tempdir_for_thread;
 use dbsp::utils::Tup2;
 use dbsp::{

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -138,17 +138,6 @@ pub struct RuntimeConfig {
     #[serde(default)]
     pub cpu_profiler: bool,
 
-    /// Enable the TCP metrics exporter.
-    ///
-    /// This is used for development purposes only.
-    /// If enabled, the `metrics-observer` CLI tool
-    /// can be used to inspect metrics from the pipeline.
-    ///
-    /// Because of how Rust metrics work, this is only honored for the first
-    /// pipeline to be instantiated within a given process.
-    #[serde(default)]
-    pub tcp_metrics_exporter: bool,
-
     /// Minimal input batch size.
     ///
     /// The controller delays pushing input records to the circuit until at

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -51,10 +51,10 @@ refinery = {version = "0.8.10", features = ["tokio-postgres"]}
 reqwest = {version = "0.11.18", features = ["json"]}
 url = {version = "2.4.0"}
 dirs = "5.0"
-prometheus-client = "0.22.0"
-once_cell = "1.18.0"
 rdkafka = { version = "0.34.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"] }
 thiserror = "1.0"
+metrics = "0.23"
+metrics-exporter-prometheus = "0.15.1"
 
 [features]
 integration-test = []

--- a/crates/pipeline_manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline_manager/src/bin/pipeline-manager.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
     let _prober = tokio::spawn(async move {
         run_prober(&prober_config, db_clone).await.unwrap();
     });
-    pipeline_manager::metrics::create_endpoint(registry).await;
+    pipeline_manager::metrics::create_endpoint(registry, db.clone()).await;
     // The api-server blocks forever
     pipeline_manager::api::run(db, api_config).await.unwrap();
     Ok(())

--- a/crates/pipeline_manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline_manager/src/bin/pipeline-manager.rs
@@ -64,8 +64,7 @@ async fn main() -> anyhow::Result<()> {
     let local_runner_config = local_runner_config.canonicalize()?;
     let prober_config = prober_config.canonicalize()?;
 
-    let mut registry = pipeline_manager::metrics::init();
-    pipeline_manager::compiler::register_metrics(&mut registry);
+    let metrics_handle = pipeline_manager::metrics::init();
     if compiler_config.precompile {
         Compiler::precompile_dependencies(&compiler_config).await?;
         return Ok(());
@@ -97,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
     let _prober = tokio::spawn(async move {
         run_prober(&prober_config, db_clone).await.unwrap();
     });
-    pipeline_manager::metrics::create_endpoint(registry, db.clone()).await;
+    pipeline_manager::metrics::create_endpoint(metrics_handle, db.clone()).await;
     // The api-server blocks forever
     pipeline_manager::api::run(db, api_config).await.unwrap();
     Ok(())

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -981,7 +981,6 @@ async fn versioning() {
         workers: 1,
         cpu_profiler: true,
         storage: false,
-        tcp_metrics_exporter: false,
         min_batch_size_records: 0,
         max_buffering_delay_usecs: 0,
         resources: ResourceConfig::default(),
@@ -1293,7 +1292,6 @@ pub(crate) fn runtime_config() -> impl Strategy<Value = RuntimeConfig> {
         min_batch_size_records: config.2,
         max_buffering_delay_usecs: config.3,
         storage: config.4,
-        tcp_metrics_exporter: false,
         resources: ResourceConfig {
             cpu_cores_min: config.5,
             cpu_cores_max: config.6,
@@ -1329,7 +1327,6 @@ pub(crate) fn option_runtime_config() -> impl Strategy<Value = Option<RuntimeCon
             min_batch_size_records: config.2,
             max_buffering_delay_usecs: config.3,
             storage: config.4,
-            tcp_metrics_exporter: false,
             resources: ResourceConfig {
                 cpu_cores_min: config.5,
                 cpu_cores_max: config.6,

--- a/crates/pipeline_manager/src/metrics.rs
+++ b/crates/pipeline_manager/src/metrics.rs
@@ -1,7 +1,17 @@
-use actix_web::{get, http::header::ContentType, web, HttpResponse, HttpServer, Responder};
+use std::sync::Arc;
+
+use actix_web::{
+    get,
+    http::{header::ContentType, Method},
+    web, HttpResponse, HttpServer, Responder,
+};
 use prometheus_client::{encoding::text::encode, registry::Registry};
+use tokio::sync::Mutex;
 
 use crate::api::ManagerError;
+use crate::db::storage::Storage;
+use crate::db::{PipelineStatus, ProjectDB};
+use crate::runner::RunnerApi;
 
 /// Initialize a metrics registry. This registry has to be passed
 /// to every sub-system that wants to register metrics.
@@ -9,16 +19,19 @@ pub fn init() -> Registry {
     Registry::default()
 }
 
-/// Create a scrape endpoint for metrics on http://0.0.0.0:9000/metrics
-pub async fn create_endpoint(registry: Registry) {
+/// Create a scrape endpoint for metrics on http://0.0.0.0:8081/metrics
+pub async fn create_endpoint(registry: Registry, db: Arc<Mutex<ProjectDB>>) {
     let registry = web::Data::new(registry);
+    let db = web::Data::new(db);
+
     let _http = tokio::spawn(
         HttpServer::new(move || {
             actix_web::App::new()
+                .app_data(db.clone())
                 .app_data(registry.clone())
                 .service(metrics)
         })
-        .bind(("0.0.0.0", 9000))
+        .bind(("0.0.0.0", 8081))
         .unwrap()
         .run(),
     );
@@ -26,9 +39,38 @@ pub async fn create_endpoint(registry: Registry) {
 
 /// A prometheus-compatible metrics scrape endpoint.
 #[get("/metrics")]
-async fn metrics(registry: web::Data<Registry>) -> Result<impl Responder, ManagerError> {
+async fn metrics(
+    db: web::Data<Arc<Mutex<ProjectDB>>>,
+    registry: web::Data<Registry>,
+) -> Result<impl Responder, ManagerError> {
     let mut buffer = String::new();
+
+    let db = db.lock().await;
+    let pipelines = db.all_pipelines().await?;
+    for (tenant_id, pipeline_id) in pipelines {
+        let rts = db
+            .get_pipeline_runtime_state_by_id(tenant_id, pipeline_id)
+            .await?;
+
+        // Get the metrics for all running pipelines, don't write anything
+        // if the request fails.
+        if rts.current_status == PipelineStatus::Running {
+            if let Ok(r) =
+                RunnerApi::pipeline_http_request(pipeline_id, Method::GET, "metrics", &rts.location)
+                    .await
+            {
+                if r.status().is_success() {
+                    if let Ok(r) = r.text().await {
+                        buffer += &r;
+                    }
+                }
+            }
+        }
+    }
+
+    // Finally, add pipeline-manager metrics
     encode(&mut buffer, &registry).unwrap();
+
     Ok(HttpResponse::Ok()
         .content_type(ContentType::plaintext())
         .body(buffer))

--- a/openapi.json
+++ b/openapi.json
@@ -873,7 +873,6 @@
                   },
                   "storage": false,
                   "storage_config": null,
-                  "tcp_metrics_exporter": false,
                   "workers": 8
                 }
               }
@@ -4446,10 +4445,6 @@
                 "type": "boolean",
                 "description": "Should persistent storage be enabled for this pipeline?\n\n- If `false` (default), the pipeline's state is kept in in-memory data-structures.\nThis is useful if the pipeline is ephemeral and does not need to be recovered\nafter a restart. The pipeline will most likely run faster since it does not\nneed to read from, or write to disk\n\n- If `true`, the pipeline state is stored in the specified location,\nis persisted across restarts, and can be checkpointed and recovered.\nThis feature is currently experimental."
               },
-              "tcp_metrics_exporter": {
-                "type": "boolean",
-                "description": "Enable the TCP metrics exporter.\n\nThis is used for development purposes only.\nIf enabled, the `metrics-observer` CLI tool\ncan be used to inspect metrics from the pipeline.\n\nBecause of how Rust metrics work, this is only honored for the first\npipeline to be instantiated within a given process."
-              },
               "workers": {
                 "type": "integer",
                 "format": "int32",
@@ -4988,10 +4983,6 @@
           "storage": {
             "type": "boolean",
             "description": "Should persistent storage be enabled for this pipeline?\n\n- If `false` (default), the pipeline's state is kept in in-memory data-structures.\nThis is useful if the pipeline is ephemeral and does not need to be recovered\nafter a restart. The pipeline will most likely run faster since it does not\nneed to read from, or write to disk\n\n- If `true`, the pipeline state is stored in the specified location,\nis persisted across restarts, and can be checkpointed and recovered.\nThis feature is currently experimental."
-          },
-          "tcp_metrics_exporter": {
-            "type": "boolean",
-            "description": "Enable the TCP metrics exporter.\n\nThis is used for development purposes only.\nIf enabled, the `metrics-observer` CLI tool\ncan be used to inspect metrics from the pipeline.\n\nBecause of how Rust metrics work, this is only honored for the first\npipeline to be instantiated within a given process."
           },
           "workers": {
             "type": "integer",


### PR DESCRIPTION
- Use metrics-prometheus-exporter t inject dbsp
      metrics into the adapter metrics endpoint.
- Access metrics of all running pipelines from
      pipeline-manager /metrics endpoint
- Move dbsp metrics description from storage to circuit
      module since they are global anyways.
- Annotate all metrics from a pipeline with
      the name of the pipeline.
- Remove support for the tcp-metrics-exporter since
      I expect we just use prometheus/grafana from now on
- Add a dummy metrics to measure steps since most
      dbsp metrics we have right now only kick in when we use
      storage code which makes it so no metrics appear
      for a long time

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
