### PR TITLE
[SQL] tumble windows on nullable timestamps

### DIFF
--- a/python/tests/aggregate_tests/test_varchar_max.py
+++ b/python/tests/aggregate_tests/test_varchar_max.py
@@ -4,58 +4,64 @@ from .aggtst_base import TstView
 class aggtst_varchar_max_value(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': 'hello', 'c2': 'variable-length'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max AS SELECT
+        self.data = [{"c1": "hello", "c2": "variable-length"}]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max AS SELECT
                       MAX(c1) AS c1, MAX(c2) AS c2
-                      FROM varchar_tbl'''
-                      
-                      
+                      FROM varchar_tbl"""
+
+
 class aggtst_varchar_max_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': 'hello', 'c2': 'fred'},
-                     {'id': 1, 'c1': 'hello', 'c2': 'variable-length'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max_gby AS SELECT
+        self.data = [
+            {"id": 0, "c1": "hello", "c2": "fred"},
+            {"id": 1, "c1": "hello", "c2": "variable-length"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max_gby AS SELECT
                       id, MAX(c1) AS c1, MAX(c2) AS c2
                       FROM varchar_tbl
-                      GROUP BY id'''
+                      GROUP BY id"""
 
 
 class aggtst_varchar_max_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': 'hello', 'c2': 'variable-length'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max_distinct AS SELECT
+        self.data = [{"c1": "hello", "c2": "variable-length"}]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max_distinct AS SELECT
                       MAX(DISTINCT c1) AS c1, MAX(DISTINCT c2) AS c2
-                      FROM varchar_tbl'''
-                      
-                      
+                      FROM varchar_tbl"""
+
+
 class aggtst_varchar_max_distinct_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': 'hello', 'c2': 'fred'},
-                     {'id': 1, 'c1': 'hello', 'c2': 'variable-length'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max_distinct_gby AS SELECT
+        self.data = [
+            {"id": 0, "c1": "hello", "c2": "fred"},
+            {"id": 1, "c1": "hello", "c2": "variable-length"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max_distinct_gby AS SELECT
                       id, MAX(DISTINCT c1) AS c1, MAX(DISTINCT c2) AS c2
                       FROM varchar_tbl
-                      GROUP BY id'''
-                      
-                      
+                      GROUP BY id"""
+
+
 class aggtst_varchar_max_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': 'hello', 'c2': 'fred'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max_where AS SELECT
+        self.data = [{"c1": "hello", "c2": "fred"}]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max_where AS SELECT
                       MAX(c1) FILTER(WHERE len(c1)>4) AS c1, MAX(c2) FILTER(WHERE len(c1)>4) AS c2
-                      FROM varchar_tbl'''
-                      
-                      
+                      FROM varchar_tbl"""
+
+
 class aggtst_varchar_max_where_gby(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'id': 0, 'c1': 'hello', 'c2': 'fred'},
-                     {'id': 1, 'c1': 'hello', 'c2': 'exampl e'}]
-        self.sql = '''CREATE MATERIALIZED VIEW varchar_max_where_gby AS SELECT
+        self.data = [
+            {"id": 0, "c1": "hello", "c2": "fred"},
+            {"id": 1, "c1": "hello", "c2": "exampl e"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW varchar_max_where_gby AS SELECT
                       id, MAX(c1) FILTER(WHERE len(c1)>4) AS c1, MAX(c2) FILTER(WHERE len(c1)>4) AS c2
                       FROM varchar_tbl
-                      GROUP BY id'''
+                      GROUP BY id"""

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -92,6 +92,7 @@ public class RustSqlRuntimeLibrary {
         this.dateFunctions.put("is_distinct", DBSPOpcode.IS_DISTINCT);
         this.dateFunctions.put("agg_max", DBSPOpcode.AGG_MAX);
         this.dateFunctions.put("agg_min", DBSPOpcode.AGG_MIN);
+        this.dateFunctions.put("agg_lte", DBSPOpcode.AGG_LTE);
         this.dateFunctions.put("agg_gte", DBSPOpcode.AGG_GTE);
         this.dateFunctions.put("gte_left", DBSPOpcode.GTE_LEFT);
         this.dateFunctions.put("min", DBSPOpcode.MIN);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -442,6 +442,14 @@ public class Simplify extends InnerRewriteVisitor {
                     result = cast.source;
                 }
             }
+        } else if (expression.operation == DBSPOpcode.NOT) {
+            if (source.is(DBSPBoolLiteral.class)) {
+                DBSPBoolLiteral b = source.to(DBSPBoolLiteral.class);
+                if (b.value == null)
+                    result = b;
+                else
+                    result = new DBSPBoolLiteral(expression.getNode(), expression.getType(), !b.value);
+            }
         }
         this.map(expression, result.cast(expression.getType()));
         return VisitDecision.STOP;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -91,8 +91,15 @@ public abstract class DBSPExpression
 
     /** Unwrap an expression with a nullable type */
     public DBSPExpression unwrap() {
-        assert this.type.mayBeNull;
+        assert this.type.mayBeNull : "Unwrapping non-nullable type";
         return new DBSPUnwrapExpression(this);
+    }
+
+    /** Unwrap an expression if the type is nullable */
+    public DBSPExpression unwrapIfNullable() {
+        if (this.type.mayBeNull)
+            return this.unwrap();
+        return this;
     }
 
     public DBSPExpressionStatement toStatement() {


### PR DESCRIPTION
A tumble window on a nullable timestamp needs to filter out null timestamps first.
For some unexplained reason we never tested this case.