### PR TITLE
Do not automatically distinct ouputs.

### DIFF
--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -1017,7 +1017,6 @@ impl CompilationJob {
             .arg("-i")
             .arg("-je")
             .arg("--alltables")
-            .arg("--outputsAreSets")
             .arg("--ignoreOrder")
             .arg("--unquotedCasing")
             .arg("lower")


### PR DESCRIPTION
This commit reverts our earlier decision to force views to behave as sets.

DBSP outputs can have non-unit weights.  As a result, a consumer that tracks the output of a circuit must generally keep track of multiplicities of records.  For example, two inserts followed by a delete leave the record in the Z-set with weight 1.  It turns out that many of the destinations we write to either do not support this semantics (or make it expensive to implement) and expect inputs to be distinct collections.

To support such destinations without surprising users with unexpected behavior, we used to automatically apply the `distinct` operator to all non-local views (by passing a --outputsAreSets flag to the compiler).

This no longer looks like a good choice for several reasons:

- Memory(storage) and CPU overhead, whether the consumer actually requires this or not (or if there's even a connector attached to the view).

- Attaching DISTINCT to the output is in any cases not sufficient for many destinations, e.g., Snowflake and Delta don't support deletions at all.  Such destinations usually require logging all changes (insertions and deletions) to a staging area and merging them into the main table using some kind of a periodic task.

- The user can always enforce set semantics manually by using `SELECT DISTINCT`

- As we are starting to work on support for ad hoc queries, we will enable scenarios where users can query outputs directly from Feldera without sending them to a database.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
