### PR TITLE
Point to tutorial instead of demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker compose -f - --profile demo up
 
 It can take some time for the container images to be downloaded. About ten seconds after that, the Feldera
 web console will become available. Visit [http://localhost:8080](http://localhost:8080) on your browser
-to bring it up. We suggest going through our [demo](https://www.feldera.com/docs/demo) next.
+to bring it up. We suggest going through our [tutorial](https://www.feldera.com/docs/tutorials/basics/) next.
 
 Our [Getting Started](https://www.feldera.com/docs/get-started) guide has more detailed instructions on running the demo.
 


### PR DESCRIPTION
The demo is now outdated, so it's better to point the user to the up-to-date tutorial.

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
