### PR TITLE
scripts: Pass --events to Feldera SQL benchmark.

### DIFF
--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -51,6 +51,7 @@ sql_benchmark() {
     local csv=$1 metrics=$2; shift; shift
     python3 benchmark/feldera-sql/run.py \
 	    --api-url $FELDERA_API \
+	    --events $MAX_EVENTS \
 	    -O bootstrap.servers=$KAFKA_BROKER \
 	    --csv "$RESULTS_DIR/$name/$csv" \
 	    --csv-metrics "$RESULTS_DIR/$name/$metrics" \


### PR DESCRIPTION
This used to be implicit because the number of events came from the number of events in the Kafka topic, but now that the events are internally generated it needs to be passed in.

Thanks to Mihai for reporting the problem.

Is this a user-visible change (yes/no): no