### PR TITLE
Disable tracing by default.

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -42,8 +42,10 @@ fn default_tracing_endpoint() -> String {
 }
 
 /// Default value of `RuntimeConfig::tracing`.
+// We discovered that the jaeger crate can use up gigabytes of RAM, so it's not harmless
+// to keep it on by default.
 fn default_tracing() -> bool {
-    true
+    false
 }
 
 /// Pipeline deployment configuration.


### PR DESCRIPTION
We use jaeger for tracing. The default pipeline configuration had tracing enabled, the assumption being that it has negligible runtime cost. However, we've discovered that it can consume gigabytes of RAM (and I'm not even sure there's an upper bound) presumably buffering events in memory. We therefore switch the default to false.