### PR TITLE
Improve profiling output to make storage performance easier to understand

### DIFF
--- a/crates/dbsp/src/monitor/circuit_graph.rs
+++ b/crates/dbsp/src/monitor/circuit_graph.rs
@@ -415,19 +415,25 @@ impl CircuitGraph {
 
 fn label(name: &str, location: OperatorLocation) -> String {
     if let Some(location) = location {
-        let file = if location.file().starts_with(env!("CARGO_MANIFEST_DIR")) {
-            let mut path = location
-                .file()
-                // Strip the crate's path from any of its operators
-                .trim_start_matches(env!("CARGO_MANIFEST_DIR"))
-                .replace('\\', "\\\\");
-            path.insert_str(0, "database-stream-processor");
-            path
-        } else {
-            location
-                .file() // Windows uses "\" for paths which dot interprets as an escape char
-                .replace('\\', "\\\\")
-        };
+        let file = location
+            .file()
+            // Strip the crate's path from any of its operators
+            .trim_start_matches(env!("CARGO_MANIFEST_DIR"))
+            // Windows uses "\" for paths which dot interprets as an escape char
+            .replace('\\', "/");
+
+        // Abbreviate the file name to the first letter of each directory
+        // followed by the full name of the file.
+        let mut components = file.split('/');
+        let base_name = components.next_back().unwrap();
+        let mut file = String::new();
+        for dir_name in components {
+            if let Some(c) = dir_name.chars().next() {
+                file.push(c);
+                file.push('/');
+            }
+        }
+        file.push_str(base_name);
 
         format!(
             "{} @ {}:{}:{}",

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -834,6 +834,10 @@ where
             "allocations" => bytes.distinct_allocations(),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
+
+        if let Some(trace) = self.trace.as_ref() {
+            trace.metadata(meta);
+        }
     }
 
     fn fixedpoint(&self, scope: Scope) -> bool {

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -15,8 +15,8 @@ use crate::{
                 VecIndexedWSetMerger,
             },
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, FileIndexedWSet,
-        FileIndexedWSetFactories, Filter, Merger, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder,
+        FileIndexedWSet, FileIndexedWSetFactories, Filter, Merger, WeightedItem,
     },
     DBData, DBWeight, NumEntries,
 };
@@ -334,6 +334,14 @@ where
         match &self.inner {
             Inner::File(file) => file.approximate_byte_size(),
             Inner::Vec(vec) => vec.approximate_byte_size(),
+        }
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        match &self.inner {
+            Inner::Vec(vec) => vec.location(),
+            Inner::File(file) => file.location(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -9,8 +9,8 @@ use crate::{
             vec::key_batch::{VecKeyBuilder, VecKeyMerger},
             FileKeyBatch, OrdKeyBatch,
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, FileKeyBatchFactories,
-        Filter, Merger, OrdKeyBatchFactories, TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder,
+        FileKeyBatchFactories, Filter, Merger, OrdKeyBatchFactories, TimedBuilder, WeightedItem,
     },
     DBData, DBWeight, NumEntries, Timestamp,
 };
@@ -251,6 +251,14 @@ where
         match &self.inner {
             Inner::Vec(vec) => vec.approximate_byte_size(),
             Inner::File(file) => file.approximate_byte_size(),
+        }
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        match &self.inner {
+            Inner::Vec(vec) => vec.location(),
+            Inner::File(file) => file.location(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use crate::trace::cursor::DelegatingCursor;
 use crate::trace::ord::file::val_batch::FileValBuilder;
 use crate::trace::ord::vec::val_batch::VecValBuilder;
-use crate::trace::TimedBuilder;
+use crate::trace::{BatchLocation, TimedBuilder};
 use crate::{
     dynamic::{DataTrait, DynPair, DynVec, DynWeightedPairs, Erase, Factory, WeightTrait},
     time::AntichainRef,
@@ -260,6 +260,14 @@ where
         match &self.inner {
             Inner::File(file) => file.approximate_byte_size(),
             Inner::Vec(vec) => vec.approximate_byte_size(),
+        }
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        match &self.inner {
+            Inner::Vec(vec) => vec.location(),
+            Inner::File(file) => file.location(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -12,7 +12,7 @@ use crate::{
             merge_batcher::MergeBatcher,
             vec::wset_batch::{VecWSet, VecWSetBuilder, VecWSetFactories, VecWSetMerger},
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, FileWSet,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, FileWSet,
         FileWSetFactories, Filter, Merger, WeightedItem,
     },
     DBData, DBWeight, NumEntries,
@@ -330,6 +330,14 @@ where
         match &self.inner {
             Inner::File(file) => file.approximate_byte_size(),
             Inner::Vec(vec) => vec.approximate_byte_size(),
+        }
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        match &self.inner {
+            Inner::Vec(vec) => vec.location(),
+            Inner::File(file) => file.location(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -13,8 +13,8 @@ use crate::{
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
-        TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Filter, Merger, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -360,6 +360,11 @@ where
 
     fn approximate_byte_size(&self) -> usize {
         self.file.byte_size().unwrap() as usize
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        BatchLocation::Storage
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -12,8 +12,8 @@ use crate::{
     trace::{
         cursor::{HasTimeDiffCursor, TimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Filter, Merger,
-        TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Filter, Merger, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime, Timestamp,
@@ -256,6 +256,11 @@ where
 
     fn approximate_byte_size(&self) -> usize {
         self.file.byte_size().unwrap() as usize
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        BatchLocation::Storage
     }
 
     fn lower(&self) -> AntichainRef<'_, T> {

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::trace::cursor::{HasTimeDiffCursor, TimeDiffCursor};
-use crate::trace::TimedBuilder;
+use crate::trace::{BatchLocation, TimedBuilder};
 use crate::{
     dynamic::{
         DataTrait, DynDataTyped, DynOpt, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase,
@@ -283,6 +283,11 @@ where
 
     fn approximate_byte_size(&self) -> usize {
         self.file.byte_size().unwrap() as usize
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        BatchLocation::Storage
     }
 
     fn lower(&self) -> AntichainRef<'_, T> {

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -13,8 +13,8 @@ use crate::{
     trace::{
         cursor::{HasTimeDiffCursor, SingletonTimeDiffCursor},
         ord::{filter, merge_batcher::MergeBatcher},
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Deserializer, Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries, Runtime,
@@ -354,6 +354,11 @@ where
 
     fn approximate_byte_size(&self) -> usize {
         self.file.byte_size().unwrap() as usize
+    }
+
+    #[inline]
+    fn location(&self) -> BatchLocation {
+        BatchLocation::Storage
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/spine_async/tests.rs
+++ b/crates/dbsp/src/trace/spine_async/tests.rs
@@ -48,7 +48,7 @@ fn merger_can_merge_stuff() {
     let level = Spine::<VecWSet<DynI32, DynZWeight>>::size_to_level(len_after_merge);
     assert_eq!(trace.levels[level].len(), 1);
     assert_eq!(
-        trace.levels[level].first_entry().unwrap().get().len(),
+        trace.levels[level].first_entry().unwrap().get().n_updates(),
         len_after_merge
     );
 }


### PR DESCRIPTION
@gz, this modifies the async spine code, mostly to simplify it a bit, but also to add some more profiling output to make it easier to understand what's happening storage-wise.

@ryzhyk, I changed the profiling output a bit to shorten paths because that makes the boxes a lot smaller and therefore it's easier to read the profiles. Would like your OK on that.

Is this a user-visible change (yes/no): no