### PR TITLE
[adapters] Speed up pausing/unpausing Kafka.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,7 +3794,9 @@ dependencies = [
  "csv",
  "csv-core",
  "dbsp",
+ "dbsp_nexmark",
  "deltalake",
+ "enum-map",
  "env_logger 0.10.2",
  "erased-serde",
  "fake",
@@ -4398,6 +4400,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -7058,6 +7080,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "csv",
+ "enum-map",
  "lazy_static",
  "libc",
  "log",


### PR DESCRIPTION
I noticed that setting `max_queue_size` to a small values (10000 or less in my use case) significantly reduced Kafka throughput.  This was due to the pause/unpause operation being very expensive.  This was in turn due to two factors:

* The POLL_TIMEOUT constant being too high (100ms), bounded the pause/unpause latency.

* Pausing the Kafka connector involves pausing all its partitions, which is an expensive operation as it flushes rdkafka's internal buffers, potentially dropping thousands of messages. Not pausing it is not possible in the current design, as rdkafka requires the consumer to keep polling to make sure that control traffic gets processed, so we must poll but without receiving any messages.

We solve the second problem by waiting for three seconds befor pausing the connector.  We don't poll during this time, so no messages get delivered.  If a resume command is received during this time, then we can go back to normal operation; otherwise we assume that this is a long-term pause and actually pause the partitions.

This commit also changes the connector so it doesn't kill polling threads while pausing, instead using the `park`/`unpark` API to suspend the workers while the connector is paused.

Overall, this is a temporary solution.  We probably need to rewrite this connector using the async API (if not a whole different Kafka crate).

Is this a user-visible change (yes/no): no

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
