### PR TITLE
benchmark: Fix bug in feldera-sql runner for non-Nexmark benchmarks.

### DIFF
--- a/benchmark/feldera-sql/run.py
+++ b/benchmark/feldera-sql/run.py
@@ -61,7 +61,7 @@ def parse_queries(all_queries, arg):
     return queries
 
 def make_connector(topic, suffix):
-    name = "nexmark"
+    name = "kafka_input"
     config = {
         "topics": [topic + suffix],
         "enable.partition.eof": "true",


### PR DESCRIPTION
This was inadvertently introduced in commit 268115b8d3a9 ("dbsp_adapters: Add `nexmark` connector and use in benchmarks.").  It broke running the tiktok benchmark.

Is this a user-visible change (yes/no): no