### PR TITLE
[py] pretty SQL compilation errors

### DIFF
--- a/python/feldera/__init__.py
+++ b/python/feldera/__init__.py
@@ -7,3 +7,5 @@ import pretty_errors
 pretty_errors.configure(
     line_number_first=True,
 )
+
+pretty_errors.activate()

--- a/python/feldera/__init__.py
+++ b/python/feldera/__init__.py
@@ -1,3 +1,9 @@
 from feldera.rest.feldera_client import FelderaClient
 from feldera.pipeline import Pipeline
 from feldera.pipeline_builder import PipelineBuilder
+
+import pretty_errors
+
+pretty_errors.configure(
+    line_number_first=True,
+)

--- a/python/feldera/rest/errors.py
+++ b/python/feldera/rest/errors.py
@@ -25,31 +25,34 @@ class FelderaAPIError(FelderaError):
         self.message = None
         self.details = None
 
+        err_msg = ""
+
         if request.text:
             try:
                 json_data = json.loads(request.text)
-                self.message = json_data.get("message")
-                self.details = json_data.get("details")
+
                 self.error_code = json_data.get("error_code")
+                if self.error_code:
+                    err_msg += f"\nError Code: {self.error_code}"
+                self.message = json_data.get("message")
+                if self.message:
+                    err_msg += f"\nMessage: {self.message}"
+                self.details = json_data.get("details")
             except:
                 self.message = request.text
 
-    def __str__(self) -> str:
-        if self.error_code:
-            return f"FelderaAPIError: {self.error}\n Error code: {self.error_code}\n Error message: {self.message}\n Details: {self.details}"
-        else:
-            return f"FelderaAPIError: {self.error}\n {self.message}"
+        super().__init__(err_msg)
 
 
 class FelderaTimeoutError(FelderaError):
     """Error when Feldera operation takes longer than expected"""
 
-    def __str__(self) -> str:
-        return f"FelderaTimeoutError: {self.message}"
+    def __init__(self, err: str) -> None:
+        super().__init__(f"Timeout connecting to Feldera: {err}")
 
 
 class FelderaCommunicationError(FelderaError):
     """Error when connection to Feldera"""
 
-    def __str__(self) -> str:
-        return f"FelderaCommunicationError: {self.message}"
+    def __init__(self, err: str) -> None:
+        super().__init__(f"Cannot connect to Feldera API: {err}")

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -88,7 +88,16 @@ class FelderaClient:
             if status == "Success":
                 return p
             elif status not in wait:
-                # TODO: return a more detailed error message
+                # error handling for SQL compilation errors
+                if isinstance(status, dict):
+                    sql_errors = status.get("SqlError")
+                    if sql_errors:
+                        err_msg = f"Pipeline {name} failed to compile:\n"
+                        for sql_error in sql_errors:
+                            err_msg += f"{sql_error['error_type']}\n{sql_error['message']}\n"
+                            err_msg += f"Code snippet:\n{sql_error['snippet']}"
+                        raise RuntimeError(err_msg)
+
                 raise RuntimeError(f"The program failed to compile: {status}")
 
             logging.debug("still compiling %s, waiting for 100 more milliseconds", name)

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -220,7 +220,6 @@ class FelderaClient:
             if status == "Paused":
                 break
             elif status == "Failed":
-                # TODO: return a more detailed error message
                 raise RuntimeError(f"Failed to pause pipeline")
 
             logging.debug("still pausing %s, waiting for 100 more milliseconds", pipeline_name)
@@ -230,7 +229,7 @@ class FelderaClient:
         """
         Shutdown a pipeline
 
-        :param pipeline_name: The name of the pipeline to shutdown
+        :param pipeline_name: The name of the pipeline to shut down
         """
 
         self.http.post(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pandas",
     "typing-extensions",
     "numpy<2",
+    "pretty-errors",
 ]
 [project.urls]
 Homepage = "https://www.feldera.com"

--- a/python/tests/test_pipeline_builder.py
+++ b/python/tests/test_pipeline_builder.py
@@ -284,7 +284,6 @@ Code snippet:
     def test_kafka(self):
         import json
 
-
         in_ci = os.environ.get("IN_CI")
 
         if in_ci == "1":

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -70,12 +70,22 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "feldera"
 version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pretty-errors" },
     { name = "requests" },
     { name = "typing-extensions" },
 ]
@@ -84,6 +94,7 @@ dependencies = [
 requires-dist = [
     { name = "numpy", specifier = "<2" },
     { name = "pandas" },
+    { name = "pretty-errors" },
     { name = "requests" },
     { name = "typing-extensions" },
 ]
@@ -175,6 +186,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
     { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
     { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+]
+
+[[package]]
+name = "pretty-errors"
+version = "1.2.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/a7/823f451d48726729b4983072aad7c442f4c02fbaec04b71c1f4c03993964/pretty_errors-1.2.25.tar.gz", hash = "sha256:a16ba5c752c87c263bf92f8b4b58624e3b1e29271a9391f564f12b86e93c6755", size = 20332 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/8e/2df7467a15eae40e26c476683962fdb810cd1b36676603e2f139b4abbeaf/pretty_errors-1.2.25-py3-none-any.whl", hash = "sha256:8ce68ccd99e0f2a099265c8c1f1c23b7c60a15d69bb08816cb336e237d5dc983", size = 17195 },
 ]
 
 [[package]]


### PR DESCRIPTION
Display SQL compliation errors in a pretty format.

Also use `pretty-errors` library that improves how errors are presented in general.

Fixes: #1842
Fixes: #1802 

### Example Error

<img width="673" alt="Screenshot 2024-10-02 at 16 39 39" src="https://github.com/user-attachments/assets/0ccde9d4-4657-47c1-b20f-ae4e0609fd0e">
