### PR TITLE
Add option to configure circular buffer threshold when parsing Change Stream 

### DIFF
--- a/web-console/src/app.css
+++ b/web-console/src/app.css
@@ -9,3 +9,11 @@
 .preset-grayout-surface {
   @apply text-surface-600 hover:text-surface-950 dark:text-surface-400 hover:dark:text-surface-50;
 }
+
+.pane-divider-horizontal {
+  @apply z-[1] h-0.5 transition-colors bg-surface-100-900 before:-mt-0.5 before:flex before:h-2 before:w-full hover:bg-primary-500 active:bg-primary-500;
+}
+
+.pane-divider-vertical {
+  @apply z-[1] w-0.5 transition-colors bg-surface-100-900 before:-ml-0.5 before:flex before:h-full before:w-2 hover:bg-primary-500 active:bg-primary-500;
+}

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -196,7 +196,7 @@
         </div>
       </div>
     </Pane>
-    <PaneResizer class="h-2 bg-surface-100-900" />
+    <PaneResizer class="pane-divider-horizontal" />
     <Pane minSize={15} class="flex h-full flex-col !overflow-visible">
       {#if pipeline.current.name}
         <InteractionsPanel {pipeline} {metrics}></InteractionsPanel>

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -65,7 +65,18 @@
   }
 </script>
 
-<div class="relative flex-1" bind:this={ref}>
+<div class="relative flex flex-1 flex-col" bind:this={ref}>
+  {#if changeStream.totalSkippedBytes}
+    <div class="flex gap-1 p-1 preset-tonal-warning">
+      <span class="bx bx-error text-[24px]"></span>
+      <span>
+        Receiving changes faster than can be displayed. Skipping some records to keep up, {humanSize(
+          changeStream.totalSkippedBytes
+        )} in total.
+      </span>
+    </div>
+  {/if}
+
   <VirtualList
     width="100%"
     {height}
@@ -108,18 +119,5 @@
         setTimeout(() => (scrollOffset = len * itemSize))
       }}
     ></button>
-  {/if}
-  {#if changeStream.totalSkippedBytes}
-    <div
-      class="bx bx-error absolute right-4 top-4 rounded-full !border-2 border-warning-500 p-2 text-[24px] text-warning-800 bg-surface-50-950"
-    ></div>
-    <Tooltip
-      class=" border-2 border-warning-500 bg-surface-50-950 text-surface-950-50 "
-      trigger="click"
-      placement="right-start"
-      >Receiving changes faster than can displayed here.
-      <br />Skipping some records to keep up.
-      <br />Skipped {humanSize(changeStream.totalSkippedBytes)} in total.</Tooltip
-    >
   {/if}
 </div>

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -8,11 +8,14 @@
   import { VirtualList, type AfterScrollEvent } from 'svelte-virtuallists'
   import { useResizeObserver } from 'runed'
   import { scale } from 'svelte/transition'
+  import { humanSize } from '$lib/functions/common/string'
 
+  type Payload = { insert: XgressRecord } | { delete: XgressRecord } | { skippedBytes: number }
+  type Row = { relationName: string } & Payload
   let {
     changes
   }: {
-    changes: ({ relationName: string } & ({ insert: XgressRecord } | { delete: XgressRecord }))[]
+    changes: Row[]
   } = $props()
 
   let len = $derived(changes.length)
@@ -68,7 +71,7 @@
     {itemSize}
     {onAfterScroll}
   >
-    {#snippet slot({ item, style })}
+    {#snippet slot({ item, style }: { item: Row; style: string })}
       <div
         {style}
         class={`row whitespace-nowrap pl-2 before:inline-block before:w-2 even:!bg-opacity-30 even:bg-surface-100-900 ` +
@@ -81,7 +84,13 @@
         <span class="inline-block w-64 overflow-clip overflow-ellipsis pl-4"
           >{item.relationName}</span
         >
-        <span class="">{JSONbig.stringify((item as any).insert ?? (item as any).delete)}</span>
+        <span class=""
+          >{'insert' in item
+            ? JSONbig.stringify(item.insert)
+            : 'delete' in item
+              ? JSONbig.stringify(item.delete)
+              : `Skipped ${humanSize(item.skippedBytes)} of changes stream`}</span
+        >
       </div>
     {/snippet}
   </VirtualList>

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -9,17 +9,21 @@
   import { useResizeObserver } from 'runed'
   import { scale } from 'svelte/transition'
   import { humanSize } from '$lib/functions/common/string'
+  import Tooltip from '$lib/components/common/Tooltip.svelte'
 
   type Payload = { insert: XgressRecord } | { delete: XgressRecord } | { skippedBytes: number }
   type Row = { relationName: string } & Payload
   let {
-    changes
+    changeStream
   }: {
-    changes: Row[]
+    changeStream: {
+      rows: Row[]
+      totalSkippedBytes: number
+    }
   } = $props()
 
-  let len = $derived(changes.length)
-  let lastLen = $state(changes.length)
+  let len = $derived(changeStream.rows.length)
+  let lastLen = $state(changeStream.rows.length)
   let scrollOffset = $state(0)
   let lastScrollOffset = $state(0)
   const itemSize = 24
@@ -65,9 +69,9 @@
   <VirtualList
     width="100%"
     {height}
-    model={changes}
+    model={changeStream.rows}
     {scrollOffset}
-    modelCount={changes.length}
+    modelCount={changeStream.rows.length}
     {itemSize}
     {onAfterScroll}
   >
@@ -104,5 +108,18 @@
         setTimeout(() => (scrollOffset = len * itemSize))
       }}
     ></button>
+  {/if}
+  {#if changeStream.totalSkippedBytes}
+    <div
+      class="bx bx-error absolute right-4 top-4 rounded-full !border-2 border-warning-500 p-2 text-[24px] text-warning-800 bg-surface-50-950"
+    ></div>
+    <Tooltip
+      class=" border-2 border-warning-500 bg-surface-50-950 text-surface-950-50 "
+      trigger="click"
+      placement="right-start"
+      >Receiving changes faster than can displayed here.
+      <br />Skipping some records to keep up.
+      <br />Skipped {humanSize(changeStream.totalSkippedBytes)} in total.</Tooltip
+    >
   {/if}
 </div>

--- a/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
+++ b/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
@@ -39,6 +39,7 @@
     }
   }
   $effect(() => {
+    pipelineName
     setTimeout(() => pipelineActionCallbacks.add(pipelineName, 'start_paused', switchTo))
     return () => {
       pipelineActionCallbacks.remove(pipelineName, 'start_paused', switchTo)

--- a/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
+++ b/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
@@ -9,7 +9,7 @@
   import PanelPipelineErrors from '$lib/components/pipelines/editor/TabPipelineErrors.svelte'
   import { tuple } from '$lib/functions/common/tuple'
   import { Tabs } from '@skeletonlabs/skeleton-svelte'
-  import type { ExtendedPipeline, Pipeline } from '$lib/services/pipelineManager'
+  import type { ExtendedPipeline } from '$lib/services/pipelineManager'
   import { listPipelineErrors } from '$lib/compositions/health/systemErrors.svelte'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
@@ -92,5 +92,5 @@
   list={tabList}
   panels={tabPanels}
   panelsClasses="flex-1"
-  classes="flex flex-col flex-1 space-y-0"
+  classes="flex flex-col flex-1 !space-y-0"
 ></Tabs>

--- a/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
+++ b/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
@@ -81,12 +81,16 @@
       value={tabName}
       classes="h-full overflow-y-auto relative"
     >
-      <div class="ggg absolute h-full w-full p-4 pt-0">
+      <div class="absolute h-full w-full">
         <TabComponent {pipeline} {metrics}></TabComponent>
       </div>
     </Tabs.Panel>
   {/each}
 {/snippet}
 
-<Tabs list={tabList} panels={tabPanels} panelsClasses="flex-1" classes="flex flex-col flex-1"
+<Tabs
+  list={tabList}
+  panels={tabPanels}
+  panelsClasses="flex-1"
+  classes="flex flex-col flex-1 space-y-0"
 ></Tabs>

--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -70,7 +70,7 @@
         .filter((relation) => relation[1].selected)
         .map((relation) => relation[0])
       for (const relationName of relations) {
-        changeStream[pipelineName].rows.length = 0 // Clear row buffer when starting pipeline again
+        changeStream[pipelineName] = { rows: [], totalSkippedBytes: 0 } // Clear row buffer when starting pipeline again
         getChangeStream = () => changeStream
         pipelinesRelations[pipelineName][relationName].cancelStream = startReadingStream(
           pipelineName,

--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -38,8 +38,9 @@
       if ('message' in stream) {
         return undefined
       }
-      const cancel = parseJSONInStream(stream, pushChanges(pipelineName, relationName), {
-        paths: ['$.json_data.*']
+      const cancel = parseJSONInStream(stream, pushChanges(pipelineName, relationName), undefined, {
+        paths: ['$.json_data.*'],
+        bufferSize: 10 * 1024 * 1024
       })
       return () => {
         cancel()
@@ -168,8 +169,7 @@
                     startReadingStream(pipelineName, relation.relationName)
                 }
               }}
-              value={relation}
-            />
+              value={relation} />
             {relation.relationName}
           </label>
         {/snippet}
@@ -196,7 +196,7 @@
       {#if getRows()[pipelineName]?.length}
         <ChangeStream changes={getRows()[pipelineName]}></ChangeStream>
       {:else}
-        <span class="p-2 text-surface-500">
+        <span class="text-surface-500 p-2">
           {#if Object.values(pipelinesRelations[pipelineName] ?? {}).some((r) => r.selected)}
             The selected tables and views have not emitted any new changes
           {:else}

--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -146,7 +146,7 @@
 
 <div class="flex h-full flex-row">
   <PaneGroup direction="horizontal">
-    <Pane defaultSize={20} minSize={5} class="flex h-full">
+    <Pane defaultSize={20} minSize={5} class="flex h-full p-2 pr-0">
       <div class="flex w-full flex-col overflow-y-auto text-nowrap">
         {#snippet relationItem(relation: RelationInfo & ExtraType)}
           <label class="flex-none overflow-hidden overflow-ellipsis">
@@ -190,13 +190,13 @@
         {/if}
       </div>
     </Pane>
-    <PaneResizer class="w-2 bg-surface-100-900"></PaneResizer>
+    <PaneResizer class="pane-divider-vertical"></PaneResizer>
 
     <Pane minSize={70} class="flex h-full">
       {#if getRows()[pipelineName]?.length}
         <ChangeStream changes={getRows()[pipelineName]}></ChangeStream>
       {:else}
-        <span class="px-4 text-surface-500">
+        <span class="p-2 text-surface-500">
           {#if Object.values(pipelinesRelations[pipelineName] ?? {}).some((r) => r.selected)}
             The selected tables and views have not emitted any new changes
           {:else}

--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -17,7 +17,7 @@
 </script>
 
 {#if global}
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-4 p-2">
     <div class="flex w-full flex-col-reverse gap-2 lg:flex-row">
       <div class="mb-auto flex flex-col">
         <span class="w-full border-b-2 text-center text-surface-600-400">Total records</span>
@@ -100,5 +100,5 @@
     {/if}
   </div>
 {:else}
-  <span class="text-surface-600-400">Pipeline is not running</span>
+  <span class="flex p-2 text-surface-600-400">Pipeline is not running</span>
 {/if}

--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -47,7 +47,7 @@
         <div class="relative h-44 w-full">
           <PipelineMemoryGraph
             metrics={metrics.current}
-            refetchMs={500}
+            refetchMs={1000}
             keepMs={60 * 1000}
             {pipeline}
           ></PipelineMemoryGraph>

--- a/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
@@ -7,7 +7,7 @@
   let errors = useSystemErrors(pipeline)
 </script>
 
-<div class="flex h-full flex-col gap-4">
+<div class="flex h-full flex-col gap-4 p-2">
   {#each errors.current as systemError}
     <div class="whitespace-nowrap">
       <a href={systemError.cause.source}>

--- a/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -4,6 +4,7 @@ import type { ParsedElementInfo } from '@streamparser/json/utils/types/parsedEle
 import { discreteDerivative } from '$lib/functions/common/math'
 import { tuple } from '$lib/functions/common/tuple'
 import { chunkIndices } from '$lib/functions/common/array'
+import { humanSize } from '$lib/functions/common/string'
 
 class BigNumberTokenizer extends Tokenizer {
   parseNumber = BigNumber as any
@@ -110,6 +111,7 @@ export const parseJSONInStream = <T>(
                 chunksToParse.shift()
               }
               if (restart) {
+                console.log(`Skipped ${humanSize(previousBufferSize - bufferSize)} of change stream. New buffer size is ${humanSize(bufferSize)}`)
                 onBytesSkipped?.(previousBufferSize - bufferSize)
                 parser = mkParser(onValue, options)
                 break

--- a/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -111,7 +111,9 @@ export const parseJSONInStream = <T>(
                 chunksToParse.shift()
               }
               if (restart) {
-                console.log(`Skipped ${humanSize(previousBufferSize - bufferSize)} of change stream. New buffer size is ${humanSize(bufferSize)}`)
+                console.log(
+                  `Skipped ${humanSize(previousBufferSize - bufferSize)} of change stream. New buffer size is ${humanSize(bufferSize)}`
+                )
                 onBytesSkipped?.(previousBufferSize - bufferSize)
                 parser = mkParser(onValue, options)
                 break

--- a/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -24,21 +24,33 @@ const mkParser = (
   })
 }
 
+/**
+ *
+ * @param stream
+ * @param pushChanges
+ * @param options.bufferSize Threshold size of the buffer that holds unprocessed JSON chunks.
+ * If the buffer size exceeds this value - when the new JSON batch arrives previous JSON batches are dropped
+ * until the buffer size is under the threshold, or only one batch remains.
+ * @returns
+ */
 export const parseJSONInStream = <T>(
   stream: ReadableStream<Uint8Array>,
   pushChanges: (changes: T[]) => void,
-  options?: TokenParserOptions
+  onBytesSkipped?: (bytes: number) => void,
+  options?: TokenParserOptions & { bufferSize?: number }
 ) => {
   const reader = stream.getReader()
   let count = 0
-  let resultBuffer = new Array()
+  let resultBuffer = [] as any[]
 
   const onValue = ({ value }: ParsedElementInfo) => {
     resultBuffer[count] = value
     ++count
   }
 
-  const chunksToParse = [] as Uint8Array[]
+  // chunksToParse is a list of batches (complete JSON objects), each split into a list of bytestring chunks
+  // chunksToParse contains no empty bytestrings
+  let chunksToParse = [[]] as Uint8Array[][]
 
   const startInterruptableParse = () => {
     let parser = mkParser(onValue, options)
@@ -52,7 +64,7 @@ export const parseJSONInStream = <T>(
         // We ignore the error because we just want to interrupt parsing and production of values
       }
       parser = mkParser(onValue, options)
-      chunksToParse.length = 0
+      chunksToParse = [[]]
       while (!done) {
         // Release thread to parse JSON
         await new Promise((resolve) => setTimeout(resolve))
@@ -62,8 +74,13 @@ export const parseJSONInStream = <T>(
     return {
       start: async () => {
         while (!isEnd) {
-          const value = chunksToParse.shift()
-          if (!value || value.length === 0) {
+          const value = chunksToParse[0]?.shift()
+          if (!value) {
+            if (chunksToParse.length > 1) {
+              // Keep atleast a single empty batch in chunksToParse
+              chunksToParse.shift()
+              parser = mkParser(onValue, options)
+            }
             await new Promise((resolve) => setTimeout(resolve))
             continue
           }
@@ -76,12 +93,24 @@ export const parseJSONInStream = <T>(
             if (isEnd) {
               break
             }
+
             {
-              // In each iteration we check if an empty array has been added to the parse queue
-              // If so, we drop all chunks before the latest empty array
-              const emptyChunkIdx = chunksToParse.findLastIndex((chunk) => chunk.length === 0)
-              if (emptyChunkIdx !== -1) {
-                chunksToParse.splice(0, emptyChunkIdx + 1)
+              // In each parse iteration we check if buffer is not too large
+              // If so, we drop oldest batches until buffer fits the threshold, or a single batch remains
+              const batchLengths = chunksToParse.map((batch) =>
+                batch.reduce((acc, cur) => acc + cur.length, 0)
+              )
+              const previousBufferSize = batchLengths.reduce((acc, cur) => acc + cur, 0)
+              let bufferSize = previousBufferSize
+              const tooLarge = () =>
+                chunksToParse.length > 1 && bufferSize > (options?.bufferSize ?? 0)
+              const restart = tooLarge()
+              while (tooLarge()) {
+                bufferSize -= batchLengths.shift()!
+                chunksToParse.shift()
+              }
+              if (restart) {
+                onBytesSkipped?.(previousBufferSize - bufferSize)
                 parser = mkParser(onValue, options)
                 break
               }
@@ -124,7 +153,13 @@ export const parseJSONInStream = <T>(
         stop()
         break
       }
-      splitByNewline(chunksToParse.push.bind(chunksToParse), value)
+
+      splitByNewline(
+        (chunk) => chunksToParse.at(-1)!.push(chunk),
+        () => chunksToParse.push([]),
+        value
+      )
+
       // Release thread to process UI
       await new Promise((resolve) => setTimeout(resolve))
     }
@@ -139,21 +174,19 @@ export const parseJSONInStream = <T>(
  * Split stream by newline character (LF, 0x0A), sending an empty chunk on each occurrence
  * Empty chunk is also sent when the upstream has ended
  */
-function splitByNewline(onChunk: (chunk: Uint8Array) => void, chunk: Uint8Array) {
+function splitByNewline(
+  onChunk: (chunk: Uint8Array) => void,
+  onBatch: () => void,
+  chunk: Uint8Array
+) {
   let start = 0
-
-  // TODO: currently splitting is stateless, so when chunk has a divider at its end empty chunk will not be injected.
-  // This may be suboptimal, as ideal behavior could be inserting empty chunk when the next upstream chunk arrives.
-  // This would require introducing state to splitting algorithm.
-
   while (start < chunk.length) {
     const newlineIndex = chunk.indexOf(10, start)
     const end = newlineIndex === -1 ? chunk.length : newlineIndex
 
     onChunk(chunk.subarray(start, end))
-    if (end < chunk.length - 1) {
-      // If found newline not at the end of the chunk
-      onChunk(new Uint8Array())
+    if (end !== chunk.length) {
+      onBatch()
     }
 
     // Move start to after the newline character
@@ -168,7 +201,11 @@ function splitByNewline(onChunk: (chunk: Uint8Array) => void, chunk: Uint8Array)
 function splitStreamByNewline(): TransformStream<Uint8Array, Uint8Array> {
   return new TransformStream<Uint8Array, Uint8Array>({
     transform(chunk, controller) {
-      splitByNewline(controller.enqueue.bind(controller), chunk)
+      splitByNewline(
+        controller.enqueue.bind(controller),
+        () => controller.enqueue(new Uint8Array()),
+        chunk
+      )
     },
     flush(controller) {
       controller.enqueue(new Uint8Array())

--- a/web-console/src/lib/functions/pipelines/status.ts
+++ b/web-console/src/lib/functions/pipelines/status.ts
@@ -71,7 +71,7 @@ export const isMetricsAvailable = (status: PipelineStatus) => {
     .with('Pausing', () => true)
     .with('Resuming', () => true)
     .with('ShuttingDown', () => false)
-    .with({ PipelineError: P.select() }, () => true)
+    .with({ PipelineError: P.select() }, () => false)
     .with('Compiling sql', () => false)
     .with('Queued', () => false)
     .with('Compiling bin', () => false)


### PR DESCRIPTION
Improve look and padding around split pane resizers

Set a limit of 10 MiB which fits a couple batches of JSON from pipeline with a high throughput. Easily configurable hardcoded value.