### PR TITLE
Make profiles downloadable via API

### DIFF
--- a/crates/adapters/src/circuit_handle.rs
+++ b/crates/adapters/src/circuit_handle.rs
@@ -1,5 +1,5 @@
 use crate::ControllerError;
-use dbsp::DBSPHandle;
+use dbsp::{profile::GraphProfile, DBSPHandle};
 use std::path::PathBuf;
 
 /// Trait for DBSP circuit handle objects.
@@ -9,6 +9,8 @@ pub trait DbspCircuitHandle {
     fn enable_cpu_profiler(&mut self) -> Result<(), ControllerError>;
 
     fn dump_profile(&mut self, dir_path: &str) -> Result<PathBuf, ControllerError>;
+
+    fn graph_profile(&mut self) -> Result<GraphProfile, ControllerError>;
 
     fn kill(self: Box<Self>) -> std::thread::Result<()>;
 }
@@ -24,6 +26,10 @@ impl DbspCircuitHandle for DBSPHandle {
 
     fn dump_profile(&mut self, dir_path: &str) -> Result<PathBuf, ControllerError> {
         DBSPHandle::dump_profile(self, dir_path).map_err(ControllerError::dbsp_error)
+    }
+
+    fn graph_profile(&mut self) -> Result<GraphProfile, ControllerError> {
+        DBSPHandle::graph_profile(self).map_err(ControllerError::dbsp_error)
     }
 
     fn kill(self: Box<Self>) -> std::thread::Result<()> {

--- a/crates/adapters/src/controller/error.rs
+++ b/crates/adapters/src/controller/error.rs
@@ -545,6 +545,9 @@ pub enum ControllerError {
 
     /// Panic inside the DBSP controller.
     ControllerPanic,
+
+    /// Controller terminated before profile ran.
+    ControllerExit,
 }
 
 fn serialize_io_error<S>(
@@ -634,6 +637,7 @@ impl DetailedError for ControllerError {
             Self::DbspError { error } => error.error_code(),
             Self::DbspPanic => Cow::from("DbspPanic"),
             Self::ControllerPanic => Cow::from("ControllerPanic"),
+            Self::ControllerExit => Cow::from("ControllerExit"),
         }
     }
 }
@@ -717,6 +721,9 @@ impl Display for ControllerError {
             }
             Self::ControllerPanic => {
                 write!(f, "Panic inside the DBSP controller")
+            }
+            ControllerError::ControllerExit => {
+                write!(f, "Controller exited without running profile")
             }
         }
     }

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -74,6 +74,7 @@ libc = "0.2.153"
 static_assertions = "1.1.0"
 lazy_static = "1.4.0"
 dashmap = "5"
+zip = "0.6.2"
 
 [dependencies.time]
 version = "0.3.20"
@@ -91,7 +92,6 @@ proptest-state-machine = { version = "0.1.0" }
 futures = { version = "0.3.30", features = ["executor"] }
 pretty_assertions = { version = "1.4" }
 csv = "1.2.2"
-zip = "0.6.2"
 tar = "0.4.38"
 zstd = "0.12.0"
 criterion = "0.5.1"

--- a/crates/dbsp/src/monitor/visual_graph.rs
+++ b/crates/dbsp/src/monitor/visual_graph.rs
@@ -1,16 +1,23 @@
 //! Intermediate representation of a circuit graph suitable for
 //! conversion to a visual format like dot.
 
-use std::fmt::{self, Write};
+use std::fmt::{self, Debug, Write};
 
 type Id = String;
 
 /// Visual representation of a circuit graph.
 ///
 /// The graph consists of a tree of cluster nodes populated with simple nodes.
+#[derive(Clone, Default)]
 pub struct Graph {
     nodes: ClusterNode,
     edges: Vec<Edge>,
+}
+
+impl Debug for Graph {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Graph {{ \"{}\" }}", self.to_dot())
+    }
 }
 
 impl Graph {
@@ -37,6 +44,7 @@ impl Graph {
     }
 }
 
+#[derive(Clone)]
 pub(super) struct SimpleNode {
     id: Id,
     label: String,
@@ -56,6 +64,7 @@ impl SimpleNode {
 // TODO:
 // * Visually distinguish subcircuits from regions (e.g., dashed vs solid
 //   boundaries).
+#[derive(Clone, Default)]
 pub(super) struct ClusterNode {
     id: Id,
     label: String,
@@ -86,6 +95,7 @@ impl ClusterNode {
     }
 }
 
+#[derive(Clone)]
 pub(super) enum Node {
     Simple(SimpleNode),
     Cluster(ClusterNode),
@@ -107,6 +117,7 @@ impl Node {
     }
 }
 
+#[derive(Clone)]
 pub(super) struct Edge {
     from_node: Id,
     // Is `from_node` a cluster?

--- a/crates/pipeline_manager/src/api/pipeline.rs
+++ b/crates/pipeline_manager/src/api/pipeline.rs
@@ -667,8 +667,8 @@ pub(crate) async fn pipeline_delete(
 #[utoipa::path(
     responses(
     (status = OK
-    , description = "Profile dump initiated."
-    , content_type = "application/json"
+    , description = "Obtains a circuit performance profile."
+    , content_type = "application/zip"
     , body = Object),
     (status = BAD_REQUEST
     , description = "Specified pipeline id is not a valid uuid."

--- a/openapi.json
+++ b/openapi.json
@@ -1265,9 +1265,9 @@
         ],
         "responses": {
           "200": {
-            "description": "Profile dump initiated.",
+            "description": "Obtains a circuit performance profile.",
             "content": {
-              "application/json": {
+              "application/zip": {
                 "schema": {
                   "type": "object"
                 }

--- a/web-console/src/lib/services/manager/services/PipelinesService.ts
+++ b/web-console/src/lib/services/manager/services/PipelinesService.ts
@@ -180,7 +180,7 @@ export class PipelinesService {
   /**
    * Initiate profile dump.
    * @param pipelineName Unique pipeline name
-   * @returns any Profile dump initiated.
+   * @returns any Obtains a circuit performance profile.
    * @throws ApiError
    */
   public static dumpProfile(pipelineName: string): CancelablePromise<Record<string, any>> {


### PR DESCRIPTION
With this change, `/dump_profile` becomes a way to download a profile of a running circuit. Previously, it just wrote the profile to the file system and left the user to go find it.

Is this a user-visible change (yes/no): no