### PR TITLE
pipeline-manager: less verbose logging at lower level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7053,6 +7053,7 @@ dependencies = [
 name = "pipeline_types"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "csv",
  "lazy_static",

--- a/crates/pipeline-types/Cargo.toml
+++ b/crates/pipeline-types/Cargo.toml
@@ -25,6 +25,7 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 # Revert after https://github.com/paupino/rust-decimal/pull/637 is merged:
 rust_decimal = { git = "https://github.com/gz/rust-decimal.git", rev = "ea85fdf" }
+actix-web = "4.3"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -16,6 +16,7 @@ development = ["pg-client-config"]
 [dependencies]
 pipeline_types = { path = "../pipeline-types/" }
 actix-web = "4.3"
+actix-http = "3.8.0"
 actix-web-static-files = "4.0.0"
 actix-files = "0.6.2"
 awc = {version = "3.1.0", features = ["openssl"] } # Needed for auth workflows

--- a/crates/pipeline_manager/src/api/api_key.rs
+++ b/crates/pipeline_manager/src/api/api_key.rs
@@ -155,7 +155,7 @@ pub(crate) async fn delete_api_key(
         .delete_api_key(*tenant_id, &name)
         .await
         .map(|_| HttpResponse::Ok().finish())?;
-    info!("Deleted API key {name} (tenant:{})", *tenant_id);
+    info!("Deleted API key {name} (tenant: {})", *tenant_id);
     Ok(resp)
 }
 
@@ -193,7 +193,7 @@ async fn create_api_key(
         )
         .await
         .map(|_| {
-            info!("Created new API key {} (tenant:{})", &req.name, *tenant_id);
+            info!("Created API key {} (tenant: {})", &req.name, *tenant_id);
             HttpResponse::Created()
                 .insert_header(CacheControl(vec![CacheDirective::NoCache]))
                 .json(&NewApiKeyResponse {

--- a/crates/pipeline_manager/src/api/config_api.rs
+++ b/crates/pipeline_manager/src/api/config_api.rs
@@ -1,7 +1,6 @@
 // Configuration API to retrieve the current authentication configuration and list of demos
 use crate::demo::{read_demos_from_directory, Demo};
 use actix_web::{get, web::Data as WebData, HttpRequest, HttpResponse};
-use log::debug;
 use serde::Serialize;
 use std::path::Path;
 use utoipa::ToSchema;
@@ -28,7 +27,6 @@ async fn get_config_authentication(
     state: WebData<ServerState>,
     req: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!("Received {req:?}");
     if state._config.auth_provider == crate::config::AuthProviderType::None {
         return Ok(HttpResponse::Ok().json(EmptyResponse {}));
     }

--- a/crates/pipeline_manager/src/api/pipeline.rs
+++ b/crates/pipeline_manager/src/api/pipeline.rs
@@ -18,7 +18,7 @@ use actix_web::{
     HttpRequest, HttpResponse,
 };
 use chrono::{DateTime, Utc};
-use log::{debug, info};
+use log::info;
 use pipeline_types::config::{PipelineConfig, RuntimeConfig};
 use pipeline_types::error::ErrorResponse;
 use serde::{Deserialize, Serialize};
@@ -131,10 +131,6 @@ pub(crate) async fn list_pipelines(
     tenant_id: ReqData<TenantId>,
     query: web::Query<ListPipelinesQueryParameters>,
 ) -> Result<HttpResponse, DBError> {
-    debug!(
-        "API: tenant {} requests to GET list of pipelines",
-        *tenant_id
-    );
     let pipelines = state.db.lock().await.list_pipelines(*tenant_id).await?;
     let pipelines: Vec<ExtendedPipelineDescrOptionalCode> = pipelines
         .iter()
@@ -171,10 +167,6 @@ pub(crate) async fn get_pipeline(
     req: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
     let pipeline_name = parse_string_param(&req, "pipeline_name")?;
-    debug!(
-        "API: tenant {} requests to GET pipeline {pipeline_name}",
-        *tenant_id
-    );
     let pipeline = state
         .db
         .lock()
@@ -211,10 +203,6 @@ pub(crate) async fn post_pipeline(
     tenant_id: ReqData<TenantId>,
     body: web::Json<PipelineDescr>,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to POST pipeline {body:?}",
-        *tenant_id
-    );
     let pipeline = state
         .db
         .lock()
@@ -265,10 +253,6 @@ async fn put_pipeline(
     request: HttpRequest,
     body: web::Json<PipelineDescr>,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to PUT pipeline {request:?} {body:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     let (is_new, pipeline) = state
         .db
@@ -334,10 +318,6 @@ pub(crate) async fn patch_pipeline(
     request: HttpRequest,
     body: web::Json<PatchPipeline>,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to PATCH pipeline {request:?} {body:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     let pipeline = state
         .db
@@ -390,10 +370,6 @@ pub(crate) async fn delete_pipeline(
     tenant_id: ReqData<TenantId>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to DELETE pipeline {request:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     let pipeline_id = state
         .db
@@ -463,10 +439,6 @@ pub(crate) async fn post_pipeline_action(
     tenant_id: ReqData<TenantId>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to POST pipeline action {request:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     let action = parse_pipeline_action(&request)?;
     match action {
@@ -590,10 +562,6 @@ pub(crate) async fn get_pipeline_stats(
     tenant_id: ReqData<TenantId>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to GET pipeline statistics {request:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     state
         .runner
@@ -630,10 +598,6 @@ pub(crate) async fn get_pipeline_circuit_profile(
     tenant_id: ReqData<TenantId>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to GET circuit profile {request:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     state
         .runner
@@ -670,10 +634,6 @@ pub(crate) async fn get_pipeline_heap_profile(
     tenant_id: ReqData<TenantId>,
     request: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    debug!(
-        "API: tenant {} requests to GET heap profile {request:?}",
-        *tenant_id
-    );
     let pipeline_name = parse_string_param(&request, "pipeline_name")?;
     state
         .runner

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -455,7 +455,7 @@ inherits = "release"
                                         .await
                                     {
                                         if !is_used {
-                                            warn!("About to remove binary file '{:?}' that is no longer in use by any program", path.file_name());
+                                            info!("About to remove binary file '{:?}' that is no longer in use by any program", path.file_name());
                                             let r = fs::remove_file(path.path()).await;
                                             if let Err(e) = r {
                                                 error!(

--- a/crates/pipeline_manager/src/db/error.rs
+++ b/crates/pipeline_manager/src/db/error.rs
@@ -6,7 +6,6 @@ use actix_web::{
     body::BoxBody, http::StatusCode, HttpResponse, HttpResponseBuilder, ResponseError,
 };
 use deadpool_postgres::PoolError;
-use log::Level;
 use pipeline_types::error::DetailedError;
 use pipeline_types::error::ErrorResponse;
 use refinery::Error as RefineryError;
@@ -463,13 +462,6 @@ impl DetailedError for DBError {
             Self::IllegalPipelineStateTransition { .. } => {
                 Cow::from("IllegalPipelineStateTransition")
             }
-        }
-    }
-
-    fn log_level(&self) -> Level {
-        match self {
-            Self::UnknownPipeline { .. } => Level::Info,
-            _ => Level::Error,
         }
     }
 }

--- a/crates/pipeline_manager/src/error.rs
+++ b/crates/pipeline_manager/src/error.rs
@@ -23,7 +23,6 @@ use crate::runner::RunnerError;
 use actix_web::{
     body::BoxBody, http::StatusCode, HttpResponse, HttpResponseBuilder, ResponseError,
 };
-use log::Level;
 use pipeline_types::error::{DetailedError, ErrorResponse};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
@@ -230,14 +229,6 @@ impl DetailedError for ManagerError {
             Self::IoError { .. } => Cow::from("ManagerIoError"),
             Self::InvalidProgramSchema { .. } => Cow::from("InvalidProgramSchema"),
             Self::RustCompilerError { .. } => Cow::from("RustCompilerError"),
-        }
-    }
-
-    fn log_level(&self) -> Level {
-        match self {
-            Self::DBError { db_error } => db_error.log_level(),
-            Self::RunnerError { runner_error } => runner_error.log_level(),
-            _ => Level::Error,
         }
     }
 }

--- a/crates/pipeline_manager/src/pipeline_automata.rs
+++ b/crates/pipeline_manager/src/pipeline_automata.rs
@@ -536,6 +536,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             Err(e) => {
                 // Cannot reach the pipeline.
                 if pipeline.deployment_status != PipelineStatus::Failed {
+                    error!("Failed to probe deployed pipeline {} which thus will transition to Failed status", pipeline.id);
                     Ok(State::Transition(
                         PipelineStatus::Failed,
                         Some(e.into()),

--- a/demo/simple-count/run.py
+++ b/demo/simple-count/run.py
@@ -97,7 +97,7 @@ def main():
 
         if response.ok:
             pipeline = json.loads(response.content.decode("utf-8"))
-            print(json.dumps(pipeline, indent=4))
+            # print(json.dumps(pipeline, indent=4))
             print("Program status: %s" % pipeline["program_status"])
             if pipeline["program_status"] == "Success":
                 print("SUCCESS: pipeline program is compiled")


### PR DESCRIPTION
**Try it out**
```bash
# Default
cargo run --package=pipeline-manager --features pg-embed --bin pipeline-manager -- --dev-mode

# Default (which is info level) with backtrace
RUST_BACKTRACE=1 RUST_LOG=info,tokio_postgres=info cargo run --package=pipeline-manager --features pg-embed --bin pipeline-manager -- --dev-mode

# Debug
RUST_BACKTRACE=1 RUST_LOG=debug,tokio_postgres=debug cargo run --package=pipeline-manager --features pg-embed --bin pipeline-manager -- --dev-mode
```

**Logging policy notes and changes**

Endpoints:
- Creation, update and deletion of pipelines and API keys are logged at info level
- Pipeline actions are logged at info level

Actix middleware:
- Requests are logged at debug level
- Success (200-299) and Not Modified (304) responses are logged at debug level
- Client responses (400-499) are logged at info level
- Other responses are logged at error level

Error handler:
- Client responses (400-499) are logged at info level
- All other responses (including success and 304 as the handler should not encounter those) are logged at error level

Pipeline actix middleware:
- Requests are logged at debug level
- Success (200-299) responses are logged at debug level
- Other responses are logged at error level

Compiler:
- Reduce logging level of binary clean-up from warn to info

Pipeline automata:
- Extra log message at error level if a pipeline probe fails

Is this a user-visible change (yes/no): no