### PR TITLE
[WebConsole] Temporary fix for corrupted code editor state

### DIFF
--- a/web-console/src/routes/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.svelte
+++ b/web-console/src/routes/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.svelte
@@ -40,6 +40,11 @@
     () => data.preloadedPipeline,
     () => goto(`${base}/`)
   )
+
+  $effect(() => {
+    // TODO: fix https://github.com/feldera/feldera/issues/2740
+    return () => window.location.reload()
+  })
 </script>
 
 <PipelineEditLayout {pipeline}></PipelineEditLayout>


### PR DESCRIPTION
Temporary fix for https://github.com/feldera/feldera/issues/2740 : Code from a deleted pipeline shows up in a different pipeline

Steps to reproduce:
- Reload the page
- Click between any pipelines, note the visited pipelines
- Go to home page (click on Feldera logo)
- Click on any non-visited pipeline: the code is as expected
- Click on any visited pipeline: the code is from the last pipeline before going to home page

Proper fix is in progress