### PR TITLE
py: fix build error introduced in `60390d3`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -566,7 +566,7 @@ ci-tests:
     # BUILD +test-s3
 
 nightly-tests:
-    #BUILD +test-python
+    BUILD +test-python
     BUILD +test-debezium-postgres
     BUILD +test-debezium-jdbc-sink
     BUILD +test-debezium-mysql

--- a/python/tests/test_pipeline_builder.py
+++ b/python/tests/test_pipeline_builder.py
@@ -5,8 +5,8 @@ import pandas as pd
 from kafka import KafkaProducer, KafkaConsumer
 from kafka.admin import KafkaAdminClient, NewTopic
 
-from build.lib.feldera.enums import PipelineStatus
 from feldera import PipelineBuilder, Pipeline
+from feldera.enums import PipelineStatus
 from tests import TEST_CLIENT
 
 


### PR DESCRIPTION
Instead of importing from `feldera` package, the import was made from `build.lib.feldera`.