### PR TITLE
[adapters] Fix deadlock around catalog handle.

### DIFF
--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -173,7 +173,7 @@ pub trait AvroStream: Send {
 
 /// A handle to an input collection that can be used to feed serialized data
 /// to the collection.
-pub trait DeCollectionHandle: Send {
+pub trait DeCollectionHandle: Send + Sync {
     /// Create a [`DeCollectionStream`] object to parse input data encoded
     /// using the format specified in `RecordFormat`.
     fn configure_deserializer(
@@ -515,7 +515,7 @@ impl<'a> SerCursor for CursorWithPolarity<'a> {
 }
 
 /// A catalog of input and output stream handles of a circuit.
-pub trait CircuitCatalog: Send {
+pub trait CircuitCatalog: Send + Sync {
     /// Look up an input stream handle by name.
     fn input_collection_handle(&self, name: &SqlIdentifier) -> Option<&InputCollectionHandle>;
 

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -174,29 +174,23 @@ impl Controller {
         let backpressure_thread_unparker = backpressure_thread_parker.unparker().clone();
 
         let (profile_request_sender, profile_request_receiver) = channel();
-        let inner = Arc::new(ControllerInner::new(
+        let inner = ControllerInner::new(
             config,
             circuit_thread_unparker,
             backpressure_thread_unparker,
             error_cb,
             profile_request_sender,
-        ));
+        );
 
-        let backpressure_thread_handle = {
-            let inner = inner.clone();
-            spawn(move || Self::backpressure_thread(inner, backpressure_thread_parker))
-        };
-
-        let circuit_thread_handle = {
-            let inner = inner.clone();
-
+        let (circuit_thread_handle, inner) = {
             // A channel to communicate circuit initialization status.
             // The `circuit_factory` closure must be invoked in the context of
             // the circuit thread, because the circuit handle it returns doesn't
             // implement `Send`.  So we need this channel to communicate circuit
-            // initialization status back to this thread.
+            // initialization status back to this thread.  On success, the worker
+            // thread adds a catalog to `inner`, and returns it wrapped in an `Arc`.
             let (init_status_sender, init_status_receiver) =
-                sync_channel::<Result<(), ControllerError>>(0);
+                sync_channel::<Result<Arc<ControllerInner>, ControllerError>>(0);
             let handle = spawn(move || {
                 Self::circuit_thread(
                     circuit_factory,
@@ -208,10 +202,15 @@ impl Controller {
             });
             // If `recv` fails, it indicates that the circuit thread panicked
             // during initialization.
-            init_status_receiver
+            let inner = init_status_receiver
                 .recv()
                 .map_err(|_| ControllerError::dbsp_panic())??;
-            handle
+            (handle, inner)
+        };
+
+        let backpressure_thread_handle = {
+            let inner = inner.clone();
+            spawn(move || Self::backpressure_thread(inner, backpressure_thread_parker))
         };
 
         for (input_name, input_config) in config.inputs.iter() {
@@ -428,7 +427,7 @@ impl Controller {
         &self.inner.status
     }
 
-    pub fn catalog(&self) -> &Arc<Mutex<Box<dyn CircuitCatalog>>> {
+    pub fn catalog(&self) -> &Arc<Box<dyn CircuitCatalog>> {
         &self.inner.catalog
     }
 
@@ -496,9 +495,9 @@ impl Controller {
     /// produced by the circuit to output pipelines.
     fn circuit_thread<F>(
         circuit_factory: F,
-        controller: Arc<ControllerInner>,
+        mut controller: ControllerInner,
         parker: Parker,
-        init_status_sender: SyncSender<Result<(), ControllerError>>,
+        init_status_sender: SyncSender<Result<Arc<ControllerInner>, ControllerError>>,
         profile_request_receiver: Receiver<GraphProfileCallbackFn>,
     ) -> Result<(), ControllerError>
     where
@@ -525,13 +524,14 @@ impl Controller {
             min_storage_bytes,
             init_checkpoint: Uuid::nil(),
         };
-        let mut circuit = match circuit_factory(config) {
+        let (mut circuit, controller) = match circuit_factory(config) {
             Ok((circuit, catalog)) => {
                 // Complete initialization before sending back the confirmation to
                 // prevent a race.
                 controller.set_catalog(catalog);
-                let _ = init_status_sender.send(Ok(()));
-                circuit
+                let controller = Arc::new(controller);
+                let _ = init_status_sender.send(Ok(controller.clone()));
+                (circuit, controller)
             }
             Err(e) => {
                 let _ = init_status_sender.send(Err(e));
@@ -643,9 +643,8 @@ impl Controller {
                             .set_num_total_processed_records(processed_records);
 
                         // Update `trace_snapshot` to the latest traces
-                        let catalog = controller.catalog.lock().unwrap();
                         let mut consistent_snapshot = controller.trace_snapshot.blocking_lock();
-                        for (name, clh) in catalog.output_iter() {
+                        for (name, clh) in controller.catalog.output_iter() {
                             if let Some(ih) = &clh.integrate_handle {
                                 consistent_snapshot.insert(name.to_string(), ih.take_from_all());
                             }
@@ -1051,7 +1050,7 @@ pub struct ControllerInner {
     pub status: Arc<ControllerStatus>,
     num_api_connections: AtomicU64,
     profile_request: Sender<GraphProfileCallbackFn>,
-    catalog: Arc<Mutex<Box<dyn CircuitCatalog>>>,
+    catalog: Arc<Box<dyn CircuitCatalog>>,
     // Always lock this after the catalog is locked to avoid deadlocks
     trace_snapshot: ConsistentSnapshots,
     inputs: Mutex<BTreeMap<EndpointId, InputEndpointDescr>>,
@@ -1094,7 +1093,7 @@ impl ControllerInner {
             status,
             num_api_connections: AtomicU64::new(0),
             profile_request,
-            catalog: Arc::new(Mutex::new(Box::new(Catalog::new()))),
+            catalog: Arc::new(Box::new(Catalog::new())),
             trace_snapshot: Arc::new(TokioMutex::new(BTreeMap::new())),
             inputs: Mutex::new(BTreeMap::new()),
             outputs: ShardedLock::new(OutputEndpoints::new()),
@@ -1125,7 +1124,7 @@ impl ControllerInner {
         Err(ControllerError::unknown_input_endpoint(endpoint_name))
     }
 
-    fn set_catalog(&self, catalog: Box<dyn CircuitCatalog>) {
+    fn set_catalog(&mut self, catalog: Box<dyn CircuitCatalog>) {
         // Sync feldera catalog with datafusion catalog
         for (name, clh) in catalog.output_iter() {
             if clh.integrate_handle.is_some() {
@@ -1153,7 +1152,7 @@ impl ControllerInner {
             }
         }
 
-        *self.catalog.lock().unwrap() = catalog;
+        *Arc::get_mut(&mut self.catalog).unwrap() = catalog;
     }
 
     /// Sets the global metrics recorder and returns a `Snapshotter` and
@@ -1223,8 +1222,8 @@ impl ControllerInner {
         // │endpoint├──►│InputProbe├──►│parser├──►
         // └────────┘   └──────────┘   └──────┘
 
-        let catalog = self.catalog.lock().unwrap();
-        let input_handle = catalog
+        let input_handle = self
+            .catalog
             .input_collection_handle(&SqlIdentifier::from(&endpoint_config.stream))
             .ok_or_else(|| {
                 ControllerError::unknown_input_stream(endpoint_name, &endpoint_config.stream)
@@ -1407,8 +1406,6 @@ impl ControllerInner {
         // Lookup output handle in catalog.
         let handles = self
             .catalog
-            .lock()
-            .unwrap()
             .output_query_handles(
                 &SqlIdentifier::from(&endpoint_config.stream),
                 endpoint_config.query,

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -973,8 +973,6 @@ async fn output_endpoint(
 
                     if let Err(e) = controller
                         .catalog()
-                        .lock()
-                        .unwrap()
                         .output_handles(&SqlIdentifier::from(config.stream))
                         // The following `unwrap` is safe because `table_name` was previously
                         // validated by `add_output_endpoint`.
@@ -998,8 +996,6 @@ async fn output_endpoint(
                 OutputQuery::Quantiles => {
                     controller
                         .catalog()
-                        .lock()
-                        .unwrap()
                         .output_handles(&SqlIdentifier::from(config.stream))
                         .unwrap()
                         .num_quantiles_handle
@@ -1094,7 +1090,6 @@ mod test_with_kafka {
     use tempfile::NamedTempFile;
 
     #[actix_web::test]
-    #[ignore = "This test is flaky and needs to be fixed"]
     async fn test_server() {
         ensure_default_crypto_provider();
 

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -63,6 +63,7 @@ impl Catalog {
             + Clone
             + Debug
             + Send
+            + Sync
             + 'static,
         Z: ZSet + Debug + Send + Sync,
         Z::InnerBatch: Send,
@@ -94,6 +95,7 @@ impl Catalog {
             + Clone
             + Debug
             + Send
+            + Sync
             + 'static,
         Z: ZSet + Debug + Send + Sync,
         Z::InnerBatch: Send,
@@ -128,6 +130,7 @@ impl Catalog {
             + Clone
             + Debug
             + Send
+            + Sync
             + 'static,
         Z: ZSet + Debug + Send + Sync,
         Z::InnerBatch: Send,
@@ -159,6 +162,7 @@ impl Catalog {
             + Clone
             + Debug
             + Send
+            + Sync
             + 'static,
         Z: ZSet + Debug + Send + Sync,
         Z::InnerBatch: Send,

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -99,7 +99,7 @@ const MAX_REUSABLE_CAPACITY: usize = 100_000;
 
 /// An input handle that allows pushing serialized data to an
 /// [`InputHandle`].
-pub trait DeScalarHandle: Send {
+pub trait DeScalarHandle: Send + Sync {
     /// Create a [`DeScalarStream`] object to parse input data encoded
     /// using the format specified in `RecordFormat`.
     fn configure_deserializer(
@@ -166,7 +166,7 @@ impl<T, D, F> DeScalarHandle for DeScalarHandleImpl<T, D, F>
 where
     T: Default + Send + Clone + 'static,
     D: Default + for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Clone + 'static,
-    F: Fn(D) -> T + Send + Clone + 'static,
+    F: Fn(D) -> T + Send + Sync + Clone + 'static,
 {
     fn configure_deserializer(
         &self,
@@ -295,7 +295,7 @@ impl<K, D> DeZSetHandle<K, D> {
 impl<K, D> DeCollectionHandle for DeZSetHandle<K, D>
 where
     K: DBData + From<D>,
-    D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
 {
     fn configure_deserializer(
         &self,
@@ -559,7 +559,7 @@ impl<K, D> DeSetHandle<K, D> {
 impl<K, D> DeCollectionHandle for DeSetHandle<K, D>
 where
     K: DBData + From<D>,
-    D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
+    D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
 {
     fn configure_deserializer(
         &self,
@@ -847,8 +847,8 @@ where
     VD: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
     U: DBData + From<UD>,
     UD: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + 'static,
-    VF: Fn(&V) -> K + Clone + Send + 'static,
-    UF: Fn(&U) -> K + Clone + Send + 'static,
+    VF: Fn(&V) -> K + Clone + Send + Sync + 'static,
+    UF: Fn(&U) -> K + Clone + Send + Sync + 'static,
 {
     fn configure_deserializer(
         &self,


### PR DESCRIPTION
The circuit thread locked the catalog for much longer than needed, grabbing unrelated locks while holding the catalog lock and causing a deadlock.  A simple fix would have been narrowing the critical section, but @gz pointed out that the catalog is only read after it is initially populated, so the mutex is not necessary.  This commit refactors the code to eliminate the mutex around the catalog and enables previously disabled tests.