### PR TITLE
Script to build compiler with released/unreleased Calcite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,10 +160,10 @@ You can build the rust sources by runnning the following at the top level of thi
 cargo build
 ```
 
-To build the SQL to DBSP compiler, run the following from `sql-to-dbsp-compiler/SQL-compiler`:
+To build the SQL to DBSP compiler, run the following from `sql-to-dbsp-compiler`:
 
 ```
-mvn package
+./build.sh
 ```
 
 If you want to develop Feldera without installing the required toolchains

--- a/Earthfile
+++ b/Earthfile
@@ -154,7 +154,7 @@ build-sql:
     COPY demo/project_demo03-GreenTrip/project.sql demo/project_demo03-GreenTrip/project.sql
     COPY demo/project_demo04-SimpleSelect/project.sql demo/project_demo04-SimpleSelect/project.sql
     CACHE /root/.m2
-    RUN cd "sql-to-dbsp-compiler/SQL-compiler" && mvn package -DskipTests --no-transfer-progress -q -B
+    RUN cd "sql-to-dbsp-compiler" && ./build.sh
     SAVE ARTIFACT sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar sql2dbsp-jar-with-dependencies.jar
     SAVE ARTIFACT sql-to-dbsp-compiler
 
@@ -179,7 +179,7 @@ build-manager:
 test-sql:
     # SQL-generated code imports adapters crate.
     FROM +build-adapters
-    RUN cd "sql-to-dbsp-compiler/SQL-compiler" && mvn package -q --no-transfer-progress -B
+    RUN cd "sql-to-dbsp-compiler" && ./build.sh
 
 build-nexmark:
     FROM +build-dbsp

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Feldera has the [unique](#theory) ability to *evaluate arbitrary SQL programs
 incrementally*, making it more powerful, expressive and performant than existing
 alternatives like batch engines, warehouses, stream processors or streaming databases.
 
-Our approach to incremental computation is simple. A Feldera `pipeline` is a set of SQL tables and views. Views can be deeply nested. 
+Our approach to incremental computation is simple. A Feldera `pipeline` is a set of SQL tables and views. Views can be deeply nested.
 Users start, stop or pause pipelines to manage and advance a computation.
 Pipelines continuously process
 **changes**, which are any number of inserts, updates or deletes to a set of tables. When the pipeline receives changes,
 Feldera **incrementally** updates all the views by only looking at the changes and it completely avoids recomputing over older data.
 While a pipeline is running, users can inspect the results of the views at any time.
 
-Our approach to incremental computation makes Feldera incredibly fast (millions of events per second on a laptop). 
-It also enables unified offline and online compute over both live and historical data. Feldera users have built batch and real-time 
+Our approach to incremental computation makes Feldera incredibly fast (millions of events per second on a laptop).
+It also enables unified offline and online compute over both live and historical data. Feldera users have built batch and real-time
 feature engineering pipelines, ETL pipelines, various forms of incremental and periodic analytical jobs over batch data, and more.
 
 Our defining features:
@@ -79,7 +79,7 @@ After that, the first step is to build the SQL compiler:
 
 ```
 cd sql-to-dbsp-compiler
-mvn package -DskipTests
+./build.sh
 ```
 
 Next, from the repository root, run the pipeline-manager:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -101,7 +101,7 @@ RUN apt install maven -y
 RUN mkdir sql
 COPY sql-to-dbsp-compiler /sql/sql-to-dbsp-compiler
 RUN --mount=type=cache,target=/root/.m2 \
-    cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -ntp -DskipTests package
+    cd /sql/sql-to-dbsp-compiler && ./build.sh
 
 # Minimal image for running the pipeline manager
 FROM base AS release

--- a/docs/contributors/dev-flow.md
+++ b/docs/contributors/dev-flow.md
@@ -14,7 +14,9 @@ sudo chown -R user /workspaces/feldera
 Build the SQL Compiler:
 
 ```bash
-mvn -f ./sql-to-dbsp-compiler/SQL-compiler -DskipTests package
+cd ./sql-to-dbsp-compiler
+./build.sh
+cd. ..
 ```
 
 Build and start the Pipeline Manager (that also serves the Feldera Web Console):

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -13,7 +13,7 @@ fi
 #    exit 1
 # fi
 
-cd "${SQL_COMPILER_DIR}/SQL-compiler" && mvn -DskipTests package
+cd "${SQL_COMPILER_DIR}" && ./build.sh
 
 WORKING_DIR="${1:-${HOME}/.dbsp}"
 

--- a/sql-to-dbsp-compiler/README.md
+++ b/sql-to-dbsp-compiler/README.md
@@ -25,7 +25,7 @@ to also install graphviz as described here <https://graphviz.org/download/>.
 
 To build the compiler run:
 ```
-mvn -DskipTests package
+./build.sh
 ```
 
 ## Rust compilation errors
@@ -141,12 +141,6 @@ One of the means of testing the compiler is using sqllogictests:
 The sqllogictests includes more than 5 million tests.  It takes weeks
 to run all of them.  Most of the time is spent compiling Rust.
 We hope to speed that up at some point.
-
-To start running these tests:
-
-```
-$ ./run-tests.sh
-```
 
 We have implemented a [general-purpose testing
 framework](https://github.com/hydromatic/sql-logic-test) in Java for

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -169,6 +169,7 @@
                             </includes>
                             <lookAhead>2</lookAhead>
                             <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
+                            <sanityCheck>false</sanityCheck>
                         </configuration>
                     </execution>
                 </executions>

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -1,2 +1,66 @@
-#!/bin/sh
-mvn package -DskipTests
+#!/bin/bash
+
+# This script builds the SQL compiler
+# it has an optional argument which specifies whether to build
+# using the current version of Calcite or the next unreleased version
+
+# Default is to use the current version
+NEXT='n'
+
+CALCITE_NEXT="1.38.0"
+CALCITE_NEXT_COMMIT="7fa73c0079b03b8cd9657df0058a5743b80c1be9"
+CALCITE_CURRENT="1.37.0"
+
+usage() {
+    echo "This script builds the sql-to-dbsp compiler"
+    echo "known options: -n -c"
+    echo "-c use the current released (${CALCITE_CURRENT}) version of Calcite [default]"
+    echo "-n use the next (unreleased, ${CALCITE_NEXT}) version of Calcite"
+    exit 1
+}
+
+update_pom() {
+    VERSION=$1
+    sed -i -E "s/<calcite.version>(.*)<\/calcite.version>/<calcite.version>${VERSION}<\/calcite.version>/" ./SQL-compiler/pom.xml
+}
+
+while getopts ":nc" flag
+do
+    case "${flag}" in
+        c) NEXT='n'
+           ;;
+        n) NEXT='y'
+           ;;
+        *) echo "Invalid option: ${OPTARG}"
+           usage
+           ;;
+    esac
+done
+
+if [ ${NEXT} = 'y' ]; then
+    update_pom ${CALCITE_NEXT}
+    echo "Building calcite"
+    pushd /tmp
+    git clone git@github.com:apache/calcite.git
+    cd calcite
+    git reset --hard ${CALCITE_NEXT_COMMIT}
+
+    GROUP=org.apache.calcite
+    VERSION=${CALCITE_NEXT}
+
+    ./gradlew build -x test -x checkStyleMain -x autoStyleJavaCheck build --console=plain -Dorg.gradle.logging.level=quiet
+    for DIR in core babel server linq4j
+    do
+        ARTIFACT=calcite-${DIR}
+        mvn install:install-file -Dfile=${DIR}/build/libs/${ARTIFACT}-${VERSION}-SNAPSHOT.jar -DgroupId=${GROUP} -DartifactId=${ARTIFACT} -Dversion=${VERSION} -Dpackaging=jar -DgeneratePom=true
+    done
+    popd
+    rm -rf /tmp/calcite
+else
+    update_pom ${CALCITE_CURRENT}
+fi
+
+mvn package -DskipTests --no-transfer-progress -q -B
+
+
+

--- a/sql-to-dbsp-compiler/run-tests.sh
+++ b/sql-to-dbsp-compiler/run-tests.sh
@@ -5,7 +5,7 @@ set -e
 pushd temp; cargo update; popd
 
 mvn clean
-mvn -DskipTests package
+./build.sh
 mvn test
 echo "Running sqllogictest tests"
 java -jar ./slt/target/slt-jar-with-dependencies.jar -inc -v -e hybrid


### PR DESCRIPTION
I am not sure whether I got all the necessary changes.
Currently the script builds with the released version of Calcite by default.
If we want to merge the asof branch we probably need to switch the default to be the unreleased version..
