### PR TITLE
[SQL] Do not carry in joins fields that are already available in keys

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFilterMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinFilterMapOperator.java
@@ -37,7 +37,7 @@ public final class DBSPJoinFilterMapOperator extends DBSPBinaryOperator {
     }
 
     public DBSPType getKeyType() {
-        return left().getOutputIndexedZSetType().keyType;
+        return this.left().getOutputIndexedZSetType().keyType;
     }
 
     public DBSPExpression getFilter() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToDotVisitor.java
@@ -45,6 +45,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.IndentStream;
 import org.dbsp.util.Logger;
@@ -114,7 +115,9 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
     }
 
     public String getEdgeLabel(DBSPOperator source) {
-        return source.getOutputRowType().toString();
+        DBSPType type = source.getOutputRowType();
+        return ToRustInnerVisitor.toRustString(
+                this.errorReporter, type, CompilerOptions.getDefault(), true);
     }
 
     void addInputs(DBSPOperator node) {
@@ -314,8 +317,8 @@ public class ToDotVisitor extends CircuitVisitor implements IWritesLogs {
         CircuitVisitor create(IndentStream stream);
     }
 
-    public static void toDot(String fileName,
-                      @Nullable String outputFormat, DBSPCircuit circuit, VisitorConstructor constructor) {
+    public static void toDot(String fileName, @Nullable String outputFormat,
+                             DBSPCircuit circuit, VisitorConstructor constructor) {
         if (circuit.isEmpty())
             return;
         System.out.println("Writing circuit to " + fileName);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -63,6 +63,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IHasZero;
 import org.dbsp.sqlCompiler.ir.type.IsNumericType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
@@ -421,7 +422,7 @@ public class Simplify extends InnerRewriteVisitor {
         this.pop(expression);
         DBSPExpression result = new DBSPUnaryExpression(
                 expression.getNode(), type, expression.operation, source);
-        if (expression.operation.equals(DBSPOpcode.NEG)) {
+        if (expression.operation == DBSPOpcode.NEG) {
             if (source.is(DBSPLiteral.class)) {
                 DBSPLiteral lit = source.to(DBSPLiteral.class);
                 if (lit.is(IsNumericLiteral.class)) {
@@ -430,6 +431,15 @@ public class Simplify extends InnerRewriteVisitor {
                     } catch (ArithmeticException ex) {
                         // ignore
                     }
+                }
+            }
+        } else if (expression.operation == DBSPOpcode.WRAP_BOOL) {
+            // wrap_bool(cast_to_bn_b(expression)) => expression
+            if (source.is(DBSPCastExpression.class)) {
+                DBSPCastExpression cast = source.to(DBSPCastExpression.class);
+                if (cast.source.getType().is(DBSPTypeBool.class) &&
+                    !cast.source.getType().mayBeNull) {
+                    result = cast.source;
                 }
             }
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/KeyPropagation.java
@@ -206,11 +206,9 @@ public class KeyPropagation extends CircuitVisitor {
             return;
         }
 
-        List<Pair<Integer, Integer>> ioMap = projection.getIoMap();
+        Projection.IOMap ioMap = projection.getIoMap();
         StreamDescription result = new StreamDescription();
-        for (Pair<Integer, Integer> source : ioMap) {
-            assert source.getFirst() == 0;
-            int sourceColumnIndex = source.getSecond();
+        for (int sourceColumnIndex: ioMap.getFieldsOfInput(0)) {
             FieldProperties fieldProperties = inputKeys.get(sourceColumnIndex);
             result.addProperties(fieldProperties);
         }
@@ -303,11 +301,11 @@ public class KeyPropagation extends CircuitVisitor {
         Projection projection = new Projection(this.errorReporter, true);
         projection.apply(operator.getFunction());
         if (projection.hasIoMap()) {
-            List<Pair<Integer, Integer>> ioMap = projection.getIoMap();
+            Projection.IOMap ioMap = projection.getIoMap();
             StreamDescription result = new StreamDescription();
-            for (Pair<Integer, Integer> source : ioMap) {
-                int input = source.getFirst();
-                int sourceColumnIndex = source.getSecond();
+            for (Projection.InputAndFieldIndex source : ioMap.fields()) {
+                int input = source.inputIndex();
+                int sourceColumnIndex = source.fieldIndex();
                 FieldProperties props = switch (input) {
                     case 0 -> foreignKeyIndex.get(sourceColumnIndex);
                     case 1 -> keyOnLeft ? new FieldProperties() : foreignKey.get(sourceColumnIndex);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MonotoneAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MonotoneAnalyzer.java
@@ -27,10 +27,10 @@ public class MonotoneAnalyzer implements CircuitTransform, IWritesLogs {
 
         @Override
         public String getEdgeLabel(DBSPOperator source) {
-            String result = source.getOutputRowType().toString();
+            String result = source.id + " " + super.getEdgeLabel(source);
             MonotoneExpression expr = info.get(source);
             if (expr != null) {
-                result = source.getIdString() + " " + Monotonicity.getBodyType(expr);
+                result = source.id + " " + Monotonicity.getBodyType(expr);
             }
             return result;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
@@ -1,6 +1,5 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
-import org.apache.commons.math3.util.Pair;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
@@ -142,9 +141,9 @@ public class NarrowJoins extends CircuitCloneVisitor {
         int rightSize = joinFunction.parameters[2].getType().deref().to(DBSPTypeTupleBase.class).size();
 
         // Create a projection map for each input which has unused fields
-        List<Pair<Integer, Integer>> outputMap = projection.getIoMap();
-        List<Integer> leftInputs = Linq.map(Linq.where(outputMap, p -> p.getFirst() == 1), Pair::getSecond);
-        List<Integer> rightInputs = Linq.map(Linq.where(outputMap, p -> p.getFirst() == 2), Pair::getSecond);
+        Projection.IOMap outputMap = projection.getIoMap();
+        List<Integer> leftInputs = outputMap.getFieldsOfInput(1);
+        List<Integer> rightInputs = outputMap.getFieldsOfInput(2);
         // If all the fields are used there is no point in optimizing this
         if (leftInputs.size() == leftSize && rightInputs.size() == rightSize)
             return false;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
@@ -23,6 +23,7 @@ import java.util.List;
 /**
  * Optimizes patterns containing Map operators.
  * - Merge Maps operations into the previous operation (Map, Join) if possible.
+ Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 4);
  * - Swap Maps with operations such as Distinct, Integral, Differential, etc.
  * - Merge Maps with subsequent MapIndex operators
  * - Merge consecutive apply operators


### PR DESCRIPTION
Fixes #2532 
This should also reduce memory consumption because we carry fewer redundant fields in joins