### PR TITLE
[sql] support ilike for postgres string

### DIFF
--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -85,6 +85,17 @@ pub fn like3___(value: String, pattern: String, escape: String) -> bool {
 
 some_function3!(like3, String, String, String, bool);
 
+pub fn ilike2__(value: String, pattern: String) -> bool {
+    // Convert both the value and the pattern to lowercase for case-insensitive comparison
+    Like::<false>::like(
+        value.to_lowercase().as_str(),
+        pattern.to_lowercase().as_str(),
+    )
+    .unwrap()
+}
+
+some_function2!(ilike2, String, String, bool);
+
 pub fn position__(needle: String, haystack: String) -> i32 {
     let pos = haystack.find(needle.as_str());
     match pos {

--- a/docs/sql/string.md
+++ b/docs/sql/string.md
@@ -97,6 +97,21 @@ addition to the normal way of `''`.
     <td>See below for details.</td>
   </tr>
   <tr>
+    <td>
+        <code>string ILIKE pattern </code> and
+        <code>string NOT ILIKE pattern</code>
+    </td>
+    <td>
+        The <code>ILIKE</code> expression returns true if the string matches the supplied pattern,
+        performing a case-insensitive comparison. This means that differences in character case
+        between the string and the pattern are ignored.
+        (Similarly, the <code>NOT ILIKE</code> expression returns false if <code>ILIKE</code> returns true.)
+    </td>
+    <td>
+        See below for details.
+    </td>
+  </tr>
+  <tr>
     <td><code>string RLIKE pattern</code> and
         <code>string NOT RLIKE pattern</code></td>
     <td>The RLIKE expression returns true if the string matches the supplied pattern.
@@ -247,6 +262,30 @@ SELECT 'h%awkeye' LIKE 'h#%a%k%e' ESCAPE '#'   true
 ```
 
 When either argument or `LIKE`, `NOT LIKE` is `NULL`, the result is `NULL`.
+
+## `ILIKE`
+
+string `ILIKE` pattern
+
+string `NOT ILIKE` pattern
+
+The `ILIKE` expression performs a case-insensitive pattern match. If the pattern does not contain percent signs or underscores, then the pattern represents the string itself, and `ILIKE` acts like the equals operator, ignoring character case. An underscore (`_`) in the pattern matches any single character, while a percent sign (`%`) matches any sequence of zero or more characters.
+
+Some examples:
+
+```sql
+SELECT 'hawkeye' ILIKE 'h%'        true
+SELECT 'hawkeye' NOT ILIKE 'h%'    false
+SELECT 'hawkeye' ILIKE 'H%'        true
+SELECT 'hawkeye' NOT ILIKE 'H%'    false
+SELECT 'hawkeye' ILIKE 'H%Eye'     true
+SELECT 'hawkeye' NOT ILIKE 'H%Eye' false
+SELECT 'Hawkeye' ILIKE 'h%'        true
+SELECT 'Hawkeye' NOT ILIKE 'h%'    false
+SELECT 'ABC'     ILIKE '_b_'       true
+SELECT 'ABC'     NOT ILIKE '_b_'   false
+```
+When either argument or `ILIKE`, `NOT ILIKE` is `NULL`, the result is `NULL`.
 
 ## POSIX regular expressions
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -1206,6 +1206,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 return compileFunction(call, node, type, ops, 2, 3);
             }
             case LIKE:
+            // ILIKE will also match LIKE in Calcite, it's just a special case for case-insensitive matching
             case SIMILAR: {
                 return compileFunction(call, node, type, ops, 2, 3);
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
@@ -823,7 +823,60 @@ public class PostgresStringTests extends SqlIoTest {
                  t""");
     }
 
-    // TODO ILIKE
+    @Test
+    public void testILike2() {
+        this.q("""
+                SELECT 'hawkeye' ILIKE 'h%' AS "true";
+                 true
+                ------
+                 t""");
+        this.q("""
+                SELECT 'hawkeye' NOT ILIKE 'h%' AS "false";
+                 false
+                -------
+                 f""");
+        this.q("""
+                SELECT 'hawkeye' ILIKE 'H%' AS "true";
+                 true
+                ------
+                 t""");
+        this.q("""
+                SELECT 'hawkeye' NOT ILIKE 'H%' AS "false";
+                 false
+                -------
+                 f""");
+        this.q("""
+                SELECT 'hawkeye' ILIKE 'H%Eye' AS "true";
+                 true
+                ------
+                 t""");
+        this.q("""
+                SELECT 'hawkeye' NOT ILIKE 'H%Eye' AS "false";
+                 false
+                -------
+                 f""");
+        this.q("""
+                SELECT 'Hawkeye' ILIKE 'h%' AS "true";
+                 true
+                ------
+                 t""");
+        this.q("""
+                SELECT 'Hawkeye' NOT ILIKE 'h%' AS "false";
+                 false
+                -------
+                 f""");
+        this.q("""
+                SELECT 'ABC' ILIKE '_b_' AS "true";
+                 true
+                -------
+                 t""");
+        this.q("""
+                SELECT 'ABC' NOT ILIKE '_b_' AS "false";
+                 false
+                ------
+                 f""");
+    }
+
 
     @Test
     public void testLikeCombinations() {


### PR DESCRIPTION
Since calcite already support ilike, we can support ilike for postgres string in feldera.