### PR TITLE
Enable CPU profiler by default.

### DIFF
--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -124,6 +124,11 @@ impl StorageCacheConfig {
     }
 }
 
+/// Enable the CPU profile by default.
+fn default_cpu_profiler() -> bool {
+    true
+}
+
 /// Global pipeline configuration settings. This is the publicly
 /// exposed type for users to configure pipelines.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -146,7 +151,9 @@ pub struct RuntimeConfig {
     pub storage: bool,
 
     /// Enable CPU profiler.
-    #[serde(default)]
+    ///
+    /// The default value is `true`.
+    #[serde(default = "default_cpu_profiler")]
     pub cpu_profiler: bool,
 
     /// Enable pipeline tracing.

--- a/openapi.json
+++ b/openapi.json
@@ -805,7 +805,7 @@
                   "$ref": "#/components/schemas/Pipeline"
                 },
                 "example": {
-                  "cpu_profiler": false,
+                  "cpu_profiler": true,
                   "inputs": {
                     "Input-To-Table": {
                       "enable_output_buffer": false,
@@ -4480,7 +4480,7 @@
             "properties": {
               "cpu_profiler": {
                 "type": "boolean",
-                "description": "Enable CPU profiler."
+                "description": "Enable CPU profiler.\n\nThe default value is `true`."
               },
               "max_buffering_delay_usecs": {
                 "type": "integer",
@@ -5091,7 +5091,7 @@
         "properties": {
           "cpu_profiler": {
             "type": "boolean",
-            "description": "Enable CPU profiler."
+            "description": "Enable CPU profiler.\n\nThe default value is `true`."
           },
           "max_buffering_delay_usecs": {
             "type": "integer",


### PR DESCRIPTION
The `cpu_profiler` flag was set to `false` by default.  The reasoning behind this was that enabling the profiler can introduce some overhead; however I don't think this overhead is significant (or measurable) in practice.  It is valuable to make the CPU profile available on all pipelines, so we change the default to `true`.  We may eliminate the flag altogether in the future.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
