### PR TITLE
dbsp_adapters: Wait a bit before disconnecting on pause in `url` adapter.

### DIFF
--- a/crates/pipeline-types/src/transport/url.rs
+++ b/crates/pipeline-types/src/transport/url.rs
@@ -8,6 +8,20 @@ use utoipa::ToSchema;
 pub struct UrlInputConfig {
     /// URL.
     pub path: String,
+
+    /// Timeout before disconnection when paused.
+    ///
+    /// If the pipeline is paused, or if the input adapter reads data faster
+    /// than the pipeline can process it, then the controller will pause the
+    /// input adapter. If the input adapter stays paused longer than this
+    /// timeout, it will drop the network connection to the server. It will
+    /// automatically reconnect when the input adapter starts running again.
+    #[serde(default = "default_pause_timeout")]
+    pub pause_timeout: u32,
+}
+
+const fn default_pause_timeout() -> u32 {
+    60
 }
 
 impl TransportConfigVariant for UrlInputConfig {

--- a/openapi.json
+++ b/openapi.json
@@ -5492,6 +5492,12 @@
           "path": {
             "type": "string",
             "description": "URL."
+          },
+          "pause_timeout": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Timeout before disconnection when paused.\n\nIf the pipeline is paused, or if the input adapter reads data faster\nthan the pipeline can process it, then the controller will pause the\ninput adapter. If the input adapter stays paused longer than this\ntimeout, it will drop the network connection to the server. It will\nautomatically reconnect when the input adapter starts running again.",
+            "minimum": 0
           }
         }
       },

--- a/web-console/src/lib/services/manager/models/UrlInputConfig.ts
+++ b/web-console/src/lib/services/manager/models/UrlInputConfig.ts
@@ -11,4 +11,14 @@ export type UrlInputConfig = {
    * URL.
    */
   path: string
+  /**
+   * Timeout before disconnection when paused.
+   *
+   * If the pipeline is paused, or if the input adapter reads data faster
+   * than the pipeline can process it, then the controller will pause the
+   * input adapter. If the input adapter stays paused longer than this
+   * timeout, it will drop the network connection to the server. It will
+   * automatically reconnect when the input adapter starts running again.
+   */
+  pause_timeout?: number
 }


### PR DESCRIPTION
Until now, the `url` adapter has disconnected from the server immediately if the input adapter was paused, and then reconnected later if it was restarted.  If the pause is due to a backlog filling up, this is likely only a short pause, and incurs the cost of churning the connection to the server, for no gain given that the connection will be resumed later.

This commit adds a delay before disconnecting, solving the problem.

Is this a user-visible change (yes/no): no