### PR TITLE
[SQL] Restrict tumbling window to 'short' SQL intervals

### DIFF
--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -294,27 +294,6 @@ year | desks | tables | chairs
 (3 rows)
 ```
 
-## Streaming window functions
-
-Grouped window functions occur in the `GROUP BY` clause and define a
-key value that represents a window containing several rows.
-
-| Operator syntax      | Description |
-|:-------------------- |:------------|
-| TUMBLE(datetime, interval [, time ]) | Indicates a tumbling window of *interval* for *datetime*, optionally aligned at *time* |
-
-Here is an example query using a tumbling window:
-
-```sql
-CREATE TABLE series (
-   distance DOUBLE,
-   pickup TIMESTAMP NOT NULL
-)
-SELECT AVG(distance), TUMBLE_START(pickup, INTERVAL '1' DAY)
-FROM series
-GROUP BY TUMBLE(pickup, INTERVAL '1' DAY)
-```
-
 ### Grouped auxiliary functions
 
 Grouped auxiliary functions allow you to access properties of a window

--- a/docs/sql/table.md
+++ b/docs/sql/table.md
@@ -30,6 +30,9 @@ absolute time), and that’s why tumbling sometimes is named as “fixed
 windowing”. The first parameter of the `TUMBLE` table function is a
 table parameter.
 
+The `timecol` must have a `TIMESTAMP` type.  The `size` must be a
+"short" SQL interval type (e.g., `DAYS` or shorter).
+
 #### Syntax:
 
 ```

--- a/docs/sql/table.md
+++ b/docs/sql/table.md
@@ -31,7 +31,9 @@ windowing”. The first parameter of the `TUMBLE` table function is a
 table parameter.
 
 The `timecol` must have a `TIMESTAMP` type.  The `size` must be a
-"short" SQL interval type (e.g., `DAYS` or shorter).
+"short" SQL interval type (e.g., `DAYS` or shorter), because "long"
+SQL interval values are not constant values (e.g., the duration of a
+month is not a constant).
 
 #### Syntax:
 
@@ -82,7 +84,9 @@ Indicates a hopping window for `timecol`, covering rows within the
 interval of `size`, shifting every `slide` and optionally aligned at
 `offset`.  The type of the `timecol` has to be `TIMESTAMP`.  The
 intervals must be compile-time constants, and be expressed as a
-"short" interval (i.e., days or smaller time units).
+"short" interval (i.e., days or smaller time units), because "long"
+SQL interval values are not constant values (e.g., the duration of a
+month is not a constant).
 
 Here is an example:
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -169,6 +169,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
@@ -424,6 +425,11 @@ public class CalciteToDBSPCompiler extends RelVisitor
         assert call.operandCount() == 2 || call.operandCount() == 3;
         int timestampIndex = this.getDescriptor(operands.get(0));
         DBSPExpression interval = expressionCompiler.compile(operands.get(1));
+        if (interval.getType().is(DBSPTypeMonthsInterval.class)) {
+            throw new UnsupportedException(
+                    "Tumbling window intervals must be 'short' SQL intervals (days and lower)",
+                    interval.getNode());
+        }
         DBSPExpression start = null;
         if (call.operandCount() == 3)
             start = expressionCompiler.compile(operands.get(2));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -47,6 +47,7 @@ import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePosition;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ExternalFunction;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
@@ -1166,9 +1167,18 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             case TRIM: {
                 return compileKeywordFunction(call, node, null, type, ops, 0, 3);
             }
-            case TUMBLE:
+            case TUMBLE: {
+                if (ops.size() >= 2) {
+                    DBSPExpression op = ops.get(1);
+                    if (op.getType().is(DBSPTypeMonthsInterval.class)) {
+                        throw new UnsupportedException(
+                                "Tumbling window intervals must be 'short' SQL intervals (days and lower)",
+                                op.getNode());
+                    }
+                }
                 return compilePolymorphicFunction(
                         "tumble", node, type, ops, 2, 3);
+            }
             case ARRAY_LENGTH:
             case ARRAY_SIZE: {
                 if (call.operands.size() != 1)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -19,6 +19,26 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue2242() {
+        String sql = """
+                create table TRANSACTION (
+                    cc_num bigint,
+                    unix_time timestamp,
+                    id bigint
+                );
+                
+                CREATE VIEW TRANSACTION_MONTHLY_AGGREGATE AS
+                select cc_num, window_start as month_start, COUNT(*) num_transactions from TABLE(
+                  TUMBLE(
+                    TABLE transaction,
+                    DESCRIPTOR(unix_time),
+                    INTERVAL 1 MONTH))
+                GROUP BY cc_num, window_start;
+                """;
+        this.statementsFailingInCompilation(sql, "Tumbling window intervals must be 'short'");
+    }
+
+    @Test
     public void issue2039() {
         String sql = """
                 CREATE TABLE transactions (


### PR DESCRIPTION
Is this a user-visible change (yes/no): no
