### PR TITLE
Increase and make HTTP timeouts more specific.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,7 +4909,6 @@ dependencies = [
  "prettyplease",
  "progenitor",
  "progenitor-client",
- "quote 1.0.37",
  "reqwest 0.11.27",
  "rustyline",
  "serde",

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -33,7 +33,6 @@ progenitor = { version = "0.7.0" }
 serde_json = "1.0"
 syn = "2.0.76"
 reqwest = { version = "0.11", features = ["json", "stream"] }
-quote = "1.0"
 
 [package.metadata.cargo-machete]
 ignored = ["progenitor-client", "chrono", "prettytable-rs", "serde", "serde_json", "uuid"]

--- a/crates/fda/build.rs
+++ b/crates/fda/build.rs
@@ -1,5 +1,4 @@
 use progenitor::{GenerationSettings, InterfaceStyle};
-use quote::quote;
 use std::{env, fs, path::Path};
 
 fn type_replacement() -> Vec<(&'static str, &'static str)> {
@@ -172,10 +171,7 @@ fn main() {
     println!("cargo:rerun-if-changed=../../openapi.json");
     let spec = serde_json::from_reader(&openapi[..]).unwrap();
     let mut settings = GenerationSettings::new();
-    settings
-        .with_interface(InterfaceStyle::Builder)
-        .with_inner_type(quote! {Option<String>})
-        .with_pre_hook_async(quote! { crate::add_auth_headers });
+    settings.with_interface(InterfaceStyle::Builder);
     for (from, to) in type_replacement() {
         let impls = vec![];
         settings.with_replacement(from, to, impls.into_iter());

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -7,6 +7,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
+    /// The format in which the output should be displayed.
+    #[arg(long, default_value = "text", env = "FELDERA_OUTPUT_FORMAT")]
+    pub format: OutputFormat,
     /// The Feldera host to connect to.
     #[arg(long, env = "FELDERA_HOST", default_value_t = String::from("https://try.feldera.com"))]
     pub host: String,
@@ -17,9 +20,13 @@ pub struct Cli {
     /// If not specified, a request without authentication will be used.
     #[arg(long, env = "FELDERA_API_KEY")]
     pub auth: Option<String>,
-    /// The format in which the output should be displayed.
-    #[arg(long, default_value = "text", env = "FELDERA_OUTPUT_FORMAT")]
-    pub format: OutputFormat,
+    /// The client timeout for requests in seconds.
+    ///
+    /// In almost all cases you should not need to change this value.
+    /// It can be helpful to increase this if you want to evaluate long-running
+    /// ad-hoc queries in the shell.
+    #[arg(long, default_value_t = 120, env = "FELDERA_REQUEST_TIMEOUT")]
+    pub timeout: u64,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]

--- a/crates/fda/src/shell.rs
+++ b/crates/fda/src/shell.rs
@@ -124,8 +124,13 @@ fn handle_sql_response_error(err: Error<ErrorResponse>) {
             eprintln!("{}", UGPRADE_NOTICE);
         }
         Error::CommunicationError(e) => {
-            eprintln!("ERROR: {}: ", e);
-            eprintln!("Check your network connection.");
+            if e.is_timeout() {
+                eprintln!("ERROR: Request timed out.");
+                eprintln!("Try increasing the limit with the `--timeout` argument.");
+            } else {
+                eprintln!("ERROR: {}: ", e);
+                eprintln!("Check your network connection.");
+            }
         }
         Error::InvalidUpgrade(e) => {
             eprintln!("ERROR: {}: ", e);

--- a/crates/pipeline-manager/src/api/pipeline.rs
+++ b/crates/pipeline-manager/src/api/pipeline.rs
@@ -22,6 +22,7 @@ use feldera_types::config::{PipelineConfig, RuntimeConfig};
 use feldera_types::error::ErrorResponse;
 use log::info;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
@@ -524,6 +525,7 @@ pub(crate) async fn input_endpoint_action(
             Method::GET,
             &format!("input_endpoints/{endpoint_name}/{action}"),
             "",
+            None,
         )
         .await?;
 
@@ -573,6 +575,7 @@ pub(crate) async fn get_pipeline_stats(
             Method::GET,
             "stats",
             request.query_string(),
+            None,
         )
         .await
 }
@@ -615,6 +618,7 @@ pub(crate) async fn get_pipeline_circuit_profile(
             Method::GET,
             "dump_profile",
             request.query_string(),
+            Some(Duration::from_secs(120)),
         )
         .await
 }
@@ -657,6 +661,7 @@ pub(crate) async fn get_pipeline_heap_profile(
             Method::GET,
             "heap_profile",
             request.query_string(),
+            None,
         )
         .await
 }
@@ -701,6 +706,7 @@ pub(crate) async fn pipeline_adhoc_sql(
             Method::GET,
             "query",
             request.query_string(),
+            Some(Duration::MAX),
         )
         .await
 }

--- a/crates/pipeline-manager/src/metrics.rs
+++ b/crates/pipeline-manager/src/metrics.rs
@@ -84,6 +84,7 @@ async fn metrics(
                 "metrics",
                 &rts.deployment_location.unwrap(),
                 "",
+                None,
             ) // TODO: unwrap
             .await
             {

--- a/crates/pipeline-manager/src/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/pipeline_automata.rs
@@ -735,7 +735,7 @@ async fn pipeline_http_request_json_response(
     port: &str,
 ) -> Result<(StatusCode, JsonValue), RunnerError> {
     let response =
-        RunnerApi::pipeline_http_request(pipeline_id, method, endpoint, port, "").await?;
+        RunnerApi::pipeline_http_request(pipeline_id, method, endpoint, port, "", None).await?;
     let status = response.status();
 
     let value = response


### PR DESCRIPTION
Increase timeouts generally, but especially choose larger values for ad-hoc SQL and to get the circuit profile as they can be long running.