### PR TITLE
[SQL] Enable 3 more Nexmark queries using SQL user-defined functions

### DIFF
--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q12.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q12.sql
@@ -1,0 +1,8 @@
+CREATE VIEW Q12 AS
+SELECT
+    B.bidder,
+    count(*) as bid_count,
+    TUMBLE_START(B.p_time, INTERVAL '10' SECOND) as starttime,
+    TUMBLE_END(B.p_time, INTERVAL '10' SECOND) as endtime
+FROM (SELECT *, NOW() as p_time FROM bid) B
+GROUP BY B.bidder, TUMBLE(B.p_time, INTERVAL '10' SECOND);

--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q14.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q14.sql
@@ -1,0 +1,18 @@
+CREATE FUNCTION COUNT_CHAR(S VARCHAR, C CHAR) RETURNS INT
+AS LENGTH(S) - LENGTH(REPLACE(S, C, ''));
+
+CREATE VIEW Q14 AS
+SELECT
+    auction,
+    bidder,
+    0.908 * price as price,
+    CASE
+        WHEN HOUR(date_time) >= 8 AND HOUR(date_time) <= 18 THEN 'dayTime'
+        WHEN HOUR(date_time) <= 6 OR HOUR(date_time) >= 20 THEN 'nightTime'
+        ELSE 'otherTime'
+    END AS bidTimeType,
+    date_time,
+    extra,
+    count_char(extra, 'c') AS c_counts
+FROM bid
+WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;

--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q22.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q22.sql
@@ -1,0 +1,9 @@
+CREATE FUNCTION SPLIT_INDEX(s VARCHAR, sep CHAR, index INT) RETURNS VARCHAR
+AS SPLIT(s, CAST(sep AS VARCHAR))[index + 1];
+
+CREATE VIEW Q22 AS
+SELECT
+    auction, bidder, price, channel,
+    SPLIT_INDEX(url, '/', 3) as dir1,
+    SPLIT_INDEX(url, '/', 4) as dir2,
+    SPLIT_INDEX(url, '/', 5) as dir3 FROM bid;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -2093,7 +2093,9 @@ public class CalciteToDBSPCompiler extends RelVisitor
         }
         if (metadata.isPrimaryKey) {
             if (type.mayBeNull) {
-                this.compiler.reportError(metadata.getNode().getPositionRange(),
+                // This is either an error or a warning, depending on the value of the 'lenient' flag
+                this.compiler.reportProblem(metadata.getNode().getPositionRange(),
+                        this.compiler.options.languageOptions.lenient,
                         "PRIMARY KEY cannot be nullable",
                         "PRIMARY KEY column " + Utilities.singleQuote(metadata.getName()) +
                                 " has type " + metadata.getType().getFullTypeString() + ", which is nullable");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -1161,17 +1161,14 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     throw new UnimplementedException(node);
                 DBSPType collectionType = ops.get(0).getType();
                 DBSPExpression index = ops.get(1);
-                if (collectionType.is(DBSPTypeVec.class)) {
-                    // index into a vector: cast to unsigned
-                    index = index.cast(new DBSPTypeUSize(CalciteObject.EMPTY, false));
-                } else if (collectionType.is(DBSPTypeMap.class)) {
+                DBSPOpcode opcode = DBSPOpcode.SQL_INDEX;
+                if (collectionType.is(DBSPTypeMap.class)) {
                     // index into a map
                     DBSPTypeMap map = collectionType.to(DBSPTypeMap.class);
                     index = index.cast(map.getKeyType());
-                } else {
-                    throw new UnsupportedException(node);
+                    opcode = DBSPOpcode.MAP_INDEX;
                 }
-                return new DBSPBinaryExpression(node, type, DBSPOpcode.SQL_INDEX, ops.get(0), index);
+                return new DBSPBinaryExpression(node, type, opcode, ops.get(0), index);
             }
             case TIMESTAMP_DIFF:
             case TRIM: {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
@@ -162,7 +162,7 @@ public class ExternalFunction extends SqlFunction {
             // +1 because the first parameter is the source position parameter
             int index = inputRef.getIndex() + 1;
             if (index < this.parameters.size()) {
-                return this.parameters.get(index).asVariable();
+                return this.parameters.get(index).asVariable().applyCloneIfNeeded();
             }
             throw new InternalCompilerError("Parameter index out of bounds ", node);
         }
@@ -183,7 +183,7 @@ public class ExternalFunction extends SqlFunction {
     public DBSPFunction getImplementation(TypeCompiler typeCompiler, DBSPCompiler compiler) {
         if (this.body != null) {
             List<DBSPParameter> parameters = new ArrayList<>();
-            // First paramter is always source position
+            // First parameter is always source position
             parameters.add(sourcePositionParameter());
             for (RelDataTypeField param: this.parameterList) {
                 DBSPType type = typeCompiler.convertType(param.getType(), true);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -42,6 +42,7 @@ public enum DBSPOpcode {
     IS_DISTINCT("is_distinct", false),
     IS_NOT_DISTINCT("is_not_distinct", false),
     SQL_INDEX("[]", false),
+    MAP_INDEX("[]", false),
     RUST_INDEX("[]", false),
 
     // Aggregate operations.  These operations

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimeTests.java
@@ -135,25 +135,25 @@ public class PostgresTimeTests extends SqlIoTest {
         // Extract second and millisecond return integers in Calcite instead of DECIMAL
         this.qs("""
                 SELECT EXTRACT(MILLISECOND FROM TIME '13:30:25.575401');
-                  extract \s
+                  extract
                 -----------
                  25575
                 (1 row)
 
                 SELECT EXTRACT(SECOND      FROM TIME '13:30:25.575401');
-                  extract \s
+                  extract
                 -----------
                  25
                 (1 row)
 
                 SELECT EXTRACT(MINUTE      FROM TIME '13:30:25.575401');
-                 extract\s
+                 extract
                 ---------
                       30
                 (1 row)
 
                 SELECT EXTRACT(HOUR        FROM TIME '13:30:25.575401');
-                 extract\s
+                 extract
                 ---------
                       13
                 (1 row)""");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
@@ -100,7 +100,7 @@ SELECT
     0.908 * price as price, -- convert dollar to euro
     date_time,
     extra
-FROM bid""",
+FROM bid;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -118,7 +118,7 @@ FROM bid""",
 -- To make it more interesting we instead choose bids for every 123'th auction.
 -- -------------------------------------------------------------------------------------------------
 
-CREATE VIEW q2 AS SELECT auction, price FROM bid WHERE MOD(auction, 123) = 0
+CREATE VIEW q2 AS SELECT auction, price FROM bid WHERE MOD(auction, 123) = 0;
 """,
 
             """
@@ -134,7 +134,7 @@ CREATE VIEW q3 AS SELECT
 FROM
     auction AS A INNER JOIN person AS P on A.seller = P.id
 WHERE
-    A.category = 10 and (P.state = 'OR' OR P.state = 'ID' OR P.state = 'CA')""",
+    A.category = 10 and (P.state = 'OR' OR P.state = 'ID' OR P.state = 'CA');""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -153,7 +153,7 @@ FROM (
     WHERE A.id = B.auction AND B.date_time BETWEEN A.date_time AND A.expires
     GROUP BY A.id, A.category
 ) Q
-GROUP BY Q.category""",
+GROUP BY Q.category;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -199,7 +199,7 @@ SELECT AuctionBids.auction, AuctionBids.num
  ) AS MaxBids
  ON AuctionBids.starttime = MaxBids.starttime AND
     AuctionBids.endtime = MaxBids.endtime AND
-    AuctionBids.num >= MaxBids.maxn""",
+    AuctionBids.num >= MaxBids.maxn;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -215,11 +215,11 @@ SELECT
     AVG(Q.final) OVER
         (PARTITION BY Q.seller ORDER BY Q.date_time ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
 FROM (
-    SELECT MAX(B.price) AS final, A.seller, B.date_time
+    SELECT MAX(B.price) AS final, A.seller, ARG_MAX(B.price, B.date_time) as date_time
     FROM auction AS A, bid AS B
     WHERE A.id = B.auction and B.date_time between A.date_time and A.expires
     GROUP BY A.id, A.seller
-) AS Q""",
+) AS Q;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -241,7 +241,7 @@ JOIN (
   GROUP BY TUMBLE(B1.date_time, INTERVAL '10' SECOND)
 ) B1
 ON B.price = B1.maxprice
-WHERE B.date_time BETWEEN B1.date_time  - INTERVAL '10' SECOND AND B1.date_time
+WHERE B.date_time BETWEEN B1.date_time  - INTERVAL '10' SECOND AND B1.date_time;
 """,
             """
 -- -------------------------------------------------------------------------------------------------
@@ -270,7 +270,7 @@ JOIN (
   FROM auction A
   GROUP BY A.seller, TUMBLE(A.date_time, INTERVAL '10' SECOND)
 ) A
-ON P.id = A.seller AND P.starttime = A.starttime AND P.endtime = A.endtime""",
+ON P.id = A.seller AND P.starttime = A.starttime AND P.endtime = A.endtime;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -289,7 +289,7 @@ FROM (
    FROM auction A, bid B
    WHERE A.id = B.auction AND B.date_time BETWEEN A.date_time AND A.expires
 )
-WHERE rownum <= 1""",
+WHERE rownum <= 1;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -302,7 +302,7 @@ WHERE rownum <= 1""",
 
 CREATE VIEW Q10 AS -- PARTITIONED BY (dt, hm) AS
 SELECT auction, bidder, price, date_time, extra, FORMAT_DATE('yyyy-MM-dd', date_time), FORMAT_DATE('HH:mm', date_time)
-FROM bid""",
+FROM bid;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -321,7 +321,7 @@ SELECT
     SESSION_START(B.date_time, INTERVAL '10' SECOND) as starttime,
     SESSION_END(B.date_time, INTERVAL '10' SECOND) as endtime
 FROM bid B
-GROUP BY B.bidder, SESSION(B.date_time, INTERVAL '10' SECOND)""",
+GROUP BY B.bidder, SESSION(B.date_time, INTERVAL '10' SECOND);""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -340,8 +340,8 @@ SELECT
     count(*) as bid_count,
     TUMBLE_START(B.p_time, INTERVAL '10' SECOND) as starttime,
     TUMBLE_END(B.p_time, INTERVAL '10' SECOND) as endtime
-FROM (SELECT *, PROCTIME() as p_time FROM bid) B
-GROUP BY B.bidder, TUMBLE(B.p_time, INTERVAL '10' SECOND)""",
+FROM (SELECT *, NOW() as p_time FROM bid) B
+GROUP BY B.bidder, TUMBLE(B.p_time, INTERVAL '10' SECOND);""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -357,9 +357,9 @@ SELECT
     B.price,
     B.date_time,
     S.value
-FROM (SELECT *, PROCTIME() as p_time FROM bid) B
-JOIN side_input FOR SYSTEM_TIME AS OF B.p_time AS S
-ON mod(B.auction, 10000) = S.key""",
+FROM (SELECT *, NOW() as p_time FROM bid) B
+ASOF JOIN side_input MATCH_CONDITION B.p_time <= side_input.time AS S
+ON mod(B.auction, 10000) = S.key;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -370,6 +370,9 @@ ON mod(B.auction, 10000) = S.key""",
 -- -------------------------------------------------------------------------------------------------
 
 -- CREATE FUNCTION count_char AS 'com.github.nexmark.flink.udf.CountChar';
+
+CREATE FUNCTION COUNT_CHAR(S VARCHAR, C CHAR) RETURNS INT
+AS LENGTH(S) - LENGTH(REPLACE(S, C, ''));
 
 CREATE VIEW Q14 AS
 SELECT
@@ -385,8 +388,7 @@ SELECT
     extra,
     count_char(extra, 'c') AS c_counts
 FROM bid
-WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000""",
-
+WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;""",
             """
 -- -------------------------------------------------------------------------------------------------
 -- Query 15: Bidding Statistics Report (Not in original suite)
@@ -411,7 +413,7 @@ SELECT
      count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
      count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
 FROM bid
-GROUP BY FORMAT_DATE('yyyy-MM-dd', date_time)""",
+GROUP BY FORMAT_DATE('yyyy-MM-dd', date_time);""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -439,7 +441,7 @@ SELECT
     count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
     count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
 FROM bid
-GROUP BY channel, format_date('yyyy-MM-dd', date_time)""",
+GROUP BY channel, format_date('yyyy-MM-dd', date_time);""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -462,7 +464,7 @@ SELECT
      avg(price) AS avg_price,
      sum(price) AS sum_price
 FROM bid
-GROUP BY auction, format_date('yyyy-MM-dd', date_time)""",
+GROUP BY auction, format_date('yyyy-MM-dd', date_time);""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -476,7 +478,7 @@ CREATE VIEW Q18 AS
 SELECT auction, bidder, price, channel, url, date_time, extra
  FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
        FROM bid)
- WHERE rank_number <= 1""",
+ WHERE rank_number <= 1;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -489,7 +491,7 @@ SELECT auction, bidder, price, channel, url, date_time, extra
 CREATE VIEW Q19 AS
 SELECT * FROM
 (SELECT *, ROW_NUMBER() OVER (PARTITION BY auction ORDER BY price DESC) AS rank_number FROM bid)
-WHERE rank_number <= 10""",
+WHERE rank_number <= 10;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -505,7 +507,7 @@ SELECT
     itemName, description, initialBid, reserve, A.date_time as AdateTime, expires, seller, category, A.extra as Aextra
 FROM
     bid AS B INNER JOIN auction AS A on B.auction = A.id
-WHERE A.category = 10""",
+WHERE A.category = 10;""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -527,7 +529,7 @@ SELECT
         END
     AS channel_id FROM bid
     where REGEXP_EXTRACT(url, '(&|^)channel_id=([^&]*)', 2) is not null or
-          lower(channel) in ('apple', 'google', 'facebook', 'baidu')""",
+          lower(channel) in ('apple', 'google', 'facebook', 'baidu');""",
 
             """
 -- -------------------------------------------------------------------------------------------------
@@ -537,12 +539,15 @@ SELECT
 -- Illustrates a SPLIT_INDEX SQL.
 -- -------------------------------------------------------------------------------------------------
 
+CREATE FUNCTION SPLIT_INDEX(s VARCHAR, sep CHAR, index INT) RETURNS VARCHAR
+AS SPLIT(s, CAST(sep AS VARCHAR))[index + 1];
+
 CREATE VIEW Q22 AS
 SELECT
     auction, bidder, price, channel,
     SPLIT_INDEX(url, '/', 3) as dir1,
     SPLIT_INDEX(url, '/', 4) as dir2,
-    SPLIT_INDEX(url, '/', 5) as dir3 FROM bid"""
+    SPLIT_INDEX(url, '/', 5) as dir3 FROM bid;"""
     };
 
     @Override
@@ -717,6 +722,16 @@ INSERT INTO Bid VALUES(4, 1, 60, 'my-channel', 'https://example.com', '2020-01-0
         );
     }
 
+    @Test @Ignore("OVER with ROWS")
+    public void q6test() {
+        this.createTest(6,
+                """
+                """,
+                """
+                 auction | price | bidder | date_time           | extra | weight
+                -----------------------------------------------------------------""");
+    }
+
     @Test @Ignore("The results are wrong, must investigate")
     public void q7test() {
         this.createTest(7,
@@ -849,24 +864,30 @@ INSERT INTO auction VALUES(101, 'item-name', 'description', 5, 10, '2020-01-01 0
     }
 
     @Test
+    public void q22test() {
+        this.createTest(22, "",
+                """
+ auction | bidder | price | channel | dir1 | dir2 | dir3
+---------------------------------------------------------""");
+    }
+
+    @Test
     public void testCompile() {
         DBSPCompiler compiler = this.testCompiler();
         this.prepareInputs(compiler);
+
         Set<Integer> unsupported = new HashSet<>() {{
-            add(5); // hop
-            add(6); // group-by problem
+            add(5);  // hop
+            add(6);  // over with rows
             add(11); // session
-            add(12); // proctime
-            add(13); // proctime
-            add(14); // count_char
+            add(13); // asof join
             add(21); // regexp_extract
-            add(22); // split_index
         }};
 
         int index = 0;
         for (String query: queries) {
             if (!unsupported.contains(index)) {
-                compiler.compileStatement(query);
+                compiler.compileStatements(query);
             }
             index++;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -72,7 +72,9 @@ public class BaseSQLTests {
         compiler.compileStatements(statements);
         getCircuit(compiler);
         Assert.assertTrue(compiler.messages.exitCode != 0);
+        // compiler.options.ioOptions.emitJsonErrors = true;
         String message = compiler.messages.toString();
+        // System.out.println(message);
         boolean contains = message.contains(messageFragment);
         if (!contains)
             Assert.fail("Error message\n" + Utilities.singleQuote(message) +

--- a/sql-to-dbsp-compiler/lib/sqllib/src/array.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/array.rs
@@ -40,10 +40,14 @@ pub fn cardinalityN<T>(value: Option<Vec<T>>) -> Option<i32> {
 // nullability of vector element
 // nullability of index
 
-pub fn index___<T>(value: Vec<T>, index: usize) -> Option<T>
+pub fn index___<T>(value: Vec<T>, index: isize) -> Option<T>
 where
     T: Clone,
 {
+    if index < 0 {
+        return None;
+    };
+    let index: usize = index as usize;
     if index >= value.len() {
         None
     } else {
@@ -51,7 +55,7 @@ where
     }
 }
 
-pub fn index___N<T>(value: Vec<T>, index: Option<usize>) -> Option<T>
+pub fn index___N<T>(value: Vec<T>, index: Option<isize>) -> Option<T>
 where
     T: Clone,
 {
@@ -59,10 +63,14 @@ where
     index___(value, index)
 }
 
-pub fn index__N_<T>(value: Vec<Option<T>>, index: usize) -> Option<T>
+pub fn index__N_<T>(value: Vec<Option<T>>, index: isize) -> Option<T>
 where
     T: Clone,
 {
+    if index < 0 {
+        return None;
+    };
+    let index: usize = index as usize;
     if index >= value.len() {
         None
     } else {
@@ -70,11 +78,15 @@ where
     }
 }
 
-pub fn index__N_N<T>(value: Vec<Option<T>>, index: Option<usize>) -> Option<T>
+pub fn index__N_N<T>(value: Vec<Option<T>>, index: Option<isize>) -> Option<T>
 where
     T: Clone,
 {
     let index = index?;
+    if index < 0 {
+        return None;
+    };
+    let index: usize = index as usize;
     if index >= value.len() {
         None
     } else {
@@ -82,7 +94,7 @@ where
     }
 }
 
-pub fn index_N__<T>(value: Option<Vec<T>>, index: usize) -> Option<T>
+pub fn index_N__<T>(value: Option<Vec<T>>, index: isize) -> Option<T>
 where
     T: Clone,
 {
@@ -92,7 +104,7 @@ where
     }
 }
 
-pub fn index_N__N<T>(value: Option<Vec<T>>, index: Option<usize>) -> Option<T>
+pub fn index_N__N<T>(value: Option<Vec<T>>, index: Option<isize>) -> Option<T>
 where
     T: Clone,
 {
@@ -103,7 +115,7 @@ where
     }
 }
 
-pub fn index_N_N_<T>(value: Option<Vec<Option<T>>>, index: usize) -> Option<T>
+pub fn index_N_N_<T>(value: Option<Vec<Option<T>>>, index: isize) -> Option<T>
 where
     T: Clone,
 {
@@ -113,7 +125,7 @@ where
     }
 }
 
-pub fn index_N_N_N<T>(value: Option<Vec<Option<T>>>, index: Option<usize>) -> Option<T>
+pub fn index_N_N_N<T>(value: Option<Vec<Option<T>>>, index: Option<isize>) -> Option<T>
 where
     T: Clone,
 {

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -1401,12 +1401,30 @@ pub fn cast_to_u_i32(value: i32) -> usize {
         .unwrap_or_else(|_| panic!("Value '{}' out of range for type 'usize'", value))
 }
 
+cast_function!(u, usize, i32, i32);
+
 #[inline]
 pub fn cast_to_u_i64(value: i64) -> usize {
     value
         .try_into()
         .unwrap_or_else(|_| panic!("Value '{}' out of range for type 'usize'", value))
 }
+
+cast_function!(u, usize, i64, i64);
+
+#[inline]
+pub fn cast_to_i_i32(value: i32) -> isize {
+    value as isize
+}
+
+cast_function!(i, isize, i32, i32);
+
+#[inline]
+pub fn cast_to_i_i64(value: i64) -> isize {
+    value as isize
+}
+
+cast_function!(i, isize, i64, i64);
 
 pub fn cast_to_bytesN_nullN(_value: Option<()>) -> Option<ByteArray> {
     None


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Turns out you can write some of the UDFs required in SQL, so I implemented `count_char` and `split_index`.
The remaining UDF is about regular expressions, so it cannot be done efficiently in SQL, we need a real UDF.
I also hopefully implemented q6 correctly using ARG_MAX instead of TOPK.

