### PR TITLE
dbsp: Fix performance with small input batches.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/input.rs
+++ b/crates/dbsp/src/operator/dynamic/input.rs
@@ -617,12 +617,16 @@ pub struct CollectionHandle<K: DataTrait + ?Sized, V: DataTrait + ?Sized> {
     // workers will immediately repartition the inputs based on the hash
     // of the key; however this is more efficient than doing it here, as
     // the work will be evenly split across workers.
-    next_worker: AtomicUsize,
+    next_worker: Arc<AtomicUsize>,
 }
 
 impl<K: DataTrait + ?Sized, V: DataTrait + ?Sized> Clone for CollectionHandle<K, V> {
     fn clone(&self) -> Self {
-        Self::new(self.pair_factory, self.input_handle.clone())
+        Self {
+            pair_factory: self.pair_factory,
+            input_handle: self.input_handle.clone(),
+            next_worker: self.next_worker.clone(),
+        }
     }
 }
 
@@ -634,7 +638,7 @@ impl<K: DataTrait + ?Sized, V: DataTrait + ?Sized> CollectionHandle<K, V> {
         Self {
             pair_factory,
             input_handle,
-            next_worker: AtomicUsize::new(0),
+            next_worker: Arc::new(AtomicUsize::new(0)),
         }
     }
 


### PR DESCRIPTION
Commit 6bf4e2dbbb6d ("dbsp_adapters: Allow the size of each step to be limited.") changed input adapters to take batches out of parsers in the form of `Box<dyn InputBuffer>` and then eventually flush those batches into the circuit's input handles.

This works fine when each of those buffers has many records, but there was an unexpected pitfall for the case where buffers have only one (or a few) records.  That is that each of the buffers, when it is taken from its parser, is cloned, and through a couple of layers of indirection this meant that the `CollectionHandle` that ultimately appends to the input handle was cloned too.  That `CollectionHandle` maintains an index into the workers, which points to the next worker to receive a record.  But when it was cloned every time, this meant that it was starting off with the same initial value every time, and in turn that meant that only worker 0 received any records.

This commit fixes the problem by changing the worker index into an `Arc`, which means that cloning it maintains a reference to the same index, so that records are well distributed across the workers again.

This problem didn't show up with the nexmark benchmark because it flushes many records at a time.  It does show up with a new version of the nexmark input adapter that I'm working on, which flushes only one record at a time. I imagine that it shows up in many other cases as well.

This only impacts input.  Any operator that reshards will cause the data to be redistributed properly.