### PR TITLE
Added TPC-H benchmark suite

### DIFF
--- a/benchmark/feldera-sql/benchmarks/tpc-h/disabled-queries/q21.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/disabled-queries/q21.sql
@@ -1,0 +1,44 @@
+create view q21 (
+    s_name,
+    numwait
+) as
+select
+    s_name,
+    count(*) as numwait
+from
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+where
+    s_suppkey = l1.l_suppkey
+    and o_orderkey = l1.l_orderkey
+    and o_orderstatus = 'F'
+    and l1.l_receiptdate > l1.l_commitdate
+    and exists (
+        select
+            *
+        from
+            lineitem l2
+        where
+            l2.l_orderkey = l1.l_orderkey
+            and l2.l_suppkey <> l1.l_suppkey
+    )
+    and not exists (
+        select
+            *
+        from
+            lineitem l3
+        where
+            l3.l_orderkey = l1.l_orderkey
+            and l3.l_suppkey <> l1.l_suppkey
+            and l3.l_receiptdate > l3.l_commitdate
+    )
+    and s_nationkey = n_nationkey
+    and n_name = 'GERMANY'
+group by
+    s_name
+order by
+    numwait desc,
+    s_name
+LIMIT 100;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/generate.bash
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/generate.bash
@@ -1,0 +1,10 @@
+cd "$(dirname "$0")"
+
+if [ ! -d "data-large" ]; then
+	git clone git@github.com:dbtoaster/dbtoaster-experiments-data.git
+	mv dbtoaster-experiments-data/tpch/big data-large
+	mv dbtoaster-experiments-data/tpch/standard data-medium
+	rm -rf dbtoaster-experiments-data
+fi 
+
+python3 generate.py

--- a/benchmark/feldera-sql/benchmarks/tpc-h/generate.py
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/generate.py
@@ -1,0 +1,20 @@
+import os
+from itertools import islice
+from plumbum.cmd import rpk
+import pandas as pd
+
+# File locations
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
+
+print('Pushing data to Kafka topic...')
+for input in ['customer', 'lineitem', 'nation', 'orders', 'part', 'partsupp', 'region', 'supplier']:
+    print(input)
+    data_csv = os.path.join(SCRIPT_DIR, 'data-large/' + input + '.csv')
+
+    batch_size = 3000
+    data = pd.read_csv(data_csv, delimiter="|", header=None)
+    count = len(data.index)
+    (rpk['topic', 'create', input])()
+    for i in range(int((count - 1) / batch_size) + 1):
+        csv = data.iloc[(i * batch_size):((i + 1) * batch_size)].to_csv(index=False, header=None)
+        (rpk['topic', 'produce', input, '-f', '%v'] << csv)()

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q1.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q1.sql
@@ -1,0 +1,33 @@
+create view q1 (
+    l_returnflag,
+    l_linestatus,
+    sum_qty,
+    sum_base_price,
+    sum_disc_price,
+    sum_charge,
+    avg_qty,
+    avg_price,
+    avg_disc,
+    count_order
+) as
+select
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+from
+    lineitem
+where
+    l_shipdate <= date '1998-12-01' - interval '71' DAY
+group by
+    l_returnflag,
+    l_linestatus
+order by
+    l_returnflag,
+    l_linestatus;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q10.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q10.sql
@@ -1,0 +1,42 @@
+create view q10 (
+    c_custkey,
+    c_name,
+    revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+) as
+select
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+from
+    customer,
+    orders,
+    lineitem,
+    nation
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate >= date '1994-01-01'
+    and o_orderdate < date '1994-01-01' + interval '3' month
+    and l_returnflag = 'R'
+    and c_nationkey = n_nationkey
+group by
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+order by
+    revenue desc
+LIMIT 20;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q11.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q11.sql
@@ -1,0 +1,31 @@
+create view q11 (
+    ps_partkey,
+    value
+) as
+select
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) as value
+from
+    partsupp,
+    supplier,
+    nation
+where
+    ps_suppkey = s_suppkey
+    and s_nationkey = n_nationkey
+    and n_name = 'ARGENTINA'
+group by
+    ps_partkey having
+        sum(ps_supplycost * ps_availqty) > (
+            select
+                sum(ps_supplycost * ps_availqty) * 0.0001000000
+            from
+                partsupp,
+                supplier,
+                nation
+            where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = 'ARGENTINA'
+        )
+order by
+    value desc;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q12.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q12.sql
@@ -1,0 +1,33 @@
+create view q12 (
+    l_shipmode,
+    high_line_count,
+    low_line_count
+) as
+select
+    l_shipmode,
+    sum(case
+        when o_orderpriority = '1-URGENT'
+            or o_orderpriority = '2-HIGH'
+            then 1
+        else 0
+    end) as high_line_count,
+    sum(case
+        when o_orderpriority <> '1-URGENT'
+            and o_orderpriority <> '2-HIGH'
+            then 1
+        else 0
+    end) as low_line_count
+from
+    orders,
+    lineitem
+where
+    o_orderkey = l_orderkey
+    and l_shipmode in ('FOB', 'SHIP')
+    and l_commitdate < l_receiptdate
+    and l_shipdate < l_commitdate
+    and l_receiptdate >= date '1994-01-01'
+    and l_receiptdate < date '1994-01-01' + interval '1' year
+group by
+    l_shipmode
+order by
+    l_shipmode;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q13.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q13.sql
@@ -1,0 +1,24 @@
+create view q13 (
+    c_count,
+    custdist
+) as
+select
+    c_count,
+    count(*) as custdist
+from
+    (
+        select
+            c_custkey,
+            count(o_orderkey)
+        from
+            customer left outer join orders on
+                c_custkey = o_custkey
+                and o_comment not like '%express%packages%'
+        group by
+            c_custkey
+    ) as c_orders (c_custkey, c_count)
+group by
+    c_count
+order by
+    custdist desc,
+    c_count desc;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q14.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q14.sql
@@ -1,0 +1,16 @@
+create view q14 (
+    promo_revenue
+) as
+select
+    100.00 * sum(case
+        when p_type like 'PROMO%'
+            then l_extendedprice * (1 - l_discount)
+        else 0
+    end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+    lineitem,
+    part
+where
+    l_partkey = p_partkey
+    and l_shipdate >= date '1994-03-01'
+    and l_shipdate < date '1994-03-01' + interval '1' month;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q15.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q15.sql
@@ -1,0 +1,34 @@
+-- using 1433771997 as a seed to the RNG
+
+create view revenue0 (supplier_no, total_revenue) as
+    select
+        l_suppkey,
+        sum(l_extendedprice * (1 - l_discount))
+    from
+        lineitem
+    where
+        l_shipdate >= date '1993-01-01'
+        and l_shipdate < date '1993-01-01' + interval '3' month
+    group by
+        l_suppkey;
+
+
+create view q15 as select
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+from
+    supplier,
+    revenue0
+where
+    s_suppkey = supplier_no
+    and total_revenue = (
+        select
+            max(total_revenue)
+        from
+            revenue0
+    )
+order by
+    s_suppkey;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q16.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q16.sql
@@ -1,0 +1,36 @@
+create view q16 (
+    p_brand,
+    p_type,
+    p_size,
+    supplier_cnt
+) as
+select
+    p_brand,
+    p_type,
+    p_size,
+    count(distinct ps_suppkey) as supplier_cnt
+from
+    partsupp,
+    part
+where
+    p_partkey = ps_partkey
+    and p_brand <> 'Brand#45'
+    and p_type not like 'SMALL PLATED%'
+    and p_size in (19, 17, 16, 23, 10, 4, 38, 11)
+    and ps_suppkey not in (
+        select
+            s_suppkey
+        from
+            supplier
+        where
+            s_comment like '%Customer%Complaints%'
+    )
+group by
+    p_brand,
+    p_type,
+    p_size
+order by
+    supplier_cnt desc,
+    p_brand,
+    p_type,
+    p_size;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q17.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q17.sql
@@ -1,0 +1,20 @@
+create view q17 (
+    avg_yearly
+) as
+select
+    sum(l_extendedprice) / 7.0 as avg_yearly
+from
+    lineitem,
+    part
+where
+    p_partkey = l_partkey
+    and p_brand = 'Brand#52'
+    and p_container = 'LG CAN'
+    and l_quantity < (
+        select
+            0.2 * avg(l_quantity)
+        from
+            lineitem
+        where
+            l_partkey = p_partkey
+    );

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q18.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q18.sql
@@ -1,0 +1,41 @@
+create view q18 (
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum_quantity
+) as
+select
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity) as sum_quantity
+from
+    customer,
+    orders,
+    lineitem
+where
+    o_orderkey in (
+        select
+            l_orderkey
+        from
+            lineitem
+        group by
+            l_orderkey having
+                sum(l_quantity) > 313
+    )
+    and c_custkey = o_custkey
+    and o_orderkey = l_orderkey
+group by
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+order by
+    o_totalprice desc,
+    o_orderdate
+LIMIT 100;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q19.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q19.sql
@@ -1,0 +1,38 @@
+create view q19 (
+    revenue
+) as
+select
+    sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+    lineitem,
+    part
+where
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#22'
+        and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        and l_quantity >= 8 and l_quantity <= 8 + 10
+        and p_size between 1 and 5
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#23'
+        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        and l_quantity >= 10 and l_quantity <= 10 + 10
+        and p_size between 1 and 10
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#12'
+        and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        and l_quantity >= 24 and l_quantity <= 24 + 10
+        and p_size between 1 and 15
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    );

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q2.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q2.sql
@@ -1,0 +1,54 @@
+create view q2 (
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+) as
+select
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+from
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+where
+    p_partkey = ps_partkey
+    and s_suppkey = ps_suppkey
+    and p_size = 38
+    and p_type like '%TIN'
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = 'MIDDLE EAST'
+    and ps_supplycost = (
+        select
+            min(ps_supplycost)
+        from
+            partsupp,
+            supplier,
+            nation,
+            region
+        where
+            p_partkey = ps_partkey
+            and s_suppkey = ps_suppkey
+            and s_nationkey = n_nationkey
+            and n_regionkey = r_regionkey
+            and r_name = 'MIDDLE EAST'
+    )
+order by
+    s_acctbal desc,
+    n_name,
+    s_name,
+    p_partkey
+LIMIT 100;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q20.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q20.sql
@@ -1,0 +1,41 @@
+create view q20 (
+    s_name,
+    s_address
+) as
+select
+    s_name,
+    s_address
+from
+    supplier,
+    nation
+where
+    s_suppkey in (
+        select
+            ps_suppkey
+        from
+            partsupp
+        where
+            ps_partkey in (
+                select
+                    p_partkey
+                from
+                    part
+                where
+                    p_name like 'frosted%'
+            )
+            and ps_availqty > (
+                select
+                    0.5 * sum(l_quantity)
+                from
+                    lineitem
+                where
+                    l_partkey = ps_partkey
+                    and l_suppkey = ps_suppkey
+                    and l_shipdate >= date '1994-01-01'
+                    and l_shipdate < date '1994-01-01' + interval '1' year
+            )
+    )
+    and s_nationkey = n_nationkey
+    and n_name = 'IRAN'
+order by
+    s_name;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q22.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q22.sql
@@ -1,0 +1,42 @@
+create view q22 (
+    cntrycode,
+    numcust,
+    totacctbal
+) as
+select
+    cntrycode,
+    count(*) as numcust,
+    sum(c_acctbal) as totacctbal
+from
+    (
+        select
+            substring(c_phone from 1 for 2) as cntrycode,
+            c_acctbal
+        from
+            customer
+        where
+            substring(c_phone from 1 for 2) in
+                ('30', '24', '31', '38', '25', '34', '37')
+            and c_acctbal > (
+                select
+                    avg(c_acctbal)
+                from
+                    customer
+                where
+                    c_acctbal > 0.00
+                    and substring(c_phone from 1 for 2) in
+                        ('30', '24', '31', '38', '25', '34', '37')
+            )
+            and not exists (
+                select
+                    *
+                from
+                    orders
+                where
+                    o_custkey = c_custkey
+            )
+    ) as custsale
+group by
+    cntrycode
+order by
+    cntrycode;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q3.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q3.sql
@@ -1,0 +1,29 @@
+create view q3 (
+    l_orderkey,
+    revenue,
+    o_orderdate,
+    o_shippriority
+) as
+select
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    o_orderdate,
+    o_shippriority
+from
+    customer,
+    orders,
+    lineitem
+where
+    c_mktsegment = 'FURNITURE'
+    and c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate < date '1995-03-29'
+    and l_shipdate > date '1995-03-29'
+group by
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+order by
+    revenue desc,
+    o_orderdate
+LIMIT 10;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q4.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q4.sql
@@ -1,0 +1,25 @@
+create view q4 (
+    o_orderpriority,
+    order_count
+) as
+select
+    o_orderpriority,
+    count(*) as order_count
+from
+    orders
+where
+    o_orderdate >= date '1997-07-01'
+    and o_orderdate < date '1997-07-01' + interval '3' month
+    and exists (
+        select
+            *
+        from
+            lineitem
+        where
+            l_orderkey = o_orderkey
+            and l_commitdate < l_receiptdate
+    )
+group by
+    o_orderpriority
+order by
+    o_orderpriority;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q5.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q5.sql
@@ -1,0 +1,28 @@
+create view q5 (
+    n_name,
+    revenue
+) as
+select
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and l_suppkey = s_suppkey
+    and c_nationkey = s_nationkey
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = 'MIDDLE EAST'
+    and o_orderdate >= date '1994-01-01'
+    and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+    n_name
+order by
+    revenue desc;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q6.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q6.sql
@@ -1,0 +1,12 @@
+create view q6 (
+    revenue
+) as
+select
+    sum(l_extendedprice * l_discount) as revenue
+from
+    lineitem
+where
+    l_shipdate >= date '1994-01-01'
+    and l_shipdate < date '1994-01-01' + interval '1' year
+    and l_discount between 0.08 - 0.01 and 0.08 + 0.01
+    and l_quantity < 24;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q7.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q7.sql
@@ -1,0 +1,45 @@
+create view q7 (
+    supp_nation,
+    cust_nation,
+    l_year,
+    revenue
+) as
+select
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) as revenue
+from
+    (
+        select
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            extract(year from l_shipdate) as l_year,
+            l_extendedprice * (1 - l_discount) as volume
+        from
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        where
+            s_suppkey = l_suppkey
+            and o_orderkey = l_orderkey
+            and c_custkey = o_custkey
+            and s_nationkey = n1.n_nationkey
+            and c_nationkey = n2.n_nationkey
+            and (
+                (n1.n_name = 'ROMANIA' and n2.n_name = 'INDIA')
+                or (n1.n_name = 'INDIA' and n2.n_name = 'ROMANIA')
+            )
+            and l_shipdate between date '1995-01-01' and date '1996-12-31'
+    ) as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q8.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q8.sql
@@ -1,0 +1,41 @@
+create view q8 (
+    o_year,
+    mkt_share
+) as
+select
+    o_year,
+    sum(case
+        when nation = 'INDIA' then volume
+        else 0
+    end) / sum(volume) as mkt_share
+from
+    (
+        select
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+            p_partkey = l_partkey
+            and s_suppkey = l_suppkey
+            and l_orderkey = o_orderkey
+            and o_custkey = c_custkey
+            and c_nationkey = n1.n_nationkey
+            and n1.n_regionkey = r_regionkey
+            and r_name = 'ASIA'
+            and s_nationkey = n2.n_nationkey
+            and o_orderdate between date '1995-01-01' and date '1996-12-31'
+            and p_type = 'PROMO BRUSHED COPPER'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/queries/q9.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/queries/q9.sql
@@ -1,0 +1,37 @@
+create view q9 (
+    nation,
+    o_year,
+    sum_profit
+) as
+select
+    nation,
+    o_year,
+    sum(amount) as sum_profit
+from
+    (
+        select
+            n_name as nation,
+            extract(year from o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+        from
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        where
+            s_suppkey = l_suppkey
+            and ps_suppkey = l_suppkey
+            and ps_partkey = l_partkey
+            and p_partkey = l_partkey
+            and o_orderkey = l_orderkey
+            and s_nationkey = n_nationkey
+            and p_name like '%yellow%'
+    ) as profit
+group by
+    nation,
+    o_year
+order by
+nation,
+    o_year desc;

--- a/benchmark/feldera-sql/benchmarks/tpc-h/table.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/table.sql
@@ -1,0 +1,87 @@
+-- The queries are taken from https://github.com/2ndQuadrant/pg-tpch/tree/master/queries
+
+CREATE TABLE LINEITEM ( 
+        L_ORDERKEY    INTEGER NOT NULL,
+        L_PARTKEY     INTEGER NOT NULL,
+        L_SUPPKEY     INTEGER NOT NULL,
+        L_LINENUMBER  INTEGER NOT NULL,
+        L_QUANTITY    DECIMAL(15,2) NOT NULL,
+        L_EXTENDEDPRICE  DECIMAL(15,2) NOT NULL,
+        L_DISCOUNT    DECIMAL(15,2) NOT NULL,
+        L_TAX         DECIMAL(15,2) NOT NULL,
+        L_RETURNFLAG  CHAR(1) NOT NULL,
+        L_LINESTATUS  CHAR(1) NOT NULL,
+        L_SHIPDATE    DATE NOT NULL,
+        L_COMMITDATE  DATE NOT NULL,
+        L_RECEIPTDATE DATE NOT NULL,
+        L_SHIPINSTRUCT CHAR(25) NOT NULL,
+        L_SHIPMODE     CHAR(10) NOT NULL,
+        L_COMMENT      VARCHAR(44) NOT NULL
+   ) WITH ('connectors' = '{lineitem}');
+
+CREATE TABLE ORDERS  ( 
+        O_ORDERKEY       INTEGER NOT NULL,
+        O_CUSTKEY        INTEGER NOT NULL,
+        O_ORDERSTATUS    CHAR(1) NOT NULL,
+        O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+        O_ORDERDATE      DATE NOT NULL,
+        O_ORDERPRIORITY  CHAR(15) NOT NULL,
+        O_CLERK          CHAR(15) NOT NULL,
+        O_SHIPPRIORITY   INTEGER NOT NULL,
+        O_COMMENT        VARCHAR(79) NOT NULL
+   ) WITH ('connectors' = '{orders}');
+
+CREATE TABLE PART ( 
+        P_PARTKEY     INTEGER NOT NULL,
+        P_NAME        VARCHAR(55) NOT NULL,
+        P_MFGR        CHAR(25) NOT NULL,
+        P_BRAND       CHAR(10) NOT NULL,
+        P_TYPE        VARCHAR(25) NOT NULL,
+        P_SIZE        INTEGER NOT NULL,
+        P_CONTAINER   CHAR(10) NOT NULL,
+        P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+        P_COMMENT     VARCHAR(23) NOT NULL 
+    ) WITH ('connectors' = '{part}');
+
+CREATE TABLE CUSTOMER ( 
+        C_CUSTKEY     INTEGER NOT NULL,
+        C_NAME        VARCHAR(25) NOT NULL,
+        C_ADDRESS     VARCHAR(40) NOT NULL,
+        C_NATIONKEY   INTEGER NOT NULL,
+        C_PHONE       CHAR(15) NOT NULL,
+        C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+        C_MKTSEGMENT  CHAR(10) NOT NULL,
+        C_COMMENT     VARCHAR(117) NOT NULL
+    ) WITH ('connectors' = '{customer}');
+
+CREATE TABLE SUPPLIER ( 
+        S_SUPPKEY     INTEGER NOT NULL,
+        S_NAME        CHAR(25) NOT NULL,
+        S_ADDRESS     VARCHAR(40) NOT NULL,
+        S_NATIONKEY   INTEGER NOT NULL,
+        S_PHONE       CHAR(15) NOT NULL,
+        S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+        S_COMMENT     VARCHAR(101) NOT NULL
+    ) WITH ('connectors' = '{supplier}');
+
+CREATE TABLE PARTSUPP ( 
+        PS_PARTKEY     INTEGER NOT NULL,
+        PS_SUPPKEY     INTEGER NOT NULL,
+        PS_AVAILQTY    INTEGER NOT NULL,
+        PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+        PS_COMMENT     VARCHAR(199) NOT NULL 
+    ) WITH ('connectors' = '{partsupp}');
+
+CREATE TABLE NATION  ( 
+        N_NATIONKEY  INTEGER NOT NULL,
+        N_NAME       CHAR(25) NOT NULL,
+        N_REGIONKEY  INTEGER NOT NULL,
+        N_COMMENT    VARCHAR(152)
+    ) WITH ('connectors' = '{nation}');
+
+CREATE TABLE REGION  ( 
+        R_REGIONKEY  INTEGER NOT NULL,
+        R_NAME       CHAR(25) NOT NULL,
+        R_COMMENT    VARCHAR(152)
+    ) WITH ('connectors' = '{region}');
+


### PR DESCRIPTION
Is this a user-visible change (yes/no): no

This PR adds the TPC-H benchmark to the suite. Two datasets are included, medium and large, and large is tested by default. You can change the dataset used by editing generate.py.

