### PR TITLE
[SQL] Added compiler flag --plan to generate Calcite plan as JSON

### DIFF
--- a/sql-to-dbsp-compiler/README.md
+++ b/sql-to-dbsp-compiler/README.md
@@ -86,8 +86,7 @@ views                                           V
 
 ## Using the compiler
 
-See the documentation in `docs/contributors/compiler.md` in this repo,
-or [online](/contributors/compiler).
+See the documentation in [using.md](using.md).
 
 ## Compiler architecture
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
@@ -184,6 +184,24 @@ public class CompilerMain {
                 return compiler.messages;
             }
         }
+        if (this.options.ioOptions.emitPlan) {
+            if (this.options.ioOptions.outputFile.isEmpty()) {
+                compiler.reportError(SourcePositionRange.INVALID, "Invalid output",
+                        "Must specify an output file when outputting the plan");
+                return compiler.messages;
+            }
+            try {
+                PrintStream outputStream = new PrintStream(
+                        Files.newOutputStream(Paths.get(this.options.ioOptions.outputFile)));
+                String plan = compiler.getPlans();
+                outputStream.println(plan);
+                outputStream.close();
+            } catch (IOException e) {
+                compiler.reportError(SourcePositionRange.INVALID,
+                        "Error writing to file", e.getMessage());
+            }
+            return compiler.messages;
+        }
 
         String dotFormat = (this.options.ioOptions.emitJpeg ? "jpg"
                             : this.options.ioOptions.emitPng ? "png"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -162,6 +162,8 @@ public class CompilerOptions implements IDiff<CompilerOptions> {
         public boolean emitJpeg = false;
         @Parameter(names = "-png", description = "Emit a png image of the circuit instead of Rust")
         public boolean emitPng = false;
+        @Parameter(names = "--plan", description = "Emit the Calcite plan of the optimized program instead of Rust")
+        public boolean emitPlan = false;
         @Parameter(names = "-je", description = "Emit error messages as a JSON array to stderr")
         public boolean emitJsonErrors = false;
         @Parameter(names = "-js",
@@ -197,9 +199,10 @@ public class CompilerOptions implements IDiff<CompilerOptions> {
             return "IO{" +
                     "outputFile=" + Utilities.singleQuote(this.outputFile) +
                     ", metadataSource=" + this.metadataSource +
-                    ", emitJpeg=" + this.emitJpeg +
                     ", emitHandles=" + this.emitHandles +
+                    ", emitJpeg=" + this.emitJpeg +
                     ", emitPng=" + this.emitPng +
+                    ", emitPlan=" + this.emitPlan +
                     ", emitJsonErrors=" + this.emitJsonErrors +
                     ", emitJsonSchema=" + Utilities.singleQuote(this.emitJsonSchema) +
                     ", inputFile=" + Utilities.singleQuote(this.inputFile) +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -2437,7 +2437,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
     DBSPNode compileCreateView(CreateViewStatement view) {
         RelNode rel = view.getRelNode();
         Logger.INSTANCE.belowLevel(this, 2)
-                .append(CalciteCompiler.getPlan(rel))
+                .append(CalciteCompiler.getPlan(rel, false))
                 .newline();
         this.go(rel);
         DBSPOperator op = this.getOperator(rel);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -406,9 +406,9 @@ public class CalciteCompiler implements IWritesLogs {
         return false;
     }
 
-    public static String getPlan(RelNode rel) {
+    public static String getPlan(RelNode rel, boolean json) {
         return RelOptUtil.dumpPlan("[Logical plan]", rel,
-                SqlExplainFormat.TEXT,
+                json ? SqlExplainFormat.JSON : SqlExplainFormat.TEXT,
                 SqlExplainLevel.NON_COST_ATTRIBUTES);
     }
 
@@ -486,7 +486,7 @@ public class CalciteCompiler implements IWritesLogs {
         Logger.INSTANCE.belowLevel(this, level)
                 .append("Before optimizer")
                 .increase()
-                .append(getPlan(rel))
+                .append(getPlan(rel, false))
                 .decrease()
                 .newline();
 
@@ -498,7 +498,7 @@ public class CalciteCompiler implements IWritesLogs {
         Logger.INSTANCE.belowLevel(this, level)
                 .append("After optimizer ")
                 .increase()
-                .append(getPlan(rel))
+                .append(getPlan(rel, false))
                 .decrease()
                 .newline();
         return rel;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
@@ -105,7 +105,7 @@ public class CalciteOptimizer implements IWritesLogs {
                         .append("After ")
                         .append(step.getName())
                         .increase()
-                        .append(CalciteCompiler.getPlan(optimized))
+                        .append(CalciteCompiler.getPlan(optimized, false))
                         .decrease()
                         .newline();
             };

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -163,10 +163,7 @@ public class NegativeParserTests extends BaseSQLTests {
 
     @Test
     public void errorTest() throws IOException, SQLException {
-        String[] statements = new String[]{
-                "This is not SQL"
-        };
-        File file = createInputScript(statements);
+        File file = createInputScript("This is not SQL");
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
         Assert.assertEquals(messages.exitCode, 1);
         Assert.assertEquals(messages.errorCount(), 1);
@@ -174,10 +171,7 @@ public class NegativeParserTests extends BaseSQLTests {
         Assert.assertFalse(msg.warning);
         Assert.assertEquals(msg.message, "Non-query expression encountered in illegal context");
 
-        statements = new String[] {
-                "CREATE VIEW V AS SELECT * FROM T"
-        };
-        file = createInputScript(statements);
+        file = createInputScript("CREATE VIEW V AS SELECT * FROM T;");
         messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
         Assert.assertEquals(messages.exitCode, 1);
         Assert.assertEquals(messages.errorCount(), 1);
@@ -185,10 +179,7 @@ public class NegativeParserTests extends BaseSQLTests {
         Assert.assertFalse(msg.warning);
         Assert.assertEquals(msg.message, "Object 't' not found");
 
-        statements = new String[] {
-                "CREATE VIEW V AS SELECT ST_MAKELINE(ST_POINT(0,0), ST_POINT(0, 0))"
-        };
-        file = createInputScript(statements);
+        file = createInputScript("CREATE VIEW V AS SELECT ST_MAKELINE(ST_POINT(0,0), ST_POINT(0, 0));");
         messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
         Assert.assertEquals(messages.exitCode, 1);
         Assert.assertEquals(messages.errorCount(), 1);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -168,14 +168,10 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     public void loggingParameter() throws IOException, InterruptedException, SQLException {
         StringBuilder builder = new StringBuilder();
         Appendable save = Logger.INSTANCE.setDebugStream(builder);
-        String[] statements = new String[]{
-                "CREATE TABLE T (\n" +
-                        "COL1 INT NOT NULL" +
-                        ", COL2 DOUBLE NOT NULL" +
-                        ")",
-                "CREATE VIEW V AS SELECT COL1 FROM T"
-        };
-        File file = createInputScript(statements);
+        String sql = """
+                CREATE TABLE T (COL1 INT NOT NULL, COL2 DOUBLE NOT NULL);
+                CREATE VIEW V AS SELECT COL1 FROM T;""";
+        File file = createInputScript(sql);
         CompilerMain.execute("-TCalciteCompiler=2", "-TPasses=2",
                 "-o", BaseSQLTests.testFilePath, file.getPath());
         Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, true);
@@ -388,14 +384,10 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
 
     @Test
     public void testNoOutput() throws IOException, SQLException {
-        String[] statements = new String[]{
-                "CREATE TABLE T (\n" +
-                        "COL1 INT NOT NULL" +
-                        ", COL2 DOUBLE NOT NULL" +
-                        ")",
-                "CREATE VIEW V AS SELECT COL1 FROM T"
-        };
-        File file = createInputScript(statements);
+        String sql = """
+                 CREATE TABLE T (COL1 INT NOT NULL COL2 DOUBLE NOT NULL);
+                 CREATE VIEW V AS SELECT COL1 FROM T""";
+        File file = createInputScript(sql);
         // Redirect error stream
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(os);
@@ -409,14 +401,10 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
 
     @Test
     public void testRustCompiler() throws IOException, InterruptedException, SQLException {
-        String[] statements = new String[]{
-                "CREATE TABLE T (\n" +
-                        "COL1 INT NOT NULL" +
-                        ", COL2 DOUBLE NOT NULL" +
-                        ")",
-                "CREATE VIEW V AS SELECT COL1 FROM T"
-        };
-        File file = createInputScript(statements);
+        String sql = """
+                CREATE TABLE T (COL1 INT NOT NULL, COL2 DOUBLE NOT NULL);
+                CREATE VIEW V AS SELECT COL1 FROM T;""";
+        File file = createInputScript(sql);
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
         System.err.println(messages);
         Assert.assertEquals(0, messages.exitCode);
@@ -425,7 +413,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
 
     @Test
     public void testCompilerExample() throws IOException, InterruptedException, SQLException {
-        // The example in docs/contributors/compiler.md
+        // The example in sql-to-dbsp-compiler/using.md
         String sql = """
                 -- define Person table
                 CREATE TABLE Person
@@ -522,14 +510,10 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     public void testCompilerToPng() throws IOException, SQLException {
         if (!Utilities.isDotInstalled())
             return;
-        String[] statements = new String[]{
-                "CREATE TABLE T (\n" +
-                        "COL1 INT NOT NULL" +
-                        ", COL2 DOUBLE NOT NULL" +
-                        ")",
-                "CREATE VIEW V AS SELECT COL1 FROM T WHERE COL1 > 5"
-        };
-        File file = createInputScript(statements);
+        String sql ="""
+                 CREATE TABLE T (COL1 INT NOT NULL, COL2 DOUBLE NOT NULL);
+                 CREATE VIEW V AS SELECT COL1 FROM T WHERE COL1 > 5;""";
+        File file = createInputScript(sql);
         File png = File.createTempFile("out", ".png", new File("."));
         png.deleteOnExit();
         CompilerMessages message = CompilerMain.execute("-png", "-o", png.getPath(), file.getPath());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -211,17 +211,17 @@ public class BaseSQLTests {
         testsToRun.clear();
     }
 
-    public static File createInputFile(File file, String separator, String... contents) throws IOException {
+    public static File createInputFile(File file, String contents) throws IOException {
         file.deleteOnExit();
         PrintWriter script = new PrintWriter(file, StandardCharsets.UTF_8);
-        script.println(String.join(separator, contents));
+        script.println(contents);
         script.close();
         return file;
     }
 
-    public static File createInputScript(String... contents) throws IOException {
+    public static File createInputScript(String contents) throws IOException {
         File result = File.createTempFile("script", ".sql", new File(rustDirectory));
-        return createInputFile(result, ";" + System.lineSeparator(), contents);
+        return createInputFile(result, contents);
     }
 
     DBSPCompiler noThrowCompiler() {

--- a/sql-to-dbsp-compiler/using.md
+++ b/sql-to-dbsp-compiler/using.md
@@ -59,11 +59,17 @@ Usage: sql-to-dbsp [options] Input file to compile
       Lenient SQL validation.  If true it allows duplicate column names in a
       view
       Default: false
+    --no-restrict-io
+      Do not restrict the types of columns allowed in tables and views
+      Default: false
     --nowstream
       Implement NOW as a stream (true) or as an internal operator (false)
       Default: false
     --outputsAreSets
       Ensure that outputs never contain duplicates
+      Default: false
+    --plan
+      Emit the Calcite plan of the optimized program instead of Rust
       Default: false
     --streaming
       Compiling a streaming program, where only inserts are allowed
@@ -72,9 +78,6 @@ Usage: sql-to-dbsp [options] Input file to compile
       How unquoted identifiers are treated.  Choices are: 'upper', 'lower',
       'unchanged'
       Default: lower
-    --no-restrict-io
-      Do not restrict the types of columns allowed in tables and views
-      Default: false
     -O
       Optimization level (0, 1, or 2)
       Default: 2
@@ -146,6 +149,9 @@ Here is a description of the non-obvious command-line options:
      `CREATE VIEW V AS SELECT T.COL2 AS TCOL2, S.COL2 AS SCOL2 from T, S`
 
      Using the `--lenient` flag will only emit warnings, but compile such programs.
+
+--plan: Generates a JSON structure for each view compiled, representing the Calcite
+     optimized plan for computing the view
 
 --outputsAreSets: SQL queries can produce outputs that contain duplicates, but
      such outputs are rarely useful in practice.  Using this flag will ensure that


### PR DESCRIPTION
Fixes #2694 
I am not sure that the JSON version of the Calcite plans is actually useful. Perhaps a simple string would be better.
Please note that each view generates a separate plan, so the output is a map from view name to plan.
There is an example of the generated JSON in a test.