### PR TITLE
[adhoc] Fix serialization of time values.

### DIFF
--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -40,7 +40,7 @@ pub mod test;
 pub const fn arrow_serde_config() -> &'static SqlSerdeConfig {
     &SqlSerdeConfig {
         timestamp_format: TimestampFormat::MicrosSinceEpoch,
-        time_format: TimeFormat::Nanos,
+        time_format: TimeFormat::NanosSigned,
         date_format: DateFormat::String("%Y-%m-%d"),
         decimal_format: DecimalFormat::String,
         variant_format: VariantFormat::JsonString,

--- a/crates/feldera-types/src/serde_with_context/serde_config.rs
+++ b/crates/feldera-types/src/serde_with_context/serde_config.rs
@@ -22,8 +22,10 @@ pub enum TimeFormat {
     Micros,
     /// Time specified in milliseconds from the start of the day.
     Millis,
-    /// Time specified in nanoseconds from the start of the day.
+    /// Time specified in nanoseconds from the start of the day as an unsigned 64-bit integer.
     Nanos,
+    /// Time specified in nanoseconds from the start of the day as a signed 64-bit integer.
+    NanosSigned,
 }
 
 impl Default for TimeFormat {

--- a/sql-to-dbsp-compiler/lib/sqllib/src/timestamp.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/timestamp.rs
@@ -1305,6 +1305,7 @@ impl SerializeWithContext<SqlSerdeConfig> for Time {
                 serializer.serialize_str(&time.format(format_string).to_string())
             }
             TimeFormat::Nanos => serializer.serialize_u64(self.nanoseconds),
+            TimeFormat::NanosSigned => serializer.serialize_i64(self.nanoseconds as i64),
             TimeFormat::Micros => serializer.serialize_u64(self.nanoseconds / 1_000),
             TimeFormat::Millis => serializer.serialize_u64(self.nanoseconds / 1_000_000),
         }
@@ -1331,6 +1332,9 @@ impl<'de> DeserializeWithContext<'de, SqlSerdeConfig> for Time {
             }
             TimeFormat::Nanos => Ok(Self {
                 nanoseconds: u64::deserialize(deserializer)?,
+            }),
+            TimeFormat::NanosSigned => Ok(Self {
+                nanoseconds: i64::deserialize(deserializer)? as u64,
             }),
             TimeFormat::Micros => Ok(Self {
                 nanoseconds: u64::deserialize(deserializer)? * 1_000,


### PR DESCRIPTION
Addresses #2380.

When serializing time values as 64-bit numbers that represent nanoseconds since midnight, `serde_arrow` for some reason expects a signed integer, whereas we only supported unsigned values (what in the world is a negative time of day?).  I added another time serialization option for this purpose.  With this change, FDA is able to display time columns.  I also checked that it correctly displays timestamps and dates.

We will add more systematic tests for different combinations of types shortly.