### PR TITLE
pipeline-manager: demos with user defined functions

### DIFF
--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -182,6 +182,8 @@ pub struct ApiServerConfig {
     /// For each directory, the files are read sorted on the filename.
     /// For multiple directories, the lists of demos are appended one after the other into a single one.
     /// Files which do not end in `.sql` and directories are ignored. Symlinks are followed.
+    /// If a `<filename>.sql` exists, checks for `<filename>.udf.rs` and `<filename>.udf.toml`.
+    /// If present, these will be included in the demo as well.
     #[arg(long, default_values_t = default_demos_dir())]
     pub demos_dir: Vec<String>,
 

--- a/demo/packaged/sql/05-udf-tutorial.sql
+++ b/demo/packaged/sql/05-udf-tutorial.sql
@@ -1,0 +1,48 @@
+-- Tutorial: User Defined Function (UDF) (udf-tutorial)
+--
+-- Learn how to define and implement a UDF in Feldera
+-- using a simple example in which to encode incoming
+-- binary data as base64.
+--
+-- WORKFLOW
+-- 1. Within the SQL, declare UDFs using CREATE FUNCTION and use them in views
+-- 2. Compile the SQL: the SQL compiler generates for each FUNCTION a stub Rust function,
+--    which are shown in `stubs.rs`
+-- 3. Copy the function signatures from `stubs.rs` into `udf.rs` and implement them there
+-- 4. Declare any external crate dependencies in `udf.toml`
+--
+-- For more detailed documentation: https://docs.feldera.com/sql/udf
+
+-- Binary data entries come in at a rate of 1 per second.
+CREATE TABLE binary_data (
+    entry VARBINARY
+) WITH (
+    'materialized' = 'true',
+    'connectors' = '[{
+        "transport": {
+            "name": "datagen",
+            "config": {
+                "plan": [{
+                    "limit": 1000000,
+                    "rate": 1,
+                    "fields": {
+                        "entry": {
+                            "range": [1, 20],
+                            "strategy": "uniform",
+                            "value": { "strategy": "uniform", "range": [0, 256] }
+                        }
+                    }
+                }]
+            }
+        }
+    }]'
+);
+
+-- UDF which encodes binary data as base64.
+CREATE FUNCTION base64(s VARBINARY) RETURNS VARCHAR;
+
+-- View of base64-encoded binary data entries.
+CREATE MATERIALIZED VIEW base64_data AS (
+    SELECT  base64(b.entry)
+    FROM    binary_data AS b
+);

--- a/demo/packaged/sql/05-udf-tutorial.udf.rs
+++ b/demo/packaged/sql/05-udf-tutorial.udf.rs
@@ -1,0 +1,9 @@
+// Implement the function signatures from stubs.rs
+
+use crate::*;
+use feldera_sqllib::*;
+use base64::prelude::*; // Able to use external crates declared in udf.toml
+
+pub fn base64(s: Option<ByteArray>) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    Ok(s.map(|v| BASE64_STANDARD.encode(v.as_slice())))
+}

--- a/demo/packaged/sql/05-udf-tutorial.udf.toml
+++ b/demo/packaged/sql/05-udf-tutorial.udf.toml
@@ -1,0 +1,3 @@
+# Declare any external crates that are used in udf.rs
+# in the same way as in the [dependencies] section of a Cargo.toml
+base64 = "0.22.1"

--- a/openapi.json
+++ b/openapi.json
@@ -2330,7 +2330,9 @@
           "name",
           "title",
           "description",
-          "program_code"
+          "program_code",
+          "udf_rust",
+          "udf_toml"
         ],
         "properties": {
           "description": {
@@ -2348,6 +2350,14 @@
           "title": {
             "type": "string",
             "description": "Title of the demo (parsed from SQL preamble)."
+          },
+          "udf_rust": {
+            "type": "string",
+            "description": "User defined function (UDF) Rust code."
+          },
+          "udf_toml": {
+            "type": "string",
+            "description": "User defined function (UDF) TOML dependencies."
           }
         }
       },

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -19,9 +19,6 @@ cd "${SQL_COMPILER_DIR}" && ./build.sh
 
 WORKING_DIR="${1:-${HOME}/.dbsp}"
 
-# This is the most portable way to get an absolute path since
-# 'realpath' is not available on MacOS by default.
-WORKING_DIR_ABS=$(cd "$(dirname "${WORKING_DIR}")" && pwd -P)/$(basename "${WORKING_DIR}")
 DEFAULT_BIND_ADDRESS="127.0.0.1"
 BIND_ADDRESS="${2:-$DEFAULT_BIND_ADDRESS}"
 
@@ -44,11 +41,6 @@ if [ -n "$manager_pid" ]; then
 fi
 
 cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo build $RUST_BUILD_PROFILE $PG_EMBED
-cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --bin pipeline-manager $RUST_BUILD_PROFILE $PG_EMBED -- \
+cd "${ROOT_DIR}" && ~/.cargo/bin/cargo run --bin pipeline-manager $RUST_BUILD_PROFILE $PG_EMBED -- \
     --bind-address="${BIND_ADDRESS}" \
-    --api-server-working-directory="${WORKING_DIR_ABS}" \
-    --compiler-working-directory="${WORKING_DIR_ABS}" \
-    --runner-working-directory="${WORKING_DIR_ABS}" \
-    --sql-compiler-home="${SQL_COMPILER_DIR}" \
-    --dbsp-override-path="${ROOT_DIR}" \
     ${DB_CONNECTION_STRING}

--- a/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
+++ b/web-console/src/lib/compositions/pipelines/useTryPipeline.ts
@@ -13,7 +13,9 @@ export const useTryPipeline = () => {
         description: pipeline.description,
         program_code: pipeline.program_code,
         program_config: {},
-        runtime_config: {}
+        runtime_config: {},
+        udf_rust: pipeline.udf_rust,
+        udf_toml: pipeline.udf_toml
       })
       updatePipelines((pipelines) => (pipelines.push(newPipeline), pipelines))
     } catch {}

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -553,7 +553,7 @@ For specific options available for different storage backends, see:
 
 export const $Demo = {
   type: 'object',
-  required: ['name', 'title', 'description', 'program_code'],
+  required: ['name', 'title', 'description', 'program_code', 'udf_rust', 'udf_toml'],
   properties: {
     description: {
       type: 'string',
@@ -570,6 +570,14 @@ export const $Demo = {
     title: {
       type: 'string',
       description: 'Title of the demo (parsed from SQL preamble).'
+    },
+    udf_rust: {
+      type: 'string',
+      description: 'User defined function (UDF) Rust code.'
+    },
+    udf_toml: {
+      type: 'string',
+      description: 'User defined function (UDF) TOML dependencies.'
     }
   }
 } as const

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -437,6 +437,14 @@ export type Demo = {
    * Title of the demo (parsed from SQL preamble).
    */
   title: string
+  /**
+   * User defined function (UDF) Rust code.
+   */
+  udf_rust: string
+  /**
+   * User defined function (UDF) TOML dependencies.
+   */
+  udf_toml: string
 }
 
 /**


### PR DESCRIPTION
If a `<filename>.sql` is found in a demos directory, also check for `<filename>.udf.rs` and `<filename>.udf.toml`. If present, these will be included in the demo as well.

Add a UDF tutorial demo in which to encode incoming binary data as base64.