### PR TITLE
docs: make the user-relevant sections of the documentation more prominent

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,18 +1,46 @@
-# Docker Install
+# Docker
 
 These instructions explain how to run Feldera on a single machine
 in a configuration suitable for demos, development, and testing.  For production
-use, or for developing parts of Feldera itself, Feldera
-supports other forms of deployment.
+use, check out [Feldera Enterprise](/enterprise).
 
-## Install prerequisites
+## Docker Quickstart
 
-To run the demo, you will first need to install Docker and the Docker
-Compose plugin.  If you don't already have them, install them one of
-these ways:
+```
+docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:0.28.0
+```
 
-* On Mac OS, Windows, or Linux, install [Docker Desktop][1], which
-  includes the Docker Compose plugin. If you're on Apple Silicon,
+Once you see the Feldera logo on your terminal, go ahead and open the Web Console
+at `http://localhost:8080` and try out one of our pre-packaged demo pipelines.
+
+## Optional: Docker Compose Quickstart
+
+We also make a Docker Compose file available. It's useful if you want to use
+Feldera with auxiliary services included in the Docker Compose file
+like Redpanda, Prometheus and Grafana.
+
+```
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+docker compose -f - up
+```
+
+You can enable specific services from the Docker Compose file as follows:
+
+```
+curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+docker compose -f - up pipeline-manager redpanda
+```
+
+Similar to the previous section, once you see the Feldera logo on your
+terminal, go ahead and open the Web Console at `http://localhost:8080` and try
+out one of our pre-packaged demo pipelines.
+
+## Installing Docker
+
+If you don't already have Docker or Docker Compose installed, follow one of these steps first:
+
+* On Mac OS, Windows, or Linux, install [Docker Desktop][1]. 
+  If you're on Apple Silicon,
   we recommend [enabling Rosetta](https://docs.docker.com/desktop/settings/mac/#use-rosetta-for-x86amd64-emulation-on-apple-silicon)
   for x86/amd64 emulation.
 
@@ -45,105 +73,3 @@ You also need `curl` and a web browser such as Chrome or Firefox.
 [3]: https://docs.docker.com/compose/install/linux
 [4]: https://docs.docker.com/engine/install/linux-postinstall/
 
-## Start the demo
-
-1. Download the `docker-compose.yml` file that tells Docker Compose
-   how to set up the demo's containers:
-
-   ```bash
-   curl -LO https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml
-   ```
-
-   You only need to do this the first time.
-
-   :::caution
-
-   This will replace any existing file named `docker-compose.yml` in
-   the current directory.
-
-   :::
-
-2. Launch containers for the demo, including the pipeline manager,
-   Postgres to support it, and a SecOps demo that uses Redpanda.  From
-   the directory where you ran the command above:
-
-   ```bash
-   docker compose --profile demo up
-   ```
-
-   This command takes over the terminal where you run it as long as
-   the demo is active.  It will print a lot of log messages,
-   which can be useful for debugging if something goes wrong but which
-   otherwise are not important.
-
-   The first time you run this command, it will download container
-   images, which can take a while.  Once `docker compose` begins
-   bringing up the images, it takes about 10 seconds for the Feldera user
-   interface to become available.  On fast systems, this includes a
-   pause of a few seconds in which nothing is logged.
-
-3. Visit `http://localhost:8080/` in your web browser to bring up the
-   Feldera Console UI.
-
-4. Try out one of the [demos](demo/).
-
-## Stop the demo
-
-To shut down the demo, type <kbd>Ctrl+C</kbd> in the terminal
-where `docker compose` is running.  Docker Compose will show its
-progress as it shuts down each of the containers in turn.  It can take
-up to about 15 seconds to complete shutdown.
-
-## Restart the demo
-
-If you start and then stop the demo as described above, you can
-restart it a few different ways:
-
-* To restart it without changes, run:
-
-   ```bash
-   docker compose up
-   ```
-
-* Run this command to reload the demo afresh, while discarding all
-  additional programs, connectors and pipelines you've added:
-
-   ```bash
-   docker compose --profile demo up
-   ```
-
-* Run this command to upgrade to a new version of the demo, while
-  discarding all additional programs, connectors and pipelines you've
-  added:
-
-  ```bash
-  docker compose --profile demo up --pull always --force-recreate -V
-  ```
-
-## Troubleshooting
-
-If the demo fails to start after it previously ran successfully, then
-it might not have fully shut down from the previous run. To ensure
-that it is fully shut down, run the following command, and then try
-starting it again:
-
-```bash
-docker compose --profile demo down
-```
-
-If starting the demo fails with `bind: address already in use`, then
-something on your machine is already listening on one of the ports
-required for the demo.  The message should say the particular port.
-To correct the problem, find and stop the process listening on the
-port, or edit a copy of `docker-compose.yml` to use a different port
-number.
-
-## Development
-
-If you would like to build and run Feldera from source check out the
-[Development workflow](contributors/dev-flow) guide.
-
-## Testing
-You can contribute by reading the guides and expanding test coverage
-for the following Feldera components:
-- [WebConsole](contributors/ui-testing)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,7 +39,7 @@ out one of our pre-packaged demo pipelines.
 
 If you don't already have Docker or Docker Compose installed, follow one of these steps first:
 
-* On Mac OS, Windows, or Linux, install [Docker Desktop][1]. 
+* On Mac OS, Windows, or Linux, install [Docker Desktop][1].
   If you're on Apple Silicon,
   we recommend [enabling Rosetta](https://docs.docker.com/desktop/settings/mac/#use-rosetta-for-x86amd64-emulation-on-apple-silicon)
   for x86/amd64 emulation.

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -1,17 +1,25 @@
 # Feldera Enterprise
 
 Feldera Enterprise is our commercial offering aimed at production use.
-It is designed such that you can bring your own cloud, on which you deploy Feldera.
+It let's you bring your own cloud or Kubernetes Cluster, 
+on which you deploy Feldera. Your data never leaves your premises.
+
+Feldera Enterprise adds
+[features](https://www.feldera.com/pricing) that are not available in the
+Docker offering. This includes multi-node clusters, pipeline and control plane
+fault-tolerance, pipeline resource isolation, pipeline scale-out (coming soon),
+and dedicated support.
+
 The documentation we provide here is publicly available, both to guide
 our existing customers and to provide insight to interested parties.
-Feldera Enterprise installation is only possible with a license key.
-Please contact us at `learnmore@feldera.com` if you are interested to learn
-more or would like to try out Feldera Enterprise. We'd be happy to get you started!
+
+Using Feldera Enterprise is only possible with a license key.
+Please [contact sales](https://calendly.com/d/cn7m-grv-mzm/feldera-demo) if you
+are interested.
 
 :::tip
-Don't forget to first try out the [Docker demo container](/docker), which requires
-no license key. The Docker demo already showcases many of Feldera's features.
-This documentation is about setting up a distributed cloud deployment.
+You can try a Feldera Enterprise instance by visiting
+our [free online sandbox](https://try.feldera.com`).
 :::
 
 ## Overview
@@ -19,10 +27,3 @@ This documentation is about setting up a distributed cloud deployment.
 1. [**Quickstart**](quickstart.md)
 2. [**Helm guide**](helm-guide.md)
 3. [**Kubernetes guides**](kubernetes-guides)
-
-## Supported cloud providers
-
-We currently support Amazon AWS. We are planning to expand our support
-offering to other cloud providers such as GCP and Azure. Please reach out
-if you are interested, we would be happy to hear more about how we can
-facilitate your use case.

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -1,7 +1,7 @@
 # Feldera Enterprise
 
 Feldera Enterprise is our commercial offering aimed at production use.
-It let's you bring your own cloud or Kubernetes Cluster, 
+It let's you bring your own cloud or Kubernetes Cluster,
 on which you deploy Feldera. Your data never leaves your premises.
 
 Feldera Enterprise adds

--- a/docs/enterprise/quickstart.md
+++ b/docs/enterprise/quickstart.md
@@ -4,7 +4,7 @@ Brief instructions explaining how to install and run Feldera Enterprise
 in a Kubernetes cluster.
 
 1. **License:** [contact sales](https://calendly.com/d/cn7m-grv-mzm/feldera-demo) to obtain a Feldera account ID and license key.
-   
+
 2. **Installation using Helm:**
    ```bash
    ACCOUNT_ID="00000000-0000-0000-0000-000000000000"  # Set to own

--- a/docs/enterprise/quickstart.md
+++ b/docs/enterprise/quickstart.md
@@ -3,9 +3,8 @@
 Brief instructions explaining how to install and run Feldera Enterprise
 in a Kubernetes cluster.
 
-1. **License:** obtain a Feldera account id and license key
-   (reach out to `learnmore@feldera.com`)
-
+1. **License:** [contact sales](https://calendly.com/d/cn7m-grv-mzm/feldera-demo) to obtain a Feldera account ID and license key.
+   
 2. **Installation using Helm:**
    ```bash
    ACCOUNT_ID="00000000-0000-0000-0000-000000000000"  # Set to own

--- a/docs/interact/index.mdx
+++ b/docs/interact/index.mdx
@@ -1,0 +1,41 @@
+# Feldera Interface
+
+There are four different ways to interact with Feldera. All methods allow users to define and run pipelines,
+monitor their performance and interact with materialized tables, views and change streams. 
+
+```mdx-code-block
+import Link from '@docusaurus/Link';
+
+<div className="card">
+  <div className="card__body">
+    <h3>
+      <Link to="/concepts">Web Console</Link>
+    </h3>
+    <p>The Web Console is the most convenient starting point to using Feldera. Simply aim your web browser at a running Feldera instance (and authenticate if required). This is typically `localhost:8080` if you are using our Docker instance or `try.feldera.com` if you are using our public cloud sandbox.</p>
+  </div>
+</div>
+<div className="card">
+  <div className="card__body">
+    <h3>
+      <Link to="/reference/cli">Commandline Interface (`fda`)</Link>
+    </h3>
+    <p>`fda` allows users to interact with a Feldera instances from the CLI. It also provides a shell that makes it convenient to issue ad-hoc queries and start/stop pipelines.</p>
+  </div>
+</div>
+<div className="card">
+  <div className="card__body">
+    <h3>
+      <Link to="/python/index.html">Python SDK</Link>
+    </h3>
+    <p>The Python SDK provides a convenient wrapper around our REST API. It allows you to programmatically define pipelines.</p>
+  </div>
+</div>
+<div className="card">
+  <div className="card__body">
+    <h3>
+      <Link to="/api">REST API</Link>
+    </h3>
+    <p>All the above methods interact with Feldera using the REST API. This is intended for users who would like to build their own automation to Feldera. `Pipeline` is the most important API type. </p>
+  </div>
+</div>
+```

--- a/docs/interact/index.mdx
+++ b/docs/interact/index.mdx
@@ -1,7 +1,7 @@
 # Feldera Interface
 
 There are four different ways to interact with Feldera. All methods allow users to define and run pipelines,
-monitor their performance and interact with materialized tables, views and change streams. 
+monitor their performance and interact with materialized tables, views and change streams.
 
 ```mdx-code-block
 import Link from '@docusaurus/Link';

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,4 +1,4 @@
-# Command line utility (fda)
+# Command line tool (fda)
 
 `fda` is a command line utility for interacting with the Feldera Manager's REST API.
 It allows you to create, manage, and monitor pipelines. It also features an interactive

--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -1,3 +1,5 @@
 # REST API
 
-Automatically-generated documentation for our [REST APIs](../../../api).
+The Web Console, CLI and the python SDK are all built on top of the Feldera
+REST API. Please refer to the
+automatically generated [API documentation](../../../api).

--- a/docs/reference/web-console.md
+++ b/docs/reference/web-console.md
@@ -1,0 +1,6 @@
+# Web Console
+
+The Web Console is the most convenient starting point to using Feldera. Simply
+aim your web browser at a running Feldera instance (and authenticate if
+required). This is typically `localhost:8080` if you are using our Docker
+instance or [try.feldera.com](try.feldera.com) if you are using our public cloud sandbox.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,13 +1,8 @@
-# Feldera Cloud Sandbox
+# Feldera Sandbox
 
-Feldera maintains an [online sandbox](https://try.feldera.com) where you can try tutorials and
-demos to help you learn about Feldera's product and features, without
+Feldera maintains a free [online sandbox](https://try.feldera.com) where you can try tutorials and
+demos to learn about Feldera's features, without
 having to install anything yourself.
-
-Inside the sandbox, you can pick any demo that suits your situation.
-Each demo is a pre-built configuration consisting of a SQL program
-that runs in a pipeline.  Each pipeline receives input rows into
-tables and automatically generates results from the views.
 
 The sandbox automatically shuts down a pipeline after 24 hours of
 runtime.  We will occasionally refresh the deployment, which may

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -15,10 +15,9 @@
 const sidebars = {
     docsSidebar: [
         'what-is-feldera',
-        'concepts',
         {
             type: 'category',
-            label: 'Get Started',
+            label: 'Install Feldera',
             link: {
                 type: 'doc',
                 id: 'get-started'
@@ -26,55 +25,51 @@ const sidebars = {
             items: [
                 'docker',
                 'sandbox',
-            ]
-        },
-        {
-            type: 'category',
-            label: 'Feldera Enterprise',
-            link: {
-                type: 'doc',
-                id: 'enterprise/index'
-            },
-            items: [
-                'enterprise/quickstart',
-                'enterprise/helm-guide',
                 {
                     type: 'category',
-                    label: 'Kubernetes guides',
+                    label: 'Feldera Enterprise',
                     link: {
                         type: 'doc',
-                        id: 'enterprise/kubernetes-guides/index',
+                        id: 'enterprise/index'
                     },
                     items: [
-                        'enterprise/kubernetes-guides/k3d',
+                        'enterprise/quickstart',
+                        'enterprise/helm-guide',
                         {
                             type: 'category',
-                            label: 'EKS',
+                            label: 'Kubernetes guides',
                             link: {
                                 type: 'doc',
-                                id: 'enterprise/kubernetes-guides/eks/index',
+                                id: 'enterprise/kubernetes-guides/index',
                             },
                             items: [
-                                'enterprise/kubernetes-guides/eks/cluster',
-                                'enterprise/kubernetes-guides/eks/ingress'
+                                'enterprise/kubernetes-guides/k3d',
+                                {
+                                    type: 'category',
+                                    label: 'EKS',
+                                    link: {
+                                        type: 'doc',
+                                        id: 'enterprise/kubernetes-guides/eks/index',
+                                    },
+                                    items: [
+                                        'enterprise/kubernetes-guides/eks/cluster',
+                                        'enterprise/kubernetes-guides/eks/ingress'
+                                    ]
+                                },
+                                'enterprise/kubernetes-guides/secret-management'
                             ]
-                        },
-                        'enterprise/kubernetes-guides/secret-management'
+                        }
                     ]
-                }
+                },
             ]
         },
         {
             type: 'category',
-            label: 'Tutorials',
-            link: {
-                type: 'doc',
-                id: 'tutorials/index'
-            },
+            label: 'Guides',
             items: [
                 {
                     type: 'category',
-                    label: 'Interactive',
+                    label: 'Tutorial: writing your first SQL pipeline',
                     link: {
                         type: 'doc',
                         id: 'tutorials/basics/index',
@@ -86,36 +81,75 @@ const sidebars = {
                         'tutorials/basics/part4'
                     ]
                 },
-                'tutorials/rest_api/index',
-                'tutorials/monitoring/index'
-            ]
-        },
-        {
-            type: 'category',
-            label: 'Use Cases',
-            items: [
                 {
-                    type: 'doc',
-                    id: 'use_cases/fraud_detection/fraud_detection',
-                    label: 'Real-time Fraud Detection',
+                    type: 'category',
+                    label: 'Use Cases',
+                    items: [
+                        {
+                            type: 'doc',
+                            id: 'use_cases/fraud_detection/fraud_detection',
+                            label: 'Real-time Fraud Detection',
+                        },
+                    ]
                 },
-                {
-                    type: 'doc',
-                    id: 'tour/tour',
-                    label: 'Security Operations',
-                }
+                'tutorials/rest_api/index',
+                'tutorials/monitoring/index',
             ]
         },
         {
             type: 'category',
-            label: 'Reference',
+            label: 'Feldera Interface',
+            collapsed: false,
+            link: {
+                type: 'doc',
+                id: 'interact/index'
+            },
             items: [
+                'reference/web-console',
+                'reference/cli',
                 {
                     type: 'link',
                     label: "Python SDK",
                     href: "pathname:///python/index.html",
                 },
-                'reference/rest',
+                'reference/rest']
+        },
+        {
+            type: 'category',
+            label: 'Write SQL Pipelines',
+            collapsed: false,
+            link: {
+                type: 'doc',
+                id: 'writing/index'
+            },
+            items: [
+                {
+                    type: 'category',
+                    label: 'SQL Reference',
+                    items: [
+                        'sql/grammar',
+                        'sql/identifiers',
+                        'sql/operators',
+                        'sql/aggregates',
+                        'sql/casts',
+                        'sql/types',
+                        'sql/boolean',
+                        'sql/comparisons',
+                        'sql/integer',
+                        'sql/json',
+                        'sql/float',
+                        'sql/decimal',
+                        'sql/string',
+                        'sql/binary',
+                        'sql/array',
+                        'sql/map',
+                        'sql/datetime',
+                        'sql/materialized',
+                        'sql/streaming',
+                        'sql/table',
+                        'sql/udf'
+                    ]
+                },
                 {
                     type: 'category',
                     label: 'Connectors',
@@ -225,50 +259,13 @@ const sidebars = {
                         'formats/csv',
                     ],
                 },
-                {
-                    type: 'category',
-                    label: 'SQL Reference',
-                    link: {type: 'doc', id: 'sql/intro'},
-                    items: [
-                        'sql/grammar',
-                        'sql/identifiers',
-                        'sql/operators',
-                        'sql/aggregates',
-                        'sql/casts',
-                        'sql/types',
-                        'sql/boolean',
-                        'sql/comparisons',
-                        'sql/integer',
-                        'sql/json',
-                        'sql/float',
-                        'sql/decimal',
-                        'sql/string',
-                        'sql/binary',
-                        'sql/array',
-                        'sql/map',
-                        'sql/datetime',
-                        'sql/materialized',
-                        'sql/streaming',
-                        'sql/table',
-                        'sql/udf'
-                    ]
-                },
-                'reference/rust',
-                'reference/cli']
-        },
+            ]
+        }
+        ,
         {
             type: 'category',
-            label: 'Learn',
+            label: 'Literature',
             items: ['papers', 'videos']
-        },
-        {
-            type: 'category',
-            label: 'Contributing',
-            link: {
-                type: 'doc',
-                id: 'contributors/intro',
-            },
-            items: ['contributors/dev-flow', 'contributors/ui-testing']
         }
     ]
 }

--- a/docs/tutorials/monitoring/index.md
+++ b/docs/tutorials/monitoring/index.md
@@ -1,4 +1,4 @@
-# Monitoring & Performance
+# Monitoring and Profiling
 
 A Feldera instance and its pipelines can be monitored using various tools. This tutorial
 will guide you through setting up monitoring for your Feldera instance.

--- a/docs/tutorials/rest_api/index.md
+++ b/docs/tutorials/rest_api/index.md
@@ -1,4 +1,4 @@
-# Using REST API
+# Using the REST API
 
 Feldera features a comprehensive REST API for managing
 [pipelines](/api/introduction#pipeline).

--- a/docs/writing/index.mdx
+++ b/docs/writing/index.mdx
@@ -1,0 +1,16 @@
+# Write SQL Pipelines
+
+Feldera expresses incremental computations via `Pipelines`. A `Pipeline` is defined using SQL tables and views. Pipelines receive input data
+through input connectors. Pipelines can send the results computed by views to destinations via output connectors.
+
+A connector is a combination of two things: a transport and often a format. The transport describes where the input data comes from or output data is sent to (e.g., Kafka,
+S3, PubSub and so on). The format defines the shape or envelope of the data (e.g., JSON, CSV, Parquet and more). Typically, the format has to be compatible
+with the schema of the tables and views. 
+
+Read the references below to learn more about the SQL, connectors and formats that we support.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/docs/writing/index.mdx
+++ b/docs/writing/index.mdx
@@ -5,7 +5,7 @@ through input connectors. Pipelines can send the results computed by views to de
 
 A connector is a combination of two things: a transport and often a format. The transport describes where the input data comes from or output data is sent to (e.g., Kafka,
 S3, PubSub and so on). The format defines the shape or envelope of the data (e.g., JSON, CSV, Parquet and more). Typically, the format has to be compatible
-with the schema of the tables and views. 
+with the schema of the tables and views.
 
 Read the references below to learn more about the SQL, connectors and formats that we support.
 

--- a/scripts/bump-versions.sh
+++ b/scripts/bump-versions.sh
@@ -64,6 +64,9 @@ release() {
     sed -i.backup "s/FELDERA_VERSION=${old_version}/FELDERA_VERSION=${new_version}/g" ../Earthfile
     sed -i.backup "s/pipeline-manager\:${old_version}/pipeline-manager\:${new_version}/g" ../Earthfile
     sed -i.backup "s/demo-container\:${old_version}/demo-container\:${new_version}/g" ../Earthfile
+
+    # Patch the latest stable pipeline manager version in the documentation
+    sed -i.backup "s/pipeline-manager\:${old_version}/pipeline-manager\:${new_version}/g" ../docs/docker.md
 }
 
 release "$@"


### PR DESCRIPTION
Current sidebar:

<img width="303" alt="image" src="https://github.com/user-attachments/assets/b60e81c1-e161-478c-8852-ebac5f6d18e3">


I also removed some stale content.

As for next steps:
* [ ] Ideally we'd have all the examples from the packaged SQL/UDFs show up too
* [ ] We are missing good deployment docs
* [ ] Feldera Enterprise needs a more thorough architecture description
* [ ] We need a section on troubleshooting and operational tips

Signed-off-by: Lalith Suresh <lalith@feldera.com>
