### PR TITLE
pipeline-manager: handle pipeline deletion in compiler server

### DIFF
--- a/web-console/src/lib/compositions/health/systemErrors.ts
+++ b/web-console/src/lib/compositions/health/systemErrors.ts
@@ -102,7 +102,7 @@ export const extractProgramError =
         (() => ({
           name: `Error compiling ${pipeline.name}`,
           message:
-            'Compilation error occurred when compiling the program - see the details below:\n' +
+            'Program compilation error. See details below:\n' +
             e.RustError,
           cause: {
             entityName: pipeline.name,


### PR DESCRIPTION
Every database interaction to transition the program status of a pipeline can yield the UnknownPipeline error as pipelines can be deleted at any point in time. This is now handled by either skipping its re-queueing or canceling the corresponding job.

Also fixes: https://github.com/feldera/feldera/issues/2643