### PR TITLE
[SQL] For the first step use the minimum possible waterline everywhere

### DIFF
--- a/crates/dbsp/src/num_entries.rs
+++ b/crates/dbsp/src/num_entries.rs
@@ -93,6 +93,7 @@ macro_rules! num_entries_scalar_test {
 }
 
 num_entries_scalar! {
+    bool,
     u8,
     u16,
     u32,
@@ -123,6 +124,7 @@ num_entries_scalar! {
 }
 
 num_entries_scalar_test! {
+    bool,
     u8,
     u16,
     u32,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
@@ -16,8 +16,8 @@ import java.util.Objects;
  * The inputs and outputs do not have to be Z-sets or indexed Z-sets. */
 public final class DBSPApply2Operator extends DBSPBinaryOperator {
     public DBSPApply2Operator(CalciteObject node, DBSPClosureExpression function,
-                              DBSPType outputType, DBSPOperator left, DBSPOperator right) {
-        super(node, "apply2", function, outputType, false, left, right);
+                              DBSPOperator left, DBSPOperator right) {
+        super(node, "apply2", function, function.getResultType(), false, left, right);
         assert function.parameters.length == 2: "Expected 2 parameters for function " + function;
         DBSPType param0Type = function.parameters[0].getType().deref();
         assert left.outputType.sameType(param0Type):
@@ -31,7 +31,7 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPApply2Operator(
                 this.getNode(), Objects.requireNonNull(expression).to(DBSPClosureExpression.class),
-                outputType, this.left(), this.right())
+                this.left(), this.right())
                 .copyAnnotations(this);
     }
 
@@ -41,7 +41,7 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
         if (force || this.inputsDiffer(newInputs)) {
             return new DBSPApply2Operator(
                     this.getNode(), this.getClosureFunction(),
-                    this.getType(), newInputs.get(0), newInputs.get(1))
+                    newInputs.get(0), newInputs.get(1))
                     .copyAnnotations(this);
         }
         return this;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
@@ -26,6 +26,11 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
                 "Function return type " + function.getResultType() + " does not match output type " + outputType;
     }
 
+    public DBSPApplyOperator(CalciteObject node, DBSPClosureExpression function,
+                             DBSPOperator input, @Nullable String comment) {
+        this(node, function, function.getResultType(), input, comment);
+    }
+
     @Override
     public DBSPOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
         return new DBSPApplyOperator(
@@ -40,7 +45,7 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
         if (force || this.inputsDiffer(newInputs)) {
             return new DBSPApplyOperator(
                     this.getNode(), this.getClosureFunction(),
-                    this.getType(), newInputs.get(0), this.comment)
+                    newInputs.get(0), this.comment)
                     .copyAnnotations(this);
         }
         return this;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPDelayOperator.java
@@ -46,6 +46,10 @@ public final class DBSPDelayOperator extends DBSPUnaryOperator {
         super(node, initial == null ? "delay" : "delay_with_initial_value",
                 initial, source.outputType, source.isMultiset, source);
         this.output = output;
+        if (initial != null) {
+            assert initial.getType().sameType(source.outputType) :
+                    "Delay input has type " + source.outputType + " but initial value has type " + initial.getType();
+        }
     }
 
     public DBSPDelayOperator(CalciteObject node, @Nullable DBSPExpression initial, DBSPOperator source) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
@@ -9,6 +9,7 @@ import org.dbsp.sqlCompiler.ir.DBSPParameter;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,10 @@ public final class DBSPIntegrateTraceRetainValuesOperator extends DBSPBinaryOper
     public static DBSPIntegrateTraceRetainValuesOperator create(
             CalciteObject node, DBSPOperator data, IMaybeMonotoneType dataProjection, DBSPOperator control) {
         DBSPType controlType = control.getType();
+        assert controlType.is(DBSPTypeTupleBase.class) : "Control type is not a tuple: " + controlType;
+        DBSPTypeTupleBase controlTuple = controlType.to(DBSPTypeTupleBase.class);
+        assert controlTuple.size() == 2;
+
         DBSPVariablePath controlArg = controlType.ref().var();
         assert data.outputType.is(DBSPTypeIndexedZSet.class);
         DBSPType valueType = data.getOutputIndexedZSetType().elementType;
@@ -37,7 +42,7 @@ public final class DBSPIntegrateTraceRetainValuesOperator extends DBSPBinaryOper
                 .getField(1)
                 .projectExpression(dataArg);
         DBSPExpression compare = DBSPControlledFilterOperator.generateTupleCompare(
-                project, controlArg.deref());
+                project, controlArg.deref().field(1));
         DBSPExpression closure = compare.closure(param, controlArg.asParameter());
         return new DBSPIntegrateTraceRetainValuesOperator(node, closure, data, control);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitRewriter;
@@ -103,6 +104,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Base class for Inner visitors which rewrite expressions, types, and statements.
@@ -1189,5 +1191,10 @@ public abstract class InnerRewriteVisitor
      */
     public CircuitRewriter circuitRewriter() {
         return new CircuitRewriter(this.errorReporter, this);
+    }
+
+    /** Create a circuit rewriter with a predicate that selects which node to optimize */
+    public CircuitRewriter circuitRewriter(Predicate<DBSPOperator> toOptimize) {
+        return new CircuitRewriter(this.errorReporter, this, toOptimize);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/SimplifyWaterline.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/SimplifyWaterline.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.dbsp.sqlCompiler.compiler.visitors.inner;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeRef;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTupleBase;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+
+import java.util.function.Predicate;
+
+/** Visitor tailored for optimizing the functions in Apply nodes produced by
+ * the InsertLimiters pass.  These nodes have the closures of the shape:
+ * clo = |v: (bool, T) -> expression.  These expressions are optimized using the following
+ * rewrite:
+ *
+ * <p>
+ * |v: (bool, T) -> if v.0 { clo((true, v.1)) } else { clo((false, v.1)) }
+ */
+public class SimplifyWaterline extends Simplify {
+    public SimplifyWaterline(IErrorReporter reporter) {
+        super(reporter);
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPClosureExpression expression) {
+        this.push(expression);
+        DBSPExpression body = this.transform(expression.body);
+        this.pop(expression);
+        DBSPClosureExpression transformed = body.closure(expression.parameters);
+
+        DBSPExpression result = transformed;
+        if (transformed.parameters.length != 1) {
+            this.map(expression, result);
+            return VisitDecision.STOP;
+        }
+        DBSPType type = transformed.parameters[0].getType();
+        if (!type.is(DBSPTypeRef.class)) {
+            this.map(expression, result);
+            return VisitDecision.STOP;
+        }
+        DBSPTypeTupleBase tuple = type.deref().as(DBSPTypeTupleBase.class);
+        if (tuple == null || tuple.size() != 2) {
+            this.map(expression, result);
+            return VisitDecision.STOP;
+        }
+
+        if (!tuple.tupFields[0].is(DBSPTypeBool.class) || tuple.tupFields[0].mayBeNull) {
+            this.map(expression, result);
+            return VisitDecision.STOP;
+        }
+
+        DBSPVariablePath var = type.var();
+        DBSPExpression ifTrue = transformed.call(
+                tuple.makeTuple(new DBSPBoolLiteral(true), var.deref().field(1)).borrow())
+                .reduce(this.errorReporter);
+        DBSPExpression ifFalse = transformed.call(
+                tuple.makeTuple(new DBSPBoolLiteral(false), var.deref().field(1)).borrow())
+                .reduce(this.errorReporter);
+        result = new DBSPIfExpression(expression.getNode(),
+                var.deref().field(0), ifTrue, ifFalse).closure(var.asParameter());
+        this.map(expression, result);
+        return VisitDecision.STOP;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -31,6 +31,8 @@ import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EliminateFunctions;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpandWriteLog;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.Simplify;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.SimplifyWaterline;
+import org.dbsp.sqlCompiler.ir.annotation.Waterline;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,6 +92,8 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
             passes.add(new OptimizeWithGraph(reporter, g -> new FilterMapVisitor(reporter, g)));
             // optimize the maps introduced by the deindex removal
             passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
+            passes.add(new SimplifyWaterline(reporter)
+                    .circuitRewriter(node -> node.hasAnnotation(a -> a.is(Waterline.class))));
         }
         passes.add(new EliminateFunctions(reporter).circuitRewriter());
         passes.add(new ExpandWriteLog(reporter).circuitRewriter());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Waterline.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/annotation/Waterline.java
@@ -1,0 +1,4 @@
+package org.dbsp.sqlCompiler.ir.annotation;
+
+/** Annotation used on operators that are used for computing the waterline */
+public class Waterline extends Annotation { }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/IsBoundedType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/IsBoundedType.java
@@ -1,9 +1,9 @@
 package org.dbsp.sqlCompiler.ir.type;
 
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 
 /** A type which has minimum and maximum values */
 public interface IsBoundedType {
-    DBSPLiteral getMaxValue();
-    DBSPLiteral getMinValue();
+    DBSPExpression getMaxValue();
+    DBSPExpression getMinValue();
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBool.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBool.java
@@ -28,7 +28,6 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.IsBoundedType;
@@ -62,12 +61,12 @@ public class DBSPTypeBool extends DBSPTypeBaseType implements IsBoundedType {
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPBoolLiteral(false, this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPBoolLiteral(true, this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDate.java
@@ -29,7 +29,6 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDateLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IsDateType;
 
@@ -66,12 +65,12 @@ public class DBSPTypeDate extends DBSPTypeBaseType implements IsDateType {
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPDateLiteral(this.getNode(), this, new DateString("9999-12-12"));
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPDateLiteral(this.getNode(), this, new DateString("0001-01-01"));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDecimal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDecimal.java
@@ -80,12 +80,12 @@ public class DBSPTypeDecimal extends DBSPTypeBaseType
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         throw new UnsupportedException(this.getNode());
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         throw new UnsupportedException(this.getNode());
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDouble.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeDouble.java
@@ -26,6 +26,7 @@ package org.dbsp.sqlCompiler.ir.type.primitive;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
@@ -72,12 +73,12 @@ public class DBSPTypeDouble extends DBSPTypeFP implements IsNumericType {
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPDoubleLiteral(Double.MAX_VALUE, this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPDoubleLiteral(Double.MIN_VALUE, this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeISize.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeISize.java
@@ -81,12 +81,12 @@ public class DBSPTypeISize extends DBSPTypeBaseType implements IsNumericType {
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         throw new UnsupportedException(this.getNode());
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         throw new UnsupportedException(this.getNode());
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeInteger.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeInteger.java
@@ -132,7 +132,7 @@ public class DBSPTypeInteger extends DBSPTypeBaseType
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         if (this.signed) {
             switch (this.width) {
                 case 8: return new DBSPI8Literal(Byte.MAX_VALUE, this.mayBeNull);
@@ -156,7 +156,7 @@ public class DBSPTypeInteger extends DBSPTypeBaseType
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         if (this.signed) {
             switch (this.width) {
                 case 8: return new DBSPI8Literal(Byte.MIN_VALUE, this.mayBeNull);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
@@ -56,12 +56,12 @@ public class DBSPTypeMillisInterval
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPIntervalMillisLiteral(Long.MIN_VALUE, this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPIntervalMillisLiteral(Long.MAX_VALUE, this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
@@ -55,12 +55,12 @@ public class DBSPTypeMonthsInterval
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPIntervalMonthsLiteral(Integer.MIN_VALUE, this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPIntervalMonthsLiteral(Integer.MAX_VALUE, this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeReal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeReal.java
@@ -26,6 +26,7 @@ package org.dbsp.sqlCompiler.ir.type.primitive;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
@@ -72,12 +73,12 @@ public class DBSPTypeReal extends DBSPTypeFP implements IsNumericType {
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPRealLiteral(Float.MAX_VALUE, this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPRealLiteral(Float.MIN_VALUE, this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeTime.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeTime.java
@@ -28,7 +28,6 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IsDateType;
@@ -78,12 +77,12 @@ public class DBSPTypeTime extends DBSPTypeBaseType implements IsDateType {
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPTimeLiteral(this.getNode(), this, new TimeString(0, 0, 0));
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPTimeLiteral(this.getNode(), this, new TimeString(23, 59, 59)
                 .withNanos(999999999));
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeTimestamp.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeTimestamp.java
@@ -27,7 +27,6 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IsDateType;
@@ -50,12 +49,12 @@ public class DBSPTypeTimestamp extends DBSPTypeBaseType
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         return new DBSPTimestampLiteral("9999-12-12 23:59:59.99999999", this.mayBeNull);
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         return new DBSPTimestampLiteral("0001-01-01 00:00:00", this.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeUSize.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeUSize.java
@@ -76,12 +76,12 @@ public class DBSPTypeUSize extends DBSPTypeBaseType
     }
 
     @Override
-    public DBSPLiteral getMaxValue() {
+    public DBSPExpression getMaxValue() {
         throw new UnsupportedException(this.getNode());
     }
 
     @Override
-    public DBSPLiteral getMinValue() {
+    public DBSPExpression getMinValue() {
         throw new UnsupportedException(this.getNode());
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeTypedBox.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeTypedBox.java
@@ -2,12 +2,16 @@ package org.dbsp.sqlCompiler.ir.type.user;
 
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.IsBoundedType;
 
 import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.TYPEDBOX;
 import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.USER;
 
-public class DBSPTypeTypedBox extends DBSPTypeUser {
+public class DBSPTypeTypedBox extends DBSPTypeUser implements IsBoundedType {
     static DBSPType[] makeTypeArgs(DBSPType arg, boolean typed) {
         DBSPType[] result = new DBSPType[2];
         result[0] = arg;
@@ -40,6 +44,18 @@ public class DBSPTypeTypedBox extends DBSPTypeUser {
     @Override
     public boolean hasCopy() {
         return false;
+    }
+
+    @Override
+    public DBSPExpression getMaxValue() {
+        DBSPExpression max = this.typeArgs[0].to(IsBoundedType.class).getMaxValue();
+        return new DBSPUnaryExpression(this.getNode(), this, DBSPOpcode.TYPEDBOX, max);
+    }
+
+    @Override
+    public DBSPExpression getMinValue() {
+        DBSPExpression min = this.typeArgs[0].to(IsBoundedType.class).getMinValue();
+        return new DBSPUnaryExpression(this.getNode(), this, DBSPOpcode.TYPEDBOX, min);
     }
 
     // sameType and hashCode inherited from TypeUser.


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

Fixes #2228 

The way this works is that the circuits that evaluate the waterline for the SQL operators have the following structure:

```rust
fn (input: &(boolean, T)) -> S {
  if input.0 { // first step
     (input.0, min_value)
  } else {
     (input.0, actual_waterline(input.1))
  }
}
```

input.0 is "true" for the first step, and "false" subsequently (achieved using a delay operator).

Upon reflection, even this fix isn't 100% safe, because it is conceivable that the conservative analysis of the compiler could deduce some bounds for waterlines that are outside the legal range of a datatype. For example, consider the case of dates BC - given early enough dates and a large enough LATENESS the minimum bound may be BC, which we don't support - the `actual_waterline` function above could still cause a panic.

The only fully safe approach would be to do saturated arithmetic computation on all such values. In Java we could write an exception handler to return the minimum value instead.
