### PR TITLE
Enable ingesting insert_delete changes by copy-paste in Change Stream

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -2,16 +2,15 @@
 </script>
 
 <script lang="ts">
-  import type { XgressRecord } from '$lib/types/pipelineManager'
   import JSONbig from 'true-json-bigint'
 
   import { VirtualList, type AfterScrollEvent } from 'svelte-virtuallists'
   import { useResizeObserver } from 'runed'
   import { scale } from 'svelte/transition'
   import { humanSize } from '$lib/functions/common/string'
-  import Tooltip from '$lib/components/common/Tooltip.svelte'
+  import type { XgressEntry } from '$lib/services/pipelineManager'
 
-  type Payload = { insert: XgressRecord } | { delete: XgressRecord } | { skippedBytes: number }
+  type Payload = XgressEntry | { skippedBytes: number }
   type Row = { relationName: string } & Payload
   let {
     changeStream
@@ -88,6 +87,10 @@
   >
     {#snippet slot({ item, style }: { item: Row; style: string })}
       <div
+        oncopy={(e) => {
+          e.clipboardData!.setData('text/plain', JSONbig.stringify(item))
+          e.preventDefault()
+        }}
         {style}
         class={`row whitespace-nowrap pl-2 before:inline-block before:w-2 even:!bg-opacity-30 even:bg-surface-100-900 ` +
           ('insert' in item

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -19,7 +19,8 @@ import {
   createApiKey,
   deleteApiKey as _deleteApiKey,
   httpOutput,
-  getConfigDemos
+  getConfigDemos,
+  httpInput
 } from '$lib/services/manager'
 export type {
   // PipelineDescr,
@@ -30,7 +31,7 @@ export type {
   RuntimeConfig
 } from '$lib/services/manager'
 import { P, match } from 'ts-pattern'
-import type { ControllerStatus } from '$lib/types/pipelineManager'
+import type { ControllerStatus, XgressRecord } from '$lib/types/pipelineManager'
 export type { ProgramSchema, ProgramStatus } from '$lib/services/manager'
 
 import * as AxaOidc from '@axa-fr/oidc-client'
@@ -326,6 +327,25 @@ export const relationEggressStream = async (pipelineName: string, relationName: 
     }
   )
   return result.status === 200 && result.body ? result.body : (result.json() as Promise<Error>)
+}
+
+export type XgressEntry = { insert: XgressRecord } | { delete: XgressRecord }
+
+/**
+ * @param force Insert changes immediately even if pipeline is stopped
+ */
+export const relationIngress = async (
+  pipelineName: string,
+  relationName: string,
+  data: XgressEntry[],
+  force?: 'force'
+) => {
+  return httpInput({
+    path: { pipeline_name: pipelineName, table_name: relationName },
+    parseAs: 'text', // Response is empty, so no need to parse it as JSON
+    query: { format: 'json', array: true, update_format: 'insert_delete', force: !!force },
+    body: data as any
+  })
 }
 
 export const getDemos = handled(getConfigDemos)

--- a/web-console/src/routes/+layout.ts
+++ b/web-console/src/routes/+layout.ts
@@ -18,6 +18,7 @@ export const load = async ({ fetch, url }): Promise<{ auth: AuthDetails }> => {
       auth: 'none'
     }
   }
+
   const authConfig = await loadAuthConfig()
   if (!authConfig) {
     return {


### PR DESCRIPTION
You can click on any (single) row in Change Stream and copy the row in the ingress JSON insert_delete format. For now only one row at a time can be copied.

You can paste rows by Ctrl+V or otherwise after clicking anywhere within Change Stream tab. Pasted row
```
{"insert":{"num":42},"relationName":"numbers"}
```
or array of rows
```
[
  {"delete":{"num":42},"relationName":"numbers"},
  {"insert":{"num":27},"relationName":"numbers"}
]
```
will be sent via HTTP ingress with flag `force`, so the change can be seen immediately even if the pipeline is PAUSED (and you checked the checkbox to follow the corresponding table).

You can insert records for different tables in the same operation. In this scenario all changes for each table will be sent in a single batch, preserving ordering of changes within a batch, while each batch is sent concurrently.

In case of an error (column type mismatch etc.) insert will fail silently with no indication of en error. (Will be implemented later)