### PR TITLE
[SQL] Run sqllogictests by rotation, some every day

### DIFF
--- a/sql-to-dbsp-compiler/run-tests.sh
+++ b/sql-to-dbsp-compiler/run-tests.sh
@@ -7,6 +7,4 @@ pushd temp; cargo update; popd
 mvn clean
 ./build.sh
 mvn test
-echo "Running sqllogictest tests"
-java -jar ./slt/target/slt-jar-with-dependencies.jar -inc -v -e hybrid
 

--- a/sql-to-dbsp-compiler/slt/pom.xml
+++ b/sql-to-dbsp-compiler/slt/pom.xml
@@ -44,6 +44,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -32,15 +32,51 @@ import org.dbsp.sqllogictest.executors.DbspJdbcExecutor;
 import org.dbsp.util.Linq;
 
 import java.io.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** Execute some or all of SqlLogicTest tests. */
 public class Main {
-    public static final String rustDirectory = "./temp/src/";
+    static final String rustDirectory = "./temp/src/";
     public static final String testFileName = "lib";
+
+    public static String getAbsoluteRustDirectory() {
+        String wd = System.getProperty("user.dir");
+        return wd + "/" + rustDirectory;
+    }
+
+    /** Executes a few test files based on the day of the month */
+    public static void rotateTests() throws IOException, ClassNotFoundException {
+        Set<String> tests = net.hydromatic.sqllogictest.Main.getTestList();
+        // Number of days required to run all tests
+        final int rotationPeriodInDays = 365;
+        int testsPerDay = (tests.size() + rotationPeriodInDays - 1) / rotationPeriodInDays;
+        LocalDate date = LocalDate.now();
+        final int day = date.getDayOfYear() % rotationPeriodInDays;
+        final int firstTest = testsPerDay * (day - 1);
+        final int lastTest = firstTest + testsPerDay;
+
+        List<String> list = new ArrayList<>(tests);
+        list.sort(String::compareTo);
+        List<String> toRun = list.subList(firstTest, lastTest);
+        String[] args = new String[] { "-v", "-x", "-inc", "-e", "hybrid" };
+
+        String wd = System.getProperty("user.dir");
+        File directory = new File(wd + "/..").getAbsoluteFile();
+        System.setProperty("user.dir", directory.getAbsolutePath());
+        wd = System.getProperty("user.dir");
+        System.out.println("working directory is " + wd);
+
+        String[] argv = new String[args.length + toRun.size()];
+        System.arraycopy(args, 0, argv, 0, args.length);
+        for (int i = 0; i < toRun.size(); i++)
+            argv[i + args.length] = toRun.get(i);
+        main(argv);
+    }
 
     @SuppressWarnings("SpellCheckingInspection")
     public static void main(String[] argv) throws IOException, ClassNotFoundException {

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -195,7 +195,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             this.startTest();
             if (this.execute) {
                 String[] extraArgs = new String[0];
-                Utilities.compileAndTestRust(Main.rustDirectory, true, extraArgs);
+                Utilities.compileAndTestRust(Main.getAbsoluteRustDirectory(), true, extraArgs);
             }
             this.queriesToRun.clear();
             System.out.println(elapsedTime(queryNo));
@@ -309,7 +309,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
     }
 
     void cleanupFilesystem() {
-        File directory = new File(Main.rustDirectory);
+        File directory = new File(Main.getAbsoluteRustDirectory());
         FilenameFilter filter = (dir, name) -> name.startsWith(Main.testFileName) || name.endsWith("csv");
         File[] files = directory.listFiles(filter);
         if (files == null)
@@ -558,7 +558,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             List<ProgramAndTester> functions
     ) throws IOException {
         String genFileName = Main.testFileName + ".rs";
-        String testFilePath = Main.rustDirectory + "/" + genFileName;
+        String testFilePath = Main.getAbsoluteRustDirectory() + "/" + genFileName;
         PrintStream stream = new PrintStream(testFilePath, StandardCharsets.UTF_8);
         RustFileWriter rust = new RustFileWriter(stream).forSlt();
 

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/InputFunctionGenerator.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/InputFunctionGenerator.java
@@ -55,7 +55,7 @@ class InputFunctionGenerator {
         if (totalSize > 10) {
             // If the data is large write, it to a set of CSV files and read it at runtime.
             for (int i = 0; i < inputSets.length; i++) {
-                String fileName = (Main.rustDirectory + inputSets[i].tableName) + ".csv";
+                String fileName = (Main.getAbsoluteRustDirectory() + inputSets[i].tableName) + ".csv";
                 File file = new File(fileName);
                 ToCsvVisitor.toCsv(compiler, file, inputSets[i].contents);
                 fields[i] = new DBSPApplyExpression(CalciteObject.EMPTY, "read_csv",

--- a/sql-to-dbsp-compiler/slt/src/test/java/org/dbsp/sqllogictest/RotateTests.java
+++ b/sql-to-dbsp-compiler/slt/src/test/java/org/dbsp/sqllogictest/RotateTests.java
@@ -1,0 +1,13 @@
+package org.dbsp.sqllogictest;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/** A unit test that invokes tests in rotation */
+public class RotateTests {
+    @Test
+    public void rotate() throws IOException, ClassNotFoundException {
+        Main.rotateTests();
+    }
+}

--- a/sql-to-dbsp-compiler/slt/src/test/java/org/dbsp/sqllogictest/package-info.java
+++ b/sql-to-dbsp-compiler/slt/src/test/java/org/dbsp/sqllogictest/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Package that doesn't allow null values as method parameters.
+ */
+
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsAreNonnullByDefault
+package org.dbsp.sqllogictest;
+
+import org.dbsp.util.FieldsAreNonnullByDefault;
+import org.dbsp.util.MethodsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This spreads the SLT tests over a number of days, using the current date to decide which tests to run.
Currently the tests are spread over 1 year, requiring running about 15K tests/day.
This is a trade-off between CI time and test coverage which we can tweak.
