### PR TITLE
[DBSP]: Change radix value for radix trees to 2.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/mod.rs
@@ -109,7 +109,7 @@ use updater::radix_tree_update;
 
 // We use constant radix to reduce the need to dynamically allocate a vector of
 // child nodes.
-const RADIX: usize = 16;
+const RADIX: usize = 2;
 
 // Number of bits in `RADIX`.
 const RADIX_BITS: u32 = RADIX.trailing_zeros();

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/treenode.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/treenode.rs
@@ -453,7 +453,7 @@ mod test {
         assert_eq!(aggregate_default(node), None);
 
         node.slot_mut(1).set_some_with(&mut |ptr| {
-            ptr.from_timestamp(0x1000_0000_0000_0000u64, 10u64.erase_mut())
+            ptr.from_timestamp(0x8000_0000_0000_0000u64, 10u64.erase_mut())
         });
         assert_eq!(node.occupied_slots(), 1);
 
@@ -461,40 +461,47 @@ mod test {
             node.first_occupied_slot()
                 .unwrap()
                 .downcast_checked::<ChildPtr<_, _>>(),
-            &child_from_timestamp(0x1000_0000_0000_0000u64, 10u64)
+            &child_from_timestamp(0x8000_0000_0000_0000u64, 10u64)
         );
 
         assert_eq!(aggregate_default(node), Some(10));
 
-        node.slot_mut(4).set_some_with(&mut |ptr| {
-            ptr.from_timestamp(0x4000_0000_0000_0000u64, 40u64.erase_mut())
+        // Used for testing with RADIX=16.
+        // node.slot_mut(4).set_some_with(&mut |ptr| {
+        //     ptr.from_timestamp(0x4000_0000_0000_0000u64, 40u64.erase_mut())
+        // });
+        // assert_eq!(node.occupied_slots(), 2);
+        // assert_eq!(
+        //     node.first_occupied_slot()
+        //         .unwrap()
+        //         .downcast_checked::<ChildPtr<_, _>>(),
+        //     &child_from_timestamp(0x1000_0000_0000_0000u64, 10u64)
+        // );
+        // assert_eq!(aggregate_default(node), Some(50));
+
+        node.slot_mut(0).set_some_with(&mut |ptr| {
+            *ptr.downcast_mut_checked() = ChildPtr::new(
+                Prefix {
+                    key: 0x0fff_ffff_ffff_ffffu64,
+                    prefix_len: 4,
+                },
+                80u64,
+            )
         });
         assert_eq!(node.occupied_slots(), 2);
         assert_eq!(
             node.first_occupied_slot()
                 .unwrap()
                 .downcast_checked::<ChildPtr<_, _>>(),
-            &child_from_timestamp(0x1000_0000_0000_0000u64, 10u64)
-        );
-        assert_eq!(aggregate_default(node), Some(50));
-
-        node.slot_mut(8).set_some_with(&mut |ptr| {
-            *ptr.downcast_mut_checked() = ChildPtr::new(
+            &ChildPtr::new(
                 Prefix {
-                    key: 0x8fff_ffff_ffff_ffffu64,
+                    key: 0x0fff_ffff_ffff_ffffu64,
                     prefix_len: 4,
                 },
                 80u64,
             )
-        });
-        assert_eq!(node.occupied_slots(), 3);
-        assert_eq!(
-            node.first_occupied_slot()
-                .unwrap()
-                .downcast_checked::<ChildPtr<_, _>>(),
-            &child_from_timestamp(0x1000_0000_0000_0000u64, 10u64)
         );
-        assert_eq!(aggregate_default(node), Some(130));
+        assert_eq!(aggregate_default(node), Some(90));
     }
 
     #[test]


### PR DESCRIPTION
This commit reduces the memory overhead of radix trees. Each radix tree node consists of RADIX entries, each storing a child pointer and the pre-computed value of the aggregate.  The tree is supposed to be self-adjusting, merging nodes with a single child into the parent node; however it can still waste a lot of memory when there are many nodes with >=2 children.  This is especially bad when using the tree to compute multiple rolling aggregates where each entry stores multiple aggregate values.  In one example I saw the tree using 10x the memory of the input collection.

The simplest solution implemented here is to reduce the arity of the tree to a smaller power of two (8, 4, or 2).  I tried 4 and 2.  In both cases I didn't see significant impact on performance (but haven't done systematic benchmarking), but 2 saves more memory than 4.

This is really a two-byte change, the rest of this commit adjusts manually written tests.

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
