### PR TITLE
[manager] Gracefully handling missing stubs.rs.

### DIFF
--- a/crates/pipeline-manager/src/compiler.rs
+++ b/crates/pipeline-manager/src/compiler.rs
@@ -726,10 +726,9 @@ inherits = "release"
                                 })?;
 
                             let stub_path = config.udf_stub_path(pipeline_id);
-                            let stubs = fs::read_to_string(&stub_path).await
-                                .map_err(|e| {
-                                    ManagerError::io_error(format!("reading '{}'", stub_path.display()), e)
-                                })?;
+
+                            // stubs.rs may be missing in an old pipeline compiled without UDF support.
+                            let stubs = fs::read_to_string(&stub_path).await.unwrap_or_default();
 
                             let schema: ProgramSchema = serde_json::from_str(&schema_json)
                                 .map_err(|e| { ManagerError::invalid_program_schema(e.to_string()) })?;


### PR DESCRIPTION
A pipeline compiled with a pre-UDF version of Feldera may not have a stubs.rs file in the source directory.  Handle this situation gracefully by returning an empty string instead of failing the compiler task.