### PR TITLE
Automate Flink testing in CI

### DIFF
--- a/.github/workflows/benchmark-command.yml
+++ b/.github/workflows/benchmark-command.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Run Benchmarks
         run: earthly --verbose -P +benchmark
 
+      - name: Fetch previous results
+        run: bash ./scripts/clone-gh-pages.bash
+
+      - name: Refresh Flink Benchmark
+        run: bash ./benchmark/flink/refresh-flink-benchmark.sh
+
       - name: Publish results
         run: bash ./scripts/bench-publish.bash
 

--- a/.github/workflows/benchmark-command.yml
+++ b/.github/workflows/benchmark-command.yml
@@ -43,10 +43,7 @@ jobs:
 
       - name: Fetch previous results
         run: bash ./scripts/clone-gh-pages.bash
-
-      - name: Refresh Flink Benchmark
-        run: bash ./benchmark/flink/refresh-flink-benchmark.sh
-
+        
       - name: Publish results
         run: bash ./scripts/bench-publish.bash
 

--- a/.github/workflows/flink-benchmark.yml
+++ b/.github/workflows/flink-benchmark.yml
@@ -1,0 +1,43 @@
+name: Benchmark Flink
+
+on:
+  schedule:
+    # Run every month on the first day
+    - cron:  '0 0 1 * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+  CI_MACHINE_TYPE: "skylake-2x"
+  FORCE_COLOR: 1
+
+jobs:
+  benchmark:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: [ self-hosted, skylake40, benchmark-machine ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8.14
+
+      - name: Earthly version
+        run: earthly --version
+
+      - name: Fetch previous results
+        run: bash ./scripts/clone-gh-pages.bash
+
+      - name: Refresh Flink Benchmark
+        run: bash ./benchmark/flink/refresh-flink-benchmark.sh
+
+      - name: Publish Flink Results
+        run: bash ./benchmark/flink/publish-flink.sh

--- a/Earthfile
+++ b/Earthfile
@@ -597,7 +597,8 @@ flink-benchmark:
     RUN echo "when,runner,mode,language,name,num_cores,num_events,elapsed" >> flink_results.csv
     WITH DOCKER 
         RUN docker compose -f benchmark/flink/docker-compose.yml -p nexmark up --build --force-recreate --renew-anon-volumes -d && \
-            docker exec -i nexmark-jobmanager-1 run.sh 2>&1 | ./benchmark/run-nexmark.sh --runner flink --parse >> flink_results.csv
+            docker exec -i nexmark-jobmanager-1 run.sh -q q0 2>&1 | tee flink_log.txt && \
+            ./benchmark/run-nexmark.sh --runner flink --parse < flink_log.txt >> flink_results.csv
     END
     SAVE ARTIFACT flink_results.csv AS LOCAL .
 

--- a/benchmark/flink/publish-flink.sh
+++ b/benchmark/flink/publish-flink.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Push results to gh-pages repo
+cd "$(dirname "$0")"
+
+cd ../../gh-pages
+if [ "$CI" = true ] ; then
+    git config user.email "no-reply@dbsp.systems"
+    git config user.name "dbsp-ci"
+fi
+git add .
+git commit -a -m "Refreshed Flink benchmark results."
+git push origin main
+cd ..
+rm -rf gh-pages
+git clean -f

--- a/benchmark/flink/refresh-flink-benchmark.sh
+++ b/benchmark/flink/refresh-flink-benchmark.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -x
+
+# How old should Flink results be before they are re-run, in days
+expiry_days=30
+
+cd "$(dirname "$0")"
+
+last_time=0
+flink_dir=../../gh-pages/flink/
+flink_last_run_file="${flink_dir}last_flink_run"
+
+if [ -f $flink_last_run_file ]; then
+	last_time=$(cat $flink_last_run_file) 
+else
+	echo "Could not find previous Flink results. They will be recomputed."
+fi
+
+time=$(date +%s)
+diff=$((time - last_time))
+diff_days=$((diff / (60 * 60 * 24)))
+
+echo "Flink benchmark results were last computed $diff_days days ago. Results expire after $expiry_days days."
+if [ $diff_days -gt $expiry_days ]; then
+	echo "Flink results have expired, re-running Flink benchmarks!"
+	mkdir $flink_dir
+	cd ../..	
+	earthly --verbose -P +flink-benchmark
+	cd benchmark/flink
+	mv ../../flink_results.csv $flink_dir
+	echo $time > $flink_last_run_file
+else
+	echo "Flink results were recently computed, skipping Flink benchmarks."
+fi

--- a/benchmark/flink/refresh-flink-benchmark.sh
+++ b/benchmark/flink/refresh-flink-benchmark.sh
@@ -1,33 +1,11 @@
 #!/bin/sh -x
 
-# How old should Flink results be before they are re-run, in days
-expiry_days=30
-
 cd "$(dirname "$0")"
 
-last_time=0
+# Run Flink benchmark
 flink_dir=../../gh-pages/flink/
-flink_last_run_file="${flink_dir}last_flink_run"
-
-if [ -f $flink_last_run_file ]; then
-	last_time=$(cat $flink_last_run_file) 
-else
-	echo "Could not find previous Flink results. They will be recomputed."
-fi
-
-time=$(date +%s)
-diff=$((time - last_time))
-diff_days=$((diff / (60 * 60 * 24)))
-
-echo "Flink benchmark results were last computed $diff_days days ago. Results expire after $expiry_days days."
-if [ $diff_days -gt $expiry_days ]; then
-	echo "Flink results have expired, re-running Flink benchmarks!"
-	mkdir $flink_dir
-	cd ../..	
-	earthly --verbose -P +flink-benchmark
-	cd benchmark/flink
-	mv ../../flink_results.csv $flink_dir
-	echo $time > $flink_last_run_file
-else
-	echo "Flink results were recently computed, skipping Flink benchmarks."
-fi
+mkdir $flink_dir
+cd ../..	
+earthly --verbose -P +flink-benchmark
+cd benchmark/flink
+mv ../../flink_results.csv $flink_dir

--- a/scripts/bench-publish.bash
+++ b/scripts/bench-publish.bash
@@ -10,11 +10,6 @@ if [ -v ${CI_MACHINE_TYPE} ]; then
     exit 1
 fi
 
-# Clean-up old results
-if [ "$SMOKE" = "" ]; then
-rm -rf gh-pages
-fi
-
 NEXMARK_CSV_FILE='nexmark_results.csv'
 NEXMARK_DRAM_CSV_FILE='dram_nexmark_results.csv'
 NEXMARK_SQL_CSV_FILE='sql_nexmark_results.csv'
@@ -24,12 +19,7 @@ NEXMARK_SQL_STORAGE_METRICS_CSV_FILE='sql_storage_nexmark_metrics.csv'
 NEXMARK_PERSISTENCE_CSV_FILE='persistence_nexmark_results.csv'
 GALEN_CSV_FILE='galen_results.csv'
 LDBC_CSV_FILE='ldbc_results.csv'
-rm -f nexmark_comment.txt
 
-# Clone repo
-if [ ! -d "gh-pages" ]; then
-    git clone --depth 1 -b main git@github.com:feldera/benchmarks.git gh-pages
-fi
 pip3 install -r gh-pages/requirements.txt
 
 # If you change this, adjust the command also in the append_csv function in utils.py:

--- a/scripts/clone-gh-pages.bash
+++ b/scripts/clone-gh-pages.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# For CI env: Don't set `SMOKE`
+#
+set -ex
+
+# Clean-up old results
+if [ "$SMOKE" = "" ]; then
+rm -rf gh-pages
+fi
+
+rm -f nexmark_comment.txt
+
+# Clone repo
+if [ ! -d "gh-pages" ]; then
+    git clone --depth 1 -b main git@github.com:feldera/benchmarks.git gh-pages
+fi


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This PR automates Flink benchmarks to be run every 30 days. Flink results are now stored in the benchmarks repo.

A new GitHub actions script, "Refresh Flink Benchmark", was added, and executes in the middle of what used to be bench-publish, between what are now 2 phases - clone-gh-pages, which clones the benchmarks repo, and the rest of bench-publish. This new script checks the benchmarks repo in a new flink folder for last_flink_run, which stores the last time flink was run, and if the last run is over 30 days ago, runs flink benchmarks and stores their results in flink_results.csv in the same folder. These results are then uploaded to the benchmarks repo.

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
