### PR TITLE
demo: packaged SQL-only demos

### DIFF
--- a/crates/pipeline-manager/src/api/config_api.rs
+++ b/crates/pipeline-manager/src/api/config_api.rs
@@ -1,9 +1,7 @@
 // Configuration API to retrieve the current authentication configuration and list of demos
-use crate::demo::{read_demos_from_directory, Demo};
 use actix_web::{get, web::Data as WebData, HttpRequest, HttpResponse};
 use serde::Serialize;
 use serde_json::json;
-use std::path::Path;
 use utoipa::ToSchema;
 
 use super::{ManagerError, ServerState};
@@ -69,11 +67,11 @@ async fn get_config_authentication(
     path="/config/demos",
     responses(
         (status = OK
-            , description = "List of demos."
+            , description = "List of demos"
             , content_type = "application/json"
             , body = Vec<Demo>),
         (status = INTERNAL_SERVER_ERROR
-            , description = "Failed to read demos from the demos directory."
+            , description = "Failed to read demos from the demos directories"
             , body = ErrorResponse),
     ),
     context_path = "/v0",
@@ -82,12 +80,7 @@ async fn get_config_authentication(
 )]
 #[get("/config/demos")]
 async fn get_config_demos(state: WebData<ServerState>) -> Result<HttpResponse, ManagerError> {
-    match &state._config.demos_dir {
-        None => Ok(HttpResponse::Ok().json(Vec::<Demo>::new())),
-        Some(demos_dir) => {
-            Ok(HttpResponse::Ok().json(read_demos_from_directory(Path::new(&demos_dir))?))
-        }
-    }
+    Ok(HttpResponse::Ok().json(&state.demos))
 }
 
 #[derive(Serialize, ToSchema)]

--- a/crates/pipeline-manager/src/api/mod.rs
+++ b/crates/pipeline-manager/src/api/mod.rs
@@ -26,6 +26,7 @@ mod pipeline;
 use crate::auth::JwkCache;
 use crate::config::ApiServerConfig;
 use crate::db::storage_postgres::StoragePostgres;
+use crate::demo::{read_demos_from_directories, Demo};
 use crate::error::ManagerError;
 use crate::probe::Probe;
 use crate::runner::interaction::RunnerInteraction;
@@ -327,18 +328,21 @@ pub(crate) struct ServerState {
     _config: ApiServerConfig,
     pub jwk_cache: Arc<Mutex<JwkCache>>,
     probe: Arc<Mutex<Probe>>,
+    demos: Vec<Demo>,
 }
 
 impl ServerState {
     pub async fn new(config: ApiServerConfig, db: Arc<Mutex<StoragePostgres>>) -> AnyResult<Self> {
         let runner = RunnerInteraction::new(config.clone(), db.clone());
         let db_copy = db.clone();
+        let demos = read_demos_from_directories(&config.demos_dir);
         Ok(Self {
             db,
             runner,
             _config: config,
             jwk_cache: Arc::new(Mutex::new(JwkCache::new())),
             probe: Probe::new(db_copy).await,
+            demos,
         })
     }
 }

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -721,7 +721,7 @@ mod test {
             dump_openapi: false,
             config_file: None,
             allowed_origins: None,
-            demos_dir: None,
+            demos_dir: vec![],
             telemetry: "".to_owned(),
             runner_hostname_port: "127.0.0.1:8089".to_string(),
         };

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -50,6 +50,10 @@ fn default_compilation_profile() -> CompilationProfile {
     CompilationProfile::Optimized
 }
 
+fn default_demos_dir() -> Vec<String> {
+    vec!["demo/packaged/sql".to_string()]
+}
+
 /// Pipeline manager configuration read from a YAML config file or from command
 /// line arguments.
 #[derive(Parser, Deserialize, Debug, Clone)]
@@ -170,13 +174,16 @@ pub struct ApiServerConfig {
     #[arg(long)]
     pub dev_mode: bool,
 
-    /// Local directory in which demos are stored for supplying clients like the UI with
+    /// Local directories in which demos are stored for supplying clients like the UI with
     /// a set of demos to present to the user. Administrators can use this option to set
     /// up environment-specific demos for users (e.g., ones that connect to an internal
     /// data source).
-    #[serde(default)]
-    #[arg(long)]
-    pub demos_dir: Option<String>,
+    ///
+    /// For each directory, the files are read sorted on the filename.
+    /// For multiple directories, the lists of demos are appended one after the other into a single one.
+    /// Files which do not end in `.sql` and directories are ignored. Symlinks are followed.
+    #[arg(long, default_values_t = default_demos_dir())]
+    pub demos_dir: Vec<String>,
 
     /// Telemetry key.
     ///

--- a/crates/pipeline-manager/src/integration_test.rs
+++ b/crates/pipeline-manager/src/integration_test.rs
@@ -105,7 +105,7 @@ async fn initialize_local_pipeline_manager_instance() -> TempDir {
         dump_openapi: false,
         config_file: None,
         allowed_origins: None,
-        demos_dir: None,
+        demos_dir: vec![],
         telemetry: "".to_string(),
         runner_hostname_port: "127.0.0.1:8089".to_string(),
     }

--- a/demo/packaged/README.md
+++ b/demo/packaged/README.md
@@ -1,0 +1,79 @@
+# Packaged SQL-only demos
+
+The SQL of packaged demo starts with a preamble to convey explicitly the
+title, name and description. This information is for example extracted by the
+Web Console for display on the demos overview.
+
+All the SQL files in `sql/` are packaged demos with every Feldera release.
+
+- **Preamble validation:**
+  ```bash
+  python3 validate-preamble.py sql/*.sql
+  ```
+
+- **Cargo run with demos:**
+  ```bash
+  cargo run --features pg-embed --bin pipeline-manager \
+            -- --demos-dir demo/packaged/sql
+  ```
+
+- **Docker:** in the Dockerfile, directory `demo/packaged/sql` was copied over to
+  `/home/feldera/demos`, and `--demos-dir /home/feldera/demos` has been added to
+  the entry point command. Bring it up for example with:
+  ```bash
+  docker compose -f deploy/docker-compose.yml \
+                 -f deploy/docker-compose-dev.yml up --build
+  ```
+
+## Specification
+
+The format is as follows:
+
+```
+-- [title] ([pipeline-name])
+--
+-- [description-line1]
+-- [description-line2]
+-- ...
+-- [description-lineN]
+--
+[other-sql]
+```
+
+... with the following constraints:
+
+- `[title]` is non-empty and at most 100 characters.
+- `[pipeline-name]` adheres to the name constraints: at most 100 characters and follow pattern `[a-zA-Z0-9_-]+`.
+- There must be at least one `[description-line]`.
+- All `[description-line]` joined together as description is non-empty and at most 1000 characters.
+- The whitespace at the end of each preamble line is ignored.
+- The empty comment line in-between title/pipeline-name and description,
+  and after the description, is mandatory.
+
+**How to validate: regular expression**
+```regexp
+^-- (.+) \(([a-zA-Z0-9_-]+)\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n
+```
+... with afterward:
+- First group is title, second group is name, and third group is description lines.
+- The description lines can then be parsed by finding in it all regex matches of `-- .+\r?\n`,
+  of each removing the `-- ` prefix and trimming whitespace, finally join with
+  a space character (` `), and trim whitespace.
+- Trim whitespace from the title, and check it is non-empty and at most 100 characters
+- Check name is at most 100 characters
+- Check description is at most 1000 characters
+
+## Example
+
+```sql
+-- Example (example-1)
+--
+-- This is a description of the example demo
+-- which must span at least one line.
+--
+-- More comments not part of the description
+-- can be written.
+
+-- Explanation about the table
+CREATE TABLE example ( col1 INT );
+```

--- a/demo/packaged/sql/00-fraud-detection.sql
+++ b/demo/packaged/sql/00-fraud-detection.sql
@@ -1,0 +1,123 @@
+-- Use Case: Feature Engineering for Real-Time Fraud Detection (fraud-detection)
+--
+-- Build real-time feature pipelines in SQL.
+--
+-- ## How to run
+--
+-- * Paste this SQL code in the Feldera WebConsole and hit Play ▶️.
+-- * In the Change Stream tab, select the `transaction_with_aggregates` view.
+-- * You should see feature vectors being produced in real-time as the
+--   data generator pushes input changes to the pipeline.
+--
+-- ## Detailed description
+--
+-- When it comes to fraud detection, training an accurate ML model is only the
+-- beginning. To ensure its effectiveness, you must supply the model with
+-- up-to-date features computed from the latest data.
+--
+-- Feldera's unique incremental query engine makes it an ideal compute platform for
+-- fraud detection teams:
+--
+-- * Expressive: Write complex feature pipelines in SQL
+-- * Unified online/offline processing: run the same SQL queries during model
+--   training and real-time inference.
+-- * Throughput: process millions of records per second on a single host.
+-- * Feature freshness: Upon ingesting new events, Feldera outputs new and
+--   updated feature vectors within milliseconds.
+-- * No online/offline skew: Feldera guarantees identical outputs on batch and
+--   streaming inputs.
+--
+-- In this example we show how to implement two important types of feature
+-- queries in Feldera:
+--
+-- * Data enrichment queries, which combine (or enrich) raw transaction data
+--   with data from other sources.
+-- * Rolling aggregate queries: foe each event in a time series, compute an
+--   aggregate (e.g., count, sum, average, etc.) over a fixed time frame
+--  preceding this event.
+--
+-- See https://feldera.com/fraud_detection for more details.
+
+
+-- Credit card holders.
+CREATE TABLE CUSTOMER (
+    cc_num BIGINT NOT NULL PRIMARY KEY, -- Credit card number
+    name varchar,                       -- Customer name
+    lat DOUBLE,                         -- Customer home address latitude
+    long DOUBLE                         -- Customer home address longitude
+) WITH (
+    'materialized' = 'true',
+    -- Configure the random data generator to generate 100000 customer records.
+    -- (see https://www.feldera.com/docs/connectors/sources/datagen)
+    'connectors' = '[{
+      "transport": {
+        "name": "datagen",
+        "config": {
+          "plan": [{
+            "limit": 100000,
+            "fields": {
+              "name": { "strategy": "name" },
+              "cc_num": { "range": [ 100000000000000, 100000000100000 ] },
+              "lat": { "strategy": "uniform", "range": [ 25, 50 ] },
+              "long": { "strategy": "uniform", "range": [ -126, -67 ] }
+            }
+          }]
+        }
+      }
+    }]'
+);
+
+-- Credit card transactions.
+CREATE TABLE TRANSACTION (
+    ts TIMESTAMP LATENESS INTERVAL 10 MINUTES, -- Transaction time
+    amt DOUBLE,                                -- Transaction amount
+    cc_num BIGINT NOT NULL,                    -- Credit card number
+    shipping_lat DOUBLE,                       -- Shipping address latitude
+    shipping_long DOUBLE,                      -- Shipping address longitude
+    FOREIGN KEY (cc_num) REFERENCES CUSTOMER(cc_num)
+) WITH (
+    'materialized' = 'true',
+    -- Configure the random data generator to generate 1M transactions at the rate of 1000 transactions/s.
+    'connectors' = '[{
+      "transport": {
+      "name": "datagen",
+        "config": {
+          "plan": [{
+            "limit": 1000000,
+            "rate": 1000,
+            "fields": {
+              "ts": { "strategy": "increment", "scale": 1000, "range": [1722063600000,2226985200000] },
+              "amt": { "strategy": "zipf", "range": [ 1, 10000 ] },
+              "cc_num": { "strategy": "uniform", "range": [ 100000000000000, 100000000100000 ] },
+              "shipping_lat": { "strategy": "uniform", "range": [ 25, 50 ] },
+              "shipping_long": { "strategy": "uniform", "range": [ -126, -67 ] }
+            }
+          }]
+        }
+      }
+    }]'
+);
+
+-- Data enrichment query: left-join the TRANSACTION table with the CUSTOMER table to compute the
+-- distance between the shipping address and the customer's home address for each transaction.
+CREATE VIEW TRANSACTION_WITH_DISTANCE AS
+    SELECT
+        t.*,
+        ST_DISTANCE(ST_POINT(shipping_long, shipping_lat), ST_POINT(long,lat)) AS distance
+    FROM
+        TRANSACTION as t
+        LEFT JOIN CUSTOMER as c
+        ON t.cc_num = c.cc_num;
+
+-- Compute two rolling aggregates over a 1-day time window for each transaction:
+-- 1. Average spend per transaction.
+-- 2. The number of transactions whose shipping address is more than 50,000 meters away from
+--    the card holder's home address.
+CREATE VIEW TRANSACTION_WITH_AGGREGATES AS
+SELECT
+   *,
+   AVG(amt) OVER window_1_day as avg_1day,
+   SUM(case when distance > 50000 then 1 else 0 end) OVER window_1_day as count_1day
+FROM
+  TRANSACTION_WITH_DISTANCE
+WINDOW window_1_day AS (PARTITION BY cc_num ORDER BY ts RANGE BETWEEN INTERVAL 1 DAYS PRECEDING AND CURRENT ROW);

--- a/demo/packaged/sql/01-sec-ops.sql
+++ b/demo/packaged/sql/01-sec-ops.sql
@@ -1,0 +1,317 @@
+-- Use Case: Incremental Analytics for Security Operations (sec-ops)
+--
+-- Detect security vulnerabilities in Kubernetes deployments in real-time.
+--
+-- This example illustrates the use of incremental analytics to detect security
+-- vulnerabilities affecting production Kubernetes deployments in real-time.
+-- It tracks security vulnerabilities as they propagate through the software supply
+-- chain, instantly updating the list of affected Kubernetes objects in response
+-- to input changes.
+--
+-- ## How to run
+--
+-- * Paste this SQL code in the Feldera WebConsole and hit Play ▶️.
+-- * In the Change Stream tab, select the `k8scluster_vulnerability_stats` view.
+-- * You should see vulnerability counts change in real-time as the
+--   data generator pushes input changes to the pipeline.
+--
+-- ## Detailed Description
+--
+-- We analyze how security vulnerabilities propagate through the software supply
+-- chain starting from source code into production Kubernetes cluster:
+--
+-- 1. A vulnerability is introduced into source code in a particular Git commit.
+--    We assume that this vulnerability is detected and reported by a security scanner.
+-- 2. The affected commit is picked up by a CI/CD pipeline, which uses it to
+--    generate one or more binary artifacts.
+-- 3. These binary artifacts are deployed in a Kubernetes cluster.
+--
+-- Traditional batch analytics tools implement this analysis by periodically
+-- re-running all queries from scratch, which can take hours, ultimately
+-- delaying the discovery of vulnerabilities.
+--
+-- In contrast, Feldera evaluates the queries incrementally, instantly updating
+-- SQL views whenever new or modified data is added to the input tables.
+--
+-- We configure Feldera's builtin data generator to produce a continuous stream
+-- of updates to input tables, which model Kubernetes clusters, CI/CD pipelines, Git
+-- commits, etc.
+--
+-- ## Takeaways
+--
+-- This example illustrates how Feldera can run complex analytical workloads in real-time:
+--
+-- * It enables users to convert slow batch jobs into real-time pipelines,
+--   reducing time to results from hours to seconds.
+--
+-- * Feldera allows constructing complex analytical pipelines in a modular way
+--   by breaking them up into multiple views, with more complex views being
+--   defined on top of simpler views.
+
+
+-- CI/CD pipelines.
+create table pipeline (
+    pipeline_id bigint not null primary key,
+    create_date timestamp not null,
+    createdby_user_id bigint not null,
+    update_date timestamp,
+    updatedby_user_id bigint
+) WITH ('connectors' = '[{
+    "transport": {
+        "name": "datagen",
+        "config": {
+            "plan": [{
+                "rate": 100,
+                "fields": {
+                    "pipeline_id": { "strategy": "uniform", "range": [1, 1001] },
+                    "create_date": { "strategy": "uniform" },
+                    "createdby_user_id": { "strategy": "uniform", "range": [1, 101] },
+                    "update_date": { "strategy": "uniform" },
+                    "updatedby_user_id": { "strategy": "uniform", "range": [1,101] }
+                }
+            }]
+        }
+    }
+}]');
+
+-- Git commits used by each pipeline.
+create table pipeline_sources (
+    pipeline_source_id bigint not null primary key,
+    git_commit_id bigint not null,
+    pipeline_id bigint not null foreign key references pipeline(pipeline_id)
+) WITH (
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "rate": 100,
+                    "fields": {
+                        "pipeline_source_id": { "strategy": "uniform", "range": [1, 10001] },
+                        "git_commit_id": { "strategy": "uniform", "range": [1, 5001] },
+                        "pipeline_id": { "strategy": "uniform", "range": [1, 1001] }
+                    }
+                }]
+            }
+
+        }
+    }]'
+);
+
+-- Binary artifacts created by CI pipelines.
+create table artifact (
+    artifact_id bigint not null primary key,
+    -- artifact_uri varchar not null,
+    checksum varchar not null,
+    artifact_size_in_bytes bigint not null,
+    artifact_type int not null,
+    builtby_pipeline_id bigint not null foreign key references pipeline(pipeline_id),
+    parent_artifact_id bigint foreign key references artifact(artifact_id)
+) WITH (
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "rate": 100,
+                    "fields": {
+                        "artifact_id": { "strategy": "uniform", "range": [1,10001] },
+                        "checksum": { "strategy": "uniform", "range": [64,65] },
+                        "artifact_size_in_bytes": { "strategy": "uniform", "range": [0, 1000000001] },
+                        "artifact_type": { "strategy": "uniform", "range": [1,11] },
+                        "builtby_pipeline_id": { "strategy": "uniform", "range": [1,1001] },
+                        "parent_artifact_id": { "strategy": "uniform", "range": [1, 10001] }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+-- Vulnerabilities discovered in source code.
+create table vulnerability (
+    vulnerability_id bigint not null primary key,
+    discovered_in bigint not null,
+    discovery_date timestamp not null,
+    checksum varchar not null,
+    vulnerability_reference_id varchar,
+    severity int,
+    priority varchar
+)
+WITH (
+    -- Instruct Feldera to store the snapshot of the table, allowing the
+    -- user to browse it via the UI or API.
+    'materialized' = 'true',
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "rate": 100,
+                    "fields": {
+                        "vulnerability_id": { "strategy": "uniform", "range": [1, 1001] },
+                        "discovered_in": { "strategy": "uniform", "range": [1, 5001] },
+                        "discovery_date": { "strategy": "uniform" },
+                        "checksum": { "strategy": "uniform", "range": [64,65] },
+                        "vulnerability_reference_id": { "strategy": "word" },
+                        "severity": { "strategy": "uniform", "range": [1,11] },
+                        "priority": { "values": ["LOW", "MEDIUM", "HIGH"], "strategy": "uniform" }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+-- Kubernetes clusters.
+create table k8scluster (
+    k8scluster_id bigint not null primary key,
+    name varchar not null)
+WITH  (
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "limit": 10,
+                    "fields": {
+                        "name": { "values": ["cluster1", "cluster2", "cluster3", "cluster4", "cluster5", "cluster6", "cluster7", "cluster8", "cluster9", "cluster10"] }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+
+-- Deployed Kubernetes objects.
+create table k8sobject (
+    k8sobject_id bigint not null primary key,
+    artifact_id bigint not null foreign key references artifact(artifact_id),
+    checksum varchar not null,
+    deployed_id bigint not null foreign key references k8scluster(k8scluster_id),
+    k8snamespace varchar not null
+)WITH  (
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "rate": 100,
+                    "fields": {
+                        "k8sobject_id": { "strategy": "uniform", "range": [1, 10001] },
+                        "artifact_id": { "strategy": "uniform", "range": [1, 10001] },
+                        "checksum": { "strategy": "uniform", "range": [64,65] },
+                        "deployed_id": { "strategy": "uniform", "range": [0,10] },
+                        "k8snamespace": { "strategy": "word" }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+-- Vulnerabilities that affect each CI/CD pipeline.
+create view pipeline_vulnerability (
+    pipeline_id,
+    vulnerability_id
+) as
+    SELECT pipeline_sources.pipeline_id as pipeline_id, vulnerability.vulnerability_id as vulnerability_id FROM
+    pipeline_sources
+    INNER JOIN
+    vulnerability
+    ON pipeline_sources.git_commit_id = vulnerability.discovered_in;
+
+-- Vulnerabilities that affect each artifact.
+--
+-- Note that this view uses the `pipeline_vulnerability` view defined above as
+-- input. This pattern continues below, where we continue building more complex
+-- views on top. This illustrates how Feldera enables the construction of complex
+-- analytical pipelines in a modular way.
+create view artifact_vulnerability (
+    artifact_id,
+    vulnerability_id
+) as
+    SELECT artifact.artifact_id as artifact_id, pipeline_vulnerability.vulnerability_id as vulnerability_id FROM
+    artifact
+    INNER JOIN
+    pipeline_vulnerability
+    ON artifact.builtby_pipeline_id = pipeline_vulnerability.pipeline_id;
+
+-- Vulnerabilities in the artifact or any of its children.
+create view transitive_artifact_vulnerability(
+    artifact_id,
+    via_artifact_id,
+    vulnerability_id
+) as
+    SELECT artifact_id, artifact_id as via_artifact_id, vulnerability_id from artifact_vulnerability
+    UNION
+    (
+        SELECT
+            artifact.parent_artifact_id as artifact_id,
+            artifact.artifact_id as via_artifact_id,
+            artifact_vulnerability.vulnerability_id as vulnerability_id FROM
+        artifact
+        INNER JOIN
+        artifact_vulnerability
+        ON artifact.artifact_id = artifact_vulnerability.artifact_id
+        WHERE artifact.parent_artifact_id IS NOT NULL
+    );
+
+-- Vulnerabilities that affect each k8s object.
+create view k8sobject_vulnerability (
+    k8sobject_id,
+    vulnerability_id
+) as
+    SELECT k8sobject.k8sobject_id, transitive_artifact_vulnerability.vulnerability_id FROM
+    k8sobject
+    INNER JOIN
+    transitive_artifact_vulnerability
+    ON k8sobject.artifact_id = transitive_artifact_vulnerability.artifact_id;
+
+-- Vulnerabilities that affect each k8s cluster.
+create view k8scluster_vulnerability (
+    k8scluster_id,
+    vulnerability_id
+) as
+    SELECT
+        k8sobject.deployed_id as k8scluster_id,
+        k8sobject_vulnerability.vulnerability_id FROM
+    k8sobject_vulnerability
+    INNER JOIN
+    k8sobject
+    ON k8sobject_vulnerability.k8sobject_id = k8sobject.k8sobject_id;
+
+-- Per-cluster statistics:
+-- * Number of vulnerabilities.
+-- * Most severe vulnerability.
+create materialized view k8scluster_vulnerability_stats (
+    k8scluster_id,
+    k8scluster_name,
+    total_vulnerabilities,
+    most_severe_vulnerability
+) AS
+    SELECT
+        cluster_id,
+        k8scluster.name as k8scluster_name,
+        total_vulnerabilities,
+        most_severe_vulnerability
+    FROM
+    (
+        SELECT
+            cluster_id,
+            COUNT(*) as total_vulnerabilities,
+            MAX(severity) as most_severe_vulnerability
+        FROM
+        (
+            SELECT k8scluster_vulnerability.k8scluster_id as cluster_id, vulnerability.vulnerability_id, vulnerability.severity FROM
+            k8scluster_vulnerability
+            INNER JOIN
+            vulnerability
+            ON k8scluster_vulnerability.vulnerability_id = vulnerability.vulnerability_id
+        )
+        GROUP BY cluster_id
+    )
+    INNER JOIN
+    k8scluster
+    ON k8scluster.k8scluster_id = cluster_id;

--- a/demo/packaged/sql/02-product-availability.sql
+++ b/demo/packaged/sql/02-product-availability.sql
@@ -1,6 +1,29 @@
+-- Use Case: Product Availability (product-availability)
+--
+-- Track product availability across warehouses as inventory is continuously
+-- updated with changes from a generator source.
+--
+-- ## How to run
+--
+-- * Paste this SQL code in the Feldera WebConsole and hit Play ▶️.
+-- * In the Change Stream tab, select the `top3_warehouse_volume` view.
+-- * You should see the list of the top-3 warehouses change in real-time.
+--
+-- ## Detailed description
+--
+-- This simple example illustrates incremental computation in action.
+---
+-- The input tables represent the availability of various inventory items across
+-- multiple warehouses. We define analytical queries over these tables to calculate
+-- metrics, such as the total availability of individual items across all warehouses.
+--
+-- A random data generator continuously produces updates to the tables, simulating
+-- changes in inventory levels. As Feldera processes these updates, it generates a
+-- stream of changes to the query results in real-time.
+
 -- Warehouse
 CREATE TABLE warehouse (
-    id INT PRIMARY KEY,
+    id INT NOT NULL PRIMARY KEY,
     name VARCHAR NOT NULL,
     address VARCHAR NOT NULL
 ) with (
@@ -12,7 +35,7 @@ CREATE TABLE warehouse (
                 "plan": [{
                     "limit": 10,
                     "fields": {
-                        "name": { "values": ["Warehouse no. 1", "Warehouse no. 2", "Warehouse no. 3", "Warehouse no. 4", "Warehouse no. 5", "Warehouse no. 6", "Warehouse no. 7", "Warehouse no. 8", "Warehouse no. 9", "Warehouse no. 10"] },
+                        "name": { "values": ["Warhouse no. 1", "Warehouse no. 2", "Warehouse no. 3", "Warehouse no. 4", "Warehouse no. 5", "Warehouse no. 6", "Warehouse no. 7", "Warehouse no. 8", "Warehouse no. 9", "Warehouse no. 10"] },
                         "address": { "strategy": "street_name" }
                     }
                 }]
@@ -23,7 +46,7 @@ CREATE TABLE warehouse (
 
 -- Product
 CREATE TABLE product (
-    id INT PRIMARY KEY,
+    id INT NOT NULL PRIMARY KEY,
     name VARCHAR NOT NULL,
     mass DOUBLE NOT NULL,
     volume DOUBLE NOT NULL
@@ -48,8 +71,8 @@ CREATE TABLE product (
 
 -- Each warehouse stores products
 CREATE TABLE storage (
-    warehouse_id INT FOREIGN KEY REFERENCES warehouse(id),
-    product_id INT FOREIGN KEY REFERENCES product(id),
+    warehouse_id INT NOT NULL FOREIGN KEY REFERENCES warehouse(id),
+    product_id INT NOT NULL FOREIGN KEY REFERENCES product(id),
     num_available INT NOT NULL,
     updated_at TIMESTAMP NOT NULL,
     PRIMARY KEY (warehouse_id, product_id)

--- a/demo/packaged/sql/03-statistics.sql
+++ b/demo/packaged/sql/03-statistics.sql
@@ -1,0 +1,33 @@
+-- Statistics (statistics)
+--
+-- Statistics (e.g., mean, standard deviation, etc.) being continuously
+-- updated as data is produced by a generator source.
+--
+
+-- Table with as data source randomly generated numbers at a rate of 1000/s
+CREATE TABLE numbers (
+    num DOUBLE
+) WITH (
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "rate": 1000,
+                    "fields": {
+                        "num": {
+                            "range": [0, 1000],
+                            "strategy": "uniform"
+                        }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+-- Calculate statistics over the stream of incoming numbers
+CREATE MATERIALIZED VIEW stats AS (
+    SELECT COUNT(*), MIN(num), MAX(num), AVG(num), SUM(num), STDDEV_SAMP(num), STDDEV_POP(num)
+    FROM   numbers
+);

--- a/demo/packaged/sql/04-supply-chain.sql
+++ b/demo/packaged/sql/04-supply-chain.sql
@@ -1,0 +1,130 @@
+-- Tutorial: Feldera Basics (supply-chain)
+--
+-- Learn Feldera's key concepts and features using a simple example inspired
+-- by supply chain analytics use cases.
+--
+-- This example accompanies the Feldera Basics tutorial:
+-- https://www.feldera.com/docs/tutorials/basics/
+--
+-- ## How to run
+--
+-- * Paste this SQL code in the Feldera WebConsole.
+-- * In the Change Stream tab, select the `preferred_vendor` view.
+-- * Hit Play ▶️.
+-- * You should see several output records in the Change Stream.
+-- * Use the following `curl` command to update the PRICE table
+--   and observe output changes in the Change Stream view:
+--
+--   ```
+--   curl -H "Authorization: Bearer <API-KEY>" -X 'POST'
+--   https://try.feldera.com/v0/pipelines/supply-chain/ingress/PRICE?format=json -d '
+--   > {"delete": {"part": 1, "vendor": 2, "price": 10000}}
+--   > {"insert": {"part": 1, "vendor": 2, "price": 30000}}
+--   > {"delete": {"part": 2, "vendor": 1, "price": 15000}}
+--   > {"insert": {"part": 2, "vendor": 1, "price": 50000}}
+--   > {"insert": {"part": 1, "vendor": 3, "price": 20000}}
+--   > {"insert": {"part": 2, "vendor": 3, "price": 11000}}'
+--   ```
+--
+--   (use the account menu in the top right corner of the WebConsole to generate
+--   an API key if you don't have one yet).
+--
+-- ## Detailed description
+--
+-- In this example we build a simple Feldera pipeline that ingests data about
+-- vendors, parts, and prices, and continuously tracks the lowest available
+-- price for each part across all vendors.
+--
+-- It shows how to:
+--
+-- * Define inputs to Feldera using `CREATE TABLE` statements.
+-- * Specify queries against these input tables using `CREATE VIEW` statements.
+-- * Configure data sources for each input table
+--   (in this example, we use the HTTP GET connector: http://localhost:3000/docs/connectors/sources/http-get)
+-- * Send data to the pipeline using the Feldera REST API.
+--
+-- See https://www.feldera.com/docs/tutorials/basics/ for a detailed
+-- description.
+
+-- Vendors.
+CREATE TABLE vendor (
+    id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR,
+    address VARCHAR
+) WITH ('connectors' = '[{
+    "transport": {
+        "name": "url_input",
+        "config": {
+            "path": "https://feldera-basics-tutorial.s3.amazonaws.com/vendor.json"
+        }
+    },
+    "format": {
+        "name": "json"
+    }
+}]');
+
+-- Parts.
+CREATE TABLE part (
+    id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR
+) WITH ('connectors' = '[{
+    "transport": {
+        "name": "url_input",
+        "config": {
+            "path": "https://feldera-basics-tutorial.s3.amazonaws.com/part.json"
+        }
+    },
+    "format": {
+        "name": "json"
+    }
+}]');
+
+-- Prices.
+CREATE TABLE price (
+    part BIGINT NOT NULL,
+    vendor BIGINT NOT NULL,
+    price DECIMAL
+) WITH ('connectors' = '[{
+    "name": "tutorial-price-s3",
+    "transport": {
+        "name": "url_input",
+        "config": {
+            "path": "https://feldera-basics-tutorial.s3.amazonaws.com/price.json"
+        }
+    },
+    "format": {
+        "name": "json"
+    }
+}]');
+
+-- Lowest available price for each part across all vendors
+CREATE VIEW lowest_price (part, price) AS
+    SELECT    part, MIN(price) AS price
+    FROM      price
+    GROUP BY  part;
+
+-- Lowest available price for each part along with part and vendor details
+CREATE VIEW preferred_vendor (
+    part_id,
+    part_name,
+    vendor_id,
+    vendor_name,
+    price
+) AS (
+    SELECT
+        part.id AS part_id,
+        part.name AS part_name,
+        vendor.id AS vendor_id,
+        vendor.name AS vendor_name,
+        price.price
+    FROM
+        price,
+        part,
+        vendor,
+        lowest_price
+    WHERE
+        price.price = lowest_price.price AND
+        price.part = lowest_price.part AND
+        part.id = price.part AND
+        vendor.id = price.vendor
+);

--- a/demo/packaged/validate-preamble.py
+++ b/demo/packaged/validate-preamble.py
@@ -1,0 +1,61 @@
+import re
+import sys
+
+# Format the SQL must adhere to
+SQL_FORMAT_REGEX_PATTERN = re.compile("^-- (.+) \(([a-zA-Z0-9_-]+)\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n")
+
+# Format of each description line
+SQL_FORMAT_DESCRIPTION_LINE = re.compile("-- .+\r?\n")
+
+def main():
+    args = sys.argv[1:]
+    for filename in args:
+        print(f"Validating: {filename}")
+        sql = open(filename, "rt").read()
+        result = re.match(SQL_FORMAT_REGEX_PATTERN, sql)
+        if result is None:
+            print(f"FAIL: preamble does not match regex pattern")
+            exit(1)
+
+        # Extract from the SQL preamble the metadata
+        title = result.group(1).strip()
+        name = result.group(2)
+        description_lines = result.group(3)
+
+        # Post-process description lines
+        description_match = re.findall(SQL_FORMAT_DESCRIPTION_LINE, description_lines)
+        if description_match is None:
+            print(f"FAIL: description line did not match pattern which should not happen")
+            exit(1)
+        description = " ".join(list(map(lambda l: l.removeprefix("-- ").strip(), description_match))).strip()
+
+        # Character limits
+        if len(title) == 0:
+            print(f"FAIL: title is empty")
+            exit(1)
+        if len(title) > 100:
+            print(f"FAIL: title '{title}' exceeds 100 characters")
+            exit(1)
+        # Name is already checked to be non-empty due to regex
+        if len(name) > 100:
+            print(f"FAIL: name '{name}' exceeds 100 characters")
+            exit(1)
+        if len(description) == 0:
+            print(f"FAIL: description is empty")
+            exit(1)
+        if len(description) > 1000:
+            print(f"FAIL: description '{description}' exceeds 1000 characters")
+            exit(1)
+
+        # Print
+        print("Read preamble:")
+        print(f"  > Title......... {title}")
+        print(f"  > Name.......... {name}")
+        print(f"  > Description... {description}")
+
+        # Finish
+        print(f"PASS: preamble is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -112,6 +112,10 @@ COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar
 RUN mkdir -p .feldera/cargo_workspace
 COPY --chown=feldera Cargo.lock .feldera/cargo_workspace/Cargo.lock
 
+# Copy over demos
+RUN mkdir -p demos
+COPY demo/packaged/sql demos
+
 # The crates needed for the SQL compiler
 COPY crates/dbsp lib/crates/dbsp
 COPY crates/feldera-types lib/crates/feldera-types
@@ -141,7 +145,7 @@ ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 # Run the precompile phase to speed up Rust compilations during deployment
 RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler --dbsp-override-path=/home/feldera/lib --precompile
 ENV BANNER_ADDR=localhost
-ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--dbsp-override-path=/home/feldera/lib", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080"]
+ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--dbsp-override-path=/home/feldera/lib", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080", "--demos-dir", "/home/feldera/demos"]
 
 ##### The stages below are used to build the demo container
 

--- a/openapi.json
+++ b/openapi.json
@@ -268,7 +268,7 @@
         "operationId": "get_config_demos",
         "responses": {
           "200": {
-            "description": "List of demos.",
+            "description": "List of demos",
             "content": {
               "application/json": {
                 "schema": {
@@ -281,7 +281,7 @@
             }
           },
           "500": {
-            "description": "Failed to read demos from the demos directory.",
+            "description": "Failed to read demos from the demos directories",
             "content": {
               "application/json": {
                 "schema": {
@@ -2307,16 +2307,27 @@
       "Demo": {
         "type": "object",
         "required": [
+          "name",
           "title",
-          "pipeline"
+          "description",
+          "program_code"
         ],
         "properties": {
-          "pipeline": {
-            "$ref": "#/components/schemas/PipelineDescr"
+          "description": {
+            "type": "string",
+            "description": "Description of the demo (parsed from SQL preamble)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the demo (parsed from SQL preamble)."
+          },
+          "program_code": {
+            "type": "string",
+            "description": "Program SQL code."
           },
           "title": {
             "type": "string",
-            "description": "Demo title."
+            "description": "Title of the demo (parsed from SQL preamble)."
           }
         }
       },

--- a/web-console/src/lib/compositions/health/systemErrors.ts
+++ b/web-console/src/lib/compositions/health/systemErrors.ts
@@ -101,9 +101,7 @@ export const extractProgramError =
       .with({ RustError: P.any }, (e) => [
         (() => ({
           name: `Error compiling ${pipeline.name}`,
-          message:
-            'Program compilation error. See details below:\n' +
-            e.RustError,
+          message: 'Program compilation error. See details below:\n' + e.RustError,
           cause: {
             entityName: pipeline.name,
             tag: 'programError',

--- a/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
+++ b/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
@@ -1,14 +1,20 @@
 import { goto } from '$app/navigation'
 import { base } from '$app/paths'
 import { useUpdatePipelineList } from '$lib/compositions/pipelines/usePipelineList.svelte'
-import type { PipelineDescr } from '$lib/services/manager'
+import type { Demo } from '$lib/services/manager'
 import { postPipeline } from '$lib/services/pipelineManager'
 
 export const useTryPipeline = () => {
   const { updatePipelines } = useUpdatePipelineList()
-  return async (pipeline: PipelineDescr) => {
+  return async (pipeline: Demo) => {
     try {
-      const newPipeline = await postPipeline(pipeline)
+      const newPipeline = await postPipeline({
+        name: pipeline.name,
+        description: pipeline.description,
+        program_code: pipeline.program_code,
+        program_config: {},
+        runtime_config: {}
+      })
       updatePipelines((pipelines) => (pipelines.push(newPipeline), pipelines))
     } catch {}
     goto(`${base}/pipelines/${encodeURIComponent(pipeline.name)}/`)

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -54,6 +54,9 @@ import type {
   InputEndpointActionData,
   InputEndpointActionError,
   InputEndpointActionResponse,
+  GetPipelineLogsData,
+  GetPipelineLogsError,
+  GetPipelineLogsResponse,
   PipelineAdhocSqlData,
   PipelineAdhocSqlError,
   PipelineAdhocSqlResponse,
@@ -282,6 +285,25 @@ export const inputEndpointAction = (options: Options<InputEndpointActionData>) =
   return (options?.client ?? client).post<InputEndpointActionResponse, InputEndpointActionError>({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/input_endpoints/{endpoint_name}/{action}'
+  })
+}
+
+/**
+ * Retrieve pipeline logs as a stream.
+ * The logs stream catches up to the extent of the internally configured per-pipeline
+ * circular logs buffer (limited to a certain byte size and number of lines, whichever
+ * is reached first). After the catch-up, new lines are pushed whenever they become
+ * available.
+ *
+ * The logs stream will end when the pipeline is shut down. It is also possible for the
+ * logs stream to end prematurely due to the runner back-end (temporarily) losing
+ * connectivity to the pipeline instance (e.g., process). In this case, it is needed
+ * to issue again a new request to this endpoint.
+ */
+export const getPipelineLogs = (options: Options<GetPipelineLogsData>) => {
+  return (options?.client ?? client).get<GetPipelineLogsResponse, GetPipelineLogsError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/logs'
   })
 }
 

--- a/web-console/src/routes/(authenticated)/+page.svelte
+++ b/web-console/src/routes/(authenticated)/+page.svelte
@@ -17,11 +17,11 @@
     >
       {#each data.demos as demo}
         <div class="card flex flex-col gap-2 bg-white p-4 dark:bg-black">
-          <button class="text-left text-primary-500" onclick={() => tryPipeline(demo.pipeline)}>
+          <button class="text-left text-primary-500" onclick={() => tryPipeline(demo)}>
             <span class="text-lg">{demo.title}</span>
-            <span class="fd fd-arrow_forward w-0 translate-y-0.5 scale-150"></span>
+            <span class="fd fd-arrow_forward w-0 text-[24px]"></span>
           </button>
-          <span class="text-left">{demo.pipeline.description}</span>
+          <span class="text-left">{demo.description}</span>
         </div>
       {/each}
     </div>


### PR DESCRIPTION
- Support multiple demos directories
- Ignore directories and files not ending with '.sql' within a demo directory
- Python SQL preamble validation script which is called in Earthfile
- pipeline-manager does SQL preamble validation
- Copy demos in Earthfile/Dockerfile and add argument to entry points
- First five packaged demos
- Web Console uses new demos endpoint format