### PR TITLE
Switch from log to tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,8 +3647,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "libc",
- "log",
- "metrics",
+ "metrics 0.23.0",
  "mimalloc-rust-sys",
  "nix 0.27.1",
  "num",
@@ -3685,6 +3684,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "typedmap",
  "uuid",
  "xxhash-rust",
@@ -3728,8 +3728,7 @@ dependencies = [
  "futures-util",
  "jemalloc_pprof",
  "lazy_static",
- "log",
- "metrics",
+ "metrics 0.22.3",
  "metrics-exporter-tcp",
  "metrics-util",
  "mime",
@@ -3766,6 +3765,7 @@ dependencies = [
  "tempfile",
  "test_bin",
  "tokio",
+ "tracing",
  "url",
  "utoipa",
  "uuid",
@@ -3785,7 +3785,7 @@ dependencies = [
  "env_logger 0.10.2",
  "hdrhist",
  "indicatif",
- "metrics",
+ "metrics 0.22.3",
  "metrics-util",
  "mimalloc-rust-sys",
  "num-format",
@@ -5873,6 +5873,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
 name = "metrics-exporter-tcp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5881,7 +5891,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "home",
- "metrics",
+ "metrics 0.22.3",
  "mio",
  "prost 0.12.6",
  "prost-build",
@@ -5900,7 +5910,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
- "metrics",
+ "metrics 0.22.3",
  "num_cpus",
  "ordered-float 4.2.0",
  "quanta",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -44,7 +44,7 @@ aws-types = "1.1.7"
 actix = "0.13.1"
 actix-web = { version = "4.4.0", default-features = false, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
 mime = "0.3.16"
-log = "0.4.20"
+tracing = { version = "0.1.40" }
 # Once chrono is released with `849932` chrono version needs to be updated in size-of crate:
 size-of = { git = "https://github.com/gz/size-of.git", rev = "3ec40db", features = ["time-std", "ordered-float"], optional = true }
 futures = { version = "0.3.28" }

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -51,8 +51,6 @@ use crossbeam::{
     sync::{Parker, ShardedLock, Unparker},
 };
 use dbsp::circuit::{CircuitConfig, Layout};
-use log::trace;
-use log::{debug, error, info};
 use metrics::set_global_recorder;
 use metrics_util::{
     debugging::{DebuggingRecorder, Snapshotter},
@@ -70,6 +68,7 @@ use std::{
     thread::{spawn, JoinHandle},
     time::{Duration, Instant},
 };
+use tracing::{debug, error, info, trace};
 use uuid::Uuid;
 
 mod error;

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -37,7 +37,6 @@ use crate::{
 };
 use anyhow::Error as AnyError;
 use crossbeam::sync::{ShardedLock, ShardedLockReadGuard, Unparker};
-use log::error;
 use metrics::{KeyName, SharedString as MetricString, Unit as MetricUnit};
 use metrics_util::{
     debugging::{DebugValue, Snapshot},
@@ -58,6 +57,7 @@ use std::{
         Mutex,
     },
 };
+use tracing::error;
 
 #[derive(Default, Serialize)]
 pub struct GlobalControllerMetrics {

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -5,7 +5,6 @@ use actix_web::HttpRequest;
 use anyhow::{anyhow, bail, Result as AnyResult};
 use apache_avro::{to_avro_datum, Schema as AvroSchema};
 use erased_serde::Serialize as ErasedSerialize;
-use log::{debug, error};
 use pipeline_types::format::avro::AvroEncoderConfig;
 use pipeline_types::program_schema::Relation;
 use schema_registry_converter::avro_common::get_supplied_schema;
@@ -16,6 +15,7 @@ use serde_yaml::Value as YamlValue;
 use std::borrow::Cow;
 use std::str::FromStr;
 use std::time::Duration;
+use tracing::{debug, error};
 
 // TODOs:
 // - This connector currently only supports raw Avro format, i.e., deletes cannot be represented.
@@ -312,11 +312,11 @@ mod test {
     use crate::{Encoder, SerBatch};
     use dbsp::utils::Tup2;
     use dbsp::{DBData, OrdZSet};
-    use log::trace;
     use pipeline_types::serde_with_context::{SerializeWithContext, SqlSerdeConfig};
     use proptest::proptest;
     use serde::Deserialize;
     use std::sync::Arc;
+    use tracing::trace;
 
     fn test_avro<T>(avro_schema: &str, batches: Vec<Vec<Tup2<T, i64>>>)
     where

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -452,13 +452,13 @@ mod test {
         transport::InputConsumer,
         FormatConfig, ParseError,
     };
-    use log::trace;
     use pipeline_types::{
         deserialize_table_record,
         format::json::{JsonFlavor, JsonParserConfig, JsonUpdateFormat},
         serde_with_context::{DeserializeWithContext, SqlSerdeConfig},
     };
     use std::{borrow::Cow, fmt::Debug};
+    use tracing::trace;
 
     #[derive(PartialEq, Debug, Eq)]
     struct TestStruct {

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -386,12 +386,12 @@ mod test {
         test::{generate_test_batches_with_weights, MockOutputConsumer, TestStruct},
     };
     use dbsp::{utils::Tup2, OrdZSet};
-    use log::trace;
     use pipeline_types::format::json::JsonUpdateFormat;
     use pipeline_types::program_schema::Relation;
     use proptest::prelude::*;
     use serde::Deserialize;
     use std::{cell::RefCell, fmt::Debug, rc::Rc, sync::Arc};
+    use tracing::trace;
 
     trait OutputUpdate: Debug + for<'de> Deserialize<'de> + Eq + Ord {
         type Val;

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -173,6 +173,6 @@ fn debug_parquet_buffer(buffer: Vec<u8>) {
         .expect("Row iterator creation should succeed");
     for maybe_record in row_iter {
         let record = maybe_record.expect("Record should be read successfully");
-        log::info!("record = {:?}", record.to_string());
+        tracing::info!("record = {:?}", record.to_string());
     }
 }

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -26,7 +26,6 @@ use deltalake::table::PeekCommit;
 use deltalake::{datafusion, DeltaTable, DeltaTableBuilder, Path};
 use env_logger::builder;
 use futures_util::StreamExt;
-use log::{debug, error, info, trace};
 use pipeline_types::config::{InputEndpointConfig, TransportConfigVariant};
 use pipeline_types::format::json::JsonFlavor;
 use pipeline_types::program_schema::Relation;
@@ -42,6 +41,7 @@ use tokio::select;
 use tokio::sync::mpsc;
 use tokio::sync::watch::{channel, Receiver, Sender};
 use tokio::time::sleep;
+use tracing::{debug, error, info, trace};
 use url::Url;
 use utoipa::ToSchema;
 

--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -19,7 +19,6 @@ use deltalake::operations::transaction::{CommitBuilder, TableReference};
 use deltalake::operations::writer::{DeltaWriter, WriterConfig};
 use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::DeltaTable;
-use log::{debug, error, info, trace};
 use pipeline_types::transport::delta_table::DeltaTableWriteMode;
 use pipeline_types::{program_schema::Relation, transport::delta_table::DeltaTableWriterConfig};
 use serde_arrow::schema::SerdeArrowSchema;
@@ -27,6 +26,7 @@ use serde_arrow::ArrayBuilder;
 use std::cmp::min;
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tracing::{debug, error, info, trace};
 
 struct DeltaTableWriterInner {
     endpoint_id: EndpointId,

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -25,7 +25,6 @@ use deltalake::operations::create::CreateBuilder;
 use deltalake::protocol::SaveMode;
 use deltalake::{DeltaOps, DeltaTable, DeltaTableBuilder};
 use env_logger::Env;
-use log::{debug, info, trace};
 use parquet::file::reader::Length;
 use pipeline_types::config::PipelineConfig;
 use pipeline_types::program_schema::{Field, Relation};
@@ -52,6 +51,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tempfile::{tempdir, NamedTempFile, TempDir};
 use tokio::time::sleep;
+use tracing::{debug, info, trace};
 use uuid::Uuid;
 
 fn delta_output_serde_config() -> SqlSerdeConfig {

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -21,7 +21,6 @@ use colored::Colorize;
 use dbsp::circuit::CircuitConfig;
 use dbsp::operator::sample::MAX_QUANTILES;
 use env_logger::Env;
-use log::{debug, error, info, warn};
 use pipeline_types::{format::json::JsonFlavor, transport::http::EgressMode};
 use pipeline_types::{query::OutputQuery, transport::http::SERVER_PORT_FILE};
 use serde::Deserialize;
@@ -41,6 +40,7 @@ use tokio::{
     spawn,
     sync::mpsc::{channel, Sender},
 };
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 pub mod error;
@@ -966,8 +966,8 @@ mod test_with_kafka {
             .unwrap()
             .current();
 
-        //let _ = log::set_logger(&TEST_LOGGER);
-        //log::set_max_level(LevelFilter::Debug);
+        //let _ = tracing::set_logger(&TEST_LOGGER);
+        //tracing::set_max_level(LevelFilter::Debug);
 
         // Create topics.
         let kafka_resources = KafkaResources::create_topics(&[

--- a/crates/adapters/src/test/http.rs
+++ b/crates/adapters/src/test/http.rs
@@ -7,7 +7,7 @@ use awc::{error::PayloadError, ClientRequest};
 use csv::ReaderBuilder as CsvReaderBuilder;
 use csv::WriterBuilder as CsvWriterBuilder;
 use futures::{Stream, StreamExt};
-use log::trace;
+use tracing::trace;
 
 pub struct TestHttpSender;
 pub struct TestHttpReceiver;

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -7,7 +7,6 @@ use anyhow::{anyhow, bail, Result as AnyResult};
 use csv::WriterBuilder as CsvWriterBuilder;
 use futures::executor::block_on;
 use lazy_static::lazy_static;
-use log::{error, info};
 use pipeline_types::program_schema::Relation;
 use pipeline_types::transport::kafka::default_redpanda_server;
 use rdkafka::message::BorrowedMessage;
@@ -29,6 +28,7 @@ use std::{
     thread::{sleep, JoinHandle},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use tracing::{error, info};
 
 static MAX_TOPIC_PROBE_TIMEOUT: Duration = Duration::from_millis(20_000);
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use anyhow::Result as AnyResult;
 use dbsp::{DBData, OrdZSet, Runtime};
-use log::{Log, Metadata, Record};
 use pipeline_types::serde_with_context::{
     DeserializeWithContext, SerializeWithContext, SqlSerdeConfig,
 };
@@ -43,23 +42,7 @@ pub use mock_input_consumer::MockInputConsumer;
 pub use mock_output_consumer::MockOutputConsumer;
 use pipeline_types::program_schema::{Field, Relation};
 
-pub struct TestLogger;
-
-pub static TEST_LOGGER: TestLogger = TestLogger;
-
 pub static DEFAULT_TIMEOUT_MS: u128 = 600_000;
-
-impl Log for TestLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        println!("{} - {}", record.level(), record.args());
-    }
-
-    fn flush(&self) {}
-}
 
 /// Wait for `predicate` to become `true`.
 ///

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -9,7 +9,6 @@ use actix_web::{web::Payload, HttpResponse};
 use anyhow::{anyhow, Error as AnyError, Result as AnyResult};
 use circular_queue::CircularQueue;
 use futures_util::StreamExt;
-use log::debug;
 use num_traits::FromPrimitive;
 use serde::Deserialize;
 use std::{
@@ -20,6 +19,7 @@ use std::{
     time::Duration,
 };
 use tokio::{sync::watch, time::timeout};
+use tracing::debug;
 
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) enum HttpIngressMode {

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -3,8 +3,6 @@ use actix_web::{http::header::ContentType, web::Bytes, HttpResponse};
 use anyhow::{anyhow, bail, Result as AnyResult};
 use async_stream::stream;
 use crossbeam::sync::ShardedLock;
-use log::debug;
-use log::error;
 use serde::{ser::SerializeStruct, Serializer};
 use serde_json::value::RawValue;
 use std::{
@@ -18,6 +16,8 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::timeout,
 };
+use tracing::debug;
+use tracing::error;
 
 // TODO: make this configurable via endpoint config.
 const MAX_BUFFERS: usize = 100;

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -5,7 +5,6 @@ use crate::{InputConsumer, TransportInputEndpoint};
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
 use crossbeam::sync::{Parker, Unparker};
 use futures::executor::block_on;
-use log::{debug, error, info, warn};
 use pipeline_types::transport::kafka::KafkaInputConfig;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
 use rdkafka::config::{FromClientConfig, FromClientConfigAndContext};
@@ -32,6 +31,7 @@ use std::{
     sync::{Arc, Mutex},
     thread::{Builder, JoinHandle},
 };
+use tracing::{debug, error, info, warn};
 
 use super::CommonConfig;
 

--- a/crates/adapters/src/transport/kafka/ft/mod.rs
+++ b/crates/adapters/src/transport/kafka/ft/mod.rs
@@ -16,7 +16,6 @@ mod output;
 
 use crate::transport::kafka::refine_kafka_error;
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
-use log::{debug, error, info, warn};
 use pipeline_types::transport::kafka::{default_redpanda_server, KafkaLogLevel};
 use rdkafka::{
     client::Client as KafkaClient,
@@ -38,6 +37,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 pub use input::Endpoint as KafkaFtInputEndpoint;

--- a/crates/adapters/src/transport/kafka/ft/output.rs
+++ b/crates/adapters/src/transport/kafka/ft/output.rs
@@ -4,7 +4,6 @@ use crate::{
     AsyncErrorCallback, OutputEndpoint,
 };
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
-use log::{debug, info, warn};
 use pipeline_types::transport::kafka::KafkaOutputConfig;
 use rdkafka::message::OwnedHeaders;
 use rdkafka::{
@@ -21,6 +20,7 @@ use std::{
     sync::{Condvar, Mutex, RwLock},
     time::Duration,
 };
+use tracing::{debug, info, warn};
 
 use super::{count_partitions_in_topic, CommonConfig, Ctp, DataConsumerContext};
 

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -11,7 +11,6 @@ use crate::{
 use anyhow::Error as AnyError;
 use crossbeam::sync::{Parker, Unparker};
 use env_logger::Env;
-use log::info;
 use proptest::prelude::*;
 use rdkafka::mocking::MockCluster;
 use std::{
@@ -23,6 +22,7 @@ use std::{
     thread::sleep,
     time::{Duration, Instant},
 };
+use tracing::info;
 use uuid::Uuid;
 
 /// Wait to receive all records in `data` in the same order.

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -104,7 +104,7 @@ impl DeferredLogging {
         *self.0.lock().unwrap() = Some(Vec::new());
         let r = f();
         for (level, fac, message) in self.0.lock().unwrap().take().unwrap().drain(..) {
-            log::info!("{level:?} {fac} {message}");
+            tracing::info!("{level:?} {fac} {message}");
         }
         r
     }
@@ -151,19 +151,19 @@ impl DeferredLogging {
             | RDKafkaLogLevel::Alert
             | RDKafkaLogLevel::Critical
             | RDKafkaLogLevel::Error => {
-                log::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Warning => {
-                log::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Notice => {
-                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Info => {
-                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Debug => {
-                log::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
         }
     }

--- a/crates/adapters/src/transport/kafka/nonft/input.rs
+++ b/crates/adapters/src/transport/kafka/nonft/input.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use crossbeam::queue::ArrayQueue;
-use log::debug;
 use num_traits::FromPrimitive;
 use pipeline_types::{secret_ref::MaybeSecretRef, transport::kafka::KafkaInputConfig};
 use rdkafka::config::RDKafkaLogLevel;
@@ -28,6 +27,7 @@ use std::{
     thread::spawn,
     time::{Duration, Instant},
 };
+use tracing::debug;
 
 const POLL_TIMEOUT: Duration = Duration::from_millis(100);
 

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -3,7 +3,6 @@ use crate::transport::secret_resolver::MaybeSecret;
 use crate::{AsyncErrorCallback, OutputEndpoint};
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use crossbeam::sync::{Parker, Unparker};
-use log::debug;
 use pipeline_types::secret_ref::MaybeSecretRef;
 use pipeline_types::transport::kafka::KafkaOutputConfig;
 use rdkafka::message::OwnedHeaders;
@@ -15,6 +14,7 @@ use rdkafka::{
     ClientConfig, ClientContext,
 };
 use std::{sync::RwLock, time::Duration};
+use tracing::debug;
 
 const OUTPUT_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 

--- a/crates/adapters/src/transport/kafka/nonft/test.rs
+++ b/crates/adapters/src/transport/kafka/nonft/test.rs
@@ -7,7 +7,6 @@ use crate::{
     Controller, PipelineConfig,
 };
 use env_logger::Env;
-use log::info;
 use parquet::data_type::AsBytes;
 use proptest::prelude::*;
 use rdkafka::message::{BorrowedMessage, Header, Headers};
@@ -21,6 +20,7 @@ use std::{
     thread::sleep,
     time::Duration,
 };
+use tracing::info;
 
 /// Wait to receive all records in `data` in the same order.
 fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct, TestStruct>, data: &[Vec<TestStruct>]) {

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use aws_sdk_s3::operation::{get_object::GetObjectOutput, list_objects_v2::ListObjectsV2Error};
-use log::error;
 use tokio::sync::{
     mpsc,
     watch::{channel, Receiver, Sender},
 };
+use tracing::error;
 
 use crate::{InputConsumer, InputReader, PipelineState, TransportInputEndpoint};
 #[cfg(test)]

--- a/crates/adapters/src/transport/secret_resolver.rs
+++ b/crates/adapters/src/transport/secret_resolver.rs
@@ -6,9 +6,9 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{anyhow, Result as AnyResult};
-use log::debug;
 use pipeline_types::secret_ref::MaybeSecretRef;
 use regex::Regex;
+use tracing::debug;
 
 /// Enumeration which holds a simple string or a resolved secret's string.
 ///

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -63,8 +63,8 @@ thiserror = "1.0"
 uuid = { version = "1.6.1", features = ["v7"] }
 clap = { version = "4.4.14", features = ["derive", "env", "wrap_help"] }
 fdlimit = { version = "0.3.0" }
-metrics = { version = "0.22.0" }
-log = { version = "0.4", features = [] }
+metrics = { version = "0.23.0" }
+tracing = { version = "0.1.40" }
 rlimit = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 ptr_meta = "0.2.0"

--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -126,15 +126,15 @@ impl Checkpointer {
             ) || path.is_dir()
             {
                 if path.is_dir() {
-                    log::debug!("Removing unused directory '{}'", path.display());
+                    tracing::debug!("Removing unused directory '{}'", path.display());
                     fs::remove_dir_all(path)?;
                 } else {
                     match fs::remove_file(path) {
                         Ok(_) => {
-                            log::debug!("Removed unused file '{}'", path.display());
+                            tracing::debug!("Removed unused file '{}'", path.display());
                         }
                         Err(e) => {
-                            log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", path.display(), e);
+                            tracing::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", path.display(), e);
                         }
                     }
                 }
@@ -250,10 +250,10 @@ impl Checkpointer {
             );
             match fs::remove_file(file) {
                 Ok(_) => {
-                    log::debug!("Removed file {}", file.as_ref().display());
+                    tracing::debug!("Removed file {}", file.as_ref().display());
                 }
                 Err(e) => {
-                    log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", file.as_ref().display(), e);
+                    tracing::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", file.as_ref().display(), e);
                 }
             }
         }
@@ -266,7 +266,7 @@ impl Checkpointer {
         assert_ne!(cpm.uuid, Uuid::nil());
         let checkpoint_dir = self.storage_path.join(cpm.uuid.to_string());
         if !checkpoint_dir.exists() {
-            log::warn!(
+            tracing::warn!(
                 "Tried to remove a checkpoint directory '{}' that doesn't exist.",
                 checkpoint_dir.display()
             );

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -846,7 +846,7 @@ impl RuntimeHandle {
         match st {
             StorageLocation::Temporary(path) => {
                 if std::thread::panicking() || did_runtime_panic {
-                    log::info!("Preserved runtime storage at: {:?} due to panic", path);
+                    tracing::info!("Preserved runtime storage at: {:?} due to panic", path);
                 } else {
                     let _ = std::fs::remove_dir_all(path);
                 }

--- a/crates/dbsp/src/error.rs
+++ b/crates/dbsp/src/error.rs
@@ -1,6 +1,5 @@
 use crate::{storage::backend::StorageError, RuntimeError, SchedulerError};
 use anyhow::Error as AnyError;
-use log::Level;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     borrow::Cow,
@@ -8,11 +7,12 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     io::Error as IOError,
 };
+use tracing::Level;
 
 pub trait DetailedError: StdError + Serialize {
     fn error_code(&self) -> Cow<'static, str>;
     fn log_level(&self) -> Level {
-        Level::Error
+        Level::ERROR
     }
 }
 

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -20,11 +20,11 @@ use std::{
     },
 };
 
-use log::{trace, warn};
 use pipeline_types::config::StorageCacheConfig;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use tempfile::TempDir;
 use thiserror::Error;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use crate::storage::buffer_cache::FBuf;

--- a/crates/dbsp/src/storage/dirlock/mod.rs
+++ b/crates/dbsp/src/storage/dirlock/mod.rs
@@ -3,12 +3,12 @@
 //! Makes sure we don't accidentally run multiple instances of the program
 //! using the same data directory.
 
-use log::{debug, warn};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Error as IoError, ErrorKind, Read, Write};
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use sysinfo::{Pid, System};
+use tracing::{debug, warn};
 
 use crate::storage::backend::StorageError;
 
@@ -110,12 +110,12 @@ impl LockedDirectory {
                     // The pidfile is ours, just leave it as is.
                 } else {
                     // The process doesn't exist, so we can safely overwrite the pidfile.
-                    log::debug!("Found stale pidfile: {}", pid_file.display());
+                    tracing::debug!("Found stale pidfile: {}", pid_file.display());
                 }
             } else {
                 // If the pidfile is corrupt, we won't take ownership of the storage dir until
                 // the user fixes it.
-                log::error!(
+                tracing::error!(
                     "Invalid pidfile contents: '{}' in {}, pipeline refused to take ownership of storage dir.",
                     contents,
                     pid_file.display(),

--- a/crates/dbsp/src/storage/mod.rs
+++ b/crates/dbsp/src/storage/mod.rs
@@ -11,10 +11,10 @@ pub mod file;
 mod test;
 
 use fdlimit::{raise_fd_limit, Outcome::LimitRaised};
-use log::{info, warn};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use tracing::{info, warn};
 
 use crate::{Error, Runtime};
 use std::sync::Once;

--- a/crates/dbsp/src/trace/spine_async/merger.rs
+++ b/crates/dbsp/src/trace/spine_async/merger.rs
@@ -55,7 +55,7 @@ impl BatchMerger {
                 Err(e) => {
                     // We dropped all references to the recv channel, this means
                     // the circuit was destroyed, we can exit the compactor thread.
-                    log::trace!(
+                    tracing::trace!(
                         "exiting compactor thread due to rx error on channel: {:?}",
                         e
                     );


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/1939

This just migrates the `log::` statements to `tracing::` statements. It doesn't add integration with e.g., jaegertracing yet.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
