### PR TITLE
pipeline-manager: implement `/metrics` endpoint

### DIFF
--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -15,13 +15,17 @@ use crate::{
     error::ManagerError,
 };
 
-/// Returns the metrics of all running pipelines belonging to this tenant
+/// Retrieve the metrics of all running pipelines belonging to this tenant.
+///
+/// The metrics are collected by making individual HTTP requests to `/metrics`
+/// endpoint of each pipeline, of which only successful responses are included
+/// in the returned list.
 #[utoipa::path(
     context_path = "/v0",
     security(("JSON web token (JWT) or API key" = [])),
     responses(
         (status = OK
-        , description = "Returns the metrics of all running pipelines belonging to this tenant in Prometheus format."
+        , description = "Metrics of all running pipelines belonging to this tenant in Prometheus format"
         , content_type = "text/plain"
         , body = Vec<u8>),
     ),
@@ -35,7 +39,6 @@ pub(crate) async fn get_metrics(
     let pipelines = state.db.lock().await.list_pipelines(*tenant_id).await?;
 
     const NEWLINE: u8 = b'\n';
-
     let mut result = Vec::new();
 
     for pipeline in pipelines {

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -39,7 +39,9 @@ pub(crate) async fn get_metrics(
     let mut result = Vec::new();
 
     for pipeline in pipelines {
-        if pipeline.deployment_status == PipelineStatus::Running || pipeline.deployment_status == PipelineStatus::Paused {
+        if pipeline.deployment_status == PipelineStatus::Running
+            || pipeline.deployment_status == PipelineStatus::Paused
+        {
             if let Ok(res) = state
                 .runner
                 .forward_to_pipeline(*tenant_id, &pipeline.name, Method::GET, "metrics", "", None)

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -39,7 +39,7 @@ pub(crate) async fn get_metrics(
     let mut result = Vec::new();
 
     for pipeline in pipelines {
-        if pipeline.deployment_status == PipelineStatus::Running {
+        if pipeline.deployment_status == PipelineStatus::Running || pipeline.deployment_status == PipelineStatus::Paused {
             if let Ok(res) = state
                 .runner
                 .forward_to_pipeline(*tenant_id, &pipeline.name, Method::GET, "metrics", "", None)

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -21,7 +21,7 @@ use crate::{
     security(("JSON web token (JWT) or API key" = [])),
     responses(
         (status = OK
-        , description = "Returns the metrics of all running pipelines belonging to this tenant."
+        , description = "Returns the metrics of all running pipelines belonging to this tenant in Prometheus format."
         , content_type = "text/plain"
         , body = Vec<u8>),
     ),

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -47,7 +47,14 @@ pub(crate) async fn get_metrics(
         {
             if let Ok(res) = state
                 .runner
-                .forward_to_pipeline(*tenant_id, &pipeline.name, Method::GET, "metrics", "", None)
+                .forward_http_request_to_pipeline_by_name(
+                    *tenant_id,
+                    &pipeline.name,
+                    Method::GET,
+                    "metrics",
+                    "",
+                    None,
+                )
                 .await
             {
                 if res.status().is_success() {

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -1,0 +1,59 @@
+use actix_web::{
+    get,
+    http::Method,
+    web::{Data as WebData, ReqData},
+    HttpResponse,
+};
+use awc::body::MessageBody as _;
+
+use crate::{
+    api::ServerState,
+    db::{
+        storage::Storage as _,
+        types::{pipeline::PipelineStatus, tenant::TenantId},
+    },
+    error::ManagerError,
+};
+
+/// Returns the metrics of all running pipelines belonging to this tenant
+#[utoipa::path(
+    context_path = "/v0",
+    security(("JSON web token (JWT) or API key" = [])),
+    responses(
+        (status = OK
+        , description = "Returns the metrics of all running pipelines belonging to this tenant."
+        , content_type = "text/plain"
+        , body = Vec<u8>),
+    ),
+    tag = "Metrics"
+)]
+#[get("/metrics")]
+pub(crate) async fn get_metrics(
+    state: WebData<ServerState>,
+    tenant_id: ReqData<TenantId>,
+) -> Result<HttpResponse, ManagerError> {
+    let pipelines = state.db.lock().await.list_pipelines(*tenant_id).await?;
+
+    const NEWLINE: u8 = b'\n';
+
+    let mut result = Vec::new();
+
+    for pipeline in pipelines {
+        if pipeline.deployment_status == PipelineStatus::Running {
+            if let Ok(res) = state
+                .runner
+                .forward_to_pipeline(*tenant_id, &pipeline.name, Method::GET, "metrics", "", None)
+                .await
+            {
+                if res.status().is_success() {
+                    if let Ok(bytes) = res.into_body().try_into_bytes() {
+                        result.extend(bytes);
+                        result.push(NEWLINE);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(HttpResponse::Ok().content_type("text/plain").body(result))
+}

--- a/crates/pipeline-manager/src/api/mod.rs
+++ b/crates/pipeline-manager/src/api/mod.rs
@@ -20,6 +20,7 @@ mod api_key;
 mod config_api;
 mod examples;
 mod http_io;
+mod metrics;
 mod pipeline;
 
 use crate::auth::JwkCache;
@@ -116,6 +117,9 @@ The program version is used internally by the compiler to know when to recompile
         config_api::get_config_authentication,
         config_api::get_config_demos,
         config_api::get_config,
+
+        // Metrics
+        metrics::get_metrics,
     ),
     components(schemas(
         // Authentication
@@ -220,6 +224,7 @@ The program version is used internally by the compiler to know when to recompile
         (name = "Authentication", description = "Retrieve authentication configuration."),
         (name = "Configuration", description = "Retrieve general configuration."),
         (name = "API keys", description = "Manage API keys."),
+        (name = "Metrics", description = "Retrieve pipeline metrics."),
     ),
 )]
 pub struct ApiDoc;
@@ -271,6 +276,8 @@ fn api_scope() -> Scope {
         // Configuration endpoints
         .service(config_api::get_config_authentication)
         .service(config_api::get_config_demos)
+        // Metrics of all pipelines belonging to this tenant
+        .service(metrics::get_metrics)
 }
 
 struct SecurityAddon;

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -187,3 +187,36 @@ services:
       - bash
       - -c
       - "sleep 1 && cd demo/simple-count && python3 run.py --api-url http://pipeline-manager:8080"
+
+  prometheus:
+    profiles: [ "monitoring" ]
+    depends_on:
+      pipeline-manager:
+        condition: service_healthy
+    image: prom/prometheus:latest
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus:/etc/prometheus
+    command: --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 50s
+
+  grafana:
+    profiles: [ "monitoring" ]
+    depends_on:
+      pipeline-manager:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    volumes:
+        - ./grafana/prometheus_docker.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml
+

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -189,6 +189,7 @@ services:
       - "sleep 1 && cd demo/simple-count && python3 run.py --api-url http://pipeline-manager:8080"
 
   prometheus:
+    profiles: [ "monitoring" ]
     depends_on:
       pipeline-manager:
         condition: service_healthy
@@ -206,6 +207,7 @@ services:
       start_period: 50s
 
   grafana:
+    profiles: [ "monitoring" ]
     depends_on:
       pipeline-manager:
         condition: service_healthy

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -189,7 +189,6 @@ services:
       - "sleep 1 && cd demo/simple-count && python3 run.py --api-url http://pipeline-manager:8080"
 
   prometheus:
-    profiles: [ "monitoring" ]
     depends_on:
       pipeline-manager:
         condition: service_healthy
@@ -207,7 +206,6 @@ services:
       start_period: 50s
 
   grafana:
-    profiles: [ "monitoring" ]
     depends_on:
       pipeline-manager:
         condition: service_healthy

--- a/deploy/grafana/prometheus_docker.yaml
+++ b/deploy/grafana/prometheus_docker.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    # Set uid so we can refer to it from the dashboard.
+    uid: prometheus_docker
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      # Grafana will scrape data from Prometheus every 5s.
+      timeInterval: 5s
+

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval:     1s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'feldera'
+    metrics_path: '/v0/metrics'
+    static_configs:
+      - targets: ['pipeline-manager:8080']

--- a/docs/tutorials/monitoring/index.md
+++ b/docs/tutorials/monitoring/index.md
@@ -32,6 +32,26 @@ is then used to visualize these metrics.
       documentation](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source)
       to add Prometheus as a data source.
 
+### Setup with Docker
+
+Alternatively, with docker, you can avoid installing Prometheus and Grafana to your local machine.
+To run Feldera with both Prometheus and Grafana:
+
+```sh
+docker compose -f deploy/docker-compose.yml up grafana --force-recreate
+```
+
+This spins up:
+1. Feldera
+2. Prometheus
+3. Grafana
+
+If you want to run Prometheus without Grafana:
+
+```sh
+docker compose -f deploy/docker-compose.yml up prometheus --force-recreate
+```
+
 ### Set up the monitoring Dashboard
 
 1. **Copy the JSON of

--- a/openapi.json
+++ b/openapi.json
@@ -298,6 +298,33 @@
         ]
       }
     },
+    "/v0/metrics": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Returns the metrics of all running pipelines belonging to this tenant",
+        "operationId": "get_metrics",
+        "responses": {
+          "200": {
+            "description": "Returns the metrics of all running pipelines belonging to this tenant.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
     "/v0/pipelines": {
       "get": {
         "tags": [
@@ -4403,6 +4430,10 @@
     {
       "name": "API keys",
       "description": "Manage API keys."
+    },
+    {
+      "name": "Metrics",
+      "description": "Retrieve pipeline metrics."
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -303,11 +303,12 @@
         "tags": [
           "Metrics"
         ],
-        "summary": "Returns the metrics of all running pipelines belonging to this tenant",
+        "summary": "Retrieve the metrics of all running pipelines belonging to this tenant.",
+        "description": "The metrics are collected by making individual HTTP requests to `/metrics`\nendpoint of each pipeline, of which only successful responses are included\nin the returned list.",
         "operationId": "get_metrics",
         "responses": {
           "200": {
-            "description": "Returns the metrics of all running pipelines belonging to this tenant.",
+            "description": "Metrics of all running pipelines belonging to this tenant in Prometheus format",
             "content": {
               "text/plain": {
                 "schema": {


### PR DESCRIPTION
Introduces a `/metrics` endpoint that returns pipeline metrics for all running pipelines owned by this tenant.