### PR TITLE
[Rust] update faker crate; version 2.10 is not backwards compatible with 2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
  "http 1.1.0",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -96,7 +96,7 @@ ordered-float = { version = "4.2.0", features = ["serde"] }
 minitrace = { version = "0.6", features = ["enable"] }
 minitrace-jaeger = { version = "0.6" }
 governor = { version = "0.6.3" }
-fake = { version = "2.9.2", features = ["http"] }
+fake = { version = "2.10", features = ["http"] }
 atomic = "0.6.0"
 bytemuck = "1.16.3"
 dbsp_nexmark = { path = "../nexmark", features = [], optional = true }

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -434,6 +434,7 @@ outputs:
 /// - When `snapshot` is `true`, runs the connector in `snapshot_and_follow`
 ///   mode.  The dataset is split in halves; the first half is consumed as a
 ///   single snapshot and the second half is processed in follow mode.
+#[allow(clippy::too_many_arguments)]
 async fn test_follow(
     schema: &[Field],
     input_table_uri: &str,

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use crate::catalog::InputCollectionHandle;
 use crate::{
     test::{wait, MockDeZSet, MockUpdate, TestStruct, DEFAULT_TIMEOUT_MS},
@@ -128,7 +130,7 @@ impl KafkaResources {
         // Now create the topics and wait for the creations to complete.
         let new_topics = topics
             .iter()
-            .filter(|&(topic_name, partitions)| (*partitions > 0))
+            .filter(|&(_topic_name, partitions)| (*partitions > 0))
             .map(|(topic_name, partitions)| {
                 NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1))
             })

--- a/crates/adapters/src/test/mock_output_consumer.rs
+++ b/crates/adapters/src/test/mock_output_consumer.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use crate::{transport::Step, OutputConsumer};
 use std::sync::{Arc, Mutex};
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -1,5 +1,7 @@
 //! Test framework for the `adapters` crate.
 
+#![allow(clippy::type_complexity)]
+
 use crate::{
     controller::InputEndpointConfig, transport::InputReader, Catalog, CircuitCatalog,
     DbspCircuitHandle, FormatConfig, InputFormat,
@@ -69,6 +71,7 @@ impl Log for TestLogger {
 /// Wait for `predicate` to become `true`.
 ///
 /// Returns the number of milliseconds elapsed or `Err(())` on timeout.
+#[allow(clippy::result_unit_err)]
 pub fn wait<P>(mut predicate: P, timeout_ms: u128) -> Result<u128, ()>
 where
     P: FnMut() -> bool,

--- a/crates/adapters/src/transport/datagen.rs
+++ b/crates/adapters/src/transport/datagen.rs
@@ -1560,6 +1560,7 @@ impl RecordGenerator {
 }
 
 #[cfg(test)]
+#[allow(clippy::type_complexity)]
 mod test {
     use crate::test::{mock_input_pipeline, MockDeZSet, MockInputConsumer, TestStruct2};
     use crate::InputReader;

--- a/crates/adapters/src/transport/datagen.rs
+++ b/crates/adapters/src/transport/datagen.rs
@@ -1222,7 +1222,7 @@ impl RecordGenerator {
                     *str = Dummy::dummy_with_rng(&BuzzwordTail(EN), rng)
                 }
                 (DatagenStrategy::CatchPhrase, _) => {
-                    *str = Dummy::dummy_with_rng(&CatchPhase(EN), rng)
+                    *str = Dummy::dummy_with_rng(&CatchPhrase(EN), rng)
                 }
                 (DatagenStrategy::BsVerb, _) => *str = Dummy::dummy_with_rng(&BsVerb(EN), rng),
                 (DatagenStrategy::BsAdj, _) => *str = Dummy::dummy_with_rng(&BsAdj(EN), rng),

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::borrowed_box)]
+
 use crate::format::InputBuffer;
 use crate::transport::{input_transport_config_to_endpoint, output_transport_config_to_endpoint};
 use crate::{

--- a/crates/adapters/src/transport/secret_resolver.rs
+++ b/crates/adapters/src/transport/secret_resolver.rs
@@ -148,7 +148,7 @@ mod tests {
                 assert_eq!("example", simple_string);
             }
             _ => {
-                assert!(false);
+                unreachable!();
             }
         }
     }
@@ -176,7 +176,7 @@ mod tests {
                 assert_eq!("example", secret_string);
             }
             _ => {
-                assert!(false);
+                unreachable!();
             }
         }
     }
@@ -218,7 +218,7 @@ mod tests {
             "-example".to_string(),
         )) {
             Ok(_) => {
-                assert!(false);
+                unreachable!();
             }
             Err(err) => {
                 assert_eq!(
@@ -243,7 +243,7 @@ mod tests {
             MaybeSecretRef::SecretRef("the-secret".to_string()),
         ) {
             Ok(_) => {
-                assert!(false);
+                unreachable!();
             }
             Err(err) => {
                 let err_string = err.to_string();
@@ -274,7 +274,7 @@ mod tests {
             MaybeSecretRef::SecretRef("the-secret".to_string()),
         ) {
             Ok(_) => {
-                assert!(false);
+                unreachable!();
             }
             Err(err) => {
                 let err_string = err.to_string();
@@ -315,12 +315,12 @@ mod tests {
                 assert_eq!(simple_string, "example123");
             }
             MaybeSecret::Secret(_) => {
-                assert!(false);
+                unreachable!();
             }
         }
         match MaybeSecret::Secret("example123".to_string()) {
             MaybeSecret::String(_) => {
-                assert!(false);
+                unreachable!();
             }
             MaybeSecret::Secret(secret_string) => {
                 assert_eq!(secret_string, "example123");

--- a/crates/dbsp/benches/gdelt/data.rs
+++ b/crates/dbsp/benches/gdelt/data.rs
@@ -104,6 +104,7 @@ impl PartialEq for PersonalNetworkGkgEntry {
 
 impl Eq for PersonalNetworkGkgEntry {}
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for PersonalNetworkGkgEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.id.partial_cmp(&other.id)

--- a/crates/dbsp/benches/gdelt/main.rs
+++ b/crates/dbsp/benches/gdelt/main.rs
@@ -133,7 +133,7 @@ fn main() {
 
     let mut file_urls = BufReader::new(get_master_file(args.update_master_list))
         .lines()
-        .flatten()
+        .map_while(Result::ok)
         .filter_map(|line| {
             let line = line.trim();
             // We now have a url in this form: `http://data.gdeltproject.org/gdeltv2/20150218230000.gkg.csv.zip`

--- a/crates/dbsp/examples/dist/pool.rs
+++ b/crates/dbsp/examples/dist/pool.rs
@@ -33,6 +33,7 @@ struct Args {
     address: SocketAddr,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> AnyResult<(

--- a/crates/dbsp/examples/tutorial/tutorial4.rs
+++ b/crates/dbsp/examples/tutorial/tutorial4.rs
@@ -28,6 +28,7 @@ struct Record {
     daily_vaccinations: Option<u64>,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/examples/tutorial/tutorial5.rs
+++ b/crates/dbsp/examples/tutorial/tutorial5.rs
@@ -31,6 +31,7 @@ struct Record {
     daily_vaccinations: Option<u64>,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/examples/tutorial/tutorial6.rs
+++ b/crates/dbsp/examples/tutorial/tutorial6.rs
@@ -31,6 +31,7 @@ struct Record {
     daily_vaccinations: Option<u64>,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/examples/tutorial/tutorial7.rs
+++ b/crates/dbsp/examples/tutorial/tutorial7.rs
@@ -53,6 +53,7 @@ struct VaxMonthly {
     month: u8,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/examples/tutorial/tutorial8.rs
+++ b/crates/dbsp/examples/tutorial/tutorial8.rs
@@ -31,6 +31,7 @@ struct Record {
     daily_vaccinations: Option<u64>,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/examples/tutorial/tutorial9.rs
+++ b/crates/dbsp/examples/tutorial/tutorial9.rs
@@ -53,6 +53,7 @@ struct VaxMonthly {
     month: u8,
 }
 
+#[allow(clippy::type_complexity)]
 fn build_circuit(
     circuit: &mut RootCircuit,
 ) -> Result<(

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1358,6 +1358,7 @@ mod tests {
 
     /// This test exercises the checkpoint/restore path of the Z1 operator.
     #[test]
+    #[allow(clippy::borrowed_box)]
     fn test_z1_checkpointing() {
         let (_temp, mut cconf) = mkconfig();
 

--- a/crates/dbsp/src/operator/dynamic/asof_join.rs
+++ b/crates/dbsp/src/operator/dynamic/asof_join.rs
@@ -1015,7 +1015,7 @@ mod test {
                     *w = -*w;
                 }
                 for Tup2(_u, w) in us.iter_mut() {
-                     *w =-*w;
+                     *w = -*w;
                 }
             }
 

--- a/crates/dbsp/src/operator/dynamic/neighborhood.rs
+++ b/crates/dbsp/src/operator/dynamic/neighborhood.rs
@@ -611,7 +611,6 @@ mod test {
             V: DBData,
         {
             if let Some(descr) = &descr {
-                let descr = descr;
                 let anchor_k = &descr.anchor;
                 let anchor_v = &descr.anchor_val;
 

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -542,12 +542,12 @@ mod test {
 
     // Checks that `aggregate_range` correctly computes aggregates for all
     // possible ranges in all partitions.
-    fn test_partitioned_aggregate_range<PK, TS, A, C, S>(
+    fn test_partitioned_aggregate_range</* PK, */ TS, A, C, S>(
         cursor: &mut C,
         contents: &BTreeMap<Box<DynData /* <PK> */>, BTreeMap<TS, Box<DynData /* <A> */>>>,
     ) where
         C: PartitionedRadixTreeCursor<DynData /* <PK> */, TS, DynData /* <A> */>,
-        PK: DBData,
+        /* PK: DBData, */
         TS: DBData + PrimInt,
         A: DBData,
         S: Semigroup<A>,
@@ -637,7 +637,7 @@ mod test {
                         .validate(&contents_clone.lock().unwrap(), &|acc, val| {
                             acc.downcast_mut_checked::<u64>().add_assign_by_ref(val.downcast_checked::<u64>())
                         });
-                    test_partitioned_aggregate_range::<u64, u64, u64, _, DefaultSemigroup<_>>(
+                    test_partitioned_aggregate_range::</* u64, */u64, u64, _, DefaultSemigroup<_>>(
                         &mut tree_trace.cursor(),
                         &contents_clone.lock().unwrap(),
                     );

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/treenode.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/treenode.rs
@@ -428,7 +428,7 @@ mod test {
     fn aggregate_default(node: &mut DynTreeNode<u64, DynData /* <u64> */>) -> Option<u64> {
         let mut result: Option<u64> = None;
         node.aggregate(
-            &mut |acc, x| *acc.downcast_mut_checked::<u64>() += *x.downcast_checked::<u64>(),
+            &|acc, x| *acc.downcast_mut_checked::<u64>() += *x.downcast_checked::<u64>(),
             result.erase_mut(),
         );
         result

--- a/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
@@ -1104,7 +1104,7 @@ mod test {
             let output_500_500_waterline = aggregate_500_500_waterline.gather(0).integrate();
 
             let bound: TraceBound<DynPair<DynDataTyped<u64>, DynOpt<DynData>>> = TraceBound::new();
-            let b: Tup2<u64, Option<i64>> = Tup2(u64::max_value(), None::<i64>);
+            let b: Tup2<u64, Option<i64>> = Tup2(u64::MAX, None::<i64>);
 
             bound.set(Box::new(b).erase_box());
 
@@ -1155,7 +1155,7 @@ mod test {
 
     #[test]
     fn test_partitioned_over_range_2() {
-        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::MAX, None);
 
         circuit.step().unwrap();
 
@@ -1170,7 +1170,7 @@ mod test {
 
     #[test]
     fn test_partitioned_over_range() {
-        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::MAX, None);
 
         circuit.step().unwrap();
 
@@ -1426,7 +1426,7 @@ mod test {
     proptest! {
         #[test]
         fn proptest_partitioned_over_range_sparse(trace in input_trace(5, 1_000_000, 10, 10)) {
-            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::MAX, None);
 
             for mut batch in trace {
                 input.append(&mut batch);
@@ -1438,7 +1438,7 @@ mod test {
 
         #[test]
         fn proptest_partitioned_over_range_dense(trace in input_trace(5, 500, 25, 10)) {
-            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::MAX, None);
 
             for mut batch in trace {
                 input.append(&mut batch);

--- a/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
@@ -164,6 +164,7 @@ mod tests {
     };
     use std::cmp::max;
 
+    #[allow(clippy::borrowed_box)]
     fn test_waterline_monotonic(workers: usize) {
         let mut expected_waterlines = vec![115, 115, 125, 145].into_iter();
 

--- a/crates/dbsp/src/operator/dynamic/time_series/window.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/window.rs
@@ -681,7 +681,7 @@ mod test {
                     });
 
             let bound = TraceBound::new();
-            bound.set(Box::new(i64::max_value()).erase_box());
+            bound.set(Box::new(i64::MAX).erase_box());
 
             input.window((true, false), &bounds);
 

--- a/crates/dbsp/src/storage/backend/tests.rs
+++ b/crates/dbsp/src/storage/backend/tests.rs
@@ -85,6 +85,7 @@ impl Debug for Transition {
 /// - `ALLOW_OVERWRITE = true`: allows overwriting data in the file.
 /// - `ALLOW_OVERWRITE = false`: does not allow overwriting data in the file
 ///   (returns an error on writes).
+///
 /// This ensures we can test the raw backend as well as the buffer cache (which
 /// does not allow overwrites).
 #[derive(Default, Debug)]
@@ -109,7 +110,7 @@ impl<const ALLOW_OVERWRITE: bool> Clone for InMemoryBackend<ALLOW_OVERWRITE> {
     }
 }
 fn insert_slice_at_offset(
-    vec: &Vec<Option<u8>>,
+    vec: &[Option<u8>],
     offset: usize,
     slice: &[u8],
     allow_overwrite: bool,
@@ -117,7 +118,7 @@ fn insert_slice_at_offset(
     // we clone the file so the write is 'atomic'. For this particular check
     // (overlapping writes) this happens before any writes to the FS in the
     // BufferCache implementation.
-    let mut new_vec = vec.clone();
+    let mut new_vec = vec.to_owned();
 
     if offset > vec.len() {
         new_vec.resize(offset, None);

--- a/crates/dbsp/src/trace/layers/test.rs
+++ b/crates/dbsp/src/trace/layers/test.rs
@@ -264,10 +264,7 @@ type Trie2 /* <K, T, R> */ = Layer<DynData, Trie1>;
 type Trie3 /* <K, V, T, R> */ = Layer<DynData, Trie2>;
 
 // Generate a layer-based representation of the trie.
-fn tuples_to_trie1<T: DBData, R: DBWeight + ZRingValue, L: Trie>(
-    factories: &L::Factories,
-    tuples: &Tuples1<T, R>,
-) -> L
+fn tuples_to_trie1<T, R, L>(factories: &L::Factories, tuples: &Tuples1<T, R>) -> L
 where
     T: DBData,
     R: DBWeight + ZRingValue,

--- a/crates/dbsp/src/trace/test/mod.rs
+++ b/crates/dbsp/src/trace/test/mod.rs
@@ -432,27 +432,27 @@ proptest! {
     }
 
     #[test]
-    fn test_vec_zset_spine(batches in kr_batches(50, 2, 100, 20), seed in 0..u64::max_value()) {
+    fn test_vec_zset_spine(batches in kr_batches(50, 2, 100, 20), seed in 0..u64::MAX) {
         let factories = <OrdZSetFactories<DynI32>>::new::<i32, (), ZWeight>();
 
         test_zset_spine::<OrdZSet<DynI32>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_file_zset_spine(batches in kr_batches(50, 2, 50, 10), seed in 0..u64::max_value()) {
+    fn test_file_zset_spine(batches in kr_batches(50, 2, 50, 10), seed in 0..u64::MAX) {
         let factories = <FallbackWSetFactories<DynI32, DynZWeight>>::new::<i32, (), ZWeight>();
 
         test_zset_spine::<FallbackWSet<DynI32, DynZWeight>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_vec_indexed_zset_spine(batches in kvr_batches(100, 5, 2, 500, 20), seed in 0..u64::max_value()) {
+    fn test_vec_indexed_zset_spine(batches in kvr_batches(100, 5, 2, 500, 20), seed in 0..u64::MAX) {
         let factories = <OrdIndexedZSetFactories<DynI32, DynI32>>::new::<i32, i32, ZWeight>();
         test_indexed_zset_spine::<OrdIndexedZSet<DynI32, DynI32>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_file_indexed_zset_spine(batches in kvr_batches(100, 5, 2, 200, 10), seed in 0..u64::max_value()) {
+    fn test_file_indexed_zset_spine(batches in kvr_batches(100, 5, 2, 200, 10), seed in 0..u64::MAX) {
         let factories = <FallbackIndexedWSetFactories<DynI32, DynI32, DynZWeight>>::new::<i32, i32, ZWeight>();
         test_indexed_zset_spine::<FallbackIndexedWSet<DynI32, DynI32, DynZWeight>>(&factories, batches, seed)
     }
@@ -460,7 +460,7 @@ proptest! {
 
     // Like `test_indexed_zset_spine` but keeps even values only.
     #[test]
-    fn test_indexed_zset_spine_even_values(batches in kvr_batches(100, 5, 2, 500, 10), seed in 0..u64::max_value()) {
+    fn test_indexed_zset_spine_even_values(batches in kvr_batches(100, 5, 2, 500, 10), seed in 0..u64::MAX) {
         let factories = <OrdIndexedZSetFactories<DynI32, DynI32>>::new::<i32, i32, ZWeight>();
 
         let mut trace: Spine<OrdIndexedZSet<DynI32, DynI32>> = Spine::new(&factories);
@@ -501,7 +501,7 @@ proptest! {
     }
 
     #[test]
-    fn test_indexed_zset_spine_even_keys(batches in kvr_batches(100, 5, 2, 500, 10), seed in 0..u64::max_value()) {
+    fn test_indexed_zset_spine_even_keys(batches in kvr_batches(100, 5, 2, 500, 10), seed in 0..u64::MAX) {
         let factories = <OrdIndexedZSetFactories<DynI32, DynI32>>::new::<i32, i32, ZWeight>();
 
         let mut trace: Spine<OrdIndexedZSet<DynI32, DynI32>> = Spine::new(&factories);
@@ -542,26 +542,26 @@ proptest! {
     }
 
     #[test]
-    fn test_vec_zset_trace_spine(batches in kr_batches(100, 2, 500, 20), seed in 0..u64::max_value()) {
+    fn test_vec_zset_trace_spine(batches in kr_batches(100, 2, 500, 20), seed in 0..u64::MAX) {
         let factories = <OrdKeyBatchFactories<DynI32, u32, DynZWeight>>::new::<i32, (), ZWeight>();
         test_zset_trace_spine::<OrdKeyBatch<DynI32, u32, DynZWeight>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_file_zset_trace_spine(batches in kr_batches(100, 2, 200, 10), seed in 0..u64::max_value()) {
+    fn test_file_zset_trace_spine(batches in kr_batches(100, 2, 200, 10), seed in 0..u64::MAX) {
         let factories = <FileKeyBatchFactories<DynI32, u32, DynZWeight>>::new::<i32, (), ZWeight>();
         test_zset_trace_spine::<FileKeyBatch<DynI32, u32, DynZWeight>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_vec_indexed_zset_trace_spine(batches in kvr_batches(100, 5, 2, 300, 20), seed in 0..u64::max_value()) {
+    fn test_vec_indexed_zset_trace_spine(batches in kvr_batches(100, 5, 2, 300, 20), seed in 0..u64::MAX) {
         let factories = <OrdValBatchFactories<DynI32, DynI32, u32, DynZWeight>>::new::<i32, i32, ZWeight>();
 
         test_indexed_zset_trace_spine::<OrdValBatch<DynI32, DynI32, u32, DynZWeight>>(&factories, batches, seed)
     }
 
     #[test]
-    fn test_file_indexed_zset_trace_spine(batches in kvr_batches(100, 5, 2, 100, 10), seed in 0..u64::max_value()) {
+    fn test_file_indexed_zset_trace_spine(batches in kvr_batches(100, 5, 2, 100, 10), seed in 0..u64::MAX) {
         let factories =
         <FileValBatchFactories<DynI32, DynI32, u32, DynZWeight>>::new::<i32, i32, ZWeight>();
 
@@ -570,7 +570,7 @@ proptest! {
 
     // Like `test_indexed_zset_trace_spine` but keeps even values only.
     #[test]
-    fn test_indexed_zset_trace_spine_retain_even_values(batches in kvr_batches(100, 5, 2, 300, 20), seed in 0..u64::max_value()) {
+    fn test_indexed_zset_trace_spine_retain_even_values(batches in kvr_batches(100, 5, 2, 300, 20), seed in 0..u64::MAX) {
         let factories = <OrdValBatchFactories<DynI32, DynI32, u32, DynZWeight>>::new::<i32, i32, ZWeight>();
 
         // `trace1` uses `truncate_keys_below`.
@@ -607,7 +607,7 @@ proptest! {
     }
 
     #[test]
-    fn test_indexed_zset_trace_spine_retain_even_keys(batches in kvr_batches(100, 5, 2, 300, 10), seed in 0..u64::max_value()) {
+    fn test_indexed_zset_trace_spine_retain_even_keys(batches in kvr_batches(100, 5, 2, 300, 10), seed in 0..u64::MAX) {
         let factories = <OrdValBatchFactories<DynI32, DynI32, u32, DynZWeight>>::new::<i32, i32, ZWeight>();
 
         // `trace1` uses `truncate_keys_below`.

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -845,6 +845,7 @@ where
         Self { data: Vec::new() }
     }
 
+    #[allow(clippy::borrowed_box)]
     fn work(
         &mut self,
         source1: &TestBatch<K, V, T, R>,
@@ -1023,7 +1024,7 @@ where
     fn step_key(&mut self) {
         let current_key = clone_box(self.data[self.index].0 .0.as_ref());
 
-        while self.index < self.data.len() && &self.data[self.index].0 .0 == &current_key {
+        while self.index < self.data.len() && self.data[self.index].0 .0 == current_key {
             self.index += 1;
         }
 
@@ -1056,8 +1057,8 @@ where
         let current_key = clone_box(self.data[self.index].0 .0.as_ref());
         let current_val = clone_box(self.data[self.index].0 .1.as_ref());
 
-        while self.index < self.data.len() && &self.data[self.index].0 .1 == &current_val {
-            if self.index + 1 < self.data.len() && &self.data[self.index + 1].0 .0 == &current_key {
+        while self.index < self.data.len() && self.data[self.index].0 .1 == current_val {
+            if self.index + 1 < self.data.len() && self.data[self.index + 1].0 .0 == current_key {
                 self.index += 1;
             } else {
                 self.val_valid = false;
@@ -1095,7 +1096,7 @@ where
         let current_key = clone_box(self.data[self.index].0 .0.as_ref());
         let current_val = clone_box(self.data[self.index].0 .1.as_ref());
 
-        while &self.data[self.index].0 .1 == &current_val {
+        while self.data[self.index].0 .1 == current_val {
             if self.index > 0 && self.data[self.index - 1].0 .0 == current_key {
                 self.index -= 1;
             } else {

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -141,6 +141,7 @@ fn spawn_source_producer(
         .unwrap();
 }
 
+#[allow(clippy::too_many_arguments)]
 fn coordinate_input_and_steps(
     progress: bool,
     expected_num_events: u64,
@@ -352,7 +353,7 @@ fn run_queries(nexmark_config: &NexmarkConfig, snapshotter: &Snapshotter) -> Vec
 // grab elapsed time for each query run.  See
 // https://github.com/matklad/t-cmd/blob/master/src/main.rs Also CpuMonitor.java
 // in nexmark (binary that uses procfs to get cpu usage ever 100ms?)
-
+#[allow(clippy::mutable_key_type)]
 fn parse_counter(metrics: &MetricsSnapshot, name: &'static str) -> u64 {
     if let Some((_, _, DebugValue::Counter(value))) = metrics.get(&CompositeKey::new(
         MetricKind::Counter,

--- a/crates/pipeline-manager/src/demo.rs
+++ b/crates/pipeline-manager/src/demo.rs
@@ -100,17 +100,12 @@ mod test {
     fn demos_dir_does_not_exist() {
         let dir = tempfile::tempdir().unwrap();
         let dir_path = dir.path().join("does-not-exist");
-        assert!(
-            match read_demos_from_directory(dir_path.as_path()).unwrap_err() {
-                ManagerError::DemoError { demo_error } => {
-                    match demo_error {
-                        DemoError::UnableToReadDirectory { .. } => true,
-                        _ => false,
-                    }
-                }
-                _ => false,
+        assert!(matches!(
+            read_demos_from_directory(dir_path.as_path()).unwrap_err(),
+            ManagerError::DemoError {
+                demo_error: DemoError::UnableToReadDirectory { .. },
             }
-        );
+        ));
     }
 
     #[test]
@@ -118,35 +113,31 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let dir_path = dir.path();
         fs::create_dir(dir_path.join("does-exist").as_path()).unwrap();
-        assert!(match read_demos_from_directory(dir_path).unwrap_err() {
-            ManagerError::DemoError { demo_error } => {
-                match demo_error {
-                    DemoError::UnableToReadFile { .. } => true,
-                    _ => false,
-                }
+        assert!(matches!(
+            read_demos_from_directory(dir_path).unwrap_err(),
+            ManagerError::DemoError {
+                demo_error: DemoError::UnableToReadFile { .. },
             }
-            _ => false,
-        });
+        ));
     }
 
     #[test]
+    #[allow(clippy::unused_io_amount)]
     fn demos_dir_deserialization_failed() {
         let dir = tempfile::tempdir().unwrap();
         let dir_path = dir.path();
         let mut file = File::create(dir_path.join("file.txt").as_path()).unwrap();
         file.write("this_is_not_valid".as_bytes()).unwrap();
-        assert!(match read_demos_from_directory(dir_path).unwrap_err() {
-            ManagerError::DemoError { demo_error } => {
-                match demo_error {
-                    DemoError::DeserializationFailed { .. } => true,
-                    _ => false,
-                }
+        assert!(matches!(
+            read_demos_from_directory(dir_path).unwrap_err(),
+            ManagerError::DemoError {
+                demo_error: DemoError::DeserializationFailed { .. },
             }
-            _ => false,
-        });
+        ));
     }
 
     #[test]
+    #[allow(clippy::unused_io_amount)]
     fn demos_dir_one() {
         let dir = tempfile::tempdir().unwrap();
         let dir_path = dir.path();
@@ -169,6 +160,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::unused_io_amount)]
     fn demos_dir_multiple() {
         let dir = tempfile::tempdir().unwrap();
         let dir_path = dir.path();

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -1450,7 +1450,7 @@ mod test {
         )
     }
 
-    fn serialize_with_default_config<'de, T>(val: &T) -> Result<String, serde_json::Error>
+    fn serialize_with_default_config<T>(val: &T) -> Result<String, serde_json::Error>
     where
         T: SerializeWithContext<SqlSerdeConfig>,
     {
@@ -1460,7 +1460,7 @@ mod test {
         Ok(String::from_utf8(data).unwrap())
     }
 
-    fn serialize_with_snowflake_config<'de, T>(val: &T) -> Result<String, serde_json::Error>
+    fn serialize_with_snowflake_config<T>(val: &T) -> Result<String, serde_json::Error>
     where
         T: SerializeWithContext<SqlSerdeConfig>,
     {

--- a/crates/sqllib/src/variant.rs
+++ b/crates/sqllib/src/variant.rs
@@ -1019,7 +1019,7 @@ mod test {
                             (
                                 Variant::String("d".to_string()),
                                 Variant::Date(Date::from_date(
-                                    NaiveDate::from_ymd_opt(2024, 01, 01).unwrap(),
+                                    NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
                                 )),
                             ),
                             (

--- a/demo/project_demo12-HopsworksTikTokRecSys/tiktok-gen/Cargo.toml
+++ b/demo/project_demo12-HopsworksTikTokRecSys/tiktok-gen/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.9", features = ["derive"] }
 csv = "1.3.0"
-fake = { version = "2.9.2", features = ["derive", "chrono"] }
+fake = { version = "2.10", features = ["derive", "chrono"] }
 rand = "0.8.5"
 rdkafka = "0.36.2"
 serde = { version = "1.0.204", features = ["derive"] }


### PR DESCRIPTION
The faker crate renamed a public function without changing the major version, thus breaking our build.
