### PR TITLE
Update real-time clock periodically

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -352,17 +352,19 @@ fn error_handler(state: &Weak<ServerState>, error: ControllerError) {
         // Prepare to handle poisoned locks in the following code.
 
         if let Ok(mut controller) = state.controller.lock() {
-            *controller = None;
-            // Don't risk calling `controller.stop()`.  If the error is caused
-            // by a panic in a DBSP worker thread, the `join` call in
-            // `controller.stop()` will panic.  We may consider calling `stop()`
-            // on errors do not indicate a panic, but that still seems risky.
+            if controller.is_some() {
+                *controller = None;
+                // Don't risk calling `controller.stop()`.  If the error is caused
+                // by a panic in a DBSP worker thread, the `join` call in
+                // `controller.stop()` will panic.  We may consider calling `stop()`
+                // on errors do not indicate a panic, but that still seems risky.
 
-            /*if let Some(controller) = controller.take() {
-                let _ = controller.stop();
-            }*/
-            if let Ok(mut phase) = state.phase.write() {
-                *phase = PipelinePhase::Failed(Arc::new(error));
+                /*if let Some(controller) = controller.take() {
+                    let _ = controller.stop();
+                }*/
+                if let Ok(mut phase) = state.phase.write() {
+                    *phase = PipelinePhase::Failed(Arc::new(error));
+                }
             }
         }
 

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -145,10 +145,13 @@ fn ft_kafka_end_to_end_test(
 
     // Create controller.
 
+    // Set clock_resolution_usecs to null below, so that periodic clock ticks
+    // don't interfere with the test.
     let config_str = format!(
         r#"
 name: test
 workers: 4
+clock_resolution_usecs: null
 inputs:
     test_input1:
         stream: test_input1

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -76,7 +76,7 @@ impl Display for Error {
                 }
                 Ok(())
             }
-            Self::Terminated => f.write_str("circuit terminated by the user"),
+            Self::Terminated => f.write_str("circuit has been terminated"),
             Self::IncompatibleStorage => {
                 f.write_str("Supplied storage directory does not fit the runtime circuit")
             }

--- a/crates/pipeline-types/src/config.rs
+++ b/crates/pipeline-types/src/config.rs
@@ -137,6 +137,11 @@ fn default_cpu_profiler() -> bool {
     true
 }
 
+/// Update the clock every 100ms by default.
+fn default_clock_resolution_usecs() -> Option<u64> {
+    Some(100_000)
+}
+
 /// Global pipeline configuration settings. This is the publicly
 /// exposed type for users to configure pipelines.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -201,6 +206,19 @@ pub struct RuntimeConfig {
     /// values provide a threshold.  `usize::MAX` would effectively disable
     /// storage.
     pub min_storage_bytes: Option<usize>,
+
+    /// Real-time clock resolution in microseconds.
+    ///
+    /// This parameter controls the execution of queries that use the `NOW()` function.  The output of such
+    /// queries depends on the real-time clock and can change over time without any external
+    /// inputs.  The pipeline will update the clock value and trigger incremental recomputation
+    /// at most each `clock_resolution_usecs` microseconds.
+    ///
+    /// It is set to 100 milliseconds (100,000 microseconds) by default.
+    ///
+    /// Set to `null` to disable periodic clock updates.
+    #[serde(default = "default_clock_resolution_usecs")]
+    pub clock_resolution_usecs: Option<u64>,
 }
 
 impl Default for RuntimeConfig {
@@ -215,6 +233,7 @@ impl Default for RuntimeConfig {
             max_buffering_delay_usecs: 0,
             resources: ResourceConfig::default(),
             min_storage_bytes: None,
+            clock_resolution_usecs: default_clock_resolution_usecs(),
         }
     }
 }

--- a/crates/pipeline_manager/src/api/examples.rs
+++ b/crates/pipeline_manager/src/api/examples.rs
@@ -43,6 +43,7 @@ pub(crate) fn pipeline_1() -> PipelineDescr {
             max_buffering_delay_usecs: 0,
             resources: Default::default(),
             min_storage_bytes: None,
+            clock_resolution_usecs: Some(100_000),
         },
         program_code: "CREATE TABLE table1 ( col1 INT );".to_string(),
         program_config: ProgramConfig {
@@ -68,6 +69,7 @@ pub(crate) fn extended_pipeline_1() -> ExtendedPipelineDescr {
             max_buffering_delay_usecs: 0,
             resources: Default::default(),
             min_storage_bytes: None,
+            clock_resolution_usecs: Some(100_000),
         },
         program_code: "CREATE TABLE table1 ( col1 INT );".to_string(),
         program_config: ProgramConfig {
@@ -111,6 +113,7 @@ pub(crate) fn extended_pipeline_2() -> ExtendedPipelineDescr {
                 storage_class: None,
             },
             min_storage_bytes: None,
+            clock_resolution_usecs: Some(100_000),
         },
         program_code: "CREATE TABLE table2 ( col2 VARCHAR );".to_string(),
         program_config: ProgramConfig {

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -207,6 +207,7 @@ struct RuntimeConfigPropVal {
     val11: Option<u64>,
     val12: Option<String>,
     val13: Option<usize>,
+    val14: Option<u64>,
 }
 type ProgramConfigPropVal = (bool, bool);
 type ProgramInfoPropVal = ();
@@ -240,6 +241,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> RuntimeConfig
             storage_class: val.val12,
         },
         min_storage_bytes: val.val13,
+        clock_resolution_usecs: val.val14,
     }
 }
 
@@ -789,6 +791,7 @@ async fn pipeline_versioning() {
         max_buffering_delay_usecs: 0,
         resources: Default::default(),
         min_storage_bytes: None,
+        clock_resolution_usecs: Some(100_000),
     };
     handle
         .db

--- a/openapi.json
+++ b/openapi.json
@@ -350,6 +350,7 @@
                     "program_status_since": "1970-01-01T00:00:00Z",
                     "program_version": 2,
                     "runtime_config": {
+                      "clock_resolution_usecs": 100000,
                       "cpu_profiler": false,
                       "max_buffering_delay_usecs": 0,
                       "min_batch_size_records": 0,
@@ -390,6 +391,7 @@
                     "program_status_since": "1970-01-01T00:00:00Z",
                     "program_version": 1,
                     "runtime_config": {
+                      "clock_resolution_usecs": 100000,
                       "cpu_profiler": false,
                       "max_buffering_delay_usecs": 0,
                       "min_batch_size_records": 100000,
@@ -450,6 +452,7 @@
                   "profile": "optimized"
                 },
                 "runtime_config": {
+                  "clock_resolution_usecs": 100000,
                   "cpu_profiler": false,
                   "max_buffering_delay_usecs": 0,
                   "min_batch_size_records": 0,
@@ -501,6 +504,7 @@
                   "program_status_since": "1970-01-01T00:00:00Z",
                   "program_version": 2,
                   "runtime_config": {
+                    "clock_resolution_usecs": 100000,
                     "cpu_profiler": false,
                     "max_buffering_delay_usecs": 0,
                     "min_batch_size_records": 0,
@@ -593,6 +597,7 @@
                   "program_status_since": "1970-01-01T00:00:00Z",
                   "program_version": 2,
                   "runtime_config": {
+                    "clock_resolution_usecs": 100000,
                     "cpu_profiler": false,
                     "max_buffering_delay_usecs": 0,
                     "min_batch_size_records": 0,
@@ -670,6 +675,7 @@
                   "profile": "optimized"
                 },
                 "runtime_config": {
+                  "clock_resolution_usecs": 100000,
                   "cpu_profiler": false,
                   "max_buffering_delay_usecs": 0,
                   "min_batch_size_records": 0,
@@ -721,6 +727,7 @@
                   "program_status_since": "1970-01-01T00:00:00Z",
                   "program_version": 2,
                   "runtime_config": {
+                    "clock_resolution_usecs": 100000,
                     "cpu_profiler": false,
                     "max_buffering_delay_usecs": 0,
                     "min_batch_size_records": 0,
@@ -771,6 +778,7 @@
                   "program_status_since": "1970-01-01T00:00:00Z",
                   "program_version": 2,
                   "runtime_config": {
+                    "clock_resolution_usecs": 100000,
                     "cpu_profiler": false,
                     "max_buffering_delay_usecs": 0,
                     "min_batch_size_records": 0,
@@ -953,6 +961,7 @@
                   "program_status_since": "1970-01-01T00:00:00Z",
                   "program_version": 2,
                   "runtime_config": {
+                    "clock_resolution_usecs": 100000,
                     "cpu_profiler": false,
                     "max_buffering_delay_usecs": 0,
                     "min_batch_size_records": 0,
@@ -3017,6 +3026,13 @@
             "type": "object",
             "description": "Global pipeline configuration settings. This is the publicly\nexposed type for users to configure pipelines.",
             "properties": {
+              "clock_resolution_usecs": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 100 milliseconds (100,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
+                "nullable": true,
+                "minimum": 0
+              },
               "cpu_profiler": {
                 "type": "boolean",
                 "description": "Enable CPU profiler.\n\nThe default value is `true`."
@@ -3602,6 +3618,13 @@
         "type": "object",
         "description": "Global pipeline configuration settings. This is the publicly\nexposed type for users to configure pipelines.",
         "properties": {
+          "clock_resolution_usecs": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 100 milliseconds (100,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
+            "nullable": true,
+            "minimum": 0
+          },
           "cpu_profiler": {
             "type": "boolean",
             "description": "Enable CPU profiler.\n\nThe default value is `true`."

--- a/python/feldera/runtime_config.py
+++ b/python/feldera/runtime_config.py
@@ -53,6 +53,7 @@ class RuntimeConfig:
             max_buffering_delay_usecs: int = 0,
             min_batch_size_records: int = 0,
             min_storage_bytes: Optional[int] = None,
+            clock_resolution_usecs: Optional[int] = None,
             resources: Optional[Resources] = None,
     ):
         self.workers = workers
@@ -63,6 +64,7 @@ class RuntimeConfig:
         self.max_buffering_delay_usecs = max_buffering_delay_usecs
         self.min_batch_size_records = min_batch_size_records
         self.min_storage_bytes = min_storage_bytes
+        self.clock_resolution_usecs = clock_resolution_usecs
         if resources is not None:
             self.resources = resources.__dict__
 

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="${THIS_DIR}/.."
 SQL_COMPILER_DIR="${ROOT_DIR}/sql-to-dbsp-compiler"


### PR DESCRIPTION
Adds a pipeline configuration parameter that forces the pipeline to
perform a step periodically even in the absence of an external input.
This allows the value of `NOW()` to change, triggering any queries that
depend on it to incrementally update their output.

The default value of the timeout is 100ms.  With this feature, the
following example works.  It populates the input table with 100K
records, starting with the current time (expressed in ms since epoch),
spaced at 100ms intervals.  The output view contains all input records
whose timestamp is in the future.  Initially the view contains all
input records.  You will then see 1 record removed from the view every
100ms as the clock moves forward

```sql
create table test (
    id bigint,
    ts timestamp
) WITH (
    'connectors' = '[{
        "transport":{
            "name": "datagen",
            "config": {
                "plan": [{
                    "limit": 100000,
                    "fields": {
                        "ts": {
                            "range": [1724707350000, 1724717350000],
                            "scale": 100
                        }
                    }
                }]
            }
        }
    }]'
);

create view v as select * from test where ts > now();
```

You can also change `>` to `<` and observe records getting added to the
view in real time.

Is this a user-visible change (yes/no): yes

<!-- If yes, please add 1) a description of the PR to CHANGELOG.md and 2) add the label "User-facing" to this PR -->
