### PR TITLE
Set default_workers() to 8.

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -33,7 +33,7 @@ pub const fn default_max_batch_size() -> u64 {
 
 /// Default number of DBSP worker threads.
 const fn default_workers() -> u16 {
-    1
+    8
 }
 
 /// Default endpoint to send tracing data to.


### PR DESCRIPTION
We don't use RuntimeConfig::default anywhere except in `fda create`, so I don't see harm in adjusting this default directly.

If #workers is 1, users not familiar with feldera
will likely have sub-optimal settings creating a new pipeline with fda and not get great performance as we'd like them to see.