### PR TITLE
benchmark: Make output from Feldera SQL runs appear without buffering.

### DIFF
--- a/benchmark/run-nexmark.sh
+++ b/benchmark/run-nexmark.sh
@@ -551,7 +551,7 @@ case $runner:$language in
 	fi
 	rm -f results.csv
 	CARGO=$(find_program cargo)
-	run_log feldera-sql/run.py \
+	PYTHONUNBUFFERED=1 run_log feldera-sql/run.py \
 	    --api-url="$api_url" \
 	    -O bootstrap.servers="${kafka_from_feldera:-${kafka_broker}}" \
 	    --cores $cores \


### PR DESCRIPTION
Running output through `tee` as this does makes it look to Python that its stdout is non-interactive, so by default it buffers up a few kilobytes of output before printing it, which makes it hard to see a run's progress in anything like real time.  This fixes the problem.

It would be better to do this in `benchmark/feldera-sql/run.py`, making it set its stdout to always line-buffered, like one could do with a call to `setvbuf` in C, but I can't figure out how to do that in Python.

Is this a user-visible change (yes/no): no