### PR TITLE
pipeline-manager: info log level for feldera crates and warn for others

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,17 @@ Here are some guidelines when contributing code that affects this database's sch
 * Do not modify an existing migration file. If you want to evolve the schema, add a new SQL or rust file to the migrations folder following [refinery's versioning and naming scheme](https://docs.rs/refinery/latest/refinery/#usage). The migration script should update an existing schema as opposed to assuming a clean slate. For example, use `ALTER TABLE` to add a new column to an existing table and fill that column for existing rows with the appropriate defaults.
 * If you add a new migration script `V{i}`, add tests for migrations from `V{i-1}` to `V{i}`. For example, add tests that invoke the pipeline manager APIs before and after the migration.
 
+## Logging
+
+By default, the pipeline-manager and pipelines create an `env_logger` which logs
+the Feldera crates at INFO level and all other crates at WARN level.
+This can be overridden by setting the `RUST_LOG` environment variable.
+For example, the following would be the same as the default with additionally
+backtrace enabled:
+
+```bash
+RUST_BACKTRACE=1 RUST_LOG=warn,pipeline_manager=info,pipeline_types=info,project=info,dbsp=info,dbsp_adapters=info,dbsp_nexmark=info cargo run --package=pipeline-manager --features pg-embed --bin pipeline-manager -- --dev-mode
+```
 
 ## Release process
 

--- a/crates/pipeline_manager/src/api/mod.rs
+++ b/crates/pipeline_manager/src/api/mod.rs
@@ -43,7 +43,7 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 use actix_web_static_files::ResourceFiles;
 use anyhow::{Error as AnyError, Result as AnyResult};
 use futures_util::FutureExt;
-use log::{debug, error, info, log, Level};
+use log::{error, info, log, trace, Level};
 use std::{env, net::TcpListener, sync::Arc};
 use tokio::sync::Mutex;
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
@@ -395,7 +395,7 @@ pub async fn run(db: Arc<Mutex<StoragePostgres>>, api_config: ApiServerConfig) -
                     .app_data(auth_configuration.clone())
                     .app_data(client)
                     .wrap_fn(|req, srv| {
-                        debug!("Request: {} {}", req.method(), req.path());
+                        trace!("Request: {} {}", req.method(), req.path());
                         srv.call(req).map(log_response)
                     })
                     .wrap(api_config.cors())
@@ -411,7 +411,7 @@ pub async fn run(db: Arc<Mutex<StoragePostgres>>, api_config: ApiServerConfig) -
                     .app_data(state.clone())
                     .app_data(client)
                     .wrap_fn(|req, srv| {
-                        debug!("Request: {} {}", req.method(), req.path());
+                        trace!("Request: {} {}", req.method(), req.path());
                         srv.call(req).map(log_response)
                     })
                     .wrap(api_config.cors())
@@ -437,7 +437,7 @@ pub async fn run(db: Arc<Mutex<StoragePostgres>>, api_config: ApiServerConfig) -
 ██      ██      ██      ██   ██ ██      ██  ██  ██   ██
 ██      ███████ ███████ ██████  ███████ ██   ██ ██   ██
 
-Web UI URL: {}
+Web console URL: {}
 API server URL: {}
 Documentation: https://www.feldera.com/docs/
 Version: {}

--- a/crates/pipeline_manager/src/compiler.rs
+++ b/crates/pipeline_manager/src/compiler.rs
@@ -510,7 +510,7 @@ inherits = "release"
         config: &CompilerConfig,
         db: &Arc<Mutex<StoragePostgres>>,
     ) -> Result<(), DBError> {
-        info!("Reconciling local state with API state");
+        debug!("Reconciling local compiler state with API state...");
         let mut map: HashSet<(Uuid, i64)> = HashSet::new();
         let read_dir = fs::read_dir(config.binaries_dir()).await;
         match read_dir {
@@ -598,6 +598,7 @@ inherits = "release"
                 .await?;
             }
         }
+        debug!("Local compiler state has been reconciled with API state");
         Ok(())
     }
 

--- a/crates/pipeline_manager/src/logging.rs
+++ b/crates/pipeline_manager/src/logging.rs
@@ -3,18 +3,25 @@ use env_logger::Env;
 use std::io::Write;
 
 pub fn init_logging(name: ColoredString) {
-    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .format(move |buf, record| {
-            let t = chrono::Utc::now();
-            let t = format!("{}", t.format("%Y-%m-%d %H:%M:%S"));
-            writeln!(
-                buf,
-                "{} {} {} {}",
-                t,
-                buf.default_styled_level(record.level()),
-                name,
-                record.args()
-            )
-        })
-        .try_init();
+    // By default, logging is set to INFO level for the Feldera crates:
+    // - "pipeline_manager" for the pipeline_manager crate
+    // - "pipeline_types" for the pipeline-types crate
+    // For all others, the WARN level is used.
+    // Note that this can be overridden by setting the RUST_LOG environment variable.
+    let _ = env_logger::Builder::from_env(
+        Env::default().default_filter_or("warn,pipeline_manager=info,pipeline_types=info"),
+    )
+    .format(move |buf, record| {
+        let t = chrono::Utc::now();
+        let t = format!("{}", t.format("%Y-%m-%d %H:%M:%S"));
+        writeln!(
+            buf,
+            "{} {} {} {}",
+            t,
+            buf.default_styled_level(record.level()),
+            name,
+            record.args()
+        )
+    })
+    .try_init();
 }


### PR DESCRIPTION
- By default, the Feldera crates have info log level, other crates have warn log level
- API request log level is reduced from debug to trace
- Migrations log level is reduced from info to debug if no migrations were applied
- Compiler reconciliation log level is reduced from info to debug
- Instructions on how to configure log levels is added to CONTRIBUTING

Is this a user-visible change (yes/no): no