### PR TITLE
[SQL] Extract temporal filters from more kinds of comparison expressions 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,21 @@ When opening a new issue, try to roughly follow the commit message format conven
 
 # For developers
 
+## Running CI tests locally
+
+This can be done using `earthly`.  The `Earthfile` in the root
+directory has sections for tests.  You can run tests from one section
+using a command like:
+
+`earthly -P --ci +section`
+
+You can find the list of sections using `earthly ls`.
+
+For example, to run tests from the `test-python` section, the command
+would look like:
+
+`earthly -P --ci +test-python`
+
 ## Building Feldera from sources
 
 Feldera is implemented in Rust and uses Rust's `cargo` build system. The SQL

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
@@ -678,12 +678,14 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
         boolean allArgsConstant = Linq.all(expression.arguments, this.constantExpressions::contains);
         DBSPExpression reduced = null;
         IMaybeMonotoneType resultType = new NonMonotoneType(expression.getType());
+        boolean isDeterministic = true;
         if (allArgsMonotone || allArgsConstant) {
             DBSPExpression[] reducedArgs = Linq.map(
                     arguments, MonotoneExpression::getReducedExpression, DBSPExpression.class);
             if (expression.function.is(DBSPPathExpression.class)) {
                 DBSPPathExpression path = expression.function.to(DBSPPathExpression.class);
                 String name = path.toString();
+                isDeterministic = !name.equals("now");
                 if (name.startsWith("log10_") ||
                         name.startsWith("ln_") ||
                         name.startsWith("ceil_") ||
@@ -719,7 +721,7 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
                     }
                 }
             }
-            if (allArgsConstant) {
+            if (allArgsConstant && isDeterministic) {
                 this.constantExpressions.add(expression);
             }
         }


### PR DESCRIPTION
Fixes #2584 

We now decompose a filter condition into a sequence of conjunctions.
Each conjunct has one of the forms
- noNow (does not involve now)
- temporal (involves now and it can be implemented as a temporal comparison - complicated rules)
- nonTemporal (involves now and it cannot be implemented as a temporal comparison)

We implement 
- noNow conditions using standard (chained) filters, 
- temporal conjuncts using temporal windows
- nonTemporal conjuncts using joins and filters

As a bonus, we can sometimes combine multiple temporal conjuncts into a single window operator call.

So the example in the test case is written as a regular filter followed by a temporal filter.
Subtly, we take advantage of the fact that in SQL the AND operator is *not* short circuit as in C/Java.