### PR TITLE
Use json as internal config format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3778,10 +3778,12 @@ dependencies = [
  "arrow 52.0.0",
  "async-stream",
  "async-trait",
+ "atomic",
  "awc",
  "aws-sdk-s3",
  "aws-types 1.3.2",
  "bstr",
+ "bytemuck",
  "bytes",
  "bytestring",
  "chrono",
@@ -3792,7 +3794,9 @@ dependencies = [
  "csv",
  "csv-core",
  "dbsp",
+ "dbsp_nexmark",
  "deltalake",
+ "enum-map",
  "env_logger 0.10.2",
  "erased-serde",
  "fake",
@@ -3802,7 +3806,6 @@ dependencies = [
  "futures-util",
  "governor",
  "jemalloc_pprof",
- "json5",
  "lazy_static",
  "log",
  "metrics",
@@ -4396,6 +4399,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -5687,17 +5710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6519,9 +6531,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -6560,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -6896,51 +6908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pest"
-version = "2.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
-dependencies = [
- "memchr",
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.68",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7074,7 +7041,6 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger 0.10.2",
  "futures-util",
- "json5",
  "jsonwebtoken",
  "log",
  "metrics",
@@ -7109,9 +7075,10 @@ dependencies = [
 name = "pipeline_types"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "csv",
- "json5",
+ "enum-map",
  "lazy_static",
  "libc",
  "log",
@@ -10004,12 +9971,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3778,12 +3778,10 @@ dependencies = [
  "arrow 52.0.0",
  "async-stream",
  "async-trait",
- "atomic",
  "awc",
  "aws-sdk-s3",
  "aws-types 1.3.2",
  "bstr",
- "bytemuck",
  "bytes",
  "bytestring",
  "chrono",
@@ -3804,6 +3802,7 @@ dependencies = [
  "futures-util",
  "governor",
  "jemalloc_pprof",
+ "json5",
  "lazy_static",
  "log",
  "metrics",
@@ -3839,7 +3838,6 @@ dependencies = [
  "serde_arrow",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
  "serial_test",
  "size-of",
  "sqllib",
@@ -5689,6 +5687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6510,9 +6519,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -6551,9 +6560,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -6887,6 +6896,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7020,6 +7074,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger 0.10.2",
  "futures-util",
+ "json5",
  "jsonwebtoken",
  "log",
  "metrics",
@@ -7036,7 +7091,6 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_yaml",
  "serial_test",
  "static-files",
  "static_assertions",
@@ -7055,9 +7109,9 @@ dependencies = [
 name = "pipeline_types"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "anyhow",
  "csv",
+ "json5",
  "lazy_static",
  "libc",
  "log",
@@ -7067,7 +7121,6 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serde_yaml",
  "utoipa",
 ]
 
@@ -8705,19 +8758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9966,6 +10006,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10042,12 +10088,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -33,8 +33,8 @@ dbsp = { path = "../dbsp" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 erased-serde = "0.3.23"
 once_cell = "1.9.0"
-serde_yaml = "0.9.14"
 serde_json = { version = "1.0.103", features = ["raw_value"] }
+json5 = "0.4.1"
 serde_urlencoded = "0.7.1"
 form_urlencoded = "1.2.0"
 csv = "1.2.2"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -34,7 +34,6 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 erased-serde = "0.3.23"
 once_cell = "1.9.0"
 serde_json = { version = "1.0.103", features = ["raw_value"] }
-json5 = "0.4.1"
 serde_urlencoded = "0.7.1"
 form_urlencoded = "1.2.0"
 csv = "1.2.2"

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1155,7 +1155,7 @@ impl ControllerInner {
                     }
                     FormatConfig {
                         name: Cow::from("json"),
-                        config: serde_yaml::to_value(JsonParserConfig {
+                        config: serde_json::to_value(JsonParserConfig {
                             update_format: JsonUpdateFormat::Raw,
                             json_flavor: JsonFlavor::Datagen,
                             array: true,
@@ -1928,7 +1928,7 @@ outputs:
 
             println!("input file: {}", temp_input_file.path().to_str().unwrap());
             println!("output file: {output_path}");
-            let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+            let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
             let controller = Controller::with_config(
                     |circuit_config| Ok(test_circuit::<TestStruct>(circuit_config, &[])),
                     &config,

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -65,7 +65,7 @@ impl OutputFormat for AvroOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &json5::to_string(config).unwrap_or_default(),
+                &serde_json::to_string(config).unwrap_or_default(),
             )
         })?;
 
@@ -105,14 +105,14 @@ impl AvroEncoder {
                     "'schema' string '{}' is not a valid JSON document: {e}",
                     &config.schema
                 ),
-                &json5::to_string(&config).unwrap_or_default(),
+                &serde_json::to_string(&config).unwrap_or_default(),
             )
         })?;
         let schema = AvroSchema::parse(&schema_json).map_err(|e| {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &format!("invalid Avro schema: {e}"),
-                &json5::to_string(&config).unwrap_or_default(),
+                &serde_json::to_string(&config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -11,12 +11,11 @@ use pipeline_types::program_schema::Relation;
 use schema_registry_converter::avro_common::get_supplied_schema;
 use schema_registry_converter::blocking::schema_registry::{post_schema, SrSettings};
 use serde::Deserialize;
+use serde_json::Value;
 use serde_urlencoded::Deserializer as UrlDeserializer;
-use serde_yaml::Value as YamlValue;
 use std::borrow::Cow;
 use std::str::FromStr;
 use std::time::Duration;
-
 // TODOs:
 // - This connector currently only supports raw Avro format, i.e., deletes cannot be represented.
 //   Add support for other variants such as Debezium that are able to represent deletions.
@@ -58,7 +57,7 @@ impl OutputFormat for AvroOutputFormat {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &Value,
         _schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError> {
@@ -66,7 +65,7 @@ impl OutputFormat for AvroOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &serde_yaml::to_string(config).unwrap_or_default(),
+                &json5::to_string(config).unwrap_or_default(),
             )
         })?;
 
@@ -106,14 +105,14 @@ impl AvroEncoder {
                     "'schema' string '{}' is not a valid JSON document: {e}",
                     &config.schema
                 ),
-                &serde_yaml::to_string(&config).unwrap_or_default(),
+                &json5::to_string(&config).unwrap_or_default(),
             )
         })?;
         let schema = AvroSchema::parse(&schema_json).map_err(|e| {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &format!("invalid Avro schema: {e}"),
-                &serde_yaml::to_string(&config).unwrap_or_default(),
+                &json5::to_string(&config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/csv.rs
+++ b/crates/adapters/src/format/csv.rs
@@ -246,7 +246,7 @@ impl OutputFormat for CsvOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &json5::to_string(&config).unwrap_or_default(),
+                &serde_json::to_string(&config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/csv.rs
+++ b/crates/adapters/src/format/csv.rs
@@ -18,7 +18,7 @@ use crate::catalog::{InputCollectionHandle, SerBatchReader};
 pub use deserializer::byte_record_deserializer;
 pub use deserializer::string_record_deserializer;
 use pipeline_types::program_schema::Relation;
-use serde_yaml::Value as YamlValue;
+use serde_json::Value;
 
 /// When including a long CSV record in an error message,
 /// truncate it to `MAX_RECORD_LEN_IN_ERRMSG` bytes.
@@ -47,7 +47,7 @@ impl InputFormat for CsvInputFormat {
         &self,
         _endpoint_name: &str,
         input_stream: &InputCollectionHandle,
-        _config: &YamlValue,
+        _config: &Value,
     ) -> Result<Box<dyn Parser>, ControllerError> {
         let input_stream = input_stream
             .handle
@@ -238,7 +238,7 @@ impl OutputFormat for CsvOutputFormat {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &Value,
         _schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError> {
@@ -246,7 +246,7 @@ impl OutputFormat for CsvOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &serde_yaml::to_string(&config).unwrap_or_default(),
+                &json5::to_string(&config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -13,8 +13,8 @@ use erased_serde::Serialize as ErasedSerialize;
 use pipeline_types::format::json::{JsonParserConfig, JsonUpdateFormat};
 use serde::Deserialize;
 use serde_json::value::RawValue;
+use serde_json::Value;
 use serde_urlencoded::Deserializer as UrlDeserializer;
-use serde_yaml::Value as YamlValue;
 use std::{borrow::Cow, mem::take};
 
 /// JSON format parser.
@@ -175,13 +175,13 @@ impl InputFormat for JsonInputFormat {
         &self,
         endpoint_name: &str,
         input_handle: &InputCollectionHandle,
-        config: &YamlValue,
+        config: &Value,
     ) -> Result<Box<dyn Parser>, ControllerError> {
         let config = JsonParserConfig::deserialize(config).map_err(|e| {
             ControllerError::parser_config_parse_error(
                 endpoint_name,
                 &e,
-                &serde_yaml::to_string(config).unwrap_or_default(),
+                &json5::to_string(config).unwrap_or_default(),
             )
         })?;
         validate_parser_config(&config, endpoint_name)?;
@@ -534,7 +534,7 @@ mod test {
             trace!("test: {test:?}");
             let format_config = FormatConfig {
                 name: Cow::from("json"),
-                config: serde_yaml::to_value(test.config).unwrap(),
+                config: serde_json::to_value(test.config).unwrap(),
             };
 
             let (mut consumer, outputs) = mock_parser_pipeline(&format_config).unwrap();

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -181,7 +181,7 @@ impl InputFormat for JsonInputFormat {
             ControllerError::parser_config_parse_error(
                 endpoint_name,
                 &e,
-                &json5::to_string(config).unwrap_or_default(),
+                &serde_json::to_string(config).unwrap_or_default(),
             )
         })?;
         validate_parser_config(&config, endpoint_name)?;

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -13,8 +13,8 @@ use pipeline_types::format::json::{JsonEncoderConfig, JsonFlavor, JsonUpdateForm
 use pipeline_types::program_schema::Relation;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::Deserialize;
+use serde_json::Value;
 use serde_urlencoded::Deserializer as UrlDeserializer;
-use serde_yaml::Value as YamlValue;
 use std::{borrow::Cow, io::Write, mem::take};
 
 /// JSON format encoder.
@@ -50,7 +50,7 @@ impl OutputFormat for JsonOutputFormat {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &Value,
         schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError> {
@@ -58,7 +58,7 @@ impl OutputFormat for JsonOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &serde_yaml::to_string(config).unwrap_or_default(),
+                &json5::to_string(config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -58,7 +58,7 @@ impl OutputFormat for JsonOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &json5::to_string(config).unwrap_or_default(),
+                &serde_json::to_string(config).unwrap_or_default(),
             )
         })?;
 

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use pipeline_types::program_schema::Relation;
 use pipeline_types::serde_with_context::FieldParseError;
 use serde::Serialize;
-use serde_yaml::Value as YamlValue;
+use serde_json::Value;
 use std::{
     borrow::Cow,
     collections::BTreeMap,
@@ -383,7 +383,7 @@ pub trait InputFormat: Send + Sync {
         &self,
         endpoint_name: &str,
         input_stream: &InputCollectionHandle,
-        config: &YamlValue,
+        config: &Value,
     ) -> Result<Box<dyn Parser>, ControllerError>;
 }
 
@@ -476,7 +476,7 @@ pub trait OutputFormat: Send + Sync {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &Value,
         schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError>;

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -15,8 +15,8 @@ use parquet::file::reader::{FileReader, SerializedFileReader};
 use serde::Deserialize;
 use serde_arrow::schema::SerdeArrowSchema;
 use serde_arrow::ArrayBuilder;
+use serde_json::Value;
 use serde_urlencoded::Deserializer as UrlDeserializer;
-use serde_yaml::Value as YamlValue;
 
 use crate::catalog::{CursorWithPolarity, SerBatchReader};
 use crate::format::MAX_DUPLICATES;
@@ -55,7 +55,7 @@ impl InputFormat for ParquetInputFormat {
         &self,
         _endpoint_name: &str,
         input_stream: &InputCollectionHandle,
-        _config: &YamlValue,
+        _config: &Value,
     ) -> Result<Box<dyn Parser>, ControllerError> {
         let input_stream = input_stream
             .handle
@@ -204,7 +204,7 @@ impl OutputFormat for ParquetOutputFormat {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &Value,
         schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError> {
@@ -212,7 +212,7 @@ impl OutputFormat for ParquetOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &serde_yaml::to_string(&config).unwrap_or_default(),
+                &json5::to_string(&config).unwrap_or_default(),
             )
         })?;
         Ok(Box::new(ParquetEncoder::new(

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -212,7 +212,7 @@ impl OutputFormat for ParquetOutputFormat {
             ControllerError::encoder_config_parse_error(
                 endpoint_name,
                 &e,
-                &json5::to_string(&config).unwrap_or_default(),
+                &serde_json::to_string(&config).unwrap_or_default(),
             )
         })?;
         Ok(Box::new(ParquetEncoder::new(

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -56,16 +56,19 @@ fn parquet_input() {
     let test_data = TestStruct2::data();
     let temp_file = NamedTempFile::new().unwrap();
     let config_str = format!(
-        r#"
-stream: test_input
-transport:
-    name: file_input
-    config:
-        path: {:?}
+        r#"{{
+stream: "test_input",
+transport: {{
+    name: "file_input",
+    config: {{
+        path: {:?},
         buffer_size_bytes: 5
-format:
-    name: parquet
-"#,
+    }}
+}},
+format: {{
+    name: "parquet"
+}},
+}}"#,
         temp_file.path().to_str().unwrap()
     );
 
@@ -84,7 +87,7 @@ format:
 
     // Send the data through the mock pipeline
     let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct2, TestStruct2>(
-        serde_yaml::from_str(&config_str).unwrap(),
+        json5::from_str(&config_str).unwrap(),
         Relation::new("test", false, TestStruct2::schema(), false, BTreeMap::new()),
     )
     .unwrap();

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -87,7 +87,7 @@ format: {{
 
     // Send the data through the mock pipeline
     let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct2, TestStruct2>(
-        json5::from_str(&config_str).unwrap(),
+        serde_json::from_str(&config_str).unwrap(),
         Relation::new("test", false, TestStruct2::schema(), false, BTreeMap::new()),
     )
     .unwrap();

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -200,32 +200,44 @@ where
     // Create controller.
     let config_str = format!(
         r#"
-name: test
-workers: 4
-outputs:
-    test_output1:
-        stream: test_output1
-        transport:
-            name: file_output
-            config:
-                path: "{output_file_path}"
-        format:
-            name: json
-            config:
-                update_format: "insert_delete"
-inputs:
-    test_input1:
-        stream: test_input1
-        transport:
-            name: "delta_table_input"
-            config:
-                uri: "{table_uri}"
-{}
+{{
+  name: "test",
+  workers: 4,
+  outputs: {{
+    test_output1: {{
+      stream: "test_output1",
+      transport: {{
+        name: "file_output",
+        config: {{
+          path: "{output_file_path}"
+        }}
+      }},
+      format: {{
+        name: "json",
+        config: {{
+          update_format: "insert_delete"
+        }}
+      }}
+    }}
+  }},
+  inputs: {{
+    test_input1: {{
+      stream: "test_input1",
+      transport: {{
+        name: "delta_table_input",
+        config: {{
+          uri: "{table_uri}"
+        }}
+      }}
+    }}
+  }},
+  {}
+}}
 "#,
         storage_options,
     );
 
-    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
 
     Controller::with_config(
         |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
@@ -265,32 +277,42 @@ where
     // Create controller.
     let config_str = format!(
         r#"
-name: test
-workers: 4
-inputs:
-    test_input1:
-        stream: test_input1
-        transport:
-            name: "delta_table_input"
-            config:
-                uri: "{input_table_uri}"
-{}
-outputs:
-    test_output1:
-        stream: test_output1
-        transport:
-            name: "delta_table_output"
-            config:
-                uri: "{output_table_uri}"
-{}
-        enable_output_buffer: true
-        max_output_buffer_size_records: {buffer_size}
-        max_output_buffer_time_millis: {buffer_timeout_ms}
+{{
+  name: "test",
+  workers: 4,
+  inputs: {{
+    test_input1: {{
+      stream: "test_input1",
+      transport: {{
+        name: "delta_table_input",
+        config: {{
+          uri: "{input_table_uri}",
+          {}
+        }}
+      }}
+    }}
+  }},
+  outputs: {{
+    test_output1: {{
+      stream: "test_output1",
+      transport: {{
+        name: "delta_table_output",
+        config: {{
+          uri: "{output_table_uri}",
+          {}
+        }}
+      }},
+      enable_output_buffer: true,
+      max_output_buffer_size_records: {buffer_size},
+      max_output_buffer_time_millis: {buffer_timeout_ms}
+    }}
+  }}
+}}
 "#,
         input_storage_options, output_storage_options,
     );
 
-    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
 
     Controller::with_config(
         |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
@@ -343,32 +365,43 @@ fn delta_table_output_test(
 
     // Create controller.
     let config_str = format!(
-        r#"
-name: test
-workers: 4
-inputs:
-    test_input1:
-        stream: test_input1
-        transport:
-            name: file_input
-            config:
-                path: "{}"
-        format:
-            name: json
-            config:
-                update_format: "raw"
-outputs:
-    test_output1:
-        stream: test_output1
-        transport:
-            name: "delta_table_output"
-            config:
-                uri: "{table_uri}"
-                mode: "truncate"
+        r#"{{
+  name: "test",
+  workers: 4,
+  inputs: {{
+    test_input1: {{
+      stream: "test_input1",
+      transport: {{
+        name: "file_input",
+        config: {{
+          path: "{}"
+        }}
+      }},
+      format: {{
+        name: "json",
+        config: {{
+          update_format: "raw"
+        }}
+      }}
+    }}
+  }},
+  outputs: {{
+    test_output1: {{
+      stream: "test_output1",
+      transport: {{
+        name: "delta_table_output",
+        config: {{
+          uri: "{table_uri}",
+          mode: "truncate"
+        }}
+      }},
 {}
-        enable_output_buffer: true
-        max_output_buffer_size_records: {buffer_size}
-        max_output_buffer_time_millis: {buffer_timeout_ms}
+      enable_output_buffer: true,
+      max_output_buffer_size_records: {buffer_size},
+      max_output_buffer_time_millis: {buffer_timeout_ms}
+    }}
+  }}
+}}
 "#,
         input_file.path().display(),
         storage_options,
@@ -379,7 +412,7 @@ outputs:
         data.len(),
         input_file.path().display(),
     );
-    let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
 
     let controller = Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct2>(workers, &TestStruct2::schema())),

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -237,7 +237,7 @@ where
         storage_options,
     );
 
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     Controller::with_config(
         |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
@@ -312,7 +312,7 @@ where
         input_storage_options, output_storage_options,
     );
 
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     Controller::with_config(
         |workers| Ok(test_circuit::<T>(workers, &TestStruct2::schema())),
@@ -412,7 +412,7 @@ fn delta_table_output_test(
         data.len(),
         input_file.path().display(),
     );
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     let controller = Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct2>(workers, &TestStruct2::schema())),

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -303,7 +303,7 @@ fn parse_config(config_file: &str) -> Result<PipelineConfig, ControllerError> {
     // Still running without logger here.
     eprintln!("Pipeline configuration:\n{yaml_config}");
 
-    json5::from_str(yaml_config.as_str())
+    serde_json::from_str(yaml_config.as_str())
         .map_err(|e| ControllerError::pipeline_config_parse_error(&e))
 }
 

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -303,7 +303,7 @@ fn parse_config(config_file: &str) -> Result<PipelineConfig, ControllerError> {
     // Still running without logger here.
     eprintln!("Pipeline configuration:\n{yaml_config}");
 
-    serde_yaml::from_str(yaml_config.as_str())
+    json5::from_str(yaml_config.as_str())
         .map_err(|e| ControllerError::pipeline_config_parse_error(&e))
 }
 
@@ -737,7 +737,7 @@ pub fn parser_config_from_http_request(
     // strongly typed format-specific config.
     Ok(FormatConfig {
         name: Cow::from(format_name.to_string()),
-        config: serde_yaml::to_value(config)
+        config: serde_json::to_value(config)
             .map_err(|e| ControllerError::parser_config_parse_error(endpoint_name, &e, ""))?,
     })
 }
@@ -756,7 +756,7 @@ pub fn encoder_config_from_http_request(
 
     Ok(FormatConfig {
         name: Cow::from(format_name.to_string()),
-        config: serde_yaml::to_value(config)
+        config: serde_json::to_value(config)
             .map_err(|e| ControllerError::encoder_config_parse_error(endpoint_name, &e, ""))?,
     })
 }

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -252,7 +252,7 @@ impl BufferConsumer {
             .new_parser(
                 "BaseConsumer",
                 &InputCollectionHandle::new(schema, buffer.clone()),
-                &json5::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
+                &serde_json::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
             )
             .unwrap();
 

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -252,7 +252,7 @@ impl BufferConsumer {
             .new_parser(
                 "BaseConsumer",
                 &InputCollectionHandle::new(schema, buffer.clone()),
-                &serde_yaml::from_str::<serde_yaml::Value>(format_config_yaml).unwrap(),
+                &json5::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
             )
             .unwrap();
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -130,7 +130,7 @@ where
 {
     let default_format = FormatConfig {
         name: Cow::from("json"),
-        config: serde_yaml::to_value(JsonParserConfig {
+        config: serde_json::to_value(JsonParserConfig {
             update_format: JsonUpdateFormat::Raw,
             json_flavor: JsonFlavor::Datagen,
             array: true,
@@ -233,7 +233,7 @@ where
         .new_parser(
             "BaseConsumer",
             &InputCollectionHandle::new(schema, buffer.clone()),
-            &serde_yaml::from_str::<serde_yaml::Value>(format_config_yaml).unwrap(),
+            &json5::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
         )
         .unwrap();
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -233,7 +233,7 @@ where
         .new_parser(
             "BaseConsumer",
             &InputCollectionHandle::new(schema, buffer.clone()),
-            &json5::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
+            &serde_json::from_str::<serde_json::Value>(format_config_yaml).unwrap(),
         )
         .unwrap();
 

--- a/crates/adapters/src/transport/datagen.rs
+++ b/crates/adapters/src/transport/datagen.rs
@@ -1290,7 +1290,7 @@ mod test {
     {
         let relation = Relation::new("test_input", false, fields, true, BTreeMap::new());
         let (endpoint, consumer, zset) =
-            mock_input_pipeline::<T, U>(json5::from_str(config_str).unwrap(), relation)?;
+            mock_input_pipeline::<T, U>(serde_json::from_str(config_str).unwrap(), relation)?;
         endpoint.start(0)?;
         Ok((endpoint, consumer, zset))
     }
@@ -1462,7 +1462,7 @@ mod test {
   }
 }
 "#;
-        let cfg: InputEndpointConfig = json5::from_str(config_str).unwrap();
+        let cfg: InputEndpointConfig = serde_json::from_str(config_str).unwrap();
 
         if let TransportConfig::Datagen(dtg) = cfg.connector_config.transport {
             assert_eq!(dtg.plan.len(), 1);

--- a/crates/adapters/src/transport/datagen.rs
+++ b/crates/adapters/src/transport/datagen.rs
@@ -1290,19 +1290,27 @@ mod test {
     {
         let relation = Relation::new("test_input", false, fields, true, BTreeMap::new());
         let (endpoint, consumer, zset) =
-            mock_input_pipeline::<T, U>(serde_yaml::from_str(config_str).unwrap(), relation)?;
+            mock_input_pipeline::<T, U>(json5::from_str(config_str).unwrap(), relation)?;
         endpoint.start(0)?;
         Ok((endpoint, consumer, zset))
     }
 
     #[test]
     fn test_limit_increment() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 10, fields: {} } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 10,
+          fields: {}
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1327,13 +1335,26 @@ transport:
 
     #[test]
     fn test_scaled_range_increment() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 10, fields: { "id": { "strategy": "increment", "range": [10, 20], scale: 3 } } } ]
-"#;
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 10,
+          fields: {
+            "id": {
+              strategy: "increment",
+              range: [10, 20],
+              scale: 3
+            }
+          }
+        }
+      ]
+    }
+  }
+}"#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
 
@@ -1353,12 +1374,25 @@ transport:
 
     #[test]
     fn test_uniform_range() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 1, fields: { "id": { "strategy": "uniform", "range": [10, 20] } } } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 1,
+          fields: {
+            "id": {
+              strategy: "uniform",
+              range: [10, 20]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1377,12 +1411,24 @@ transport:
 
     #[test]
     fn test_values() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 4, fields: { "id": { values: [99, 100, 101] } } } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 4,
+          fields: {
+            "id": {
+              values: [99, 100, 101]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1406,14 +1452,17 @@ transport:
 
     #[test]
     fn missing_config_does_something_sane() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
       workers: 3
+    }
+  }
+}
 "#;
-        let cfg: InputEndpointConfig = serde_yaml::from_str(config_str).unwrap();
+        let cfg: InputEndpointConfig = json5::from_str(config_str).unwrap();
 
         if let TransportConfig::Datagen(dtg) = cfg.connector_config.transport {
             assert_eq!(dtg.plan.len(), 1);
@@ -1423,12 +1472,24 @@ transport:
 
     #[test]
     fn test_null() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 10, fields: { "name": { null_percentage: 100 } } } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 10,
+          fields: {
+            "name": {
+              null_percentage: 100
+            }
+          }
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1447,12 +1508,24 @@ transport:
 
     #[test]
     fn test_null_percentage() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 100, fields: { "name": { null_percentage: 50 } } } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 100,
+          fields: {
+            "name": {
+              null_percentage: 50
+            }
+          }
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1475,12 +1548,24 @@ transport:
 
     #[test]
     fn test_string_generators() {
-        let config_str = r#"
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ { limit: 2, fields: { "name": { "strategy": "word" } } } ]
+        let config_str = r#"{
+  stream: "test_input",
+  transport: {
+    name: "datagen",
+    config: {
+      plan: [
+        {
+          limit: 2,
+          fields: {
+            "name": {
+              strategy: "word"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
 "#;
         let (_endpoint, consumer, zset) =
             mk_pipeline::<TestStruct2, TestStruct2>(config_str, TestStruct2::schema()).unwrap();
@@ -1511,13 +1596,16 @@ transport:
             .unwrap_or(DEFAULT_WORKERS);
 
         let config_str = format!(
-            "
-stream: test_input
-transport:
-    name: datagen
-    config:
-        plan: [ {{ limit: {size}, fields: {{}} }} ]
-        workers: {workers}
+            "{{
+  stream: \"test_input\",
+  transport: {{
+    name: \"datagen\",
+    config: {{
+      plan: [ {{ limit: {size}, fields: {{}} }} ],
+      workers: {workers}
+    }}
+  }}
+}}
 "
         );
         let (_endpoint, consumer, _zset) =

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -233,14 +233,19 @@ mod test {
         // Use a very small buffer size for testing.
         let config_str = format!(
             r#"
-stream: test_input
-transport:
-    name: file_input
-    config:
-        path: {:?}
-        buffer_size_bytes: 5
-format:
-    name: csv
+{{
+  stream: "test_input",
+  transport: {{
+    name: "file_input",
+    config: {{
+      path: {:?},
+      buffer_size_bytes: 5
+    }}
+  }},
+  format: {{
+    name: "csv"
+  }}
+}}
 "#,
             temp_file.path().to_str().unwrap()
         );
@@ -256,7 +261,7 @@ format:
         writer.flush().unwrap();
 
         let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-            serde_yaml::from_str(&config_str).unwrap(),
+            json5::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap();
@@ -290,16 +295,20 @@ format:
         // Create a transport endpoint attached to the file.
         // Use a very small buffer size for testing.
         let config_str = format!(
-            r#"
-stream: test_input
-transport:
-    name: file_input
-    config:
-        path: {:?}
-        buffer_size_bytes: 5
-        follow: true
-format:
-    name: csv
+            r#"{{
+  stream: "test_input",
+  transport: {{
+    name: "file_input",
+    config: {{
+      path: {:?},
+      buffer_size_bytes: 5,
+      follow: true
+    }}
+  }},
+  format: {{
+    name: "csv"
+  }}
+}}
 "#,
             temp_file.path().to_str().unwrap()
         );
@@ -311,7 +320,7 @@ format:
             .from_writer(temp_file.as_file());
 
         let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-            serde_yaml::from_str(&config_str).unwrap(),
+            json5::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap();

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -261,7 +261,7 @@ mod test {
         writer.flush().unwrap();
 
         let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-            json5::from_str(&config_str).unwrap(),
+            serde_json::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap();
@@ -320,7 +320,7 @@ mod test {
             .from_writer(temp_file.as_file());
 
         let (endpoint, consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-            json5::from_str(&config_str).unwrap(),
+            serde_json::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap();

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -117,7 +117,7 @@ fn test_kafka_output_errors() {
     info!("test_kafka_output_errors: Creating circuit");
 
     info!("test_kafka_output_errors: Starting controller");
-    let config: PipelineConfig = json5::from_str(config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(config_str).unwrap();
 
     match Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
@@ -196,7 +196,7 @@ fn ft_kafka_end_to_end_test(
     info!("{test_name}: Creating circuit. Config {config_str}");
 
     info!("{test_name}: Starting controller");
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     let running = Arc::new(AtomicBool::new(true));
     let running_clone = running.clone();
@@ -265,7 +265,7 @@ fn test_empty_input() {
 "#
     );
 
-    let endpoint = input_transport_config_to_endpoint(json5::from_str(&config_str).unwrap())
+    let endpoint = input_transport_config_to_endpoint(serde_json::from_str(&config_str).unwrap())
         .unwrap()
         .unwrap();
     assert!(endpoint.is_fault_tolerant());
@@ -345,7 +345,7 @@ fn test_input() {
 "#
     );
 
-    let endpoint = input_transport_config_to_endpoint(json5::from_str(&config_str).unwrap())
+    let endpoint = input_transport_config_to_endpoint(serde_json::from_str(&config_str).unwrap())
         .unwrap()
         .unwrap();
     assert!(endpoint.is_fault_tolerant());
@@ -599,9 +599,10 @@ fn kafka_output_test(
 }}
 "#
     );
-    let mut endpoint = output_transport_config_to_endpoint(json5::from_str(&config_str).unwrap())
-        .unwrap()
-        .unwrap();
+    let mut endpoint =
+        output_transport_config_to_endpoint(serde_json::from_str(&config_str).unwrap())
+            .unwrap()
+            .unwrap();
     assert!(endpoint.is_fault_tolerant());
     endpoint
         .connect(Box::new(|fatal, error| info!("({fatal:?}, {error:?})")))
@@ -626,9 +627,10 @@ fn _test() {
 }
 "#;
 
-    let mut endpoint = output_transport_config_to_endpoint(json5::from_str(&config_str).unwrap())
-        .unwrap()
-        .unwrap();
+    let mut endpoint =
+        output_transport_config_to_endpoint(serde_json::from_str(&config_str).unwrap())
+            .unwrap()
+            .unwrap();
     assert!(endpoint.is_fault_tolerant());
     endpoint
         .connect(Box::new(|fatal, error| info!("({fatal:?}, {error:?})")))
@@ -679,7 +681,7 @@ fn test_ft_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str) {
     );
 
     let (reader, consumer, _input_handle) = mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(&config_str).unwrap(),
+        serde_json::from_str(&config_str).unwrap(),
         Relation::empty(),
     )
     .unwrap();
@@ -711,7 +713,7 @@ fn test_ft_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str) {
 "#;
 
     let (reader, consumer, _input_handle) = mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(config_str).unwrap(),
+        serde_json::from_str(config_str).unwrap(),
         Relation::empty(),
     )
     .unwrap();
@@ -745,7 +747,7 @@ fn test_ft_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str) {
     info!("proptest_kafka_input: Building input pipeline");
 
     let (endpoint, _consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(&config_str).unwrap(),
+        serde_json::from_str(&config_str).unwrap(),
         Relation::empty(),
     )
     .unwrap();

--- a/crates/adapters/src/transport/kafka/nonft/test.rs
+++ b/crates/adapters/src/transport/kafka/nonft/test.rs
@@ -114,7 +114,7 @@ fn test_kafka_output_errors() {
     info!("test_kafka_output_errors: Creating circuit");
 
     info!("test_kafka_output_errors: Starting controller");
-    let config: PipelineConfig = json5::from_str(config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(config_str).unwrap();
 
     match Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
@@ -194,7 +194,7 @@ fn kafka_end_to_end_test(
     info!("{test_name}: Creating circuit. Config {config_str}");
 
     info!("{test_name}: Starting controller");
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     let running = Arc::new(AtomicBool::new(true));
     let running_clone = running.clone();
@@ -265,7 +265,7 @@ fn test_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str, poll
     );
 
     match mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(&config_str).unwrap(),
+        serde_json::from_str(&config_str).unwrap(),
         Relation::empty(),
     ) {
         Ok(_) => panic!("expected an error"),
@@ -292,7 +292,7 @@ fn test_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str, poll
 "#;
 
     match mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(config_str).unwrap(),
+        serde_json::from_str(config_str).unwrap(),
         Relation::empty(),
     ) {
         Ok(_) => panic!("expected an error"),
@@ -326,7 +326,7 @@ fn test_kafka_input(data: Vec<Vec<TestStruct>>, topic1: &str, topic2: &str, poll
     info!("proptest_kafka_input: Building input pipeline");
 
     let (endpoint, _consumer, zset) = mock_input_pipeline::<TestStruct, TestStruct>(
-        json5::from_str(&config_str).unwrap(),
+        serde_json::from_str(&config_str).unwrap(),
         Relation::empty(),
     )
     .unwrap();
@@ -490,7 +490,7 @@ fn buffer_test() {
     info!("buffer_test: Creating circuit. Config {config_str}");
 
     info!("buffer_test: Starting controller");
-    let config: PipelineConfig = json5::from_str(&config_str).unwrap();
+    let config: PipelineConfig = serde_json::from_str(&config_str).unwrap();
 
     let running = Arc::new(AtomicBool::new(true));
     let running_clone = running.clone();

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -37,10 +37,10 @@ impl InputEndpoint for S3InputEndpoint {
 impl TransportInputEndpoint for S3InputEndpoint {
     fn open(
         &self,
-        consumer: Box<dyn crate::InputConsumer>,
+        consumer: Box<dyn InputConsumer>,
         _start_step: super::Step,
         _schema: Relation,
-    ) -> anyhow::Result<Box<dyn crate::InputReader>> {
+    ) -> anyhow::Result<Box<dyn InputReader>> {
         Ok(Box::new(S3InputReader::new(&self.config, consumer)))
     }
 }
@@ -312,43 +312,59 @@ mod test {
     deserialize_without_context!(TestStruct);
 
     const MULTI_KEY_CONFIG_STR: &str = r#"
-stream: test_input
-transport:
-    name: s3_input
-    config:
-        credentials:
-            type: AccessKey
-            aws_access_key_id: FAKE_ACCESS_KEY
-            aws_secret_access_key: FAKE_SECRET
-        bucket_name: test-bucket
-        region: us-west-1
-        read_strategy:
-            type: Prefix
-            prefix: ''
-        consume_strategy:
-            type: Fragment
-format:
-    name: csv
+{
+  stream: "test_input",
+  transport: {
+    name: "s3_input",
+    config: {
+      credentials: {
+        type: "AccessKey",
+        aws_access_key_id: "FAKE_ACCESS_KEY",
+        aws_secret_access_key: "FAKE_SECRET"
+      },
+      bucket_name: "test-bucket",
+      region: "us-west-1",
+      read_strategy: {
+        type: "Prefix",
+        prefix: ""
+      },
+      consume_strategy: {
+        type: "Fragment"
+      }
+    }
+  },
+  format: {
+    name: "csv"
+  }
+}
 "#;
 
     const SINGLE_KEY_CONFIG_STR: &str = r#"
-stream: test_input
-transport:
-    name: s3_input
-    config:
-        credentials:
-            type: AccessKey
-            aws_access_key_id: FAKE_ACCESS_KEY
-            aws_secret_access_key: FAKE_SECRET
-        bucket_name: test-bucket
-        region: us-west-1
-        read_strategy:
-            type: SingleKey
-            key: obj1
-        consume_strategy:
-            type: Object
-format:
-    name: csv
+{
+  stream: "test_input",
+  transport: {
+    name: "s3_input",
+    config: {
+      credentials: {
+        type: "AccessKey",
+        aws_access_key_id: "FAKE_ACCESS_KEY",
+        aws_secret_access_key: "FAKE_SECRET"
+      },
+      bucket_name: "test-bucket",
+      region: "us-west-1",
+      read_strategy: {
+        type: "SingleKey",
+        key: "obj1"
+      },
+      consume_strategy: {
+        type: "Object"
+      }
+    }
+  },
+  format: {
+    name: "csv"
+  }
+}
 "#;
 
     fn test_setup(
@@ -359,7 +375,7 @@ format:
         MockInputConsumer,
         MockDeZSet<TestStruct, TestStruct>,
     ) {
-        let config: InputEndpointConfig = serde_yaml::from_str(&config_str).unwrap();
+        let config: InputEndpointConfig = json5::from_str(&config_str).unwrap();
         let transport_config = config.connector_config.transport.clone();
         let transport_config: Arc<S3InputConfig> = match transport_config {
             TransportConfig::S3Input(config) => Arc::new(config),

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -375,7 +375,7 @@ mod test {
         MockInputConsumer,
         MockDeZSet<TestStruct, TestStruct>,
     ) {
-        let config: InputEndpointConfig = json5::from_str(&config_str).unwrap();
+        let config: InputEndpointConfig = serde_json::from_str(&config_str).unwrap();
         let transport_config = config.connector_config.transport.clone();
         let transport_config: Arc<S3InputConfig> = match transport_config {
             TransportConfig::S3Input(config) => Arc::new(config),

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -362,19 +362,24 @@ mod test {
         // Create a transport endpoint attached to the file.
         let config_str = format!(
             r#"
-stream: test_input
-transport:
-    name: url_input
-    config:
-        path: http://{addr}/{path}
-        pause_timeout: {pause_timeout}
-format:
-    name: csv
+{{
+  stream: "test_input",
+  transport: {{
+    name: "url_input",
+    config: {{
+      path: "http://{addr}/{path}",
+      pause_timeout: {pause_timeout}
+    }}
+  }},
+  format: {{
+    name: "csv"
+  }}
+}}
 "#
         );
 
         mock_input_pipeline::<TestStruct, TestStruct>(
-            serde_yaml::from_str(&config_str).unwrap(),
+            json5::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap()

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -379,7 +379,7 @@ mod test {
         );
 
         mock_input_pipeline::<TestStruct, TestStruct>(
-            json5::from_str(&config_str).unwrap(),
+            serde_json::from_str(&config_str).unwrap(),
             Relation::empty(),
         )
         .unwrap()

--- a/crates/dbsp/src/operator/dynamic/time_series/range.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/range.rs
@@ -21,8 +21,7 @@ use crate::{
 /// `RelOffset::Before(0)` and `RelOffset::After(0)` both represent the same
 /// relative time.  This is also true for `RelOffset::Before(1)` and
 /// `RelOffset::After(-1)`, but the former is preferred.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum RelOffset<TS> {
     Before(TS),
     After(TS),
@@ -85,8 +84,7 @@ where
 /// `RelRange::new(RelOffset::Before(0), RelOffset::Before(0))` spans 1 unit of
 /// time; `RelRange::new(RelOffset::Before(2), RelOffset::Before(0))` spans 3
 /// units:
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct RelRange<TS> {
     pub from: RelOffset<TS>,
     pub to: RelOffset<TS>,

--- a/crates/pipeline-types/Cargo.toml
+++ b/crates/pipeline-types/Cargo.toml
@@ -15,7 +15,6 @@ testing = ["proptest", "proptest-derive"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_yaml = "0.9.14"
 serde_json = { version = "1.0.103", features = ["raw_value"] }
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 libc = "0.2.153"
@@ -27,6 +26,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 actix-web = "4.3"
 enum-map = "2.7.3"
+json5 = "0.4.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/pipeline-types/Cargo.toml
+++ b/crates/pipeline-types/Cargo.toml
@@ -26,7 +26,6 @@ proptest-derive = { version = "0.3.0", optional = true }
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
 actix-web = "4.3"
 enum-map = "2.7.3"
-json5 = "0.4.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -2,8 +2,8 @@
 //!
 //! This module defines the controller configuration structure.  The leaves of
 //! this structure are individual transport-specific and data-format-specific
-//! endpoint configs.  We represent these configs as opaque yaml values, so
-//! that the entire configuration tree can be deserialized from a yaml file.
+//! endpoint configs.  We represent these configs as opaque json5 values, so
+//! that the entire configuration tree can be deserialized from a JSON5 file.
 
 use crate::query::OutputQuery;
 use crate::transport::datagen::DatagenInputConfig;
@@ -14,7 +14,7 @@ use crate::transport::nexmark::NexmarkInputConfig;
 use crate::transport::s3::S3InputConfig;
 use crate::transport::url::UrlInputConfig;
 use serde::{Deserialize, Serialize};
-use serde_yaml::Value as YamlValue;
+use serde_json::Value;
 use std::{borrow::Cow, collections::BTreeMap};
 use utoipa::ToSchema;
 
@@ -72,12 +72,12 @@ pub struct PipelineConfig {
 }
 
 impl PipelineConfig {
-    pub fn from_yaml(s: &str) -> Self {
-        serde_yaml::from_str(s).unwrap()
+    pub fn from_json5(s: &str) -> Self {
+        json5::from_str(s).unwrap()
     }
 
-    pub fn to_yaml(&self) -> String {
-        serde_yaml::to_string(self).unwrap()
+    pub fn to_json5(&self) -> String {
+        json5::to_string(self).unwrap()
     }
 }
 
@@ -203,12 +203,12 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
-    pub fn from_yaml(s: &str) -> Self {
-        serde_yaml::from_str(s).unwrap()
+    pub fn from_json5(s: &str) -> Self {
+        json5::from_str(s).unwrap()
     }
 
-    pub fn to_yaml(&self) -> String {
-        serde_yaml::to_string(self).unwrap()
+    pub fn to_json5(&self) -> String {
+        json5::to_string(self).unwrap()
     }
 }
 
@@ -267,11 +267,11 @@ pub struct ConnectorConfig {
 }
 
 fn default_max_buffer_time_millis() -> usize {
-    usize::MAX
+    i64::MAX as usize
 }
 
 fn default_max_buffer_size_records() -> usize {
-    usize::MAX
+    i64::MAX as usize
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -412,7 +412,7 @@ pub struct FormatConfig {
     /// Format-specific parser or encoder configuration.
     #[serde(default)]
     #[schema(value_type = Object)]
-    pub config: YamlValue,
+    pub config: Value,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize, ToSchema)]

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -2,8 +2,8 @@
 //!
 //! This module defines the controller configuration structure.  The leaves of
 //! this structure are individual transport-specific and data-format-specific
-//! endpoint configs.  We represent these configs as opaque json5 values, so
-//! that the entire configuration tree can be deserialized from a JSON5 file.
+//! endpoint configs.  We represent these configs as opaque json values, so
+//! that the entire configuration tree can be deserialized from a json file.
 
 use crate::query::OutputQuery;
 use crate::transport::datagen::DatagenInputConfig;
@@ -72,12 +72,12 @@ pub struct PipelineConfig {
 }
 
 impl PipelineConfig {
-    pub fn from_json5(s: &str) -> Self {
-        json5::from_str(s).unwrap()
+    pub fn from_json(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
     }
 
-    pub fn to_json5(&self) -> String {
-        json5::to_string(self).unwrap()
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }
 
@@ -203,12 +203,12 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
-    pub fn from_json5(s: &str) -> Self {
-        json5::from_str(s).unwrap()
+    pub fn from_json(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
     }
 
-    pub fn to_json5(&self) -> String {
-        json5::to_string(self).unwrap()
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }
 

--- a/crates/pipeline-types/src/error.rs
+++ b/crates/pipeline-types/src/error.rs
@@ -111,11 +111,11 @@ impl ErrorResponse {
         }
     }
 
-    pub fn from_yaml(s: &str) -> Self {
-        serde_yaml::from_str(s).unwrap()
+    pub fn from_json5(s: &str) -> Self {
+        json5::from_str(s).unwrap()
     }
 
-    pub fn to_yaml(&self) -> String {
-        serde_yaml::to_string(self).unwrap()
+    pub fn to_json5(&self) -> String {
+        json5::to_string(self).unwrap()
     }
 }

--- a/crates/pipeline-types/src/error.rs
+++ b/crates/pipeline-types/src/error.rs
@@ -111,11 +111,11 @@ impl ErrorResponse {
         }
     }
 
-    pub fn from_json5(s: &str) -> Self {
-        json5::from_str(s).unwrap()
+    pub fn from_json(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
     }
 
-    pub fn to_json5(&self) -> String {
-        json5::to_string(self).unwrap()
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }

--- a/crates/pipeline-types/src/secret_ref.rs
+++ b/crates/pipeline-types/src/secret_ref.rs
@@ -88,7 +88,7 @@ mod tests {
     fn test_deserialize_string() {
         let data = "{ \"string\": \"example123\" }";
         assert_eq!(
-            json5::from_str::<MaybeSecretRef>(data).unwrap(),
+            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
             MaybeSecretRef::String("example123".to_string())
         );
     }
@@ -97,7 +97,7 @@ mod tests {
     fn test_deserialize_secret_ref() {
         let data = "{ \"secret_ref\": \"example456\" }";
         assert_eq!(
-            json5::from_str::<MaybeSecretRef>(data).unwrap(),
+            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
             MaybeSecretRef::SecretRef("example456".to_string())
         );
     }

--- a/crates/pipeline-types/src/secret_ref.rs
+++ b/crates/pipeline-types/src/secret_ref.rs
@@ -88,12 +88,7 @@ mod tests {
     fn test_deserialize_string() {
         let data = "{ \"string\": \"example123\" }";
         assert_eq!(
-            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
-            MaybeSecretRef::String("example123".to_string())
-        );
-        let data = "!string \"example123\"";
-        assert_eq!(
-            serde_yaml::from_str::<MaybeSecretRef>(data).unwrap(),
+            json5::from_str::<MaybeSecretRef>(data).unwrap(),
             MaybeSecretRef::String("example123".to_string())
         );
     }
@@ -102,12 +97,7 @@ mod tests {
     fn test_deserialize_secret_ref() {
         let data = "{ \"secret_ref\": \"example456\" }";
         assert_eq!(
-            serde_json::from_str::<MaybeSecretRef>(data).unwrap(),
-            MaybeSecretRef::SecretRef("example456".to_string())
-        );
-        let data = "!secret_ref \"example456\"";
-        assert_eq!(
-            serde_yaml::from_str::<MaybeSecretRef>(data).unwrap(),
+            json5::from_str::<MaybeSecretRef>(data).unwrap(),
             MaybeSecretRef::SecretRef("example456".to_string())
         );
     }

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -28,7 +28,6 @@ log = "0.4.20"
 env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.103"
-serde_yaml = "0.9.14"
 clap = { version = "4.0.32", features = ["derive"] }
 utoipa = { version = "4.1", features = ["actix_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "4", features = ["actix-web"] }
@@ -55,6 +54,7 @@ dirs = "5.0"
 thiserror = "1.0"
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15.1"
+json5 = "0.4.1"
 
 [features]
 integration-test = []

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -54,7 +54,6 @@ dirs = "5.0"
 thiserror = "1.0"
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15.1"
-json5 = "0.4.1"
 
 [features]
 integration-test = []

--- a/crates/pipeline_manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline_manager/src/bin/pipeline-manager.rs
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
             anyhow::Error::msg(format!("error reading config file '{config_file}': {e}"))
         })?;
         let config_yaml = String::from_utf8_lossy(&config_yaml);
-        api_config = serde_yaml::from_str(&config_yaml).map_err(|e| {
+        api_config = json5::from_str(&config_yaml).map_err(|e| {
             anyhow::Error::msg(format!("error parsing config file '{config_file}': {e}"))
         })?;
     }

--- a/crates/pipeline_manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline_manager/src/bin/pipeline-manager.rs
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
             anyhow::Error::msg(format!("error reading config file '{config_file}': {e}"))
         })?;
         let config_yaml = String::from_utf8_lossy(&config_yaml);
-        api_config = json5::from_str(&config_yaml).map_err(|e| {
+        api_config = serde_json::from_str(&config_yaml).map_err(|e| {
             anyhow::Error::msg(format!("error parsing config file '{config_file}': {e}"))
         })?;
     }

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -1006,7 +1006,7 @@ mod test {
                 PipelineDescr {
                     name: pname.to_string(),
                     description: "Description of the pipeline".to_string(),
-                    runtime_config: RuntimeConfig::from_json5(""),
+                    runtime_config: RuntimeConfig::from_json(""),
                     program_code: "code-not-used".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -1006,7 +1006,7 @@ mod test {
                 PipelineDescr {
                     name: pname.to_string(),
                     description: "Description of the pipeline".to_string(),
-                    runtime_config: RuntimeConfig::from_yaml(""),
+                    runtime_config: RuntimeConfig::from_json5(""),
                     program_code: "code-not-used".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),

--- a/crates/pipeline_manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline_manager/src/db/operations/pipeline.rs
@@ -30,19 +30,19 @@ fn row_to_extended_pipeline_descriptor(row: &Row) -> Result<ExtendedPipelineDesc
         description: row.get(3),
         created_at: row.get(4),
         version: Version(row.get(5)),
-        runtime_config: RuntimeConfig::from_yaml(row.get(6)),
+        runtime_config: RuntimeConfig::from_json5(row.get(6)),
         program_code: row.get(7),
-        program_config: ProgramConfig::from_yaml(row.get(8)),
+        program_config: ProgramConfig::from_json5(row.get(8)),
         program_version: Version(row.get(9)),
         program_status: ProgramStatus::from_columns(row.get(10), row.get(12))?,
         program_status_since: row.get(11),
-        program_info: program_info_str.map(|s| ProgramInfo::from_yaml(&s)),
+        program_info: program_info_str.map(|s| ProgramInfo::from_json5(&s)),
         program_binary_url: row.get(14),
         deployment_status: row.get::<_, String>(15).try_into()?,
         deployment_status_since: row.get(16),
         deployment_desired_status: row.get::<_, String>(17).try_into()?,
-        deployment_error: deployment_error_str.map(|s| ErrorResponse::from_yaml(&s)),
-        deployment_config: deployment_config_str.map(|s| PipelineConfig::from_yaml(&s)),
+        deployment_error: deployment_error_str.map(|s| ErrorResponse::from_json5(&s)),
+        deployment_config: deployment_config_str.map(|s| PipelineConfig::from_json5(&s)),
         deployment_location: row.get(20),
     })
 }
@@ -151,9 +151,9 @@ pub(crate) async fn new_pipeline(
             &pipeline.name,                         // $3: name
             &pipeline.description,                  // $4: description
             &Version(1).0,                          // $5: version
-            &pipeline.runtime_config.to_yaml(),     // $6: runtime_config
+            &pipeline.runtime_config.to_json5(),    // $6: runtime_config
             &pipeline.program_code,                 // $7: program_code
-            &pipeline.program_config.to_yaml(),     // $8: program_config
+            &pipeline.program_config.to_json5(),    // $8: program_config
             &Version(1).0,                          // $9: program_version
             &ProgramStatus::Pending.to_columns().0, // $10: program_status
             &PipelineStatus::Shutdown.to_string(),  // $11: deployment_status
@@ -231,9 +231,9 @@ pub(crate) async fn update_pipeline(
             &[
                 &name,
                 &description,
-                &runtime_config.as_ref().map(|v| v.to_yaml()),
+                &runtime_config.as_ref().map(|v| v.to_json5()),
                 &program_code,
-                &program_config.as_ref().map(|v| v.to_yaml()),
+                &program_config.as_ref().map(|v| v.to_json5()),
                 &tenant_id.0,
                 &original_name,
             ],
@@ -372,7 +372,7 @@ pub(crate) async fn set_program_status(
             &[
                 &new_program_status_columns.0,
                 &new_program_status_columns.1,
-                &final_program_info.as_ref().map(|v| v.to_yaml()),
+                &final_program_info.as_ref().map(|v| v.to_json5()),
                 &final_program_binary_url,
                 &tenant_id.0,
                 &pipeline_id.0,
@@ -541,8 +541,8 @@ pub(crate) async fn set_deployment_status(
             &stmt,
             &[
                 &deployment_status.to_string(),
-                &final_deployment_error.map(|v| v.to_yaml()),
-                &final_deployment_config.map(|v| v.to_yaml()),
+                &final_deployment_error.map(|v| v.to_json5()),
+                &final_deployment_config.map(|v| v.to_json5()),
                 &final_deployment_location,
                 &tenant_id.0,
                 &pipeline_id.0,

--- a/crates/pipeline_manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline_manager/src/db/operations/pipeline.rs
@@ -30,19 +30,19 @@ fn row_to_extended_pipeline_descriptor(row: &Row) -> Result<ExtendedPipelineDesc
         description: row.get(3),
         created_at: row.get(4),
         version: Version(row.get(5)),
-        runtime_config: RuntimeConfig::from_json5(row.get(6)),
+        runtime_config: RuntimeConfig::from_json(row.get(6)),
         program_code: row.get(7),
-        program_config: ProgramConfig::from_json5(row.get(8)),
+        program_config: ProgramConfig::from_json(row.get(8)),
         program_version: Version(row.get(9)),
         program_status: ProgramStatus::from_columns(row.get(10), row.get(12))?,
         program_status_since: row.get(11),
-        program_info: program_info_str.map(|s| ProgramInfo::from_json5(&s)),
+        program_info: program_info_str.map(|s| ProgramInfo::from_json(&s)),
         program_binary_url: row.get(14),
         deployment_status: row.get::<_, String>(15).try_into()?,
         deployment_status_since: row.get(16),
         deployment_desired_status: row.get::<_, String>(17).try_into()?,
-        deployment_error: deployment_error_str.map(|s| ErrorResponse::from_json5(&s)),
-        deployment_config: deployment_config_str.map(|s| PipelineConfig::from_json5(&s)),
+        deployment_error: deployment_error_str.map(|s| ErrorResponse::from_json(&s)),
+        deployment_config: deployment_config_str.map(|s| PipelineConfig::from_json(&s)),
         deployment_location: row.get(20),
     })
 }
@@ -151,9 +151,9 @@ pub(crate) async fn new_pipeline(
             &pipeline.name,                         // $3: name
             &pipeline.description,                  // $4: description
             &Version(1).0,                          // $5: version
-            &pipeline.runtime_config.to_json5(),    // $6: runtime_config
+            &pipeline.runtime_config.to_json(),     // $6: runtime_config
             &pipeline.program_code,                 // $7: program_code
-            &pipeline.program_config.to_json5(),    // $8: program_config
+            &pipeline.program_config.to_json(),     // $8: program_config
             &Version(1).0,                          // $9: program_version
             &ProgramStatus::Pending.to_columns().0, // $10: program_status
             &PipelineStatus::Shutdown.to_string(),  // $11: deployment_status
@@ -231,9 +231,9 @@ pub(crate) async fn update_pipeline(
             &[
                 &name,
                 &description,
-                &runtime_config.as_ref().map(|v| v.to_json5()),
+                &runtime_config.as_ref().map(|v| v.to_json()),
                 &program_code,
-                &program_config.as_ref().map(|v| v.to_json5()),
+                &program_config.as_ref().map(|v| v.to_json()),
                 &tenant_id.0,
                 &original_name,
             ],
@@ -372,7 +372,7 @@ pub(crate) async fn set_program_status(
             &[
                 &new_program_status_columns.0,
                 &new_program_status_columns.1,
-                &final_program_info.as_ref().map(|v| v.to_json5()),
+                &final_program_info.as_ref().map(|v| v.to_json()),
                 &final_program_binary_url,
                 &tenant_id.0,
                 &pipeline_id.0,
@@ -541,8 +541,8 @@ pub(crate) async fn set_deployment_status(
             &stmt,
             &[
                 &deployment_status.to_string(),
-                &final_deployment_error.map(|v| v.to_json5()),
-                &final_deployment_config.map(|v| v.to_json5()),
+                &final_deployment_error.map(|v| v.to_json()),
+                &final_deployment_config.map(|v| v.to_json()),
                 &final_deployment_location,
                 &tenant_id.0,
                 &pipeline_id.0,

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -659,7 +659,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_json5("");
+//     let rc = RuntimeConfig::from_json("");
 //     let _ = handle
 //         .db
 //         .new_pipeline(
@@ -811,7 +811,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_json5("");
+//     let rc = RuntimeConfig::from_json("");
 //     let _ = handle
 //         .db
 //         .new_pipeline(
@@ -850,7 +850,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_json5("");
+//     let rc = RuntimeConfig::from_json("");
 //     handle
 //         .db
 //         .new_pipeline(
@@ -949,7 +949,7 @@ async fn save_api_key() {
 //         .set_program_status_guarded(tenant_id, program_id, Version(1), ProgramStatus::Success)
 //         .await
 //         .unwrap();
-//     let rc = RuntimeConfig::from_json5("");
+//     let rc = RuntimeConfig::from_json("");
 //     let (pipeline_id, _version) = handle
 //         .db
 //         .new_pipeline(
@@ -1044,7 +1044,7 @@ async fn save_api_key() {
 //         connector_name: "d".to_string(),
 //         relation_name: "v1".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_json5("");
+//     let rc = RuntimeConfig::from_json("");
 //     let (pipeline_id, _version) = handle
 //         .db
 //         .new_pipeline(

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -659,7 +659,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_yaml("");
+//     let rc = RuntimeConfig::from_json5("");
 //     let _ = handle
 //         .db
 //         .new_pipeline(
@@ -811,7 +811,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_yaml("");
+//     let rc = RuntimeConfig::from_json5("");
 //     let _ = handle
 //         .db
 //         .new_pipeline(
@@ -850,7 +850,7 @@ async fn save_api_key() {
 //         connector_name: "a".to_string(),
 //         relation_name: "".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_yaml("");
+//     let rc = RuntimeConfig::from_json5("");
 //     handle
 //         .db
 //         .new_pipeline(
@@ -949,7 +949,7 @@ async fn save_api_key() {
 //         .set_program_status_guarded(tenant_id, program_id, Version(1), ProgramStatus::Success)
 //         .await
 //         .unwrap();
-//     let rc = RuntimeConfig::from_yaml("");
+//     let rc = RuntimeConfig::from_json5("");
 //     let (pipeline_id, _version) = handle
 //         .db
 //         .new_pipeline(
@@ -1044,7 +1044,7 @@ async fn save_api_key() {
 //         connector_name: "d".to_string(),
 //         relation_name: "v1".to_string(),
 //     };
-//     let rc = RuntimeConfig::from_yaml("");
+//     let rc = RuntimeConfig::from_json5("");
 //     let (pipeline_id, _version) = handle
 //         .db
 //         .new_pipeline(

--- a/crates/pipeline_manager/src/db/types/program.rs
+++ b/crates/pipeline_manager/src/db/types/program.rs
@@ -258,12 +258,12 @@ pub struct ProgramConfig {
 }
 
 impl ProgramConfig {
-    pub fn from_yaml(s: &str) -> Self {
-        serde_yaml::from_str(s).unwrap()
+    pub fn from_json5(s: &str) -> Self {
+        json5::from_str(s).unwrap()
     }
 
-    pub fn to_yaml(&self) -> String {
-        serde_yaml::to_string(self).unwrap()
+    pub fn to_json5(&self) -> String {
+        json5::to_string(self).unwrap()
     }
 }
 
@@ -338,18 +338,17 @@ fn parse_named_connectors(
     }
     match properties.get("connectors") {
         Some(value) => {
-            let connectors =
-                serde_json::from_str::<Vec<NamedConnector>>(&value.value).map_err(|e| {
-                    ConnectorGenerationError::InvalidPropertyValue {
-                        position: value.value_position,
-                        relation: relation.clone(),
-                        key: "connectors".to_string(),
-                        value: value.value.clone(),
-                        reason: Box::new(format!(
-                            "deserialization failed: {e} (position is within the string itself)"
-                        )),
-                    }
-                })?;
+            let connectors = json5::from_str::<Vec<NamedConnector>>(&value.value).map_err(|e| {
+                ConnectorGenerationError::InvalidPropertyValue {
+                    position: value.value_position,
+                    relation: relation.clone(),
+                    key: "connectors".to_string(),
+                    value: value.value.clone(),
+                    reason: Box::new(format!(
+                        "deserialization failed: {e} (position is within the string itself)"
+                    )),
+                }
+            })?;
             for connector in &connectors {
                 if let Some(name) = &connector.name {
                     validate_name(name).map_err(|e| {
@@ -463,12 +462,17 @@ pub struct ProgramInfo {
 }
 
 impl ProgramInfo {
-    pub fn from_yaml(s: &str) -> Self {
-        serde_yaml::from_str(s).unwrap()
+    pub fn from_json5(s: &str) -> Self {
+        if let Err(e) = json5::from_str::<Self>(s) {
+            log::error!("Error: {:?}", e);
+            panic!("String: {:?}", s);
+        } else {
+            json5::from_str(s).unwrap()
+        }
     }
 
-    pub fn to_yaml(&self) -> String {
-        serde_yaml::to_string(self).unwrap()
+    pub fn to_json5(&self) -> String {
+        json5::to_string(self).unwrap()
     }
 }
 

--- a/crates/pipeline_manager/src/db/types/program.rs
+++ b/crates/pipeline_manager/src/db/types/program.rs
@@ -258,12 +258,12 @@ pub struct ProgramConfig {
 }
 
 impl ProgramConfig {
-    pub fn from_json5(s: &str) -> Self {
-        json5::from_str(s).unwrap()
+    pub fn from_json(s: &str) -> Self {
+        serde_json::from_str(s).unwrap()
     }
 
-    pub fn to_json5(&self) -> String {
-        json5::to_string(self).unwrap()
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }
 
@@ -338,17 +338,18 @@ fn parse_named_connectors(
     }
     match properties.get("connectors") {
         Some(value) => {
-            let connectors = json5::from_str::<Vec<NamedConnector>>(&value.value).map_err(|e| {
-                ConnectorGenerationError::InvalidPropertyValue {
-                    position: value.value_position,
-                    relation: relation.clone(),
-                    key: "connectors".to_string(),
-                    value: value.value.clone(),
-                    reason: Box::new(format!(
-                        "deserialization failed: {e} (position is within the string itself)"
-                    )),
-                }
-            })?;
+            let connectors =
+                serde_json::from_str::<Vec<NamedConnector>>(&value.value).map_err(|e| {
+                    ConnectorGenerationError::InvalidPropertyValue {
+                        position: value.value_position,
+                        relation: relation.clone(),
+                        key: "connectors".to_string(),
+                        value: value.value.clone(),
+                        reason: Box::new(format!(
+                            "deserialization failed: {e} (position is within the string itself)"
+                        )),
+                    }
+                })?;
             for connector in &connectors {
                 if let Some(name) = &connector.name {
                     validate_name(name).map_err(|e| {
@@ -462,17 +463,17 @@ pub struct ProgramInfo {
 }
 
 impl ProgramInfo {
-    pub fn from_json5(s: &str) -> Self {
-        if let Err(e) = json5::from_str::<Self>(s) {
+    pub fn from_json(s: &str) -> Self {
+        if let Err(e) = serde_json::from_str::<Self>(s) {
             log::error!("Error: {:?}", e);
             panic!("String: {:?}", s);
         } else {
-            json5::from_str(s).unwrap()
+            serde_json::from_str(s).unwrap()
         }
     }
 
-    pub fn to_json5(&self) -> String {
-        json5::to_string(self).unwrap()
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
     }
 }
 

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -235,7 +235,7 @@ mod test {
                     PipelineDescr {
                         name: format!("example{i}"),
                         description: "Description of example".to_string(),
-                        runtime_config: RuntimeConfig::from_json5(""),
+                        runtime_config: RuntimeConfig::from_json(""),
                         program_code: "CREATE TABLE example ( col1 INT );".to_string(),
                         program_config: ProgramConfig {
                             profile: Some(CompilationProfile::Unoptimized),
@@ -308,7 +308,7 @@ mod test {
                 PipelineDescr {
                     name: "example1".to_string(),
                     description: "Description of example1".to_string(),
-                    runtime_config: RuntimeConfig::from_json5(""),
+                    runtime_config: RuntimeConfig::from_json(""),
                     program_code: "CREATE TABLE example1 ( col1 INT );".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),

--- a/crates/pipeline_manager/src/db_notifier.rs
+++ b/crates/pipeline_manager/src/db_notifier.rs
@@ -235,7 +235,7 @@ mod test {
                     PipelineDescr {
                         name: format!("example{i}"),
                         description: "Description of example".to_string(),
-                        runtime_config: RuntimeConfig::from_yaml(""),
+                        runtime_config: RuntimeConfig::from_json5(""),
                         program_code: "CREATE TABLE example ( col1 INT );".to_string(),
                         program_config: ProgramConfig {
                             profile: Some(CompilationProfile::Unoptimized),
@@ -308,7 +308,7 @@ mod test {
                 PipelineDescr {
                     name: "example1".to_string(),
                     description: "Description of example1".to_string(),
-                    runtime_config: RuntimeConfig::from_yaml(""),
+                    runtime_config: RuntimeConfig::from_json5(""),
                     program_code: "CREATE TABLE example1 ( col1 INT );".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -116,7 +116,7 @@ impl PipelineExecutor for ProcessRunner {
         }
 
         let config_file_path = self.config.config_file_path(pipeline_id);
-        let expanded_config = serde_yaml::to_string(&ped.deployment_config).unwrap();
+        let expanded_config = json5::to_string(&ped.deployment_config).unwrap();
         fs::write(&config_file_path, &expanded_config)
             .await
             .map_err(|e| {

--- a/crates/pipeline_manager/src/local_runner.rs
+++ b/crates/pipeline_manager/src/local_runner.rs
@@ -116,7 +116,7 @@ impl PipelineExecutor for ProcessRunner {
         }
 
         let config_file_path = self.config.config_file_path(pipeline_id);
-        let expanded_config = json5::to_string(&ped.deployment_config).unwrap();
+        let expanded_config = serde_json::to_string(&ped.deployment_config).unwrap();
         fs::write(&config_file_path, &expanded_config)
             .await
             .map_err(|e| {

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -866,7 +866,7 @@ mod test {
                 PipelineDescr {
                     name: "example1".to_string(),
                     description: "Description of example1".to_string(),
-                    runtime_config: RuntimeConfig::from_yaml(""),
+                    runtime_config: RuntimeConfig::from_json5(""),
                     program_code: "CREATE TABLE example1 ( col1 INT );".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -866,7 +866,7 @@ mod test {
                 PipelineDescr {
                     name: "example1".to_string(),
                     description: "Description of example1".to_string(),
-                    runtime_config: RuntimeConfig::from_json5(""),
+                    runtime_config: RuntimeConfig::from_json(""),
                     program_code: "CREATE TABLE example1 ( col1 INT );".to_string(),
                     program_config: ProgramConfig {
                         profile: Some(CompilationProfile::Unoptimized),


### PR DESCRIPTION
This makes it less error prone to write these connector configs:

- allows trailing commas,
- don't have to quote the key
- comments
- more https://github.com/json5/json5?tab=readme-ov-file#summary-of-features

I also got rid of our internal representation with serde_yaml and removed the crate, it is deprecated: https://github.com/dtolnay/serde-yaml

Is this a user-visible change (yes/no): ___

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
