### PR TITLE
[SQL] Have the compiler synthesize the 'NOW' table

### DIFF
--- a/docs/sql/datetime.md
+++ b/docs/sql/datetime.md
@@ -267,22 +267,21 @@ computation on whole days.
 Since DBSP is a *deterministic* query engine, it supports real-time
 based functions in way which is different from other SQL engines.
 Currently the only such function supported is `NOW`.  This function
-returns a TIMESTAMP value.  Programs that use the `NOW` function need
-to also declare the following table as the first table in the program:
+returns a TIMESTAMP value.
+
+Programs that use the `NOW` function introduce a new input table,
+which is equivalent with the following declaration:
 
 ```sql
 CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
 ```
 
-(In the future this table will be automatically synthesized by the
-compiler, but for now its declaration must exist in the program.)
-
-The environment has to maintain the invariant that this table always
-contains a single value.  Moreover, deleting a value and inserting a
-new one requires the newly inserted value to be larger than the
-original value.  All invocations of the `NOW()` function within the
-program will in fact produce the value that currently exists in this
-table.
+The user is responsible for supplying the data in this table.  The
+user has to maintain the invariant that this table always contains a
+single value.  Moreover, deleting a value and inserting a new one
+requires the newly inserted value to be larger than the original
+value.  All invocations of the `NOW()` function within the program
+will in fact produce the value that currently exists in this table.
 
 | Operation     | Description         | Example                        |
 |---------------|---------------------|--------------------------------|

--- a/docs/sql/datetime.md
+++ b/docs/sql/datetime.md
@@ -267,21 +267,27 @@ computation on whole days.
 Since DBSP is a *deterministic* query engine, it supports real-time
 based functions in way which is different from other SQL engines.
 Currently the only such function supported is `NOW`.  This function
-returns a TIMESTAMP value.
+returns a `TIMESTAMP` value.
 
-Programs that use the `NOW` function introduce a new input table,
-which is equivalent with the following declaration:
+When a program uses the `NOW` function, the following input table is
+automatically injected by the compiler:
 
 ```sql
 CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
 ```
 
-The user is responsible for supplying the data in this table.  The
-user has to maintain the invariant that this table always contains a
+All invocations of the `NOW()` function within the program
+will produce the value that currently exists in this table.
+
+This table does not currently get populated automatically.
+Instead, the user is responsible for supplying the data to this table.
+The user has to maintain the invariant that this table always contains a
 single value.  Moreover, deleting a value and inserting a new one
 requires the newly inserted value to be larger than the original
-value.  All invocations of the `NOW()` function within the program
-will in fact produce the value that currently exists in this table.
+value.  The user can periodically update the contents of the table with
+the current physical timestamp.  Alternatively, they can use this table to
+evaluate queries over historical data by writing a series of increasing
+past timestamps to it.
 
 | Operation     | Description         | Example                        |
 |---------------|---------------------|--------------------------------|

--- a/docs/sql/grammar.md
+++ b/docs/sql/grammar.md
@@ -10,6 +10,9 @@ form.
 - Parentheses `()` are used for grouping productions together.
 - The vertical bar `|` indicates choice between two constructs.
 
+SQL reserved keywords cannot be used as table and view names.
+In addition, the following keywords are reserved: `USER`, `NOW`.
+
 ```
 statementList:
       statement [ ';' statement ]* [ ';' ]

--- a/python/feldera/sql_context.py
+++ b/python/feldera/sql_context.py
@@ -266,7 +266,7 @@ class SQLContext:
 
         tbl = self.tables.get(table_name)
 
-        if tbl is None:
+        if tbl is None and table_name.lower() != "now":
             raise ValueError(f"Cannot push to table '{table_name}' as it is not registered yet")
         else:
             # tbl.validate_schema(df)   TODO: something like this would be nice

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPPartialCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPPartialCircuit.java
@@ -107,16 +107,22 @@ public final class DBSPPartialCircuit extends DBSPNode implements IDBSPOuterNode
 
     public Iterable<DBSPOperator> getAllOperators() { return this.allOperators; }
 
+    /** Get the table with the specified name.
+     * @param tableName must use the proper casing */
     @Nullable
     public DBSPSourceBaseOperator getInput(String tableName) {
         return this.sourceOperators.get(tableName);
     }
 
+    /** Get the local view with the specified name.
+     * @param viewName must use the proper casing */
     @Nullable
     public DBSPViewOperator getView(String viewName) {
         return this.viewOperators.get(viewName);
     }
 
+    /** Get the external view with the specified name.
+     * @param viewName must use the proper casing */
     @Nullable
     public DBSPSinkOperator getSink(String viewName) {
         return this.sinkOperators.get(viewName);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -26,14 +26,15 @@ package org.dbsp.sqlCompiler.compiler;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.parser.SqlParserUtil;
 import org.dbsp.util.IDiff;
 import org.dbsp.util.SqlLexicalRulesConverter;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 /** Packages options for a compiler from SQL to Rust. */
@@ -128,11 +129,12 @@ public class CompilerOptions implements IDiff<CompilerOptions> {
     }
 
     public String canonicalName(String name) {
-        return switch (this.languageOptions.unquotedCasing) {
-            case "upper" -> name.toUpperCase(Locale.ENGLISH);
-            case "lower" -> name.toLowerCase(Locale.ENGLISH);
-            default -> name;
+        Casing casing = switch (this.languageOptions.unquotedCasing) {
+            case "upper" -> Casing.TO_UPPER;
+            case "lower" -> Casing.TO_LOWER;
+            default -> Casing.UNCHANGED;
         };
+        return SqlParserUtil.toCase(name, casing);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ProgramMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ProgramMetadata.java
@@ -45,6 +45,10 @@ public class ProgramMetadata {
         this.inputTables.put(description.getName(), description);
     }
 
+    public void removeTable(String name) {
+        this.inputTables.remove(name);
+    }
+
     public void addView(IHasSchema description) {
         this.outputViews.put(description.getName(), description);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
@@ -48,13 +48,9 @@ import java.util.Map;
  */
 public class TableContents implements ICompilerComponent {
     public final List<String> tablesCreated = new ArrayList<>();
-    /**
-     * Remember the last statement that created each table.
-     */
+    /** Remember the last statement that created each table. */
     final Map<String, CreateTableStatement> tableCreation = new HashMap<>();
-    /**
-     * Keep track of the contents of each table.
-     */
+    /** Keep track of the contents of each table. */
     @Nullable
     final Map<String, DBSPZSetLiteral> tableContents;
     final DBSPCompiler compiler;
@@ -127,5 +123,12 @@ public class TableContents implements ICompilerComponent {
         for (Map.Entry<String, DBSPZSetLiteral> entry: this.tableContents.entrySet()) {
             entry.setValue(DBSPZSetLiteral.emptyWithElementType(entry.getValue().getElementType()));
         }
+    }
+
+    public void removeTable(String name) {
+        if (this.tableContents == null)
+            return;
+        this.tableContents.remove(name);
+        this.tablesCreated.remove(name);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -49,7 +49,7 @@ public class CircuitOptimizer implements ICompilerComponent {
         IErrorReporter reporter = this.getCompiler();
         CompilerOptions options = this.getCompiler().options;
 
-        passes.add(new ImplementNow(reporter));
+        passes.add(new ImplementNow(reporter, compiler));
         if (options.languageOptions.outputsAreSets)
             passes.add(new EnsureDistinctOutputs(reporter));
         if (options.languageOptions.optimizationLevel < 2) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -140,15 +140,15 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         String expected;
         expected = """
                 Circuit circuit {
-                    // DBSPSourceMultisetOperator 39
+                    // DBSPSourceMultisetOperator 59
                     // CREATE TABLE `T` (`COL1` INTEGER NOT NULL, `COL2` DOUBLE NOT NULL, `COL3` BOOLEAN NOT NULL, `COL4` VARCHAR NOT NULL, `COL5` INTEGER, `COL6` DOUBLE)
-                    let stream39 = T();
-                    // DBSPMapOperator 61
-                    let stream61: stream<WSet<Tup1<b>>> = stream39.map((|t_1: &Tup6<i32, d, b, s, i32?, d?>| Tup1::new(((*t_1).2), )));
+                    let stream59 = T();
+                    // DBSPMapOperator 81
+                    let stream81: stream<WSet<Tup1<b>>> = stream59.map((|t_1: &Tup6<i32, d, b, s, i32?, d?>| Tup1::new(((*t_1).2), )));
                     // CREATE VIEW `V` AS
                     // SELECT `T`.`COL3`
                     // FROM `T`
-                    let stream178: stream<WSet<Tup1<b>>> = stream61;
+                    let stream200: stream<WSet<Tup1<b>>> = stream81;
                 }
                 """;
         Assert.assertEquals(expected, str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -66,7 +66,6 @@ public class StreamingTests extends StreamingTest {
     @Test
     public void testNow() {
         String sql = """
-                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
                 CREATE VIEW V AS SELECT 1, NOW() < TIMESTAMP '2025-12-12 00:00:00';""";
         DBSPCompiler compiler = this.testCompiler();
         compiler.compileStatements(sql);
@@ -82,7 +81,6 @@ public class StreamingTests extends StreamingTest {
     @Test
     public void testNow2() {
         String sql = """
-                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
                 CREATE TABLE T(value INT);
                 CREATE VIEW V AS SELECT *, NOW() FROM T;""";
         DBSPCompiler compiler = this.testCompiler();
@@ -114,7 +112,6 @@ public class StreamingTests extends StreamingTest {
     @Test
     public void testNow3() {
         String sql = """
-                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
                 CREATE TABLE T(value INT);
                 CREATE VIEW V AS SELECT SUM(value) + MINUTE(NOW()) FROM T;""";
         DBSPCompiler compiler = this.testCompiler();
@@ -144,7 +141,6 @@ public class StreamingTests extends StreamingTest {
     public void testNow4() {
         // now() used in WHERE
         String sql = """
-                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
                 CREATE TABLE transactions (
                   id INT PRIMARY KEY,
                   ts TIMESTAMP,


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

With this PR the user no longer has to declare the 'NOW' table, it is synthesized internally by the compiler if the now() function is ever invoked in the program. (In fact, the table is always inserted, but it's removed if the function is never used.)

Fixes #2037 #2011 