### PR TITLE
[manager] Improve reporting when the pipeline is dead.

### DIFF
--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -83,6 +83,9 @@ pub enum RunnerError {
         pipeline_id: PipelineId,
         error: String,
     },
+    PipelineUnreachable {
+        original_error: String,
+    },
 }
 
 impl DetailedError for RunnerError {
@@ -113,6 +116,7 @@ impl DetailedError for RunnerError {
             Self::PipelineShutdownError { .. } => Cow::from("PipelineShutdownError"),
             Self::PortFileParseError { .. } => Cow::from("PortFileParseError"),
             Self::BinaryFetchError { .. } => Cow::from("BinaryFetchError"),
+            Self::PipelineUnreachable { .. } => Cow::from("PipelineUnreachable"),
         }
     }
 }
@@ -261,6 +265,9 @@ impl Display for RunnerError {
                     "Failed to fetch binary executable for running pipeline {pipeline_id}: {error}"
                 )
             }
+            Self::PipelineUnreachable { original_error } => {
+                write!(f, "Pipeline is unreachable. This indicates that the pipeline ran out of memory or crashed unexpectedly (original error: {original_error}).")
+            }
         }
     }
 }
@@ -293,6 +300,7 @@ impl ResponseError for RunnerError {
             Self::PipelineShutdownTimeout { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::PortFileParseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::BinaryFetchError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::PipelineUnreachable { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -605,7 +605,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 }
             }
             Err(e) => State::TransitionToFailed {
-                error: ErrorResponse::from_error_nolog(&e),
+                error: ErrorResponse::from_error_nolog(&RunnerError::PipelineUnreachable {
+                    original_error: e.to_string(),
+                }),
             },
         }
     }
@@ -642,7 +644,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 }
             }
             Err(e) => State::TransitionToFailed {
-                error: ErrorResponse::from_error_nolog(&e),
+                error: ErrorResponse::from_error_nolog(&RunnerError::PipelineUnreachable {
+                    original_error: e.to_string(),
+                }),
             },
         }
     }
@@ -761,7 +765,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     pipeline.deployment_status, pipeline.id
                 );
                 State::TransitionToFailed {
-                    error: ErrorResponse::from_error_nolog(&e),
+                    error: ErrorResponse::from_error_nolog(&RunnerError::PipelineUnreachable {
+                        original_error: e.to_string(),
+                    }),
                 }
             }
         }


### PR DESCRIPTION
Whe the pipeline crashes due to OOM or some other reason that we cannot catch, the manager reported TCP connection error, which is confusing to the user.

This is a purely cosmetic fix, which gives a better explanation of the error.

We can improve this by extracting additional info from the OOM killer in the local form factor or from k8s in the cloud form factor.