### PR TITLE
Enable query q13 in nexmark

### DIFF
--- a/benchmark/feldera-sql/benchmarks/nexmark/queries/q13.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/queries/q13.sql
@@ -1,0 +1,11 @@
+CREATE VIEW Q13 AS
+SELECT
+    B.auction,
+    B.bidder,
+    B.price,
+    B.date_time,
+    S.value
+FROM (SELECT *, date_time as p_time, mod(auction, 10000) as mod FROM bid) B
+LEFT ASOF JOIN side_input AS S
+MATCH_CONDITION B.p_time >= S.date_time
+ON B.mod = S.key;

--- a/benchmark/feldera-sql/benchmarks/nexmark/table.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/table.sql
@@ -74,3 +74,8 @@ CREATE TABLE bid (
         }}
     }}
 ]');
+CREATE TABLE side_input (
+  date_time TIMESTAMP,
+  key BIGINT,
+  value VARCHAR
+);

--- a/benchmark/feldera-sql/benchmarks/nexmark/table.sql
+++ b/benchmark/feldera-sql/benchmarks/nexmark/table.sql
@@ -78,4 +78,19 @@ CREATE TABLE side_input (
   date_time TIMESTAMP,
   key BIGINT,
   value VARCHAR
-);
+) WITH ('connectors' = '[{{
+  "transport": {{
+      "name": "datagen",
+      "config": {{
+        "plan": [
+          {{
+            "limit": 100,
+            "fields": {{
+              "date_time": {{ "range": [1724444408000, 4102444800000] }},
+              "key": {{ "range": [0, 100] }}
+            }}
+          }}
+        ]
+      }}
+    }}
+}}]');;


### PR DESCRIPTION
This PR cannot be merged until we make a few other changes:
- the nexmark connector needs to populate the newly introduced `side_input` table
- the Calcite PR https://github.com/apache/calcite/pull/3924 is merged
