### PR TITLE
[adapters] Shutdown pipeline on a fatal error.

### DIFF
--- a/crates/pipeline-manager/src/integration_test.rs
+++ b/crates/pipeline-manager/src/integration_test.rs
@@ -884,10 +884,12 @@ async fn pipeline_panic() {
         .await;
 
     // Push some data, which should cause a panic
-    let response = config
+    let _ = config
         .post_csv("/v0/pipelines/test/ingress/t1", "1\n2\n3\n".to_string())
         .await;
-    assert_eq!(response.status(), StatusCode::OK, "Val: {:?}", response);
+
+    // Ignore failures
+    // assert_eq!(response.status(), StatusCode::OK, "Val: {:?}", response);
 
     // Should discover the error next time it polls the pipeline.
     let pipeline = config


### PR DESCRIPTION
Addresses #2342.

After a fatal error like panic, we changed pipeline state to failed, but did not shutdown the controller, which kept trying to step every 100ms by default, logging an error message on each step.  The motivation for this was the possibility of a nested panic, which would crash the pipeline process, preventing it from reporting the original error. However, this can be easily prevented.