### PR TITLE
dbsp: Summarize operator metadata into root in circuit profiles.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -605,7 +605,7 @@ where
         meta.extend(metadata! {
             "total updates" => MetaItem::bytes(size),
             USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
-            "allocations" => bytes.distinct_allocations(),
+            "allocations" => MetaItem::Count(bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
     }

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1051,27 +1051,22 @@ where
         };
 
         // Find the percentage of consolidated outputs
-        let mut output_redundancy = ((self.stats.output_tuples as f64
-            - self.stats.produced_tuples as f64)
-            / self.stats.output_tuples as f64)
-            * 100.0;
-        if output_redundancy.is_nan() {
-            output_redundancy = 0.0;
-        } else if output_redundancy.is_infinite() {
-            output_redundancy = 100.0;
-        }
+        let output_redundancy = MetaItem::Percent {
+            numerator: (self.stats.output_tuples - self.stats.produced_tuples) as u64,
+            denominator: self.stats.output_tuples as u64,
+        };
 
         meta.extend(metadata! {
-            NUM_ENTRIES_LABEL => total_size,
+            NUM_ENTRIES_LABEL => MetaItem::Count(total_size),
             "batch sizes" => batch_sizes,
             USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
-            "allocations" => bytes.distinct_allocations(),
+            "allocations" => MetaItem::Count(bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
             "left inputs" => self.stats.lhs_tuples,
             "right inputs" => self.stats.rhs_tuples,
             "computed outputs" => self.stats.output_tuples,
             "produced outputs" => self.stats.produced_tuples,
-            "output redundancy" => MetaItem::Percent(output_redundancy),
+            "output redundancy" => output_redundancy,
         });
     }
 

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -828,10 +828,10 @@ where
             .unwrap_or_default();
 
         meta.extend(metadata! {
-            NUM_ENTRIES_LABEL => total_size,
+            NUM_ENTRIES_LABEL => MetaItem::Count(total_size),
             ALLOCATED_BYTES_LABEL => MetaItem::bytes(bytes.total_bytes()),
             USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
-            "allocations" => bytes.distinct_allocations(),
+            "allocations" => MetaItem::Count(bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
 

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -265,10 +265,10 @@ where
     fn metadata(&self, meta: &mut OperatorMeta) {
         let bytes = self.values.size_of();
         meta.extend(metadata! {
-            NUM_ENTRIES_LABEL => self.values.num_entries_deep(),
+            NUM_ENTRIES_LABEL => MetaItem::Count(self.values.num_entries_deep()),
             ALLOCATED_BYTES_LABEL => MetaItem::bytes(bytes.total_bytes()),
             USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
-            "allocations" => bytes.distinct_allocations(),
+            "allocations" => MetaItem::Count(bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
         });
     }
@@ -452,11 +452,11 @@ where
         };
 
         meta.extend(metadata! {
-            NUM_ENTRIES_LABEL => total_size,
+            NUM_ENTRIES_LABEL => MetaItem::Count(total_size),
             "batch sizes" => MetaItem::Array(batch_sizes),
             ALLOCATED_BYTES_LABEL => MetaItem::bytes(total_bytes.total_bytes()),
             USED_BYTES_LABEL => MetaItem::bytes(total_bytes.used_bytes()),
-            "allocations" => total_bytes.distinct_allocations(),
+            "allocations" => MetaItem::Count(total_bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(total_bytes.shared_bytes()),
         });
     }


### PR DESCRIPTION
With this, the root node in circuit profiles includes additional information that summarizes all the operators in the circuit, like this:

```
total size: 14385360
allocated bytes: 4.75 GiB
used bytes: 4.75 GiB
allocations: 34030654
shared bytes: 4.75 GiB
batches: 210
storage size: 3.53 GiB
merging batches: 20
merging size: 2.18 GiB
merge reduction: 23.93%
output redundancy: 0.00%
```