### PR TITLE
[dbsp] Chain aggregate operator.

### DIFF
--- a/crates/dbsp/src/operator/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/chain_aggregate.rs
@@ -1,0 +1,54 @@
+use std::mem;
+
+use crate::{
+    dynamic::{DowncastTrait, DynData},
+    trace::BatchReaderFactories,
+    DBData, OrdIndexedZSet, RootCircuit, Stream, ZWeight,
+};
+
+impl<K, V> Stream<RootCircuit, OrdIndexedZSet<K, V>>
+where
+    K: DBData,
+    V: DBData,
+{
+    /// Aggregate whose value depends on the previous value of the aggregate
+    /// and changes to the input collection.
+    ///
+    /// Unlike general aggregates, such aggregates don't require storing the integral
+    /// of the input collection and hence require only O(1) memory per key.
+    ///
+    /// Examples include min and max over append-only collections.
+    ///
+    /// # Arguments
+    ///
+    /// * `finit` - returns the initial value of the aggregate.
+    /// * `fupdate` - updates the aggregate given its previous value and a
+    ///   new element of the group.
+    pub fn chain_aggregate<A, FInit, FUpdate>(
+        &self,
+        finit: FInit,
+        fupdate: FUpdate,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<K, A>>
+    where
+        A: DBData,
+        FInit: Fn(&V, ZWeight) -> A + 'static,
+        FUpdate: Fn(A, &V, ZWeight) -> A + 'static,
+    {
+        let input_factories = BatchReaderFactories::new::<K, V, ZWeight>();
+        let output_factories = BatchReaderFactories::new::<K, A, ZWeight>();
+
+        self.inner()
+            .dyn_chain_aggregate(
+                &input_factories,
+                &output_factories,
+                Box::new(move |acc: &mut DynData, v: &DynData, w: ZWeight| unsafe {
+                    *acc.downcast_mut() = finit(v.downcast(), w)
+                }),
+                Box::new(move |acc: &mut DynData, v: &DynData, w: ZWeight| unsafe {
+                    *acc.downcast_mut() =
+                        fupdate(mem::take(acc.downcast_mut::<A>()), v.downcast(), w)
+                }),
+            )
+            .typed()
+    }
+}

--- a/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
@@ -1,0 +1,245 @@
+use std::{borrow::Cow, cmp::Ordering, marker::PhantomData};
+
+use dyn_clone::clone_box;
+use minitrace::trace;
+
+use crate::{
+    algebra::IndexedZSet,
+    circuit::operator_traits::{BinaryOperator, Operator},
+    dynamic::{ClonableTrait, Erase},
+    operator::dynamic::trace::{TraceBounds, TraceFeedback},
+    trace::{BatchReader, BatchReaderFactories, Builder, Cursor, Spine},
+    Circuit, RootCircuit, Scope, Stream, ZWeight,
+};
+
+impl<Z> Stream<RootCircuit, Z>
+where
+    Z: IndexedZSet,
+{
+    /// See [Stream::chain_aggregate].
+    pub fn dyn_chain_aggregate<OZ>(
+        &self,
+        input_factories: &Z::Factories,
+        output_factories: &OZ::Factories,
+        finit: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+        fupdate: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+    ) -> Stream<RootCircuit, OZ>
+    where
+        OZ: IndexedZSet<Key = Z::Key>,
+    {
+        // ```
+        //  stream ┌──────────────┐   output   ┌──────────────────┐
+        // ───────►│ChainAggregate├────────────┤UntimedTraceAppend├───┐
+        //         └──────────────┘            └──────────────────┘   │
+        //                ▲                          ▲                │
+        //                │        delayed_trace   ┌─┴──┐             │
+        //                └────────────────────────┤Z^-1│◄────────────┘
+        //                                         └────┘
+        // ```
+
+        let circuit = self.circuit();
+        let stream = self.dyn_shard(input_factories);
+
+        let bounds = TraceBounds::unbounded();
+
+        let feedback = circuit.add_integrate_trace_feedback::<Spine<OZ>>(output_factories, bounds);
+
+        let output = circuit
+            .add_binary_operator(
+                ChainAggregate::new(output_factories, finit, fupdate),
+                &stream,
+                &feedback.delayed_trace,
+            )
+            .mark_sharded();
+
+        feedback.connect(&output);
+
+        output
+    }
+}
+
+struct ChainAggregate<Z, OZ>
+where
+    Z: IndexedZSet,
+    OZ: IndexedZSet,
+{
+    output_factories: OZ::Factories,
+    finit: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+    fupdate: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+    _phantom: PhantomData<(Z, OZ)>,
+}
+
+impl<Z, OZ> ChainAggregate<Z, OZ>
+where
+    Z: IndexedZSet,
+    OZ: IndexedZSet,
+{
+    fn new(
+        output_factories: &OZ::Factories,
+        finit: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+        fupdate: Box<dyn Fn(&mut OZ::Val, &Z::Val, ZWeight)>,
+    ) -> Self {
+        Self {
+            output_factories: output_factories.clone(),
+            finit,
+            fupdate,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Z, OZ> Operator for ChainAggregate<Z, OZ>
+where
+    Z: IndexedZSet,
+    OZ: IndexedZSet,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("ChainAggregate")
+    }
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+impl<Z, OZ> BinaryOperator<Z, Spine<OZ>, OZ> for ChainAggregate<Z, OZ>
+where
+    Z: IndexedZSet,
+    OZ: IndexedZSet<Key = Z::Key>,
+{
+    #[trace]
+    fn eval<'a>(&mut self, delta: &Z, output_trace: &Spine<OZ>) -> OZ {
+        let mut delta_cursor = delta.cursor();
+        let mut output_trace_cursor = output_trace.cursor();
+
+        let mut builder = OZ::Builder::with_capacity(&self.output_factories, (), delta.len());
+
+        let mut old = self.output_factories.val_factory().default_box();
+        let mut new = self.output_factories.val_factory().default_box();
+
+        while delta_cursor.key_valid() {
+            let mut key = clone_box(delta_cursor.key());
+            let mut retract = false;
+
+            output_trace_cursor.seek_key(&key);
+
+            // Read the current value of the aggregate, be careful to skip entries with weight 0.
+            if output_trace_cursor.key_valid() && output_trace_cursor.key() == key.as_ref() {
+                while output_trace_cursor.val_valid() {
+                    if **output_trace_cursor.weight() == 0 {
+                        output_trace_cursor.step_val();
+                    } else {
+                        output_trace_cursor.val().clone_to(&mut old);
+                        retract = true;
+                        break;
+                    }
+                }
+            };
+
+            // If there is an existing value, start from it, otherwise start from finit().
+            if retract {
+                old.clone_to(&mut new);
+            } else {
+                let w = **delta_cursor.weight();
+                (self.finit)(&mut new, delta_cursor.val(), w);
+                delta_cursor.step_val();
+            }
+
+            // Iterate over new values.
+            while delta_cursor.val_valid() {
+                let w = **delta_cursor.weight();
+                (self.fupdate)(&mut new, delta_cursor.val(), w);
+                delta_cursor.step_val();
+            }
+
+            // Apply retraction and insertion in correct order.
+            if retract {
+                match new.cmp(&old) {
+                    Ordering::Less => {
+                        builder.push_refs(&key, &new, (1 as ZWeight).erase());
+                        builder.push_vals(&mut key, &mut old, (-1 as ZWeight).erase_mut());
+                    }
+                    Ordering::Greater => {
+                        builder.push_refs(&key, &old, (-1 as ZWeight).erase());
+                        builder.push_vals(&mut key, &mut new, (1 as ZWeight).erase_mut());
+                    }
+                    _ => (),
+                }
+                // do nothing if new == old.
+            } else {
+                builder.push_vals(&mut key, &mut new, 1.erase_mut());
+            }
+
+            delta_cursor.step_key();
+        }
+        builder.done()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{cmp::min, i32};
+
+    use crate::{
+        circuit::CircuitConfig, operator::Min, utils::Tup2, OrdIndexedZSet, OutputHandle,
+        RootCircuit, Runtime, ZSetHandle, ZWeight,
+    };
+    use proptest::{collection, prelude::*};
+
+    fn min_test_circuit(
+        circuit: &mut RootCircuit,
+    ) -> (
+        ZSetHandle<Tup2<u64, i32>>,
+        OutputHandle<OrdIndexedZSet<u64, String>>,
+        OutputHandle<OrdIndexedZSet<u64, String>>,
+    ) {
+        let (input, input_handle) = circuit.add_input_zset::<Tup2<u64, i32>>();
+
+        let input_indexed = input.map_index(|Tup2(x, y)| (*x, *y));
+        let aggregate = input_indexed
+            .aggregate(Min)
+            .map_index(|(x, y)| (*x, y.to_string()))
+            .output();
+        let delta_aggregate = input_indexed
+            .chain_aggregate(|v, _w| *v, |acc, i, _w| min(acc, *i))
+            .map_index(|(x, y)| (*x, y.to_string()))
+            .output();
+
+        (input_handle, aggregate, delta_aggregate)
+    }
+
+    pub fn test_input(
+        num_keys: u64,
+        max_val: i32,
+        max_tuples: usize,
+    ) -> impl Strategy<Value = Vec<Tup2<Tup2<u64, i32>, ZWeight>>> {
+        collection::vec(
+            (
+                (0..num_keys, -max_val..max_val).prop_map(|(x, y)| Tup2(x, y)),
+                1..=2i64,
+            )
+                .prop_map(|(x, y)| Tup2(x, y)),
+            0..max_tuples,
+        )
+    }
+
+    pub fn test_inputs() -> impl Strategy<Value = Vec<Vec<Tup2<Tup2<u64, i32>, ZWeight>>>> {
+        collection::vec(test_input(20, 1000, 30), 0..10)
+    }
+
+    proptest! {
+        #[test]
+        fn chain_aggregate_min_test(inputs in test_inputs()) {
+            let (mut dbsp, (input, aggregate, delta_aggregate)) =
+                Runtime::init_circuit(CircuitConfig::with_workers(4), |circuit| {
+                    Ok(min_test_circuit(circuit))
+                })
+                .unwrap();
+
+            for mut batch in inputs.into_iter() {
+                input.append(&mut batch);
+                dbsp.step().unwrap();
+                assert_eq!(aggregate.consolidate(), delta_aggregate.consolidate());
+            }
+        }
+    }
+}

--- a/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 mod aggregator;
 // Some standard aggregators.
 mod average;
+mod chain_aggregate;
 mod fold;
 mod max;
 mod min;
@@ -285,7 +286,7 @@ where
         aggregator: &dyn DynAggregator<Z::Val, (), Z::R, Accumulator = Acc, Output = Out>,
     ) -> Stream<C, OrdIndexedZSet<Z::Key, Out>>
     where
-        Z: IndexedZSet + Send,
+        Z: IndexedZSet,
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
     {
@@ -301,7 +302,7 @@ where
     where
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
-        Z: Batch<Time = ()> + Send,
+        Z: Batch<Time = ()>,
         O: IndexedZSet<Key = Z::Key, Val = Out>,
     {
         self.circuit()
@@ -370,7 +371,7 @@ where
     where
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
-        Z: IndexedZSet + Send,
+        Z: IndexedZSet,
     {
         self.dyn_aggregate_generic::<Acc, Out, OrdIndexedZSet<Z::Key, Out>>(factories, aggregator)
     }
@@ -390,7 +391,7 @@ where
     where
         Acc: DataTrait + ?Sized,
         Out: DataTrait + ?Sized,
-        Z: Batch<Time = ()> + Send,
+        Z: Batch<Time = ()>,
         O: IndexedZSet<Key = Z::Key, Val = Out>,
     {
         let circuit = self.circuit();
@@ -796,7 +797,7 @@ impl<Z, IT, Acc, Out, Clk> Operator for AggregateIncremental<Z, IT, Acc, Out, Cl
 where
     Clk: WithClock<Time = IT::Time> + 'static,
     Z: BatchReader,
-    IT: BatchReader + 'static,
+    IT: BatchReader,
     Acc: DataTrait + ?Sized,
     Out: DataTrait + ?Sized,
 {
@@ -943,7 +944,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use anyhow::Result as AnyResult;
 
     use std::{
@@ -1119,7 +1120,7 @@ mod test {
     const MAX_VAL: i64 = 3;
     const MAX_TUPLES: usize = 8;
 
-    fn test_zset() -> impl Strategy<Value = TestZSet> {
+    pub fn test_zset() -> impl Strategy<Value = TestZSet> {
         collection::vec(
             (
                 (0..NUM_KEYS, -MAX_VAL..MAX_VAL).prop_map(|(x, y)| Tup2(x, y)),
@@ -1137,7 +1138,7 @@ mod test {
             )
         })
     }
-    fn test_input() -> impl Strategy<Value = Vec<Vec<TestZSet>>> {
+    pub fn test_input() -> impl Strategy<Value = Vec<Vec<TestZSet>>> {
         collection::vec(
             collection::vec(test_zset(), 0..MAX_ITERATIONS),
             0..MAX_ROUNDS,

--- a/crates/dbsp/src/operator/dynamic/group/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/group/mod.rs
@@ -368,8 +368,8 @@ where
 
 impl<B, OB, T, OT> Operator for GroupTransform<B, OB, T, OT>
 where
-    B: IndexedZSet + 'static,
-    OB: IndexedZSet + 'static,
+    B: IndexedZSet,
+    OB: IndexedZSet,
     T: 'static,
     OT: 'static,
 {

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -31,6 +31,7 @@ mod z1;
 mod aggregate;
 mod asof_join;
 mod average;
+pub mod chain_aggregate;
 mod consolidate;
 mod distinct;
 pub mod dynamic;


### PR DESCRIPTION
Introduce a specialized operator that computes an aggregate whose value depends on the previous value of the aggregate and changes to the input collection.  Unlike general aggregates, such aggregates don't require storing the integral of the input collection and hence require only O(1) memory per key, similar to linear aggregates.

Examples include min and max over append-only collections.