### PR TITLE
dbsp_adapters: remove dependency on `prometheus` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,7 +3662,6 @@ dependencies = [
  "ordered-float 4.2.2",
  "parquet",
  "pretty_assertions",
- "prometheus",
  "proptest",
  "proptest-derive 0.3.0",
  "psutil",
@@ -7359,21 +7358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "protobuf",
- "thiserror",
-]
-
-[[package]]
 name = "proptest"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,12 +7496,6 @@ checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost 0.13.3",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psutil"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -61,7 +61,6 @@ proptest-derive = { version = "0.3.0", optional = true }
 env_logger = "0.10.0"
 clap = { version = "4.0.32", features = ["derive"] }
 tokio = { version = "1.25.0", features = ["sync", "macros", "fs", "rt"] }
-prometheus = "0.13.3"
 utoipa = "4.1"
 chrono = { version = "0.4.38", features = ["rkyv-64", "serde"] }
 colored = "2.0.0"

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -810,7 +810,7 @@ pub trait Node {
     /// another node).
     unsafe fn clock_end(&mut self, scope: Scope);
 
-    fn init_metrics(&mut self, _gid: &GlobalNodeId) {}
+    fn init(&mut self, _gid: &GlobalNodeId) {}
 
     fn metrics(&self) {}
 
@@ -951,10 +951,24 @@ impl GlobalNodeId {
     }
 
     pub(crate) fn metrics_id(&self) -> String {
-        self.to_string()
-            .replace("[]", "root")
-            .replace(['[', ']'], "")
-            .replace('.', "_")
+        let mut mid = String::with_capacity(3 + self.0.len() * 3);
+        mid.push('o');
+
+        let path = self.path();
+
+        if path.is_empty() {
+            mid.push_str("root");
+            return mid;
+        }
+
+        for i in 0..path.len() {
+            mid.push_str(&path[i].0.to_string());
+            if i < path.len() - 1 {
+                mid.push('_');
+            }
+        }
+
+        mid
     }
 }
 
@@ -1829,7 +1843,7 @@ where
     where
         N: Node + 'static,
     {
-        node.init_metrics(&self.global_node_id);
+        node.init(&self.global_node_id);
         self.nodes.push(Box::new(node) as Box<dyn Node>);
     }
 
@@ -3234,8 +3248,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3326,8 +3340,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3424,8 +3438,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3515,8 +3529,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3626,8 +3640,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3757,8 +3771,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -3892,8 +3906,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -4045,8 +4059,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -4183,8 +4197,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        self.operator.init_metrics(gid);
+    fn init(&mut self, gid: &GlobalNodeId) {
+        self.operator.init(gid);
     }
 
     fn metrics(&self) {
@@ -4303,8 +4317,8 @@ where
         (*self.operator.get()).clock_end(scope);
     }
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        unsafe { (*self.operator.get()).init_metrics(gid) };
+    fn init(&mut self, gid: &GlobalNodeId) {
+        unsafe { (*self.operator.get()).init(gid) };
     }
 
     fn metrics(&self) {
@@ -4395,8 +4409,8 @@ where
 
     unsafe fn clock_end(&mut self, _scope: Scope) {}
 
-    fn init_metrics(&mut self, gid: &GlobalNodeId) {
-        unsafe { (*self.operator.get()).init_metrics(gid) };
+    fn init(&mut self, gid: &GlobalNodeId) {
+        unsafe { (*self.operator.get()).init(gid) };
     }
 
     fn metrics(&self) {

--- a/crates/dbsp/src/circuit/metrics.rs
+++ b/crates/dbsp/src/circuit/metrics.rs
@@ -6,7 +6,6 @@
 use crate::circuit::GlobalNodeId;
 use crate::Runtime;
 use ::metrics::{describe_counter, describe_gauge, describe_histogram, Unit as MetricUnit};
-use size_of::{Context, SizeOf};
 
 /// Total number of files created.
 pub const FILES_CREATED: &str = "disk.total_files_created";
@@ -77,8 +76,8 @@ fn metric_name(name: &str) -> String {
 ///
 /// Gauge represents a single value that can go up or down over time, and always starts out
 /// with an initial value of zero.
-#[derive(Clone)]
-pub(crate) struct Gauge(metrics::Gauge);
+#[derive(Clone, size_of::SizeOf)]
+pub(crate) struct Gauge(#[size_of(skip)] metrics::Gauge);
 
 impl Gauge {
     /// Describe and initialize a new [`Gauge`].
@@ -130,16 +129,12 @@ impl Gauge {
     }
 }
 
-impl SizeOf for Gauge {
-    fn size_of_children(&self, _: &mut Context) {}
-}
-
 /// Metric of type `Histogram`.
 ///
 /// Histograms measure the distribution of values for a given set of measurements,
 /// and start with no initial values.
-#[derive(Clone)]
-pub(crate) struct Histogram(metrics::Histogram);
+#[derive(Clone, size_of::SizeOf)]
+pub(crate) struct Histogram(#[size_of(skip)] metrics::Histogram);
 
 impl Histogram {
     /// Describe and initialize a new [`Histogram`].
@@ -180,16 +175,12 @@ impl Histogram {
     }
 }
 
-impl SizeOf for Histogram {
-    fn size_of_children(&self, _: &mut Context) {}
-}
-
 /// Metric of type `Counter`.
 ///
 /// Counters represent a single monotonic value, which means the value can only be incremented,
 /// not decremented, and always starts out with an initial value of zero.
-#[derive(Clone)]
-pub(crate) struct Counter(metrics::Counter);
+#[derive(Clone, size_of::SizeOf)]
+pub(crate) struct Counter(#[size_of(skip)] metrics::Counter);
 
 impl Counter {
     /// Describe and initialize a new [`Counter`].
@@ -229,10 +220,6 @@ impl Counter {
     pub(crate) fn increment(&self, value: u64) {
         self.0.increment(value)
     }
-}
-
-impl SizeOf for Counter {
-    fn size_of_children(&self, _: &mut Context) {}
 }
 
 /// Adds descriptions for the metrics we expose.

--- a/crates/dbsp/src/circuit/metrics.rs
+++ b/crates/dbsp/src/circuit/metrics.rs
@@ -2,7 +2,16 @@
 //!
 //! The constants defined in this module are the names of metrics that the
 //! backends maintain via [`metrics`] crate interfaces.
-use ::metrics::{describe_counter, describe_histogram, Unit};
+
+use crate::circuit::GlobalNodeId;
+use crate::Runtime;
+use ::metrics::{
+    describe_counter, describe_histogram, SharedString as MetricString, Unit as MetricUnit,
+};
+use lazy_static::lazy_static;
+use metrics::{describe_gauge, Counter, Gauge, Histogram, IntoLabels, KeyName};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 /// Total number of files created.
 pub const FILES_CREATED: &str = "disk.total_files_created";
@@ -57,8 +66,289 @@ pub const COMPACTION_DURATION: &str = "file.compaction_duration";
 /// Time a worker was stalled waiting for more merges to complete.
 pub const COMPACTION_STALL_TIME: &str = "file.compaction_stall_time";
 
-/// Number of records dropped due to LATENES annotations
+/// Number of records dropped due to LATENESS annotations
 pub const TOTAL_LATE_RECORDS: &str = "records.late";
+
+/// Runtime in microseconds of an Operator evaluation
+pub const OPERATOR_EVAL_DURATION: &str = "operator.runtime_micros";
+
+/// Holds a map of the [`DBSPMetric`] and their equivalent [`metrics`] type.
+///
+/// [`RwLock`]s here should be very efficient, as reading is the most common operation.
+/// Writing is only necessary while adding a new metric.
+///
+/// Updating the inner type in the map doesn't require mutable access due to the interior
+/// mutability of the [`Counter`], [`Gauge`] and [`Histogram`] types.
+#[allow(unused)]
+#[derive(Default)]
+struct MetricsRecorder {
+    counters: RwLock<HashMap<DBSPMetric, Counter>>,
+    gauge: RwLock<HashMap<DBSPMetric, Gauge>>,
+    histogram: RwLock<HashMap<DBSPMetric, Histogram>>,
+}
+
+lazy_static! {
+    /// Global recorder for DBSP related metrics.
+    static ref METRICS_RECORDER: Arc<MetricsRecorder> = Arc::new(MetricsRecorder::new());
+}
+
+impl MetricsRecorder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a new [`Counter`] and saves it to the map.
+    #[allow(unused)]
+    fn register_counter(
+        &self,
+        metric: DBSPMetric,
+        unit: Option<MetricUnit>,
+        description: Option<String>,
+    ) {
+        {
+            let c = self.counters.read().unwrap();
+            if c.contains_key(&metric) {
+                return;
+            }
+        }
+
+        metric.describe(MetricType::Counter, unit, description);
+
+        {
+            let mut c = self.counters.write().unwrap();
+            let counter = metrics::counter!(metric.name(), metric.labels.into_labels());
+            c.insert(metric, counter);
+        }
+    }
+
+    /// Increments the [`Counter`] for the given `metric` by `value`.
+    #[allow(unused)]
+    fn increment_counter(&self, metric: DBSPMetric, value: u64) {
+        let c = self.counters.read().unwrap();
+        if let Some(counter) = c.get(&metric) {
+            counter.increment(value);
+        }
+    }
+
+    /// Registers a new [`Gauge`] and saves it to the map.
+    fn register_gauge(
+        &self,
+        metric: DBSPMetric,
+        unit: Option<MetricUnit>,
+        description: Option<String>,
+    ) {
+        {
+            let c = self.gauge.read().unwrap();
+            if c.contains_key(&metric) {
+                return;
+            }
+        }
+
+        metric.describe(MetricType::Gauge, unit, description);
+
+        {
+            let mut c = self.gauge.write().unwrap();
+            let gauge = metrics::gauge!(metric.name(), metric.labels.into_labels());
+            c.insert(metric, gauge);
+        }
+    }
+
+    /// Sets value of the [`Gauge`] for the given `metric` to `value`.
+    fn set_gauge(&self, metric: DBSPMetric, value: f64) {
+        let g = self.gauge.read().unwrap();
+        if let Some(gauge) = g.get(&metric) {
+            gauge.set(value);
+        }
+    }
+
+    /// Registers a new [`Histogram`] and saves it to the map.
+    fn register_histogram(
+        &self,
+        metric: DBSPMetric,
+        unit: Option<MetricUnit>,
+        description: Option<String>,
+    ) {
+        {
+            let c = self.histogram.read().unwrap();
+            if c.contains_key(&metric) {
+                return;
+            }
+        }
+
+        metric.describe(MetricType::Histogram, unit, description);
+
+        {
+            let mut c = self.histogram.write().unwrap();
+            let h = metrics::histogram!(metric.name(), metric.labels.into_labels());
+            c.insert(metric, h);
+        }
+    }
+
+    /// Records this `value` to the [`Histogram`] for the given `metric`.
+    fn record_histogram(&self, metric: DBSPMetric, value: f64) {
+        let h = self.histogram.read().unwrap();
+        if let Some(histogram) = h.get(&metric) {
+            histogram.record(value);
+        }
+    }
+}
+
+enum MetricType {
+    #[allow(unused)]
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+#[derive(Debug, Hash, PartialOrd, PartialEq, Eq, Clone)]
+pub(crate) struct DBSPMetric {
+    /// Name of the metric.
+    key: KeyName,
+
+    /// The global node ID of the operator.
+    global_node_id: GlobalNodeId,
+
+    /// The worker index of the operator.
+    worker_index: usize,
+
+    /// Optional key-value pairs that provide additional metadata about this
+    /// metric.
+    labels: Vec<(MetricString, MetricString)>,
+}
+
+impl DBSPMetric {
+    fn new(
+        key: KeyName,
+        global_node_id: GlobalNodeId,
+        labels: Vec<(MetricString, MetricString)>,
+    ) -> Self {
+        Self {
+            key,
+            global_node_id,
+            worker_index: Runtime::worker_index(),
+            labels,
+        }
+    }
+
+    fn describe(
+        &self,
+        metric_type: MetricType,
+        unit: Option<MetricUnit>,
+        description: Option<String>,
+    ) {
+        let description = description.unwrap_or_default();
+        let key = self.key.clone();
+        match metric_type {
+            MetricType::Counter => {
+                if let Some(unit) = unit {
+                    describe_counter!(key, unit, description);
+                } else {
+                    describe_counter!(key, description);
+                }
+            }
+            MetricType::Gauge => {
+                if let Some(unit) = unit {
+                    describe_gauge!(key, unit, description);
+                } else {
+                    describe_gauge!(key, description);
+                }
+            }
+            MetricType::Histogram => {
+                if let Some(unit) = unit {
+                    describe_histogram!(key, unit, description);
+                } else {
+                    describe_histogram!(key, description);
+                }
+            }
+        }
+    }
+
+    fn name(&self) -> String {
+        format!("dbsp_{}", self.key.as_str(),)
+    }
+}
+
+/// Sets the value for the [`Gauge`] to `value`.
+///
+/// The metric is named in the form: `dbsp_{name}`.
+/// Automatically adds the worker index and global node id as labels.
+pub(crate) fn gauge(
+    global_id: GlobalNodeId,
+    name: String,
+    value: f64,
+    mut labels: Vec<(MetricString, MetricString)>,
+    unit: Option<MetricUnit>,
+    description: Option<String>,
+) {
+    labels.push((
+        "worker".to_string().into(),
+        Runtime::worker_index().to_string().into(),
+    ));
+    labels.push((
+        "global_id".to_string().into(),
+        global_id.metrics_id().into(),
+    ));
+
+    let metric = DBSPMetric::new(name.into(), global_id, labels);
+    METRICS_RECORDER.register_gauge(metric.clone(), unit, description);
+
+    METRICS_RECORDER.set_gauge(metric, value);
+}
+
+/// Records the `value` in the [`Histogram`].
+///
+/// The metric is named in the form: `dbsp_{name}`.
+/// Automatically adds the worker index and global node id as labels.
+pub(crate) fn histogram(
+    global_id: GlobalNodeId,
+    name: String,
+    value: f64,
+    mut labels: Vec<(MetricString, MetricString)>,
+    unit: Option<MetricUnit>,
+    description: Option<String>,
+) {
+    labels.push((
+        "worker".to_string().into(),
+        Runtime::worker_index().to_string().into(),
+    ));
+    labels.push((
+        "global_id".to_string().into(),
+        global_id.metrics_id().into(),
+    ));
+
+    let metric = DBSPMetric::new(name.into(), global_id, labels);
+    METRICS_RECORDER.register_histogram(metric.clone(), unit, description);
+
+    METRICS_RECORDER.record_histogram(metric, value);
+}
+
+/// Increments the [`Counter`] by the `value`.
+///
+/// The metric is named in the form: `dbsp_{name}`.
+/// Automatically adds worker index and global node id as labels.
+#[allow(unused)]
+pub(crate) fn counter(
+    global_id: GlobalNodeId,
+    name: String,
+    value: u64,
+    mut labels: Vec<(MetricString, MetricString)>,
+    unit: Option<MetricUnit>,
+    description: Option<String>,
+) {
+    labels.push((
+        "worker".to_string().into(),
+        Runtime::worker_index().to_string().into(),
+    ));
+    labels.push((
+        "global_id".to_string().into(),
+        global_id.metrics_id().into(),
+    ));
+
+    let metric = DBSPMetric::new(name.into(), global_id, labels);
+    METRICS_RECORDER.register_counter(metric.clone(), unit, description);
+
+    METRICS_RECORDER.increment_counter(metric, value);
+}
 
 /// Adds descriptions for the metrics we expose.
 pub(crate) fn describe_metrics() {
@@ -72,17 +362,22 @@ pub(crate) fn describe_metrics() {
 
     describe_counter!(
         TOTAL_BYTES_WRITTEN,
-        Unit::Bytes,
+        MetricUnit::Bytes,
         "total number of bytes written to disk"
     );
     describe_counter!(
         TOTAL_BYTES_READ,
-        Unit::Bytes,
+        MetricUnit::Bytes,
         "total number of bytes read from disk"
     );
 
-    describe_histogram!(READ_LATENCY, Unit::Seconds, "Read request latency");
-    describe_histogram!(WRITE_LATENCY, Unit::Seconds, "Write request latency");
+    describe_histogram!(READ_LATENCY, MetricUnit::Seconds, "Read request latency");
+    describe_histogram!(WRITE_LATENCY, MetricUnit::Seconds, "Write request latency");
+    describe_histogram!(
+        OPERATOR_EVAL_DURATION,
+        MetricUnit::Microseconds,
+        "evaluation duration of an operator"
+    );
 
     // Buffer cache metrics.
     describe_counter!(BUFFER_CACHE_HIT, "total number of buffer cache hits");
@@ -92,19 +387,23 @@ pub(crate) fn describe_metrics() {
     describe_counter!(TOTAL_COMPACTIONS, "total number of compactions");
     describe_histogram!(
         COMPACTION_SIZE,
-        Unit::Count,
+        MetricUnit::Count,
         "Batch sizes encountered in compaction"
     );
     describe_counter!(
         COMPACTION_SIZE_SAVINGS,
-        Unit::Count,
+        MetricUnit::Count,
         "Eliminated entries in batches through merging"
     );
-    describe_histogram!(COMPACTION_DURATION, Unit::Seconds, "Time to compact batch");
+    describe_histogram!(
+        COMPACTION_DURATION,
+        MetricUnit::Seconds,
+        "Time to compact batch"
+    );
 
     describe_counter!(
         COMPACTION_STALL_TIME,
-        Unit::Seconds,
+        MetricUnit::Seconds,
         "Time a worker was stalled waiting for more merges to complete"
     );
 

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -11,6 +11,8 @@ use crate::Error;
 use std::borrow::Cow;
 use uuid::Uuid;
 
+use super::GlobalNodeId;
+
 /// Minimal requirements for values exchanged by operators.
 pub trait Data: Clone + 'static {}
 
@@ -25,6 +27,9 @@ pub trait Operator: 'static {
     fn location(&self) -> OperatorLocation {
         None
     }
+
+    /// Reports metrics about the current operator
+    fn metrics(&self, _global_id: &GlobalNodeId) {}
 
     /// Collects metadata about the current operator
     fn metadata(&self, _meta: &mut OperatorMeta) {}

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -28,8 +28,8 @@ pub trait Operator: 'static {
         None
     }
 
-    /// Initialize the metrics reported by this operator
-    fn init_metrics(&mut self, _global_id: &GlobalNodeId) {}
+    /// Initialize the operator
+    fn init(&mut self, _global_id: &GlobalNodeId) {}
 
     /// Reports metrics about this operator
     fn metrics(&self) {}

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -28,8 +28,11 @@ pub trait Operator: 'static {
         None
     }
 
-    /// Reports metrics about the current operator
-    fn metrics(&self, _global_id: &GlobalNodeId) {}
+    /// Initialize the metrics reported by this operator
+    fn init_metrics(&mut self, _global_id: &GlobalNodeId) {}
+
+    /// Reports metrics about this operator
+    fn metrics(&self) {}
 
     /// Collects metadata about the current operator
     fn metadata(&self, _meta: &mut OperatorMeta) {}

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -1,5 +1,6 @@
 //! Distinct operator.
 
+use crate::circuit::metrics::gauge;
 use crate::{
     algebra::{
         AddByRef, HasOne, HasZero, IndexedZSet, IndexedZSetReader, Lattice, OrdIndexedZSet,
@@ -15,6 +16,7 @@ use crate::{
     trace::{Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor},
     DBData, Timestamp, ZWeight,
 };
+use metrics::Unit;
 use minitrace::trace;
 use size_of::SizeOf;
 use std::{
@@ -596,6 +598,19 @@ where
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("DistinctIncremental")
+    }
+
+    fn metrics(&self, global_id: &GlobalNodeId) {
+        let size: usize = self.keys_of_interest.values().map(|v| v.len()).sum();
+
+        gauge(
+            global_id.to_owned(),
+            "total_updates".to_owned(),
+            size as f64,
+            vec![],
+            Some(Unit::Count),
+            None,
+        );
     }
 
     fn metadata(&self, meta: &mut OperatorMeta) {

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -602,7 +602,7 @@ where
         Cow::Borrowed("DistinctIncremental")
     }
 
-    fn init_metrics(&mut self, global_id: &GlobalNodeId) {
+    fn init(&mut self, global_id: &GlobalNodeId) {
         self.total_updates_metric = Some(Gauge::new(
             "total_updates",
             None,

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1033,7 +1033,7 @@ where
             .all(|time| !time.less_equal(&self.clock.time())));
     }
 
-    fn init_metrics(&mut self, global_id: &GlobalNodeId) {
+    fn init(&mut self, global_id: &GlobalNodeId) {
         self.left_tuples_metric = Some(Gauge::new(
             "left_tuples",
             None,

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -818,7 +818,7 @@ where
         self.time.advance(scope + 1);
     }
 
-    fn init_metrics(&mut self, global_id: &GlobalNodeId) {
+    fn init(&mut self, global_id: &GlobalNodeId) {
         self.total_size_metric = Some(Gauge::new(
             "total_size",
             None,

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -1,3 +1,4 @@
+use crate::circuit::metrics::gauge;
 use crate::{
     circuit::{
         metadata::{
@@ -14,6 +15,7 @@ use crate::{
     Error, Timestamp,
 };
 use dyn_clone::clone_box;
+use metrics::Unit;
 use minitrace::trace;
 use size_of::SizeOf;
 use std::{
@@ -812,6 +814,23 @@ where
             }
         }
         self.time.advance(scope + 1);
+    }
+
+    fn metrics(&self, global_id: &GlobalNodeId) {
+        let total_size = self
+            .trace
+            .as_ref()
+            .map(|trace| trace.num_entries_deep())
+            .unwrap_or(0);
+
+        gauge(
+            global_id.to_owned(),
+            NUM_ENTRIES_LABEL.to_string(),
+            total_size as f64,
+            vec![],
+            Some(Unit::Count),
+            None,
+        );
     }
 
     fn metadata(&self, meta: &mut OperatorMeta) {

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -266,7 +266,7 @@ where
         self.values = self.zero.clone();
     }
 
-    fn init_metrics(&mut self, global_id: &GlobalNodeId) {
+    fn init(&mut self, global_id: &GlobalNodeId) {
         self.total_size_metric = Some(Gauge::new(
             NUM_ENTRIES_LABEL,
             Some("Total number of entries stored by the operator".to_owned()),
@@ -454,7 +454,7 @@ where
         }
     }
 
-    fn init_metrics(&mut self, global_id: &GlobalNodeId) {
+    fn init(&mut self, global_id: &GlobalNodeId) {
         self.total_size_metric = Some(Gauge::new(
             NUM_ENTRIES_LABEL,
             Some("Total number of entries stored by the operator".to_owned()),

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -1,5 +1,6 @@
 //! z^-1 operator delays its input by one timestamp.
 
+use crate::circuit::metrics::gauge;
 use crate::{
     algebra::HasZero,
     circuit::checkpointer::Checkpoint,
@@ -16,6 +17,7 @@ use crate::{
     storage::{checkpoint_path, file::to_bytes, write_commit_metadata},
     Error, NumEntries,
 };
+use metrics::Unit;
 use size_of::{Context, SizeOf};
 use std::{borrow::Cow, fs, mem::replace, path::PathBuf};
 use uuid::Uuid;
@@ -262,6 +264,17 @@ where
         self.values = self.zero.clone();
     }
 
+    fn metrics(&self, global_id: &GlobalNodeId) {
+        gauge(
+            global_id.to_owned(),
+            NUM_ENTRIES_LABEL.to_string(),
+            self.values.num_entries_deep() as f64,
+            vec![],
+            Some(Unit::Count),
+            Some("Total number of entries stored by the operator".to_string()),
+        )
+    }
+
     fn metadata(&self, meta: &mut OperatorMeta) {
         let bytes = self.values.size_of();
         meta.extend(metadata! {
@@ -428,6 +441,23 @@ where
         if scope > 0 {
             self.reset();
         }
+    }
+
+    fn metrics(&self, global_id: &GlobalNodeId) {
+        let total_size: usize = self
+            .values
+            .iter()
+            .map(|batch| batch.num_entries_deep())
+            .sum();
+
+        gauge(
+            global_id.to_owned(),
+            NUM_ENTRIES_LABEL.to_string(),
+            total_size as f64,
+            vec![],
+            Some(Unit::Count),
+            Some("Total number of entries stored by the operator".to_string()),
+        )
     }
 
     fn metadata(&self, meta: &mut OperatorMeta) {

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -268,7 +268,7 @@ pub trait Trace: BatchReader {
     fn restore<P: AsRef<str>>(&mut self, _cid: Uuid, _pid: P) -> Result<(), Error> {
         Ok(())
     }
-    fn init_metrics(&mut self, _gid: &GlobalNodeId) {}
+    fn init(&mut self, _gid: &GlobalNodeId) {}
     fn metrics(&self) {}
 
     /// Allows the trace to report additional metadata.

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -33,6 +33,7 @@
 //! [`Antichain`].
 
 use crate::circuit::metadata::OperatorMeta;
+use crate::circuit::GlobalNodeId;
 use crate::dynamic::{ClonableTrait, Weight};
 pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};
 use crate::time::Antichain;
@@ -267,6 +268,8 @@ pub trait Trace: BatchReader {
     fn restore<P: AsRef<str>>(&mut self, _cid: Uuid, _pid: P) -> Result<(), Error> {
         Ok(())
     }
+
+    fn metrics(&self, _global_id: &GlobalNodeId) {}
 
     /// Allows the trace to report additional metadata.
     fn metadata(&self, _meta: &mut OperatorMeta) {}

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -268,8 +268,8 @@ pub trait Trace: BatchReader {
     fn restore<P: AsRef<str>>(&mut self, _cid: Uuid, _pid: P) -> Result<(), Error> {
         Ok(())
     }
-
-    fn metrics(&self, _global_id: &GlobalNodeId) {}
+    fn init_metrics(&mut self, _gid: &GlobalNodeId) {}
+    fn metrics(&self) {}
 
     /// Allows the trace to report additional metadata.
     fn metadata(&self, _meta: &mut OperatorMeta) {}


### PR DESCRIPTION
dbsp_adapters: remove dependency on `prometheus` crate
dbsp: introduces `metrics` method in Node and Operator

1. This removes the dependency on the `prometheus` crate on `dbsp_adapters`. We just use `metrics` instead. I think it can be simplified further by messing with `Controller` and `ControllerInner`, but we can do that later if necessary. Fixes: #2361
2. Adds the method `metrics` in `Node` and `Operator` traits. `metrics` has an empty body by default, and is overridden by operators that already have an implementation for `metadata`.