### PR TITLE
dbsp: Speed up sharding by implementing N-way merge.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/communication/gather.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/gather.rs
@@ -5,7 +5,7 @@ use crate::{
         GlobalNodeId, OwnershipPreference, Scope,
     },
     circuit_cache_key,
-    trace::{merge_batches, Batch},
+    trace::{merge_untimed_batches, Batch},
     Circuit, Runtime, Stream,
 };
 use arc_swap::ArcSwap;
@@ -330,7 +330,7 @@ where
         // Safety: This is the gather thread
         debug_assert!(unsafe { self.gather.all_channels_ready() });
 
-        merge_batches(
+        merge_untimed_batches(
             &self.factories,
             (0..self.gather.workers()).map(|worker| unsafe { self.gather.pop(worker) }),
         )

--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -9,7 +9,7 @@ use crate::{
     circuit_cache_key,
     dynamic::Data,
     operator::communication::new_exchange_operators,
-    trace::{merge_batches, Batch, BatchReader, BatchReaderFactories, Builder, Cursor},
+    trace::{merge_untimed_batches, Batch, BatchReader, BatchReaderFactories, Builder, Cursor},
     Circuit, Runtime, Stream,
 };
 
@@ -101,7 +101,7 @@ where
                                 self.circuit()
                                     .add_exchange(sender, receiver, self)
                                     .apply_owned_named("merge shards", move |batches| {
-                                        merge_batches(&factories_clone2, batches)
+                                        merge_untimed_batches(&factories_clone2, batches)
                                     })
                             });
 

--- a/crates/dbsp/src/operator/dynamic/output.rs
+++ b/crates/dbsp/src/operator/dynamic/output.rs
@@ -1,5 +1,5 @@
 use crate::{
-    trace::{merge_batches, Batch},
+    trace::{merge_untimed_batches, Batch},
     OutputHandle,
 };
 
@@ -9,6 +9,6 @@ where
 {
     /// See [`OutputHandle::consolidate`].
     pub fn dyn_consolidate(&self, factories: &T::Factories) -> T {
-        merge_batches(factories, self.take_from_all())
+        merge_untimed_batches(factories, self.take_from_all())
     }
 }

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     circuit_cache_key,
     dynamic::DataTrait,
-    trace::{copy_batch, Batch, BatchReader, Filter, Spine, Trace},
+    trace::{Batch, BatchReader, Filter, Spine, Trace},
     Error, Timestamp,
 };
 use dyn_clone::clone_box;
@@ -721,7 +721,7 @@ where
     fn eval_owned_and_ref(&mut self, mut trace: T, batch: &B) -> T {
         // TODO: extend `trace` type to feed untimed batches directly
         // (adding fixed timestamp on the fly).
-        trace.insert(copy_batch(
+        trace.insert(T::Batch::from_batch(
             batch,
             &self.clock.time(),
             &self.output_factories,
@@ -737,7 +737,7 @@ where
 
     #[trace]
     fn eval_owned(&mut self, mut trace: T, batch: B) -> T {
-        trace.insert(copy_batch(
+        trace.insert(T::Batch::from_batch(
             &batch,
             &self.clock.time(),
             &self.output_factories,


### PR DESCRIPTION
For Nexmark q9 with 16 workers and 100M events, this reduces the overall runtime on my system from 133 seconds to 114 seconds, by doing less data copying during merges.