### PR TITLE
pipeline-manager: provide position in ConnectorGenerationError

### DIFF
--- a/crates/pipeline-types/src/program_schema.rs
+++ b/crates/pipeline-types/src/program_schema.rs
@@ -38,23 +38,21 @@ pub struct ProgramSchema {
     pub outputs: Vec<Relation>,
 }
 
-#[derive(Serialize, Deserialize, ToSchema, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, ToSchema, Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "testing", derive(proptest_derive::Arbitrary))]
 pub struct SourcePosition {
-    start_line_number: usize,
-    start_column: usize,
-    end_line_number: usize,
-    end_column: usize,
+    pub start_line_number: usize,
+    pub start_column: usize,
+    pub end_line_number: usize,
+    pub end_column: usize,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "testing", derive(proptest_derive::Arbitrary))]
 pub struct PropertyValue {
-    value: String,
-    key_position: SourcePosition,
-    value_position: SourcePosition,
-}
-
-impl PropertyValue {
-    pub fn get_value(&self) -> String { self.value.clone() }
+    pub value: String,
+    pub key_position: SourcePosition,
+    pub value_position: SourcePosition,
 }
 
 /// A SQL table or view. It has a name and a list of fields.

--- a/openapi.json
+++ b/openapi.json
@@ -3307,7 +3307,7 @@
           "properties": {
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "$ref": "#/components/schemas/PropertyValue"
             }
           }
         }
@@ -3511,26 +3511,26 @@
       },
       "SqlCompilerMessage": {
         "type": "object",
-        "description": "A SQL compiler error.\n\nThe SQL compiler returns a list of errors in the following JSON format if\nit's invoked with the `-je` option.\n\n```ignore\n[ {\n\"startLineNumber\" : 2,\n\"startColumn\" : 4,\n\"endLineNumber\" : 2,\n\"endColumn\" : 8,\n\"warning\" : false,\n\"errorType\" : \"PRIMARY KEY cannot be nullable\",\n\"message\" : \"PRIMARY KEY column 'C' has type INTEGER, which is nullable\",\n\"snippet\" : \"    2|   c INT PRIMARY KEY\\n         ^^^^^\\n    3|);\\n\"\n} ]\n```",
+        "description": "A SQL compiler error.\n\nThe SQL compiler returns a list of errors in the following JSON format if\nit's invoked with the `-je` option.\n\n```ignore\n[ {\n\"start_line_number\" : 2,\n\"start_column\" : 4,\n\"end_line_number\" : 2,\n\"end_column\" : 8,\n\"warning\" : false,\n\"error_type\" : \"PRIMARY KEY cannot be nullable\",\n\"message\" : \"PRIMARY KEY column 'C' has type INTEGER, which is nullable\",\n\"snippet\" : \"    2|   c INT PRIMARY KEY\\n         ^^^^^\\n    3|);\\n\"\n} ]\n```",
         "required": [
-          "startLineNumber",
-          "startColumn",
-          "endLineNumber",
-          "endColumn",
+          "start_line_number",
+          "start_column",
+          "end_line_number",
+          "end_column",
           "warning",
-          "errorType",
+          "error_type",
           "message"
         ],
         "properties": {
-          "endColumn": {
+          "end_column": {
             "type": "integer",
             "minimum": 0
           },
-          "endLineNumber": {
+          "end_line_number": {
             "type": "integer",
             "minimum": 0
           },
-          "errorType": {
+          "error_type": {
             "type": "string"
           },
           "message": {
@@ -3540,11 +3540,11 @@
             "type": "string",
             "nullable": true
           },
-          "startColumn": {
+          "start_column": {
             "type": "integer",
             "minimum": 0
           },
-          "startLineNumber": {
+          "start_line_number": {
             "type": "integer",
             "minimum": 0
           },

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
@@ -79,7 +79,7 @@ public class CompilerMessages {
             ObjectNode result = mapper.createObjectNode();
             this.range.appendAsJson(result);
             result.put("warning", this.warning);
-            result.put("errorType", this.errorType);
+            result.put("error_type", this.errorType);
             result.put("message", this.message);
             String snippet = contents.getFragment(this.range, true);
             result.put("snippet", snippet);


### PR DESCRIPTION
- [x] pipeline-manager generates ConnectorGenerationError with the position of key or value depending on the variant
- [ ] UI: use the snake_case fields that were previously camelCase (@Karakatiza666 )

Is this a user-visible change (yes/no): yes