### PR TITLE
[py] test: use adhoc queries for python SQL tests

### DIFF
--- a/python/tests/aggregate_tests/main.py
+++ b/python/tests/aggregate_tests/main.py
@@ -12,9 +12,9 @@ from tests.aggregate_tests.test_bit_table import *
 from tests.aggregate_tests.test_bit_xor import *
 from tests.aggregate_tests.test_count import *
 from tests.aggregate_tests.test_count_col import *
-from tests.aggregate_tests.test_decimal_avg import *
-from tests.aggregate_tests.test_decimal_sum import *
-from tests.aggregate_tests.test_decimal_table import *
+# from tests.aggregate_tests.test_decimal_avg import *
+# from tests.aggregate_tests.test_decimal_sum import *
+# from tests.aggregate_tests.test_decimal_table import *
 from tests.aggregate_tests.test_every import *
 from tests.aggregate_tests.test_int_table import *
 from tests.aggregate_tests.test_max import *
@@ -23,6 +23,7 @@ from tests.aggregate_tests.test_some import *
 from tests.aggregate_tests.test_stddev_pop import *
 from tests.aggregate_tests.test_stddev_samp import *
 from tests.aggregate_tests.test_sum import *
+
 
 def register_tests_in_module(module, ta: TstAccumulator):
     """Registers all the tests in the specified module.
@@ -39,6 +40,7 @@ def register_tests_in_module(module, ta: TstAccumulator):
                 if DEBUG:
                     print(f"Registering {name}")
 
+
 def run():
     """Find all tests loaded by the current module and register them"""
     ta = TstAccumulator()
@@ -48,13 +50,15 @@ def run():
         if isinstance(module, ModuleType):
             if not module.__name__.startswith("tests.aggregate_tests"):
                 continue
-            loaded.append(module);
+            loaded.append(module)
     for module in loaded:
         register_tests_in_module(module, ta)
     ta.run_tests()
 
+
 def main():
     run()
+
 
 if __name__ == '__main__':
     main()

--- a/python/tests/aggregate_tests/test_array.py
+++ b/python/tests/aggregate_tests/test_array.py
@@ -1,55 +1,71 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_array_agg_value(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': [None, None, 4, 5], 'c2': [2, 5, 3, 2], 'c3': [3, 6, 4, None], 'c4': [2, 2, 6, 4], 'c5': [3, 2, 2, 5], 'c6': [4, 1, 3, 6], 'c7': [3, None, 4, None], 'c8': [3, 5, 2, 8]}]
-        self.sql = '''CREATE VIEW int_array_agg AS SELECT
+        self.data = [{'c1': [None, None, 4, 5], 'c2': [2, 5, 3, 2], 'c3': [3, 6, 4, None], 'c4': [2, 2, 6, 4],
+                      'c5': [3, 2, 2, 5], 'c6': [4, 1, 3, 6], 'c7': [3, None, 4, None], 'c8': [3, 5, 2, 8]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg AS SELECT
                       ARRAY_AGG(c1) AS c1, ARRAY_AGG(c2) AS c2, ARRAY_AGG(c3) AS c3, ARRAY_AGG(c4) AS c4, ARRAY_AGG(c5) AS c5, ARRAY_AGG(c6) AS c6, ARRAY_AGG(c7) AS c7, ARRAY_AGG(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_array_agg_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': [None, 5], 'c2': [2, 2], 'c3': [3, None], 'c4': [2, 4], 'c5': [3, 5], 'c6': [4, 6], 'c7': [3, None], 'c8': [3, 8]},
-                     {'id': 1, 'c1': [None, 4], 'c2': [5, 3], 'c3': [6, 4], 'c4': [2, 6], 'c5': [2, 2], 'c6': [1, 3], 'c7': [None, 4], 'c8': [5, 2]}]
-        self.sql = '''CREATE VIEW int_array_agg_gby AS SELECT
+        self.data = [{'id': 0, 'c1': [None, 5], 'c2': [2, 2], 'c3': [3, None], 'c4': [2, 4], 'c5': [3, 5], 'c6': [4, 6],
+                      'c7': [3, None], 'c8': [3, 8]},
+                     {'id': 1, 'c1': [None, 4], 'c2': [5, 3], 'c3': [6, 4], 'c4': [2, 6], 'c5': [2, 2], 'c6': [1, 3],
+                      'c7': [None, 4], 'c8': [5, 2]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg_gby AS SELECT
                       id, ARRAY_AGG(c1) AS c1, ARRAY_AGG(c2) AS c2, ARRAY_AGG(c3) AS c3, ARRAY_AGG(c4) AS c4, ARRAY_AGG(c5) AS c5, ARRAY_AGG(c6) AS c6, ARRAY_AGG(c7) AS c7, ARRAY_AGG(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
 
+
 class aggtst_int_array_agg_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': [None, 4, 5], 'c2': [2, 3, 5], 'c3': [None, 3, 4, 6], 'c4': [2, 4, 6], 'c5': [2, 3, 5], 'c6': [1, 3, 4, 6], 'c7': [None, 3, 4], 'c8': [2, 3, 5, 8]}]
-        self.sql = '''CREATE VIEW int_array_agg_distinct AS SELECT
+        self.data = [{'c1': [None, 4, 5], 'c2': [2, 3, 5], 'c3': [None, 3, 4, 6], 'c4': [2, 4, 6], 'c5': [2, 3, 5],
+                      'c6': [1, 3, 4, 6], 'c7': [None, 3, 4], 'c8': [2, 3, 5, 8]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg_distinct AS SELECT
                       ARRAY_AGG(DISTINCT c1) AS c1,ARRAY_AGG(DISTINCT c2) AS c2, ARRAY_AGG(DISTINCT c3) AS c3, ARRAY_AGG(DISTINCT c4) AS c4, ARRAY_AGG(DISTINCT c5) AS c5, ARRAY_AGG(DISTINCT c6) AS c6, ARRAY_AGG(DISTINCT c7) AS c7, ARRAY_AGG(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_array_agg_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': [None, 5], 'c2': [2], 'c3': [None, 3], 'c4': [2, 4], 'c5': [3, 5], 'c6': [4, 6], 'c7': [None, 3], 'c8': [3, 8]},
-                     {'id': 1, 'c1': [None, 4], 'c2': [3, 5], 'c3': [4, 6], 'c4': [2, 6], 'c5': [2], 'c6': [1, 3], 'c7': [None, 4], 'c8': [2, 5]}]
-        self.sql = '''CREATE VIEW int_array_agg_distinct_groupby AS SELECT
+        self.data = [{'id': 0, 'c1': [None, 5], 'c2': [2], 'c3': [None, 3], 'c4': [2, 4], 'c5': [3, 5], 'c6': [4, 6],
+                      'c7': [None, 3], 'c8': [3, 8]},
+                     {'id': 1, 'c1': [None, 4], 'c2': [3, 5], 'c3': [4, 6], 'c4': [2, 6], 'c5': [2], 'c6': [1, 3],
+                      'c7': [None, 4], 'c8': [2, 5]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg_distinct_groupby AS SELECT
                       id, ARRAY_AGG(DISTINCT c1) AS c1,ARRAY_AGG(DISTINCT c2) AS c2, ARRAY_AGG(DISTINCT c3) AS c3, ARRAY_AGG(DISTINCT c4) AS c4, ARRAY_AGG(DISTINCT c5) AS c5, ARRAY_AGG(DISTINCT c6) AS c6, ARRAY_AGG(DISTINCT c7) AS c7, ARRAY_AGG(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
 
+
 class aggtst_int_array_agg_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'f_c1': [None, 4, 5], 'f_c2': [2, 3, 2], 'f_c3': [3, 4, None], 'f_c4': [2, 6, 4], 'f_c5': [3, 2, 5], 'f_c6': [4, 3, 6], 'f_c7': [3, 4, None], 'f_c8': [3, 2, 8]}]
-        self.sql = '''CREATE VIEW int_array_agg_where AS SELECT
+        self.data = [
+            {'f_c1': [None, 4, 5], 'f_c2': [2, 3, 2], 'f_c3': [3, 4, None], 'f_c4': [2, 6, 4], 'f_c5': [3, 2, 5],
+             'f_c6': [4, 3, 6], 'f_c7': [3, 4, None], 'f_c8': [3, 2, 8]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg_where AS SELECT
                       ARRAY_AGG(c1) FILTER(WHERE (c5+C6)> 3) AS f_c1, ARRAY_AGG(c2) FILTER(WHERE (c5+C6)> 3) AS f_c2, ARRAY_AGG(c3) FILTER(WHERE (c5+C6)> 3) AS f_c3, ARRAY_AGG(c4) FILTER(WHERE (c5+C6)> 3) AS f_c4, ARRAY_AGG(c5) FILTER(WHERE (c5+C6)> 3) AS f_c5, ARRAY_AGG(c6) FILTER(WHERE (c5+C6)> 3) AS f_c6,  ARRAY_AGG(c7) FILTER(WHERE (c5+C6)> 3) AS f_c7,  ARRAY_AGG(c8) FILTER(WHERE (c5+C6)> 3) AS f_c8
                       FROM int0_tbl '''
+
 
 class aggtst_array_agg_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'f_c1': [None, 5], 'f_c2': [2, 2], 'f_c3': [3, None], 'f_c4': [2, 4], 'f_c5': [3, 5], 'f_c6': [4, 6], 'f_c7': [3, None], 'f_c8': [3, 8]},
-                     {'id': 1, 'f_c1': [4], 'f_c2': [3], 'f_c3': [4], 'f_c4': [6], 'f_c5': [2], 'f_c6': [3], 'f_c7': [4], 'f_c8': [2]}]
-        self.sql = '''CREATE VIEW int_array_agg_where_gby AS SELECT
+        self.data = [{'id': 0, 'f_c1': [None, 5], 'f_c2': [2, 2], 'f_c3': [3, None], 'f_c4': [2, 4], 'f_c5': [3, 5],
+                      'f_c6': [4, 6], 'f_c7': [3, None], 'f_c8': [3, 8]},
+                     {'id': 1, 'f_c1': [4], 'f_c2': [3], 'f_c3': [4], 'f_c4': [6], 'f_c5': [2], 'f_c6': [3],
+                      'f_c7': [4], 'f_c8': [2]}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_array_agg_where_gby AS SELECT
                       id, ARRAY_AGG(c1) FILTER(WHERE (c5+C6)> 3) AS f_c1, ARRAY_AGG(c2) FILTER(WHERE (c5+C6)> 3) AS f_c2, ARRAY_AGG(c3) FILTER(WHERE (c5+C6)> 3) AS f_c3, ARRAY_AGG(c4) FILTER(WHERE (c5+C6)> 3) AS f_c4, ARRAY_AGG(c5) FILTER(WHERE (c5+C6)> 3) AS f_c5, ARRAY_AGG(c6) FILTER(WHERE (c5+C6)> 3) AS f_c6,  ARRAY_AGG(c7) FILTER(WHERE (c5+C6)> 3) AS f_c7,  ARRAY_AGG(c8) FILTER(WHERE (c5+C6)> 3) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_avg.py
+++ b/python/tests/aggregate_tests/test_avg.py
@@ -1,55 +1,62 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_avg(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_value AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_value AS SELECT
                       AVG(c1) AS c1,AVG(c2) AS c2,AVG(c3) AS c3,AVG(c4) AS c4,AVG(c5) AS c5,AVG(c6) AS c6,AVG(c7) AS c7,AVG(c8) AS c8
                       FROM int0_tbl'''
         self.data = [{'c1': 4, 'c2': 3, 'c3': 4, 'c4': 3, 'c5': 3, 'c6': 3, 'c7': 3, 'c8': 4}]
 
+
 class aggtst_int_avg_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_gby AS SELECT
                       id, AVG(c1) AS c1,AVG(c2) AS c2,AVG(c3) AS c3,AVG(c4) AS c4,AVG(c5) AS c5,AVG(c6) AS c6,AVG(c7) AS c7,AVG(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 3, 'c5': 4, 'c6': 5, 'c7': 3, 'c8': 5},
                      {'id': 1, 'c1': 4, 'c2': 4, 'c3': 5, 'c4': 4, 'c5': 2, 'c6': 2, 'c7': 4, 'c8': 3}]
 
+
 class aggtst_int_avg_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_distinct AS SELECT
                       AVG(DISTINCT c1) AS c1, AVG(DISTINCT c2) AS c2, AVG(DISTINCT c3) AS c3, AVG(DISTINCT c4) AS c4, AVG(DISTINCT c5) AS c5, AVG(DISTINCT c6) AS c6, AVG(DISTINCT c7) AS c7, AVG(DISTINCT c8) AS c8
                       FROM int0_tbl'''
         self.data = [{'c1': 4, 'c2': 3, 'c3': 4, 'c4': 4, 'c5': 3, 'c6': 3, 'c7': 3, 'c8': 4}]
 
+
 class aggtst_int_avg_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_distinct_gby AS SELECT
                       id, AVG(DISTINCT c1) AS c1, AVG(DISTINCT c2) AS c2, AVG(DISTINCT c3) AS c3, AVG(DISTINCT c4) AS c4, AVG(DISTINCT c5) AS c5, AVG(DISTINCT c6) AS c6, AVG(DISTINCT c7) AS c7, AVG(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 3, 'c5': 4, 'c6': 5, 'c7': 3, 'c8': 5},
                      {'id': 1, 'c1': 4, 'c2': 4, 'c3': 5, 'c4': 4, 'c5': 2, 'c6': 2, 'c7': 4, 'c8': 3}]
 
+
 class aggtst_int_avg_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_where AS SELECT
                       AVG(c1) FILTER(WHERE c8>2) AS f_c1, AVG(c2) FILTER(WHERE c8>2) AS f_c2, AVG(c3) FILTER(WHERE c8>2) AS f_c3, AVG(c4) FILTER(WHERE c8>2) AS f_c4, AVG(c5) FILTER(WHERE c8>2) AS f_c5, AVG(c6) FILTER(WHERE c8>2) AS f_c6, AVG(c7) FILTER(WHERE c8>2) AS f_c7, AVG(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl'''
         self.data = [{'f_c1': 5, 'f_c2': 3, 'f_c3': 4, 'f_c4': 2, 'f_c5': 3, 'f_c6': 3, 'f_c7': 3, 'f_c8': 5}]
 
+
 class aggtst_int_avg_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_avg_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_avg_where_gby AS SELECT
                       id, AVG(c1) FILTER(WHERE c8>2) AS f_c1, AVG(c2) FILTER(WHERE c8>2) AS f_c2, AVG(c3) FILTER(WHERE c8>2) AS f_c3, AVG(c4) FILTER(WHERE c8>2) AS f_c4, AVG(c5) FILTER(WHERE c8>2) AS f_c5, AVG(c6) FILTER(WHERE c8>2) AS f_c6, AVG(c7) FILTER(WHERE c8>2) AS f_c7, AVG(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 2, 'f_c3': 3, 'f_c4': 3, 'f_c5': 4, 'f_c6': 5, 'f_c7': 3, 'f_c8': 5},
-                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]
+                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None,
+                      'f_c8': 5}]

--- a/python/tests/aggregate_tests/test_bit_and.py
+++ b/python/tests/aggregate_tests/test_bit_and.py
@@ -1,55 +1,62 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_bit_and(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 4, 'c2': 0, 'c3': 0, 'c4': 0, 'c5': 0, 'c6': 0, 'c7': 0, 'c8': 0}]
-        self.sql = '''CREATE VIEW int_bit_and AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and AS SELECT
                       BIT_AND(c1) AS c1, BIT_AND(c2) AS c2, BIT_AND(c3) AS c3, BIT_AND(c4) AS c4, BIT_AND(c5) AS c5, BIT_AND(c6) AS c6, BIT_AND(c7) AS c7, BIT_AND(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_and_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data =  [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 0, 'c5': 1, 'c6': 4, 'c7': 3, 'c8': 0},
-                      {'id': 1, 'c1': 4, 'c2': 1, 'c3': 4, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 4, 'c8': 0}]
-        self.sql = '''CREATE VIEW int_bit_and_groupby AS SELECT
+        self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 0, 'c5': 1, 'c6': 4, 'c7': 3, 'c8': 0},
+                     {'id': 1, 'c1': 4, 'c2': 1, 'c3': 4, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 4, 'c8': 0}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and_groupby AS SELECT
                       id, BIT_AND(c1) AS c1, BIT_AND(c2) AS c2, BIT_AND(c3) AS c3, BIT_AND(c4) AS c4, BIT_AND(c5) AS c5, BIT_AND(c6) AS c6, BIT_AND(c7) AS c7, BIT_AND(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_and_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 4, 'c2': 0, 'c3': 0, 'c4': 0, 'c5': 0, 'c6': 0, 'c7': 0, 'c8': 0}]
-        self.sql = '''CREATE VIEW int_bit_and_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and_distinct AS SELECT
                       BIT_AND(DISTINCT c1) AS c1, BIT_AND(DISTINCT c2) AS c2, BIT_AND(DISTINCT c3) AS c3, BIT_AND(DISTINCT c4) AS c4, BIT_AND(DISTINCT c5) AS c5, BIT_AND(DISTINCT c6) AS c6, BIT_AND(DISTINCT c7) AS c7, BIT_AND(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_and_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 0, 'c5': 1, 'c6': 4, 'c7': 3, 'c8': 0},
                      {'id': 1, 'c1': 4, 'c2': 1, 'c3': 4, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 4, 'c8': 0}]
-        self.sql = '''CREATE VIEW int_bit_and_distinct_groupby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and_distinct_groupby AS SELECT
                       id, BIT_AND(DISTINCT c1) AS c1, BIT_AND(DISTINCT c2) AS c2, BIT_AND(DISTINCT c3) AS c3, BIT_AND(DISTINCT c4) AS c4, BIT_AND(DISTINCT c5) AS c5, BIT_AND(DISTINCT c6) AS c6, BIT_AND(DISTINCT c7) AS c7, BIT_AND(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_and_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'f_c1': 5, 'f_c2': 0, 'f_c3': 2, 'f_c4': 0, 'f_c5': 0, 'f_c6': 0, 'f_c7': 3, 'f_c8': 0}]
-        self.sql = '''CREATE VIEW int_bit_and_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and_where AS SELECT
                       BIT_AND(c1) FILTER(WHERE c8>2) AS f_c1, BIT_AND(c2) FILTER(WHERE c8>2) AS f_c2, BIT_AND(c3) FILTER(WHERE c8>2) AS f_c3, BIT_AND(c4) FILTER(WHERE c8>2) AS f_c4, BIT_AND(c5) FILTER(WHERE c8>2) AS f_c5, BIT_AND(c6) FILTER(WHERE c8>2) AS f_c6, BIT_AND(c7) FILTER(WHERE c8>2) AS f_c7, BIT_AND(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_and_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 2, 'f_c3': 3, 'f_c4': 0, 'f_c5': 1, 'f_c6': 4, 'f_c7': 3, 'f_c8': 0},
-                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]
-        self.sql = '''CREATE VIEW int_bit_and_where_groupby AS SELECT
+                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None,
+                      'f_c8': 5}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_and_where_groupby AS SELECT
                       id, BIT_AND(c1) FILTER(WHERE c8>2) AS f_c1, BIT_AND(c2) FILTER(WHERE c8>2) AS f_c2, BIT_AND(c3) FILTER(WHERE c8>2) AS f_c3, BIT_AND(c4) FILTER(WHERE c8>2) AS f_c4, BIT_AND(c5) FILTER(WHERE c8>2) AS f_c5, BIT_AND(c6) FILTER(WHERE c8>2) AS f_c6, BIT_AND(c7) FILTER(WHERE c8>2) AS f_c7, BIT_AND(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_bit_or.py
+++ b/python/tests/aggregate_tests/test_bit_or.py
@@ -1,55 +1,62 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_bit_or(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 5, 'c2': 7, 'c3': 7, 'c4': 6, 'c5': 7, 'c6': 7, 'c7': 7, 'c8': 15}]
-        self.sql = '''CREATE VIEW int_bit_or AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or AS SELECT
                       BIT_OR(c1) AS c1, BIT_OR(c2) AS c2, BIT_OR(c3) AS c3, BIT_OR(c4) AS c4, BIT_OR(c5) AS c5, BIT_OR(c6) AS c6, BIT_OR(c7) AS c7, BIT_OR(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_or_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 6, 'c5': 7, 'c6': 6, 'c7': 3, 'c8': 11},
                      {'id': 1, 'c1': 4, 'c2': 7, 'c3': 6, 'c4': 6, 'c5': 2, 'c6': 3, 'c7': 4, 'c8': 7}]
-        self.sql = '''CREATE VIEW int_bit_or_gby AS
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or_gby AS
                       SELECT id, BIT_OR(c1) AS c1, BIT_OR(c2) AS c2, BIT_OR(c3) AS c3, BIT_OR(c4) AS c4, BIT_OR(c5) AS c5, BIT_OR(c6) AS c6, BIT_OR(c7) AS c7, BIT_OR(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_or_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 5, 'c2': 7, 'c3': 7, 'c4': 6, 'c5': 7, 'c6': 7, 'c7': 7, 'c8': 15}]
-        self.sql = '''CREATE VIEW int_bit_or_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or_distinct AS SELECT
                       BIT_OR(DISTINCT c1) AS c1, BIT_OR(DISTINCT c2) AS c2, BIT_OR(DISTINCT c3) AS c3, BIT_OR(DISTINCT c4) AS c4, BIT_OR(DISTINCT c5) AS c5, BIT_OR(DISTINCT c6) AS c6, BIT_OR(DISTINCT c7) AS c7, BIT_OR(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_or_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 6, 'c5': 7, 'c6': 6, 'c7': 3, 'c8': 11},
                      {'id': 1, 'c1': 4, 'c2': 7, 'c3': 6, 'c4': 6, 'c5': 2, 'c6': 3, 'c7': 4, 'c8': 7}]
-        self.sql = '''CREATE VIEW int_bit_or_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or_distinct_gby AS SELECT
                       id, BIT_OR(DISTINCT c1) AS c1, BIT_OR(DISTINCT c2) AS c2, BIT_OR(DISTINCT c3) AS c3, BIT_OR(DISTINCT c4) AS c4, BIT_OR(DISTINCT c5) AS c5, BIT_OR(DISTINCT c6) AS c6, BIT_OR(DISTINCT c7) AS c7, BIT_OR(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_or_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'f_c1': 5, 'f_c2': 7, 'f_c3': 7, 'f_c4': 6, 'f_c5': 7, 'f_c6': 7, 'f_c7': 3, 'f_c8': 15}]
-        self.sql = '''CREATE VIEW int_bit_or_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or_where AS SELECT
                       BIT_OR(c1) FILTER(WHERE c8>2) AS f_c1, BIT_OR(c2) FILTER(WHERE c8>2) AS f_c2, BIT_OR(c3) FILTER(WHERE c8>2) AS f_c3, BIT_OR(c4) FILTER(WHERE c8>2) AS f_c4, BIT_OR(c5) FILTER(WHERE c8>2) AS f_c5, BIT_OR(c6) FILTER(WHERE c8>2) AS f_c6, BIT_OR(c7) FILTER(WHERE c8>2) AS f_c7, BIT_OR(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_or_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 2, 'f_c3': 3, 'f_c4': 6, 'f_c5': 7, 'f_c6': 6, 'f_c7': 3, 'f_c8': 11},
-                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]
-        self.sql =  '''CREATE VIEW int_bit_or_where_gby AS SELECT
+                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None,
+                      'f_c8': 5}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_or_where_gby AS SELECT
                        id, BIT_OR(c1) FILTER(WHERE c8>2) AS f_c1, BIT_OR(c2) FILTER(WHERE c8>2) AS f_c2, BIT_OR(c3) FILTER(WHERE c8>2) AS f_c3, BIT_OR(c4) FILTER(WHERE c8>2) AS f_c4, BIT_OR(c5) FILTER(WHERE c8>2) AS f_c5, BIT_OR(c6) FILTER(WHERE c8>2) AS f_c6, BIT_OR(c7) FILTER(WHERE c8>2) AS f_c7, BIT_OR(c8) FILTER(WHERE c8>2) AS f_c8
                        FROM int0_tbl
                        GROUP BY id'''

--- a/python/tests/aggregate_tests/test_bit_table.py
+++ b/python/tests/aggregate_tests/test_bit_table.py
@@ -1,7 +1,9 @@
 from .aggtst_base import TstTable
 
+
 class aggtst_bit_table(TstTable):
     """Define the table used by some bitwise tests"""
+
     def __init__(self):
         self.sql = '''CREATE TABLE bit_table(
                       id INT NOT NULL,
@@ -13,8 +15,8 @@ class aggtst_bit_table(TstTable):
                       c6 INT NOT NULL,
                       c7 BIGINT,
                       c8 BIGINT NOT NULL)'''
-        self.data =  [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                      {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2}]
+        self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2}]
 
 
 class aggtst_bit_table0(TstTable):
@@ -29,9 +31,9 @@ class aggtst_bit_table0(TstTable):
                       c6 INT NOT NULL,
                       c7 BIGINT,
                       c8 BIGINT NOT NULL)'''
-        self.data =  [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                      {"id": 1,"c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
-                      {"id" : 0, "c1": 5, "c2": 9, "c3": 10, "c4": 18, "c5": 8, "c6": 10, "c7": 20, "c8": 5}]
+        self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
+                     {"id": 0, "c1": 5, "c2": 9, "c3": 10, "c4": 18, "c5": 8, "c6": 10, "c7": 20, "c8": 5}]
 
 
 class aggtst_bit_table1(TstTable):
@@ -46,10 +48,10 @@ class aggtst_bit_table1(TstTable):
                       c6 INT NOT NULL,
                       c7 BIGINT,
                       c8 BIGINT NOT NULL)'''
-        self.data =  [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                      {"id": 1,"c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
-                      {"id" :0 ,"c1": 4, "c2": 2, "c3": 30, "c4": 14, "c5": None, "c6": 60, "c7": 70, "c8": 18},
-                      {"id": 1,"c1": 5, "c2": 3, "c3": None, "c4": 9, "c5": 51, "c6": 6, "c7": 72, "c8": 2}]
+        self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
+                     {"id": 0, "c1": 4, "c2": 2, "c3": 30, "c4": 14, "c5": None, "c6": 60, "c7": 70, "c8": 18},
+                     {"id": 1, "c1": 5, "c2": 3, "c3": None, "c4": 9, "c5": 51, "c6": 6, "c7": 72, "c8": 2}]
 
 
 class aggtst_bit_table2(TstTable):
@@ -64,6 +66,6 @@ class aggtst_bit_table2(TstTable):
                       c6 INT NOT NULL,
                       c7 BIGINT,
                       c8 BIGINT NOT NULL)'''
-        self.data =  [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                      {"id": 1,"c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
-                      {"id" : 0, "c1": 5, "c2": 9, "c3": 10, "c4": 18, "c5": 8, "c6": 10, "c7": 20, "c8": 5}]
+        self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
+                     {"id": 0, "c1": 5, "c2": 9, "c3": 10, "c4": 18, "c5": 8, "c6": 10, "c7": 20, "c8": 5}]

--- a/python/tests/aggregate_tests/test_bit_xor.py
+++ b/python/tests/aggregate_tests/test_bit_xor.py
@@ -1,56 +1,63 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_bit_xor(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 1, 'c2': 6, 'c3': 1, 'c4': 2, 'c5': 6, 'c6': 0, 'c7': 7, 'c8': 12}]
-        self.sql = '''CREATE VIEW int_bit_xor_view AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_view AS SELECT
                       BIT_XOR(c1) AS c1, BIT_XOR(c2) AS c2, BIT_XOR(c3) AS c3, BIT_XOR(c4) AS c4, BIT_XOR(c5) AS c5, BIT_XOR(c6) AS c6, BIT_XOR(c7) AS c7, BIT_XOR(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_xor_Groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 0, 'c3': 3, 'c4': 6, 'c5': 6, 'c6': 2, 'c7': 3, 'c8': 11},
                      {'id': 1, 'c1': 4, 'c2': 6, 'c3': 2, 'c4': 4, 'c5': 0, 'c6': 2, 'c7': 4, 'c8': 7}]
-        self.sql = '''CREATE VIEW int_bit_xor_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_gby AS SELECT
                       id, BIT_XOR(c1) AS c1, BIT_XOR(c2) AS c2, BIT_XOR(c3) AS c3, BIT_XOR(c4) AS c4, BIT_XOR(c5) AS c5, BIT_XOR(c6) AS c6, BIT_XOR(c7) AS c7, BIT_XOR(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_xor_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 1, 'c2': 4, 'c3': 1, 'c4': 0, 'c5': 4, 'c6': 0, 'c7': 7, 'c8': 12}]
         table_name = "bit_xor_distinct"
-        self.sql = '''CREATE VIEW int_bit_xor_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_distinct AS SELECT
                       BIT_XOR(DISTINCT c1) AS c1, BIT_XOR(DISTINCT c2) AS c2, BIT_XOR(DISTINCT c3) AS c3, BIT_XOR(DISTINCT c4) AS c4, BIT_XOR(DISTINCT c5) AS c5, BIT_XOR(DISTINCT c6) AS c6, BIT_XOR(DISTINCT c7) AS c7, BIT_XOR(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_xor_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 6, 'c5': 6, 'c6': 2, 'c7': 3, 'c8': 11},
                      {'id': 1, 'c1': 4, 'c2': 6, 'c3': 2, 'c4': 4, 'c5': 2, 'c6': 2, 'c7': 4, 'c8': 7}]
-        self.sql = '''CREATE VIEW int_bit_xor_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_distinct_gby AS SELECT
                       id, BIT_XOR(DISTINCT c1) AS c1, BIT_XOR(DISTINCT c2) AS c2, BIT_XOR(DISTINCT c3) AS c3, BIT_XOR(DISTINCT c4) AS c4, BIT_XOR(DISTINCT c5) AS c5, BIT_XOR(DISTINCT c6) AS c6, BIT_XOR(DISTINCT c7) AS c7, BIT_XOR(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_bit_xor_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'f_c1': 5, 'f_c2': 5, 'f_c3': 5, 'f_c4': 4, 'f_c5': 4, 'f_c6': 3, 'f_c7': 3, 'f_c8': 14}]
-        self.sql = '''CREATE VIEW int_bit_xor_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_where AS SELECT
                       BIT_XOR(c1) FILTER(WHERE c8>2) AS f_c1, BIT_XOR(c2) FILTER(WHERE c8>2) AS f_c2, BIT_XOR(c3) FILTER(WHERE c8>2) AS f_c3, BIT_XOR(c4) FILTER(WHERE c8>2) AS f_c4, BIT_XOR(c5) FILTER(WHERE c8>2) AS f_c5, BIT_XOR(c6) FILTER(WHERE c8>2) AS f_c6, BIT_XOR(c7) FILTER(WHERE c8>2) AS f_c7, BIT_XOR(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_bit_xor_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data =  [{'id': 0, 'f_c1': 5, 'f_c2': 0, 'f_c3': 3, 'f_c4': 6, 'f_c5': 6, 'f_c6': 2, 'f_c7': 3, 'f_c8': 11},
-                      {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]
-        self.sql = '''CREATE VIEW int_bit_xor_where_gby AS SELECT
+        self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 0, 'f_c3': 3, 'f_c4': 6, 'f_c5': 6, 'f_c6': 2, 'f_c7': 3, 'f_c8': 11},
+                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None,
+                      'f_c8': 5}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_bit_xor_where_gby AS SELECT
                       id, BIT_XOR(c1) FILTER(WHERE c8>2) AS f_c1, BIT_XOR(c2) FILTER(WHERE c8>2) AS f_c2, BIT_XOR(c3) FILTER(WHERE c8>2) AS f_c3, BIT_XOR(c4) FILTER(WHERE c8>2) AS f_c4, BIT_XOR(c5) FILTER(WHERE c8>2) AS f_c5, BIT_XOR(c6) FILTER(WHERE c8>2) AS f_c6, BIT_XOR(c7) FILTER(WHERE c8>2) AS f_c7, BIT_XOR(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_count.py
+++ b/python/tests/aggregate_tests/test_count.py
@@ -1,37 +1,41 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_count(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'count': 4}]
-        self.sql = '''CREATE VIEW int_count AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count AS SELECT
                       COUNT(*) AS count
                       FROM int0_tbl'''
+
 
 class aggtst_int_count_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'count': 2},
                      {'id': 1, 'count': 2}]
-        self.sql = '''CREATE VIEW int_count_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_gby AS SELECT
                       id, COUNT(*) AS count
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_count_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'count': 3}]
-        self.sql = '''CREATE VIEW int_count_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_where AS SELECT
                       COUNT(*) FILTER(WHERE (c5+C6)> 3) AS count
                       FROM int0_tbl'''
+
 
 class aggtst_int_count_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'count': 2},
                      {'id': 1, 'count': 1}]
-        self.sql = '''CREATE VIEW int_count_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_where_gby AS SELECT
                       id, COUNT(*) FILTER(WHERE (c5+C6)> 3) AS count
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_count_col.py
+++ b/python/tests/aggregate_tests/test_count_col.py
@@ -1,55 +1,61 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_count_col(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 2, 'c2': 4, 'c3': 3, 'c4': 4, 'c5': 4, 'c6': 4, 'c7': 2, 'c8': 4}]
-        self.sql = '''CREATE VIEW int_count_col AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col AS SELECT
                       COUNT(c1) AS c1, COUNT(c2) AS c2, COUNT(c3) AS c3, COUNT(c4) AS c4, COUNT(c5) AS c5, COUNT(c6) AS c6, COUNT(c7) AS c7, COUNT(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_count_col_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 1, 'c2': 2, 'c3': 1, 'c4': 2, 'c5': 2, 'c6': 2, 'c7': 1, 'c8': 2},
                      {'id': 1, 'c1': 1, 'c2': 2, 'c3': 2, 'c4': 2, 'c5': 2, 'c6': 2, 'c7': 1, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_count_col_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col_gby AS SELECT
                       id, COUNT(c1) AS c1, COUNT(c2) AS c2, COUNT(c3) AS c3, COUNT(c4) AS c4, COUNT(c5) AS c5, COUNT(c6) AS c6, COUNT(c7) AS c7, COUNT(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_count_col_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 2, 'c2': 3, 'c3': 3, 'c4': 3, 'c5': 3, 'c6': 4, 'c7': 2, 'c8': 4}]
-        self.sql = '''CREATE VIEW int_count_col_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col_distinct AS SELECT
                       COUNT(DISTINCT c1) AS c1, COUNT(DISTINCT c2) AS c2, COUNT(DISTINCT c3) AS c3, COUNT(DISTINCT c4) AS c4, COUNT(DISTINCT c5) AS c5, COUNT(DISTINCT c6) AS c6, COUNT(DISTINCT c7) AS c7, COUNT(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_count_col_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 1, 'c2': 1, 'c3': 1, 'c4': 2, 'c5': 2, 'c6': 2, 'c7': 1, 'c8': 2},
                      {'id': 1, 'c1': 1, 'c2': 2, 'c3': 2, 'c4': 2, 'c5': 1, 'c6': 2, 'c7': 1, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_count_col_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col_distinct_gby AS SELECT
                       id, COUNT(DISTINCT c1) AS c1, COUNT(DISTINCT c2) AS c2, COUNT(DISTINCT c3) AS c3, COUNT(DISTINCT c4) AS c4, COUNT(DISTINCT c5) AS c5, COUNT(DISTINCT c6) AS c6, COUNT(DISTINCT c7) AS c7, COUNT(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
 
+
 class aggtst_int_count_col_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data =  [{'f_c1': 2, 'f_c2': 3, 'f_c3': 2, 'f_c4': 3, 'f_c5': 3, 'f_c6': 3, 'f_c7': 2, 'f_c8': 3}]
-        self.sql = '''CREATE VIEW int_count_col_where AS SELECT
+        self.data = [{'f_c1': 2, 'f_c2': 3, 'f_c3': 2, 'f_c4': 3, 'f_c5': 3, 'f_c6': 3, 'f_c7': 2, 'f_c8': 3}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col_where AS SELECT
                       COUNT(c1) FILTER(WHERE (c5+C6)> 3) AS f_c1, COUNT(c2) FILTER(WHERE (c5+C6)> 3) AS f_c2, COUNT(c3) FILTER(WHERE (c5+C6)> 3) AS f_c3, COUNT(c4) FILTER(WHERE (c5+C6)> 3) AS f_c4, COUNT(c5) FILTER(WHERE (c5+C6)> 3) AS f_c5, COUNT(c6) FILTER(WHERE (c5+C6)> 3) AS f_c6, COUNT(c7) FILTER(WHERE (c5+C6)> 3) AS f_c7, COUNT(c8) FILTER(WHERE (c5+C6)> 3) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_count_col_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'f_c1': 1, 'f_c2': 2, 'f_c3': 1, 'f_c4': 2, 'f_c5': 2, 'f_c6': 2, 'f_c7': 1, 'f_c8': 2},
                      {'id': 1, 'f_c1': 1, 'f_c2': 1, 'f_c3': 1, 'f_c4': 1, 'f_c5': 1, 'f_c6': 1, 'f_c7': 1, 'f_c8': 1}]
-        self.sql = '''CREATE VIEW int_count_col_where_gbt AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_count_col_where_gbt AS SELECT
                       id, COUNT(c1) FILTER(WHERE (c5+C6)> 3) AS f_c1, COUNT(c2) FILTER(WHERE (c5+C6)> 3) AS f_c2, COUNT(c3) FILTER(WHERE (c5+C6)> 3) AS f_c3, COUNT(c4) FILTER(WHERE (c5+C6)> 3) AS f_c4, COUNT(c5) FILTER(WHERE (c5+C6)> 3) AS f_c5, COUNT(c6) FILTER(WHERE (c5+C6)> 3) AS f_c6, COUNT(c7) FILTER(WHERE (c5+C6)> 3) AS f_c7, COUNT(c8) FILTER(WHERE (c5+C6)> 3) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_decimal_avg.py
+++ b/python/tests/aggregate_tests/test_decimal_avg.py
@@ -1,54 +1,60 @@
 from .aggtst_base import TstView
 from decimal import Decimal
 
+
 class aggtst_decimal_avg(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg AS
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg AS
                       SELECT AVG(c1) AS c1, AVG(c2) AS c2
                       FROM decimal_tbl'''
         self.data = [{'c1': Decimal('4157.89'), 'c2': Decimal('5265.09')}]
 
+
 class aggtst_decimal_avg_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg_gby AS SELECT
                       id, AVG(c1) AS c1, AVG(c2) AS c2
                       FROM decimal_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': Decimal('1111.52'), 'c2': Decimal('3017.30')},
                      {'id': 1, 'c1': Decimal('5681.08'), 'c2': Decimal('7512.88')}]
 
+
 class aggtst_decimal_avg_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg_distinct AS SELECT
                       AVG(DISTINCT c1) AS c1, AVG(DISTINCT c2) AS c2
                       FROM decimal_tbl'''
         self.data = [{'c1': Decimal('3396.30'), 'c2': Decimal('5265.09')}]
 
+
 class aggtst_decimal_avg_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg_distinct_gby AS SELECT
                       id, AVG(DISTINCT c1) AS c1, AVG(DISTINCT c2) AS c2
                       FROM decimal_tbl
                       GROUP BY id'''
-        self.data = [{'id':0,'c1': Decimal('1111.52'), 'c2': Decimal('3017.30')},
-                     {'id':1,'c1': Decimal('5681.08'), 'c2': Decimal('7512.88')}]
+        self.data = [{'id': 0, 'c1': Decimal('1111.52'), 'c2': Decimal('3017.30')},
+                     {'id': 1, 'c1': Decimal('5681.08'), 'c2': Decimal('7512.88')}]
+
 
 class aggtst_decimal_avg_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg_where AS SELECT
                       AVG(c1) FILTER(WHERE c2>2231.90) AS f_c1, AVG(c2) FILTER(WHERE c2>2231.90) AS f_c2
                       FROM decimal_tbl'''
         self.data = [{'f_c1': Decimal('5681.08'), 'f_c2': Decimal('6276.15')}]
 
+
 class aggtst_decimal_avg_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_avg_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_avg_where_gby AS SELECT
                       id, AVG(c1) FILTER(WHERE c2>2231.90) AS f_c1, AVG(c2) FILTER(WHERE c2>2231.90) AS f_c2
                       FROM decimal_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_decimal_sum.py
+++ b/python/tests/aggregate_tests/test_decimal_sum.py
@@ -1,54 +1,60 @@
 from .aggtst_base import TstView
 from decimal import Decimal
 
+
 class aggtst_decimal_sum(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum AS SELECT
                       SUM(c1) AS c1, SUM(c2) AS c2
                       FROM decimal_tbl'''
         self.data = [{'c1': Decimal('12473.68'), 'c2': Decimal('21060.37')}]
 
+
 class aggtst_decimal_sum_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum_gby AS SELECT
                       id, SUM(c1) AS c1, SUM(c2) AS c2
                       FROM decimal_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': Decimal('1111.52'), 'c2': Decimal('6034.61')},
                      {'id': 1, 'c1': Decimal('11362.16'), 'c2': Decimal('15025.76')}]
 
+
 class aggtst_decimal_sum_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum_distinct AS SELECT
                       SUM(DISTINCT c1) AS c1, SUM(DISTINCT c2) AS c2
                       FROM decimal_tbl'''
         self.data = [{'c1': Decimal('6792.60'), 'c2': Decimal('21060.37')}]
 
+
 class aggtst_decimal_sum_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum_distinct_gby AS SELECT
                       id, SUM(DISTINCT c1) AS c1, SUM(DISTINCT c2) AS c2
                       FROM decimal_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': Decimal('1111.52'), 'c2': Decimal('6034.61')},
-                     {'id': 1,'c1': Decimal('5681.08'), 'c2': Decimal('15025.76')}]
+                     {'id': 1, 'c1': Decimal('5681.08'), 'c2': Decimal('15025.76')}]
+
 
 class aggtst_decimal_sum_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum_where AS SELECT
                            SUM(c1) FILTER(WHERE c2>2231.90) AS f_c1, SUM(c2) FILTER(WHERE c2>2231.90) AS f_c2
                         FROM decimal_tbl'''
         self.data = [{'f_c1': Decimal('11362.16'), 'f_c2': Decimal('18828.47')}]
 
+
 class aggtst_decimal_sum_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW decimal_sum_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW decimal_sum_where_gby AS SELECT
                       id, SUM(c1) FILTER(WHERE c2>2231.90) AS f_c1, SUM(c2) FILTER(WHERE c2>2231.90) AS f_c2
                       FROM decimal_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_decimal_table.py
+++ b/python/tests/aggregate_tests/test_decimal_table.py
@@ -1,7 +1,9 @@
 from .aggtst_base import TstTable
 
+
 class aggtst_decimal_table(TstTable):
     """Define the table used by all decimal tests"""
+
     def __init__(self):
         self.sql = '''CREATE TABLE decimal_tbl(
                       id INT, c1 DECIMAL(6,2), c2 DECIMAL(6,2) NOT NULL

--- a/python/tests/aggregate_tests/test_every.py
+++ b/python/tests/aggregate_tests/test_every.py
@@ -1,55 +1,69 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_every(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_value AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_value AS SELECT
                       EVERY(c1 = 4) AS c1, EVERY(c2 > 1) AS c2, EVERY(c3>3) AS c3, EVERY(c4>1) AS c4, EVERY(c5>1) AS c5, EVERY(c6 % 2 = 1) AS c6, EVERY(c7>2) AS c7, EVERY(c8>2) AS c8
                       FROM int0_tbl'''
-        self.data = [{'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+        self.data = [
+            {'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+
 
 class aggtst_int_every_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_gby AS SELECT
                       id, EVERY(c1 = 4) AS c1, EVERY(c2 > 1) AS c2, EVERY(c3>3) AS c3, EVERY(c4>1) AS c4, EVERY(c5>1) AS c5, EVERY(c6 % 2 = 1) AS c6, EVERY(c7>2) AS c7, EVERY(c8>2) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]
+        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True,
+                      'c8': True},
+                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True,
+                      'c8': False}]
+
 
 class aggtst_int_every_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_distinct AS SELECT
                       EVERY(DISTINCT(c1 = 4)) AS c1, EVERY(DISTINCT(c2 > 1)) AS c2, EVERY(DISTINCT(c3>3)) AS c3, EVERY(DISTINCT(c4>1)) AS c4, EVERY(DISTINCT(c5>1)) AS c5, EVERY(DISTINCT(c6 % 2 = 1)) AS c6, EVERY(DISTINCT(c7>2)) AS c7, EVERY(DISTINCT(c8>2)) AS c8
                       FROM int0_tbl'''
-        self.data = [{'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+        self.data = [
+            {'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+
 
 class aggtst_int_every_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_distinct_gby AS SELECT
                       id, EVERY(DISTINCT(c1 = 4)) AS c1, EVERY(DISTINCT(c2 > 1)) AS c2, EVERY(DISTINCT(c3>3)) AS c3, EVERY(DISTINCT(c4>1)) AS c4, EVERY(DISTINCT(c5>1)) AS c5, EVERY(DISTINCT(c6 % 2 = 1)) AS c6, EVERY(DISTINCT(c7>2)) AS c7, EVERY(DISTINCT(c8>2)) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]
+        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True,
+                      'c8': True},
+                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True,
+                      'c8': False}]
+
 
 class aggtst_int_every_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_where AS SELECT
                       EVERY(c1 = 4) FILTER (WHERE c1 > 0) AS c1, EVERY(c2 > 1) FILTER (WHERE c1 > 0) AS c2, EVERY(c3 > 3) FILTER (WHERE c1 > 0) AS c3, EVERY(c4 > 1) FILTER (WHERE c1 > 0) AS c4, EVERY(c5 > 1) FILTER (WHERE c1 > 0) AS c5, EVERY(c6 % 2 = 1) FILTER (WHERE c1 > 0) AS c6, EVERY(c7 > 2) FILTER (WHERE c1 > 0) AS c7, EVERY(c8 > 2) FILTER (WHERE c1 > 0) AS c8
                       FROM int0_tbl'''
-        self.data = [{'c1': False, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+        self.data = [
+            {'c1': False, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': False}]
+
 
 class aggtst_int_every_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_every_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_every_where_gby AS SELECT
                       id, EVERY(c1 = 4) FILTER (WHERE c1 > 0) AS c1, EVERY(c2 > 1) FILTER (WHERE c1 > 0) AS c2, EVERY(c3 > 3) FILTER (WHERE c1 > 0) AS c3, EVERY(c4 > 1) FILTER (WHERE c1 > 0) AS c4, EVERY(c5 > 1) FILTER (WHERE c1 > 0) AS c5, EVERY(c6 % 2 = 1) FILTER (WHERE c1 > 0) AS c6, EVERY(c7 > 2) FILTER (WHERE c1 > 0) AS c7, EVERY(c8 > 2) FILTER (WHERE c1 > 0) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': None, 'c4': True, 'c5': True, 'c6': False, 'c7': None, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]
+        self.data = [
+            {'id': 0, 'c1': False, 'c2': True, 'c3': None, 'c4': True, 'c5': True, 'c6': False, 'c7': None, 'c8': True},
+            {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]

--- a/python/tests/aggregate_tests/test_int_table.py
+++ b/python/tests/aggregate_tests/test_int_table.py
@@ -1,13 +1,16 @@
 from .aggtst_base import TstTable
 
+
 class aggtst_int_table(TstTable):
     """Define the table used by some integer tests"""
+
     def __init__(self):
         self.sql = '''CREATE TABLE int_tbl(
                       id INT, c1 INT, c2 INT NOT NULL)'''
-        self.data =  [{"id": 0, "c1": None, "c2": 20},
-                      {"id": 1, "c1": 11, "c2": 22},
-                      {"id": 0, "c1": 1, "c2": 2}]
+        self.data = [{"id": 0, "c1": None, "c2": 20},
+                     {"id": 1, "c1": 11, "c2": 22},
+                     {"id": 0, "c1": 1, "c2": 2}]
+
 
 class aggtst_int0_table(TstTable):
     def __init__(self):
@@ -23,9 +26,10 @@ class aggtst_int0_table(TstTable):
                       c8 BIGINT NOT NULL)'''
 
         self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                     {"id": 1,"c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
-                     {"id" : 0, "c1": None, "c2": 2, "c3": 3, "c4": 2, "c5": 3, "c6": 4, "c7": 3, "c8": 3},
-                     {"id" : 1, "c1": None, "c2": 5, "c3": 6, "c4": 2, "c5": 2, "c6": 1, "c7": None, "c8": 5}]
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2},
+                     {"id": 0, "c1": None, "c2": 2, "c3": 3, "c4": 2, "c5": 3, "c6": 4, "c7": 3, "c8": 3},
+                     {"id": 1, "c1": None, "c2": 5, "c3": 6, "c4": 2, "c5": 2, "c6": 1, "c7": None, "c8": 5}]
+
 
 class aggtst_int_stddev_table(TstTable):
     def __init__(self):
@@ -41,4 +45,4 @@ class aggtst_int_stddev_table(TstTable):
                       c8 BIGINT NOT NULL)'''
 
         self.data = [{"id": 0, "c1": 5, "c2": 2, "c3": None, "c4": 4, "c5": 5, "c6": 6, "c7": None, "c8": 8},
-                     {"id": 1,"c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2}]
+                     {"id": 1, "c1": 4, "c2": 3, "c3": 4, "c4": 6, "c5": 2, "c6": 3, "c7": 4, "c8": 2}]

--- a/python/tests/aggregate_tests/test_max.py
+++ b/python/tests/aggregate_tests/test_max.py
@@ -1,55 +1,61 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_max(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 5, 'c2': 5, 'c3': 6, 'c4': 6, 'c5': 5, 'c6': 6, 'c7': 4, 'c8': 8}]
-        self.sql = '''CREATE VIEW int_max_view AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_view AS SELECT
                       MAX(c1) AS c1, MAX(c2) AS c2, MAX(c3) AS c3, MAX(c4) AS c4, MAX(c5) AS c5, MAX(c6) AS c6, MAX(c7) AS c7, MAX(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_max_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 4, 'c5': 5, 'c6': 6, 'c7': 3, 'c8': 8},
                      {'id': 1, 'c1': 4, 'c2': 5, 'c3': 6, 'c4': 6, 'c5': 2, 'c6': 3, 'c7': 4, 'c8': 5}]
-        self.sql = '''CREATE VIEW int_max_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_gby AS SELECT
                       id, MAX(c1) AS c1, MAX(c2) AS c2, MAX(c3) AS c3, MAX(c4) AS c4, MAX(c5) AS c5, MAX(c6) AS c6, MAX(c7) AS c7, MAX(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_max_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 5, 'c2': 5, 'c3': 6, 'c4': 6, 'c5': 5, 'c6': 6, 'c7': 4, 'c8': 8}]
-        self.sql = '''CREATE VIEW int_max_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_distinct AS SELECT
                       MAX(DISTINCT c1) AS c1, MAX(DISTINCT c2) AS c2, MAX(DISTINCT c3) AS c3, MAX(DISTINCT c4) AS c4, MAX(DISTINCT c5) AS c5, MAX(DISTINCT c6) AS c6, MAX(DISTINCT c7) AS c7, MAX(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_max_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 4, 'c5': 5, 'c6': 6, 'c7': 3, 'c8': 8},
                      {'id': 1, 'c1': 4, 'c2': 5, 'c3': 6, 'c4': 6, 'c5': 2, 'c6': 3, 'c7': 4, 'c8': 5}]
-        self.sql = '''CREATE VIEW int_max_distinct_gbt AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_distinct_gbt AS SELECT
                       id, MAX(DISTINCT c1) AS c1, MAX(DISTINCT c2) AS c2, MAX(DISTINCT c3) AS c3, MAX(DISTINCT c4) AS c4, MAX(DISTINCT c5) AS c5, MAX(DISTINCT c6) AS c6, MAX(DISTINCT c7) AS c7, MAX(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_max_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'f_c1': 5, 'f_c2': 3, 'f_c3': 4, 'f_c4': 6, 'f_c5': 5, 'f_c6': 6, 'f_c7': 4, 'f_c8': 8}]
-        self.sql = '''CREATE VIEW int_max_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_where AS SELECT
                       MAX(c1) FILTER(WHERE c5 + C6>3) AS f_c1, MAX(c2) FILTER(WHERE c5 + C6>3) AS f_c2, MAX(c3) FILTER(WHERE c5 + C6>3) AS f_c3, MAX(c4) FILTER(WHERE c5 + C6>3) AS f_c4, MAX(c5) FILTER(WHERE c5 + C6>3) AS f_c5, MAX(c6) FILTER(WHERE c5 + C6>3) AS f_c6,  MAX(c7) FILTER(WHERE c5 + C6>3) AS f_c7,  MAX(c8) FILTER(WHERE c5 + C6>3) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_max_Where_Groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 2, 'f_c3': 3, 'f_c4': 4, 'f_c5': 5, 'f_c6': 6, 'f_c7': 3, 'f_c8': 8},
                      {'id': 1, 'f_c1': 4, 'f_c2': 3, 'f_c3': 4, 'f_c4': 6, 'f_c5': 2, 'f_c6': 3, 'f_c7': 4, 'f_c8': 2}]
-        self.sql = '''CREATE VIEW int_max_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_max_where_gby AS SELECT
                       id, MAX(c1) FILTER(WHERE c5 + C6>3) AS f_c1, MAX(c2) FILTER(WHERE c5 + C6>3) AS f_c2, MAX(c3) FILTER(WHERE c5 + C6>3) AS f_c3, MAX(c4) FILTER(WHERE c5 + C6>3) AS f_c4, MAX(c5) FILTER(WHERE c5 + C6>3) AS f_c5, MAX(c6) FILTER(WHERE c5 + C6>3) AS f_c6,  MAX(c7) FILTER(WHERE c5 + C6>3) AS f_c7,  MAX(c8) FILTER(WHERE c5 + C6>3) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_min.py
+++ b/python/tests/aggregate_tests/test_min.py
@@ -1,55 +1,61 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_min(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 4, 'c2': 2, 'c3': 3, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 3, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_min_view AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_view AS SELECT
                       MIN(c1) AS c1, MIN(c2) AS c2, MIN(c3) AS c3, MIN(c4) AS c4, MIN(c5) AS c5, MIN(c6) AS c6, MIN(c7) AS c7, MIN(c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_min_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 2, 'c5': 3, 'c6': 4, 'c7': 3, 'c8': 3},
                      {'id': 1, 'c1': 4, 'c2': 3, 'c3': 4, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 4, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_min_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_gby AS SELECT
                       id, MIN(c1) AS c1, MIN(c2) AS c2, MIN(c3) AS c3, MIN(c4) AS c4, MIN(c5) AS c5, MIN(c6) AS c6, MIN(c7) AS c7, MIN(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_min_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 4, 'c2': 2, 'c3': 3, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 3, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_min_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_distinct AS SELECT
                       MIN(DISTINCT c1) AS c1, MIN(DISTINCT c2) AS c2, MIN(DISTINCT c3) AS c3, MIN(DISTINCT c4) AS c4, MIN(DISTINCT c5) AS c5, MIN(DISTINCT c6) AS c6, MIN(DISTINCT c7) AS c7, MIN(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_min_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 2, 'c5': 3, 'c6': 4, 'c7': 3, 'c8': 3},
                      {'id': 1, 'c1': 4, 'c2': 3, 'c3': 4, 'c4': 2, 'c5': 2, 'c6': 1, 'c7': 4, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_min_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_distinct_gby AS SELECT
                       id, MIN(DISTINCT c1) AS c1, MIN(DISTINCT c2) AS c2, MIN(DISTINCT c3) AS c3, MIN(DISTINCT c4) AS c4, MIN(DISTINCT c5) AS c5, MIN(DISTINCT c6) AS c6, MIN(DISTINCT c7) AS c7, MIN(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_min_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'f_c1': 4, 'f_c2': 2, 'f_c3': 3, 'f_c4': 2, 'f_c5': 2, 'f_c6': 3, 'f_c7': 3, 'f_c8': 2}]
-        self.sql = '''CREATE VIEW int_min_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_where AS SELECT
                       MIN(c1) FILTER(WHERE c5 + C6>3) AS f_c1, MIN(c2) FILTER(WHERE c5 + C6>3) AS f_c2, MIN(c3) FILTER(WHERE c5 + C6>3) AS f_c3, MIN(c4) FILTER(WHERE c5 + C6>3) AS f_c4, MIN(c5) FILTER(WHERE c5 + C6>3) AS f_c5, MIN(c6) FILTER(WHERE c5 + C6>3) AS f_c6,  MIN(c7) FILTER(WHERE c5 + C6>3) AS f_c7,  MIN(c8) FILTER(WHERE c5 + C6>3) AS f_c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_min_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 2, 'f_c3': 3, 'f_c4': 2, 'f_c5': 3, 'f_c6': 4, 'f_c7': 3, 'f_c8': 3},
                      {'id': 1, 'f_c1': 4, 'f_c2': 3, 'f_c3': 4, 'f_c4': 6, 'f_c5': 2, 'f_c6': 3, 'f_c7': 4, 'f_c8': 2}]
-        self.sql = '''CREATE VIEW int_min_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_min_where_gby AS SELECT
                       id, MIN(c1) FILTER(WHERE c5 + C6>3) AS f_c1, MIN(c2) FILTER(WHERE c5 + C6>3) AS f_c2, MIN(c3) FILTER(WHERE c5 + C6>3) AS f_c3, MIN(c4) FILTER(WHERE c5 + C6>3) AS f_c4, MIN(c5) FILTER(WHERE c5 + C6>3) AS f_c5, MIN(c6) FILTER(WHERE c5 + C6>3) AS f_c6,  MIN(c7) FILTER(WHERE c5 + C6>3) AS f_c7,  MIN(c8) FILTER(WHERE c5 + C6>3) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_some.py
+++ b/python/tests/aggregate_tests/test_some.py
@@ -1,55 +1,66 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_some(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': True}]
-        self.sql = '''CREATE VIEW int_some AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_some AS SELECT
                       SOME(c1 = 4) AS c1, SOME(c2 > 1) AS c2, SOME(c3>3) AS c3, SOME(c4>1) AS c4, SOME(c5>1) AS c5, SOME(c6 % 2 = 1) AS c6, SOME(c7>2) AS c7, SOME(c8>2) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_some_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': True}]
-        self.sql = '''CREATE VIEW int_some_gby AS SELECT
+        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True,
+                      'c8': True},
+                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True,
+                      'c8': True}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_some_gby AS SELECT
                       id, SOME(c1 = 4) AS c1, SOME(c2 > 1) AS c2, SOME(c3>3) AS c3, SOME(c4>1) AS c4, SOME(c5>1) AS c5, SOME(c6 % 2 = 1) AS c6, SOME(c7>2) AS c7, SOME(c8>2) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
 
+
 class aggtst_int_some_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_some_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_some_distinct AS SELECT
                       SOME(DISTINCT(c1 = 4)) AS c1, SOME(DISTINCT(c2 > 1)) AS c2, SOME(DISTINCT(c3>3)) AS c3, SOME(DISTINCT(c4>1)) AS c4, SOME(DISTINCT(c5>1)) AS c5, SOME(DISTINCT(c6 % 2 = 1)) AS c6, SOME(DISTINCT(c7>2)) AS c7, SOME(DISTINCT(c8>2)) AS c8
                       FROM int0_tbl'''
         self.data = [{'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': True}]
 
+
 class aggtst_int_some_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_some_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_some_distinct_gby AS SELECT
                       id, SOME(DISTINCT(c1 = 4)) AS c1, SOME(DISTINCT(c2 > 1)) AS c2, SOME(DISTINCT(c3>3)) AS c3, SOME(DISTINCT(c4>1)) AS c4, SOME(DISTINCT(c5>1)) AS c5, SOME(DISTINCT(c6 % 2 = 1)) AS c6, SOME(DISTINCT(c7>2)) AS c7, SOME(DISTINCT(c8>2)) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': True}]
+        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': False, 'c4': True, 'c5': True, 'c6': False, 'c7': True,
+                      'c8': True},
+                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True,
+                      'c8': True}]
+
 
 class aggtst_int_some_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': True}]
-        self.sql = '''CREATE VIEW int_some_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_some_where AS SELECT
                       SOME(c1 = 4) FILTER (WHERE c1 > 0) AS c1, SOME(c2 > 1) FILTER (WHERE c1 > 0) AS c2, SOME(c3 > 3) FILTER (WHERE c1 > 0) AS c3, SOME(c4 > 1) FILTER (WHERE c1 > 0) AS c4, SOME(c5 > 1) FILTER (WHERE c1 > 0) AS c5, SOME(c6 % 2 = 1) FILTER (WHERE c1 > 0) AS c6, SOME(c7 > 2) FILTER (WHERE c1 > 0) AS c7, SOME(c8 > 2) FILTER (WHERE c1 > 0) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_some_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': False, 'c2': True, 'c3': None, 'c4': True, 'c5': True, 'c6': False, 'c7': None, 'c8': True},
-                     {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]
-        self.sql = '''CREATE VIEW int_some_where_gby AS SELECT
+        self.data = [
+            {'id': 0, 'c1': False, 'c2': True, 'c3': None, 'c4': True, 'c5': True, 'c6': False, 'c7': None, 'c8': True},
+            {'id': 1, 'c1': True, 'c2': True, 'c3': True, 'c4': True, 'c5': True, 'c6': True, 'c7': True, 'c8': False}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_some_where_gby AS SELECT
                       id, SOME(c1 = 4) FILTER (WHERE c1 > 0) AS c1, SOME(c2 > 1) FILTER (WHERE c1 > 0) AS c2, SOME(c3 > 3) FILTER (WHERE c1 > 0) AS c3, SOME(c4 > 1) FILTER (WHERE c1 > 0) AS c4, SOME(c5 > 1) FILTER (WHERE c1 > 0) AS c5, SOME(c6 % 2 = 1) FILTER (WHERE c1 > 0) AS c6, SOME(c7 > 2) FILTER (WHERE c1 > 0) AS c7, SOME(c8 > 2) FILTER (WHERE c1 > 0) AS c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_stddev_pop.py
+++ b/python/tests/aggregate_tests/test_stddev_pop.py
@@ -1,55 +1,61 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_stddev_pop(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 0, 'c2': 0, 'c3': 0, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 3}]
-        self.sql = '''CREATE VIEW int_stddev_pop AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop AS SELECT
                       STDDEV_POP(c1) AS c1, STDDEV_POP(c2) AS c2, STDDEV_POP(c3) AS c3, STDDEV_POP(c4) AS c4, STDDEV_POP(c5) AS c5, STDDEV_POP(c6) AS c6, STDDEV_POP(c7) AS c7, STDDEV_POP(c8) AS c8
                       FROM stddev_tbl'''
+
 
 class aggtst_int_stddev_pop_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 0, 'c2': 0, 'c3': 0, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 2},
                      {'id': 1, 'c1': 0, 'c2': 1, 'c3': 1, 'c4': 2, 'c5': 0, 'c6': 1, 'c7': 0, 'c8': 1}]
-        self.sql = '''CREATE VIEW int_stddev_pop_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop_gby AS SELECT
                       id, STDDEV_POP(c1) AS c1, STDDEV_POP(c2) AS c2, STDDEV_POP(c3) AS c3, STDDEV_POP(c4) AS c4, STDDEV_POP(c5) AS c5, STDDEV_POP(c6) AS c6, STDDEV_POP(c7) AS c7, STDDEV_POP(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
 
+
 class aggtst_int_stddev_pop_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data =  [{'c1': 0, 'c2': 1, 'c3': 1, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_stddev_pop_distinct AS SELECT
+        self.data = [{'c1': 0, 'c2': 1, 'c3': 1, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 2}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop_distinct AS SELECT
                       STDDEV_POP(DISTINCT c1) AS c1, STDDEV_POP(DISTINCT c2) AS c2, STDDEV_POP(DISTINCT c3) AS c3, STDDEV_POP(DISTINCT c4) AS c4, STDDEV_POP(DISTINCT c5) AS c5, STDDEV_POP(DISTINCT c6) AS c6, STDDEV_POP(DISTINCT c7) AS c7, STDDEV_POP(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_stddev_pop_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 0, 'c2': 0, 'c3': 0, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 2},
                      {'id': 1, 'c1': 0, 'c2': 1, 'c3': 1, 'c4': 2, 'c5': 0, 'c6': 1, 'c7': 0, 'c8': 1}]
-        self.sql = '''CREATE VIEW int_stddev_pop_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop_distinct_gby AS SELECT
                       id, STDDEV_POP(DISTINCT c1) AS c1, STDDEV_POP(DISTINCT c2) AS c2, STDDEV_POP(DISTINCT c3) AS c3, STDDEV_POP(DISTINCT c4) AS c4, STDDEV_POP(DISTINCT c5) AS c5, STDDEV_POP(DISTINCT c6) AS c6, STDDEV_POP(DISTINCT c7) AS c7, STDDEV_POP(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_stddev_pop_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 0, 'c2': 1, 'c3': 1, 'c4': 1, 'c5': 1, 'c6': 2, 'c7': 0, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_stddev_pop_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop_where AS SELECT
                       STDDEV_POP(c1) FILTER (WHERE c8>2) AS c1, STDDEV_POP(c2) FILTER (WHERE c8>2) AS c2, STDDEV_POP(c3) FILTER (WHERE c8>2) AS c3, STDDEV_POP(c4) FILTER (WHERE c8>2) AS c4, STDDEV_POP(c5) FILTER (WHERE c8>2) AS c5, STDDEV_POP(c6) FILTER (WHERE c8>2) AS c6, STDDEV_POP(c7) FILTER (WHERE c8>2) AS c7, STDDEV_POP(c8) FILTER (WHERE c8>2) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_stddev_pop_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': 0, 'c2': 0, 'c3': 0, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': 0, 'c8': 2},
                      {'id': 1, 'c1': None, 'c2': 0, 'c3': 0, 'c4': 0, 'c5': 0, 'c6': 0, 'c7': None, 'c8': 0}]
-        self.sql = '''CREATE VIEW int_stddev_pop_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_pop_where_gby AS SELECT
                       id, STDDEV_POP(c1) FILTER (WHERE c8>2) AS c1, STDDEV_POP(c2) FILTER (WHERE c8>2) AS c2, STDDEV_POP(c3) FILTER (WHERE c8>2) AS c3, STDDEV_POP(c4) FILTER (WHERE c8>2) AS c4, STDDEV_POP(c5) FILTER (WHERE c8>2) AS c5, STDDEV_POP(c6) FILTER (WHERE c8>2) AS c6, STDDEV_POP(c7) FILTER (WHERE c8>2) AS c7, STDDEV_POP(c8) FILTER (WHERE c8>2) AS c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_stddev_samp.py
+++ b/python/tests/aggregate_tests/test_stddev_samp.py
@@ -1,55 +1,62 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_stddev(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 1, 'c2': 1, 'c3': None, 'c4': 1, 'c5': 2, 'c6': 2, 'c7': None, 'c8': 4}]
-        self.sql = '''CREATE VIEW int_stddev_samp AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_samp AS SELECT
                       STDDEV_SAMP(c1) AS c1, STDDEV_SAMP(c2) AS c2, STDDEV_SAMP(c3) AS c3, STDDEV_SAMP(c4) AS c4, STDDEV_SAMP(c5) AS c5, STDDEV_SAMP(c6) AS c6, STDDEV_SAMP(c7) AS c7, STDDEV_SAMP(c8) AS c8
                       FROM stddev_tbl'''
+
 
 class aggtst_int_stddev_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': None, 'c2': 0, 'c3': None, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': None, 'c8': 3},
                      {'id': 1, 'c1': None, 'c2': 1, 'c3': 1, 'c4': 2, 'c5': 0, 'c6': 1, 'c7': None, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_stddev_samp_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_samp_gby AS SELECT
                       id, STDDEV_SAMP(c1) AS c1, STDDEV_SAMP(c2) AS c2, STDDEV_SAMP(c3) AS c3, STDDEV_SAMP(c4) AS c4, STDDEV_SAMP(c5) AS c5, STDDEV_SAMP(c6) AS c6, STDDEV_SAMP(c7) AS c7, STDDEV_SAMP(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_stddev_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 1, 'c2': 1, 'c3': 1, 'c4': 2, 'c5': 1, 'c6': 2, 'c7': 1, 'c8': 2}]
-        self.sql = '''CREATE VIEW int_stddev_samp_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_samp_distinct AS SELECT
                       STDDEV_SAMP(DISTINCT c1) AS c1, STDDEV_SAMP(DISTINCT c2) AS c2, STDDEV_SAMP(DISTINCT c3) AS c3, STDDEV_SAMP(DISTINCT c4) AS c4, STDDEV_SAMP(DISTINCT c5) AS c5, STDDEV_SAMP(DISTINCT c6) AS c6, STDDEV_SAMP(DISTINCT c7) AS c7, STDDEV_SAMP(DISTINCT c8) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_stddev_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{"id": 0, "c1": None, "c2": None, "c3": None, "c4": 1, "c5": 1, "c6": 1, "c7": None, "c8": 3},
                      {"id": 1, "c1": None, "c2": 1, "c3": 1, "c4": 2, "c5": None, "c6": 1, "c7": None, "c8": 2}]
-        self.sql = '''CREATE VIEW int_stddev_samp_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_samp_distinct_gby AS SELECT
                       id, STDDEV_SAMP(DISTINCT c1) AS c1, STDDEV_SAMP(DISTINCT c2) AS c2, STDDEV_SAMP(DISTINCT c3) AS c3, STDDEV_SAMP(DISTINCT c4) AS c4, STDDEV_SAMP(DISTINCT c5) AS c5, STDDEV_SAMP(DISTINCT c6) AS c6, STDDEV_SAMP(DISTINCT c7) AS c7, STDDEV_SAMP(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
+
 
 class aggtst_int_stddev_where(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'c1': 1, 'c2': 1, 'c3': None, 'c4': 1, 'c5': 2, 'c6': 2, 'c7': None, 'c8': 4}]
-        self.sql = '''CREATE VIEW int_stddev_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_where AS SELECT
                       STDDEV_SAMP(c1) FILTER (WHERE c1 > 0) AS c1, STDDEV_SAMP(c2) FILTER (WHERE c1 > 0) AS c2, STDDEV_SAMP(c3) FILTER (WHERE c1 > 0) AS c3, STDDEV_SAMP(c4) FILTER (WHERE c1 > 0) AS c4, STDDEV_SAMP(c5) FILTER (WHERE c1 > 0) AS c5, STDDEV_SAMP(c6) FILTER (WHERE c1 > 0) AS c6, STDDEV_SAMP(c7) FILTER (WHERE c1 > 0) AS c7, STDDEV_SAMP(c8) FILTER (WHERE c1 > 0) AS c8
                       FROM int0_tbl'''
+
 
 class aggtst_int_stddev_where_groupby1(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [{'id': 0, 'c1': None, 'c2': 0, 'c3': None, 'c4': 1, 'c5': 1, 'c6': 1, 'c7': None, 'c8': 3},
-                     {'id': 1, 'c1': None, 'c2': None, 'c3': None, 'c4': None, 'c5': None, 'c6': None, 'c7': None, 'c8': None}]
-        self.sql = '''CREATE VIEW int_stddev_where_gby1 AS SELECT
+                     {'id': 1, 'c1': None, 'c2': None, 'c3': None, 'c4': None, 'c5': None, 'c6': None, 'c7': None,
+                      'c8': None}]
+        self.sql = '''CREATE MATERIALIZED VIEW int_stddev_where_gby1 AS SELECT
                       id, STDDEV_SAMP(c1) FILTER (WHERE c8>2) AS c1, STDDEV_SAMP(c2) FILTER (WHERE c8>2) AS c2, STDDEV_SAMP(c3) FILTER (WHERE c8>2) AS c3, STDDEV_SAMP(c4) FILTER (WHERE c8>2) AS c4, STDDEV_SAMP(c5) FILTER (WHERE c8>2) AS c5, STDDEV_SAMP(c6) FILTER (WHERE c8>2) AS c6, STDDEV_SAMP(c7) FILTER (WHERE c8>2) AS c7, STDDEV_SAMP(c8) FILTER (WHERE c8>2) AS c8
                       FROM int0_tbl
                       GROUP BY id'''

--- a/python/tests/aggregate_tests/test_sum.py
+++ b/python/tests/aggregate_tests/test_sum.py
@@ -1,55 +1,62 @@
 from .aggtst_base import TstView
 
+
 class aggtst_int_sum(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_sum AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum AS SELECT
                       SUM(c1) AS c1, SUM(c2) AS c2, SUM(c3) AS c3, SUM(c4) AS c4, SUM(c5) AS c5, SUM(c6) AS c6, SUM(c7) AS c7, SUM(c8) AS c8
                       FROM int0_tbl'''
         self.data = [{'c1': 9, 'c2': 12, 'c3': 13, 'c4': 14, 'c5': 12, 'c6': 14, 'c7': 7, 'c8': 18}]
 
+
 class aggtst_int_sum_gby(TstView):
     # Validated on Postgres
     def __init__(self):
-        self.sql = '''CREATE VIEW int_sum_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum_gby AS SELECT
                       id, SUM(c1) AS c1, SUM(c2) AS c2, SUM(c3) AS c3, SUM(c4) AS c4, SUM(c5) AS c5, SUM(c6) AS c6, SUM(c7) AS c7, SUM(c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
         self.data = [{'id': 0, 'c1': 5, 'c2': 4, 'c3': 3, 'c4': 6, 'c5': 8, 'c6': 10, 'c7': 3, 'c8': 11},
                      {'id': 1, 'c1': 4, 'c2': 8, 'c3': 10, 'c4': 8, 'c5': 4, 'c6': 4, 'c7': 4, 'c8': 7}]
 
+
 class aggtst_int_sum_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_sum_distinct AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum_distinct AS SELECT
                       SUM(DISTINCT c1) AS c1, SUM(DISTINCT c2) AS c2, SUM(DISTINCT c3) AS c3, SUM(DISTINCT c4) AS c4, SUM(DISTINCT c5) AS c5, SUM(DISTINCT c6) AS c6, SUM(DISTINCT c7) AS c7, SUM(DISTINCT c8) AS c8
                       FROM int0_tbl'''
         self.data = [{'c1': 9, 'c2': 10, 'c3': 13, 'c4': 12, 'c5': 10, 'c6': 14, 'c7': 7, 'c8': 18}]
 
+
 class aggtst_int_sum_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_sum_distinct_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum_distinct_gby AS SELECT
                       id, SUM(DISTINCT c1) AS c1, SUM(DISTINCT c2) AS c2, SUM(DISTINCT c3) AS c3, SUM(DISTINCT c4) AS c4, SUM(DISTINCT c5) AS c5, SUM(DISTINCT c6) AS c6, SUM(DISTINCT c7) AS c7, SUM(DISTINCT c8) AS c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data =  [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 6, 'c5': 8, 'c6': 10, 'c7': 3, 'c8': 11},
-                      {'id': 1, 'c1': 4, 'c2': 8, 'c3': 10, 'c4': 8, 'c5': 2, 'c6': 4, 'c7': 4, 'c8': 7}]
+        self.data = [{'id': 0, 'c1': 5, 'c2': 2, 'c3': 3, 'c4': 6, 'c5': 8, 'c6': 10, 'c7': 3, 'c8': 11},
+                     {'id': 1, 'c1': 4, 'c2': 8, 'c3': 10, 'c4': 8, 'c5': 2, 'c6': 4, 'c7': 4, 'c8': 7}]
+
 
 class aggtst_int_sum_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_sum_where AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum_where AS SELECT
                       SUM(c1) FILTER(WHERE c8>2) AS f_c1, SUM(c2) FILTER(WHERE c8>2) AS f_c2, SUM(c3) FILTER(WHERE c8>2) AS f_c3, SUM(c4) FILTER(WHERE c8>2) AS f_c4, SUM(c5) FILTER(WHERE c8>2) AS f_c5, SUM(c6) FILTER(WHERE c8>2) AS f_c6,  SUM(c7) FILTER(WHERE c8>2) AS f_c7,  SUM(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl'''
         self.data = [{'f_c1': 5, 'f_c2': 9, 'f_c3': 9, 'f_c4': 8, 'f_c5': 10, 'f_c6': 11, 'f_c7': 3, 'f_c8': 16}]
 
+
 class aggtst_int_sum_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.sql = '''CREATE VIEW int_sum_where_gby AS SELECT
+        self.sql = '''CREATE MATERIALIZED VIEW int_sum_where_gby AS SELECT
                       id, SUM(c1) FILTER(WHERE c8>2) AS f_c1, SUM(c2) FILTER(WHERE c8>2) AS f_c2, SUM(c3) FILTER(WHERE c8>2) AS f_c3, SUM(c4) FILTER(WHERE c8>2) AS f_c4, SUM(c5) FILTER(WHERE c8>2) AS f_c5, SUM(c6) FILTER(WHERE c8>2) AS f_c6,  SUM(c7) FILTER(WHERE c8>2) AS f_c7,  SUM(c8) FILTER(WHERE c8>2) AS f_c8
                       FROM int0_tbl
                       GROUP BY id'''
-        self.data = [{'id': 0, 'f_c1': 5, 'f_c2': 4, 'f_c3': 3, 'f_c4': 6, 'f_c5': 8, 'f_c6': 10, 'f_c7': 3, 'f_c8': 11},
-                     {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]
+        self.data = [
+            {'id': 0, 'f_c1': 5, 'f_c2': 4, 'f_c3': 3, 'f_c4': 6, 'f_c5': 8, 'f_c6': 10, 'f_c7': 3, 'f_c8': 11},
+            {'id': 1, 'f_c1': None, 'f_c2': 5, 'f_c3': 6, 'f_c4': 2, 'f_c5': 2, 'f_c6': 1, 'f_c7': None, 'f_c8': 5}]


### PR DESCRIPTION
Fixes: #2650

Note that the adhoc query backend doesn't support DECIMAL yet, so DECIMAL tests have been currently disabled.
See issue: #2667

Re-enable them by uncommenting the DECIMAL related imports in aggtest_base.py.

**Note that it is important for the VIEWs created for the tests are materialized views.**