### PR TITLE
Add script to run flink on CI

### DIFF
--- a/benchmark/flink/run-flink.sh
+++ b/benchmark/flink/run-flink.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -x
-cd "$(dirname "$0")"
-rm -rf nexmark nexmark-flink
-git clone git@github.com:blp/nexmark.git
-(cd nexmark/nexmark-flink && ./build.sh)
-tar xzf nexmark/nexmark-flink/nexmark-flink.tgz
-cd ..
-./run-nexmark.sh --events 100000000 -r flink -o flink-results.csv

--- a/benchmark/flink/run-flink.sh
+++ b/benchmark/flink/run-flink.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -x
+cd "$(dirname "$0")"
+rm -rf nexmark nexmark-flink
+git clone git@github.com:blp/nexmark.git
+(cd nexmark/nexmark-flink && ./build.sh)
+tar xzf nexmark/nexmark-flink/nexmark-flink.tgz
+cd ..
+./run-nexmark.sh --events 100000000 -r flink -o flink-results.csv

--- a/benchmark/flink/setup-flink.sh
+++ b/benchmark/flink/setup-flink.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -x
+cd "$(dirname "$0")"
+rm -rf nexmark nexmark-flink
+git clone https://github.com/blp/nexmark.git
+(cd nexmark/nexmark-flink && ./build.sh)
+tar xzf nexmark/nexmark-flink/nexmark-flink.tgz


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Adds the flink-benchmark Earthly task which runs flink benchmarks and saves the result as flink_results.csv.

The command works as follows:
- installs a newer version of docker compose since the default one doesn't work
- installs maven, which is necessary for flink
- runs flink in docker and pipes the results to run-nexmark.sh, which parses the results into csv format

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
