### PR TITLE
feldera-types: bring back `fault_tolerance` field

### DIFF
--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -38,7 +38,10 @@ pub struct KafkaInputConfig {
     #[serde(default = "default_group_join_timeout_secs")]
     pub group_join_timeout_secs: u32,
 
-    /// If specified, this service is used to provide defaults for the Kafka options.
+    /// Deprecated.
+    pub fault_tolerance: Option<String>,
+
+    /// Deprecated.
     pub kafka_service: Option<String>,
 
     /// Set to 1 or more to fix the number of threads used to poll

--- a/openapi.json
+++ b/openapi.json
@@ -2924,6 +2924,11 @@
           "topics"
         ],
         "properties": {
+          "fault_tolerance": {
+            "type": "string",
+            "description": "Deprecated.",
+            "nullable": true
+          },
           "group_join_timeout_secs": {
             "type": "integer",
             "format": "int32",
@@ -2932,7 +2937,7 @@
           },
           "kafka_service": {
             "type": "string",
-            "description": "If specified, this service is used to provide defaults for the Kafka options.",
+            "description": "Deprecated.",
             "nullable": true
           },
           "log_level": {


### PR DESCRIPTION
This brings back the `fault_tolerance` field for the Kafka input connector for backwards compatibility. This prevents `fault_tolerance` from being deserialized as part of the flattened `kafka_options` for existing stored connectors that have its value as `null`.