### PR TITLE
[docs] Fixup a link to delta docs.

### DIFF
--- a/docs/connectors/sources/s3.md
+++ b/docs/connectors/sources/s3.md
@@ -12,7 +12,7 @@ common S3 prefix.
 
 :::tip
 When accessing an S3 bucket that stores data in the Delta Lake format, consider
-using the [Delta Lake connector](/connectors/source/delta) instead.
+using the [Delta Lake connector](/connectors/sources/delta) instead.
 :::
 
 ## Configuration options


### PR DESCRIPTION
Fixup broken link to delta lake docs from the S3 connector page.