### PR TITLE
[py] fix docs link in pyproject.toml; PyPi page

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,6 +32,6 @@ dependencies = [
 ]
 [project.urls]
 Homepage = "https://www.feldera.com"
-Documentation = "https://docs.feldera.com"
+Documentation = "https://docs.feldera.com/python"
 Repository = "https://github.com/feldera/feldera"
 Issues = "https://github.com/feldera/feldera/issues"


### PR DESCRIPTION
Updates the docs link to point to the python SDK docs at https://docs.feldera.com/python/

Fixes: #2686