### PR TITLE
Prepare for UDF UI: add file tabs to Pipeline Edit view

### DIFF
--- a/web-console/src/app.css
+++ b/web-console/src/app.css
@@ -11,9 +11,9 @@
 }
 
 .pane-divider-horizontal {
-  @apply z-[1] h-0.5 transition-colors bg-surface-100-900 before:-mt-0.5 before:flex before:h-2 before:w-full hover:bg-primary-500 active:bg-primary-500;
+  @apply z-[1] h-[2px] transition-colors before:-mt-[3px] before:flex before:h-[8px] before:w-full hover:bg-primary-500 active:bg-primary-500;
 }
 
 .pane-divider-vertical {
-  @apply z-[1] w-0.5 transition-colors bg-surface-100-900 before:-ml-0.5 before:flex before:h-full before:w-2 hover:bg-primary-500 active:bg-primary-500;
+  @apply z-[1] w-[2px] transition-colors before:-ml-[3px] before:flex before:h-full before:w-[8px] hover:bg-primary-500 active:bg-primary-500;
 }

--- a/web-console/src/lib/components/MonacoEditor.svelte
+++ b/web-console/src/lib/components/MonacoEditor.svelte
@@ -63,9 +63,11 @@
   }
   $: model &&
     markers &&
-    Object.entries(markers).forEach(([owner, markers]) =>
-      monaco.editor.setModelMarkers(model, owner, markers)
-    )
+    setTimeout(() => {
+      Object.entries(markers).forEach(([owner, markers]) =>
+        monaco.editor.setModelMarkers(model, owner, markers)
+      )
+    })
 
   onMount(async () => {
     monaco = await loader.init()

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -73,30 +73,34 @@
 
 <div class="h-full w-full">
   <PaneGroup direction="vertical" class="!overflow-visible">
-    <Pane defaultSize={60} minSize={15} class="flex flex-col-reverse !overflow-visible">
-      <CodeEditor path={pipeline.current.name} {files}>
-        {#snippet statusBarCenter()}
-          <ProgramStatus programStatus={pipeline.current.programStatus}></ProgramStatus>
-        {/snippet}
-        {#snippet statusBarEnd(downstreamChanged)}
-          {#if pipeline.current.status}
-            <DeploymentStatus
-              class="ml-auto h-full w-40 text-[1rem] "
-              status={pipeline.current.status}
-            ></DeploymentStatus>
-            <PipelineActions
-              {pipeline}
-              onDeletePipeline={(pipelineName) =>
-                updatePipelines((pipelines) => pipelines.filter((p) => p.name !== pipelineName))}
-              pipelineBusy={editDisabled}
-              unsavedChanges={downstreamChanged}
-              onActionSuccess={(action) => handleActionSuccess(pipeline.current.name, action)}
-            ></PipelineActions>
-          {/if}
-        {/snippet}
-      </CodeEditor>
-    </Pane>
-    <PaneResizer class="pane-divider-horizontal" />
+    <CodeEditor path={pipeline.current.name} {files}>
+      {#snippet textEditor(children)}
+        <Pane defaultSize={60} minSize={15} class="!overflow-visible">
+          {@render children()}
+        </Pane>
+        <PaneResizer class="pane-divider-horizontal -mb-0.5" />
+      {/snippet}
+      {#snippet statusBarCenter()}
+        <ProgramStatus programStatus={pipeline.current.programStatus}></ProgramStatus>
+      {/snippet}
+      {#snippet statusBarEnd(downstreamChanged)}
+        {#if pipeline.current.status}
+          <DeploymentStatus
+            class="ml-auto h-full w-40 text-[1rem] "
+            status={pipeline.current.status}
+          ></DeploymentStatus>
+          <PipelineActions
+            {pipeline}
+            onDeletePipeline={(pipelineName) =>
+              updatePipelines((pipelines) => pipelines.filter((p) => p.name !== pipelineName))}
+            pipelineBusy={editDisabled}
+            unsavedChanges={downstreamChanged}
+            onActionSuccess={(action) => handleActionSuccess(pipeline.current.name, action)}
+          ></PipelineActions>
+        {/if}
+      {/snippet}
+    </CodeEditor>
+    <div class="h-[1px] w-full bg-surface-100-900"></div>
     <Pane minSize={15} class="flex h-full flex-col !overflow-visible">
       {#if pipeline.current.name}
         <InteractionsPanel {pipeline} {metrics}></InteractionsPanel>

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -1,22 +1,10 @@
 <script lang="ts">
   import { PaneGroup, Pane, PaneResizer } from 'paneforge'
-  import MonacoEditor, { isMonacoEditorDisabled } from '$lib/functions/common/monacoEditor'
-  import { useDarkMode } from '$lib/compositions/useDarkMode.svelte'
   import InteractionsPanel from '$lib/components/pipelines/editor/InteractionsPanel.svelte'
-  import { useLocalStorage } from '$lib/compositions/localStore.svelte'
-  import PipelineEditorStatusBar from './PipelineEditorStatusBar.svelte'
   import DeploymentStatus from '$lib/components/pipelines/list/DeploymentStatus.svelte'
   import PipelineActions from '$lib/components/pipelines/list/Actions.svelte'
-  import { asyncDebounced } from '$lib/compositions/asyncDebounced'
-  import { useChangedPipelines } from '$lib/compositions/pipelines/useChangedPipelines.svelte'
-  import {
-    extractProgramError,
-    programErrorReport,
-    type SystemError
-  } from '$lib/compositions/health/systemErrors'
-  import { editor } from 'monaco-editor'
+  import { extractProgramError, programErrorReport } from '$lib/compositions/health/systemErrors'
   import { extractSQLCompilerErrorMarkers } from '$lib/functions/pipelines/monaco'
-  import { page } from '$app/stores'
   import {
     postPipelineAction,
     type ExtendedPipeline,
@@ -27,10 +15,9 @@
   import { nonNull } from '$lib/functions/common/function'
   import { useUpdatePipelineList } from '$lib/compositions/pipelines/usePipelineList.svelte'
   import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
-  import { useDecoupledState } from '$lib/compositions/decoupledState.svelte'
   import { useAggregatePipelineStats } from '$lib/compositions/useAggregatePipelineStats.svelte'
-
-  const autoSavePipeline = useLocalStorage('layout/pipelines/autosave', true)
+  import CodeEditor from '$lib/components/pipelines/editor/CodeEditor.svelte'
+  import ProgramStatus from '$lib/components/pipelines/editor/ProgramStatus.svelte'
 
   let {
     pipeline
@@ -41,75 +28,6 @@
       optimisticUpdate: (newPipeline: Partial<ExtendedPipeline>) => Promise<void>
     }
   } = $props()
-  const pipelineCode = {
-    get current() {
-      return pipeline.current.programCode
-    },
-    set current(programCode: string) {
-      // pipeline.optimisticUpdate({ programCode })
-      pipeline.patch({ programCode })
-    }
-  }
-
-  let wait = $derived(autoSavePipeline.value ? 1000 : ('decoupled' as const))
-  let decoupledCode = useDecoupledState(pipelineCode, () => wait)
-  {
-    // TODO: handle remote update of the program code that conflicts with currently edited version
-    let pipelineName = $derived(pipeline.current.name)
-    $effect(() => {
-      // Fetch new code when switching pipeline
-      pipelineName
-      setTimeout(() => {
-        decoupledCode.pull()
-      })
-    })
-  }
-
-  $effect(() => {
-    // Trigger save right away when autosave is turned on
-    if (!autoSavePipeline.value) {
-      return
-    }
-    setTimeout(() => decoupledCode.push())
-  })
-
-  const changedPipelines = useChangedPipelines()
-
-  $effect(() => {
-    if (!pipeline.current.name) {
-      return
-    }
-    decoupledCode.downstreamChanged
-      ? changedPipelines.add(pipeline.current.name)
-      : changedPipelines.remove(pipeline.current.name)
-  })
-
-  {
-    let oldPipelineName = $state(pipeline.current.name)
-    $effect(() => {
-      if (pipeline.current.name === oldPipelineName) {
-        return
-      }
-      changedPipelines.remove(oldPipelineName || '')
-      oldPipelineName = pipeline.current.name
-    })
-  }
-  const mode = useDarkMode()
-
-  let editorRef: editor.IStandaloneCodeEditor = $state()!
-  $effect(() => {
-    if (!editorRef) {
-      return
-    }
-    const [, line, , column] = $page.url.hash.match(/#:(\d+)(:(\d+))?/) ?? []
-    if (!line) {
-      return
-    }
-    setTimeout(() => {
-      editorRef.revealPosition({ lineNumber: parseInt(line), column: parseInt(column) ?? 1 })
-      window.location.hash = ''
-    }, 50)
-  })
 
   let editDisabled = $derived(
     nonNull(pipeline.current.status) && !isPipelineIdle(pipeline.current.status)
@@ -133,68 +51,50 @@
       status: pipeline.current.programStatus
     })
   )
-  let markers = $state<Record<string, editor.IMarkerData[]>>()
-  $effect(() => {
-    markers = programErrors ? { sql: extractSQLCompilerErrorMarkers(programErrors) } : undefined
-  })
 
   let metrics = useAggregatePipelineStats(pipeline, 1000, 61000)
+  let files = $derived([
+    {
+      // name: `${pipeline.current.name}.sql`,
+      name: `program.sql`,
+      access: {
+        get current() {
+          return pipeline.current.programCode
+        },
+        set current(programCode: string) {
+          // pipeline.optimisticUpdate({ programCode })
+          pipeline.patch({ programCode })
+        }
+      },
+      markers: programErrors ? { sql: extractSQLCompilerErrorMarkers(programErrors) } : undefined
+    }
+  ])
 </script>
 
 <div class="h-full w-full">
   <PaneGroup direction="vertical" class="!overflow-visible">
     <Pane defaultSize={60} minSize={15} class="flex flex-col-reverse !overflow-visible">
-      <div class="flex flex-nowrap items-center gap-8 pr-2">
-        <PipelineEditorStatusBar
-          downstreamChanged={decoupledCode.downstreamChanged}
-          saveCode={decoupledCode.push}
-          programStatus={pipeline.current.programStatus}
-        ></PipelineEditorStatusBar>
-        {#if pipeline.current.status}
-          <DeploymentStatus
-            class="ml-auto h-full w-40 text-[1rem] "
-            status={pipeline.current.status}
-          ></DeploymentStatus>
-          <PipelineActions
-            {pipeline}
-            onDeletePipeline={(pipelineName) =>
-              updatePipelines((pipelines) => pipelines.filter((p) => p.name !== pipelineName))}
-            pipelineBusy={editDisabled}
-            unsavedChanges={decoupledCode.downstreamChanged}
-            onActionSuccess={(action) => handleActionSuccess(pipeline.current.name, action)}
-          ></PipelineActions>
-        {/if}
-      </div>
-      <div class="relative h-full w-full">
-        <div class="absolute h-full w-full" class:opacity-50={editDisabled}>
-          <MonacoEditor
-            {markers}
-            on:ready={(x) => {
-              x.detail.onKeyDown((e) => {
-                if (e.code === 'KeyS' && (e.ctrlKey || e.metaKey)) {
-                  decoupledCode.push()
-                  e.preventDefault()
-                }
-              })
-            }}
-            bind:editor={editorRef}
-            bind:value={decoupledCode.current}
-            options={{
-              theme: mode.darkMode.value === 'light' ? 'vs' : 'vs-dark',
-              automaticLayout: true,
-              lineNumbersMinChars: 3,
-              ...isMonacoEditorDisabled(editDisabled),
-              overviewRulerLanes: 0,
-              hideCursorInOverviewRuler: true,
-              overviewRulerBorder: false,
-              scrollbar: {
-                vertical: 'visible'
-              },
-              language: 'sql'
-            }}
-          />
-        </div>
-      </div>
+      <CodeEditor path={pipeline.current.name} {files}>
+        {#snippet statusBarCenter()}
+          <ProgramStatus programStatus={pipeline.current.programStatus}></ProgramStatus>
+        {/snippet}
+        {#snippet statusBarEnd(downstreamChanged)}
+          {#if pipeline.current.status}
+            <DeploymentStatus
+              class="ml-auto h-full w-40 text-[1rem] "
+              status={pipeline.current.status}
+            ></DeploymentStatus>
+            <PipelineActions
+              {pipeline}
+              onDeletePipeline={(pipelineName) =>
+                updatePipelines((pipelines) => pipelines.filter((p) => p.name !== pipelineName))}
+              pipelineBusy={editDisabled}
+              unsavedChanges={downstreamChanged}
+              onActionSuccess={(action) => handleActionSuccess(pipeline.current.name, action)}
+            ></PipelineActions>
+          {/if}
+        {/snippet}
+      </CodeEditor>
     </Pane>
     <PaneResizer class="pane-divider-horizontal" />
     <Pane minSize={15} class="flex h-full flex-col !overflow-visible">

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditorStatusBar.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditorStatusBar.svelte
@@ -1,80 +1,32 @@
 <script lang="ts">
   import Tooltip from '$lib/components/common/Tooltip.svelte'
-  import { useLocalStorage } from '$lib/compositions/localStore.svelte'
-  import type { ProgramStatus } from '$lib/services/pipelineManager'
-  import { match, P } from 'ts-pattern'
 
   let {
     downstreamChanged,
     saveCode,
-    programStatus
+    autoSavePipeline
   }: {
     downstreamChanged: boolean
     saveCode: () => void
-    programStatus: ProgramStatus | undefined
+    autoSavePipeline: { value: boolean }
   } = $props()
-
-  const autoSavePipeline = useLocalStorage('layout/pipelines/autosave', true)
 </script>
 
-<div class="flex h-full flex-nowrap gap-2">
-  <!-- <div class="w-20 p-0.5 text-center">
-    {downstreamChanged ? 'changed' : 'saved'}
-  </div> -->
-  <div class="flex h-full flex-nowrap">
-    <button
-      class={'px-4 hover:preset-filled-primary-200-800 ' +
-        (downstreamChanged ? 'preset-tonal-primary' : 'bg-surface-50-950')}
-      class:disabled={!downstreamChanged}
-      onclick={saveCode}
-    >
-      Save
-    </button>
-    <Tooltip class="z-20 bg-white text-surface-950-50 dark:bg-black">Ctrl + S</Tooltip>
-    <button
-      class="w-32 px-2 hover:preset-filled-primary-200-800"
-      tabindex={10}
-      onclick={() => (autoSavePipeline.value = !autoSavePipeline.value)}
-    >
-      Autosave: {autoSavePipeline.value ? 'on' : 'off'}
-    </button>
-  </div>
-  <div class="flex w-16 flex-nowrap justify-end gap-2 self-center">
-    <span
-      class={match(programStatus)
-        .with(
-          'Success',
-          'CompilingRust',
-          { RustError: P.any },
-          () => 'bx bx-check -mr-1 -mt-1 h-6 text-[32px] text-success-500'
-        )
-        .with(
-          'Pending',
-          'CompilingSql',
-          undefined,
-          () => 'bx bx-loader-alt animate-spin text-[24px]'
-        )
-        .with(P.shape({}), () => 'bx bx-x-circle text-[24px] text-error-500')
-        .exhaustive()}
-    >
-    </span>
-    SQL
-  </div>
-
-  <div
-    class="{match(programStatus)
-      .with('CompilingRust', { RustError: P.any }, () => 'flex')
-      .with('Success', 'Pending', 'CompilingSql', P.shape({}), undefined, () => 'hidden')
-      .exhaustive()} w-36 flex-nowrap justify-end gap-2 self-center whitespace-nowrap"
+<div class="flex h-full flex-nowrap">
+  <button
+    class={'w-20 px-4 hover:preset-filled-primary-200-800 ' +
+      (downstreamChanged ? 'preset-tonal-primary' : 'bg-surface-50-950')}
+    class:disabled={!downstreamChanged}
+    onclick={saveCode}
   >
-    <span
-      class={match(programStatus)
-        .with('CompilingRust', () => 'bx bx-loader-alt animate-spin text-[24px]')
-        .with({ RustError: P.any }, () => 'bx bx-x-circle text-[24px] text-error-500')
-        .with('Success', 'Pending', 'CompilingSql', P.shape({}), undefined, () => '')
-        .exhaustive()}
-    >
-    </span>
-    Rust compiler
-  </div>
+    {downstreamChanged ? 'Save' : 'Saved'}
+  </button>
+  <Tooltip class="z-20 bg-white text-surface-950-50 dark:bg-black">Ctrl + S</Tooltip>
+  <button
+    class="w-32 px-2 hover:preset-filled-primary-200-800"
+    tabindex={10}
+    onclick={() => (autoSavePipeline.value = !autoSavePipeline.value)}
+  >
+    Autosave: {autoSavePipeline.value ? 'on' : 'off'}
+  </button>
 </div>

--- a/web-console/src/lib/components/layout/pipelines/PipelineThroughputGraph.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineThroughputGraph.svelte
@@ -28,7 +28,7 @@
     grid: {
       top: 10,
       left: 64,
-      right: 20,
+      right: 50,
       bottom: 48
     },
     xAxis: {

--- a/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
+++ b/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
@@ -12,6 +12,7 @@
     path,
     files,
     editDisabled,
+    textEditor,
     statusBarCenter,
     statusBarEnd
   }: {
@@ -22,6 +23,7 @@
       markers?: Record<string, editor.IMarkerData[]>
     }[]
     editDisabled?: boolean
+    textEditor: Snippet<[children: Snippet]>
     statusBarCenter?: Snippet
     statusBarEnd?: Snippet<[downstreamChanged: boolean]>
   } = $props()
@@ -71,6 +73,49 @@
   const mode = useDarkMode()
 </script>
 
+{@render textEditor(x)}
+{#snippet x()}
+  <div class="flex h-full flex-col">
+    <div class="flex">
+      {#each files as file}
+        <div class="py-1 pl-3 pr-8 {file.name === currentFileName ? 'bg-secondary-50' : ''}">
+          {file.name}
+        </div>
+      {/each}
+    </div>
+    <div class="relative flex-1">
+      <div class="absolute h-full w-full" class:opacity-50={editDisabled}>
+        <MonacoEditor
+          markers={file.markers}
+          on:ready={(x) => {
+            x.detail.onKeyDown((e) => {
+              if (e.code === 'KeyS' && (e.ctrlKey || e.metaKey)) {
+                editedText.push()
+                e.preventDefault()
+              }
+            })
+          }}
+          bind:editor={editorRef}
+          bind:value={editedText.current}
+          options={{
+            theme: mode.darkMode.value === 'light' ? 'vs' : 'vs-dark',
+            automaticLayout: true,
+            lineNumbersMinChars: 3,
+            ...isMonacoEditorDisabled(editDisabled),
+            overviewRulerLanes: 0,
+            hideCursorInOverviewRuler: true,
+            overviewRulerBorder: false,
+            scrollbar: {
+              vertical: 'visible'
+            },
+            language: 'sql'
+          }}
+        />
+      </div>
+    </div>
+  </div>
+{/snippet}
+
 <div class="flex flex-nowrap items-center gap-8 pr-2">
   <div class="flex h-full flex-nowrap gap-2">
     <PipelineEditorStatusBar
@@ -81,41 +126,4 @@
     {@render statusBarCenter?.()}
   </div>
   {@render statusBarEnd?.(editedText.downstreamChanged)}
-</div>
-<div class="relative h-full w-full">
-  <div class="absolute h-full w-full" class:opacity-50={editDisabled}>
-    <MonacoEditor
-      markers={file.markers}
-      on:ready={(x) => {
-        x.detail.onKeyDown((e) => {
-          if (e.code === 'KeyS' && (e.ctrlKey || e.metaKey)) {
-            editedText.push()
-            e.preventDefault()
-          }
-        })
-      }}
-      bind:editor={editorRef}
-      bind:value={editedText.current}
-      options={{
-        theme: mode.darkMode.value === 'light' ? 'vs' : 'vs-dark',
-        automaticLayout: true,
-        lineNumbersMinChars: 3,
-        ...isMonacoEditorDisabled(editDisabled),
-        overviewRulerLanes: 0,
-        hideCursorInOverviewRuler: true,
-        overviewRulerBorder: false,
-        scrollbar: {
-          vertical: 'visible'
-        },
-        language: 'sql'
-      }}
-    />
-  </div>
-</div>
-<div class="flex">
-  {#each files as file}
-    <div class="py-1 pl-3 pr-8 {file.name === currentFileName ? 'bg-secondary-50' : ''}">
-      {file.name}
-    </div>
-  {/each}
 </div>

--- a/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
+++ b/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { useLocalStorage } from '$lib/compositions/localStore.svelte'
+  import { useDecoupledState } from '$lib/compositions/decoupledState.svelte'
+  import { useDarkMode } from '$lib/compositions/useDarkMode.svelte'
+  import MonacoEditor, { isMonacoEditorDisabled } from '$lib/functions/common/monacoEditor'
+  import { editor } from 'monaco-editor'
+  import PipelineEditorStatusBar from '$lib/components/layout/pipelines/PipelineEditorStatusBar.svelte'
+  import { page } from '$app/stores'
+
+  let {
+    path,
+    files,
+    editDisabled,
+    statusBarCenter,
+    statusBarEnd
+  }: {
+    path: string
+    files: {
+      name: string
+      access: { current: string }
+      markers?: Record<string, editor.IMarkerData[]>
+    }[]
+    editDisabled?: boolean
+    statusBarCenter?: Snippet
+    statusBarEnd?: Snippet<[downstreamChanged: boolean]>
+  } = $props()
+
+  let currentFileName = $state(files[0].name)
+
+  const autoSavePipeline = useLocalStorage('layout/pipelines/autosave', true)
+
+  let wait = $derived(autoSavePipeline.value ? 2000 : ('decoupled' as const))
+  let file = $derived(files.find((f) => f.name === currentFileName)!)
+  let editedText = useDecoupledState(file.access, () => wait)
+  {
+    // TODO: handle remote update of the program code that conflicts with currently edited version
+    let pipelineName = $derived(path)
+    $effect(() => {
+      // Fetch new code when switching pipeline
+      pipelineName
+      setTimeout(() => {
+        editedText.pull()
+      })
+    })
+  }
+
+  $effect(() => {
+    // Trigger save right away when autosave is turned on
+    if (!autoSavePipeline.value) {
+      return
+    }
+    setTimeout(() => editedText.push())
+  })
+
+  let editorRef: editor.IStandaloneCodeEditor = $state()!
+  $effect(() => {
+    if (!editorRef) {
+      return
+    }
+    const [, line, , column] = $page.url.hash.match(/#:(\d+)(:(\d+))?/) ?? []
+    if (!line) {
+      return
+    }
+    setTimeout(() => {
+      editorRef.revealPosition({ lineNumber: parseInt(line), column: parseInt(column) ?? 1 })
+      window.location.hash = ''
+    }, 50)
+  })
+
+  const mode = useDarkMode()
+</script>
+
+<div class="flex flex-nowrap items-center gap-8 pr-2">
+  <div class="flex h-full flex-nowrap gap-2">
+    <PipelineEditorStatusBar
+      {autoSavePipeline}
+      downstreamChanged={editedText.downstreamChanged}
+      saveCode={editedText.push}
+    ></PipelineEditorStatusBar>
+    {@render statusBarCenter?.()}
+  </div>
+  {@render statusBarEnd?.(editedText.downstreamChanged)}
+</div>
+<div class="relative h-full w-full">
+  <div class="absolute h-full w-full" class:opacity-50={editDisabled}>
+    <MonacoEditor
+      markers={file.markers}
+      on:ready={(x) => {
+        x.detail.onKeyDown((e) => {
+          if (e.code === 'KeyS' && (e.ctrlKey || e.metaKey)) {
+            editedText.push()
+            e.preventDefault()
+          }
+        })
+      }}
+      bind:editor={editorRef}
+      bind:value={editedText.current}
+      options={{
+        theme: mode.darkMode.value === 'light' ? 'vs' : 'vs-dark',
+        automaticLayout: true,
+        lineNumbersMinChars: 3,
+        ...isMonacoEditorDisabled(editDisabled),
+        overviewRulerLanes: 0,
+        hideCursorInOverviewRuler: true,
+        overviewRulerBorder: false,
+        scrollbar: {
+          vertical: 'visible'
+        },
+        language: 'sql'
+      }}
+    />
+  </div>
+</div>
+<div class="flex">
+  {#each files as file}
+    <div class="py-1 pl-3 pr-8 {file.name === currentFileName ? 'bg-secondary-50' : ''}">
+      {file.name}
+    </div>
+  {/each}
+</div>

--- a/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
+++ b/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
@@ -64,7 +64,7 @@
     <Tabs.Control
       bind:group={currentTab.value}
       name={tabName}
-      contentClasses="group-hover:preset-tonal-surface"
+      contentClasses="group-hover:!bg-inherit"
     >
       {#if tabControl}
         {@render tabControl(pipeline.current)}

--- a/web-console/src/lib/components/pipelines/editor/ProgramStatus.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ProgramStatus.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { ProgramStatus } from '$lib/services/pipelineManager'
+  import { match, P } from 'ts-pattern'
+
+  let {
+    programStatus
+  }: {
+    programStatus: ProgramStatus | undefined
+  } = $props()
+</script>
+
+<div class="flex w-16 flex-nowrap justify-end gap-2 self-center">
+  <span
+    class={match(programStatus)
+      .with(
+        'Success',
+        'CompilingRust',
+        { RustError: P.any },
+        () => 'bx bx-check -mr-1 -mt-1 h-6 text-[32px] text-success-500'
+      )
+      .with('Pending', 'CompilingSql', undefined, () => 'bx bx-loader-alt animate-spin text-[24px]')
+      .with(P.shape({}), () => 'bx bx-x-circle text-[24px] text-error-500')
+      .exhaustive()}
+  >
+  </span>
+  SQL
+</div>
+
+<div
+  class="{match(programStatus)
+    .with('CompilingRust', { RustError: P.any }, () => 'flex')
+    .with('Success', 'Pending', 'CompilingSql', P.shape({}), undefined, () => 'hidden')
+    .exhaustive()} w-36 flex-nowrap justify-end gap-2 self-center whitespace-nowrap"
+>
+  <span
+    class={match(programStatus)
+      .with('CompilingRust', () => 'bx bx-loader-alt animate-spin text-[24px]')
+      .with({ RustError: P.any }, () => 'bx bx-x-circle text-[24px] text-error-500')
+      .with('Success', 'Pending', 'CompilingSql', P.shape({}), undefined, () => '')
+      .exhaustive()}
+  >
+  </span>
+  Rust compiler
+</div>

--- a/web-console/src/lib/components/pipelines/editor/ProgramStatus.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ProgramStatus.svelte
@@ -18,7 +18,12 @@
         { RustError: P.any },
         () => 'bx bx-check -mr-1 -mt-1 h-6 text-[32px] text-success-500'
       )
-      .with('Pending', 'CompilingSql', undefined, () => 'bx bx-loader-alt animate-spin text-[24px]')
+      .with(
+        'Pending',
+        'CompilingSql',
+        undefined,
+        () => 'bx bx-loader-alt animate-spin pt-[0.5px] text-[24px]'
+      )
       .with(P.shape({}), () => 'bx bx-x-circle text-[24px] text-error-500')
       .exhaustive()}
   >
@@ -34,7 +39,7 @@
 >
   <span
     class={match(programStatus)
-      .with('CompilingRust', () => 'bx bx-loader-alt animate-spin text-[24px]')
+      .with('CompilingRust', () => 'bx bx-loader-alt animate-spin pt-[0.5px] text-[24px]')
       .with({ RustError: P.any }, () => 'bx bx-x-circle text-[24px] text-error-500')
       .with('Success', 'Pending', 'CompilingSql', P.shape({}), undefined, () => '')
       .exhaustive()}

--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -227,7 +227,7 @@
         {/if}
       </div>
     </Pane>
-    <PaneResizer class="pane-divider-vertical"></PaneResizer>
+    <PaneResizer class="pane-divider-vertical bg-surface-100-900 "></PaneResizer>
 
     <Pane minSize={70} class="flex h-full">
       {#if getChangeStream()[pipelineName]?.rows?.length}

--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -2,7 +2,7 @@
   import PipelineMemoryGraph from '$lib/components/layout/pipelines/PipelineMemoryGraph.svelte'
   import PipelineThroughputGraph from '$lib/components/layout/pipelines/PipelineThroughputGraph.svelte'
   import { humanSize } from '$lib/functions/common/string'
-  import { emptyPipelineMetrics, type PipelineMetrics } from '$lib/functions/pipelineMetrics'
+  import { type PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import type { ExtendedPipeline } from '$lib/services/pipelineManager'
   import { format } from 'd3-format'
 
@@ -19,24 +19,25 @@
 {#if global}
   <div class="flex flex-col gap-4 p-2">
     <div class="flex w-full flex-col-reverse gap-2 lg:flex-row">
-      <div class="mb-auto flex flex-col">
-        <span class="w-full border-b-2 text-center text-surface-600-400">Total records</span>
-        <div
-          class=" grid max-w-64 grid-flow-col grid-rows-2 gap-x-4 lg:grid-flow-row lg:grid-cols-2"
-        >
-          <!-- <span class="col-span-2">Records</span> -->
-          <span>Ingested:</span>
-          <span class="text-end">
-            {formatQty(global.total_input_records)}
-          </span>
-          <span>Processed:</span>
-          <span class="text-end">
-            {formatQty(global.total_processed_records)}
-          </span>
-          <span>Buffered:</span>
-          <span class="text-end">
-            {formatQty(global.buffered_input_records)}
-          </span>
+      <div class="mr-auto">
+        <div class="mb-auto flex flex-col">
+          <div class="border-b-2 text-center text-surface-600-400">Total records</div>
+          <div
+            class=" grid max-w-64 grid-flow-col grid-rows-2 gap-x-4 lg:grid-flow-row lg:grid-cols-2"
+          >
+            <span>Ingested:</span>
+            <span class="text-end">
+              {formatQty(global.total_input_records)}
+            </span>
+            <span>Processed:</span>
+            <span class="text-end">
+              {formatQty(global.total_processed_records)}
+            </span>
+            <span>Buffered:</span>
+            <span class="text-end">
+              {formatQty(global.buffered_input_records)}
+            </span>
+          </div>
         </div>
       </div>
       <div class="flex w-full flex-col md:flex-row">
@@ -54,49 +55,65 @@
         </div>
       </div>
     </div>
-    <div class="grid max-w-[800px] grid-cols-5">
-      <span class="border-b-2 text-center text-surface-600-400">Table</span>
-      <span class="border-b-2 text-center text-surface-600-400">Ingested records</span>
-      <span class="border-b-2 text-center text-surface-600-400">Ingested bytes</span>
-      <span class="border-b-2 text-center text-surface-600-400">Parse errors</span>
-      <span class="border-b-2 text-center text-surface-600-400">Transport errors</span>
-      {#each metrics.current.input.entries() as [relation, stats]}
-        <span>
-          {relation}
-        </span>
-        <span class="mr-4 text-end">
-          {formatQty(stats.total_records)}
-        </span>
-        <span class="mr-4 text-end">
-          {humanSize(stats.total_bytes)}
-        </span>
-        <span class="mr-4 text-end">{formatQty(stats.num_parse_errors)} </span>
-        <span class="mr-4 text-end">{formatQty(stats.num_transport_errors)} </span>
-      {/each}
-    </div>
-    {#if metrics.current.output.size}
-      <div class="grid max-w-[960px] grid-cols-6">
-        <span class="border-b-2 text-center text-surface-600-400">View</span>
-        <span class="border-b-2 text-center text-surface-600-400">Transmitted records</span>
-        <span class="border-b-2 text-center text-surface-600-400">Transmitted bytes</span>
-        <span class="border-b-2 text-center text-surface-600-400">Processed records</span>
-        <span class="border-b-2 text-center text-surface-600-400">Encode errors</span>
-        <span class="border-b-2 text-center text-surface-600-400">Transport errors</span>
-        {#each metrics.current.output.entries() as [relation, stats]}
-          <span>
-            {relation}
-          </span>
-          <span class="mr-4 text-end">
-            {formatQty(stats.transmitted_records)}
-          </span>
-          <span class="mr-4 text-end">
-            {humanSize(stats.transmitted_bytes)}
-          </span>
-          <span class="mr-4 text-end">{formatQty(stats.total_processed_input_records)} </span>
-          <span class="mr-4 text-end">{formatQty(stats.num_encode_errors)} </span>
-          <span class="mr-4 text-end">{formatQty(stats.num_transport_errors)} </span>
+    <table class="max-w-[1000px]">
+      <thead class="border-b-2">
+        <tr>
+          <th class="text-center font-normal text-surface-600-400">Table</th>
+          <th class="text-center font-normal text-surface-600-400">Ingested records</th>
+          <th class="text-center font-normal text-surface-600-400">Ingested bytes</th>
+          <th class="text-center font-normal text-surface-600-400">Parse errors</th>
+          <th class="text-center font-normal text-surface-600-400">Transport errors</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each metrics.current.input.entries() as [relation, stats]}
+          <tr>
+            <td>
+              {relation}
+            </td>
+            <td class="text-end">
+              {formatQty(stats.total_records)}
+            </td>
+            <td class="text-end">
+              {humanSize(stats.total_bytes)}
+            </td>
+            <td class="text-end">{formatQty(stats.num_parse_errors)} </td>
+            <td class="text-end">{formatQty(stats.num_transport_errors)} </td>
+          </tr>
         {/each}
-      </div>
+      </tbody>
+    </table>
+    {#if metrics.current.output.size}
+      <table class="max-w-[1200px]">
+        <thead class="border-b-2">
+          <tr>
+            <th class="text-center font-normal text-surface-600-400">View</th>
+            <th class="text-center font-normal text-surface-600-400">Transmitted records</th>
+            <th class="text-center font-normal text-surface-600-400">Transmitted bytes</th>
+            <th class="text-center font-normal text-surface-600-400">Processed records</th>
+            <th class="text-center font-normal text-surface-600-400">Encode errors</th>
+            <th class="text-center font-normal text-surface-600-400">Transport errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each metrics.current.output.entries() as [relation, stats]}
+            <tr>
+              <td>
+                {relation}
+              </td>
+              <td class="text-end">
+                {formatQty(stats.transmitted_records)}
+              </td>
+              <td class="text-end">
+                {humanSize(stats.transmitted_bytes)}
+              </td>
+              <td class="text-end">{formatQty(stats.total_processed_input_records)} </td>
+              <td class="text-end">{formatQty(stats.num_encode_errors)} </td>
+              <td class="text-end">{formatQty(stats.num_transport_errors)} </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
     {/if}
   </div>
 {:else}

--- a/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -3,7 +3,8 @@
     postPipelineAction,
     type ExtendedPipeline,
     type Pipeline,
-    type PipelineAction
+    type PipelineAction,
+    type PipelineStatus
   } from '$lib/services/pipelineManager'
   import { match, P } from 'ts-pattern'
   import { deletePipeline as _deletePipeline } from '$lib/services/pipelineManager'
@@ -78,7 +79,8 @@
       .exhaustive()
   )
 
-  const buttonClass = ' btn-icon h-9 w-9 preset-tonal-surface text-[36px]'
+  const buttonClass =
+    'hover:brightness-90 dark:hover:brightness-110 hover:backdrop-brightness-100 text-[32px] w-9 h-9'
 </script>
 
 {#snippet deleteDialog()}
@@ -100,25 +102,26 @@
 
 {#snippet _delete()}
   <button
-    class={'bx bx-trash-alt  ' + buttonClass}
+    class="bx bx-trash-alt {buttonClass}"
     onclick={() => (globalDialog.dialog = deleteDialog)}
   >
   </button>
 {/snippet}
+{#snippet start(action: PipelineAction, status: PipelineStatus)}
+  <button
+    class:disabled={unsavedChanges}
+    class="{buttonClass} bx bx-play text-[36px] bg-success-200-800"
+    onclick={async () => {
+      const success = await postPipelineAction(pipeline.current.name, action)
+      pipeline.optimisticUpdate({ status })
+      await success()
+      onActionSuccess?.('start_paused')
+    }}
+  >
+  </button>
+{/snippet}
 {#snippet _start()}
-  <div class={buttonClass}>
-    <button
-      class:disabled={unsavedChanges}
-      class={'bx bx-play !bg-success-200-800 '}
-      onclick={async () => {
-        const success = await postPipelineAction(pipeline.current.name, 'start')
-        pipeline.optimisticUpdate({ status: 'Resuming' })
-        await success()
-        onActionSuccess?.('start')
-      }}
-    >
-    </button>
-  </div>
+  {@render start('start', 'Resuming')}
   {#if unsavedChanges}
     <Tooltip class="z-20 bg-white text-surface-950-50 dark:bg-black" placement="top">
       Save the pipeline before running
@@ -126,19 +129,7 @@
   {/if}
 {/snippet}
 {#snippet _start_paused()}
-  <div class={buttonClass}>
-    <button
-      class:disabled={unsavedChanges}
-      class={'bx bx-play !bg-success-200-800 '}
-      onclick={async () => {
-        const success = await postPipelineAction(pipeline.current.name, 'start_paused')
-        pipeline.optimisticUpdate({ status: 'Starting up' })
-        await success()
-        onActionSuccess?.('start_paused')
-      }}
-    >
-    </button>
-  </div>
+  {@render start('start_paused', 'Starting up')}
   {#if unsavedChanges}
     <Tooltip class="z-20 bg-white text-surface-950-50 dark:bg-black" placement="top">
       Save the pipeline before running
@@ -146,8 +137,8 @@
   {/if}
 {/snippet}
 {#snippet _start_disabled()}
-  <div class="{buttonClass} !filter-none">
-    <button class="bx bx-play" disabled> </button>
+  <div class="h-9">
+    <button class="{buttonClass} bx bx-play disabled text-[36px]"></button>
   </div>
 {/snippet}
 {#snippet _start_error()}
@@ -164,7 +155,7 @@
 {/snippet}
 {#snippet _pause()}
   <button
-    class={'bx bx-pause ' + buttonClass}
+    class="bx bx-pause {buttonClass}"
     onclick={() =>
       postPipelineAction(pipeline.current.name, 'pause').then(() => {
         onActionSuccess?.('pause')
@@ -175,7 +166,7 @@
 {/snippet}
 {#snippet _shutdown()}
   <button
-    class={'bx bx-stop ' + buttonClass}
+    class="bx bx-stop {buttonClass}"
     onclick={() =>
       postPipelineAction(pipeline.current.name, 'shutdown').then(() => {
         onActionSuccess?.('shutdown')
@@ -205,7 +196,7 @@
   {/snippet}
   <button
     onclick={() => (globalDialog.dialog = pipelineResourcesDialog)}
-    class={'bx bx-cog ' + buttonClass}
+    class="bx bx-cog {buttonClass}"
   >
   </button>
   {#if pipelineBusy}
@@ -218,7 +209,7 @@
   <div class="w-9"></div>
 {/snippet}
 {#snippet _spinner()}
-  <div class={'pointer-events-none h-9 ' + buttonClass}>
-    <div class="bx bx-loader-alt btn-icon animate-spin"></div>
-  </div>
+  <div
+    class="bx bx-loader-alt pointer-events-none h-9 w-9 animate-spin pt-[0.5px] !text-[36px]"
+  ></div>
 {/snippet}

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -135,10 +135,14 @@ export const getPipeline = async (pipeline_name: string) => {
   )
 }
 
-export const getExtendedPipeline = async (pipeline_name: string) => {
-  return handled(_getPipeline)({ path: { pipeline_name: encodeURIComponent(pipeline_name) } }).then(
-    toExtendedPipeline
-  )
+export const getExtendedPipeline = async (
+  pipeline_name: string,
+  options?: { fetch?: (request: Request) => ReturnType<typeof fetch> }
+) => {
+  return handled(_getPipeline)({
+    path: { pipeline_name: encodeURIComponent(pipeline_name) },
+    ...options
+  }).then(toExtendedPipeline)
 }
 
 /**

--- a/web-console/src/routes/(authenticated)/(pipelines)/+layout.svelte
+++ b/web-console/src/routes/(authenticated)/(pipelines)/+layout.svelte
@@ -3,7 +3,6 @@
   import { page as pageStore } from '$app/stores'
   import NewPipelineTabControl from '$lib/components/pipelines/tabs/NewPipelineTabControl.svelte'
   import ExistingPipelineTabControl from '$lib/components/pipelines/tabs/ExistingPipelineTabControl.svelte'
-  import { useChangedPipelines } from '$lib/compositions/pipelines/useChangedPipelines.svelte'
   import { base } from '$app/paths'
   import { Store } from 'runed'
 
@@ -14,10 +13,9 @@
       ? { new: 'new' }
       : { existing: page.current.params.pipelineName }
   )
-  const changedPipelines = useChangedPipelines()
 </script>
 
-<div class=" -mt-10 mb-4 ml-14 w-fit">
+<div class=" -mt-[35px] mb-2 ml-14 w-fit">
   {#if 'existing' in pipeline}
     {#snippet text()}
       {pipeline.existing}
@@ -26,7 +24,7 @@
       {text}
       close={undefined}
       existing={pipeline.existing}
-      tabContentChanged={changedPipelines.has(pipeline.existing)}
+      tabContentChanged={false}
     ></ExistingPipelineTabControl>
   {:else}
     {#snippet text()}

--- a/web-console/src/routes/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.ts
+++ b/web-console/src/routes/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.ts
@@ -6,9 +6,9 @@ export const prerender = false
 
 export const load = async ({ params, route, url, fetch, parent }) => {
   await parent()
-  const preloadedPipeline = await getExtendedPipeline(
-    decodeURIComponent(params.pipelineName)
-  ).catch((e) => goto(`${base}/`) as never)
+  const preloadedPipeline = await getExtendedPipeline(decodeURIComponent(params.pipelineName), {
+    fetch
+  }).catch((e) => goto(`${base}/`) as never)
   return {
     preloadedPipeline
   }

--- a/web-console/src/routes/(authenticated)/+layout.svelte
+++ b/web-console/src/routes/(authenticated)/+layout.svelte
@@ -41,7 +41,7 @@
     </div>
   </Drawer>
   <div class="flex h-full w-full flex-col">
-    <div class="flex justify-between p-3">
+    <div class="flex justify-between p-1">
       <div class="flex">
         <button
           class="btn-icon"


### PR DESCRIPTION
The goal of the PR is to introduce the UX of file tabs to Pipeline Edit page. While viewing the pipeline user can switch between multiple code tabs that represent different fields of pipeline configuration.
With initial UDF implementation the file tabs will be: `program.sql`, `udf.rs` and `Cargo.toml`.

Also: Improved Performance Tab tables, moved draggable horizontal divider to the border of code editor box, and other minor improvements.

![image](https://github.com/user-attachments/assets/9019c2b7-1807-4b09-b415-2fe1d8df788c)

Fix https://github.com/feldera/feldera/issues/2397 : Long table and view names obstruct metrics in performance tab