### PR TITLE
Improve auto-complete in shell.

### DIFF
--- a/.github/workflows/benchmark-command.yml
+++ b/.github/workflows/benchmark-command.yml
@@ -12,7 +12,11 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  benchmark:
+  # This needs to be called `build` like the ci-nightly and ci jobs because we want it to abort the PR if it fails
+  # while in the merge queue and having it named the same as the checks in pre-merge is the only way to do that :/.
+  #
+  # https://stackoverflow.com/questions/76655935/when-does-a-github-workflow-trigger-for-merge-group-and-is-it-restricted-by-bran
+  build:
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/dbspmanager
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest
@@ -34,13 +38,11 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          concurrent_skipping: "same_content_newer"
           cancel_others: "true"
           skip_after_successful_duplicate: "true"
           do_not_skip: '["workflow_dispatch", "schedule"]'
   build:
-    permissions:
-      contents: read
-      packages: write
     runs-on: [ self-hosted, skylake40 ]
     needs: [ pre_job ]
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.13",
@@ -2586,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2599,11 +2599,14 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.24"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
+ "clap_lex 0.7.2",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -2838,7 +2841,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.16",
+ "clap 4.5.17",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -3532,7 +3535,7 @@ dependencies = [
  "arc-swap",
  "binrw",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "crc32c",
  "criterion",
  "crossbeam",
@@ -3622,7 +3625,7 @@ dependencies = [
  "bytestring",
  "chrono",
  "circular-queue",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "crossbeam",
  "csv",
@@ -4394,11 +4397,12 @@ name = "fda"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
  "directories",
  "env_logger 0.11.5",
  "feldera-types",
+ "futures",
  "futures-util",
  "log",
  "prettyplease",
@@ -5535,6 +5539,15 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -6959,7 +6972,7 @@ dependencies = [
  "cached 0.43.0",
  "change-detection",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "deadpool-postgres",
  "dirs 5.0.1",
@@ -9766,9 +9779,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=$HOME/.rustup
 ENV CARGO_HOME=$HOME/.cargo
 # Adds python and rust binaries to the path
 ENV PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-ENV RUST_VERSION=1.78.0
+ENV RUST_VERSION=1.80.0
 ENV RUST_BUILD_MODE='' # set to --release for release builds
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV DEBIAN_FRONTEND=noninteractive

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -11,8 +11,8 @@ include = ["openapi.json", "/src", "build.rs", "COPYRIGHT", "README.md"]
 
 [dependencies]
 log = "0.4"
-clap = { version = "4.5.16", features = ["derive", "env", "color"] }
-clap_complete = "4.5.23"
+clap = { version = "4.5.17", features = ["derive", "env", "color"] }
+clap_complete = { version = "4.5.26", features = ["unstable-dynamic"] }
 progenitor-client = { version = "0.7.0" }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -26,13 +26,14 @@ tabled = { version = "0.16.0", features = ["macros", "ansi"] }
 rustyline = { version = "14", features = ["with-file-history"] }
 directories = { version = "5" }
 futures-util = "0.3.30"
-tokio-util = "0.7.11"
+futures = "0.3"
+tokio-util = "0.7.12"
 
 [build-dependencies]
-prettyplease = "0.2.21"
+prettyplease = "0.2.22"
 progenitor = { version = "0.7.0" }
 serde_json = "1.0"
-syn = "2.0.76"
+syn = "2.0.77"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 
 [package.metadata.cargo-machete]

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -32,9 +32,7 @@ cargo install --path .
 ### Optional: Shell completion
 
 Once the `fda` binary is installed, you can enable shell command completion for `fda`
-by adding the following line to your shell init script. We recommend generating the
-shell code anew on shell startup so that it is “self-correcting” on shell launch,
-rather than writing the generated completions to a file.
+by adding the following line to your shell init script.
 
 * Bash
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -31,15 +31,40 @@ cargo install --path .
 
 ### Optional: Shell completion
 
-Once the `fda` binary is installed, you can enable shell command completion for `fda` by generating a completion script
-for your shell and copying it to the appropriate location.
+Once the `fda` binary is installed, you can enable shell command completion for `fda`
+by adding the following line to your shell init script. We recommend generating the
+shell code anew on shell startup so that it is “self-correcting” on shell launch,
+rather than writing the generated completions to a file.
+
+* Bash
 
 ```commandline
-fda shell-completion --help
-fda shell-completion
+echo "source <(COMPLETE=bash fda)" >> ~/.bashrc
 ```
 
-Currently, Bash, Elvish, Fish, Powershell, and Zsh are supported.
+* Elvish
+
+```commandline
+echo "eval (COMPLETE=elvish fda)" >> ~/.elvish/rc.elv
+```
+
+* Fish
+
+```commandline
+echo "source (COMPLETE=fish fda | psub)" >> ~/.config/fish/config.fish
+```
+
+* Powershell
+
+```commandline
+echo "COMPLETE=powershell fda | Invoke-Expression" >> $PROFILE
+```
+
+* Zsh
+
+```commandline
+echo "source <(COMPLETE=zsh fda)" >> ~/.zshrc
+```
 
 ## Connecting & Authentication
 
@@ -75,31 +100,31 @@ Create a new pipeline `p1` from a `program.sql` file:
 ```commandline
 echo "CREATE TABLE example ( id INT NOT NULL PRIMARY KEY );
 CREATE VIEW example_count AS ( SELECT COUNT(*) AS num_rows FROM example );" > program.sql
-fda pipeline p1 create program.sql
+fda create p1 program.sql
 ```
 
 Retrieve the program for `p1` and create a new pipeline `p2` from it:
 ```commandline
-fda pipeline p1 program | fda pipeline p2 create -s -
+fda program p1 | fda create p2 -s -
 ```
 
 Enable storage for `p1`:
 ```commandline
-fda pipeline p1 set-config storage true
+fda set-config p1 storage true
 ```
 
 Run the pipeline `p1`:
 ```commandline
-fda pipeline p1 start
+fda start p1
 ```
 
 Retrieve the stats for `p1`:
 ```commandline
-fda pipeline p1 stats
+fda stats p1
 ```
 
 Shutdown and delete the pipeline `p1`:
 ```commandline
-fda pipeline p1 shutdown
-fda pipeline p1 delete
+fda shutdown p1
+fda delete p1
 ```

--- a/scripts/bench.bash
+++ b/scripts/bench.bash
@@ -75,7 +75,7 @@ sql_benchmark() {
 
 DIR="benchmark/feldera-sql/benchmarks/"
 if [[ -z "$CLOUD" ]]; then
-    TESTS="nexmark tiktok"
+    TESTS="nexmark"
 else
     TESTS="nexmark"
 fi


### PR DESCRIPTION
Dynamically fetch pipeline names for autocompletion.

Also refactored command structure because of a clap bug we can't have pipeline names that are the same as the subcommand name that follows, e.g.,

`fda pipeline shell shell`

wasn't parsed properly.

https://github.com/clap-rs/clap/issues/5513

I factored the name from pipeline into the leaf commands and folded pipeline directly into the top-level commands, which means less typing anyways so it's probably a good idea anyways.