### PR TITLE
[WebConsole] Fix monaco find widget styling

### DIFF
--- a/web-console/src/lib/components/MonacoEditor.svelte
+++ b/web-console/src/lib/components/MonacoEditor.svelte
@@ -102,4 +102,16 @@
     padding: 0;
     margin: 0;
   }
+
+  div.monaco-container :global(.monaco-editor .monaco-inputbox .input) {
+    box-shadow: none;
+  }
+
+  div.monaco-container :global(.monaco-editor .monaco-inputbox .input::placeholder) {
+    line-height: normal;
+    font-family: inherit;
+    font-size: inherit;
+    padding-top: inherit;
+    padding-bottom: inherit;
+  }
 </style>

--- a/web-console/src/lib/components/MonacoEditor_svelte5.svelte
+++ b/web-console/src/lib/components/MonacoEditor_svelte5.svelte
@@ -47,4 +47,16 @@
     width: 100%;
     height: 100%;
   }
+
+  div :global(.monaco-editor .monaco-inputbox .input) {
+    box-shadow: none;
+  }
+
+  div :global(.monaco-editor .monaco-inputbox .input::placeholder) {
+    line-height: normal;
+    font-family: inherit;
+    font-size: inherit;
+    padding-top: inherit;
+    padding-bottom: inherit;
+  }
 </style>


### PR DESCRIPTION
Some of the web console's styling is spilling over to the monaco editor. I'm assuming this is unintentional
<img width="479" alt="image" src="https://github.com/user-attachments/assets/bb2b846a-64bb-45f9-81ce-3528ebb3b7d3">

This is what VSCode normally looks like
<img width="493" alt="image" src="https://github.com/user-attachments/assets/dcea326f-4592-4f4b-ae7a-a9d3d86b1443">

Here is the styling fix
![image](https://github.com/user-attachments/assets/abc72dba-b4cd-405e-81fe-2af459b8d4c6)

This thing was bothering me. I don't have any experience in Svelte so I just did whatever worked.