### PR TITLE
[WebConsole] Terminate logs streaming HTTP request…

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
+++ b/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { scale } from 'svelte/transition'
+  import { useSkeletonTheme } from '$lib/compositions/useSkeletonTheme.svelte'
 
   let { rows }: { rows: string[] } = $props()
+
+  const theme = useSkeletonTheme()
 
   let ref = $state<HTMLElement>(undefined!)
 
@@ -23,7 +26,8 @@
 <div class="relative h-full bg-white dark:bg-black">
   <div
     onscroll={(e) => (x = e.currentTarget.scrollTop)}
-    class="h-full -scale-y-100 gap-4 overflow-y-auto p-2 font-mono"
+    class="h-full -scale-y-100 gap-4 overflow-y-auto p-2"
+    style="font-family: {theme.config.monospaceFontFamily};"
     use:invertScrollY
     bind:this={ref}
   >

--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -98,6 +98,7 @@
   import { parseUTF8JSON } from '$lib/functions/pipelines/changeStream'
   import JSONbig from 'true-json-bigint'
   import { groupBy } from '$lib/functions/common/array'
+  import { untrack } from 'svelte'
 
   let { pipeline }: { pipeline: { current: ExtendedPipeline } } = $props()
 
@@ -127,7 +128,7 @@
 
   $effect(() => {
     void pipeline.current
-    setTimeout(() => reloadSchema(pipelineName, pipeline.current))
+    untrack(() => reloadSchema(pipelineName, pipeline.current))
   })
 
   let inputs = $derived(

--- a/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -199,19 +199,25 @@ export const parseUTF8AsTextLines = (
   onValue: (value: string) => void,
   onDone?: () => void
 ) => {
+  let reader = stream.getReader()
   queueMicrotask(async () => {
-    for await (let line of makeUTF8LineIterator(stream, onDone)) {
+    for await (let line of makeUTF8LineIterator(reader, onDone)) {
       onValue(line)
     }
   })
   return {
-    cancel: () => stream.cancel()
+    cancel: () => {
+      reader.cancel()
+      stream.cancel()
+    }
   }
 }
 
-async function* makeUTF8LineIterator(stream: ReadableStream<Uint8Array>, onDone?: () => void) {
+async function* makeUTF8LineIterator(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  onDone?: () => void
+) {
   const utf8Decoder = new TextDecoder('utf-8')
-  let reader = stream.getReader()
   let readerDone = false
   let res = await reader.read()
   readerDone = res.done


### PR DESCRIPTION
…when leaving the Logs tab or switching pipeline.

Inspired by https://github.com/feldera/feldera/issues/2735.
There is no reason to keep the log stream HTTP request alive when switching the pipeline or leaving the tab since the log history is being provided by backend.