### PR TITLE
The Makefile embedded in the profile rust program needs tabs

### DIFF
--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -196,9 +196,9 @@ all: $(FORMATS)
 define format_template
 $(1): $(DOTS:.dot=.$(1))
 %.$(1): %.dot
-        dot -T$(1) $$< -o$$@
+	dot -T$(1) $$< -o$$@
 clean:
-        rm -f $(DOTS:.dot=.$$(1))
+	rm -f $(DOTS:.dot=.$$(1))
 endef
 
 $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))


### PR DESCRIPTION
This is very unpleasant, because my editor automatically replaces tabs with spaces in rust programs, so it's easy to break this.