### PR TITLE
Benchmark with 100M events

### DIFF
--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -41,7 +41,7 @@ mv crates/nexmark/${NEXMARK_CSV_FILE} $NEXMARK_RESULTS_DIR
 # This test requires a running instance of redpanda and pipeline-manager.
 # The Earthfile should run those.
 # 100M events causes out of memory problems with SQL tests
-MAX_EVENTS=10000000
+MAX_EVENTS=100000000
 if [ "$SMOKE" != "" ]; then
   MAX_EVENTS=1000000
 fi


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This PR changes the benchmark of SQL in CI to use 100M events, just like the Rust benchmark.

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
