### PR TITLE
[WebConsole] Preload Pipeline Edit page code while on welcome screen

### DIFF
--- a/web-console/src/routes/(authenticated)/+page.svelte
+++ b/web-console/src/routes/(authenticated)/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
+  import { goto, preloadCode } from '$app/navigation'
+  import { base } from '$app/paths'
   import { useTryPipeline } from '$lib/compositions/pipelines/useTryPipeline'
+
+  preloadCode(`${base}/pipelines/*`)
 
   let { data } = $props()
   const tryPipeline = useTryPipeline()


### PR DESCRIPTION
This simple change forces the preload of the bulk of code for Pipeline Edit page.
This greatly improves onboarding experience on a slower internet connection.

The following timeline of WebConsole bundle files loading in browser on a **slow connection** when the welcome page is first opened demonstrates the new app preload behavior:
![image](https://github.com/user-attachments/assets/aa3ca4d3-c2e5-4a98-860d-9e15ee1f0996)
