### PR TITLE
dbsp: Reduce memory use for merges with output smaller than the inputs.

### DIFF
--- a/crates/dbsp/src/dynamic/vec.rs
+++ b/crates/dbsp/src/dynamic/vec.rs
@@ -284,7 +284,7 @@ where
     }
 
     fn shrink_to_fit(&mut self) {
-        todo!()
+        self.vec.shrink_to_fit()
     }
 
     fn push_val(&mut self, val: &mut Trait) {

--- a/crates/dbsp/src/trace/layers/layer.rs
+++ b/crates/dbsp/src/trace/layers/layer.rs
@@ -595,6 +595,11 @@ where
             self.offs[self.keys.len()] = O::from_usize(self.vals.boundary());
         }
 
+        if self.keys.spare_capacity() >= self.keys.len() / 10 {
+            self.keys.shrink_to_fit();
+            self.offs.shrink_to_fit();
+        }
+
         Layer {
             factories: self.factories,
             keys: self.keys,

--- a/crates/dbsp/src/trace/layers/leaf.rs
+++ b/crates/dbsp/src/trace/layers/leaf.rs
@@ -585,7 +585,11 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Builder for LeafBuilder<K, 
         self.layer.len()
     }
 
-    fn done(self) -> Self::Trie {
+    fn done(mut self) -> Self::Trie {
+        if self.layer.keys.spare_capacity() >= self.layer.keys.len() / 10 {
+            self.layer.keys.shrink_to_fit();
+            self.layer.diffs.shrink_to_fit();
+        }
         self.layer
     }
 }


### PR DESCRIPTION
Is this a user-visible change (yes/no): no