### PR TITLE
[avro] Confluent JDBC sink connector Avro format.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1459,7 +1459,12 @@ impl ControllerInner {
             let format = <dyn OutputFormat>::get_format(&format_config.name).ok_or_else(|| {
                 ControllerError::unknown_output_format(endpoint_name, &format_config.name)
             })?;
-            format.new_encoder(endpoint_name, &format_config.config, &handles.schema, probe)?
+            format.new_encoder(
+                endpoint_name,
+                &endpoint_config.connector_config,
+                &handles.schema,
+                probe,
+            )?
         } else {
             // `endpoint` is `None` - instantiate an integrated endpoint.
             let endpoint = create_integrated_output_endpoint(
@@ -1940,8 +1945,8 @@ impl OutputConsumer for OutputProbe {
         }
     }
 
-    fn push_key(&mut self, key: &[u8], val: &[u8], num_records: usize) {
-        let num_bytes = key.len() + val.len();
+    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>, num_records: usize) {
+        let num_bytes = key.len() + val.map(|v| v.len()).unwrap_or_default();
 
         match self.endpoint.push_key(key, val) {
             Ok(()) => {

--- a/crates/adapters/src/format/avro/input.rs
+++ b/crates/adapters/src/format/avro/input.rs
@@ -140,6 +140,16 @@ impl AvroParser {
             ));
         }
 
+        match config.update_format {
+            AvroUpdateFormat::ConfluentJdbc => {
+                return Err(ControllerError::invalid_parser_configuration(
+                    endpoint_name,
+                    "'confluent_jdbc' data change event format is not yet supported by the Avro parser",
+                ));
+            }
+            AvroUpdateFormat::Debezium | AvroUpdateFormat::Raw => (),
+        }
+
         let mut parser = Self {
             endpoint_name: endpoint_name.to_string(),
             input_handle,
@@ -230,6 +240,9 @@ impl AvroParser {
                     schema_json(schema)
                 ))),
             },
+            AvroUpdateFormat::ConfluentJdbc => {
+                unreachable!()
+            }
         }
     }
 
@@ -356,6 +369,9 @@ impl AvroParser {
                             )
                         })?;
                 }
+            }
+            AvroUpdateFormat::ConfluentJdbc => {
+                unreachable!()
             }
         }
 

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Result as AnyResult;
 #[cfg(feature = "with-avro")]
 use avro::input::AvroInputFormat;
 use erased_serde::Serialize as ErasedSerialize;
+use feldera_types::config::ConnectorConfig;
 use feldera_types::program_schema::Relation;
 use feldera_types::serde_with_context::FieldParseError;
 use once_cell::sync::Lazy;
@@ -478,7 +479,7 @@ pub trait OutputFormat: Send + Sync {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &ConnectorConfig,
         schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError>;
@@ -507,6 +508,6 @@ pub trait OutputConsumer: Send {
 
     fn batch_start(&mut self, step: Step);
     fn push_buffer(&mut self, buffer: &[u8], num_records: usize);
-    fn push_key(&mut self, key: &[u8], val: &[u8], num_records: usize);
+    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>, num_records: usize);
     fn batch_end(&mut self);
 }

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -9,6 +9,7 @@ use arrow::datatypes::{
 };
 use bytes::Bytes;
 use erased_serde::Serialize as ErasedSerialize;
+use feldera_types::config::ConnectorConfig;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 use parquet::file::reader::{FileReader, SerializedFileReader};
@@ -204,17 +205,18 @@ impl OutputFormat for ParquetOutputFormat {
     fn new_encoder(
         &self,
         endpoint_name: &str,
-        config: &YamlValue,
+        config: &ConnectorConfig,
         schema: &Relation,
         consumer: Box<dyn OutputConsumer>,
     ) -> Result<Box<dyn Encoder>, ControllerError> {
-        let config = ParquetEncoderConfig::deserialize(config).map_err(|e| {
-            ControllerError::encoder_config_parse_error(
-                endpoint_name,
-                &e,
-                &serde_yaml::to_string(&config).unwrap_or_default(),
-            )
-        })?;
+        let config = ParquetEncoderConfig::deserialize(&config.format.as_ref().unwrap().config)
+            .map_err(|e| {
+                ControllerError::encoder_config_parse_error(
+                    endpoint_name,
+                    &e,
+                    &serde_yaml::to_string(&config).unwrap_or_default(),
+                )
+            })?;
         Ok(Box::new(ParquetEncoder::new(
             consumer,
             config,

--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -393,7 +393,7 @@ impl OutputConsumer for DeltaTableWriter {
         unreachable!()
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: &[u8], _num_records: usize) {
+    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>, _num_records: usize) {
         unreachable!()
     }
 
@@ -491,7 +491,7 @@ impl OutputEndpoint for DeltaTableWriter {
         unreachable!()
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: &[u8]) -> AnyResult<()> {
+    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
         unreachable!()
     }
 

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -45,12 +45,13 @@ impl OutputConsumer for MockOutputConsumer {
     fn push_buffer(&mut self, buffer: &[u8], _num_records: usize) {
         self.data.lock().unwrap().push((None, buffer.to_vec()))
     }
-    fn push_key(&mut self, key: &[u8], val: &[u8], _num_records: usize) {
+    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>, _num_records: usize) {
         // println!("push_key {:?} , {:?}", key, val);
+        // TODO: support None values.
         self.data
             .lock()
             .unwrap()
-            .push((Some(key.to_vec()), val.to_vec()))
+            .push((Some(key.to_vec()), val.unwrap().to_vec()))
     }
     fn batch_end(&mut self) {}
 }

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -183,7 +183,7 @@ impl OutputEndpoint for FileOutputEndpoint {
         Ok(())
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: &[u8]) -> AnyResult<()> {
+    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
         bail!(
             "File output transport does not support key-value pairs. \
 This output endpoint was configured with a data format that produces outputs as key-value pairs; \

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -301,7 +301,7 @@ impl OutputEndpoint for HttpOutputEndpoint {
             .push_buffer(Some(buffer), self.inner.backpressure)
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: &[u8]) -> AnyResult<()> {
+    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
         bail!(
             "HTTP output transport does not support key-value pairs. \
 This output endpoint was configured with a data format that produces outputs as key-value pairs; \

--- a/crates/adapters/src/transport/kafka/ft/output.rs
+++ b/crates/adapters/src/transport/kafka/ft/output.rs
@@ -248,7 +248,7 @@ impl OutputEndpoint for KafkaOutputEndpoint {
         Ok(())
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: &[u8]) -> AnyResult<()> {
+    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
         todo!()
     }
 

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -356,14 +356,14 @@ pub trait OutputEndpoint: Send {
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()>;
 
-    /// Output a message consisting of a key/value pair.
+    /// Output a message consisting of a key/value pair, with optional value.
     ///
     /// This API is implemented by Kafka and other transports that transmit
     /// messages consisting of key and value fields and in invoked by
     /// Kafka-specific data formats that rely on this message structure,
     /// e.g., Debezium. If a given transport does not implement this API, it
     /// should return an error.
-    fn push_key(&mut self, key: &[u8], val: &[u8]) -> AnyResult<()>;
+    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>) -> AnyResult<()>;
 
     /// Notifies the output endpoint that output for the current step is
     /// complete.

--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -406,6 +406,12 @@ pub enum SqlType {
     Null,
 }
 
+impl Display for SqlType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&serde_json::to_string(self).unwrap())
+    }
+}
+
 impl<'de> Deserialize<'de> for SqlType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -477,6 +483,13 @@ impl From<SqlType> for &'static str {
             SqlType::Map => "MAP",
             SqlType::Null => "NULL",
         }
+    }
+}
+
+impl SqlType {
+    /// Is this a string type?
+    pub fn is_string(&self) -> bool {
+        matches!(self, Self::Char | Self::Varchar)
     }
 }
 

--- a/demo/project_demo08-DebeziumJDBC/run.py
+++ b/demo/project_demo08-DebeziumJDBC/run.py
@@ -1,8 +1,7 @@
-# Stream output of a view to Postgres via Debesium JDBC sink connector.VIEW_NAME
+# Stream output of a view to Postgres via Debezium JDBC sink connector and Confluent JDBC sink connector.
 #
 # To run the demo, start Feldera along with RedPanda, Kafka Connect, and Postgres containers:
-# > docker compose -f deploy/docker-compose.yml -f deploy/docker-compose-jdbc.yml --profile debezium \
-#       up redpanda connect postgres --renew-anon-volumes --force-recreate
+# > docker compose -f deploy/docker-compose.yml -f deploy/docker-compose-jdbc.yml --profile debezium up redpanda connect postgres --renew-anon-volumes --force-recreate
 #
 # Run this script:
 # > python3 run.py --api-url=http://localhost:8080 --start
@@ -15,6 +14,7 @@ from plumbum.cmd import rpk
 import psycopg
 import random
 from feldera import PipelineBuilder, FelderaClient, Pipeline
+from typing import Dict
 
 # File locations
 SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
@@ -22,36 +22,97 @@ PROJECT_SQL = os.path.join(SCRIPT_DIR, "project.sql")
 
 DATABASE_NAME = "jdbc_test_db"
 PIPELINE_NAME = "demo-debezium-jdbc-pipeline"
-KAFKA_CONNECT_CONNECTOR_NAME = "jdbc-test-connector"
+JSON_CONNECTOR_NAME = "jdbc-test-connector-json"
+AVRO_CONNECTOR_NAME = "jdbc-test-connector-avro"
 FELDERA_CONNECTOR_NAME = "jdbc-sink"
 TABLE_NAME = "test_table"
-# Database view to read from. Also used as the name of the Kafka topic
-# to send updates to.
-VIEW_NAME = "test_view"
+
+# The name of the Kafka topic and the resulting Postgres table.
+JSON_TABLE_NAME = "json_jdbc_test"
+AVRO_TABLE_NAME = "avro_jdbc_test"
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--api-url", default="http://localhost:8080", help="Feldera API URL (e.g., http://localhost:8080 )")
     parser.add_argument('--start', action='store_true', default=False, help="Start the Feldera pipeline")
-    parser.add_argument('--kafka-url', required=False, default="redpanda:9092", help="Kafka URL reachable from the pipeline")
+    parser.add_argument('--kafka-url-from-pipeline', required=False, default="redpanda:9092", help="Kafka URL reachable from the pipeline")
+    parser.add_argument("--registry-url-from-pipeline", default="http://redpanda:8081", help="Schema registry address reachable from the pipeline")
+    parser.add_argument("--registry-url-from-connect", default="http://redpanda:8081", help="Schema registry address reachable from the Kafka Connect server")
 
     args = parser.parse_args()
     # Delete old connector instance first so it doesn't block topic deletion.
-    delete_connector()
+    delete_connector(JSON_CONNECTOR_NAME)
+    delete_connector(AVRO_CONNECTOR_NAME)
+
     # Drop and re-create the database.
     create_database()
     # Create fresh Kafka topics and a new connector instance listening on those topics.
-    create_debezium_jdbc_connector()
+
+    json_config = {
+            "connector.class": "io.debezium.connector.jdbc.JdbcSinkConnector",
+            "tasks.max": "1",
+            "connection.url": f"jdbc:postgresql://postgres:5432/{DATABASE_NAME}",
+            "connection.username": "postgres",
+            "connection.password": "postgres",
+            "insert.mode": "upsert",
+            "primary.key.mode": "record_key",
+            "delete.enabled": True,
+            "schema.evolution": "basic",
+            "database.time_zone": "UTC",
+            "dialect.name": "PostgreSqlDatabaseDialect",
+            "topics": JSON_TABLE_NAME,
+            "errors.deadletterqueue.topic.name": "dlq",
+            "errors.deadletterqueue.context.headers.enable": True,
+            "errors.deadletterqueue.topic.replication.factor": 1,
+            "errors.tolerance": "all",
+            "binary.handling.mode": "bytes",
+            "decimal.handling.mode": "string"
+        }
+
+    create_jdbc_connector(JSON_CONNECTOR_NAME, JSON_TABLE_NAME, json_config)
+
+    avro_config = {
+            "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+            "errors.log.include.messages": "true",
+            "dialect.name": "PostgreSqlDatabaseDialect",
+            "tasks.max": "1",
+            "connection.url": f"jdbc:postgresql://postgres:5432/{DATABASE_NAME}",
+            "connection.user": "postgres",
+            "connection.password": "postgres",
+            "insert.mode": "upsert",
+            "delete.enabled": True,
+            "pk.mode": "record_key",
+            "auto.create": True,
+            "auto.evolve": True,
+            "schema.evolution": "basic",
+            "database.time_zone": "UTC",
+            "topics": AVRO_TABLE_NAME,
+            "errors.deadletterqueue.topic.name": "dlq",
+            "errors.deadletterqueue.context.headers.enable": True,
+            "errors.deadletterqueue.topic.replication.factor": 1,
+            "errors.tolerance": "all",
+            "key.converter.key.subject.name.strategy": "io.confluent.kafka.serializers.subject.TopicNameStrategy",
+            "value.converter.value.subject.name.strategy": "io.confluent.kafka.serializers.subject.TopicNameStrategy",
+            "key.converter": "io.confluent.connect.avro.AvroConverter",
+            "value.converter": "io.confluent.connect.avro.AvroConverter",
+            "key.converter.schemas.enable": "true",
+            "value.converter.schemas.enable": "true",
+            "key.converter.schema.registry.url": args.registry_url_from_connect,
+            "value.converter.schema.registry.url": args.registry_url_from_connect,
+        }
+
+    create_jdbc_connector(AVRO_CONNECTOR_NAME, AVRO_TABLE_NAME, avro_config)
+
     # Create a pipeline that will write to the topics.
-    pipeline = create_feldera_pipeline(args.api_url, args.kafka_url, args.start)
+    pipeline = create_feldera_pipeline(args.api_url, args.kafka_url_from_pipeline, args.registry_url_from_pipeline, args.start)
     if args.start:
         generate_inputs(pipeline)
 
-def delete_connector():
-    print("Deleting old connector")
+def delete_connector(connector_name: str):
+    print(f"Deleting old connector {connector_name}")
     connect_server = os.getenv("KAFKA_CONNECT_SERVER", "http://localhost:8083")
     # Delete previous connector instance if any.
-    requests.delete(f"{connect_server}/connectors/{KAFKA_CONNECT_CONNECTOR_NAME}")
+    requests.delete(f"{connect_server}/connectors/{connector_name}")
 
 def create_database():
     postgres_server = os.getenv("POSTGRES_SERVER", "localhost:6432")
@@ -61,18 +122,19 @@ def create_database():
             print(f"(Re-)creating test database {DATABASE_NAME}")
             cur.execute(f"DROP DATABASE IF EXISTS {DATABASE_NAME}")
             cur.execute(f"CREATE DATABASE {DATABASE_NAME}")
+            print("Database created")
 
 
 # Wait until the db contains exactly expected_rows rows.
-def wait_for_n_outputs(expected_rows: int):
+def wait_for_n_outputs(table_name: str, expected_rows: int):
     postgres_server = os.getenv("POSTGRES_SERVER", "localhost:6432")
 
     with psycopg.connect(f"postgresql://postgres:postgres@{postgres_server}/{DATABASE_NAME}") as conn:
         with conn.cursor() as cur:
-            print(f"Waiting for Postgres table {VIEW_NAME} to be created")
+            print(f"Waiting for Postgres table {table_name} to be created")
             start_time = time.time()
             while True:
-                cur.execute(f"select exists(select * from information_schema.tables where table_name='{VIEW_NAME}')")
+                cur.execute(f"select exists(select * from information_schema.tables where table_name='{table_name}')")
                 if cur.fetchone()[0]:
                     print("Done!")
                     break
@@ -84,10 +146,10 @@ def wait_for_n_outputs(expected_rows: int):
                     time.sleep(3)
 
 
-            print(f"Waiting for {expected_rows} rows in table {VIEW_NAME}")
+            print(f"Waiting for {expected_rows} rows in table {table_name}")
             start_time = time.time()
             while True:
-                cur.execute(f"SELECT count(id) from {VIEW_NAME}")
+                cur.execute(f"SELECT count(id) from {table_name}")
                 nrows = cur.fetchone()[0]
                 print(f"Found {nrows} rows")
                 if nrows == expected_rows:
@@ -100,37 +162,18 @@ def wait_for_n_outputs(expected_rows: int):
                     time.sleep(3)
 
 
-def create_debezium_jdbc_connector():
+def create_jdbc_connector(connector_name: str, topic_name: str, config: Dict):
     connect_server = os.getenv("KAFKA_CONNECT_SERVER", "http://localhost:8083")
 
     # It's important to stop the connector before deleting the topics.
     print(f"(Re-)creating topic")
-    rpk["topic", "delete", VIEW_NAME]()
-    rpk["topic", "create", VIEW_NAME]()
+    rpk["topic", "delete", topic_name]()
+    rpk["topic", "create", topic_name]()
 
     print("Create connector")
     config = {
-        "name": KAFKA_CONNECT_CONNECTOR_NAME,
-        "config": {
-            "connector.class": "io.debezium.connector.jdbc.JdbcSinkConnector",
-            "tasks.max": "1",
-            "connection.url": f"jdbc:postgresql://postgres:5432/{DATABASE_NAME}",
-            "connection.username": "postgres",
-            "connection.password": "postgres",
-            "insert.mode": "upsert",
-            "primary.key.mode": "record_key",
-            "delete.enabled": True,
-            "schema.evolution": "basic",
-            "database.time_zone": "UTC",
-            "dialect.name": "PostgreSqlDatabaseDialect",
-            "topics": VIEW_NAME,
-            "errors.deadletterqueue.topic.name": "dlq",
-            "errors.deadletterqueue.context.headers.enable": True,
-            "errors.deadletterqueue.topic.replication.factor": 1,
-            "errors.tolerance": "all",
-            "binary.handling.mode": "bytes",
-            "decimal.handling.mode": "string"
-        }
+        "name": connector_name,
+        "config": config
     }
 
     requests.post(
@@ -141,7 +184,7 @@ def create_debezium_jdbc_connector():
     start_time = time.time()
     while True:
         response = requests.get(
-            f"{connect_server}/connectors/{KAFKA_CONNECT_CONNECTOR_NAME}/status"
+            f"{connect_server}/connectors/{connector_name}/status"
         )
         print(f"response: {response}")
         if response.ok:
@@ -162,7 +205,7 @@ def create_debezium_jdbc_connector():
             print("Waiting for connector creation")
             time.sleep(1)
 
-def build_sql(pipeline_to_redpanda_server: str) -> str:
+def build_sql(pipeline_to_redpanda_server: str, registry_url_from_pipeline: str) -> str:
     return f"""
 create table test_table(
     id bigint not null primary key,
@@ -179,7 +222,8 @@ create table test_table(
 
 create view test_view
 WITH (
-    'connectors' = '[{{
+    'connectors' = '[
+    {{
         "format": {{
             "name": "json",
             "config": {{
@@ -191,17 +235,38 @@ WITH (
             "name": "kafka_output",
             "config": {{
                 "bootstrap.servers": "{pipeline_to_redpanda_server}",
-                "topic": "{VIEW_NAME}"
+                "topic": "{JSON_TABLE_NAME}"
             }}
         }}
-    }}]'
+    }},
+    {{
+        "format": {{
+            "name": "avro",
+            "config": {{
+                "update_format": "confluent_jdbc",
+                "registry_urls": ["{registry_url_from_pipeline}"],
+                "key_fields": ["id"]
+            }}
+        }},
+        "transport": {{
+            "name": "kafka_output",
+            "config": {{
+                "bootstrap.servers": "{pipeline_to_redpanda_server}",
+                "topic": "{AVRO_TABLE_NAME}"
+            }}
+        }}
+    }}
+
+
+    ]'
 )
 as select * from test_table;
     """
 
-def create_feldera_pipeline(api_url: str, pipeline_to_redpanda_server: str, start_pipeline: bool):
+def create_feldera_pipeline(api_url: str, pipeline_to_redpanda_server: str, registry_url_from_pipeline: str, start_pipeline: bool):
     client = FelderaClient(api_url)
-    sql = build_sql(pipeline_to_redpanda_server)
+    print("Creating the pipeline...")
+    sql = build_sql(pipeline_to_redpanda_server, registry_url_from_pipeline)
     pipeline = PipelineBuilder(client, name=PIPELINE_NAME, sql=sql).create_or_replace()
 
     if start_pipeline:
@@ -236,11 +301,13 @@ def generate_inputs(pipeline: Pipeline):
         inserts = [{"insert": element} for element in data]
         pipeline.input_json("test_table", inserts, update_format="insert_delete")
 
-    wait_for_n_outputs(199)
+    wait_for_n_outputs(JSON_TABLE_NAME, 199)
+    wait_for_n_outputs(AVRO_TABLE_NAME, 199)
 
-    deletes = [{"delete": element} for element in data]
-    pipeline.input_json("test_table", deletes, update_format="insert_delete")
-    wait_for_n_outputs(0)
+    # deletes = [{"delete": element} for element in data]
+    # pipeline.input_json("test_table", deletes, update_format="insert_delete")
+    # # #wait_for_n_outputs(JSON_TABLE_NAME, 0)
+    # wait_for_n_outputs(AVRO_TABLE_NAME, 0)
 
 
 if __name__ == "__main__":

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -193,12 +193,16 @@ RUN apt update && apt install pkg-config \
 CMD bash
 
 # Kafka connect with all Debezium connectors + the Snowflake connector.
-FROM debezium/connect:2.5 AS kafka-connect
+FROM debezium/connect:2.7 AS kafka-connect
 RUN mkdir /kafka/connect/snowflake-kafka-connector
 RUN cd /kafka/connect/snowflake-kafka-connector \
   && curl -LO https://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/2.1.0/snowflake-kafka-connector-2.1.0.jar \
   && curl -LO https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.1/bc-fips-1.0.1.jar \
-  && curl -LO https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
+  && curl -LO https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar \
+  && curl -LO http://d2p6pa21dvn84.cloudfront.net/api/plugins/confluentinc/kafka-connect-jdbc/versions/10.7.11/confluentinc-kafka-connect-jdbc-10.7.11.zip \
+  && unzip confluentinc-kafka-connect-jdbc-10.7.11.zip
+
+#&& curl -LO https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/10.7.4/kafka-connect-jdbc-10.7.4.jar
 
 # By default, only build the release version
 FROM release


### PR DESCRIPTION
Add support for the Avro output format compatible with Confluent JDBC sink connector.

This format encodes primary key columns as Kafka message keys. Inserts and updates carry the complete value of the new record in the message payload.  Deletes are represented as tombstone messages with null values.

The connector supports all three standard subject name strategies: topic name, record name, and topic + record name.

The connector automatically generates value schema where all non-key columns are nullable.  This helps to make generated schemas predictable, as otherwise the user has little control over the nullability of SQL view columns.

Here is a minimal connector config example, which should to the right thing in most cases:

```
create view test_view
WITH (
    'connectors' = '[{
        "format": {
            "name": "avro",
            "config": {
                "update_format": "confluent_jdbc",
                "registry_urls": ["http://localhost:18081"],
                "key_fields": ["id"]
            }
        },
        "transport": {
            "name": "kafka_output",
            "config": {
                "bootstrap.servers": "localhost:19092",
                "topic": "avro_jdbc_test"
            }
        }
    }
    ]'
)
as select * from test_table;
```

Docs and more tests are coming in a separate PR.