### PR TITLE
Make sure dbsp and adapters metrics verison match.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,7 +3734,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "metrics 0.22.3",
+ "metrics 0.23.0",
  "mimalloc-rust-sys",
  "minitrace",
  "nix 0.27.1",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -79,6 +79,7 @@ apache-avro = { version = "0.16.0", optional = true }
 schema_registry_converter = { version = "4.0.0", features = ["avro", "blocking"], optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 url = "2.5.0"
+# Make sure to match metrics version in dbsp to include them!
 metrics = "0.23"
 metrics-util = "0.17"
 metrics-exporter-prometheus = "0.15.1"

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -63,7 +63,8 @@ thiserror = "1.0"
 uuid = { version = "1.6.1", features = ["v7"] }
 clap = { version = "4.4.14", features = ["derive", "env", "wrap_help"] }
 fdlimit = { version = "0.3.0" }
-metrics = { version = "0.22.0" }
+# metrics won't display if it doesn't match the adapters metrics version!
+metrics = { version = "0.23.0" }
 log = { version = "0.4", features = [] }
 rlimit = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
If not only the adapters metrics show up in the metrics endpoint. The reason is that rust can include with multiple crate version at the same time and turns out metrics from one version are not read from another version if they don't match.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
