### PR TITLE
[py] add Pipeline.query() and Pipeline.query_tabular() for adhoc queries

### DIFF
--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -184,3 +184,18 @@ class PipelineStatus(Enum):
 
     def __eq__(self, other):
         return self.value == other.value
+
+
+class QueryResponseFormat(Enum):
+    """
+    The format of the response returned for the output of a query.
+    """
+
+    JSON = 1
+    """
+    The output is serialized as JSON.
+    The response is deserialized into a python dictionary.
+    
+    """
+
+    PARQUET = 2

--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -195,7 +195,7 @@ class QueryResponseFormat(Enum):
     """
     The output is serialized as JSON.
     The response is deserialized into a python dictionary.
-    
+
     """
 
     PARQUET = 2

--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -185,17 +185,3 @@ class PipelineStatus(Enum):
     def __eq__(self, other):
         return self.value == other.value
 
-
-class QueryResponseFormat(Enum):
-    """
-    The format of the response returned for the output of a query.
-    """
-
-    JSON = 1
-    """
-    The output is serialized as JSON.
-    The response is deserialized into a python dictionary.
-
-    """
-
-    PARQUET = 2

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -353,11 +353,6 @@ class Pipeline:
         :return: A generator that yields the rows of the result as Python dictionaries.
         """
 
-        if self.status() not in [
-            PipelineStatus.RUNNING,
-            PipelineStatus.PAUSED,
-        ]:
-            raise RuntimeError("Pipeline must be running or paused to run a query")
         return self.client.query_as_json(self.name, query)
 
     def query_parquet(self, query: str, path: str):
@@ -369,11 +364,6 @@ class Pipeline:
         :param path: The path of the parquet file.
         """
 
-        if self.status() not in [
-            PipelineStatus.RUNNING,
-            PipelineStatus.PAUSED,
-        ]:
-            raise RuntimeError("Pipeline must be running or paused to run a query")
         self.client.query_as_parquet(self.name, query, path)
 
     def query_tabular(self, query: str) -> Generator[str, None, None]:
@@ -384,9 +374,4 @@ class Pipeline:
         :return: A generator that yields a string representing the query result in a human-readable, tabular format.
         """
 
-        if self.status() not in [
-            PipelineStatus.RUNNING,
-            PipelineStatus.PAUSED,
-        ]:
-            raise RuntimeError("Pipeline must be running or paused to run a query")
         return self.client.query_as_text(self.name, query)

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -62,6 +62,7 @@ class HttpRequests:
                     timeout=timeout,
                     headers=headers,
                     params=params,
+                    stream=stream,
                 )
             elif isinstance(body, bytes):
                 request = http_method(
@@ -81,8 +82,14 @@ class HttpRequests:
                     params=params,
                     stream=stream,
                 )
-                if stream:
-                    return request
+
+            if stream:
+                return request
+            if request.headers.get("content-type") == "text/plain":
+                return request.text
+            elif request.headers.get("content-type") == "application/octet-stream":
+                return request.content
+
             resp = self.__validate(request)
             logging.debug("got response: %s", str(resp))
             return resp
@@ -95,9 +102,10 @@ class HttpRequests:
     def get(
             self,
             path: str,
-            params: Optional[Mapping[str, Any]] = None
+            params: Optional[Mapping[str, Any]] = None,
+            stream: bool = False,
     ) -> Any:
-        return self.send_request(requests.get, path, params)
+        return self.send_request(requests.get, path, params=params, stream=stream)
 
     def post(
             self,

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -83,14 +83,7 @@ class HttpRequests:
                     stream=stream,
                 )
 
-            if stream:
-                return request
-            if request.headers.get("content-type") == "text/plain":
-                return request.text
-            elif request.headers.get("content-type") == "application/octet-stream":
-                return request.content
-
-            resp = self.__validate(request)
+            resp = self.__validate(request, stream=stream)
             logging.debug("got response: %s", str(resp))
             return resp
 
@@ -164,9 +157,17 @@ class HttpRequests:
         return request.json()
 
     @staticmethod
-    def __validate(request: requests.Response) -> Any:
+    def __validate(request: requests.Response, stream=False) -> Any:
         try:
             request.raise_for_status()
+
+            if stream:
+                return request
+            if request.headers.get("content-type") == "text/plain":
+                return request.text
+            elif request.headers.get("content-type") == "application/octet-stream":
+                return request.content
+
             resp = HttpRequests.__to_json(request)
             return resp
         except requests.exceptions.HTTPError as err:

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import Optional
 import logging
 import time
@@ -377,40 +378,13 @@ class FelderaClient:
             if chunk:
                 yield json.loads(chunk, parse_float=Decimal)
 
-    def query(self, pipeline_name: str, query: str, fmt: str) -> str | bytes | Generator[dict, None, None]:
+    def query_as_text(self, pipeline_name: str, query: str) -> Generator[str, None, None]:
         """
-        Executes an ad-hoc query on the specified data pipeline.
+        Executes an ad-hoc query on the specified pipeline and returns a generator that yields lines of the table.
 
         :param pipeline_name: The name of the pipeline to query.
         :param query: The SQL query to be executed.
-        :param fmt: The format in which to return the query result:
-
-            - "text": Returns a string in tabular format representing the query result.
-            - "parquet": Returns a binary blob of data in Parquet format, which can be saved as a file.
-            - "json": Returns a generator that yields each row of the result as a Python dictionary.
-
-        :return: Depending on the format (`fmt`) provided:
-
-            - For "text": A string representing the query result in tabular form.
-            - For "parquet": A binary blob representing the query result in Parquet format.
-            - For "json": A generator that produces dictionaries for each row in the query result.
-        """
-
-        match fmt.lower():
-            case "text":
-                return self.query_as_text(pipeline_name, query)
-            case "parquet":
-                return self.query_as_parquet(pipeline_name, query)
-            case _:
-                return self.query_as_json(pipeline_name, query)
-
-    def query_as_text(self, pipeline_name: str, query: str) -> str:
-        """
-        Executes an ad-hoc query on the specified pipeline and returns the result as a formatted text table.
-
-        :param pipeline_name: The name of the pipeline to query.
-        :param query: The SQL query to be executed.
-        :return: A string containing the query result in tabular format.
+        :return: A generator yielding the query result in tabular format, one line at a time.
         """
         params = {
             "pipeline_name": pipeline_name,
@@ -418,29 +392,52 @@ class FelderaClient:
             "format": "text",
         }
 
-        return self.http.get(
+        resp = self.http.get(
             path=f"/pipelines/{pipeline_name}/query",
             params=params,
+            stream=True,
         )
 
-    def query_as_parquet(self, pipeline_name: str, query: str) -> bytes:
+        chunk: bytes
+        for chunk in resp.iter_lines(chunk_size=50000000):
+            if chunk:
+                yield chunk.decode("utf-8")
+
+    def query_as_parquet(self, pipeline_name: str, query: str, path: str):
         """
-        Executes an ad-hoc query on the specified pipeline and returns the result as a Parquet binary blob.
+        Executes an ad-hoc query on the specified pipeline and saves the result to a parquet file.
+        If the extension isn't `parquet`, it will be automatically appended to `path`.
 
         :param pipeline_name: The name of the pipeline to query.
         :param query: The SQL query to be executed.
-        :return: A binary blob representing the query result in Parquet format, which can be saved as a file.
+        :param path: The path including the file name to save the resulting parquet file in.
         """
+
         params = {
             "pipeline_name": pipeline_name,
             "sql": query,
             "format": "parquet",
         }
 
-        return self.http.get(
+        resp = self.http.get(
             path=f"/pipelines/{pipeline_name}/query",
             params=params,
+            stream=True,
         )
+
+        path: pathlib.Path = pathlib.Path(path)
+
+        ext = ".parquet"
+        if path.suffix != ext:
+            path = path.with_suffix(ext)
+
+        file = open(path, "wb")
+
+        chunk: bytes
+        for chunk in resp.iter_content(chunk_size=1024):
+            if chunk:
+                file.write(chunk)
+        file.close()
 
     def query_as_json(self, pipeline_name: str, query: str) -> Generator[dict, None, None]:
         """

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -161,7 +161,7 @@ class TestPipeline(unittest.TestCase):
         TEST_CLIENT.start_pipeline(name)
 
         TEST_CLIENT.push_to_pipeline(name, "tbl", "csv", data)
-        resp = TEST_CLIENT.query(pipeline.name, "SELECT * FROM tbl", "text")
+        resp = TEST_CLIENT.query_as_text(pipeline.name, "SELECT * FROM tbl")
         expected = """+----+
 | id |
 +----+
@@ -214,7 +214,7 @@ class TestPipeline(unittest.TestCase):
         TEST_CLIENT.start_pipeline(name)
 
         TEST_CLIENT.push_to_pipeline(name, "tbl", "csv", data)
-        resp = TEST_CLIENT.query(pipeline.name, "SELECT * FROM tbl", "json")
+        resp = TEST_CLIENT.query_as_json(pipeline.name, "SELECT * FROM tbl")
         expected = [{"id": 2}, {"id": 1}]
         got = list(resp)
 

--- a/python/tests/test_variant.py
+++ b/python/tests/test_variant.py
@@ -7,6 +7,7 @@ from feldera import PipelineBuilder, Pipeline
 from tests import TEST_CLIENT
 from decimal import Decimal
 
+
 class TestVariant(unittest.TestCase):
     def test_local(self):
         sql = f"""
@@ -33,9 +34,9 @@ FROM variant_table;
         pipeline = PipelineBuilder(TEST_CLIENT, name="test_variant", sql=sql).create_or_replace()
 
         input_strings = [
-            {"json":"{\"name\":\"Bob\",\"scores\":[8,10]}"},
-            {"json":"{\"name\":\"Dunce\",\"scores\":[3,4]}"},
-            {"json":"{\"name\":\"John\",\"scores\":[9,10]}"}
+            {"json": "{\"name\":\"Bob\",\"scores\":[8,10]}"},
+            {"json": "{\"name\":\"Dunce\",\"scores\":[3,4]}"},
+            {"json": "{\"name\":\"John\",\"scores\":[9,10]}"}
         ]
 
         input_json = [
@@ -47,25 +48,25 @@ FROM variant_table;
         expected_strings = [j | {"insert_delete": 1} for j in input_strings]
 
         expected_average = [
-            { "name": "Bob", "average": Decimal(9) },
-            { "name": "Dunce", "average": Decimal(3.5) },
-            { "name": "John", "average": Decimal(9.5) }
+            {"name": "Bob", "average": Decimal(9)},
+            {"name": "Dunce", "average": Decimal(3.5)},
+            {"name": "John", "average": Decimal(9.5)}
         ]
         for datum in expected_average:
             datum.update({"insert_delete": 1})
 
         expected_typed = [
-            { "name": "Bob", "scores": [8, 10] },
-            { "name": "Dunce", "scores": [3, 4] },
-            { "name": "John", "scores": [9, 10] }
+            {"name": "Bob", "scores": [8, 10]},
+            {"name": "Dunce", "scores": [3, 4]},
+            {"name": "John", "scores": [9, 10]}
         ]
         for datum in expected_typed:
             datum.update({"insert_delete": 1})
 
         expected_variant = [
-            {"json": { "name": "Bob", "scores": [8, 10] }},
-            {"json": { "name": "Dunce", "scores": [3, 4] }},
-            {"json": { "name": "John", "scores": [9, 10] }}
+            {"json": {"name": "Bob", "scores": [8, 10]}},
+            {"json": {"name": "Dunce", "scores": [3, 4]}},
+            {"json": {"name": "John", "scores": [9, 10]}}
         ]
         for datum in expected_variant:
             datum.update({"insert_delete": 1})
@@ -97,6 +98,7 @@ FROM variant_table;
         pipeline.wait_for_completion(True)
 
         pipeline.delete()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Fixes: #2493 

Adds methods to run adhoc queries against running or paused pipelines.

In FelderaClient:
- adds ~query()~ query_as_text(), query_as_json() & query_as_parquet() methods

In Pipeline:
- adds query() for JSON (returns generator that yields dict), query_parquet() (saves to the given file) and query_tabular() (returns generator that yields string) methods

~A new enum is also added to represent the different formats of responses for ad-hoc queries: `QueryResponseFormat`.~
***

While discussing this implementation we talked about potentially introducing a `Cursor` type that users can use to iterate upon the result, however, that might not be necessary as we can just yield responses and use the generator. 

The function names could change to improve clarity.