### PR TITLE
[SQL] Preliminary implementation of the `now()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [SQL] Preliminary implementation of the `NOW()` function
+  ([#2019](https://github.com/feldera/feldera/pull/2019))
 - Service probing is removed: API endpoints and corresponding
   demo are deleted, and the database table `service_probe` is dropped
   ([#2002](https://github.com/feldera/feldera/pull/2002))

--- a/docs/sql/datetime.md
+++ b/docs/sql/datetime.md
@@ -262,12 +262,31 @@ computation on whole days.
 
 `DATE`, `TIME` and `TIMESTAMP` have no time zone.
 
-## Important unsupported operations
+## Non-deterministic functions
 
-Since DBSP is a *deterministic* query engine, it does not currently
-offer support for any function that depends on the current time.  So
-the following are *not* supported: `LOCALTIME`, `LOCALTIMESTAMP`,
-`CURRENT_TIME`, `CURRENT_DATE`, `CURRENT_TIMESTAMP`.
+Since DBSP is a *deterministic* query engine, it supports real-time
+based functions in way which is different from other SQL engines.
+Currently the only such function supported is `NOW`.  This function
+returns a TIMESTAMP value.  Programs that use the `NOW` function need
+to also declare the following table as the first table in the program:
+
+```sql
+CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+```
+
+(In the future this table will be automatically synthesized by the
+compiler, but for now its declaration must exist in the program.)
+
+The environment has to maintain the invariant that this table always
+contains a single value.  Moreover, deleting a value and inserting a
+new one requires the newly inserted value to be larger than the
+original value.  All invocations of the `NOW()` function within the
+program will in fact produce the value that currently exists in this
+table.
+
+| Operation     | Description         | Example                        |
+|---------------|---------------------|--------------------------------|
+| `NOW`         | Returns a timestamp | `NOW()` => 2024-07-10 00:00:00 |
 
 ## Date formatting
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateOperator.java
@@ -58,7 +58,8 @@ public final class DBSPAggregateOperator extends DBSPAggregateOperatorBase {
         DBSPTypeIndexedZSet ix = outputType.to(DBSPTypeIndexedZSet.class);
         return new DBSPAggregateOperator(
                 this.getNode(), ix,
-                expression, this.aggregate, this.input(), this.isLinear);
+                expression, this.aggregate, this.input(), this.isLinear)
+                .copyAnnotations(this);
     }
 
     @Override
@@ -66,7 +67,8 @@ public final class DBSPAggregateOperator extends DBSPAggregateOperatorBase {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPAggregateOperator(
                     this.getNode(), this.outputType.to(DBSPTypeIndexedZSet.class),
-                    this.function, this.aggregate, newInputs.get(0), this.isLinear);
+                    this.function, this.aggregate, newInputs.get(0), this.isLinear)
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
@@ -31,7 +31,8 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPApply2Operator(
                 this.getNode(), Objects.requireNonNull(expression).to(DBSPClosureExpression.class),
-                outputType, this.left(), this.right());
+                outputType, this.left(), this.right())
+                .copyAnnotations(this);
     }
 
     @Override
@@ -40,7 +41,8 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
         if (force || this.inputsDiffer(newInputs)) {
             return new DBSPApply2Operator(
                     this.getNode(), this.getFunction().to(DBSPClosureExpression.class),
-                    this.getType(), newInputs.get(0), newInputs.get(1));
+                    this.getType(), newInputs.get(0), newInputs.get(1))
+                    .copyAnnotations(this);
         }
         return this;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
@@ -28,7 +28,8 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPApplyOperator(
                 this.getNode(), Objects.requireNonNull(expression).to(DBSPClosureExpression.class),
-                outputType, this.input(), this.comment);
+                outputType, this.input(), this.comment)
+                .copyAnnotations(this);
     }
 
     @Override
@@ -37,7 +38,8 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs)) {
             return new DBSPApplyOperator(
                     this.getNode(), this.getFunction().to(DBSPClosureExpression.class),
-                    this.getType(), newInputs.get(0), this.comment);
+                    this.getType(), newInputs.get(0), this.comment)
+                    .copyAnnotations(this);
         }
         return this;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPConstantOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPConstantOperator.java
@@ -51,13 +51,15 @@ public final class DBSPConstantOperator extends DBSPOperator {
 
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
-        return new DBSPConstantOperator(this.getNode(), Objects.requireNonNull(expression), this.isMultiset);
+        return new DBSPConstantOperator(this.getNode(), Objects.requireNonNull(expression), this.isMultiset)
+                .copyAnnotations(this);
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPConstantOperator(this.getNode(), this.getFunction(), this.isMultiset);
+            return new DBSPConstantOperator(this.getNode(), this.getFunction(), this.isMultiset)
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledFilterOperator.java
@@ -106,7 +106,7 @@ public final class DBSPControlledFilterOperator extends DBSPBinaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPControlledFilterOperator(
                 this.getNode(), Objects.requireNonNull(expression),
-                this.left(), this.right());
+                this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -115,7 +115,8 @@ public final class DBSPControlledFilterOperator extends DBSPBinaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPControlledFilterOperator(
                     this.getNode(), this.getFunction(),
-                    newInputs.get(0), newInputs.get(1));
+                    newInputs.get(0), newInputs.get(1))
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDeindexOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDeindexOperator.java
@@ -44,7 +44,8 @@ public final class DBSPDeindexOperator extends DBSPUnaryOperator {
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPDeindexOperator(this.getNode(), newInputs.get(0));
+            return new DBSPDeindexOperator(this.getNode(), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOperator.java
@@ -63,13 +63,15 @@ public final class DBSPDelayOperator extends DBSPUnaryOperator {
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPDelayOperator(this.getNode(), this.function, newInputs.get(0), this.output);
+            return new DBSPDelayOperator(this.getNode(), this.function, newInputs.get(0), this.output)
+                    .copyAnnotations(this);
         return this;
     }
 
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression function, DBSPType unusedOutputType) {
-        return new DBSPDelayOperator(this.getNode(), function, this.input(), this.output);
+        return new DBSPDelayOperator(this.getNode(), function, this.input(), this.output)
+                .copyAnnotations(this);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOutputOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOutputOperator.java
@@ -26,13 +26,15 @@ public final class DBSPDelayOutputOperator extends DBSPSourceBaseOperator {
 
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
-        return new DBSPDelayOutputOperator(this.getNode(), outputType, this.isMultiset, this.comment);
+        return new DBSPDelayOutputOperator(this.getNode(), outputType, this.isMultiset, this.comment)
+                .copyAnnotations(this);
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPDelayOutputOperator(this.getNode(), this.outputType, this.isMultiset, this.comment);
+            return new DBSPDelayOutputOperator(this.getNode(), this.outputType, this.isMultiset, this.comment)
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDifferentiateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDifferentiateOperator.java
@@ -47,7 +47,7 @@ public final class DBSPDifferentiateOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPDifferentiateOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDistinctIncrementalOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDistinctIncrementalOperator.java
@@ -36,7 +36,7 @@ public final class DBSPDistinctIncrementalOperator extends DBSPBinaryOperator {
         assert newInputs.size() == 2;
         if (force || this.inputsDiffer(newInputs))
             return new DBSPDistinctIncrementalOperator(
-                    this.getNode(), newInputs.get(0), newInputs.get(1));
+                    this.getNode(), newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDistinctOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDistinctOperator.java
@@ -47,7 +47,7 @@ public final class DBSPDistinctOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPDistinctOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFilterOperator.java
@@ -51,14 +51,15 @@ public final class DBSPFilterOperator extends DBSPUnaryOperator {
 
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
-        return new DBSPFilterOperator(this.getNode(), Objects.requireNonNull(expression), this.input());
+        return new DBSPFilterOperator(this.getNode(), Objects.requireNonNull(expression), this.input())
+                .copyAnnotations(this);
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPFilterOperator(
-                    this.getNode(), this.getFunction(), newInputs.get(0));
+                    this.getNode(), this.getFunction(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFlatMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPFlatMapOperator.java
@@ -61,7 +61,8 @@ public final class DBSPFlatMapOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPFlatMapOperator(
                 this.getNode(), Objects.requireNonNull(expression),
-                outputType.to(DBSPTypeZSet.class), this.input());
+                outputType.to(DBSPTypeZSet.class), this.input())
+                .copyAnnotations(this);
     }
 
     @Override
@@ -69,7 +70,8 @@ public final class DBSPFlatMapOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPFlatMapOperator(
                     this.getNode(), this.getFunction(),
-                    this.getOutputZSetType(), newInputs.get(0));
+                    this.getOutputZSetType(), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPHopOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPHopOperator.java
@@ -58,7 +58,8 @@ public final class DBSPHopOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPHopOperator(
                 this.getNode(), this.timestampIndex, this.interval, this.start, this.size,
-                outputType.to(DBSPTypeZSet.class), this.input());
+                outputType.to(DBSPTypeZSet.class), this.input())
+                .copyAnnotations(this);
     }
 
     @Override
@@ -66,7 +67,8 @@ public final class DBSPHopOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPHopOperator(
                     this.getNode(), this.timestampIndex, this.interval, this.start, this.size,
-                    this.getOutputZSetType(), newInputs.get(0));
+                    this.getOutputZSetType(), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIndexedTopKOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIndexedTopKOperator.java
@@ -74,7 +74,7 @@ public final class DBSPIndexedTopKOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPIndexedTopKOperator(this.getNode(), this.numbering, this.getFunction(),
-                    this.limit, this.outputProducer, newInputs.get(0));
+                    this.limit, this.outputProducer, newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 
@@ -94,7 +94,7 @@ public final class DBSPIndexedTopKOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPIndexedTopKOperator(this.getNode(), this.numbering,
                 Objects.requireNonNull(expression), this.limit,
-                this.outputProducer, this.input());
+                this.outputProducer, this.input()).copyAnnotations(this);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateOperator.java
@@ -47,7 +47,7 @@ public final class DBSPIntegrateOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPIntegrateOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -58,7 +58,7 @@ public final class DBSPIntegrateTraceRetainKeysOperator extends DBSPBinaryOperat
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPIntegrateTraceRetainKeysOperator(
                 this.getNode(), Objects.requireNonNull(expression),
-                this.left(), this.right());
+                this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -67,7 +67,7 @@ public final class DBSPIntegrateTraceRetainKeysOperator extends DBSPBinaryOperat
         if (force || this.inputsDiffer(newInputs))
             return new DBSPIntegrateTraceRetainKeysOperator(
                     this.getNode(), this.getFunction(),
-                    newInputs.get(0), newInputs.get(1));
+                    newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFilterMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFilterMap.java
@@ -40,7 +40,7 @@ public final class DBSPJoinFilterMap extends DBSPBinaryOperator {
         return new DBSPJoinFilterMap(
                 this.getNode(), outputType.to(DBSPTypeZSet.class),
                 Objects.requireNonNull(expression), this.filter, this.map,
-                this.isMultiset, this.left(), this.right());
+                this.isMultiset, this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -49,7 +49,7 @@ public final class DBSPJoinFilterMap extends DBSPBinaryOperator {
             return new DBSPJoinFilterMap(
                     this.getNode(), this.getOutputZSetType(),
                     this.getFunction(), this.filter, this.map,
-                    this.isMultiset, newInputs.get(0), newInputs.get(1));
+                    this.isMultiset, newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinOperator.java
@@ -49,7 +49,7 @@ public final class DBSPJoinOperator extends DBSPBinaryOperator {
         return new DBSPJoinOperator(
                 this.getNode(), outputType.to(DBSPTypeZSet.class),
                 Objects.requireNonNull(expression),
-                this.isMultiset, this.left(), this.right());
+                this.isMultiset, this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -57,7 +57,8 @@ public final class DBSPJoinOperator extends DBSPBinaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPJoinOperator(
                     this.getNode(), this.getOutputZSetType(),
-                    this.getFunction(), this.isMultiset, newInputs.get(0), newInputs.get(1));
+                    this.getFunction(), this.isMultiset, newInputs.get(0), newInputs.get(1))
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPLagOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPLagOperator.java
@@ -55,7 +55,8 @@ public final class DBSPLagOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs)) {
             return new DBSPLagOperator(this.getNode(), this.offset,
                     this.projection, this.getFunction(), this.comparator,
-                    this.getOutputIndexedZSetType(), newInputs.get(0));
+                    this.getOutputIndexedZSetType(), newInputs.get(0))
+                    .copyAnnotations(this);
         }
         return this;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapIndexOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapIndexOperator.java
@@ -45,11 +45,7 @@ public final class DBSPMapIndexOperator extends DBSPUnaryOperator {
     public DBSPMapIndexOperator(CalciteObject node, DBSPExpression indexFunction,
                                 DBSPTypeIndexedZSet outputType,
                                 DBSPOperator input) {
-        super(node, "map_index", indexFunction, outputType, input.isMultiset, input);
-        DBSPType outputElementType = outputType.getKVType();
-        // Expression must return a tuple that is composed of a key and a value
-        this.checkResultType(indexFunction, outputElementType);
-        this.checkArgumentFunctionType(indexFunction, 0, input);
+        this(node, indexFunction, outputType, input.isMultiset, input);
     }
 
     /** Create an MapIndexOperator
@@ -84,7 +80,7 @@ public final class DBSPMapIndexOperator extends DBSPUnaryOperator {
         DBSPTypeIndexedZSet ixOutputType = type.to(DBSPTypeIndexedZSet.class);
         return new DBSPMapIndexOperator(
                 this.getNode(), Objects.requireNonNull(expression),
-                ixOutputType, this.input());
+                ixOutputType, this.input()).copyAnnotations(this);
     }
 
     @Override
@@ -92,7 +88,7 @@ public final class DBSPMapIndexOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPMapIndexOperator(
                     this.getNode(), this.getFunction(),
-                    this.getOutputIndexedZSetType(), newInputs.get(0));
+                    this.getOutputIndexedZSetType(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapOperator.java
@@ -58,7 +58,8 @@ public final class DBSPMapOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPMapOperator(
                 this.getNode(), Objects.requireNonNull(expression),
-                outputType.to(DBSPTypeZSet.class), this.input());
+                outputType.to(DBSPTypeZSet.class), this.input())
+                .copyAnnotations(this);
     }
 
     @Override
@@ -66,7 +67,8 @@ public final class DBSPMapOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPMapOperator(
                     this.getNode(), this.getFunction(),
-                    this.getOutputZSetType(), newInputs.get(0));
+                    this.getOutputZSetType(), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNegateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNegateOperator.java
@@ -47,7 +47,7 @@ public final class DBSPNegateOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPNegateOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
@@ -59,7 +59,8 @@ public final class DBSPNoopOperator extends DBSPUnaryOperator {
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPNoopOperator(this.getNode(), newInputs.get(0), this.comment);
+            return new DBSPNoopOperator(this.getNode(), newInputs.get(0), this.comment)
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPartitionedRollingAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPartitionedRollingAggregateOperator.java
@@ -48,7 +48,7 @@ public final class DBSPPartitionedRollingAggregateOperator extends DBSPAggregate
                 this.getNode(), this.partitioningFunction,
                 expression, this.aggregate, this.lower, this.upper,
                 outputType.to(DBSPTypeIndexedZSet.class),
-                this.input());
+                this.input()).copyAnnotations(this);
     }
 
     @Override
@@ -57,7 +57,7 @@ public final class DBSPPartitionedRollingAggregateOperator extends DBSPAggregate
             return new DBSPPartitionedRollingAggregateOperator(
                     this.getNode(), this.partitioningFunction, this.function, this.aggregate,
                     this.lower, this.upper, this.getOutputIndexedZSetType(),
-                    newInputs.get(0));
+                    newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPartitionedRollingAggregateWithWaterlineOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPartitionedRollingAggregateWithWaterlineOperator.java
@@ -77,7 +77,7 @@ public final class DBSPPartitionedRollingAggregateWithWaterlineOperator
                 this.partitioningFunction,
                 expression, this.aggregate, this.lower, this.upper,
                 outputType.to(DBSPTypeIndexedZSet.class),
-                this.left(), this.right());
+                this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -88,7 +88,7 @@ public final class DBSPPartitionedRollingAggregateWithWaterlineOperator
                     this.getNode(),
                     this.partitioningFunction, this.function, this.aggregate,
                     this.lower, this.upper, this.getOutputIndexedZSetType(),
-                    newInputs.get(0), newInputs.get(1));
+                    newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPrimitiveAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPrimitiveAggregateOperator.java
@@ -23,7 +23,7 @@ public final class DBSPPrimitiveAggregateOperator extends DBSPBinaryOperator {
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPPrimitiveAggregateOperator(this.getNode(), expression,
-                outputType, this.left(), this.right());
+                outputType, this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -31,7 +31,7 @@ public final class DBSPPrimitiveAggregateOperator extends DBSPBinaryOperator {
         assert newInputs.size() == 2: "Expected 2 inputs";
         if (force || this.inputsDiffer(newInputs))
             return new DBSPPrimitiveAggregateOperator(this.getNode(), this.function,
-                    this.outputType, newInputs.get(0), newInputs.get(1));
+                    this.outputType, newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSinkOperator.java
@@ -55,7 +55,7 @@ public final class DBSPSinkOperator extends DBSPViewBaseOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSinkOperator(
                     this.getNode(), this.viewName, this.query, this.originalRowType,
-                    this.metadata, newInputs.get(0));
+                    this.metadata, newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMapOperator.java
@@ -54,7 +54,7 @@ public final class DBSPSourceMapOperator extends DBSPSourceTableOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression unused, DBSPType outputType) {
         return new DBSPSourceMapOperator(this.getNode(), this.sourceName,
                 this.keyFields, outputType.to(DBSPTypeIndexedZSet.class), this.originalRowType,
-                this.metadata, this.tableName, this.comment);
+                this.metadata, this.tableName, this.comment).copyAnnotations(this);
     }
 
     @Override
@@ -62,7 +62,7 @@ public final class DBSPSourceMapOperator extends DBSPSourceTableOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSourceMapOperator(this.getNode(), this.sourceName,
                     this.keyFields, this.getOutputIndexedZSetType(), this.originalRowType,
-                    this.metadata, this.tableName, this.comment);
+                    this.metadata, this.tableName, this.comment).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
@@ -29,8 +29,7 @@ public final class DBSPSourceMultisetOperator
      * @param sourceName Calcite node for the identifier naming the table.
      * @param outputType Type of table.
      * @param name       The name of the table that this operator is created from.
-     * @param comment    A comment describing the operator.
-     */
+     * @param comment    A comment describing the operator. */
     public DBSPSourceMultisetOperator(
             CalciteObject node, CalciteObject sourceName,
             DBSPTypeZSet outputType, DBSPTypeStruct originalRowType,
@@ -53,7 +52,7 @@ public final class DBSPSourceMultisetOperator
     public DBSPOperator withFunction(@Nullable DBSPExpression unused, DBSPType outputType) {
         return new DBSPSourceMultisetOperator(this.getNode(), this.sourceName,
                 outputType.to(DBSPTypeZSet.class), this.originalRowType,
-                this.metadata, this.tableName, this.comment);
+                this.metadata, this.tableName, this.comment).copyAnnotations(this);
     }
 
     @Override
@@ -61,7 +60,7 @@ public final class DBSPSourceMultisetOperator
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSourceMultisetOperator(
                     this.getNode(), this.sourceName, this.getOutputZSetType(), this.originalRowType,
-                    this.metadata, this.tableName, this.comment);
+                    this.metadata, this.tableName, this.comment).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAggregateOperator.java
@@ -58,7 +58,8 @@ public final class DBSPStreamAggregateOperator extends DBSPAggregateOperatorBase
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         DBSPTypeIndexedZSet ixOutputType = outputType.to(DBSPTypeIndexedZSet.class);
         return new DBSPStreamAggregateOperator(this.getNode(),
-                ixOutputType, expression, this.aggregate, this.input(), this.isLinear);
+                ixOutputType, expression, this.aggregate, this.input(), this.isLinear)
+                .copyAnnotations(this);
     }
 
     @Override
@@ -66,7 +67,8 @@ public final class DBSPStreamAggregateOperator extends DBSPAggregateOperatorBase
         if (force || this.inputsDiffer(newInputs))
             return new DBSPStreamAggregateOperator(
                     this.getNode(), this.getOutputIndexedZSetType(),
-                    this.function, this.aggregate, newInputs.get(0), this.isLinear);
+                    this.function, this.aggregate, newInputs.get(0), this.isLinear)
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamDistinctOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamDistinctOperator.java
@@ -49,7 +49,7 @@ public final class DBSPStreamDistinctOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPStreamDistinctOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamJoinOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamJoinOperator.java
@@ -58,7 +58,7 @@ public final class DBSPStreamJoinOperator extends DBSPBinaryOperator {
         return new DBSPStreamJoinOperator(
                 this.getNode(), outputType.to(DBSPTypeZSet.class),
                 Objects.requireNonNull(expression),
-                this.isMultiset, this.left(), this.right());
+                this.isMultiset, this.left(), this.right()).copyAnnotations(this);
     }
 
     @Override
@@ -66,7 +66,8 @@ public final class DBSPStreamJoinOperator extends DBSPBinaryOperator {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPStreamJoinOperator(
                     this.getNode(), this.getOutputZSetType(),
-                    this.getFunction(), this.isMultiset, newInputs.get(0), newInputs.get(1));
+                    this.getFunction(), this.isMultiset, newInputs.get(0), newInputs.get(1))
+                    .copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSubtractOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSubtractOperator.java
@@ -59,7 +59,7 @@ public final class DBSPSubtractOperator extends DBSPBinaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPSubtractOperator(
-                    this.getNode(), newInputs.get(0), newInputs.get(1));
+                    this.getNode(), newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSumOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSumOperator.java
@@ -79,7 +79,7 @@ public final class DBSPSumOperator extends DBSPOperator {
             }
         }
         if (different)
-            return new DBSPSumOperator(this.getNode(), newInputs);
+            return new DBSPSumOperator(this.getNode(), newInputs).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUpsertFeedbackOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUpsertFeedbackOperator.java
@@ -31,7 +31,7 @@ public final class DBSPUpsertFeedbackOperator extends DBSPUnaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPUpsertFeedbackOperator(
-                    this.getNode(), newInputs.get(0));
+                    this.getNode(), newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUpsertOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUpsertOperator.java
@@ -27,7 +27,7 @@ public final class DBSPUpsertOperator extends DBSPBinaryOperator {
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         assert newInputs.size() == 2 : "Expected 2 inputs";
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPUpsertOperator(this.getNode(), newInputs.get(0), newInputs.get(1));
+            return new DBSPUpsertOperator(this.getNode(), newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPViewOperator.java
@@ -48,7 +48,7 @@ public final class DBSPViewOperator
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression ignoredFunction, DBSPType ignoredType) {
         return new DBSPViewOperator(this.getNode(), this.viewName, this.query, this.originalRowType,
-                this.metadata, this.input());
+                this.metadata, this.input()).copyAnnotations(this);
     }
 
     @Override
@@ -56,7 +56,7 @@ public final class DBSPViewOperator
         if (force || this.inputsDiffer(newInputs))
             return new DBSPViewOperator(
                     this.getNode(), this.viewName, this.query, this.originalRowType,
-                    this.metadata, newInputs.get(0));
+                    this.metadata, newInputs.get(0)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWaterlineOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWaterlineOperator.java
@@ -26,14 +26,15 @@ public final class DBSPWaterlineOperator extends DBSPUnaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPWaterlineOperator(this.getNode(), this.init,
                 Objects.requireNonNull(expression).to(DBSPClosureExpression.class),
-                this.input());
+                this.input()).copyAnnotations(this);
     }
 
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
             return new DBSPWaterlineOperator(this.getNode(), this.init,
-                    this.getFunction().to(DBSPClosureExpression.class), newInputs.get(0));
+                    this.getFunction().to(DBSPClosureExpression.class), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWeighOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWeighOperator.java
@@ -24,7 +24,8 @@ public final class DBSPWeighOperator extends DBSPUnaryOperator {
     @Override
     public DBSPOperator withInputs(List<DBSPOperator> newInputs, boolean force) {
         if (force || this.inputsDiffer(newInputs))
-            return new DBSPWeighOperator(this.getNode(), this.getFunction(), newInputs.get(0));
+            return new DBSPWeighOperator(this.getNode(), this.getFunction(), newInputs.get(0))
+                    .copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
@@ -34,7 +34,7 @@ public final class DBSPWindowOperator extends DBSPBinaryOperator {
         assert newInputs.size() == 2: "Expected 2 inputs, got " + newInputs.size();
         if (force || this.inputsDiffer(newInputs))
             return new DBSPWindowOperator(
-                    this.getNode(), newInputs.get(0), newInputs.get(1));
+                    this.getNode(), newInputs.get(0), newInputs.get(1)).copyAnnotations(this);
         return this;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -1030,6 +1030,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     }
                     case "concat":
                         return makeBinaryExpressions(node, type, DBSPOpcode.CONCAT, ops);
+                    case "now":
                     case "array":
                         return compileFunction(call, node, type, ops, 0);
                     case "gunzip":

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
@@ -35,6 +35,7 @@ public class CustomFunctions {
         this.initial.add(new GunzipFunction());
         this.initial.add(new WriteLogFunction());
         this.initial.add(new SequenceFunction());
+        this.initial.add(new NowFunction());
         this.udf = new HashMap<>();
     }
 
@@ -58,6 +59,22 @@ public class CustomFunctions {
         @Override
         public boolean isDeterministic() {
             // TODO: change this when we learn how to constant-fold in the RexToLixTranslator
+            return false;
+        }
+    }
+
+    static class NowFunction extends SqlFunction {
+        public NowFunction() {
+            super("NOW",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.TIMESTAMP,
+                    null,
+                    OperandTypes.NILADIC,
+                    SqlFunctionCategory.TIMEDATE);
+        }
+
+        @Override
+        public boolean isDeterministic() {
             return false;
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
@@ -267,8 +267,10 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
         MonotoneExpression value = this.variables.get(declaration);
         this.maybeSet(var, value);
         assert value == null || value.expression.getType().sameType(var.getType())
-                : "Variable " + var.variable + " type " + var.getType() +
-                " does not match expected type in expression " + value.expression.getType();
+                : "Variable " + var.variable + "(" + var.getId() + ") type " + var.getType() +
+                " does not match expected type in expression " + value.expression +
+                "(" + value.expression.getId() + ")" +
+                " with type " + value.expression.getType();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -109,7 +109,11 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs {
                 .append(operator.toString())
                 .newline();
         this.getResult().addOperator(operator);
-        operator.setDerivedFrom(this.getCurrent().getId());
+        if (!this.current.isEmpty()) {
+            // This can happen when operators are inserted in startVisit, for example.
+            // Such operators are not derived from the "current" operator.
+            operator.setDerivedFrom(this.getCurrent().getId());
+        }
     }
 
     @Override
@@ -361,8 +365,8 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs {
 
     @Override
     public DBSPCircuit apply(DBSPCircuit circuit) {
-        this.startVisit(circuit);
         this.result = new DBSPPartialCircuit(circuit.circuit.errorReporter, circuit.circuit.metadata);
+        this.startVisit(circuit);
         circuit.accept(this);
         this.endVisit();
         DBSPPartialCircuit result = this.getResult();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -49,6 +49,7 @@ public class CircuitOptimizer implements ICompilerComponent {
         IErrorReporter reporter = this.getCompiler();
         CompilerOptions options = this.getCompiler().options;
 
+        passes.add(new ImplementNow(reporter));
         if (!options.ioOptions.emitHandles)
             passes.add(new IndexedInputs(reporter));
         if (options.languageOptions.outputsAreSets)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Depth-first traversal of an IDBSOuterPNode hierarchy. */
+/** Depth-first traversal of an IDBSOuterNode hierarchy. */
 @SuppressWarnings({"SameReturnValue", "BooleanMethodIsAlwaysInverted"})
 public abstract class CircuitVisitor
         implements CircuitTransform, IWritesLogs, IHasId {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Conditional.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Conditional.java
@@ -1,0 +1,32 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.util.IWritesLogs;
+
+import java.util.function.Supplier;
+
+/** Applies a CircuitTransform if some condition is true */
+public class Conditional implements IWritesLogs, CircuitTransform {
+    final Supplier<Boolean> test;
+    final IErrorReporter errorReporter;
+    public final CircuitTransform transform;
+
+    public Conditional(IErrorReporter reporter, CircuitTransform visitor, Supplier<Boolean> test) {
+        this.errorReporter = reporter;
+        this.transform = visitor;
+        this.test = test;
+    }
+
+    @Override
+    public DBSPCircuit apply(DBSPCircuit circuit) {
+        if (this.test.get())
+            return this.transform.apply(circuit);
+        return circuit;
+    }
+
+    @Override
+    public String toString() {
+        return "Conditional " + this.transform;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Fail.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Fail.java
@@ -1,0 +1,27 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.util.IWritesLogs;
+
+/** This visitor fails with an error message when it is invoked */
+public class Fail implements IWritesLogs, CircuitTransform {
+    final IErrorReporter errorReporter;
+    final String message;
+
+    public Fail(IErrorReporter reporter, String message) {
+        this.errorReporter = reporter;
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return "Fail";
+    }
+
+    @Override
+    public DBSPCircuit apply(DBSPCircuit circuit) {
+        throw new InternalCompilerError(this.message, circuit.getNode());
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
@@ -1,0 +1,256 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.frontend.TypeCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerRewriteVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ReferenceMap;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ResolveReferences;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.IDBSPDeclaration;
+import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
+import org.dbsp.sqlCompiler.ir.annotation.AlwaysMonotone;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeRef;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Logger;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/** Implements the "now" operator.
+ * This requires:
+ * - using the input stream called now
+ * - rewriting map operators that have calls to "now()' into a join followed by a map
+ * - rewriting the invocations to the now() function in the map function to references to the input variable */
+public class ImplementNow extends Passes {
+    /** Discovers whether an expression contains a call to the now() function */
+    static class ContainsNow extends InnerVisitor {
+        public boolean found;
+
+        public ContainsNow(IErrorReporter reporter) {
+            super(reporter);
+            this.found = false;
+        }
+
+        static boolean isNow(DBSPApplyExpression node) {
+            String name = node.getFunctionName();
+            return name != null && name.equalsIgnoreCase("now");
+        }
+
+        static DBSPTypeTimestamp timestampType() {
+            return new DBSPTypeTimestamp(CalciteObject.EMPTY, false);
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPApplyExpression node) {
+            if (isNow(node)) {
+                Logger.INSTANCE.belowLevel(this, 1)
+                        .append("Found 'now' call")
+                        .newline();
+                found = true;
+                return VisitDecision.STOP;
+            }
+            return super.preorder(node);
+        }
+
+        public boolean found() {
+            return this.found;
+        }
+    }
+
+    /** Rewrites a closure of the form |t: &T| ... now() ...
+     * to a closure of the form |t: &T1| ... (*t).last,
+     * where T1 is T with an extra Timestamp field, and
+     * last is the index of the last field of T1. */
+    static class RewriteNowExpression extends InnerRewriteVisitor {
+        /** Replacement for the now function */
+        @Nullable
+        DBSPExpression nowReplacement;
+        /** Replacement for the parameter references */
+        @Nullable
+        DBSPExpression parameterReplacement;
+        @Nullable
+        ReferenceMap refMap;
+
+        public RewriteNowExpression(IErrorReporter reporter) {
+            super(reporter);
+            this.nowReplacement = null;
+            this.parameterReplacement = null;
+            this.refMap = null;
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPApplyExpression expression) {
+            // A function call that is `now()` is replaced with the `nowReplacement`
+            if (ContainsNow.isNow(expression)) {
+                this.map(expression, Objects.requireNonNull(this.nowReplacement));
+                return VisitDecision.STOP;
+            }
+            return super.preorder(expression);
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPVariablePath var) {
+            // A variable that references the parameter is replaced with the `parameterReplacement` expression
+            IDBSPDeclaration decl = Objects.requireNonNull(this.refMap).getDeclaration(var);
+            if (decl.is(DBSPParameter.class)) {
+                this.map(var, Objects.requireNonNull(this.parameterReplacement));
+                return VisitDecision.STOP;
+            }
+            return super.preorder(var);
+        }
+
+        @Override
+        public VisitDecision preorder(DBSPClosureExpression closure) {
+            assert this.context.isEmpty();
+            assert closure.parameters.length == 1;
+            DBSPParameter param = closure.parameters[0];
+            DBSPTypeTuple paramType = param.getType().to(DBSPTypeRef.class).deref().to(DBSPTypeTuple.class);
+            List<DBSPType> fields = Linq.list(paramType.tupFields);
+            fields.add(ContainsNow.timestampType());
+            DBSPParameter newParam = new DBSPParameter(param.getName(), paramType.makeType(fields).ref());
+            this.parameterReplacement = newParam.asVariable();
+            this.nowReplacement = newParam.asVariable().deref().field(paramType.size());
+            ResolveReferences ref = new ResolveReferences(this.errorReporter, false);
+            ref.apply(closure);
+            this.refMap = ref.reference;
+
+            this.push(closure);
+            DBSPExpression body = this.transform(closure.body);
+            this.pop(closure);
+            DBSPExpression result = body.closure(newParam);
+            this.map(closure, result);
+            return VisitDecision.STOP;
+        }
+    }
+
+    /** Replace map operators that contain now() as an expression with
+     * map operators that take an extra field and use that instead of the now() call.
+     * Insert a join prior to such operators (which also requires a MapIndex operator.
+     * Also inserts a MapIndex operator to index the 'NOW' built-in table. */
+    static class RewriteNow extends CircuitCloneVisitor {
+        // Holds the indexed version of the 'now' operator (indexed with an empty key).
+        @Nullable
+        DBSPOperator nowIndexed = null;
+
+        public RewriteNow(IErrorReporter reporter) {
+            super(reporter, false);
+        }
+
+        @Override
+        public void postorder(DBSPMapOperator operator) {
+            ContainsNow cn = new ContainsNow(this.errorReporter);
+            DBSPExpression function = operator.getFunction();
+            cn.apply(function);
+            if (cn.found()) {
+                // Index the input
+                DBSPType inputType = operator.input().getOutputZSetElementType();
+                DBSPVariablePath var = inputType.ref().var();
+                DBSPExpression indexFunction = new DBSPRawTupleExpression(
+                        new DBSPTupleExpression(),
+                        var.deref().applyClone());
+                DBSPMapIndexOperator index = new DBSPMapIndexOperator(
+                        operator.getNode(), indexFunction.closure(var.asParameter()),
+                        TypeCompiler.makeIndexedZSet(new DBSPTypeTuple(), inputType),
+                        this.mapped(operator.input()));
+                this.addOperator(index);
+
+                // Join with 'indexedNow'
+                DBSPVariablePath key = new DBSPTypeTuple().ref().var();
+                DBSPVariablePath left = inputType.ref().var();
+                DBSPVariablePath right = new DBSPTypeTuple(ContainsNow.timestampType()).ref().var();
+                List<DBSPExpression> fields = left.deref().allFields();
+                fields.add(right.deref().field(0));
+                DBSPTypeZSet joinType = TypeCompiler.makeZSet(new DBSPTypeTuple(
+                        Linq.map(fields, DBSPExpression::getType)));
+                DBSPExpression joinFunction = new DBSPTupleExpression(fields, false)
+                        .closure(key.asParameter(), left.asParameter(), right.asParameter());
+                DBSPOperator join = new DBSPStreamJoinOperator(operator.getNode(), joinType,
+                        joinFunction, operator.isMultiset, index, Objects.requireNonNull(this.nowIndexed));
+                this.addOperator(join);
+
+                RewriteNowExpression rn = new RewriteNowExpression(this.errorReporter);
+                function = rn.apply(function).to(DBSPExpression.class);
+                DBSPOperator result = new DBSPMapOperator(operator.getNode(), function, operator.getOutputZSetType(), join);
+                this.map(operator, result);
+            } else {
+                super.postorder(operator);
+            }
+        }
+
+        @Override
+        public void startVisit(IDBSPOuterNode circuit) {
+            super.startVisit(circuit);
+
+            DBSPType timestamp = ContainsNow.timestampType();
+            CalciteObject node = circuit.getNode();
+            /*
+            // TODO: have the compiler insert this instead of requiring the user to declare the table.
+            // Doing this doesn't work because the front-end of the compiler does not know about this table,
+            // so tests can't use it.
+            // This is not really a multiset, but there is no primary key in the shape expected
+            DBSPTypeTuple type = new DBSPTypeTuple(timestamp);
+            DBSPTypeStruct originalRowType = new DBSPTypeStruct(node, colName, colName,
+                    Linq.list(new DBSPTypeStruct.Field(node, colName, 0, timestamp, false)),
+                    false);
+            InputColumnMetadata colMeta = new InputColumnMetadata(
+                    node, colName, timestamp, false,
+                    // lateness of 0
+                    new DBSPIntervalMillisLiteral(0, false),
+                    null, null);
+            TableMetadata meta = new TableMetadata(Linq.list(colMeta), false);
+            DBSPOperator now = new DBSPSourceMultisetOperator(node,
+                    CalciteObject.EMPTY, TypeCompiler.makeZSet(type), originalRowType,
+                    meta, "now", null);
+            this.addOperator(now);
+             */
+            DBSPOperator now = circuit.to(DBSPCircuit.class).circuit.getInput("NOW");
+            assert now != null;
+            // We are doing this in startVisitor because we want now to be first in topological order,
+            // otherwise it may be traversed too late, after nodes that will depend on it.
+            this.visited.add(now);
+            this.addOperator(now);
+            this.map(now, now, false);
+
+            DBSPVariablePath var = new DBSPTypeTuple(timestamp).ref().var();
+            DBSPExpression indexFunction = new DBSPRawTupleExpression(
+                    new DBSPTupleExpression(),
+                    var.deref().applyClone());
+            this.nowIndexed = new DBSPMapIndexOperator(
+                    node, indexFunction.closure(var.asParameter()),
+                    TypeCompiler.makeIndexedZSet(new DBSPTypeTuple(), new DBSPTypeTuple(timestamp)), now);
+            this.nowIndexed.addAnnotation(new AlwaysMonotone());
+            this.addOperator(this.nowIndexed);
+        }
+    }
+
+    public ImplementNow(IErrorReporter reporter) {
+        super(reporter);
+        ContainsNow cn = new ContainsNow(reporter);
+        CircuitRewriter find = cn.getCircuitVisitor();
+        RewriteNow rewriteNow = new RewriteNow(reporter);
+        this.passes.add(find);
+        this.passes.add(new Conditional(reporter, rewriteNow, cn::found));
+        ContainsNow cn0 = new ContainsNow(reporter);
+        this.passes.add(new Conditional(reporter,
+                new Fail(reporter, "Instances of 'now' have not been replaced"), cn0::found));
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
@@ -266,8 +266,10 @@ public class ExpandOperators extends CircuitCloneVisitor {
     public void postorder(DBSPJoinOperator operator) {
         List<DBSPOperator> inputs = Linq.map(operator.inputs, this::mapped);
         DBSPDelayedIntegralOperator leftIntegrator = new DBSPDelayedIntegralOperator(operator.getNode(), inputs.get(0));
+        leftIntegrator.copyAnnotations(operator.left());
         this.addOperator(leftIntegrator);
         DBSPDelayedIntegralOperator rightIntegrator = new DBSPDelayedIntegralOperator(operator.getNode(), inputs.get(1));
+        rightIntegrator.copyAnnotations(operator.right());
         this.addOperator(rightIntegrator);
         DBSPStreamJoinOperator deltaJoin = new DBSPStreamJoinOperator(operator.getNode(), operator.getOutputZSetType(),
                 operator.getFunction(), operator.isMultiset, inputs.get(0), inputs.get(1));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/AlwaysMonotone.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/AlwaysMonotone.java
@@ -1,0 +1,10 @@
+package org.dbsp.sqlCompiler.ir.annotation;
+
+/** This annotation indicates that a DBSPOperator has an output that is always monotone.
+ * This is intended to mark the part of the circuit that derives from the NOW table. */
+public class AlwaysMonotone extends Annotation {
+    @Override
+    public String toString() {
+        return "AlwaysMonotone";
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Annotation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Annotation.java
@@ -1,0 +1,6 @@
+package org.dbsp.sqlCompiler.ir.annotation;
+
+import org.dbsp.util.ICastable;
+
+/** Base class for annotations that can be attached to various IR nodes. */
+public abstract class Annotation implements ICastable { }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Annotations.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Annotations.java
@@ -1,0 +1,43 @@
+package org.dbsp.sqlCompiler.ir.annotation;
+
+import org.dbsp.util.Linq;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class Annotations {
+    public final List<Annotation> annotations;
+
+    public Annotations() {
+        this.annotations = new ArrayList<>();
+    }
+
+    public Annotations(Annotations other) {
+        this.annotations = new ArrayList<>(other.annotations);
+    }
+
+    public void replace(Annotations annotations) {
+        if (!this.annotations.isEmpty())
+            this.annotations.clear();
+        if (!annotations.isEmpty())
+            this.annotations.addAll(annotations.annotations);
+    }
+
+    private boolean isEmpty() {
+        return this.annotations.isEmpty();
+    }
+
+    public void add(Annotation annotation) {
+        this.annotations.add(annotation);
+    }
+
+    public boolean contains(Predicate<Annotation> test) {
+        return Linq.any(this.annotations, test);
+    }
+
+    @Override
+    public String toString() {
+        return this.annotations.toString();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/package-info.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Package that doesn't allow null values as method parameters.
+ */
+
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsAreNonnullByDefault
+package org.dbsp.sqlCompiler.ir.annotation;
+
+import org.dbsp.util.FieldsAreNonnullByDefault;
+import org.dbsp.util.MethodsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPApplyBaseExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPApplyBaseExpression.java
@@ -6,6 +6,8 @@ import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeFunction;
 
+import javax.annotation.Nullable;
+
 /** Base class for function applications */
 public abstract class DBSPApplyBaseExpression extends DBSPExpression {
     public final DBSPExpression function;
@@ -31,6 +33,22 @@ public abstract class DBSPApplyBaseExpression extends DBSPExpression {
                     arg.getType() + " does not match parameter type " + parameterTypes[index];
             index++;
         }
+    }
+
+    /** True if the function is given by name.
+     * (It could be e.g., a lambda). */
+    public boolean functionIsNamed() {
+        return this.function.is(DBSPPathExpression.class);
+    }
+
+    /** Return the function name if the function is given by name,
+     * null otherwise. */
+    @Nullable
+    public String getFunctionName() {
+        DBSPPathExpression pe = this.function.as(DBSPPathExpression.class);
+        if (pe == null)
+            return null;
+        return pe.path.toString();
     }
 
     protected DBSPApplyBaseExpression(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -36,10 +36,13 @@ import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeRef;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeResult;
 import org.dbsp.sqlCompiler.ir.type.IHasType;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Base class for all expressions */
 public abstract class DBSPExpression
@@ -164,6 +167,18 @@ public abstract class DBSPExpression
         DBSPExpression reduced = beta.apply(this).to(DBSPExpression.class);
         Simplify simplify = new Simplify(reporter);
         return simplify.apply(reduced).to(DBSPExpression.class);
+    }
+
+    /** 'this' must be an expression with a tuple type.
+     * @return a DBSPTupleExpression that contains all fields of this expression (cloned if necessary).
+     */
+    public List<DBSPExpression> allFields() {
+        DBSPTypeTupleBase type = this.getType().to(DBSPTypeTupleBase.class);
+        List<DBSPExpression> result = new ArrayList<>();
+        for (int i = 0; i < type.tupFields.length; i++) {
+            result.add(this.deepCopy().field(i).applyCloneIfNeeded());
+        }
+        return result;
     }
 
     /** Check expressions for equivalence in a specified context.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeTupleBase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeTupleBase.java
@@ -46,10 +46,8 @@ public abstract class DBSPTypeTupleBase extends DBSPType {
      * false if it is a TupN tuple. */
     public abstract boolean isRaw();
 
-    /**
-     * If the expression has a tuple type, return the list of fields.
-     * Else return the expression itself.
-     */
+    /** If the expression has a tuple type, return the list of fields.
+     * Else return the expression itself. */
     public static List<DBSPExpression> flatten(DBSPExpression expression) {
         DBSPTypeTupleBase tuple = expression.getType().as(DBSPTypeTupleBase.class);
         if (tuple == null)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -148,7 +148,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                     // CREATE VIEW `V` AS
                     // SELECT `T`.`COL3`
                     // FROM `T`
-                    let stream130: stream<WSet<Tup1<b>>> = stream61;
+                    let stream131: stream<WSet<Tup1<b>>> = stream61;
                 }
                 """;
         Assert.assertEquals(expected, str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -144,6 +144,29 @@ public class StreamingTests extends StreamingTest {
     }
 
     @Test
+    public void testNow4() {
+        // now() used in WHERE
+        String sql = """
+                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+                CREATE TABLE transactions (
+                  id INT PRIMARY KEY,
+                  ts TIMESTAMP,
+                  users INT,
+                  AMOUNT DECIMAL
+                );
+                CREATE VIEW window_computation AS
+                SELECT
+                  users,
+                  COUNT(*) AS transaction_count_by_user
+                FROM transactions
+                WHERE ts >= now() - INTERVAL 1 DAY
+                GROUP BY users""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        new CompilerCircuitStream(compiler);
+    }
+
+    @Test
     public void issue2003() {
         String sql = """
                 CREATE TABLE event(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -9,7 +9,7 @@ import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.sql.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTest;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.Monotonicity;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.MonotoneAnalyzer;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
@@ -63,6 +63,84 @@ public class StreamingTests extends StreamingTest {
             }
         };
         visitor.apply(ccs.circuit);
+    }
+
+    @Test
+    public void testNow() {
+        String sql = """
+                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+                CREATE VIEW V AS SELECT 1, NOW() < TIMESTAMP '2025-12-12 00:00:00';""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
+        ccs.step("INSERT INTO now VALUES ('2024-12-12 00:00:00')",
+                """
+                         c | compare | weight
+                        ----------------------
+                         1 | true    | 1""");
+        this.addRustTestCase("testNow", ccs);
+    }
+
+    @Test
+    public void testNow2() {
+        String sql = """
+                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+                CREATE TABLE T(value INT);
+                CREATE VIEW V AS SELECT *, NOW() FROM T;""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
+        Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 0);
+        ccs.step("""
+                        INSERT INTO T VALUES (2), (3);
+                        INSERT INTO now VALUES ('2024-12-12 00:00:00');
+                        """,
+                """
+                         value | now                 | weight
+                        --------------------------------------
+                         2     | 2024-12-12 00:00:00 | 1
+                         3     | 2024-12-12 00:00:00 | 1""");
+        ccs.step("""
+                        REMOVE FROM now VALUES ('2024-12-12 00:00:00');
+                        INSERT INTO now VALUES ('2024-12-12 00:01:00');
+                        """,
+                """
+                         value | now                 | weight
+                        --------------------------------------
+                         2     | 2024-12-12 00:00:00 | -1
+                         3     | 2024-12-12 00:00:00 | -1
+                         2     | 2024-12-12 00:01:00 | 1
+                         3     | 2024-12-12 00:01:00 | 1""");
+        this.addRustTestCase("testNow2", ccs);
+    }
+
+    @Test
+    public void testNow3() {
+        String sql = """
+                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+                CREATE TABLE T(value INT);
+                CREATE VIEW V AS SELECT SUM(value) + MINUTE(NOW()) FROM T;""";
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.compileStatements(sql);
+        CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
+        ccs.step("""
+                        INSERT INTO T VALUES (2), (3);
+                        INSERT INTO now VALUES ('2024-12-12 00:00:00');
+                        """,
+                """
+                         value | weight
+                        ----------------
+                         5     | 1""");
+        ccs.step("""
+                        REMOVE FROM now VALUES ('2024-12-12 00:00:00');
+                        INSERT INTO now VALUES ('2024-12-12 00:01:00');
+                        """,
+                """
+                         value | weight
+                        ----------------
+                         5     | -1
+                         6     | 1""");
+        this.addRustTestCase("testNow3", ccs);
     }
 
     @Test


### PR DESCRIPTION
Is this a user-visible change (yes/no): yes

`now()` is a tricky one, since DBSP does not allow nondeterministic functions.
The implementation is interesting. We (actually at this point we ask the user) create an input table called `now` with a since column `now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS`.
Any call to the function `now()` in the code is replaced with a value read from this table.
The "environment" is required to keep at all times exactly one value in this table, which grows monotonically.
Perhaps an automatic input adapter will feed this table in normal operation.
But, by allowing the user to control the actual time values, we allow deterministic re-execution too!
