### PR TITLE
dbsp_adapters: Fix hang because a queue with 0 records could be nonem…

### DIFF
--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -369,10 +369,14 @@ where
     }
 
     fn take(&mut self) -> Option<Box<dyn InputBuffer>> {
-        Some(Box::new(Self {
-            updates: take(&mut self.updates),
-            handle: self.handle.clone(),
-        }))
+        if !self.updates.is_empty() {
+            Some(Box::new(Self {
+                updates: take(&mut self.updates),
+                handle: self.handle.clone(),
+            }))
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -267,13 +267,14 @@ impl InputQueue {
         num_bytes: usize,
         errors: Vec<ParseError>,
     ) {
-        if let Some(buffer) = buffer {
-            let num_records = buffer.len();
-            let mut guard = self.queue.lock().unwrap();
-            guard.push_back(buffer);
-            self.consumer.queued(num_bytes, num_records, errors);
-        } else {
-            self.consumer.queued(num_bytes, 0, errors);
+        match buffer {
+            Some(buffer) if !buffer.is_empty() => {
+                let num_records = buffer.len();
+                let mut guard = self.queue.lock().unwrap();
+                guard.push_back(buffer);
+                self.consumer.queued(num_bytes, num_records, errors);
+            }
+            _ => self.consumer.queued(num_bytes, 0, errors),
         }
     }
 


### PR DESCRIPTION
…pty.

`InputQueue::is_empty()` should report whether the queue is empty. However, until now it was possible to add an empty `InputBuffer` to a queue.  If the queue was otherwise empty, then `is_empty()` would report true even though it contained no records (only an empty buffer).  This commit fixes the problem, by preventing an empty buffer from entering the queue.

This was the cause for the intermittent failure of the test `server::test_with_kafka::test_server`, because
`dbsp_adapters::transport::http::input::HttpInputEndpoint::complete_request` would usually append an empty buffer to its queue at the end of input here:

```
                            num_errors += self.push(None, &mut errors);
```

and the later `loop` in that method would wait for the queue to become empty.  If the controller had already processed the non-empty buffers at that point, it would never process the empty buffer (because steps are triggered by buffered records, which were 0, not by buffer queue length).

Another way to look at this is that empty buffers shouldn't ever be created.  Most of the functions to take buffers didn't ever create them, but there was one exception and this commit fixes that one too.  Either fix would be sufficient but it seems better to fix both.

To reproduce this problem (after reverting this commit), add a brief `sleep` (say, 100 ms) just before the line quoted above, to ensure that the controller processes the real records before the empty buffer is added.