### PR TITLE
[adapters] Avro input format support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -69,7 +69,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "derive_more",
  "futures-core",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae682f693a9cd7b058f2b0b5d9a6d7728a8555779bedbbc35dd88528611d020"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -94,7 +94,7 @@ dependencies = [
  "actix-utils",
  "ahash 0.8.11",
  "base64 0.22.1",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -118,7 +118,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "zstd 0.13.0",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -152,8 +152,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02303ce8d4e8be5b855af6cf3c3a08f3eff26880faad82bab679c22d3650cb5"
+checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.8.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1988c02af8d2b718c05bc4aeb6a66395b7cdf32858c2c71131e5637a8c05a9ff"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -291,6 +291,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",
@@ -316,8 +317,8 @@ checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -354,8 +355,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -372,6 +373,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "adler32"
@@ -487,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -508,27 +515,27 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -617,9 +624,9 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -629,9 +636,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
@@ -777,7 +784,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "lexical-core",
  "num",
  "serde",
@@ -855,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "ascii_table"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2bee9b9ee0e5768772e38c07ef0ba23a490d7e1336ec7207c25712a2661c55"
+checksum = "ed8a80a95ab122e7cc43bfde1d51949c89ff67e0c76eb795dc045003418473e2"
 
 [[package]]
 name = "assert-json-diff"
@@ -875,7 +882,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -904,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
 dependencies = [
  "bzip2",
  "flate2",
@@ -916,19 +923,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "xz2",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd 0.13.2",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-lite 2.3.0",
  "slab",
 ]
@@ -941,7 +948,7 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "blocking",
  "futures-lite 2.3.0",
@@ -970,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
@@ -980,11 +987,11 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.2",
- "rustix 0.38.34",
+ "polling 3.7.3",
+ "rustix 0.38.35",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1032,26 +1039,26 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
 dependencies = [
- "async-io 2.3.3",
+ "async-io 2.3.4",
  "async-lock 3.4.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1100,8 +1107,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1112,13 +1119,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1188,9 +1195,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "awc"
-version = "3.5.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b67e44fb95d1dc9467e3930383e115f9b4ed60ca689db41409284e967a12d"
+checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -1242,7 +1249,7 @@ dependencies = [
  "fastrand 1.9.0",
  "hex",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "ring 0.16.20",
  "time",
  "tokio",
@@ -1253,27 +1260,26 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac9889352d632214df943e26740c46a0f3da6e329fbd28164fe7ae1b061da7b"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-sdk-sso 1.29.0",
+ "aws-sdk-sso 1.40.0",
  "aws-sdk-ssooidc",
- "aws-sdk-sts 1.29.0",
+ "aws-sdk-sts 1.40.0",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "hex",
  "http 0.2.12",
- "hyper 0.14.29",
  "ring 0.17.8",
  "time",
  "tokio",
@@ -1298,13 +1304,13 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "zeroize",
 ]
 
@@ -1370,22 +1376,24 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4a5e448145999d7de17bf44a886900ecb834953408dae8aaf90465ce91c1dd"
+checksum = "2424565416eef55906f9f8cece2072b6b6a76075e3ff81483ebe938a89a4c05f"
 dependencies = [
- "aws-credential-types 1.2.0",
- "aws-sigv4 1.2.2",
+ "aws-credential-types 1.2.1",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "http 0.2.12",
  "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -1419,21 +1427,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.32.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b456ed83e68bf5a1493fb2c3898841676fab73540dd7970dbeb8ce74aae123"
+checksum = "6befba9ce7b81b58b1249c854da754e2236dbee548a736b96230216ebf9bcadc"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1442,26 +1450,26 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.34.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
+checksum = "cca49303c05d2a740b8a4552fac63a4db6ead84f7e7eeed04761fd3014c26f25"
 dependencies = [
  "ahash 0.8.11",
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-sigv4 1.2.2",
+ "aws-sigv4 1.2.3",
  "aws-smithy-async 1.2.1",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -1502,19 +1510,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.29.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da75cf91cbb46686a27436d639a720a3a198b148efa76dc2467b7e5374a67fc0"
+checksum = "e5879bec6e74b648ce12f6085e7245417bc5f6d672781028384d2e494be3eb6d"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1524,19 +1532,19 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.30.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ec8a6687299685ed0a4a3137c129cdb132b5235bc3aa3443f6cffe468b9ff"
+checksum = "4ef4cd9362f638c22a3b959fd8df292e7e47fdf170270f86246b97109b5f2f7d"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
- "aws-types 1.3.2",
+ "aws-smithy-types 1.2.4",
+ "aws-types 1.3.3",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -1572,21 +1580,21 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.29.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f1031e094b1411b59b49b19e4118f069e1fe13a9c5b8888e933daaf7ffdd6"
+checksum = "0b1e2735d2ab28b35ecbb5496c9d41857f52a0d6a0075bbf6a8af306045ea6f6"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-json 0.60.7",
  "aws-smithy-query 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "aws-smithy-xml 0.60.8",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -1628,15 +1636,15 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
@@ -1680,12 +1688,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.10"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
 dependencies = [
- "aws-smithy-http 0.60.8",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-http 0.60.10",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "crc32c",
  "crc32fast",
@@ -1713,7 +1721,7 @@ dependencies = [
  "fastrand 1.9.0",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-rustls 0.23.2",
  "lazy_static",
  "pin-project-lite",
@@ -1729,7 +1737,7 @@ version = "0.60.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "crc32fast",
 ]
@@ -1746,7 +1754,7 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1758,13 +1766,13 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.8"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
+checksum = "01dbcb6e2588fd64cfb6d7529661b06466419e4c54ed1c62d6510d2d0350a728"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -1808,7 +1816,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
 ]
 
 [[package]]
@@ -1827,27 +1835,28 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.5"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d3965f6417a92a6d1009c5958a67042f57e46342afb37ca58f9ad26744ec73"
+checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-http 0.60.8",
+ "aws-smithy-http 0.60.10",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "http-body 1.0.0",
- "hyper 0.14.29",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -1859,12 +1868,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b570ea39eb95bd32543f6e4032bce172cb6209b9bc8c83c770d08169e875afc"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
 dependencies = [
  "aws-smithy-async 1.2.1",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -1889,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "273dcdfd762fae3e1650b8024624e7cd50e484e37abdab73a7a706188ad34543"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1900,7 +1909,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.1.0",
  "http-body 0.4.6",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "num-integer",
@@ -1949,14 +1958,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
 dependencies = [
- "aws-credential-types 1.2.0",
+ "aws-credential-types 1.2.1",
  "aws-smithy-async 1.2.1",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.2.0",
+ "aws-smithy-types 1.2.4",
  "rustc_version",
  "tracing",
 ]
@@ -1972,7 +1981,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit",
@@ -1998,7 +2007,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -2032,7 +2041,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -2092,7 +2101,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -2101,11 +2110,11 @@ dependencies = [
  "log",
  "prettyplease",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.77",
  "which",
 ]
 
@@ -2129,7 +2138,7 @@ dependencies = [
  "either",
  "owo-colors",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2156,9 +2165,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -2183,15 +2192,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -2233,10 +2242,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -2281,9 +2290,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta 0.1.4",
@@ -2298,7 +2307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2310,22 +2319,22 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2336,9 +2345,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bytes-utils"
@@ -2432,7 +2441,7 @@ checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.13.4",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2445,7 +2454,7 @@ dependencies = [
  "cached_proc_macro_types",
  "darling 0.14.4",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2463,13 +2472,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -2522,7 +2531,7 @@ dependencies = [
  "rkyv",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2640,7 +2649,7 @@ checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.1",
+ "clap_lex 0.7.2",
  "strsim 0.11.1",
  "terminal_size",
 ]
@@ -2663,7 +2672,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -2675,8 +2684,8 @@ checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2690,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -2705,18 +2714,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -2795,9 +2804,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -2828,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -2843,18 +2852,18 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -2930,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam"
@@ -3055,7 +3064,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -3087,12 +3096,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.9",
- "darling_macro 0.20.9",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -3104,7 +3113,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -3118,23 +3127,23 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3144,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -3155,19 +3164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.9",
- "quote 1.0.36",
- "syn 2.0.76",
+ "darling_core 0.20.10",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3225,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
+checksum = "ab9d55a9cd2634818953809f75ebe5248b00dd43c3227efb2a51a2d5feaad54e"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3240,28 +3249,28 @@ dependencies = [
  "bzip2",
  "chrono",
  "dashmap 5.5.3",
- "datafusion-common 39.0.0",
- "datafusion-common-runtime 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-functions 39.0.0",
- "datafusion-functions-aggregate 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-common-runtime 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-functions 40.0.0",
+ "datafusion-functions-aggregate 40.0.0",
  "datafusion-functions-array",
- "datafusion-optimizer 39.0.0",
- "datafusion-physical-expr 39.0.0",
- "datafusion-physical-expr-common 39.0.0",
- "datafusion-physical-plan 39.0.0",
- "datafusion-sql 39.0.0",
+ "datafusion-optimizer 40.0.0",
+ "datafusion-physical-expr 40.0.0",
+ "datafusion-physical-expr-common 40.0.0",
+ "datafusion-physical-plan 40.0.0",
+ "datafusion-sql 40.0.0",
  "flate2",
  "futures",
  "glob",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "parking_lot 0.12.3",
  "parquet",
  "paste",
@@ -3274,7 +3283,7 @@ dependencies = [
  "url",
  "uuid",
  "xz2",
- "zstd 0.13.0",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -3313,11 +3322,11 @@ dependencies = [
  "glob",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "parking_lot 0.12.3",
  "parquet",
  "paste",
@@ -3330,7 +3339,7 @@ dependencies = [
  "url",
  "uuid",
  "xz2",
- "zstd 0.13.0",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -3349,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
+checksum = "def66b642959e7f96f5d2da22e1f43d3bd35598f821e5ce351a0553e0f1b7367"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3364,7 +3373,7 @@ dependencies = [
  "instant",
  "libc",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "parquet",
  "sqlparser 0.47.0",
 ]
@@ -3386,16 +3395,16 @@ dependencies = [
  "instant",
  "libc",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "parquet",
  "sqlparser 0.49.0",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
+checksum = "f104bb9cb44c06c9badf8a0d7e0855e5f7fa5e395b887d7f835e8a9457dc1352"
 dependencies = [
  "tokio",
 ]
@@ -3411,19 +3420,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
+checksum = "2ac0fd8b5d80bbca3fc3b6f40da4e9f6907354824ec3b18bbd83fee8cf5c3c3e"
 dependencies = [
  "arrow",
  "chrono",
  "dashmap 5.5.3",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store 0.10.2",
+ "object_store",
  "parking_lot 0.12.3",
  "rand",
  "tempfile",
@@ -3444,7 +3453,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "log",
- "object_store 0.10.2",
+ "object_store",
  "parking_lot 0.12.3",
  "rand",
  "tempfile",
@@ -3453,16 +3462,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
+checksum = "2103d2cc16fb11ef1fa993a6cac57ed5cb028601db4b97566c90e5fa77aa1e68"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
  "arrow-array",
  "arrow-buffer",
  "chrono",
- "datafusion-common 39.0.0",
+ "datafusion-common 40.0.0",
  "paste",
  "serde_json",
  "sqlparser 0.47.0",
@@ -3491,19 +3500,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
+checksum = "a369332afd0ef5bd565f6db2139fb9f1dfdd0afa75a7f70f000b74208d76994f"
 dependencies = [
  "arrow",
  "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-physical-expr 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -3545,17 +3553,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
+checksum = "92718db1aff70c47e5abf9fc975768530097059e5db7c7b78cd64b5e9a11fc77"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
  "arrow-schema",
- "datafusion-common 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-physical-expr-common 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-physical-expr-common 40.0.0",
  "log",
  "paste",
  "sqlparser 0.47.0",
@@ -3581,19 +3589,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-array"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
+checksum = "30bb80f46ff3dcf4bb4510209c2ba9b8ce1b716ac8b7bf70c6bf7dca6260c831"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
- "datafusion-common 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-functions 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-functions 40.0.0",
+ "datafusion-functions-aggregate 40.0.0",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -3623,20 +3632,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
+checksum = "82f34692011bec4fdd6fc18c264bf8037b8625d801e6dd8f5111af15cb6d71d3"
 dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-physical-expr 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-physical-expr 40.0.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
+ "paste",
  "regex-syntax",
 ]
 
@@ -3653,7 +3663,7 @@ dependencies = [
  "datafusion-expr 41.0.0",
  "datafusion-physical-expr 41.0.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -3662,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
+checksum = "45538630defedb553771434a437f7ca8f04b9b3e834344aafacecb27dc65d5e5"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3675,15 +3685,14 @@ dependencies = [
  "arrow-string",
  "base64 0.22.1",
  "chrono",
- "datafusion-common 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-functions-aggregate 39.0.0",
- "datafusion-physical-expr-common 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-physical-expr-common 40.0.0",
  "half",
  "hashbrown 0.14.5",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -3713,7 +3722,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.5",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -3723,13 +3732,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
+checksum = "9d8a72b0ca908e074aaeca52c14ddf5c28d22361e9cb6bc79bb733cd6661b536"
 dependencies = [
+ "ahash 0.8.11",
  "arrow",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
+ "hashbrown 0.14.5",
  "rand",
 ]
 
@@ -3761,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
+checksum = "b504eae6107a342775e22e323e9103f7f42db593ec6103b28605b7b7b1405c4a"
 dependencies = [
  "ahash 0.8.11",
  "arrow",
@@ -3773,17 +3784,17 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common 39.0.0",
- "datafusion-common-runtime 39.0.0",
- "datafusion-execution 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-functions-aggregate 39.0.0",
- "datafusion-physical-expr 39.0.0",
- "datafusion-physical-expr-common 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-common-runtime 40.0.0",
+ "datafusion-execution 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-functions-aggregate 40.0.0",
+ "datafusion-physical-expr 40.0.0",
+ "datafusion-physical-expr-common 40.0.0",
  "futures",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -3817,7 +3828,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.12.1",
  "log",
  "once_cell",
@@ -3829,44 +3840,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8eb8d706c73f01c0e2630c64ffc61c33831b064a813ec08a3e094dc3190c0f"
+checksum = "6a38d1e3d26fcb5a7de58b068d4f6a2eff20663a6d10ad1b45c6222505409003"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion 39.0.0",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
+ "datafusion 40.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
  "datafusion-proto-common",
- "object_store 0.10.2",
+ "object_store",
  "prost 0.12.6",
 ]
 
 [[package]]
 name = "datafusion-proto-common"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7115772d326eeb78a1c77c974e7753b1538e1747675cb6b428058b654b31c"
+checksum = "cad4529d59ebcc88f9d717b3b83cab01b7b6adee3f9944deab966be1886414a3"
 dependencies = [
  "arrow",
  "chrono",
- "datafusion-common 39.0.0",
- "object_store 0.9.1",
+ "datafusion-common 40.0.0",
+ "object_store",
  "prost 0.12.6",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
+checksum = "e5db33f323f41b95ae201318ba654a9bf11113e58a51a1dff977b1a836d3d889"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
  "log",
  "regex",
  "sqlparser 0.47.0",
@@ -3981,7 +3992,7 @@ dependencies = [
  "atomic",
  "awc",
  "aws-sdk-s3",
- "aws-types 1.3.2",
+ "aws-types 1.3.3",
  "bstr",
  "bytemuck",
  "bytes",
@@ -4028,7 +4039,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "once_cell",
- "ordered-float 4.2.0",
+ "ordered-float 4.2.2",
  "parquet",
  "pretty_assertions",
  "prometheus",
@@ -4147,22 +4158,23 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ddfe35af3696786ab5f23cd995df33a66f6cff272ac1f85e09c1a6316acd4c"
+checksum = "04f22db2e9d735475ffcb97bf00b80d693b3d6b87ea11786bc48a7785e503680"
 dependencies = [
  "arrow-arith",
  "arrow-array",
+ "arrow-cast",
  "arrow-json",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "bytes",
  "chrono",
- "delta_kernel_derive 0.1.1",
+ "delta_kernel_derive 0.2.0",
  "either",
  "fix-hidden-lifetime-bug",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
  "parquet",
@@ -4196,7 +4208,7 @@ dependencies = [
  "delta_kernel_derive 0.3.0",
  "either",
  "fix-hidden-lifetime-bug",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
  "parquet",
@@ -4215,13 +4227,13 @@ dependencies = [
 
 [[package]]
 name = "delta_kernel_derive"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d2127a34b12919a6bce08225f0ca6fde8a19342a32675370edfc8795e7c38a"
+checksum = "05bdaeea7681865f265739cf1d071ed571a62deaf5b77a5eb6604bf303116164"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4231,8 +4243,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6502fa0ba72fd1f782ccebba8f4c8b9a07c7591559e39d3d05b7ead94690a13f"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4243,7 +4255,7 @@ checksum = "b287fdc19e7adbfc4f94bd2c329909f5f0e6d7b7e26d83ea0a7bbc85a0790204"
 dependencies = [
  "deltalake-aws",
  "deltalake-azure",
- "deltalake-core 0.18.1",
+ "deltalake-core 0.18.2",
  "deltalake-gcp",
 ]
 
@@ -4254,10 +4266,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae61c8427536aa2215b13109d10f4cc14ab036ad0bd3bb11ec7b54a4938f03f"
 dependencies = [
  "async-trait",
- "aws-config 1.5.1",
- "aws-credential-types 1.2.0",
+ "aws-config 1.5.5",
+ "aws-credential-types 1.2.1",
  "aws-sdk-dynamodb",
- "aws-sdk-sts 1.29.0",
+ "aws-sdk-sts 1.40.0",
  "aws-smithy-runtime-api",
  "backoff",
  "bytes",
@@ -4265,7 +4277,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "maplit",
- "object_store 0.10.2",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -4285,7 +4297,7 @@ dependencies = [
  "deltalake-core 0.19.0",
  "futures",
  "lazy_static",
- "object_store 0.10.2",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -4295,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "deltalake-core"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0068bd92347795c1c5e3b4ef7c5489de289ebe78cc9ab6667c0fbab539da3d7c"
+checksum = "03ef4f2e8560b5a0e10fcbceb31fa5d49a44f290e2c327a4a3c01c8e0ebfe7b1"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4314,22 +4326,22 @@ dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
- "dashmap 5.5.3",
- "datafusion 39.0.0",
- "datafusion-common 39.0.0",
- "datafusion-expr 39.0.0",
- "datafusion-functions 39.0.0",
+ "dashmap 6.0.1",
+ "datafusion 40.0.0",
+ "datafusion-common 40.0.0",
+ "datafusion-expr 40.0.0",
+ "datafusion-functions 40.0.0",
  "datafusion-functions-array",
- "datafusion-physical-expr 39.0.0",
+ "datafusion-physical-expr 40.0.0",
  "datafusion-proto",
- "datafusion-sql 39.0.0",
- "delta_kernel 0.1.1",
+ "datafusion-sql 40.0.0",
+ "delta_kernel 0.2.0",
  "either",
  "errno",
  "fix-hidden-lifetime-bug",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
  "libc",
@@ -4337,7 +4349,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "once_cell",
  "parking_lot 0.12.3",
  "parquet",
@@ -4348,11 +4360,12 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
- "sqlparser 0.47.0",
+ "sqlparser 0.49.0",
  "thiserror",
  "tokio",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
  "z85",
 ]
@@ -4385,7 +4398,7 @@ dependencies = [
  "fix-hidden-lifetime-bug",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "lazy_static",
  "libc",
@@ -4393,7 +4406,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
- "object_store 0.10.2",
+ "object_store",
  "once_cell",
  "parking_lot 0.12.3",
  "parquet",
@@ -4425,7 +4438,7 @@ dependencies = [
  "deltalake-core 0.19.0",
  "futures",
  "lazy_static",
- "object_store 0.10.2",
+ "object_store",
  "regex",
  "thiserror",
  "tokio",
@@ -4460,8 +4473,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4472,9 +4485,9 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4566,8 +4579,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4608,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -4648,15 +4661,15 @@ checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -4715,8 +4728,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4728,15 +4741,15 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -4866,9 +4879,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fd-lock"
@@ -4877,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.52.0",
 ]
 
@@ -4896,12 +4909,12 @@ dependencies = [
  "prettyplease",
  "progenitor",
  "progenitor-client",
- "quote 1.0.36",
+ "quote 1.0.37",
  "reqwest 0.11.27",
  "rustyline",
  "serde",
  "serde_json",
- "syn 2.0.76",
+ "syn 2.0.77",
  "tabled",
  "tokio",
  "uuid",
@@ -4975,7 +4988,7 @@ version = "1.33.1-feldera.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc62ec4b1d3f6641a0499d61efa9fc68b7b959d302595747a719aaed4a7dc5"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "borsh",
  "bytes",
  "num-traits",
@@ -4997,14 +5010,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5021,21 +5034,21 @@ dependencies = [
 
 [[package]]
 name = "fix-hidden-lifetime-bug"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ae9c2016a663983d4e40a9ff967d6dcac59819672f0b47f2b17574e99c33c8"
+checksum = "ab7b4994e93dd63050356bdde7d417591d1b348523638dc1c1f539f16e338d55"
 dependencies = [
  "fix-hidden-lifetime-bug-proc_macros",
 ]
 
 [[package]]
 name = "fix-hidden-lifetime-bug-proc_macros"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c81935e123ab0741c4c4f0d9b8377e5fb21d3de7e062fa4b1263b1fbcba1ea"
+checksum = "e8f0de9daf465d763422866d0538f07be1596e05623e120b37b4f715f5585200"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -5057,12 +5070,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -5211,7 +5224,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -5225,8 +5238,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5370,7 +5383,7 @@ dependencies = [
  "google-cloud-token",
  "home",
  "jsonwebtoken 9.3.0",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "thiserror",
@@ -5402,7 +5415,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae8ab26ef7c7c3f7dfb9cc3982293d031d8e78c85d00ddfb704b5c35aeff7c8"
 dependencies = [
- "prost 0.13.1",
+ "prost 0.13.2",
  "prost-types",
  "tonic",
 ]
@@ -5413,7 +5426,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
 dependencies = [
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "thiserror",
  "tokio",
 ]
@@ -5489,7 +5502,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5498,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5508,7 +5521,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5696,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -5713,7 +5726,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -5743,9 +5756,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5767,16 +5780,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -5793,7 +5806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs 0.6.3",
@@ -5809,7 +5822,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -5825,11 +5838,11 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "log",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.0",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -5843,7 +5856,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5857,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -5871,7 +5884,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5881,16 +5894,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -5951,7 +5964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -5968,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -5992,12 +6005,12 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.19"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.11",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "is-terminal",
  "itoa",
  "log",
@@ -6064,20 +6077,20 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -6142,18 +6155,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6301,9 +6314,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
@@ -6331,12 +6344,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6351,8 +6364,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
+ "redox_syscall 0.5.3",
 ]
 
 [[package]]
@@ -6368,9 +6382,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.18"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -6425,18 +6439,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -6525,10 +6539,10 @@ checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -6548,10 +6562,10 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "metrics",
  "num_cpus",
- "ordered-float 4.2.0",
+ "ordered-float 4.2.2",
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
@@ -6575,9 +6589,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -6623,7 +6637,7 @@ checksum = "14efd4b574325fcb981bce1ac700b9ccf071ec2eb94f7a6a6b583a84f228ba47"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -6634,6 +6648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -6648,14 +6671,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6687,8 +6711,8 @@ checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6745,7 +6769,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "libc",
 ]
@@ -6756,7 +6780,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -6809,9 +6833,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6839,7 +6863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -6850,8 +6874,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6860,7 +6884,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "itoa",
 ]
 
@@ -6941,7 +6965,7 @@ checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -6951,10 +6975,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6965,32 +6989,11 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "object_store"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "itertools 0.12.1",
- "parking_lot 0.12.3",
- "percent-encoding",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
 ]
 
 [[package]]
@@ -7005,16 +7008,16 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "itertools 0.13.0",
  "md-5",
  "parking_lot 0.12.3",
  "percent-encoding",
  "quick-xml 0.36.1",
  "rand",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "ring 0.17.8",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "snafu",
@@ -7032,9 +7035,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openapiv3"
@@ -7042,7 +7045,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_json",
 ]
@@ -7053,7 +7056,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -7069,8 +7072,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7173,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
 dependencies = [
  "num-traits",
  "rand",
@@ -7194,12 +7197,12 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7293,9 +7296,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7323,7 +7326,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
- "object_store 0.10.2",
+ "object_store",
  "paste",
  "seq-macro",
  "serde_json",
@@ -7331,7 +7334,7 @@ dependencies = [
  "thrift",
  "tokio",
  "twox-hash",
- "zstd 0.13.0",
+ "zstd 0.13.2",
  "zstd-sys",
 ]
 
@@ -7420,7 +7423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
 ]
 
 [[package]]
@@ -7506,8 +7509,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7582,12 +7585,12 @@ dependencies = [
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand 2.1.1",
  "futures-io",
 ]
 
@@ -7659,32 +7662,32 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -7698,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
 dependencies = [
  "bytes",
  "chrono",
@@ -7741,15 +7744,18 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -7757,15 +7763,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -7788,7 +7794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2 1.0.86",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7813,11 +7819,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
@@ -7828,7 +7834,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7840,7 +7846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "version_check",
 ]
 
@@ -7898,15 +7904,15 @@ dependencies = [
  "getopts",
  "heck 0.5.0",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "openapiv3",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.76",
+ "syn 2.0.77",
  "thiserror",
  "typify",
  "unicode-ident",
@@ -7921,13 +7927,13 @@ dependencies = [
  "openapiv3",
  "proc-macro2 1.0.86",
  "progenitor-impl",
- "quote 1.0.36",
+ "quote 1.0.37",
  "schemars",
  "serde",
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7953,7 +7959,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -7983,7 +7989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -7994,8 +8000,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8029,12 +8035,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
 dependencies = [
  "bytes",
- "prost-derive 0.13.1",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -8046,7 +8052,7 @@ dependencies = [
  "anyhow",
  "itertools 0.10.5",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -8059,30 +8065,30 @@ dependencies = [
  "anyhow",
  "itertools 0.12.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
 dependencies = [
- "prost 0.13.1",
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -8135,7 +8141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -8146,7 +8152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -8198,16 +8204,17 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -8215,14 +8222,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand",
  "ring 0.17.8",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -8232,9 +8239,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -8254,9 +8261,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2 1.0.86",
 ]
@@ -8339,11 +8346,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -8436,18 +8443,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -8493,17 +8500,17 @@ checksum = "bd81f69687fe8a1fa10995108b3ffc7cdbd63e682a4f8fbfd1020130780d7e17"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "refinery-core",
  "regex",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8573,7 +8580,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -8598,14 +8605,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8613,11 +8620,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -8631,8 +8638,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.0",
- "rustls-pemfile 2.1.2",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8649,7 +8656,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -8671,9 +8678,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.37"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -8733,7 +8740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -8745,18 +8752,18 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlimit"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3560f70f30a0f16d11d01ed078a07740fe6b489667abc7c7b029155d9f21c3d8"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "roaring"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
+checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -8799,7 +8806,7 @@ checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -8815,9 +8822,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -8826,22 +8833,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rust-embed-utils",
- "syn 2.0.76",
+ "syn 2.0.77",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
  "sha2",
  "walkdir",
@@ -8863,17 +8870,17 @@ version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "num-traits",
 ]
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.34.2"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e418701588729bef95e7a655f2b483ad64bb97c46e8e79fde83efd92aaab6d82"
+checksum = "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "rust_decimal",
 ]
 
@@ -8890,10 +8897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
+name = "rustc-hash"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -8914,11 +8927,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -8979,12 +8992,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -9001,9 +9014,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -9011,9 +9024,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -9061,7 +9074,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -9133,7 +9146,7 @@ dependencies = [
  "byteorder",
  "dashmap 5.5.3",
  "futures",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
 ]
@@ -9159,9 +9172,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "serde_derive_internals",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9208,11 +9221,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -9221,9 +9234,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -9246,18 +9259,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_arrow"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56acef131ef74bacc5e86c5038b524d61dee59d65c9e3e5e0f35b9de98cf99"
+checksum = "2118d57cd864dbd4fc0a54afcd1adc245051edf03c7419b99e4b7fb47bb3052a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -9271,13 +9284,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9287,8 +9300,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9305,9 +9318,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -9319,9 +9332,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "serde",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9338,15 +9351,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9356,14 +9369,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
- "darling 0.20.9",
+ "darling 0.20.10",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9372,7 +9385,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -9414,8 +9427,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9425,8 +9438,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9462,12 +9475,12 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9532,7 +9545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -9581,7 +9594,7 @@ checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -9708,8 +9721,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9794,7 +9807,7 @@ dependencies = [
  "heck 0.4.1",
  "once_cell",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "sha2",
  "sqlx-core",
  "sqlx-rt",
@@ -9821,9 +9834,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static-files"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64712ea1e3e140010e1d9605872ba205afa2ab5bd38191cc6ebd248ae1f6a06b"
+checksum = "4e8590e848e1c53be9258210bcd4a8f4118e08988f03a4e2d63b62e4ad9f7ced"
 dependencies = [
  "change-detection",
  "mime_guess",
@@ -9888,9 +9901,9 @@ checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustversion",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9901,9 +9914,9 @@ checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "rustversion",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9914,9 +9927,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.9.2"
+version = "12.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+checksum = "b1944ea8afd197111bca0c0edea1e1f56abb3edd030e240c1035cc0e3ff51fec"
 dependencies = [
  "debugid",
  "memmap2",
@@ -9926,9 +9939,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.9.2"
+version = "12.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+checksum = "ddaccaf1bf8e73c4f64f78dbb30aadd6965c71faa4ff3fba33f8d7296cf94a87"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -9953,18 +9966,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "unicode-ident",
 ]
 
@@ -9976,8 +9989,8 @@ checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -9991,12 +10004,15 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "sysinfo"
-version = "0.30.12"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -10049,7 +10065,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -10101,20 +10117,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
- "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "fastrand 2.1.1",
+ "once_cell",
+ "rustix 0.38.35",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10132,7 +10149,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.34",
+ "rustix 0.38.35",
  "windows-sys 0.48.0",
 ]
 
@@ -10167,22 +10184,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10289,9 +10306,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -10304,32 +10321,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10356,9 +10372,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -10466,21 +10482,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.14",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -10491,33 +10507,22 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
-dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -10532,17 +10537,17 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.1",
- "rustls-pemfile 2.1.2",
+ "prost 0.13.2",
+ "rustls-pemfile 2.1.3",
  "socket2 0.5.7",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -10576,15 +10581,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -10605,8 +10610,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10658,7 +10663,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "syn 1.0.109",
 ]
 
@@ -10694,8 +10699,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -10732,13 +10737,13 @@ dependencies = [
  "heck 0.5.0",
  "log",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regress",
  "schemars",
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.76",
+ "syn 2.0.77",
  "thiserror",
  "unicode-ident",
 ]
@@ -10750,13 +10755,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e6491896e955692d68361c68db2b263e3bec317ec0b684e0e2fa882fb6e31e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "schemars",
  "semver",
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.76",
+ "syn 2.0.77",
  "typify-impl",
 ]
 
@@ -10810,9 +10815,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
@@ -10894,7 +10899,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -10908,9 +10913,9 @@ checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
  "regex",
- "syn 2.0.76",
+ "syn 2.0.77",
  "uuid",
 ]
 
@@ -10923,7 +10928,7 @@ dependencies = [
  "actix-web",
  "mime_guess",
  "regex",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "rust-embed",
  "serde",
  "serde_json",
@@ -10968,19 +10973,19 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visibility"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -11007,7 +11012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "quote 1.0.37",
 ]
 
 [[package]]
@@ -11058,34 +11063,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -11095,32 +11101,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
- "quote 1.0.36",
+ "quote 1.0.37",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
@@ -11137,9 +11143,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11167,9 +11173,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11183,7 +11189,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.34",
+ "rustix 0.38.35",
 ]
 
 [[package]]
@@ -11215,11 +11221,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11235,7 +11241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11244,7 +11250,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11262,7 +11298,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11282,18 +11327,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -11304,9 +11349,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -11316,9 +11361,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11328,15 +11373,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -11346,9 +11391,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11358,9 +11403,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11370,9 +11415,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11382,9 +11427,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -11397,9 +11442,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -11409,16 +11454,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -11437,7 +11472,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -11465,7 +11500,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.14",
- "rustix 0.38.34",
+ "rustix 0.38.35",
 ]
 
 [[package]]
@@ -11476,9 +11511,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
+checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "xz2"
@@ -11503,22 +11538,23 @@ checksum = "2a599daf1b507819c1121f0bf87fa37eb19daac6aff3aefefd4e6e2e0f2020fc"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -11537,8 +11573,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.86",
- "quote 1.0.36",
- "syn 2.0.76",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -11572,7 +11608,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.2.6",
+ "indexmap 2.5.0",
  "num_enum 0.7.3",
  "thiserror",
 ]
@@ -11597,11 +11633,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.0.0",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -11626,18 +11662,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/crates/adapters/src/format/avro/input.rs
+++ b/crates/adapters/src/format/avro/input.rs
@@ -1,0 +1,446 @@
+use crate::{
+    catalog::{AvroStream, InputCollectionHandle},
+    format::avro::schema::{nullable_schema_value_schema, schema_json, validate_struct_schema},
+    ControllerError, DeCollectionHandle, InputFormat, ParseError, Parser,
+};
+use actix_web::HttpRequest;
+use apache_avro::{from_avro_datum, types::Value as AvroValue, Schema as AvroSchema};
+use erased_serde::Serialize as ErasedSerialize;
+use feldera_types::{
+    format::avro::{AvroParserConfig, AvroUpdateFormat},
+    program_schema::Relation,
+    serde_with_context::{
+        serde_config::DecimalFormat, DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat,
+    },
+};
+use log::{debug, info};
+use schema_registry_converter::blocking::schema_registry::{get_schema_by_id, SrSettings};
+use serde::Deserialize;
+use serde_urlencoded::Deserializer as UrlDeserializer;
+use serde_yaml::Value as YamlValue;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+// TODO: Error handling here is a bit of a mess. Schema parsing and validation happens
+// as part of message processing; however since input_XXX methods must return `ParseError`,
+// we end up wrapping other error types like schema validation errors in ParseError.
+// The right solution is to allow `input_chunk`, `input_fragment` to return the more general
+// `ControllerError` type.  There are multiple concurrent refactorings of this crate
+// going on at the moment, so we'll do this later.
+
+use super::schema_registry_settings;
+
+pub const fn avro_de_config() -> &'static SqlSerdeConfig {
+    &SqlSerdeConfig {
+        timestamp_format: TimestampFormat::MicrosSinceEpoch,
+        time_format: TimeFormat::Micros,
+        date_format: DateFormat::DaysSinceEpoch,
+        decimal_format: DecimalFormat::String,
+    }
+}
+
+pub struct AvroInputFormat;
+
+impl InputFormat for AvroInputFormat {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("avro")
+    }
+
+    fn new_parser(
+        &self,
+        endpoint_name: &str,
+        input_handle: &InputCollectionHandle,
+        config: &YamlValue,
+    ) -> Result<Box<dyn Parser>, ControllerError> {
+        let config = AvroParserConfig::deserialize(config).map_err(|e| {
+            ControllerError::parser_config_parse_error(
+                endpoint_name,
+                &e,
+                &serde_yaml::to_string(config).unwrap_or_default(),
+            )
+        })?;
+
+        let parser = AvroParser::create(
+            endpoint_name,
+            &input_handle.schema,
+            input_handle.handle.fork(),
+            config.clone(),
+        )?;
+
+        Ok(Box::new(parser) as Box<dyn Parser>)
+    }
+
+    fn config_from_http_request(
+        &self,
+        endpoint_name: &str,
+        request: &HttpRequest,
+    ) -> Result<Box<dyn ErasedSerialize>, ControllerError> {
+        Ok(Box::new(
+            AvroParserConfig::deserialize(UrlDeserializer::new(form_urlencoded::parse(
+                request.query_string().as_bytes(),
+            )))
+            .map_err(|e| {
+                ControllerError::parser_config_parse_error(
+                    endpoint_name,
+                    &e,
+                    request.query_string(),
+                )
+            })?,
+        ))
+    }
+}
+
+struct AvroParser {
+    endpoint_name: String,
+    sr_settings: Option<SrSettings>,
+    input_handle: Box<dyn DeCollectionHandle>,
+    input_stream: Option<Box<dyn AvroStream>>,
+    config: AvroParserConfig,
+    relation_schema: Relation,
+
+    schema_id: Option<u32>,
+    schema: Option<AvroSchema>,
+    last_event_number: u64,
+
+    /// Schema cache shared between all clones of this connector.
+    ///
+    /// When the connector first starts, the first worker to get a message will retrieve
+    /// the schema; the other workers will get it from the cache.  Likewise, if the schema
+    /// changes later, the new one will only be retrieved once.
+    ///
+    /// Note that we cache errors to avoid spamming the schema registry when the
+    /// schema is invalid.
+    schema_cache: Arc<Mutex<HashMap<u32, Result<AvroSchema, String>>>>,
+}
+
+impl AvroParser {
+    fn create(
+        endpoint_name: &str,
+        relation_schema: &Relation,
+        input_handle: Box<dyn DeCollectionHandle>,
+        config: AvroParserConfig,
+    ) -> Result<Self, ControllerError> {
+        let sr_settings = schema_registry_settings(&config.registry_config)
+            .map_err(|e| ControllerError::invalid_parser_configuration(endpoint_name, &e))?;
+
+        if config.schema.is_none() && sr_settings.is_none() {
+            return Err(ControllerError::invalid_parser_configuration(
+                endpoint_name,
+                "Avro connector configuration missing schema information; please specify either a 'schema' or a schema registry",
+            ));
+        }
+
+        if config.schema.is_none() && config.no_schema_id {
+            return Err(ControllerError::invalid_parser_configuration(
+                endpoint_name,
+                "Avro connector, configured with 'no_schema_id' flag, does not specify an Avro schema; please provide the schema definition in the 'schema' field",
+            ));
+        }
+
+        let mut parser = Self {
+            endpoint_name: endpoint_name.to_string(),
+            input_handle,
+            sr_settings,
+            input_stream: None,
+            config: config.clone(),
+            schema_id: None,
+            relation_schema: relation_schema.clone(),
+            schema: None,
+            last_event_number: 0,
+            schema_cache: Arc::new(Mutex::new(HashMap::new())),
+        };
+
+        if let Some(schema) = &config.schema {
+            let schema = parser.validate_schema(schema)?;
+            parser.set_schema(schema)?;
+        }
+
+        Ok(parser)
+    }
+
+    fn lookup_schema(&mut self, schema_id: u32) -> Result<AvroSchema, String> {
+        let mut cache = self.schema_cache.lock().unwrap();
+
+        if let Some(res) = cache.get(&schema_id) {
+            return res.clone();
+        }
+
+        info!(
+            "avro parser {}: encountered new schema id {schema_id}",
+            self.endpoint_name
+        );
+
+        match get_schema_by_id(schema_id, self.sr_settings.as_ref().unwrap()) {
+            Err(e) => {
+                let error = format!(
+                    "error retrieving Avro schema {schema_id} from the schema registry: {e}"
+                );
+
+                cache.insert(schema_id, Err(error.clone()));
+                Err(error)
+            }
+            Ok(schema) => {
+                debug!(
+                    "avro parser: {}: retrieved new schema (id: {schema_id}): {}",
+                    self.endpoint_name, &schema.schema
+                );
+
+                match self.validate_schema(&schema.schema) {
+                    Err(e) => {
+                        cache.insert(schema_id, Err(e.to_string()));
+                        Err(e.to_string())
+                    }
+                    Ok(schema) => {
+                        cache.insert(schema_id, Ok(schema.clone()));
+                        Ok(schema)
+                    }
+                }
+            }
+        }
+    }
+
+    fn set_schema(&mut self, schema: AvroSchema) -> Result<(), ControllerError> {
+        debug!("Setting Avro schema: {}", schema_json(&schema));
+        self.schema = Some(schema);
+
+        self.input_stream = Some(self.input_handle.configure_avro_deserializer()?);
+
+        Ok(())
+    }
+
+    fn value_schema<'a>(&self, schema: &'a AvroSchema) -> Result<&'a AvroSchema, ControllerError> {
+        match self.config.update_format {
+            AvroUpdateFormat::Raw => Ok(schema),
+            AvroUpdateFormat::Debezium => match schema {
+                AvroSchema::Record(record_schema) => {
+                    let before_field = *record_schema.lookup.get("before").ok_or_else(|| {
+                        ControllerError::schema_validation_error(&format!(
+                            "invalid Debezium Avro schema: schema is missing the 'before' field: {}", schema_json(schema)
+                        ))
+                    })?;
+                    let before_schema = &record_schema.fields[before_field].schema;
+                    Ok(nullable_schema_value_schema(before_schema)
+                        .ok_or_else(|| ControllerError::schema_validation_error(&format!("invalid Debezium Avro schema: 'before' must be a nullable field, but its schema is {}", schema_json(before_schema))))?)
+                }
+                _ => Err(ControllerError::schema_validation_error(&format!(
+                    "invalid Debezium Avro schema: expected schema of type 'record', but found: {}",
+                    schema_json(schema)
+                ))),
+            },
+        }
+    }
+
+    fn validate_schema(&self, schema_str: &str) -> Result<AvroSchema, ControllerError> {
+        let schema = AvroSchema::parse_str(schema_str).map_err(|e| {
+            ControllerError::invalid_parser_configuration(
+                &self.endpoint_name,
+                &format!("error parsing Avro schema: {e}"),
+            )
+        })?;
+
+        let value_schema = self.value_schema(&schema)?;
+
+        validate_struct_schema(value_schema, &self.relation_schema.fields).map_err(|e| {
+            ControllerError::schema_validation_error(&format!("error validating Avro schema: {e}"))
+        })?;
+
+        Ok(schema)
+    }
+
+    fn input(&mut self, data: &[u8]) -> Result<(), ParseError> {
+        self.last_event_number += 1;
+
+        let mut record = if !self.config.no_schema_id {
+            if data.len() < 5 {
+                return Err(ParseError::bin_event_error(
+                        "Avro record is less than 5 bytes long (valid Avro records must include a 5-byte header)".to_string(),
+                        self.last_event_number,
+                        data,
+                        None,
+                    ));
+            }
+
+            if data[0] != 0 {
+                return Err(ParseError::bin_event_error(
+                        "the first byte in an Avro record is not 0 (valid Avro records start with a 0 magic byte)".to_string(),
+                        self.last_event_number,
+                        data,
+                        None,
+                    ));
+            }
+
+            let schema_id = u32::from_be_bytes(data[1..5].try_into().unwrap());
+
+            // Ignore the schema id if the connector has a statically configured schema.
+            if self.config.schema.is_none() {
+                // New or modified schema detected - retrieve the schema from the registry.
+                if self.schema_id != Some(schema_id) {
+                    let schema = self.lookup_schema(schema_id).map_err(|e| {
+                        ParseError::bin_event_error(e, self.last_event_number, data, None)
+                    })?;
+
+                    self.set_schema(schema).map_err(|e| {
+                        ParseError::bin_event_error(
+                            e.to_string(),
+                            self.last_event_number,
+                            data,
+                            None,
+                        )
+                    })?;
+
+                    self.schema_id = Some(schema_id);
+
+                    // TODO: rate-limit errors.
+                }
+            }
+
+            &data[5..]
+        } else {
+            data
+        };
+
+        // At this point we should either have a statically configured schema or a successfully installed schema from
+        // the schema registry.
+        assert!(self.input_stream.is_some());
+        assert!(self.schema.is_some());
+        let input_stream = self.input_stream.as_mut().unwrap();
+
+        let record_copy = record;
+
+        let avro_value = from_avro_datum(self.schema.as_ref().unwrap(), &mut record, None)
+            .map_err(|e| {
+                ParseError::bin_envelope_error(
+                    format!("error parsing avro record: {e}"),
+                    record_copy,
+                    None,
+                )
+            })?;
+
+        match self.config.update_format {
+            AvroUpdateFormat::Raw => input_stream.insert(&avro_value).map_err(|e| {
+                ParseError::bin_event_error(
+                    format!(
+                        "error converting avro record to table row (record: {avro_value:?}): {e}"
+                    ),
+                    self.last_event_number,
+                    data,
+                    None,
+                )
+            })?,
+            AvroUpdateFormat::Debezium => {
+                let (before, after) = Self::extract_debezium_values(&avro_value)?;
+                if let Some(before) = before {
+                    input_stream.delete(before).map_err(|e| {
+                        ParseError::bin_event_error(
+                            format!(
+                                "error converting 'before' record to table row (record: {before:?}): {e}"
+                            ),
+                            self.last_event_number,
+                            data,
+                            None,
+                        )
+                    })?;
+                }
+                if let Some(after) = after {
+                    input_stream.insert(after).map_err(|e| {
+                            ParseError::bin_event_error(
+                                format!(
+                                    "error converting 'after' record to table row (record: {after:?}): {e}"
+                                ),
+                                self.last_event_number,
+                                data,
+                                None,
+                            )
+                        })?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract before and after fields from a debezium value.
+    fn extract_debezium_values(
+        value: &AvroValue,
+    ) -> Result<(Option<&AvroValue>, Option<&AvroValue>), ParseError> {
+        let AvroValue::Record(fields) = value else {
+            return Err(ParseError::bin_envelope_error(
+                format!(
+                    "not a valid Debezium message: expected Avro record, but found '{value:?}'"
+                ),
+                &[],
+                None,
+            ));
+        };
+
+        let mut before = None;
+        let mut after = None;
+        let mut fields = fields.iter();
+
+        let mut field = fields.next();
+
+        while let Some((name, value)) = field {
+            if name == "before" {
+                if let AvroValue::Union(_, val) = value {
+                    if **val != AvroValue::Null {
+                        before = Some(&**val);
+                    }
+                }
+            }
+
+            if name == "after" {
+                if let AvroValue::Union(_, val) = value {
+                    if **val != AvroValue::Null {
+                        after = Some(&**val);
+                    }
+                }
+                break;
+            }
+            field = fields.next();
+        }
+
+        Ok((before, after))
+    }
+}
+
+impl Parser for AvroParser {
+    fn input_fragment(&mut self, data: &[u8]) -> (usize, Vec<ParseError>) {
+        (
+            0,
+            vec![ParseError::bin_envelope_error(
+                "Avro streaming parser received an incomplete data fragment. This parser should only be used with message-based transports like Kafka.".to_string(),
+                data,
+                None,
+            )],
+        )
+    }
+
+    fn input_chunk(&mut self, data: &[u8]) -> (usize, Vec<ParseError>) {
+        match self.input(data) {
+            Ok(()) => (1, vec![]),
+            Err(e) => (1, vec![e]),
+        }
+    }
+
+    fn eoi(&mut self) -> (usize, Vec<ParseError>) {
+        (0, vec![])
+    }
+
+    fn fork(&self) -> Box<dyn Parser> {
+        Box::new(AvroParser {
+            endpoint_name: self.endpoint_name.clone(),
+            input_handle: self.input_handle.fork(),
+            sr_settings: self.sr_settings.clone(),
+            input_stream: self.input_stream.as_ref().map(|s| s.fork()),
+            config: self.config.clone(),
+            schema_id: self.schema_id,
+            relation_schema: self.relation_schema.clone(),
+            schema: self.schema.clone(),
+            last_event_number: 0,
+            schema_cache: self.schema_cache.clone(),
+        })
+    }
+}

--- a/crates/adapters/src/format/avro/mod.rs
+++ b/crates/adapters/src/format/avro/mod.rs
@@ -1,2 +1,78 @@
+use std::time::Duration;
+
+use feldera_types::format::avro::AvroSchemaRegistryConfig;
+use schema_registry_converter::blocking::schema_registry::SrSettings;
+
+pub mod input;
 pub mod output;
+mod schema;
 pub mod serializer;
+
+#[cfg(test)]
+mod test;
+
+/// Convert schema registry config to `struct SrSettings` used by the
+/// `schema_registry_converter` crate.
+fn schema_registry_settings(
+    config: &AvroSchemaRegistryConfig,
+) -> Result<Option<SrSettings>, String> {
+    if config.registry_urls.is_empty() {
+        if config.registry_username.is_some() {
+            return Err("'registry_username' requires 'registry_urls' to be set".to_string());
+        }
+        if config.registry_authorization_token.is_some() {
+            return Err(
+                "'registry_authorization_token' requires 'registry_urls' to be set".to_string(),
+            );
+        }
+        if config.registry_proxy.is_some() {
+            return Err("'registry_proxy' requires 'registry_urls' to be set".to_string());
+        }
+        if !config.registry_headers.is_empty() {
+            return Err("'registry_headers' requires 'registry_urls' to be set".to_string());
+        }
+    }
+
+    if config.registry_username.is_some() && config.registry_authorization_token.is_some() {
+        return Err(
+            "'registry_username' and 'registry_authorization_token' options are mutually exclusive"
+                .to_string(),
+        );
+    }
+
+    if config.registry_password.is_some() && config.registry_username.is_none() {
+        return Err("'registry_password' option provided without 'registry_username'".to_string());
+    }
+
+    if !config.registry_urls.is_empty() {
+        let mut sr_settings_builder = SrSettings::new_builder(config.registry_urls[0].clone());
+        for url in &config.registry_urls[1..] {
+            sr_settings_builder.add_url(url.clone());
+        }
+        if let Some(username) = &config.registry_username {
+            sr_settings_builder
+                .set_basic_authorization(username, config.registry_password.as_deref());
+        }
+        if let Some(token) = &config.registry_authorization_token {
+            sr_settings_builder.set_token_authorization(token);
+        }
+
+        for (key, val) in config.registry_headers.iter() {
+            sr_settings_builder.add_header(key.as_str(), val.as_str());
+        }
+
+        if let Some(proxy) = &config.registry_proxy {
+            sr_settings_builder.set_proxy(proxy.as_str());
+        }
+
+        if let Some(timeout) = config.registry_timeout_secs {
+            sr_settings_builder.set_timeout(Duration::from_secs(timeout));
+        }
+
+        Ok(Some(sr_settings_builder.build().map_err(|e| {
+            format!("invalid schema registry configuration: {e}")
+        })?))
+    } else {
+        Ok(None)
+    }
+}

--- a/crates/adapters/src/format/avro/schema.rs
+++ b/crates/adapters/src/format/avro/schema.rs
@@ -1,0 +1,238 @@
+//! Helpers for working with Avro schemas.
+
+use apache_avro::{schema::RecordField, Schema as AvroSchema};
+use feldera_types::program_schema::{canonical_identifier, ColumnType, Field, SqlType};
+
+/// Convert schema to JSON format.
+pub fn schema_json(schema: &AvroSchema) -> String {
+    serde_json::to_string(schema).unwrap_or_else(
+        // This should never happen, but just in case.
+        |_| "Avro schema cannot be converted to JSON".to_string(),
+    )
+}
+
+/// Extract value type schema from a nullable field schema, which has the following shape:
+/// Union[null, type] or Union[type, null]. Returns `None` if `schema` doesn't match this
+/// pattern.
+pub fn nullable_schema_value_schema(schema: &AvroSchema) -> Option<&AvroSchema> {
+    match schema {
+        AvroSchema::Union(union_schema) => match union_schema.variants() {
+            [AvroSchema::Null, s] => Some(s),
+            [s, AvroSchema::Null] => Some(s),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Find a field in a record schema.
+fn lookup_field<'a>(fields: &'a [RecordField], field: &'a Field) -> Option<&'a RecordField> {
+    let name = field.name.name();
+
+    // TODO: check `record_field.aliases`.
+    fields
+        .iter()
+        .find(|&record_field| canonical_identifier(&record_field.name) == name)
+}
+
+/// Check that Avro schema can be deserialized into a struct with
+/// specified field.
+pub fn validate_struct_schema(
+    avro_schema: &AvroSchema,
+    struct_schema: &[Field],
+) -> Result<(), String> {
+    let AvroSchema::Record(record_schema) = avro_schema else {
+        return Err(format!(
+            "expected schema of type 'record', but found {}",
+            schema_json(avro_schema)
+        ));
+    };
+
+    for field in struct_schema {
+        let avro_field = lookup_field(&record_schema.fields, field).ok_or_else(|| {
+            format!(
+                "column '{}' is missing in the Avro schema",
+                field.name.name()
+            )
+        })?;
+
+        validate_field_schema(&avro_field.schema, &field.columntype).map_err(|e| {
+            format!(
+                "error validating schema for column '{}': {e}",
+                field.name.name()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized into an array with
+/// specified element type.
+fn validate_array_schema(
+    avro_schema: &AvroSchema,
+    component_schema: &ColumnType,
+) -> Result<(), String> {
+    let AvroSchema::Array(element_schema) = avro_schema else {
+        return Err(format!(
+            "expected schema of type 'array', but found {}",
+            schema_json(avro_schema)
+        ));
+    };
+
+    validate_field_schema(element_schema, component_schema)
+        .map_err(|e| format!("error validating array element schema: {e}"))?;
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized into a map with
+/// specified value type (assumes that map keys are strings).
+fn validate_map_schema(avro_schema: &AvroSchema, value_schema: &ColumnType) -> Result<(), String> {
+    let AvroSchema::Map(element_schema) = avro_schema else {
+        return Err(format!(
+            "expected schema of type 'map', but found {}",
+            schema_json(avro_schema)
+        ));
+    };
+
+    validate_field_schema(element_schema, value_schema)
+        .map_err(|e| format!("error validating map value schema: {e}"))?;
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized as SQL `TIMESTAMP` type.
+fn validate_timestamp_schema(avro_schema: &AvroSchema) -> Result<(), String> {
+    // TODO: we can support TimestampMillis by transforming them to micros on the fly.
+    if avro_schema == &AvroSchema::TimestampMillis {
+        return Err("Avro timestamp encoding using 'timestamp-millis' type is currently not supported; use 'timestamp-micros instead'".to_string());
+    }
+
+    if avro_schema != &AvroSchema::TimestampMicros && avro_schema != &AvroSchema::Long {
+        return Err(format!(
+            "invalid Avro schema for a column of type 'TIMESTAMP': expected 'timestamp-micros' or 'long', but found {}",
+            schema_json(avro_schema)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized as SQL `TIME` type.
+fn validate_time_schema(avro_schema: &AvroSchema) -> Result<(), String> {
+    // TODO: we can support TimeMillis by transforming them to micros on the fly.
+    if avro_schema == &AvroSchema::TimeMillis {
+        return Err("Avro time encoding using 'time-millis' type is currently not supported; use 'time-micros instead'".to_string());
+    }
+
+    if avro_schema != &AvroSchema::TimeMicros && avro_schema != &AvroSchema::Long {
+        return Err(format!(
+            "invalid Avro schema for a column of type 'TIME': expected 'time-micros' ot 'long', but found {}",
+            schema_json(avro_schema)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized as SQL `DATE` type.
+fn validate_date_schema(avro_schema: &AvroSchema) -> Result<(), String> {
+    if avro_schema != &AvroSchema::Int && avro_schema != &AvroSchema::Date {
+        return Err(format!(
+            "invalid Avro schema for a column of type 'DATE': expected 'date' ot 'int', but found {}",
+            schema_json(avro_schema)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check that Avro schema can be deserialized a SQL column with the given
+/// column type.
+pub fn validate_field_schema(
+    avro_schema: &AvroSchema,
+    field_schema: &ColumnType,
+) -> Result<(), String> {
+    if field_schema.nullable {
+        let avro_inner = nullable_schema_value_schema(avro_schema).ok_or_else(|| {
+            format!(
+                "nullable column with non-nullable Avro schema {}",
+                schema_json(avro_schema)
+            )
+        })?;
+        let mut field_schema = field_schema.clone();
+        field_schema.nullable = false;
+        return validate_field_schema(avro_inner, &field_schema);
+    };
+
+    let expected = match field_schema.typ {
+        SqlType::Boolean => AvroSchema::Boolean,
+        SqlType::TinyInt | SqlType::SmallInt | SqlType::Int => AvroSchema::Int,
+        SqlType::BigInt => AvroSchema::Long,
+        SqlType::Real => AvroSchema::Float,
+        SqlType::Double => AvroSchema::Double,
+        SqlType::Decimal => {
+            return Err("not implemented: Avro deserialization for the 'DECIMAL' type".to_string());
+        }
+        SqlType::Char | SqlType::Varchar => AvroSchema::String,
+        SqlType::Binary | SqlType::Varbinary => AvroSchema::Bytes,
+        SqlType::Time => {
+            return validate_time_schema(avro_schema);
+        }
+        SqlType::Date => {
+            return validate_date_schema(avro_schema);
+        }
+        SqlType::Timestamp => {
+            return validate_timestamp_schema(avro_schema);
+        }
+        SqlType::Interval(_) => {
+            // This type currently cannot occur in SQL table declarations.
+            return Err("not implemented: Avro deserialization for 'INTERVAL' type".to_string());
+        }
+        SqlType::Array => {
+            // This schema is generated by the SQL compiler, so this should never happen.
+            if field_schema.component.is_none() {
+                return Err("internal error: relation schema contains an array field with a missing component type".to_string());
+            }
+            return validate_array_schema(avro_schema, field_schema.component.as_ref().unwrap());
+        }
+        SqlType::Struct => {
+            return validate_struct_schema(
+                avro_schema,
+                field_schema.fields.as_ref().unwrap_or(&vec![]),
+            );
+        }
+        SqlType::Map => {
+            let Some(key_type) = &field_schema.key else {
+                return Err(
+                    "internal error: relation schema contains a map field, with a missing key type"
+                        .to_string(),
+                );
+            };
+            let Some(value_type) = &field_schema.value else {
+                return Err("internal error: relation schema contains a map field, with a missing value type".to_string());
+            };
+
+            if key_type.typ != SqlType::Char || key_type.typ != SqlType::Varchar {
+                return Err(format!(
+                    "cannot deserialize map with key type '{}': Avro only allows string keys",
+                    serde_json::to_string(&key_type.typ).unwrap()
+                ));
+            }
+
+            return validate_map_schema(avro_schema, value_type);
+        }
+        SqlType::Null => AvroSchema::Null,
+    };
+
+    if avro_schema != &expected {
+        return Err(format!(
+            "expected Avro schema '{}', but found '{}'",
+            schema_json(&expected),
+            schema_json(avro_schema)
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/adapters/src/format/avro/test.rs
+++ b/crates/adapters/src/format/avro/test.rs
@@ -1,0 +1,444 @@
+use super::{
+    output::AvroEncoder,
+    schema::schema_json,
+    serializer::{avro_ser_config, AvroSchemaSerializer},
+};
+use crate::{
+    static_compile::seroutput::SerBatchImpl,
+    test::{
+        generate_test_batches_with_weights, mock_parser_pipeline, MockOutputConsumer, MockUpdate,
+        TestStruct, TestStruct2,
+    },
+    transport::InputConsumer,
+    Encoder, FormatConfig, ParseError, SerBatch,
+};
+use apache_avro::{schema::ResolvedSchema, to_avro_datum, Schema as AvroSchema};
+use dbsp::utils::Tup2;
+use dbsp::{DBData, OrdZSet};
+use feldera_types::{
+    format::avro::AvroEncoderConfig,
+    serde_with_context::{DeserializeWithContext, SerializeWithContext, SqlSerdeConfig},
+};
+use feldera_types::{
+    format::avro::{AvroParserConfig, AvroUpdateFormat},
+    serialize_struct,
+};
+use log::trace;
+use proptest::prelude::*;
+use proptest::proptest;
+use serde::Deserialize;
+use serde::Serialize;
+use std::sync::Arc;
+use std::{borrow::Cow, collections::HashMap, fmt::Debug};
+
+#[derive(Debug)]
+struct TestCase<T> {
+    config: AvroParserConfig,
+    /// Input data, expected result.
+    input_batches: Vec<(Vec<u8>, Vec<ParseError>)>,
+    /// Expected contents at the end of the test.
+    expected_output: Vec<MockUpdate<T, ()>>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct DebeziumSource {
+    version: String,
+    connector: String,
+    name: String,
+    ts_ms: i64,
+    snapshot: Option<()>,
+    db: String,
+    sequence: Option<String>,
+    schema: String,
+    table: String,
+    tx_id: Option<i64>,
+    lsn: Option<i64>,
+    xmin: Option<i64>,
+}
+
+serialize_struct!(DebeziumSource()[12]{
+    version["version"]: String,
+    connector["connector"]: String,
+    name["name"]: String,
+    ts_ms["ts_ms"]: i64,
+    snapshot["snapshot"]: Option<()>,
+    db["db"]: String,
+    sequence["sequence"]: Option<String>,
+    schema["schema"]: String,
+    table["table"]: String,
+    tx_id["txId"]: Option<i64>,
+    lsn["lsn"]: Option<i64>,
+    xmin["xmin"]: Option<i64>
+});
+
+#[derive(Debug, Serialize)]
+struct DebeziumMessage<T> {
+    before: Option<T>,
+    after: Option<T>,
+    source: DebeziumSource,
+    op: String,
+    ts_ms: Option<i64>,
+    transaction: Option<()>,
+}
+
+serialize_struct!(DebeziumMessage(T)[6]{
+    before["before"]: Option<T>,
+    after["after"]: Option<T>,
+    source["source"]: DebeziumSource,
+    op["op"]: String,
+    ts_ms["ts_ms"]: Option<i64>,
+    transaction["transaction"]: Option<()>
+});
+
+impl<T> DebeziumMessage<T> {
+    fn new(op: &str, before: Option<T>, after: Option<T>) -> Self {
+        Self {
+            before,
+            after,
+            source: Default::default(),
+            op: op.to_string(),
+            ts_ms: None,
+            transaction: None,
+        }
+    }
+}
+
+/// Debezium message Avro schema with the specified inner record schema.
+fn debezium_avro_schema(value_schema: &str, value_type_name: &str) -> AvroSchema {
+    let schema_str = r#"{
+    "type": "record",
+    "name": "Envelope",
+    "namespace": "test_namespace",
+    "fields": [
+        {
+            "name": "before",
+            "type": [
+                "null",
+                VALUE_SCHEMA
+            ],
+            "default": null
+        },
+        {
+            "name": "after",
+            "type": [
+                "null",
+                "VALUE_TYPE"
+            ],
+            "default": null
+        },
+        {
+            "name": "source",
+            "type": {
+                "type": "record",
+                "name": "Source",
+                "namespace": "io.debezium.connector.postgresql",
+                "fields": [
+                    { "name": "version", "type": "string" },
+                    { "name": "connector", "type": "string" },
+                    { "name": "name", "type": "string" },
+                    { "name": "ts_ms", "type": "long" },
+                    { "name": "snapshot", "type": [ { "type": "string", "connect.version": 1, "connect.parameters": { "allowed": "true,last,false,incremental" }, "connect.default": "false", "connect.name": "io.debezium.data.Enum" }, "null" ], "default": "false" },
+                    { "name": "db", "type": "string" },
+                    { "name": "sequence", "type": [ "null", "string" ], "default": null },
+                    { "name": "schema", "type": "string" }, { "name": "table", "type": "string" },
+                    { "name": "txId", "type": [ "null", "long" ], "default": null },
+                    { "name": "lsn", "type": [ "null", "long" ], "default": null },
+                    { "name": "xmin", "type": [ "null", "long" ], "default": null }
+                ],
+                "connect.name": "io.debezium.connector.postgresql.Source"
+            }
+        },
+        {
+            "name": "op",
+            "type": "string"
+        },
+        {
+            "name": "ts_ms",
+            "type": [
+                "null",
+                "long"
+            ],
+            "default": null
+        },
+        {
+            "name": "transaction",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "block",
+                    "namespace": "event",
+                    "fields": [
+                        { "name": "id", "type": "string" },
+                        { "name": "total_order", "type": "long" },
+                        { "name": "data_collection_order", "type": "long" }
+                    ],
+                    "connect.version": 1,
+                    "connect.name": "event.block"
+                }
+            ],
+            "default": null
+        }
+    ],
+    "connect.version": 1,
+    "connect.name": "test_namespace.Envelope"
+}"#.replace("VALUE_SCHEMA", &value_schema).replace("VALUE_TYPE", value_type_name);
+
+    println!("Debezium Avro schema: {schema_str}");
+
+    AvroSchema::parse_str(&schema_str).unwrap()
+}
+
+/// Generate a test case using raw Avro update format.
+fn gen_raw_parser_test<T>(data: &[T], avro_schema_str: &str) -> TestCase<T>
+where
+    T: Clone
+        + Debug
+        + Eq
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Send
+        + 'static,
+{
+    let config = AvroParserConfig {
+        update_format: AvroUpdateFormat::Raw,
+        schema: Some(avro_schema_str.to_string()),
+        no_schema_id: false,
+        registry_config: Default::default(),
+    };
+
+    let avro_schema = AvroSchema::parse_str(avro_schema_str).unwrap();
+
+    let input_batches = data
+        .iter()
+        .map(|x| {
+            // 5-byte header
+            let mut buffer = vec![0; 5];
+            let refs = HashMap::new();
+            let serializer = AvroSchemaSerializer::new(&avro_schema, &refs);
+            let val = x
+                .serialize_with_context(serializer, &avro_ser_config())
+                .unwrap();
+            let mut avro_record = to_avro_datum(&avro_schema, val).unwrap();
+            buffer.append(&mut avro_record);
+            (buffer, vec![])
+        })
+        .collect::<Vec<_>>();
+
+    let expected_output = data
+        .iter()
+        .map(|x| MockUpdate::Insert(x.clone()))
+        .collect::<Vec<_>>();
+
+    TestCase {
+        config,
+        input_batches,
+        expected_output,
+    }
+}
+
+/// Generate a test case using Debezium Avro update format.
+fn gen_debezium_parser_test<T>(data: &[T], avro_schema_str: &str, type_name: &str) -> TestCase<T>
+where
+    T: Clone
+        + Debug
+        + Eq
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Send
+        + 'static,
+{
+    let debezium_schema = debezium_avro_schema(avro_schema_str, type_name);
+    let resolved = ResolvedSchema::try_from(&debezium_schema).unwrap();
+
+    let config = AvroParserConfig {
+        update_format: AvroUpdateFormat::Debezium,
+        schema: Some(schema_json(&debezium_schema)),
+        no_schema_id: false,
+        registry_config: Default::default(),
+    };
+
+    let input_batches = data
+        .iter()
+        .map(|x| {
+            // 5-byte header
+            let mut buffer = vec![0; 5];
+            let serializer = AvroSchemaSerializer::new(&debezium_schema, resolved.get_names());
+            let dbz_message = DebeziumMessage::new("u", Some(x.clone()), Some(x.clone()));
+            let val = dbz_message
+                .serialize_with_context(serializer, &avro_ser_config())
+                .unwrap();
+            let mut avro_record = to_avro_datum(&debezium_schema, val).unwrap();
+            buffer.append(&mut avro_record);
+            (buffer, vec![])
+        })
+        .collect::<Vec<_>>();
+
+    let expected_output = data
+        .iter()
+        .map(|x| vec![MockUpdate::Delete(x.clone()), MockUpdate::Insert(x.clone())])
+        .flatten()
+        .collect::<Vec<_>>();
+
+    TestCase {
+        config,
+        input_batches,
+        expected_output,
+    }
+}
+
+fn run_parser_test<T>(test_cases: Vec<TestCase<T>>)
+where
+    T: Debug + Eq + for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+{
+    for test in test_cases {
+        let format_config = FormatConfig {
+            name: Cow::from("avro"),
+            config: serde_yaml::to_value(test.config).unwrap(),
+        };
+
+        let (mut consumer, outputs) = mock_parser_pipeline(&format_config).unwrap();
+        consumer.on_error(Some(Box::new(|_, _| {})));
+        for (avro, expected_result) in test.input_batches {
+            let res = consumer.input_chunk(&avro);
+            assert_eq!(&res, &expected_result);
+        }
+        consumer.eoi();
+        assert_eq!(&test.expected_output, &outputs.state().flushed);
+    }
+}
+
+#[test]
+fn test_raw_avro_parser() {
+    let test_case = gen_raw_parser_test(&TestStruct2::data(), &TestStruct2::avro_schema());
+
+    run_parser_test(vec![test_case])
+}
+
+#[test]
+fn test_debezium_avro_parser() {
+    let test_case = gen_debezium_parser_test(
+        &TestStruct2::data(),
+        &TestStruct2::avro_schema(),
+        "TestStruct2",
+    );
+
+    run_parser_test(vec![test_case])
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2))]
+
+    #[test]
+    fn proptest_raw_avro_parser(data in proptest::collection::vec(any::<TestStruct2>(), 0..=10000))
+    {
+        let test_case = gen_raw_parser_test(&data, &TestStruct2::avro_schema());
+
+        run_parser_test(vec![test_case])
+    }
+
+    #[test]
+    fn proptest_debezium_avro_parser(data in proptest::collection::vec(any::<TestStruct2>(), 0..=10000))
+    {
+        let test_case = gen_debezium_parser_test(&data, &TestStruct2::avro_schema(), "TestStruct2");
+
+        run_parser_test(vec![test_case])
+    }
+
+}
+
+fn test_avro_output<T>(avro_schema: &str, batches: Vec<Vec<Tup2<T, i64>>>)
+where
+    T: DBData + for<'de> Deserialize<'de> + SerializeWithContext<SqlSerdeConfig>,
+{
+    let config = AvroEncoderConfig {
+        schema: avro_schema.to_string(),
+        ..Default::default()
+    };
+
+    let consumer = MockOutputConsumer::new();
+    let consumer_data = consumer.data.clone();
+    let mut encoder =
+        AvroEncoder::create("avro_test_endpoint", Box::new(consumer), config).unwrap();
+    let zsets = batches
+        .iter()
+        .map(|batch| {
+            let zset = OrdZSet::from_keys(
+                (),
+                batch
+                    .iter()
+                    .map(|Tup2(x, w)| Tup2(x.clone(), *w))
+                    .collect::<Vec<_>>(),
+            );
+            Arc::new(<SerBatchImpl<_, T, ()>>::new(zset)) as Arc<dyn SerBatch>
+        })
+        .collect::<Vec<_>>();
+    for (step, zset) in zsets.iter().enumerate() {
+        encoder.consumer().batch_start(step as u64);
+        encoder.encode(zset.as_batch_reader()).unwrap();
+        encoder.consumer().batch_end();
+    }
+
+    let expected_output = batches
+        .into_iter()
+        .flat_map(|batch| {
+            let zset = OrdZSet::from_keys(
+                (),
+                batch
+                    .iter()
+                    .map(|Tup2(x, w)| Tup2(x.clone(), *w))
+                    .collect::<Vec<_>>(),
+            );
+            /*let mut deletes = zset
+            .iter()
+            .flat_map(|(data, (), weight)| {
+                trace!("data: {data:?}, weight: {weight}");
+                let range = if weight < 0 { weight..0 } else { 0..0 };
+
+                range.map(move |_| {
+                    let upd = U::update(
+                        false,
+                        data.clone(),
+                        encoder.stream_id,
+                        *seq_number.borrow(),
+                    );
+                    *seq_number.borrow_mut() += 1;
+                    upd
+                })
+            })
+            .collect::<Vec<_>>();*/
+            let inserts = zset
+                .iter()
+                .flat_map(|(data, (), weight)| {
+                    trace!("data: {data:?}, weight: {weight}");
+                    let range = if weight > 0 { 0..weight } else { 0..0 };
+
+                    range.map(move |_| data.clone())
+                })
+                .collect::<Vec<_>>();
+
+            inserts
+        })
+        .collect::<Vec<_>>();
+
+    let mut actual_output = Vec::new();
+    for (_, avro_datum) in consumer_data.lock().unwrap().iter() {
+        let avro_value =
+            apache_avro::from_avro_datum(&encoder.schema, &mut &avro_datum[5..], None).unwrap();
+        // FIXME: this will use the default `serde::Deserialize` implementation and will only work
+        // for types where it happens to do the right thing. We should use Avro-compatible
+        // deserialization logic instead, when it exists.
+        let val = apache_avro::from_value::<T>(&avro_value).unwrap();
+        actual_output.push(val);
+    }
+
+    assert_eq!(actual_output, expected_output);
+}
+
+proptest! {
+    #[test]
+    fn proptest_avro_output(data in generate_test_batches_with_weights(10, 20))
+    {
+        test_avro_output::<TestStruct>(TestStruct::avro_schema(), data)
+    }
+}

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -365,6 +365,7 @@ impl TestStruct2 {
         r#"{
             "type": "record",
             "name": "TestStruct2",
+            "connect.name": "test_namespace.TestStruct2",
             "fields": [
                 { "name": "id", "type": "long" },
                 { "name": "name", "type": ["string", "null"] },

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -31,11 +31,19 @@ pub use crate::operator::dynamic::input_upsert::{PatchFunc, Update};
 pub type IndexedZSetStream<K, V> = Stream<RootCircuit, OrdIndexedZSet<K, V>>;
 pub type ZSetStream<K> = Stream<RootCircuit, OrdZSet<K>>;
 
-#[derive(Clone)]
 #[repr(transparent)]
 pub struct ZSetHandle<K> {
     handle: CollectionHandle<DynPair<DynData, DynUnit>, DynZWeight>,
     phantom: PhantomData<fn(&K)>,
+}
+
+impl<K> Clone for ZSetHandle<K> {
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<K> Deref for ZSetHandle<K> {
@@ -101,11 +109,19 @@ where
     }
 }
 
-#[derive(Clone)]
 #[repr(transparent)]
 pub struct SetHandle<K> {
     handle: UpsertHandle<DynData, DynBool>,
     phantom: PhantomData<fn(&K)>,
+}
+
+impl<K> Clone for SetHandle<K> {
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<K> SetHandle<K>
@@ -129,11 +145,19 @@ where
     }
 }
 
-#[derive(Clone)]
 #[repr(transparent)]
 pub struct MapHandle<K, V, U> {
     handle: UpsertHandle<DynData, DynUpdate<DynData, DynData>>,
     phantom: PhantomData<fn(&K, &V, &U)>,
+}
+
+impl<K, V, U> Clone for MapHandle<K, V, U> {
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<K, V, U> MapHandle<K, V, U>

--- a/crates/feldera-types/src/format/avro.rs
+++ b/crates/feldera-types/src/format/avro.rs
@@ -2,25 +2,31 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
 
-/// Avro output format configuration.
-#[derive(Serialize, Deserialize, Debug, Default, ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct AvroEncoderConfig {
-    /// Avro schema used to encode output records.
+/// Supported Avro data change event formats.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, ToSchema)]
+pub enum AvroUpdateFormat {
+    /// Raw encoding.
     ///
-    /// Specified as a string containing schema definition in JSON format.
-    /// This schema must match precisely the SQL view definition, including
-    /// nullability of columns.
-    pub schema: String,
-    /// Set `True` if the serialized message should only contain
-    /// the data and not contain the magic byte + schema ID.
-    /// `False` by default.
-    ///
-    /// The first 5 bytes of the Avro message are the magic byte
-    /// and 4-byte schema ID.
-    /// <https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format>
-    #[serde(default)]
-    pub skip_schema_id: bool,
+    /// Every event in the stream represents a single record to be stored
+    /// in the table that the stream is connected to.  This format can represent
+    /// inserts and upsert, but not detetes.
+    #[serde(rename = "raw")]
+    Raw,
+
+    /// Debezium data change event format.
+    #[serde(rename = "debezium")]
+    Debezium,
+}
+
+impl Default for AvroUpdateFormat {
+    fn default() -> Self {
+        Self::Raw
+    }
+}
+
+/// Schema registry configuration.
+#[derive(Clone, Serialize, Deserialize, Debug, Default, ToSchema)]
+pub struct AvroSchemaRegistryConfig {
     /// List of schema registry URLs. When non-empty, the connector will
     /// post the schema to the registry and use the schema id returned
     /// by the registry.  Otherwise, schema id 0 is used.
@@ -53,4 +59,58 @@ pub struct AvroEncoderConfig {
     /// Requires `registry_urls` to be set. This option is mutually exclusive with
     /// password-based authentication (see `registry_username` and `registry_password`).
     pub registry_authorization_token: Option<String>,
+}
+
+/// Avro output format configuration.
+#[derive(Clone, Serialize, Deserialize, Debug, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AvroParserConfig {
+    /// Format used to encode data change events in this stream.
+    ///
+    /// The default value is 'raw'.
+    #[serde(default)]
+    pub update_format: AvroUpdateFormat,
+
+    /// Avro schema used to encode input records.
+    ///
+    /// Specified as a string containing schema definition in JSON format.
+    /// This schema must match precisely the SQL view definition, including
+    /// nullability of columns.
+    pub schema: Option<String>,
+
+    /// `true` if serialized messages only contain raw data without the
+    /// header carrying schema ID.
+    /// `False` by default.
+    ///
+    /// See <https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format>
+    #[serde(default)]
+    pub no_schema_id: bool,
+
+    /// Schema registry configuration.
+    #[serde(flatten)]
+    pub registry_config: AvroSchemaRegistryConfig,
+}
+
+/// Avro output format configuration.
+#[derive(Serialize, Deserialize, Debug, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AvroEncoderConfig {
+    /// Avro schema used to encode output records.
+    ///
+    /// Specified as a string containing schema definition in JSON format.
+    /// This schema must match precisely the SQL view definition, including
+    /// nullability of columns.
+    pub schema: String,
+
+    /// Set to `true` if serialized messages should only contain raw data
+    /// without the header carrying schema ID.
+    /// `False` by default.
+    ///
+    /// See <https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format>
+    #[serde(default)]
+    pub skip_schema_id: bool,
+
+    /// Schema registry configuration.
+    #[serde(flatten)]
+    pub registry_config: AvroSchemaRegistryConfig,
 }

--- a/demo/project_demo13-DebeziumPostgres/project.sql
+++ b/demo/project_demo13-DebeziumPostgres/project.sql
@@ -1,11 +1,15 @@
--- SQL program from the Debezium MySQL tutorial used to demo Feldera
--- Debezium integration.
-
-CREATE TABLE customers (
-  id int NOT NULL PRIMARY KEY,
-  first_name varchar(255) NOT NULL,
-  last_name varchar(255) NOT NULL,
-  email varchar(255) NOT NULL
+CREATE TABLE json_test_table (
+    id INT NOT NULL PRIMARY KEY,
+    bi BIGINT,
+    s VARCHAR,
+    d DOUBLE,
+    f REAL,
+    i INT,
+    b BOOLEAN,
+    ts TIMESTAMP,
+    dt DATE,
+    json VARCHAR,
+    uuid VARCHAR
 ) with (
   'materialized' = 'true',
   'connectors' = '[{
@@ -14,88 +18,46 @@ CREATE TABLE customers (
       "config": {
         "bootstrap.servers": "[REPLACE-BOOTSTRAP-SERVERS]",
         "auto.offset.reset": "earliest",
-        "topics": ["inventory.inventory.customers"]
+        "topics": ["json.test_schema.test_table"]
       }
     },
     "format": {
-      "name": "json",
-      "config": {
-        "update_format": "debezium",
-        "json_flavor": "debezium_mysql"
-      }
+        "name": "json",
+        "config": {
+            "update_format": "debezium",
+            "json_flavor": "debezium_postgres"
+        }
     }
 }]');
 
-CREATE TABLE orders (
-  id int NOT NULL,
-  order_date date NOT NULL,
-  purchaser int NOT NULL,
-  quantity int NOT NULL,
-  product_id int NOT NULL
+CREATE TABLE avro_test_table (
+    id INT NOT NULL PRIMARY KEY,
+    bi BIGINT,
+    s VARCHAR,
+    d DOUBLE,
+    f REAL,
+    i INT,
+    b BOOLEAN,
+    ts TIMESTAMP,
+    dt DATE,
+    json VARCHAR,
+    uuid VARCHAR
 ) with (
   'materialized' = 'true',
   'connectors' = '[{
     "transport": {
-           "name": "kafka_input",
-           "config": {
-               "bootstrap.servers": "[REPLACE-BOOTSTRAP-SERVERS]",
-               "auto.offset.reset": "earliest",
-               "topics": ["inventory.inventory.orders"]
-           }
-       },
-       "format": {
-           "name": "json",
-           "config": {
-               "update_format": "debezium",
-               "json_flavor": "debezium_mysql"
-           }
-       }
-  }]');
-
-CREATE TABLE products (
-  id int NOT NULL PRIMARY KEY,
-  name varchar(255) NOT NULL,
-  description varchar(512),
-  weight real
-) with (
-  'materialized' = 'true',
-     'connectors' = '[{
-       "transport": {
-           "name": "kafka_input",
-           "config": {
-               "bootstrap.servers": "[REPLACE-BOOTSTRAP-SERVERS]",
-               "auto.offset.reset": "earliest",
-               "topics": ["inventory.inventory.products"]
-           }
-       },
-       "format": {
-           "name": "json",
-           "config": {
-               "update_format": "debezium",
-               "json_flavor": "debezium_mysql"
-           }
-       }
-  }]');
-
-CREATE TABLE products_on_hand (
-  product_id int NOT NULL PRIMARY KEY,
-  quantity int NOT NULL
-) with (
-  'materialized' = 'true',
-     'connectors' = '[{
-       "transport": {
-           "name": "kafka_input",
-           "config": {
-               "bootstrap.servers": "[REPLACE-BOOTSTRAP-SERVERS]",
-               "auto.offset.reset": "earliest",
-               "topics": ["inventory.inventory.products_on_hand"]
-           }
-       },
-       "format": {
-           "name": "json",
-           "config": {
-               "update_format": "debezium",
-               "json_flavor": "debezium_mysql"
-           }
-       }
-   }]');
+      "name": "kafka_input",
+      "config": {
+        "bootstrap.servers": "[REPLACE-BOOTSTRAP-SERVERS]",
+        "auto.offset.reset": "earliest",
+        "topics": ["avro.test_schema.test_table"]
+      }
+    },
+    "format": {
+      "name": "avro",
+      "config": {
+        "registry_urls": ["[REPLACE-REGISTRY-URL]"],
+        "update_format": "debezium"
+      }
+    }
+}]');

--- a/demo/project_demo13-DebeziumPostgres/run.py
+++ b/demo/project_demo13-DebeziumPostgres/run.py
@@ -1,6 +1,9 @@
-# Postgres Debezium source connector demo
+# Postgres Debezium source connector demo.
 #
-# Start auxiliary connectors before running this demo
+# Creates a Postgres table with a mix of different column types and syncs
+# it to identical Feldera tables using JSON and Avro formats.
+#
+# Start auxiliary containers before running this demo:
 #
 # ```bash
 # docker compose -f deploy/docker-compose.yml -f deploy/docker-compose-debezium-postgres.yml --profile debezium  up postgres redpanda connect  --force-recreate  -V
@@ -11,72 +14,141 @@ import time
 import requests
 import argparse
 import json
+import psycopg
 from feldera import FelderaClient, PipelineBuilder
 from kafka.admin import KafkaAdminClient
 from kafka.errors import UnknownTopicOrPartitionError
+from typing import List, Dict
 
 # File locations
 SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
 PROJECT_SQL = os.path.join(SCRIPT_DIR, "project.sql")
-
-expected_topics = [ "inventory.inventory.orders",
-           "inventory.inventory.geom",
-           "inventory.inventory.customers",
-           "inventory.inventory.products",
-           "inventory.inventory.products_on_hand",
-         ]
+TEST_SCHEMA = "test_schema"
+TEST_TABLE = "test_table"
+NUM_RECORDS = 500000
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--api-url", required=True, help="Feldera API URL (e.g., http://localhost:8080 )")
+    parser.add_argument("--api-url", default="http://localhost:8080", help="Feldera API URL (e.g., http://localhost:8080)")
     parser.add_argument("--kafka-url-from-pipeline", default="redpanda:9092", help="Kafka broker address reachable from the pipeline")
+    parser.add_argument("--registry-url-from-pipeline", default="http://redpanda:8081", help="Schema registry address reachable from the pipeline")
+    parser.add_argument("--registry-url-from-connect", default="http://redpanda:8081", help="Schema registry address reachable from the Kafka Connect server")
     parser.add_argument("--kafka-url-from-script", default="localhost:19092", help="Kafka broker address reachable from this script")
-    args = parser.parse_args()
-    create_debezium_postgres_connector(args.kafka_url_from_script)
-    prepare_feldera_pipeline(args.api_url, args.kafka_url_from_pipeline)
 
-def create_debezium_postgres_connector(kafka_url_from_script):
+    args = parser.parse_args()
+
+    populate_database()
+
+    # Create connectors.  The new connectors will continue working with
+    # existing Kafka topics created by the previous connectors instance
+    # if they exist.
+
+    # Connector using JSON format
+    json_config = {
+        "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+        "database.hostname": "postgres",
+        "database.port": "5432",
+        "database.user": "postgres",
+        "database.password": "postgres",
+        "database.dbname": "postgres",
+        "table.include.list": f"{TEST_SCHEMA}.*",
+        "topic.prefix": "json",
+        "decimal.handling.mode": "string",
+        "time.precision.mode": "connect"
+    }
+
+    create_debezium_postgres_connector("inventory-connector-json", args.kafka_url_from_script, json_config, [f"json.{TEST_SCHEMA}.{TEST_TABLE}"])
+
+
+    # Connector using Avro format
+    avro_config = {
+        "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+        "database.hostname": "postgres",
+        "database.port": "5432",
+        "database.user": "postgres",
+        "database.password": "postgres",
+        "database.dbname": "postgres",
+        "table.include.list": f"{TEST_SCHEMA}.*",
+        "topic.prefix": f"avro",
+        "decimal.handling.mode": "string",
+        "time.precision.mode": "connect",
+        "key.converter": "io.confluent.connect.avro.AvroConverter",
+        "value.converter": "io.confluent.connect.avro.AvroConverter",
+        "key.converter.schemas.enable": "true",
+        "value.converter.schemas.enable": "true",
+        # Every connector needs a separate Postgres replication slot
+        "slot.name": "debezium_slot_1",
+        "key.converter.schema.registry.url": args.registry_url_from_connect,
+        "value.converter.schema.registry.url": args.registry_url_from_connect,
+        "time.precision.mode": "adaptive_time_microseconds"
+    }
+
+    create_debezium_postgres_connector("test-connector-avro", args.kafka_url_from_script, avro_config, [f"avro.{TEST_SCHEMA}.{TEST_TABLE}"])
+    run_feldera_pipeline(args.api_url, args.kafka_url_from_pipeline, args.registry_url_from_pipeline)
+
+def populate_database():
+    postgres_server = os.getenv("POSTGRES_SERVER", "localhost:6432")
+    with psycopg.connect(f"postgresql://postgres:postgres@{postgres_server}") as conn:
+        with conn.cursor() as cur:
+            # conn.autocommit = True
+            print(f"(Re-)creating test schema '{TEST_SCHEMA}'")
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {TEST_SCHEMA}")
+            cur.execute(f"""
+                CREATE TABLE IF NOT EXISTS {TEST_SCHEMA}.{TEST_TABLE}(
+                        id INT PRIMARY KEY,
+                        bi BIGINT,
+                        s VARCHAR,
+                        d DOUBLE PRECISION,
+                        f REAL,
+                        i INT,
+                        b BOOLEAN,
+                        ts TIMESTAMP,
+                        dt DATE,
+                        json JSON,
+                        uuid UUID)""")
+            cur.execute(f"DELETE FROM {TEST_SCHEMA}.{TEST_TABLE}")
+
+            print(f"Populating '{TEST_SCHEMA}.{TEST_TABLE}'")
+
+            for i in range(NUM_RECORDS):
+                cur.execute(f"""
+                            INSERT INTO {TEST_SCHEMA}.{TEST_TABLE}
+                                    (id, bi, s, d, f, i, b, ts, dt, json, uuid)
+                            VALUES({i}, {i * 100}, 'foo{i}', {i}.01, {i}.1, {i}, true, '2024-08-30 10:30:00', '2024-08-30', '{{"foo":"bar"}}', '123e4567-e89b-12d3-a456-426614174000')
+                    """)
+                if i % 1000 == 0:
+                    print(f"{i} records")
+
+
+def create_debezium_postgres_connector(connector_name: str, kafka_url_from_script: str, config: Dict, expected_topics: List[str]):
     connect_server = os.getenv("KAFKA_CONNECT_SERVER", "http://localhost:8083")
 
-    print("Delete old connector")
+    print(f"Delete old {connector_name} connector")
     # Delete previous connector instance if any.
     # Note: this won't delete any existing Kafka topics created
     # by the connector.
-    requests.delete(f"{connect_server}/connectors/inventory-connector")
+    requests.delete(f"{connect_server}/connectors/{connector_name}")
 
     admin_client = KafkaAdminClient(
         bootstrap_servers=kafka_url_from_script,
         client_id="demo-debezium-postgres",
     )
 
-    print("Create connector")
-    # Create connector.  The new connector will continue working with
-    # existing Kafka topics created by the previous connectors instance
-    # if they exist.
-    config = {
-        "name": "inventory-connector",
-        "config": {
-            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
-            "database.hostname": "postgres",
-            "database.port": "5432",
-            "database.user": "postgres",
-            "database.password": "postgres",
-            "database.dbname": "postgres",
-            "table.include.list": "inventory.*",
-            "topic.prefix": "inventory",
-            "decimal.handling.mode": "string",
-            "time.precision.mode": "connect"
-        },
+    print(f"Create {connector_name} connector")
+    config ={
+        "name": connector_name,
+        "config": config
     }
+
     requests.post(
         f"{connect_server}/connectors", json=config
     ).raise_for_status()
 
-    print("Checking connector status")
+    print(f"Checking {connector_name} connector status")
     start_time = time.time()
     while True:
         response = requests.get(
-            f"{connect_server}/connectors/inventory-connector/status"
+            f"{connect_server}/connectors/{connector_name}/status"
         )
         print(f"response: {response}")
         if response.ok:
@@ -98,7 +170,7 @@ def create_debezium_postgres_connector(kafka_url_from_script):
             time.sleep(1)
 
     # Connector is up, but this doesn't guarantee that it has created all 5 topics.
-    print("Waiting for the connector to create Kafka topics")
+    print(f"Waiting for the {connector_name} connector to create Kafka topics")
     start_time = time.time()
     while True:
         topics = set(admin_client.list_topics())
@@ -110,11 +182,11 @@ def create_debezium_postgres_connector(kafka_url_from_script):
         print("Waiting for topics")
         time.sleep(1)
 
-def prepare_feldera_pipeline(api_url, kafka_url):
+def run_feldera_pipeline(api_url, kafka_url, registry_url):
 
     pipeline_name = "demo-debezium-postgres-pipeline"
     client = FelderaClient(api_url)
-    sql = open(PROJECT_SQL).read().replace("[REPLACE-BOOTSTRAP-SERVERS]", kafka_url)
+    sql = open(PROJECT_SQL).read().replace("[REPLACE-BOOTSTRAP-SERVERS]", kafka_url).replace("[REPLACE-REGISTRY-URL]", registry_url)
 
     print("Starting pipeline...")
     pipeline = PipelineBuilder(client, name=pipeline_name, sql=sql).create_or_replace()


### PR DESCRIPTION
Add support for parsing Avro input streams.  We currently support two Avro-based message formats:

- Raw format that carries table records without any additional metadata. Can only be used to express inserts and upserts, but not deletes.

- Debezium Avro message format.

In both cases, message schema can be defined as part of connector config or downloaded from a schema registry if one is configured.

By default the connector supports Confluent Avro messages that carry schema id in the header.  There is a config option to ingest raw Avro messages without the header (this format is used for instance by Hopsworks).

Temporary limitations (to be addressed in an upcoming revision):

- The connector doesn't yet support decimal types
- Only supports timestamps are expressed in microseconds (Avro support microsecond and millisecond-based encodings)
- Only supports times expressed in microseconds

More fundamental limitations:

- Avro schema must precisely match the Feldera table schema that the connector is attached to, including nullability of columns.

Docs are coming in a separate commit.

Here is an example table using Debezium connector with Avro format:

```sql
CREATE TABLE avro_test_table (
    id INT NOT NULL PRIMARY KEY,
    bi BIGINT,
    s VARCHAR,
    d DOUBLE,
    f REAL,
    i INT,
    b BOOLEAN,
    ts TIMESTAMP,
    dt DATE,
    json VARCHAR,
    uuid VARCHAR
) with (
  'materialized' = 'true',
  'connectors' = '[{
    "transport": {
      "name": "kafka_input",
      "config": {
        "bootstrap.servers": "localhost:19092",
        "auto.offset.reset": "earliest",
        "topics": ["avro.test_schema.test_table"]
      }
    },
    "format": {
      "name": "avro",
      "config": {
        "registry_urls": ["http://localhost:18081"],
        "update_format": "debezium"
      }
    }
}]');

```