### PR TITLE
[adapters] kafka: workaround ssl.certificate.pem librdkafka issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "serial_test 2.0.0",
+ "sha2",
  "tempfile",
  "test_bin",
  "tokio",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -106,6 +106,7 @@ google-cloud-gax = { version = "0.19.1", optional = true}
 tokio-util = "0.7.11"
 home = "0.5.9"
 datafusion = { version = "41" }
+sha2 = "0.10.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1125,9 +1125,11 @@ impl ControllerInner {
         endpoint_name: &str,
         endpoint_config: &InputEndpointConfig,
     ) -> Result<EndpointId, ControllerError> {
-        let endpoint =
-            input_transport_config_to_endpoint(endpoint_config.connector_config.transport.clone())
-                .map_err(|e| ControllerError::input_transport_error(endpoint_name, true, e))?;
+        let endpoint = input_transport_config_to_endpoint(
+            endpoint_config.connector_config.transport.clone(),
+            endpoint_name,
+        )
+        .map_err(|e| ControllerError::input_transport_error(endpoint_name, true, e))?;
 
         // If `endpoint` is `None`, it means that the endpoint config specifies an integrated
         // input connector.  Such endpoints are instantiated inside `add_input_endpoint`.
@@ -1294,9 +1296,11 @@ impl ControllerInner {
         endpoint_name: &str,
         endpoint_config: &OutputEndpointConfig,
     ) -> Result<EndpointId, ControllerError> {
-        let endpoint =
-            output_transport_config_to_endpoint(endpoint_config.connector_config.transport.clone())
-                .map_err(|e| ControllerError::output_transport_error(endpoint_name, true, e))?;
+        let endpoint = output_transport_config_to_endpoint(
+            endpoint_config.connector_config.transport.clone(),
+            endpoint_name,
+        )
+        .map_err(|e| ControllerError::output_transport_error(endpoint_name, true, e))?;
 
         // If `endpoint` is `None`, it means that the endpoint config specifies an integrated
         // output connector.  Such endpoints are instantiated inside `add_output_endpoint`.

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -158,7 +158,7 @@ where
     )?;
 
     let endpoint =
-        input_transport_config_to_endpoint(config.connector_config.transport.clone())?.unwrap();
+        input_transport_config_to_endpoint(config.connector_config.transport.clone(), "")?.unwrap();
 
     let reader = endpoint.open(
         Box::new(consumer.clone()),

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -268,9 +268,10 @@ config:
 "#
     );
 
-    let endpoint = input_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap())
-        .unwrap()
-        .unwrap();
+    let endpoint =
+        input_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap(), "")
+            .unwrap()
+            .unwrap();
     assert!(endpoint.is_fault_tolerant());
 
     info!("checking initial steps");
@@ -351,9 +352,10 @@ config:
 "#
     );
 
-    let endpoint = input_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap())
-        .unwrap()
-        .unwrap();
+    let endpoint =
+        input_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap(), "")
+            .unwrap()
+            .unwrap();
     assert!(endpoint.is_fault_tolerant());
 
     info!("checking initial steps");
@@ -635,7 +637,7 @@ config:
     );
 
     let mut endpoint =
-        output_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap())
+        output_transport_config_to_endpoint(serde_yaml::from_str(&config_str).unwrap(), "")
             .unwrap()
             .unwrap();
     assert!(endpoint.is_fault_tolerant());
@@ -660,7 +662,7 @@ config:
 "#;
 
     let mut endpoint =
-        output_transport_config_to_endpoint(serde_yaml::from_str(config_str).unwrap())
+        output_transport_config_to_endpoint(serde_yaml::from_str(config_str).unwrap(), "")
             .unwrap()
             .unwrap();
     assert!(endpoint.is_fault_tolerant());

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -1,4 +1,6 @@
-use crate::transport::kafka::{build_headers, kafka_send, rdkafka_loglevel_from, DeferredLogging};
+use crate::transport::kafka::{
+    build_headers, kafka_send, rdkafka_loglevel_from, DeferredLogging, PemToLocation,
+};
 use crate::transport::secret_resolver::MaybeSecret;
 use crate::{AsyncErrorCallback, OutputEndpoint};
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
@@ -83,7 +85,7 @@ pub struct KafkaOutputEndpoint {
 }
 
 impl KafkaOutputEndpoint {
-    pub fn new(mut config: KafkaOutputConfig) -> AnyResult<Self> {
+    pub fn new(mut config: KafkaOutputConfig, endpoint_name: &str) -> AnyResult<Self> {
         // Create Kafka producer configuration.
         config.validate()?;
         debug!("Starting Kafka output endpoint: {config:?}");
@@ -103,6 +105,8 @@ impl KafkaOutputEndpoint {
                 }
             }
         }
+
+        client_config.pem_to_location(endpoint_name)?;
 
         let headers = build_headers(&config.headers);
 

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -83,12 +83,16 @@ pub type AtomicStep = AtomicU64;
 /// Returns `None` if the transport configuration variant is incompatible with an input endpoint.
 pub fn input_transport_config_to_endpoint(
     config: TransportConfig,
+    endpoint_name: &str,
 ) -> AnyResult<Option<Box<dyn TransportInputEndpoint>>> {
     match config {
         TransportConfig::FileInput(config) => Ok(Some(Box::new(FileInputEndpoint::new(config)))),
         #[cfg(feature = "with-kafka")]
         TransportConfig::KafkaInput(config) => match config.fault_tolerance {
-            None => Ok(Some(Box::new(KafkaInputEndpoint::new(config)?))),
+            None => Ok(Some(Box::new(KafkaInputEndpoint::new(
+                config,
+                endpoint_name,
+            )?))),
             Some(_) => Ok(Some(Box::new(KafkaFtInputEndpoint::new(config)?))),
         },
         #[cfg(not(feature = "with-kafka"))]
@@ -125,12 +129,16 @@ pub fn input_transport_config_to_endpoint(
 /// Returns `None` if the transport configuration variant is incompatible with an output endpoint.
 pub fn output_transport_config_to_endpoint(
     config: TransportConfig,
+    endpoint_name: &str,
 ) -> AnyResult<Option<Box<dyn OutputEndpoint>>> {
     match config {
         TransportConfig::FileOutput(config) => Ok(Some(Box::new(FileOutputEndpoint::new(config)?))),
         #[cfg(feature = "with-kafka")]
         TransportConfig::KafkaOutput(config) => match config.fault_tolerance {
-            None => Ok(Some(Box::new(KafkaOutputEndpoint::new(config)?))),
+            None => Ok(Some(Box::new(KafkaOutputEndpoint::new(
+                config,
+                endpoint_name,
+            )?))),
             Some(_) => Ok(Some(Box::new(KafkaFtOutputEndpoint::new(config)?))),
         },
         _ => Ok(None),

--- a/docs/connectors/sinks/kafka.md
+++ b/docs/connectors/sinks/kafka.md
@@ -36,6 +36,64 @@ WITH (
 )
 ```
 
+### Authentication & Encryption
+
+#### SSL with PEM keys
+
+```json
+"config": {
+    "bootstrap.servers": "example.com:9092",
+    "auto.offset.reset": "earliest",
+    "topic": "book-fair-sales",
+    "security.protocol": "SSL",
+    "ssl.ca.pem": "-----BEGIN CERTIFICATE-----TOPSECRET0\n-----END CERTIFICATE-----\n",
+    "ssl.key.pem": "-----BEGIN CERTIFICATE-----TOPSECRET1\n-----END CERTIFICATE-----\n",
+    "ssl.certificate.pem": "-----BEGIN CERTIFICATE-----TOPSECRET2\n-----END CERTIFICATE-----\n",
+}
+```
+
+PEM-encoded certificates can be passed directly in the configuration using
+`ssl.*.pem` keys.
+
+During development, we encountered an issue with `librdkafka` where the SSL
+handshake fails if the certificate PEM string contain more than one certificate.
+
+Feldera circumvents this issue as follows:
+
+###### Issue with librdkafka
+
+librdkafka only accepts multiple certificates when provided via
+`ssl.certificate.location` keys (file paths) rather than directly
+with `ssl.certificate.pem`.
+
+This is documented in
+[librdkafka issue #3225](https://github.com/confluentinc/librdkafka/issues/3225).
+
+##### Feldera's Approach
+
+To work around this limitation, Feldera handles PEM-encoded certificates and
+keys by:
+
+1. Storing the value passed to `ssl.certificate.pem` into a file.
+2. Naming the file using the SHA256 hash of the data.
+3. Replacing the `ssl.certificate.pem` configuration option with
+   `ssl.certificate.location` option that points to the newly saved file.
+
+**Example:**
+
+The updated configuration would look like:
+
+```json
+"config": {
+    ...,
+    "ssl.certificate.location": "path/to/certificate.pem"
+}
+```
+
+> :warning: If both `ssl.certificate.pem` and `ssl.certificate.location` are set
+the latter will be overwritten.
+
+
 ## Additional resources
 
 For more information, see:


### PR DESCRIPTION
Workaround around: https://github.com/confluentinc/librdkafka/issues/3225

Modifies kafka options `ssl.*.pem` to `ssl.*.location`, saves the PEM keys to a file named after their SHA256 hash and the file path to this file is set as the value for this option.