### PR TITLE
pipeline-manager: restrict maximum length and pattern of names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [adapters] Google Pub/Sub input connector
   ([#2312](https://github.com/feldera/feldera/pull/2312))
+- [API] Name maximum length (100) and limited characters allowed (A-Za-z0-9_-)
+  ([#2331](https://github.com/feldera/feldera/pull/2331))
 
 ## [0.24.0] - 2024-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6991,6 +6991,7 @@ dependencies = [
  "proptest-derive 0.3.0",
  "rand 0.8.5",
  "refinery",
+ "regex",
  "reqwest 0.11.27",
  "rustls 0.23.12",
  "serde",

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -58,6 +58,7 @@ metrics-exporter-prometheus = "0.15.1"
 # Make sure this is the same rustls version used by other crated in the dependency tree.
 # See the `ensure_default_crypto_provider` function at the root of this crate.
 rustls = "0.23.12"
+regex = "1.10.2"
 
 [features]
 integration-test = []

--- a/crates/pipeline_manager/src/db/types/common.rs
+++ b/crates/pipeline_manager/src/db/types/common.rs
@@ -1,4 +1,5 @@
 use crate::db::error::DBError;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
@@ -16,12 +17,83 @@ impl Display for Version {
     }
 }
 
+/// Pattern that every name must adhere to.
+pub const PATTERN_VALID_NAME: &str = r"^[a-zA-Z0-9_-]+$";
+
+/// Maximum name length.
+pub const MAXIMUM_NAME_LENGTH: usize = 100;
+
 /// Checks whether the provided name is valid.
-/// Currently the only constraint is that is cannot be empty.
+/// The constraints are as follows:
+/// - It cannot be empty
+/// - It must be at most 100 characters long
+/// - It must contain only characters which are lowercase (a-z), uppercase (A-Z),
+//    numbers (0-9), underscores (_) or hyphens (-)
 pub fn validate_name(name: &str) -> Result<(), DBError> {
     if name.is_empty() {
         Err(DBError::EmptyName)
+    } else if name.len() > MAXIMUM_NAME_LENGTH {
+        Err(DBError::TooLongName {
+            name: name.to_string(),
+            length: name.len(),
+            maximum: MAXIMUM_NAME_LENGTH,
+        })
     } else {
-        Ok(())
+        let re = Regex::new(PATTERN_VALID_NAME).expect("Pattern for name must be valid");
+        if re.is_match(name) {
+            Ok(())
+        } else {
+            Err(DBError::NameDoesNotMatchPattern {
+                name: name.to_string(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_name;
+    use crate::db::error::DBError;
+
+    #[test]
+    fn test_valid_names() {
+        let valid = vec![
+            "a",
+            "z",
+            "A",
+            "Z",
+            "0",
+            "9",
+            "-",
+            "_",
+            "exampleExample",
+            "example-1",
+            "example-of-this",
+            "Aa0_-",
+            "example_2",
+            "Example",
+            "EXAMPLE_example-example1234",
+        ];
+        for name in valid {
+            assert!(validate_name(name).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_invalid_names() {
+        assert!(matches!(validate_name(""), Err(DBError::EmptyName)));
+        assert!(
+            matches!(validate_name("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), Err(DBError::TooLongName {
+            name, length, maximum
+        }) if name == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" && length == 101 && maximum == 100)
+        );
+        let invalid_due_to_pattern = vec!["%", "$", "abc@", "example example", " ", "%20"];
+        for invalid_name in invalid_due_to_pattern {
+            assert!(
+                matches!(validate_name(invalid_name), Err(DBError::NameDoesNotMatchPattern {
+                name
+            }) if name == invalid_name)
+            );
+        }
     }
 }

--- a/crates/pipeline_manager/src/integration_test.rs
+++ b/crates/pipeline_manager/src/integration_test.rs
@@ -1844,14 +1844,28 @@ async fn upsert() {
 
 #[actix_web::test]
 #[serial]
-async fn empty_pipeline_name_not_allowed() {
+async fn pipeline_name_invalid() {
     let config = setup().await;
+    // Empty
     let request_body = json!({
         "name": "",
-        "description": "Description of the pipeline with an empty name",
-        "runtime_config": {},
-        "program_code": "",
-        "program_config": {}
+        "description": "", "runtime_config": {}, "program_code": "", "program_config": {}
+    });
+    let response = config.post("/v0/pipelines", &request_body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Too long
+    let request_body = json!({
+        "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "description": "", "runtime_config": {}, "program_code": "", "program_config": {}
+    });
+    let response = config.post("/v0/pipelines", &request_body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Invalid characters
+    let request_body = json!({
+        "name": "%abc",
+        "description": "", "runtime_config": {}, "program_code": "", "program_config": {}
     });
     let response = config.post("/v0/pipelines", &request_body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/demo/project_demo08-DebeziumJDBC/run.py
+++ b/demo/project_demo08-DebeziumJDBC/run.py
@@ -205,7 +205,7 @@ as select * from test_table;
 def create_feldera_pipeline(api_url: str, pipeline_to_redpanda_server: str, start_pipeline: bool):
     client = FelderaClient(api_url)
     sql = build_sql(pipeline_to_redpanda_server)
-    pipeline = PipelineBuilder(client, name="Debezium JDBC sink connector demo", sql=sql).create_or_replace()
+    pipeline = PipelineBuilder(client, name=PIPELINE_NAME, sql=sql).create_or_replace()
 
     if start_pipeline:
         print("Starting the pipeline...")


### PR DESCRIPTION
Name must now, besides being non-empty, also be at most 100 characters long and contain only characters which are lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-).

This naming restriction applies to:
- Pipeline name
- API key name
- Connector name

Is this a user-visible change (yes/no): yes
