### PR TITLE
docker: make sqllib crate available to sql-compiler, which got recently moved to crates/

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -123,6 +123,7 @@ COPY crates/dbsp lib/crates/dbsp
 COPY crates/feldera-types lib/crates/feldera-types
 COPY crates/adapters lib/crates/adapters
 COPY crates/nexmark lib/crates/nexmark
+COPY crates/sqllib lib/crates/sqllib
 # Storage crate got folded into the dbsp crate for now. Revert if this changes.
 # COPY crates/feldera-storage lib/crates/feldera-storage
 COPY README.md lib/README.md


### PR DESCRIPTION
This should fix the nightly container build failure.

Signed-off-by: Lalith Suresh <lalith@feldera.com>
