### PR TITLE
[SQL] Optimize programs based on foreign-key joins

### DIFF
--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q16.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q16.sql
@@ -1,0 +1,19 @@
+CREATE VIEW Q16 AS
+SELECT
+    channel,
+    format_date('yyyy-MM-dd', date_time) as 'day',
+    max(format_date('HH:mm', date_time)) as 'minute',
+    count(*) AS total_bids,
+    count(*) filter (where price < 10000) AS rank1_bids,
+    count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
+    count(*) filter (where price >= 1000000) AS rank3_bids,
+    count(distinct bidder) AS total_bidders,
+    count(distinct bidder) filter (where price < 10000) AS rank1_bidders,
+    count(distinct bidder) filter (where price >= 10000 and price < 1000000) AS rank2_bidders,
+    count(distinct bidder) filter (where price >= 1000000) AS rank3_bidders,
+    count(distinct auction) AS total_auctions,
+    count(distinct auction) filter (where price < 10000) AS rank1_auctions,
+    count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
+    count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
+FROM bid
+GROUP BY channel, format_date('yyyy-MM-dd', date_time);

--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q5.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q5.sql
@@ -1,0 +1,47 @@
+-- -------------------------------------------------------------------------------------------------
+-- Query 5: Hot Items
+-- -------------------------------------------------------------------------------------------------
+-- Which auctions have seen the most bids in the last period?
+-- Illustrates sliding windows and combiners.
+--
+-- The original Nexmark Query5 calculate the hot items in the last hour (updated every minute).
+-- To make things a bit more dynamic and easier to test we use much shorter windows,
+-- i.e. in the last 10 seconds and update every 2 seconds.
+-- -------------------------------------------------------------------------------------------------
+
+CREATE VIEW q5 AS
+SELECT AuctionBids.auction, AuctionBids.num
+ FROM (
+   SELECT
+     B1.auction,
+     count(*) AS num,
+     window_start AS starttime,
+     window_end AS endtime
+   FROM TABLE(HOP(TABLE bid, DESCRIPTOR(date_time), INTERVAL 2 SECOND, INTERVAL 10 SECOND)) AS B1
+   GROUP BY
+     B1.auction,
+     window_start,
+     window_end
+ ) AS AuctionBids
+ JOIN (
+   SELECT
+     max(CountBids.num) AS maxn,
+     CountBids.starttime,
+     CountBids.endtime
+   FROM (
+     SELECT
+       count(*) AS num,
+       window_start AS starttime,
+       window_end AS endtime
+     FROM TABLE(HOP(TABLE bid, DESCRIPTOR(date_time), INTERVAL 2 SECOND, INTERVAL 10 SECOND)) AS B2
+     GROUP BY
+       B2.auction,
+       window_start,
+       window_end
+     ) AS CountBids
+   GROUP BY CountBids.starttime, CountBids.endtime
+ ) AS MaxBids
+ ON AuctionBids.starttime = MaxBids.starttime AND
+    AuctionBids.endtime = MaxBids.endtime AND
+    AuctionBids.num >= MaxBids.maxn;
+

--- a/docs/sql/table.md
+++ b/docs/sql/table.md
@@ -57,6 +57,12 @@ SELECT * FROM TABLE(
     SIZE => INTERVAL '1' MINUTE));
 ```
 
+The result is a table that has all the columns of the `order` table,
+and in addition the following columns, defined by the `TUMBLE`
+function:
+- `window_start`, of the same type as the column `order.rowtime`
+- `window_end`, of the same type as the column `order.rowtime`
+
 ### `HOP`
 
 `HOP` assigns windows that cover rows within the interval of size and
@@ -97,5 +103,11 @@ SELECT * FROM TABLE(
 
 applies hopping with 5-minute interval size on rows from table
 `orders` and shifting every 2 minutes.
+
+The result is a table that has all the columns of the `order` table,
+and in addition the following columns, defined by the `HOP`
+function:
+- `window_start`, of the same type as the column `order.rowtime`
+- `window_end`, of the same type as the column `order.rowtime`
 
 A `NULL` timestamp produces no rows in the result.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPSourceMultisetOperator.java
@@ -1,8 +1,5 @@
 package org.dbsp.sqlCompiler.circuit.operator;
 
-import org.dbsp.sqlCompiler.compiler.IHasColumnsMetadata;
-import org.dbsp.sqlCompiler.compiler.IHasLateness;
-import org.dbsp.sqlCompiler.compiler.IHasWatermark;
 import org.dbsp.sqlCompiler.compiler.TableMetadata;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/LowerCircuitVisitor.java
@@ -262,7 +262,8 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
         DBSPExpression newFunction = lowerJoinFilterMapFunctions(this.errorReporter, node);
         DBSPOperator result = new DBSPJoinFilterMapOperator(node.getNode(), node.getOutputZSetType(),
                 newFunction, null, null, node.isMultiset,
-                this.mapped(node.left()), this.mapped(node.right()));
+                this.mapped(node.left()), this.mapped(node.right()))
+                .copyAnnotations(node);
         this.map(node, result);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -47,7 +47,6 @@ import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePosition;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
-import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ExternalFunction;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
@@ -110,7 +109,6 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeReal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
@@ -1333,6 +1331,9 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 // Calcite thinks this is nullable, but it probably shouldn't be
                 DBSPType nonNull = type.setMayBeNull(false);
                 return new DBSPApplyExpression(node, method, nonNull, ops.get(0), ops.get(1)).cast(type);
+            }
+            case HOP: {
+                throw new UnimplementedException("Please use the TABLE function HOP", node);
             }
             case DOT:
             default:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
@@ -1,0 +1,185 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctIncrementalOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPHopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamDistinctOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPViewOperator;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.util.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Keeps tabs of the streams that are append-only.
+ * A stream is append-only if it is
+ * - the output of an append-only table
+ * - produced by some stream operators from append-only streams */
+public class AppendOnly extends CircuitVisitor {
+    final Set<DBSPOperator> appendOnly;
+
+    public AppendOnly(IErrorReporter errorReporter) {
+        super(errorReporter);
+        this.appendOnly = new HashSet<>();
+    }
+
+    public boolean isAppendOnly(DBSPOperator source) {
+        return this.appendOnly.contains(source);
+    }
+
+    @Override
+    public void postorder(DBSPOperator node) {
+        // Default behavior
+        super.postorder(node);
+    }
+
+    void setAppendOnly(DBSPOperator operator) {
+        Logger.INSTANCE.belowLevel(this, 1)
+                .append(operator.getIdString())
+                .append(" ")
+                .append(operator.operation)
+                .append(" is append-only")
+                .newline();
+        this.appendOnly.add(operator);
+    }
+
+    @Override
+    public void postorder(DBSPSourceTableOperator node) {
+        super.postorder(node);
+        if (node.metadata.isAppendOnly())
+            this.setAppendOnly(node);
+    }
+
+    @Override
+    public void postorder(DBSPConstantOperator node) {
+        this.copy(node);
+    }
+
+    /** Make operator append-only if all sources are append-only */
+    void copy(DBSPOperator operator) {
+        super.postorder(operator);
+        for (DBSPOperator source: operator.inputs) {
+            if (!this.isAppendOnly(source))
+                return;
+        }
+        this.setAppendOnly(operator);
+    }
+
+    @Override
+    public void postorder(DBSPMapOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPJoinOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPStreamJoinOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPJoinFilterMapOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPDeindexOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPMapIndexOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPNoopOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPDelayedIntegralOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPIntegrateOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPDelayOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPDistinctOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPStreamDistinctOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPSumOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPDistinctIncrementalOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPFlatMapOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPViewOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPSinkOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPHopOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPIndexedTopKOperator node) {
+        this.copy(node);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -130,7 +130,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)) {
             result = new DBSPSourceMultisetOperator(operator.getNode(), operator.sourceName,
                     outputType.to(DBSPTypeZSet.class), originalRowType,
-                    operator.metadata, operator.getTableName(), operator.comment);
+                    operator.metadata, operator.getTableName(), operator.comment)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -144,7 +145,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)) {
             result = new DBSPSourceMapOperator(operator.getNode(), operator.sourceName,
                     operator.keyFields, outputType.to(DBSPTypeIndexedZSet.class), originalRowType,
-                    operator.metadata, operator.getTableName(), operator.comment);
+                    operator.metadata, operator.getTableName(), operator.comment)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -159,7 +161,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)
                 || input != operator.input()) {
             result = new DBSPSinkOperator(operator.getNode(), operator.viewName, operator.query,
-                    originalRowType, operator.metadata, input);
+                    originalRowType, operator.metadata, input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -174,7 +177,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || !outputType.sameType(operator.outputType)
                 || input != operator.input()) {
             result = new DBSPViewOperator(operator.getNode(), operator.viewName, operator.query,
-                    originalRowType, operator.metadata, input);
+                    originalRowType, operator.metadata, input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -196,7 +200,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || input != operator.input()) {
             result = new DBSPStreamAggregateOperator(operator.getNode(),
                     outputType.to(DBSPTypeIndexedZSet.class),
-                    function, aggregate, input, operator.isLinear);
+                    function, aggregate, input, operator.isLinear)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -212,7 +217,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || function != operator.getFunction()) {
             result = new DBSPFlatMapOperator(
                     operator.getNode(), function,
-                    resultType.to(DBSPTypeZSet.class), input);
+                    resultType.to(DBSPTypeZSet.class), input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -232,7 +238,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || aggregate != operator.aggregate
                 || function != operator.function) {
             result = new DBSPAggregateOperator(operator.getNode(),
-                    outputType.to(DBSPTypeIndexedZSet.class), function, aggregate, input, operator.isLinear);
+                    outputType.to(DBSPTypeIndexedZSet.class), function, aggregate, input, operator.isLinear)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -242,7 +249,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         DBSPExpression value = this.transform(operator.getFunction());
         DBSPOperator result = operator;
         if (value != operator.getFunction()) {
-            result = new DBSPConstantOperator(operator.getNode(), value, operator.isMultiset);
+            result = new DBSPConstantOperator(operator.getNode(), value, operator.isMultiset)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -258,7 +266,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || Linq.different(sources, operator.inputs)) {
             result = new DBSPJoinOperator(operator.getNode(),
                     outputType.to(DBSPTypeZSet.class), function, operator.isMultiset,
-                    sources.get(0), sources.get(1));
+                    sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -268,7 +277,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         List<DBSPOperator> sources = Linq.map(operator.inputs, this::mapped);
         DBSPOperator result = operator;
         if (Linq.different(sources, operator.inputs))
-            result = new DBSPWindowOperator(operator.getNode(), sources.get(0), sources.get(1));
+            result = new DBSPWindowOperator(operator.getNode(), sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         this.map(operator, result);
     }
 
@@ -282,7 +292,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || Linq.different(sources, operator.inputs)
                 || function != operator.getFunction()) {
             result = new DBSPControlledFilterOperator(operator.getNode(), function,
-                    sources.get(0), sources.get(1));
+                    sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -297,7 +308,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || Linq.different(sources, operator.inputs)
                 || function != operator.getFunction()) {
             result = new DBSPIntegrateTraceRetainKeysOperator(operator.getNode(), function,
-                    sources.get(0), sources.get(1));
+                    sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -312,7 +324,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || function != operator.function
                 || Linq.different(sources, operator.inputs)) {
             result = new DBSPStreamJoinOperator(operator.getNode(), outputType.to(DBSPTypeZSet.class),
-                    function, operator.isMultiset, sources.get(0), sources.get(1));
+                    function, operator.isMultiset, sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -331,7 +344,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || map != operator.map
                 || Linq.different(sources, operator.inputs)) {
             result = new DBSPJoinFilterMapOperator(operator.getNode(), outputType.to(DBSPTypeZSet.class),
-                    function, filter, map, operator.isMultiset, sources.get(0), sources.get(1));
+                    function, filter, map, operator.isMultiset, sources.get(0), sources.get(1))
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -346,7 +360,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || input != operator.input()
                 || function != operator.getFunction()) {
             result = new DBSPMapIndexOperator(operator.getNode(), function,
-                    outputType.to(DBSPTypeIndexedZSet.class), input);
+                    outputType.to(DBSPTypeIndexedZSet.class), input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -367,7 +382,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || comparator != operator.comparator) {
             result = new DBSPLagOperator(operator.getNode(), operator.offset,
                     projection, function, comparator,
-                    type.to(DBSPTypeIndexedZSet.class), input);
+                    type.to(DBSPTypeIndexedZSet.class), input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -381,7 +397,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         if (!type.sameType(operator.getType())
                 || input != operator.input()
                 || function != operator.getFunction()) {
-            result = new DBSPMapOperator(operator.getNode(), function, type.to(DBSPTypeZSet.class), input);
+            result = new DBSPMapOperator(operator.getNode(), function, type.to(DBSPTypeZSet.class), input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -408,7 +425,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || lower != operator.lower
                 || upper != operator.upper) {
             result = new DBSPPartitionedRollingAggregateOperator(
-                    operator.getNode(), partitioningFunction, function, aggregate, lower, upper, type, input);
+                    operator.getNode(), partitioningFunction, function, aggregate, lower, upper, type, input)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }
@@ -438,7 +456,8 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || upper != operator.upper) {
             result = new DBSPPartitionedRollingAggregateWithWaterlineOperator(
                     operator.getNode(), partitioningFunction, function, aggregate,
-                    lower, upper, type, left, right);
+                    lower, upper, type, left, right)
+                    .copyAnnotations(operator);
         }
         this.map(operator, result);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoinVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/FilterJoinVisitor.java
@@ -23,7 +23,8 @@ public class FilterJoinVisitor extends CircuitCloneVisitor {
             DBSPOperator result =
                     new DBSPJoinFilterMapOperator(source.getNode(), source.getOutputZSetType(),
                             source.getFunction(), operator.getFunction(), null,
-                            source.isMultiset, source.inputs.get(0), source.inputs.get(1));
+                            source.isMultiset, source.inputs.get(0), source.inputs.get(1))
+                            .copyAnnotations(operator);
             this.map(operator, result);
             return;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
@@ -181,7 +181,7 @@ public class KeyPropagation extends CircuitVisitor {
         }
     }
 
-    /** Maps each operator to a Tuple type that contains the key descriptions */
+    /** Maps each operator to a StreamDescription for its output */
     final Map<DBSPOperator, StreamDescription> keys;
     /** Maps each join that operates on a primary/foreign key to its description */
     final Map<DBSPOperator, JoinDescription> joins;
@@ -287,7 +287,7 @@ public class KeyPropagation extends CircuitVisitor {
      * @param table           Table whose primary key is being joined
      * @param foreignKeyIndex Description of the index part of the foreign key input
      * @param foreignKey      Description of the data part of the foreign key input
-     * @param keyOnLeft  True if the key is the left input of the join
+     * @param keyOnLeft       True if the key is the left input of the join
      */
     void mapJoin(DBSPOperator operator, DBSPSourceTableOperator table,
                  StreamDescription foreignKeyIndex, StreamDescription foreignKey,
@@ -341,10 +341,12 @@ public class KeyPropagation extends CircuitVisitor {
             return;
         }
 
+        // See if the key is on the left and the fk on the right
         DBSPSourceTableOperator table = this.checkForeign(leftIndex, rightIndex);
         if (table != null) {
             this.mapJoin(binary, table, rightIndex, right.tail(indexFields), true);
         } else {
+            // See if the key is on the right and the fk on the left
             table = this.checkForeign(rightIndex, leftIndex);
             if (table != null) {
                 this.mapJoin(binary, table, leftIndex, left.tail(indexFields), false);
@@ -366,6 +368,8 @@ public class KeyPropagation extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPJoinFilterMapOperator node) {
+        // The analysis assumes that there is no map function in the join
+        assert node.map == null;
         this.processJoin(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
@@ -1,0 +1,481 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.apache.commons.math3.util.Pair;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceTableOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamDistinctOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPViewOperator;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.InputColumnMetadata;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ForeignKey;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.Projection;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Logger;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Analyzes the fields of each stream that correspond to primary
+ * keys or foreign keys in input streams. */
+public class KeyPropagation extends CircuitVisitor {
+    static class PrimaryKeyField {
+        final DBSPSourceTableOperator table;
+        final int tableFieldIndex;
+
+        PrimaryKeyField(DBSPSourceTableOperator table, int tableFieldIndex) {
+            this.table = table;
+            this.tableFieldIndex = tableFieldIndex;
+        }
+
+        @Override
+        public String toString() {
+            return this.table.tableName + ":" + this.tableFieldIndex;
+        }
+    }
+
+    /** Field belongs to a foreign key pointing to some primary key */
+    static final class ForeignKeyField extends PrimaryKeyField {
+        final DBSPSourceTableOperator fkTable;
+        final int fkTableFieldIndex;
+
+        ForeignKeyField(
+                DBSPSourceTableOperator source,
+                int tableKeyIndex,
+                DBSPSourceTableOperator fkTable,
+                int fkTableFieldIndex) {
+            // Super points to the actual key
+            super(source, tableKeyIndex);
+            this.fkTable = fkTable;
+            this.fkTableFieldIndex = fkTableFieldIndex;
+        }
+
+        @Override
+        public String toString() {
+            return this.fkTable.tableName + ":" + this.fkTableFieldIndex + "->" + super.toString();
+        }
+    }
+
+    /** Properties of one output field */
+    static final class FieldProperties {
+        /** Primary key that this is part of, or null */
+        @Nullable PrimaryKeyField keyField;
+        /** Foreign keys that this is part of */
+        final List<ForeignKeyField> fkFields;
+
+        FieldProperties() {
+            this.keyField = null;
+            this.fkFields = new ArrayList<>();
+        }
+
+        FieldProperties(@Nullable PrimaryKeyField pk, List<ForeignKeyField> fk) {
+            this.keyField = pk;
+            this.fkFields = fk;
+        }
+
+        void setPrimaryKey(PrimaryKeyField kf) {
+            this.keyField = kf;
+        }
+
+        void addForeignKey(ForeignKeyField fk) {
+            this.fkFields.add(fk);
+        }
+
+        boolean isEmpty() {
+            return this.keyField == null && this.fkFields.isEmpty();
+        }
+
+        FieldProperties getForeignKeys() {
+            return new FieldProperties(null, this.fkFields);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            if (this.keyField != null) {
+                builder.append(this.keyField);
+            }
+            for (ForeignKeyField fk: this.fkFields) {
+                builder.append(" ").append(fk);
+            }
+            if (this.isEmpty()) {
+                builder.append("-");
+            }
+            return builder.toString();
+        }
+    }
+
+    static class StreamDescription {
+        /** One property for each output field.  For streams that represent
+         * indexed Z-sets the fields are flattened. */
+        final List<FieldProperties> properties;
+
+        StreamDescription() {
+            this.properties = new ArrayList<>();
+        }
+
+        protected StreamDescription(List<FieldProperties> fields) {
+            this.properties = fields;
+        }
+        void addProperties(FieldProperties fp) {
+            this.properties.add(fp);
+        }
+
+        @Override
+        public String toString() {
+            return this.properties.toString();
+        }
+
+        public FieldProperties get(int columnIndex) {
+            return this.properties.get(columnIndex);
+        }
+
+        public boolean hasSomeKey() {
+            return Linq.any(this.properties, p -> !p.isEmpty());
+        }
+
+        StreamDescription prefix(int count) {
+            return new StreamDescription(this.properties.subList(0, count));
+        }
+
+        public StreamDescription tail(int index) {
+            return new StreamDescription(this.properties.subList(index, this.properties.size()));
+        }
+    }
+
+    /**
+     * Description of joins that join a primary key with a foreign key
+     *
+     * @param join      Join operator.
+     * @param table     Table whose primary key is joined on
+     * @param leftIsKey If true the LHS of the join uses the key
+     */
+    public record JoinDescription(DBSPOperator join, DBSPSourceTableOperator table, boolean leftIsKey) {
+        @Override
+        public String toString() {
+            return "JoinDescription{" +
+                    "join=" + join +
+                    ", table=" + table +
+                    ", leftIsKey=" + leftIsKey +
+                    '}';
+        }
+    }
+
+    /** Maps each operator to a Tuple type that contains the key descriptions */
+    final Map<DBSPOperator, StreamDescription> keys;
+    /** Maps each join that operates on a primary/foreign key to its description */
+    final Map<DBSPOperator, JoinDescription> joins;
+
+    public KeyPropagation(IErrorReporter errorReporter) {
+        super(errorReporter);
+        this.keys = new HashMap<>();
+        this.joins = new HashMap<>();
+    }
+
+    void processMap(DBSPUnaryOperator node) {
+        StreamDescription inputKeys = this.keys.get(node.input());
+        if (inputKeys == null) {
+            super.postorder(node);
+            return;
+        }
+
+        Projection projection = new Projection(this.errorReporter, true);
+        projection.apply(node.getFunction());
+        if (!projection.hasIoMap()) {
+            super.postorder(node);
+            return;
+        }
+
+        List<Pair<Integer, Integer>> ioMap = projection.getIoMap();
+        StreamDescription result = new StreamDescription();
+        for (Pair<Integer, Integer> source : ioMap) {
+            assert source.getFirst() == 0;
+            int sourceColumnIndex = source.getSecond();
+            FieldProperties fieldProperties = inputKeys.get(sourceColumnIndex);
+            result.addProperties(fieldProperties);
+        }
+        if (result.hasSomeKey()) {
+            this.map(node, result);
+        }
+        super.postorder(node);
+    }
+
+    /** Source table whose keys are fully included in the specified stream, or
+     * null if no such source table exists. */
+    @Nullable
+    DBSPSourceTableOperator hasKeys(StreamDescription description) {
+        Set<Integer> keyFieldsFound = new HashSet<>();
+        DBSPSourceTableOperator source = null;
+        for (FieldProperties field: description.properties) {
+            if (field.keyField != null) {
+                if (source == null)
+                    source = field.keyField.table;
+                else
+                    // There is no way a stream could contain keys from multiple tables
+                    assert (source == field.keyField.table);
+                keyFieldsFound.add(field.keyField.tableFieldIndex);
+            }
+        }
+
+        if (source == null)
+            return null;
+
+        // If the number of fields found is the same as the key size
+        // we must have found all of them
+        if (keyFieldsFound.size() == source.metadata.getPrimaryKeys().size())
+            return source;
+        return null;
+    }
+
+    /** Check if desc contains a foreign key that contains all fields of the key
+     * of table source.
+     * @param source  Table whose key we are looking for.
+     * @param desc    Description of a stream where we look for foreign key fields.
+     * @return        The table whose key is joined, or null of no such table exists. */
+    @Nullable
+    DBSPSourceTableOperator checkForeignKeys(DBSPSourceTableOperator source, StreamDescription desc) {
+        Set<Integer> keyFieldsFound = new HashSet<>();
+        for (FieldProperties field: desc.properties) {
+            for (ForeignKeyField fk: field.fkFields) {
+                if (fk.table != source)
+                    continue;
+                keyFieldsFound.add(fk.tableFieldIndex);
+            }
+        }
+        // If the number of fields found is the same as the key size
+        // we must have found all of them
+        if (keyFieldsFound.size() == source.metadata.getPrimaryKeys().size())
+            return source;
+        return null;
+    }
+
+    /** Check if the desc0 contains all the fields of a key,
+     * and desc1 contains all the fields of a foreign key pointing to it. */
+    @Nullable
+    DBSPSourceTableOperator checkForeign(StreamDescription desc0, StreamDescription desc1) {
+        DBSPSourceTableOperator keys = this.hasKeys(desc0);
+        if (keys == null) {
+            return null;
+        }
+
+        return this.checkForeignKeys(keys, desc1);
+    }
+
+    /** Add foreign key information for a join.
+     *
+     * @param operator        Join that is being processed.
+     * @param table           Table whose primary key is being joined
+     * @param foreignKeyIndex Description of the index part of the foreign key input
+     * @param foreignKey      Description of the data part of the foreign key input
+     * @param keyOnLeft  True if the key is the left input of the join
+     */
+    void mapJoin(DBSPOperator operator, DBSPSourceTableOperator table,
+                 StreamDescription foreignKeyIndex, StreamDescription foreignKey,
+                 boolean keyOnLeft) {
+        JoinDescription desc = new JoinDescription(operator, table, keyOnLeft);
+        Logger.INSTANCE.belowLevel(this, 1)
+                        .append(desc.toString())
+                        .newline();
+        Utilities.putNew(this.joins, operator, desc);
+
+        // In addition, the foreign key information is propagated through joins
+        // (but not the primary key information).
+        Projection projection = new Projection(this.errorReporter, true);
+        projection.apply(operator.getFunction());
+        if (projection.hasIoMap()) {
+            List<Pair<Integer, Integer>> ioMap = projection.getIoMap();
+            StreamDescription result = new StreamDescription();
+            for (Pair<Integer, Integer> source : ioMap) {
+                int input = source.getFirst();
+                int sourceColumnIndex = source.getSecond();
+                FieldProperties props = switch (input) {
+                    case 0 -> foreignKeyIndex.get(sourceColumnIndex);
+                    case 1 -> keyOnLeft ? new FieldProperties() : foreignKey.get(sourceColumnIndex);
+                    case 2 -> keyOnLeft ? foreignKey.get(sourceColumnIndex) : new FieldProperties();
+                    default -> throw new IllegalStateException("Unexpected value: " + input);
+                };
+                result.addProperties(props.getForeignKeys());
+            }
+            if (result.hasSomeKey()) {
+                this.map(operator, result);
+            }
+        }
+
+    }
+
+    void processJoin(DBSPBinaryOperator binary) {
+        StreamDescription left = this.keys.get(binary.left());
+        StreamDescription right = this.keys.get(binary.right());
+        if (left == null || right == null) {
+            super.postorder(binary);
+            return;
+        }
+
+        int indexFields = binary.left()
+                .getOutputIndexedZSetType().keyType.to(DBSPTypeTuple.class)
+                .tupFields.length;
+        StreamDescription leftIndex = left.prefix(indexFields);
+        StreamDescription rightIndex = right.prefix(indexFields);
+        if (!leftIndex.hasSomeKey() || !rightIndex.hasSomeKey()) {
+            super.postorder(binary);
+            return;
+        }
+
+        DBSPSourceTableOperator table = this.checkForeign(leftIndex, rightIndex);
+        if (table != null) {
+            this.mapJoin(binary, table, rightIndex, right.tail(indexFields), true);
+        } else {
+            table = this.checkForeign(rightIndex, leftIndex);
+            if (table != null) {
+                this.mapJoin(binary, table, leftIndex, left.tail(indexFields), false);
+            }
+        }
+
+        super.postorder(binary);
+    }
+
+    @Override
+    public void postorder(DBSPJoinOperator node) {
+        this.processJoin(node);
+    }
+
+    @Override
+    public void postorder(DBSPStreamJoinOperator node) {
+        this.processJoin(node);
+    }
+
+    @Override
+    public void postorder(DBSPJoinFilterMapOperator node) {
+        this.processJoin(node);
+    }
+
+    @Override
+    public void postorder(DBSPMapIndexOperator node) {
+        this.processMap(node);
+    }
+
+    @Override
+    public void postorder(DBSPMapOperator node) {
+        this.processMap(node);
+    }
+
+    @Override
+    public void postorder(DBSPSourceTableOperator operator) {
+        StreamDescription description = new StreamDescription();
+        int index = 0;
+        boolean found = false;
+        for (InputColumnMetadata col: operator.metadata.getColumns()) {
+            FieldProperties prop = new FieldProperties();
+            if (col.isPrimaryKey) {
+                prop.setPrimaryKey(new PrimaryKeyField(operator, index));
+                found = true;
+            }
+            description.addProperties(prop);
+            index++;
+        }
+        for (ForeignKey fk: operator.metadata.getForeignKeys()) {
+            assert fk.thisTable.tableName.getString().equals(operator.tableName);
+            DBSPSourceTableOperator other = this.getCircuit().getInput(fk.otherTable.tableName.getString());
+            if (other == null)
+                // This can happen for foreign keys that refer to tables that are not in the program.
+                // This is a warning, but still a legal SQL program.
+                continue;
+            for (int i = 0; i < fk.thisTable.columns.size(); i++) {
+                String thisColumn = fk.thisTable.columns.get(i).getString();
+                String otherColumn = fk.otherTable.columns.get(i).getString();
+                int thisColumnIndex = operator.metadata.getColumnIndex(thisColumn);
+                int otherColumnIndex = other.metadata.getColumnIndex(otherColumn);
+                ForeignKeyField fkf = new ForeignKeyField(other, otherColumnIndex, operator, thisColumnIndex);
+                description.get(thisColumnIndex).addForeignKey(fkf);
+                found = true;
+            }
+        }
+        if (found) {
+            this.map(operator, description);
+        }
+        super.postorder(operator);
+    }
+
+    void map(DBSPOperator operator, StreamDescription keys) {
+        Utilities.putNew(this.keys, operator, keys);
+        Logger.INSTANCE.belowLevel(this, 1)
+                .append(operator.getIdString())
+                .append(" ")
+                .append(operator.operation)
+                .append(" ")
+                .append(keys.toString())
+                .newline();
+    }
+
+    void copy(DBSPUnaryOperator unary) {
+        StreamDescription inputKeys = this.keys.get(unary.input());
+        if (inputKeys != null)
+            this.map(unary, inputKeys);
+        super.postorder(unary);
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPNoopOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPDelayedIntegralOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPIntegrateOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPNegateOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPDistinctOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPStreamDistinctOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPViewOperator source) {
+        this.copy(source);
+    }
+
+    @Override
+    public void postorder(DBSPSinkOperator source) {
+        this.copy(source);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Monotonicity.java
@@ -60,7 +60,6 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
-import org.dbsp.util.NullableFunction;
 import org.dbsp.util.ToIndentableString;
 import org.dbsp.util.Utilities;
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Monotonicity.java
@@ -60,6 +60,7 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
+import org.dbsp.util.NullableFunction;
 import org.dbsp.util.ToIndentableString;
 import org.dbsp.util.Utilities;
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
@@ -1,9 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
-import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
@@ -14,11 +12,8 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
-import org.dbsp.sqlCompiler.compiler.visitors.inner.Projection;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.util.Linq;
 
 import java.util.ArrayList;
@@ -68,7 +63,8 @@ public class OptimizeMaps extends CircuitCloneVisitor {
             }
             DBSPOperator result = new DBSPJoinFilterMapOperator(
                     jfm.getNode(), operator.getOutputZSetType(), jfm.getFunction(),
-                    jfm.filter, newMap, operator.isMultiset, jfm.left(), jfm.right());
+                    jfm.filter, newMap, operator.isMultiset, jfm.left(), jfm.right())
+                    .copyAnnotations(operator).copyAnnotations(source);
             this.map(operator, result);
         } else if ((source.is(DBSPStreamJoinOperator.class) || source.is(DBSPJoinOperator.class)) &&
                 // We have to look up the original operator input, not source

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/CommonJoinExpansion.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/CommonJoinExpansion.java
@@ -2,8 +2,10 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer.expansion;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
 
+import javax.annotation.Nullable;
+
 /** Part that is common to the expansion of all kinds of join operators */
 public interface CommonJoinExpansion {
-    DBSPDelayedIntegralOperator getLeftIntegrator();
-    DBSPDelayedIntegralOperator getRightIntegrator();
+    @Nullable DBSPDelayedIntegralOperator getLeftIntegrator();
+    @Nullable DBSPDelayedIntegralOperator getRightIntegrator();
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/JoinExpansion.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/JoinExpansion.java
@@ -4,20 +4,26 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 
+import javax.annotation.Nullable;
+
 public final class JoinExpansion
         extends OperatorExpansion
         implements CommonJoinExpansion {
+    @Nullable
     public final DBSPDelayedIntegralOperator leftIntegrator;
+    @Nullable
     public final DBSPDelayedIntegralOperator rightIntegrator;
+    @Nullable
     public final DBSPStreamJoinOperator leftDelta;
+    @Nullable
     public final DBSPStreamJoinOperator rightDelta;
     public final DBSPStreamJoinOperator both;
     public final DBSPSumOperator sum;
 
-    public JoinExpansion(DBSPDelayedIntegralOperator leftIntegrator,
-                         DBSPDelayedIntegralOperator rightIntegrator,
-                         DBSPStreamJoinOperator leftDelta,
-                         DBSPStreamJoinOperator rightDelta,
+    public JoinExpansion(@Nullable DBSPDelayedIntegralOperator leftIntegrator,
+                         @Nullable DBSPDelayedIntegralOperator rightIntegrator,
+                         @Nullable DBSPStreamJoinOperator leftDelta,
+                         @Nullable DBSPStreamJoinOperator rightDelta,
                          DBSPStreamJoinOperator both,
                          DBSPSumOperator sum) {
         this.leftIntegrator = leftIntegrator;
@@ -28,12 +34,12 @@ public final class JoinExpansion
         this.sum = sum;
     }
 
-    @Override
+    @Override @Nullable
     public DBSPDelayedIntegralOperator getLeftIntegrator() {
         return this.leftIntegrator;
     }
 
-    @Override
+    @Override @Nullable
     public DBSPDelayedIntegralOperator getRightIntegrator() {
         return this.rightIntegrator;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/JoinFilterMapExpansion.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/JoinFilterMapExpansion.java
@@ -5,26 +5,28 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 
+import javax.annotation.Nullable;
+
 public final class JoinFilterMapExpansion
         extends OperatorExpansion
         implements CommonJoinExpansion {
-    public final DBSPDelayedIntegralOperator leftIntegrator;
-    public final DBSPDelayedIntegralOperator rightIntegrator;
-    public final DBSPStreamJoinOperator leftDelta;
-    public final DBSPStreamJoinOperator rightDelta;
+    @Nullable public final DBSPDelayedIntegralOperator leftIntegrator;
+    @Nullable public final DBSPDelayedIntegralOperator rightIntegrator;
+    @Nullable public final DBSPStreamJoinOperator leftDelta;
+    @Nullable public final DBSPStreamJoinOperator rightDelta;
     public final DBSPStreamJoinOperator both;
-    public final DBSPFilterOperator leftFilter;
-    public final DBSPFilterOperator rightFilter;
+    @Nullable public final DBSPFilterOperator leftFilter;
+    @Nullable public final DBSPFilterOperator rightFilter;
     public final DBSPFilterOperator filter;
     public final DBSPSumOperator sum;
 
-    public JoinFilterMapExpansion(DBSPDelayedIntegralOperator leftIntegrator,
-                                  DBSPDelayedIntegralOperator rightIntegrator,
-                                  DBSPStreamJoinOperator leftDelta,
-                                  DBSPStreamJoinOperator rightDelta,
+    public JoinFilterMapExpansion(@Nullable DBSPDelayedIntegralOperator leftIntegrator,
+                                  @Nullable DBSPDelayedIntegralOperator rightIntegrator,
+                                  @Nullable DBSPStreamJoinOperator leftDelta,
+                                  @Nullable DBSPStreamJoinOperator rightDelta,
                                   DBSPStreamJoinOperator both,
-                                  DBSPFilterOperator leftFilter,
-                                  DBSPFilterOperator rightFilter,
+                                  @Nullable DBSPFilterOperator leftFilter,
+                                  @Nullable DBSPFilterOperator rightFilter,
                                   DBSPFilterOperator filter,
                                   DBSPSumOperator sum) {
         this.leftIntegrator = leftIntegrator;
@@ -39,12 +41,12 @@ public final class JoinFilterMapExpansion
     }
 
     @Override
-    public DBSPDelayedIntegralOperator getLeftIntegrator() {
+    @Nullable public DBSPDelayedIntegralOperator getLeftIntegrator() {
         return this.leftIntegrator;
     }
 
     @Override
-    public DBSPDelayedIntegralOperator getRightIntegrator() {
+    @Nullable public DBSPDelayedIntegralOperator getRightIntegrator() {
         return this.rightIntegrator;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/NoIntegrator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/NoIntegrator.java
@@ -1,0 +1,18 @@
+package org.dbsp.sqlCompiler.ir.annotation;
+
+/** Annotation used on a join to indicate that it doesn't need
+ * an integrator on one or both sides. */
+public class NoIntegrator extends Annotation {
+    final boolean notNeededOnLeft;
+    final boolean notNeededOnRight;
+
+    public NoIntegrator(boolean notNeededOnLeft, boolean notNeededOnRight) {
+        this.notNeededOnLeft = notNeededOnLeft;
+        this.notNeededOnRight = notNeededOnRight;
+    }
+
+    @Override
+    public String toString() {
+        return "NoIntegrator[" + this.notNeededOnLeft + "," + this.notNeededOnRight + "]";
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
@@ -43,8 +43,7 @@ public final class DBSPUnsignedWrapExpression extends DBSPExpression {
             return switch (sourceType.code) {
                 case INT8, INT16, INT32, INT64 -> sourceType.setMayBeNull(false).to(DBSPTypeInteger.class);
                 case DATE -> new DBSPTypeInteger(sourceType.getNode(), 32, true, false);
-                case TIMESTAMP -> new DBSPTypeInteger(sourceType.getNode(), 64, true, false);
-                case TIME -> new DBSPTypeInteger(sourceType.getNode(), 64, true, false);
+                case TIMESTAMP, TIME -> new DBSPTypeInteger(sourceType.getNode(), 64, true, false);
                 default -> throw new UnimplementedException(sourceType.getNode());
             };
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVecLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVecLiteral.java
@@ -180,7 +180,7 @@ public final class DBSPVecLiteral extends DBSPLiteral implements IDBSPContainer 
             if (d.is(DBSPLiteral.class)) {
                 builder.append(d.to(DBSPLiteral.class).toSqlString());
             } else {
-                builder.append(d.toString());
+                builder.append(d);
             }
         }
         builder.append("]");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
@@ -26,7 +26,6 @@ package org.dbsp.sqlCompiler.ir.type.primitive;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.util.IIndentStream;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullableFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullableFunction.java
@@ -1,0 +1,9 @@
+package org.dbsp.util;
+
+import javax.annotation.Nullable;
+
+/** Variant of {@link java.util.function.Function} interface with nullable result */
+@FunctionalInterface
+public interface NullableFunction<S, R> {
+    @Nullable R apply(S source);
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullablePredicate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullablePredicate.java
@@ -1,0 +1,9 @@
+package org.dbsp.util;
+
+import javax.annotation.Nullable;
+
+/** Variant of {@link java.util.function.Predicate} interface with nullable result */
+@FunctionalInterface
+public interface NullablePredicate<T> {
+    @Nullable Boolean test(T value);
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -26,6 +26,18 @@ public class RegressionTests extends SqlIoTest {
         this.statementsFailingInCompilation(sql, "Expected a simple string");
     }
 
+    @Test @Ignore("https://github.com/feldera/feldera/issues/2201")
+    public void issue2201() {
+        String sql = """
+                create table customer_address(
+                    ca_zip char(10)
+                );
+                
+                CREATE VIEW V AS SELECT substr(ca_zip,1,5)
+                FROM customer_address;""";
+        this.compileRustTestCase(sql);
+    }
+
     @Test
     public void issue1189() {
         String sql = """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -29,9 +29,6 @@ import java.util.List;
 public class StreamingTests extends StreamingTestBase {
     @Test
     public void issue2004() {
-        // Based on Q9
-        // Logger.INSTANCE.setLoggingLevel(KeyPropagation.class, 1);
-        // Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 2);
         String sql = """
                 CREATE TABLE auction (
                    date_time TIMESTAMP NOT NULL LATENESS INTERVAL 1 MINUTE,
@@ -1192,6 +1189,27 @@ public class StreamingTests extends StreamingTestBase {
                  1                | -1
                  2                | 1""");
         this.addRustTestCase("testAggregate", ccs);
+    }
+
+    @Test
+    public void testHopNotImplemented() {
+        // This syntax is not supported, one should use the HOP table functions
+        String sql = """
+                CREATE TABLE bid (
+                    auction  BIGINT FOREIGN KEY REFERENCES auction(id),
+                    date_time TIMESTAMP(3) NOT NULL LATENESS INTERVAL 4 SECONDS
+                );
+                CREATE VIEW V AS SELECT
+                  B1.auction,
+                  count(*) AS num,
+                  HOP_START(B1.date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND) AS starttime,
+                  HOP_END(B1.date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND) AS endtime
+                FROM bid B1
+                GROUP BY
+                  B1.auction,
+                  HOP(B1.date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND);
+                """;
+        this.statementsFailingInCompilation(sql, "Please use the TABLE function HOP");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpcDsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpcDsTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 public class TpcDsTest extends BaseSQLTests {
-    @Test @Ignore("https://github.com/feldera/feldera/issues/1281")
+    @Test @Ignore("https://issues.apache.org/jira/browse/CALCITE-6518")
     public void compileTpcds() throws IOException {
         String tpch = TestUtil.readStringFromResourceFile("tpcds.sql");
         CompilerOptions options = this.testOptions(true, true);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
@@ -27,9 +27,6 @@ import org.apache.calcite.config.Lex;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.AppendOnly;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.KeyPropagation;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.MonotoneAnalyzer;
 import org.dbsp.util.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -820,10 +817,10 @@ INSERT INTO auction VALUES(101, 'item-name', 'description', 5, 10, '2020-01-01 0
 
     @Test
     public void q9test() {
-        Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 2);
-        Logger.INSTANCE.setLoggingLevel(KeyPropagation.class, 1);
-        Logger.INSTANCE.setLoggingLevel(AppendOnly.class, 1);
-        Logger.INSTANCE.setLoggingLevel(DBSPCompiler.class, 2);
+        // Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 2);
+        // Logger.INSTANCE.setLoggingLevel(KeyPropagation.class, 1);
+        // Logger.INSTANCE.setLoggingLevel(AppendOnly.class, 1);
+        // Logger.INSTANCE.setLoggingLevel(DBSPCompiler.class, 2);
         this.createTest(9, "", """
  id | item | description | initialBid | reserve | date_time | expires | seller | category | extra | auction | bidder | price | bid_datetime | bid_extra | weight
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------""");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -236,23 +236,6 @@ public abstract class SqlIoTest extends BaseSQLTests {
         this.addFailingRustTestCase(query, error, ccs);
     }
 
-    /** Run one or more statements that are expected to fail in compilation.
-     * @param statements        Statements to compile.
-     * @param messageFragment   This fragment should appear in the error message. */
-    public void statementsFailingInCompilation(String statements, String messageFragment) {
-        DBSPCompiler compiler = this.testCompiler();
-        compiler.options.languageOptions.throwOnError = false;
-        this.prepareInputs(compiler);
-        compiler.compileStatements(statements);
-        getCircuit(compiler);
-        Assert.assertTrue(compiler.messages.exitCode != 0);
-        String message = compiler.messages.toString();
-        boolean contains = message.contains(messageFragment);
-        if (!contains)
-            Assert.fail("Error message\n" + Utilities.singleQuote(message) +
-                    "\ndoes not contain the expected fragment\n" + Utilities.singleQuote(messageFragment));
-    }
-
     /** Run a query that is expected to fail in compilation.
      * @param query             Query to run.
      * @param messageFragment   This fragment should appear in the error message.

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -1548,7 +1548,7 @@ pub fn late() {
 pub fn zset_filter_comparator<D, T, F>(data: &WSet<D>, value: &T, comparator: F) -> WSet<D>
 where
     D: DBData + 'static,
-    T: 'static,
+    T: 'static + Debug,
     F: Fn(&D, &T) -> bool,
 {
     let factories = OrdZSetFactories::new::<D, (), ZWeight>();


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

These optimizations are applicable only for append-only relations which have foreign key information available.

These optimizations do several things:
- they do not use integrators on some sides of a join
- they can push monotonicity information past some joins

To fully take advantage of the first optimization, DBSP will have to provide a join operator where we can indicate that some integrators are not necessary. The compiler assumes that the integrators won't be there, and thus won't GC these integrators. 