### PR TITLE
benchmark: Make tiktok generation script use default `MAX_EVENTS`.

### DIFF
--- a/benchmark/feldera-sql/benchmarks/tiktok/generate.bash
+++ b/benchmark/feldera-sql/benchmarks/tiktok/generate.bash
@@ -2,5 +2,5 @@ BASEDIR="$(pwd)" # get the current directory
 cd "$(dirname "${BASH_SOURCE[0]}")" # cd to the directory this script is in
 TIKTOK_GEN="$(realpath ../../../../demo/project_demo12-HopsworksTikTokRecSys/tiktok-gen)"
 cd $TIKTOK_GEN # cd to the tiktok generator directory
-cargo run --release -- --historical --delete-topic-if-exists -I $MAX_EVENTS
+cargo run --release -- --historical --delete-topic-if-exists -I ${MAX_EVENTS:-50000000}
 cd $BASEDIR


### PR DESCRIPTION
Otherwise, if `MAX_EVENTS` was not provided, it failed with a confusing error message.

Thanks to Matei Budiu for reporting this.

Is this a user-visible change (yes/no): no