### PR TITLE
Use a single tokio runtime instead of `n`.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -7,6 +7,7 @@ use crate::{
     TransportInputEndpoint,
 };
 use anyhow::{anyhow, Result as AnyResult};
+use dbsp::circuit::tokio::TOKIO;
 use dbsp::InputHandle;
 use deltalake::datafusion::common::Column;
 use deltalake::datafusion::dataframe::DataFrame;
@@ -116,12 +117,7 @@ impl DeltaTableInputReader {
             .configure_arrow_deserializer(delta_input_serde_config())?;
 
         std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()
-                .expect("Could not create tokio runtime");
-            rt.block_on(async {
+            TOKIO.block_on(async {
                 let _ = Self::worker_task(
                     endpoint_clone,
                     input_stream,

--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -12,6 +12,7 @@ use crate::{
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema as ArrowSchema;
+use dbsp::circuit::tokio::TOKIO;
 use deltalake::kernel::{Action, DataType, StructField};
 use deltalake::operations::create::CreateBuilder;
 use deltalake::operations::transaction;
@@ -108,12 +109,7 @@ impl DeltaTableWriter {
 
         // Start tokio runtime.
         std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()
-                .expect("Could not create Tokio runtime");
-            rt.block_on(async {
+            TOKIO.block_on(async {
                 let _ = Self::worker_task(inner_clone, command_receiver, response_sender).await;
             })
         });

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -8,6 +8,7 @@ use tokio::sync::{
 use tracing::error;
 
 use crate::{InputConsumer, InputReader, PipelineState, TransportInputEndpoint};
+use dbsp::circuit::tokio::TOKIO;
 #[cfg(test)]
 use mockall::automock;
 
@@ -156,12 +157,7 @@ impl S3InputReader {
         let config_clone = config.clone();
         let receiver_clone = receiver.clone();
         std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()
-                .expect("Could not create Tokio runtime");
-            rt.block_on(async {
+            TOKIO.block_on(async {
                 let _ =
                     Self::worker_task(s3_client, config_clone, &mut consumer, receiver_clone).await;
             })

--- a/crates/dbsp/src/circuit/mod.rs
+++ b/crates/dbsp/src/circuit/mod.rs
@@ -28,6 +28,7 @@ mod fingerprinter;
 pub mod metrics;
 pub mod operator_traits;
 pub mod schedule;
+pub mod tokio;
 pub mod trace;
 
 pub use activations::{Activations, Activator};

--- a/crates/dbsp/src/circuit/tokio.rs
+++ b/crates/dbsp/src/circuit/tokio.rs
@@ -1,0 +1,7 @@
+use once_cell::sync::Lazy;
+use tokio::runtime::Runtime;
+
+/// The process running dbsp can share a single Tokio runtime.
+///
+/// This is `pub` so it can be used in adapters too for IO.
+pub static TOKIO: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());

--- a/crates/dbsp/src/operator/communication/exchange.rs
+++ b/crates/dbsp/src/operator/communication/exchange.rs
@@ -9,6 +9,7 @@ use crate::{
     circuit::{
         metadata::OperatorLocation,
         operator_traits::{Operator, SinkOperator, SourceOperator},
+        tokio::TOKIO,
         Host, LocalStoreMarker, OwnershipPreference, Runtime, Scope,
     },
     circuit_cache_key,
@@ -17,7 +18,7 @@ use crate::{
 };
 use crossbeam_utils::CachePadded;
 use futures::{future, prelude::*};
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -37,14 +38,10 @@ use tarpc::{
     tokio_util::sync::{CancellationToken, DropGuard},
 };
 use tokio::{
-    runtime::Runtime as TokioRuntime,
     sync::{Notify, OnceCell as TokioOnceCell},
     time::sleep,
 };
 use typedmap::TypedMapKey;
-
-// All circuits can share a single Tokio runtime.
-static TOKIO: Lazy<TokioRuntime> = Lazy::new(|| TokioRuntime::new().unwrap());
 
 // We use the `Runtime::local_store` mechanism to connect multiple workers
 // to an `Exchange` instance.  During circuit construction, each worker


### PR DESCRIPTION
Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
