### PR TITLE
py: wait for a failed pipeline to shutdown

### DIFF
--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -181,3 +181,6 @@ class PipelineStatus(Enum):
             if member.name.lower() == value.lower():
                 return member
         raise ValueError(f"Unknown value '{value}' for enum {PipelineStatus.__name__}")
+
+    def __eq__(self, other):
+        return self.value == other.value

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,2 +1,2 @@
-kafka-python==2.0.2
+kafka-python-ng==2.2.2
 pytest


### PR DESCRIPTION
Wait for 15 seconds for a pipeline to shutdown. If the pipeline doesn't shutdown even after the timeout, resend the shutdown request, and wait a little longer.

Fixes: #2432 