### PR TITLE
dbsp: Don't reserve excess capacity for vector merge results.

### DIFF
--- a/crates/dbsp/src/dynamic/vec.rs
+++ b/crates/dbsp/src/dynamic/vec.rs
@@ -91,6 +91,11 @@ pub trait Vector<T: DataTrait + ?Sized>: Data {
     /// Does nothing if capacity is already sufficient.
     fn reserve(&mut self, additional: usize);
 
+    /// Reserve capacity for exactly `additional` more elements.
+    ///
+    /// Does nothing if capacity is already sufficient.
+    fn reserve_exact(&mut self, additional: usize);
+
     /// Append values in the range `from..to` in `other` to `self`.
     fn extend_from_range(&mut self, other: &DynVec<T>, from: usize, to: usize);
 
@@ -324,6 +329,10 @@ where
 
     fn reserve(&mut self, reservation: usize) {
         LeanVec::reserve(self, reservation)
+    }
+
+    fn reserve_exact(&mut self, reservation: usize) {
+        LeanVec::reserve_exact(self, reservation)
     }
 
     fn extend_from_range(&mut self, other: &DynVec<Trait>, from: usize, to: usize) {

--- a/crates/dbsp/src/trace/layers/layer.rs
+++ b/crates/dbsp/src/trace/layers/layer.rs
@@ -998,7 +998,7 @@ where
         offs.push(O::zero());
 
         let mut keys = other1.factories.keys.default_box();
-        keys.reserve(other1.keys() + other2.keys());
+        keys.reserve_exact(other1.keys() + other2.keys());
 
         Self {
             factories: other1.factories.clone(),
@@ -1156,7 +1156,7 @@ where
         offs.push(O::zero());
 
         let mut keys = factories.keys.default_box();
-        keys.reserve(cap);
+        keys.reserve_exact(cap);
 
         Self {
             factories: factories.clone(),

--- a/crates/dbsp/src/trace/layers/leaf.rs
+++ b/crates/dbsp/src/trace/layers/leaf.rs
@@ -118,8 +118,8 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Leaf<K, R> {
             lower_bound: 0,
         };
 
-        result.keys.reserve(capacity);
-        result.diffs.reserve(capacity);
+        result.keys.reserve_exact(capacity);
+        result.diffs.reserve_exact(capacity);
 
         result
     }


### PR DESCRIPTION
`LeanVec::reserve` allocates more capacity than requested.  The vector-based merger used this function to allocate the maximum capacity it could need, so it was always allocating 1.5x to 2x the maximum it needed. This fixes the problem by adding `LeanVec::reserve_exact` and using it for initial allocations.

Is this a user-visible change (yes/no): no