### PR TITLE
pipeline-manager: database test model fix for Shutdown and ShuttingDown

### DIFF
--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2478,6 +2478,9 @@ impl Storage for Mutex<DbModel> {
             .await?;
         pipeline.deployment_status = new_status;
         pipeline.deployment_status_since = Utc::now();
+        pipeline.deployment_config = None;
+        pipeline.deployment_location = None;
+        pipeline.deployment_error = None;
         self.lock()
             .await
             .pipelines
@@ -2496,9 +2499,6 @@ impl Storage for Mutex<DbModel> {
             .await?;
         pipeline.deployment_status = new_status;
         pipeline.deployment_status_since = Utc::now();
-        pipeline.deployment_config = None;
-        pipeline.deployment_location = None;
-        pipeline.deployment_error = None;
         self.lock()
             .await
             .pipelines


### PR DESCRIPTION
The transition to ShuttingDown sets `deployment_config`, `deployment_location` and `deployment_error` to NULL as from that moment the deployment is being terminated and deleted. This was not yet reflected in the database test model.