### PR TITLE
Storage optimizations

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -820,7 +820,7 @@ pub trait Node {
 
     /// Instructs the node to commit the state of its inner operator to
     /// persistent storage.
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError>;
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError>;
 
     /// Instructs the node to restore the state of its inner operator to
     /// the given checkpoint.
@@ -3228,7 +3228,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3312,7 +3312,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3402,7 +3402,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3485,7 +3485,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3588,7 +3588,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), DBSPError> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), DBSPError> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3711,7 +3711,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), Error> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3838,7 +3838,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), Error> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -3983,7 +3983,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), Error> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -4113,7 +4113,7 @@ where
         self.operator.fixedpoint(scope)
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), Error> {
         self.operator.commit(cid, self.global_id().persistent_id())
     }
 
@@ -4225,7 +4225,7 @@ where
         unsafe { (*self.operator.get()).fixedpoint(scope) }
     }
 
-    fn commit(&self, cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, cid: Uuid) -> Result<(), Error> {
         unsafe { (*self.operator.get()).commit(cid, self.global_id().persistent_id()) }
     }
 
@@ -4309,7 +4309,7 @@ where
         unsafe { (*self.operator.get()).fixedpoint(scope) }
     }
 
-    fn commit(&self, _cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, _cid: Uuid) -> Result<(), Error> {
         // The Z-1 operator consists of two logical parts.
         // The first part gets invoked at the start of a clock cycle to retrieve the
         // state stored at the previous clock tick. The second one gets invoked
@@ -4467,7 +4467,7 @@ where
         self.circuit.map_nodes_recursive(f);
     }
 
-    fn commit(&self, _cid: Uuid) -> Result<(), Error> {
+    fn commit(&mut self, _cid: Uuid) -> Result<(), Error> {
         Ok(())
     }
 
@@ -4521,9 +4521,10 @@ impl CircuitHandle {
     }
 
     pub fn commit(&mut self, cid: Uuid) -> Result<(), SchedulerError> {
-        self.circuit.map_nodes_recursive(&mut |node: &dyn Node| {
-            node.commit(cid).expect("committed");
-        });
+        self.circuit
+            .map_nodes_recursive_mut(&mut |node: &mut dyn Node| {
+                node.commit(cid).expect("committed");
+            });
         Ok(())
     }
 

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -200,7 +200,7 @@ pub trait Operator: 'static {
     /// Instructors operator to checkpoint its state to persistent storage.
     ///
     /// For most operators this method is a no-op.
-    fn commit<P: AsRef<str>>(&self, _cid: Uuid, _persistent_id: P) -> Result<(), Error> {
+    fn commit<P: AsRef<str>>(&mut self, _cid: Uuid, _persistent_id: P) -> Result<(), Error> {
         Ok(())
     }
 

--- a/crates/dbsp/src/operator/dynamic/time_series/window.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/window.rs
@@ -121,8 +121,8 @@ where
         panic!("'Window' operator used in fixedpoint iteration")
     }
 
-    fn commit<P: AsRef<str>>(&self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
-        let committed: CommittedWindow = self.into();
+    fn commit<P: AsRef<str>>(&mut self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
+        let committed: CommittedWindow = (self as &Self).into();
         let as_bytes = to_bytes(&committed).expect("Serializing CommittedSpine should work.");
         write_commit_metadata(
             Self::checkpoint_file(cid, &persistent_id),

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -844,9 +844,9 @@ where
         !self.dirty[scope as usize]
     }
 
-    fn commit<P: AsRef<str>>(&self, cid: Uuid, pid: P) -> Result<(), Error> {
+    fn commit<P: AsRef<str>>(&mut self, cid: Uuid, pid: P) -> Result<(), Error> {
         self.trace
-            .as_ref()
+            .as_mut()
             .map(|trace| trace.commit(cid, pid))
             .unwrap_or(Ok(()))
     }

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -281,8 +281,8 @@ where
         }
     }
 
-    fn commit<P: AsRef<str>>(&self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
-        let committed: CommittedZ1 = self.try_into()?;
+    fn commit<P: AsRef<str>>(&mut self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
+        let committed: CommittedZ1 = (self as &Self).try_into()?;
         let as_bytes = to_bytes(&committed).expect("Serializing CommittedZ1 should work.");
         write_commit_metadata(
             Self::checkpoint_file(cid, persistent_id.as_ref()),

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -12,10 +12,7 @@ use std::{
 };
 
 use crc32c::crc32c;
-use lazy_static::lazy_static;
-use metrics::{counter, Counter};
 
-use crate::circuit::metrics::{BUFFER_CACHE_HIT, BUFFER_CACHE_MISS};
 use crate::storage::backend::Backend;
 use crate::storage::file::reader::{CorruptionError, Error};
 use crate::{
@@ -245,11 +242,6 @@ where
     }
 }
 
-lazy_static! {
-    static ref BUFFER_CACHE_HIT_COUNTER: Counter = counter!(BUFFER_CACHE_HIT);
-    static ref BUFFER_CACHE_MISS_COUNTER: Counter = counter!(BUFFER_CACHE_MISS);
-}
-
 impl<E> BufferCache<E>
 where
     E: CacheEntry,
@@ -284,12 +276,9 @@ where
     {
         let key = CacheKey::from((fd, offset));
         if let Some(aux) = self.inner.lock().unwrap().get(key) {
-            BUFFER_CACHE_HIT_COUNTER.increment(1);
             return convert(aux)
                 .map_err(|_| Error::Corruption(CorruptionError::BadBlockType { offset, size }));
         }
-
-        BUFFER_CACHE_MISS_COUNTER.increment(1);
 
         let block = Self::backend().read_block(fd, offset, size)?;
         let aux = E::from_read(block, offset, size)?;

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -189,8 +189,8 @@ where
 
     fn evict_to(&mut self, max_size: usize) {
         while self.cur_cost > max_size {
-            let (_key, value) = self.cache.pop_first().unwrap();
-            self.lru.remove(&value.serial);
+            let (_serial, key) = self.lru.pop_first().unwrap();
+            let value = self.cache.remove(&key).unwrap();
             self.cur_cost -= value.aux.cost();
         }
         self.debug_check_invariants();

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -1965,7 +1965,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum Position<K, A>
 where
     K: DataTrait + ?Sized,
@@ -1986,60 +1986,6 @@ where
             Position::Before => Position::Before,
             Position::Row(path) => Position::Row(path.clone()),
             Position::After => Position::After,
-        }
-    }
-}
-
-impl<K, A> PartialEq for Position<K, A>
-where
-    K: DataTrait + ?Sized,
-    A: DataTrait + ?Sized,
-{
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Before, Self::Before) => true,
-            (Self::Row(a), Self::Row(b)) => a.eq(b),
-            (Self::After, Self::After) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<K, A> Eq for Position<K, A>
-where
-    K: DataTrait + ?Sized,
-    A: DataTrait + ?Sized,
-{
-}
-
-impl<K, A> PartialOrd for Position<K, A>
-where
-    K: DataTrait + ?Sized,
-    A: DataTrait + ?Sized,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<K, A> Ord for Position<K, A>
-where
-    K: DataTrait + ?Sized,
-    A: DataTrait + ?Sized,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (Self::Before, Self::Before) => Equal,
-            (Self::Before, Self::Row(_)) => Less,
-            (Self::Before, Self::After) => Less,
-
-            (Self::Row(_), Self::Before) => Greater,
-            (Self::Row(a), Self::Row(b)) => a.cmp(b),
-            (Self::Row(_), Self::After) => Less,
-
-            (Self::After, Self::Before) => Greater,
-            (Self::After, Self::Row(_)) => Greater,
-            (Self::After, Self::After) => Equal,
         }
     }
 }

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -411,8 +411,7 @@ impl InnerDataBlock {
         })
     }
 
-    fn new(file: &ImmutableFileRef, node: &TreeNode) -> Result<Arc<Self>, Error>
-where {
+    fn new(file: &ImmutableFileRef, node: &TreeNode) -> Result<Arc<Self>, Error> {
         file.cache.read_data_block(
             file.file_handle.as_ref().unwrap(),
             node.location.offset,
@@ -476,8 +475,7 @@ where
         factories: &Factories<K, A>,
         file: &ImmutableFileRef,
         node: &TreeNode,
-    ) -> Result<Self, Error>
-where {
+    ) -> Result<Self, Error> {
         let inner = InnerDataBlock::new(file, node)?;
 
         let expected_rows = node.rows.end - node.rows.start;
@@ -724,8 +722,7 @@ impl InnerIndexBlock {
         })
     }
 
-    fn new(file: &ImmutableFileRef, node: &TreeNode) -> Result<Arc<Self>, Error>
-where {
+    fn new(file: &ImmutableFileRef, node: &TreeNode) -> Result<Arc<Self>, Error> {
         file.cache.read_index_block(
             file.file_handle.as_ref().unwrap(),
             node.location.offset,
@@ -770,8 +767,7 @@ where
         factories: &AnyFactories,
         file: &ImmutableFileRef,
         node: &TreeNode,
-    ) -> Result<Self, Error>
-where {
+    ) -> Result<Self, Error> {
         const MAX_DEPTH: usize = 64;
         if node.depth > MAX_DEPTH {
             // A depth of 64 (very deep) with a branching factor of 2 (very
@@ -1158,8 +1154,7 @@ where
     ///
     /// This internally creates an empty temporary file, which means that it can
     /// fail with an I/O error.
-    pub fn empty(cache: &Arc<BufferCache<FileCacheEntry>>) -> Result<Self, Error>
-where {
+    pub fn empty(cache: &Arc<BufferCache<FileCacheEntry>>) -> Result<Self, Error> {
         let file_handle = cache.create()?;
         let (file_handle, path) = cache.complete(file_handle)?;
         Ok(Self(Arc::new(ReaderInner {
@@ -1327,8 +1322,7 @@ where
 
     /// Return a cursor for the first row in the row group, or just after the
     /// row group if it is empty.
-    pub fn first(&self) -> Result<Cursor<'a, K, A, N, T>, Error>
-where {
+    pub fn first(&self) -> Result<Cursor<'a, K, A, N, T>, Error> {
         let position = if self.is_empty() {
             Position::After
         } else {
@@ -1339,8 +1333,7 @@ where {
 
     /// Return a cursor for the last row in the row group, or just after the
     /// row group if it is empty.
-    pub fn last(&self) -> Result<Cursor<'a, K, A, N, T>, Error>
-where {
+    pub fn last(&self) -> Result<Cursor<'a, K, A, N, T>, Error> {
         let position = if self.is_empty() {
             Position::After
         } else {
@@ -1352,8 +1345,7 @@ where {
     /// If `row` is less than the number of rows in the row group, returns a
     /// cursor for that row; otherwise, returns a cursor for just after the row
     /// group.
-    pub fn nth(&self, row: u64) -> Result<Cursor<'a, K, A, N, T>, Error>
-where {
+    pub fn nth(&self, row: u64) -> Result<Cursor<'a, K, A, N, T>, Error> {
         let position = if row < self.len() {
             Position::for_row(self, self.rows.start + row)?
         } else {
@@ -1821,8 +1813,7 @@ where
         mut indexes: Vec<IndexBlock<K>>,
         mut node: TreeNode,
         row: u64,
-    ) -> Result<Self, Error>
-where {
+    ) -> Result<Self, Error> {
         loop {
             let block = node.read(&reader.0.file)?;
             let next = block.lookup_row(row)?;
@@ -1841,8 +1832,7 @@ where {
             node = next.unwrap();
         }
     }
-    fn for_row_from_hint<T>(reader: &Reader<T>, hint: &Self, row: u64) -> Result<Self, Error>
-where {
+    fn for_row_from_hint<T>(reader: &Reader<T>, hint: &Self, row: u64) -> Result<Self, Error> {
         if hint.data.rows().contains(&row) {
             return Ok(Self {
                 row,
@@ -1877,8 +1867,7 @@ where {
     fn row_group(&self) -> Result<Range<u64>, Error> {
         self.data.row_group(self.row)
     }
-    fn move_to_row<T>(&mut self, reader: &Reader<T>, row: u64) -> Result<(), Error>
-where {
+    fn move_to_row<T>(&mut self, reader: &Reader<T>, row: u64) -> Result<(), Error> {
         if self.data.rows().contains(&row) {
             self.row = row;
         } else {

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -260,7 +260,7 @@ pub trait Trace: BatchReader {
 
     fn key_filter(&self) -> &Option<Filter<Self::Key>>;
     fn value_filter(&self) -> &Option<Filter<Self::Val>>;
-    fn commit<P: AsRef<str>>(&self, _cid: Uuid, _pid: P) -> Result<(), Error> {
+    fn commit<P: AsRef<str>>(&mut self, _cid: Uuid, _pid: P) -> Result<(), Error> {
         Ok(())
     }
     fn restore<P: AsRef<str>>(&mut self, _cid: Uuid, _pid: P) -> Result<(), Error> {
@@ -480,6 +480,10 @@ where
     /// replacing each timestamp `t` in the trace by `t.meet(frontier)`.  See
     /// [`Batch::recede_to`].
     fn recede_to(&mut self, frontier: &Self::Time);
+
+    /// If this batch supports writing itself to storage, this causes it to
+    /// happen.
+    fn persist(&mut self) {}
 
     fn persistent_id(&self) -> Option<PathBuf> {
         None

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -392,6 +392,15 @@ where
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
         Self::Builder::new_builder(factories, time).done()
     }
+
+    fn persist(&mut self) {
+        if let Inner::Vec(vec) = &self.inner {
+            let mut file = FileIndexedWSetBuilder::with_capacity(&self.factories.file, (), 0);
+            copy_to_builder(&mut file, vec.cursor());
+            self.inner = Inner::File(file.done());
+        }
+    }
+
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {
             Inner::Vec(vec) => vec.persistent_id(),

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -27,7 +27,7 @@ use std::fmt::{self, Debug};
 use std::{mem::replace, path::Path};
 use std::{ops::Neg, path::PathBuf};
 
-use super::utils::{copy_to_builder, BuildTo, GenericMerger, MergeTo};
+use super::utils::{copy_to_builder, pick_merge_destination, BuildTo, GenericMerger};
 
 pub struct FallbackIndexedWSetFactories<K, V, R>
 where
@@ -383,8 +383,8 @@ where
     type Builder = FallbackIndexedWSetBuilder<K, V, R>;
     type Merger = FallbackIndexedWSetMerger<K, V, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FallbackIndexedWSetMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        FallbackIndexedWSetMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -454,24 +454,25 @@ where
     fn new_merger(
         batch1: &FallbackIndexedWSet<K, V, R>,
         batch2: &FallbackIndexedWSet<K, V, R>,
+        dst_hint: Option<BatchLocation>,
     ) -> Self {
         Self {
             factories: batch1.factories.clone(),
             inner: match (
-                MergeTo::from((batch1, batch2)),
+                pick_merge_destination(batch1, batch2, dst_hint),
                 &batch1.inner,
                 &batch2.inner,
             ) {
-                (MergeTo::Memory, Inner::Vec(vec1), Inner::Vec(vec2)) => {
-                    MergerInner::AllVec(VecIndexedWSetMerger::new_merger(vec1, vec2))
+                (BatchLocation::Memory, Inner::Vec(vec1), Inner::Vec(vec2)) => {
+                    MergerInner::AllVec(VecIndexedWSetMerger::new_merger(vec1, vec2, dst_hint))
                 }
-                (MergeTo::Memory, _, _) => {
+                (BatchLocation::Memory, _, _) => {
                     MergerInner::ToVec(GenericMerger::new(&batch1.factories.vec, batch1, batch2))
                 }
-                (MergeTo::Storage, Inner::File(file1), Inner::File(file2)) => {
-                    MergerInner::AllFile(FileIndexedWSetMerger::new_merger(file1, file2))
+                (BatchLocation::Storage, Inner::File(file1), Inner::File(file2)) => {
+                    MergerInner::AllFile(FileIndexedWSetMerger::new_merger(file1, file2, dst_hint))
                 }
-                (MergeTo::Storage, _, _) => {
+                (BatchLocation::Storage, _, _) => {
                     MergerInner::ToFile(GenericMerger::new(&batch1.factories.file, batch1, batch2))
                 }
             },

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -316,6 +316,15 @@ where
         }
     }
 
+    fn persist(&mut self) {
+        if let Inner::Vec(vec) = &self.inner {
+            let mut file = FileKeyBuilder::timed_with_capacity(&self.factories.file, 0);
+            copy_to_builder(&mut file, vec.cursor());
+            self.inner =
+                Inner::File(file.done_with_bounds(vec.lower().to_owned(), vec.upper().to_owned()));
+        }
+    }
+
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {
             Inner::Vec(vec) => vec.persistent_id(),

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -23,7 +23,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::utils::{copy_to_builder, BuildTo, GenericMerger, MergeTo};
+use super::utils::{copy_to_builder, pick_merge_destination, BuildTo, GenericMerger};
 
 pub struct FallbackKeyBatchFactories<K, T, R>
 where
@@ -305,8 +305,8 @@ where
     type Builder = FallbackKeyBuilder<K, T, R>;
     type Merger = FallbackKeyMerger<K, T, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        Self::Merger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        Self::Merger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -366,24 +366,28 @@ where
     T: Timestamp,
     R: WeightTrait + ?Sized,
 {
-    fn new_merger(batch1: &FallbackKeyBatch<K, T, R>, batch2: &FallbackKeyBatch<K, T, R>) -> Self {
+    fn new_merger(
+        batch1: &FallbackKeyBatch<K, T, R>,
+        batch2: &FallbackKeyBatch<K, T, R>,
+        dst_hint: Option<BatchLocation>,
+    ) -> Self {
         FallbackKeyMerger {
             factories: batch1.factories.clone(),
             inner: match (
-                MergeTo::from((batch1, batch2)),
+                pick_merge_destination(batch1, batch2, dst_hint),
                 &batch1.inner,
                 &batch2.inner,
             ) {
-                (MergeTo::Memory, Inner::Vec(vec1), Inner::Vec(vec2)) => {
-                    MergerInner::AllVec(VecKeyMerger::new_merger(vec1, vec2))
+                (BatchLocation::Memory, Inner::Vec(vec1), Inner::Vec(vec2)) => {
+                    MergerInner::AllVec(VecKeyMerger::new_merger(vec1, vec2, dst_hint))
                 }
-                (MergeTo::Memory, _, _) => {
+                (BatchLocation::Memory, _, _) => {
                     MergerInner::ToVec(GenericMerger::new(&batch1.factories.vec, batch1, batch2))
                 }
-                (MergeTo::Storage, Inner::File(file1), Inner::File(file2)) => {
-                    MergerInner::AllFile(FileKeyMerger::new_merger(file1, file2))
+                (BatchLocation::Storage, Inner::File(file1), Inner::File(file2)) => {
+                    MergerInner::AllFile(FileKeyMerger::new_merger(file1, file2, dst_hint))
                 }
-                (MergeTo::Storage, _, _) => {
+                (BatchLocation::Storage, _, _) => {
                     MergerInner::ToFile(GenericMerger::new(&batch1.factories.file, batch1, batch2))
                 }
             },

--- a/crates/dbsp/src/trace/ord/fallback/utils.rs
+++ b/crates/dbsp/src/trace/ord/fallback/utils.rs
@@ -381,6 +381,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub(super) enum BuildTo<M, S> {
     Memory(M),
     Storage(S),
@@ -390,33 +391,18 @@ pub(super) enum BuildTo<M, S> {
 impl<M, S> BuildTo<M, S> {
     pub fn for_capacity<MF, SF, T, MC, SC>(
         vf: MF,
-        sf: SF,
+        _sf: SF,
         time: T,
         capacity: usize,
         mc: MC,
-        sc: SC,
+        _sc: SC,
     ) -> Self
     where
         MC: Fn(MF, T, usize) -> M,
         SC: Fn(SF, T, usize) -> S,
     {
-        match Runtime::min_storage_bytes() {
-            usize::MAX => {
-                // Storage is disabled.
-                Self::Memory(mc(vf, time, capacity))
-            }
-
-            min_storage_bytes if capacity >= min_storage_bytes => {
-                // If `capacity` is filled up then we'll have at least 1 byte
-                // per item (as a bottom of the barrel estimate) so we might as
-                // well start out on storage.
-                Self::Storage(sc(sf, time, capacity))
-            }
-            min_storage_bytes => {
-                // Start out in memory and spill to storage if
-                // `min_storage_bytes` is used.
-                Self::Threshold(mc(vf, time, capacity), min_storage_bytes)
-            }
-        }
+        // For now, always build to memory, because spines are the main place we
+        // want to write to storage and spines only do merging.
+        Self::Memory(mc(vf, time, capacity))
     }
 }

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -326,6 +326,15 @@ where
         }
     }
 
+    fn persist(&mut self) {
+        if let Inner::Vec(vec) = &self.inner {
+            let mut file = FileValBuilder::timed_with_capacity(&self.factories.file, 0);
+            copy_to_builder(&mut file, vec.cursor());
+            self.inner =
+                Inner::File(file.done_with_bounds(vec.lower().to_owned(), vec.upper().to_owned()));
+        }
+    }
+
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {
             Inner::Vec(vec) => vec.persistent_id(),

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -387,6 +387,15 @@ where
     fn dyn_empty(factories: &Self::Factories, time: Self::Time) -> Self {
         Self::Builder::new_builder(factories, time).done()
     }
+
+    fn persist(&mut self) {
+        if let Inner::Vec(vec) = &self.inner {
+            let mut file = FileWSetBuilder::with_capacity(&self.factories.file, (), 0);
+            copy_to_builder(&mut file, vec.cursor());
+            self.inner = Inner::File(file.done());
+        }
+    }
+
     fn persistent_id(&self) -> Option<PathBuf> {
         match &self.inner {
             Inner::Vec(vec) => vec.persistent_id(),

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -423,8 +423,8 @@ where
     type Builder = FileIndexedWSetBuilder<K, V, R>;
     type Merger = FileIndexedWSetMerger<K, V, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FileIndexedWSetMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        FileIndexedWSetMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -580,7 +580,11 @@ where
     R: WeightTrait + ?Sized,
 {
     #[inline]
-    fn new_merger(batch1: &FileIndexedWSet<K, V, R>, batch2: &FileIndexedWSet<K, V, R>) -> Self {
+    fn new_merger(
+        batch1: &FileIndexedWSet<K, V, R>,
+        batch2: &FileIndexedWSet<K, V, R>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         Self {
             factories: batch1.factories.clone(),
             lower1: batch1.lower_bound,

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -317,8 +317,8 @@ where
     type Builder = FileKeyBuilder<K, T, R>;
     type Merger = FileKeyMerger<K, T, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        Self::Merger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        Self::Merger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -477,7 +477,11 @@ where
     T: Timestamp,
     R: WeightTrait + ?Sized,
 {
-    fn new_merger(batch1: &FileKeyBatch<K, T, R>, batch2: &FileKeyBatch<K, T, R>) -> Self {
+    fn new_merger(
+        batch1: &FileKeyBatch<K, T, R>,
+        batch2: &FileKeyBatch<K, T, R>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         FileKeyMerger {
             factories: batch1.factories.clone(),
             lower: batch1.lower().meet(batch2.lower()),

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -345,8 +345,8 @@ where
     type Builder = FileValBuilder<K, V, T, R>;
     type Merger = FileValMerger<K, V, T, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FileValMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        FileValMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -680,7 +680,11 @@ where
     T: Timestamp,
     R: WeightTrait + ?Sized,
 {
-    fn new_merger(batch1: &FileValBatch<K, V, T, R>, batch2: &FileValBatch<K, V, T, R>) -> Self {
+    fn new_merger(
+        batch1: &FileValBatch<K, V, T, R>,
+        batch2: &FileValBatch<K, V, T, R>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         Self {
             factories: batch1.factories.clone(),
             result: None,

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -416,8 +416,8 @@ where
     type Builder = FileWSetBuilder<K, R>;
     type Merger = FileWSetMerger<K, R>;
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        FileWSetMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        FileWSetMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -472,7 +472,11 @@ where
     K: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    fn new_merger(batch1: &FileWSet<K, R>, batch2: &FileWSet<K, R>) -> Self {
+    fn new_merger(
+        batch1: &FileWSet<K, R>,
+        batch2: &FileWSet<K, R>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         Self {
             factories: batch1.factories.clone(),
             lower1: batch1.lower_bound,

--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -11,8 +11,8 @@ use crate::{
             Builder as _, Cursor as _, Layer, LayerBuilder, LayerCursor, LayerFactories, Leaf,
             LeafBuilder, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Deserializer, Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::Tup2,
     DBData, DBWeight, NumEntries,
@@ -489,8 +489,8 @@ where
         )
     }*/
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        VecIndexedWSetMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        VecIndexedWSetMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
@@ -529,6 +529,7 @@ where
     fn new_merger(
         batch1: &VecIndexedWSet<K, V, R, O>,
         batch2: &VecIndexedWSet<K, V, R, O>,
+        _dst_hint: Option<BatchLocation>,
     ) -> Self {
         Self {
             lower1: batch1.layer.lower_bound(),

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -10,8 +10,8 @@ use crate::{
             Builder as _, Cursor as _, Layer, LayerBuilder, LayerCursor, LayerFactories, Leaf,
             LeafBuilder, LeafCursor, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, TimedBuilder, WeightedItem,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Deserializer, Filter, Merger, Serializer, TimedBuilder, WeightedItem,
     },
     utils::{ConsolidatePairedSlices, Tup2},
     DBData, DBWeight, NumEntries, Timestamp,
@@ -343,8 +343,8 @@ where
         Self::from_tuples(time, keys)
     }*/
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        Self::Merger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        Self::Merger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -458,7 +458,11 @@ where
     R: WeightTrait + ?Sized,
     O: OrdOffset,
 {
-    fn new_merger(batch1: &VecKeyBatch<K, T, R, O>, batch2: &VecKeyBatch<K, T, R, O>) -> Self {
+    fn new_merger(
+        batch1: &VecKeyBatch<K, T, R, O>,
+        batch2: &VecKeyBatch<K, T, R, O>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         // Leonid: we do not require batch bounds to grow monotonically.
         //assert!(batch1.upper() == batch2.lower());
 

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -11,8 +11,8 @@ use crate::{
             Builder as _, Cursor as _, Layer, LayerBuilder, LayerCursor, LayerFactories, Leaf,
             LeafBuilder, LeafCursor, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
         },
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Deserializer,
-        Filter, Merger, Serializer, TimedBuilder,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
+        Deserializer, Filter, Merger, Serializer, TimedBuilder,
     },
     utils::{ConsolidatePairedSlices, Tup2},
     DBData, DBWeight, NumEntries, Timestamp,
@@ -421,8 +421,8 @@ where
         )
     }*/
 
-    fn begin_merge(&self, other: &Self) -> Self::Merger {
-        VecValMerger::new_merger(self, other)
+    fn begin_merge(&self, other: &Self, dst_hint: Option<BatchLocation>) -> Self::Merger {
+        VecValMerger::new_merger(self, other, dst_hint)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -588,6 +588,7 @@ where
     fn new_merger(
         batch1: &VecValBatch<K, V, T, R, O>,
         batch2: &VecValBatch<K, V, T, R, O>,
+        _dst_hint: Option<BatchLocation>,
     ) -> Self {
         // Leonid: we do not require batch bounds to grow monotonically.
         // assert!(batch1.upper() == batch2.lower());

--- a/crates/dbsp/src/trace/spine_async/mod.rs
+++ b/crates/dbsp/src/trace/spine_async/mod.rs
@@ -572,7 +572,7 @@ where
                 if merger.is_none() {
                     // We initialize this here because to ensure we create the new file we're
                     // writing to on the background thread that's running the closure.
-                    merger = Some(<B as Batch>::Merger::new_merger(&a, &b));
+                    merger = Some(<B as Batch>::Merger::new_merger(&a, &b, None));
                 }
 
                 merger

--- a/crates/dbsp/src/trace/spine_fueled.rs
+++ b/crates/dbsp/src/trace/spine_fueled.rs
@@ -782,8 +782,8 @@ where
         &self.value_filter
     }
 
-    fn commit<P: AsRef<str>>(&self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
-        let committed: CommittedSpine<B> = self.into();
+    fn commit<P: AsRef<str>>(&mut self, cid: Uuid, persistent_id: P) -> Result<(), Error> {
+        let committed: CommittedSpine<B> = (self as &Self).into();
         let as_bytes = to_bytes(&committed).expect("Serializing CommittedSpine should work.");
         write_commit_metadata(
             Self::checkpoint_file(cid, &persistent_id),

--- a/crates/dbsp/src/trace/spine_fueled.rs
+++ b/crates/dbsp/src/trace/spine_fueled.rs
@@ -1300,7 +1300,7 @@ where
                 //assert!(batch1.upper() == batch2.lower());
                 let start = Instant::now();
                 counter!(TOTAL_COMPACTIONS).increment(1);
-                let begin_merge = <B as Batch>::begin_merge(&batch1, &batch2);
+                let begin_merge = <B as Batch>::begin_merge(&batch1, &batch2, None);
                 MergeVariant::InProgress(batch1, batch2, begin_merge, start)
             }
             (batch @ Some(_), None) | (None, batch @ Some(_)) => MergeVariant::Complete(batch),

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     time::AntichainRef,
     trace::{
-        Batch, BatchFactories, BatchReader, BatchReaderFactories, Batcher, Builder, Cursor, Filter,
-        Merger, Trace,
+        Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Batcher, Builder,
+        Cursor, Filter, Merger, Trace,
     },
     DBData, DBWeight, NumEntries, Timestamp,
 };
@@ -824,7 +824,11 @@ where
     R: WeightTrait + ?Sized,
     T: Timestamp,
 {
-    fn new_merger(source1: &TestBatch<K, V, T, R>, source2: &TestBatch<K, V, T, R>) -> Self {
+    fn new_merger(
+        source1: &TestBatch<K, V, T, R>,
+        source2: &TestBatch<K, V, T, R>,
+        _dst_hint: Option<BatchLocation>,
+    ) -> Self {
         let data = source1
             .data
             .iter()


### PR DESCRIPTION
On my system, this series reduces the runtime of the HopWorks demo with 10M events, with storage enabled, from >600s to 35s. The final commit is the only one I'm unsure about, since it drops several metrics (to save 71% on runtime!), but the rest of the commits are ones that make sense to me in production.