### PR TITLE
[SQL] GC for emit_final WINDOW operator

### DIFF
--- a/crates/sqllib/src/aggregates.rs
+++ b/crates/sqllib/src/aggregates.rs
@@ -419,7 +419,7 @@ where
 //////////////
 
 #[doc(hidden)]
-pub fn cf_compare__<T>(left: T, right: T) -> bool
+pub fn cf_compare_gte__<T>(left: T, right: T) -> bool
 where
     T: Ord,
 {
@@ -427,7 +427,7 @@ where
 }
 
 #[doc(hidden)]
-pub fn cf_compare__N<T>(left: T, right: Option<T>) -> bool
+pub fn cf_compare_gte__N<T>(left: T, right: Option<T>) -> bool
 where
     T: Ord,
 {
@@ -438,7 +438,7 @@ where
 }
 
 #[doc(hidden)]
-pub fn cf_compare_N_<T>(left: Option<T>, right: T) -> bool
+pub fn cf_compare_gte_N_<T>(left: Option<T>, right: T) -> bool
 where
     T: Ord,
 {
@@ -449,7 +449,7 @@ where
 }
 
 #[doc(hidden)]
-pub fn cf_compare_N_N<T>(left: Option<T>, right: Option<T>) -> bool
+pub fn cf_compare_gte_N_N<T>(left: Option<T>, right: Option<T>) -> bool
 where
     T: Ord,
 {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -50,14 +50,14 @@ public final class DBSPIntegrateTraceRetainKeysOperator
                     .getField(0)
                     .projectExpression(dataArg);
             compare = DBSPControlledFilterOperator.generateTupleCompare(
-                    project, controlArg.deref().field(1).field(0));
+                    project, controlArg.deref().field(1).field(0), DBSPOpcode.CONTROLLED_FILTER_GTE);
         } else {
             DBSPType keyType = data.getOutputZSetElementType();
             DBSPVariablePath dataArg = keyType.var();
             param = new DBSPParameter(dataArg.variable, dataArg.getType().ref());
             DBSPExpression project = dataProjection.projectExpression(dataArg);
             compare = DBSPControlledFilterOperator.generateTupleCompare(
-                    project, controlArg.deref().field(1));
+                    project, controlArg.deref().field(1), DBSPOpcode.CONTROLLED_FILTER_GTE);
         }
         compare = ExpressionCompiler.makeBinaryExpression(
                 node, compare.getType(), DBSPOpcode.OR, compare0, compare);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
@@ -46,7 +46,7 @@ public final class DBSPIntegrateTraceRetainValuesOperator
                 .projectExpression(dataArg);
         DBSPExpression compare0 = controlArg.deref().field(0).not();
         DBSPExpression compare = DBSPControlledFilterOperator.generateTupleCompare(
-                project, controlArg.deref().field(1));
+                project, controlArg.deref().field(1), DBSPOpcode.CONTROLLED_FILTER_GTE);
         compare = ExpressionCompiler.makeBinaryExpression(
                 node, compare.getType(), DBSPOpcode.OR, compare0, compare);
         DBSPExpression closure = compare.closure(param, controlArg.asParameter());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -77,8 +77,8 @@ public class RustSqlRuntimeLibrary {
         this.arithmeticFunctions.put(DBSPOpcode.AGG_XOR.toString(), DBSPOpcode.AGG_XOR);
         this.arithmeticFunctions.put(DBSPOpcode.AGG_LTE.toString(), DBSPOpcode.AGG_LTE);
         this.arithmeticFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
-        this.arithmeticFunctions.put(DBSPOpcode.CONTROLLED_FILTER_COMPARE.toString(), 
-                DBSPOpcode.CONTROLLED_FILTER_COMPARE);
+        this.arithmeticFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
+                DBSPOpcode.CONTROLLED_FILTER_GTE);
 
         this.dateFunctions.put("plus", DBSPOpcode.ADD);
         this.dateFunctions.put("minus", DBSPOpcode.SUB);
@@ -95,7 +95,7 @@ public class RustSqlRuntimeLibrary {
         this.dateFunctions.put(DBSPOpcode.AGG_MIN.toString(), DBSPOpcode.AGG_MIN);
         this.dateFunctions.put(DBSPOpcode.AGG_LTE.toString(), DBSPOpcode.AGG_LTE);
         this.dateFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
-        this.dateFunctions.put(DBSPOpcode.CONTROLLED_FILTER_COMPARE.toString(), DBSPOpcode.CONTROLLED_FILTER_COMPARE);
+        this.dateFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(), DBSPOpcode.CONTROLLED_FILTER_GTE);
         this.dateFunctions.put(DBSPOpcode.MIN.toString(), DBSPOpcode.MIN);
         this.dateFunctions.put(DBSPOpcode.MAX.toString(), DBSPOpcode.MAX);
 
@@ -112,8 +112,8 @@ public class RustSqlRuntimeLibrary {
         this.stringFunctions.put(DBSPOpcode.AGG_MAX.toString(), DBSPOpcode.AGG_MAX);
         this.stringFunctions.put(DBSPOpcode.AGG_LTE.toString(), DBSPOpcode.AGG_LTE);
         this.stringFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
-        this.stringFunctions.put(DBSPOpcode.CONTROLLED_FILTER_COMPARE.toString(), 
-                DBSPOpcode.CONTROLLED_FILTER_COMPARE);
+        this.stringFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
+                DBSPOpcode.CONTROLLED_FILTER_GTE);
 
         this.booleanFunctions.put("eq", DBSPOpcode.EQ);
         this.booleanFunctions.put("neq", DBSPOpcode.NEQ);
@@ -131,8 +131,8 @@ public class RustSqlRuntimeLibrary {
         this.booleanFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
         this.booleanFunctions.put("is_same", DBSPOpcode.IS_NOT_DISTINCT);
         this.booleanFunctions.put(DBSPOpcode.IS_DISTINCT.toString(), DBSPOpcode.IS_DISTINCT);
-        this.booleanFunctions.put(DBSPOpcode.CONTROLLED_FILTER_COMPARE.toString(), 
-                DBSPOpcode.CONTROLLED_FILTER_COMPARE);
+        this.booleanFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
+                DBSPOpcode.CONTROLLED_FILTER_GTE);
 
         // These are defined for VARBIT types
         this.otherFunctions.put(DBSPOpcode.AGG_AND.toString(), DBSPOpcode.AGG_AND);
@@ -141,8 +141,8 @@ public class RustSqlRuntimeLibrary {
         this.otherFunctions.put("concat", DBSPOpcode.CONCAT);
         this.otherFunctions.put(DBSPOpcode.AGG_LTE.toString(), DBSPOpcode.AGG_LTE);
         this.otherFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
-        this.otherFunctions.put(DBSPOpcode.CONTROLLED_FILTER_COMPARE.toString(), 
-                DBSPOpcode.CONTROLLED_FILTER_COMPARE);
+        this.otherFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
+                DBSPOpcode.CONTROLLED_FILTER_GTE);
         // These are defined for all types
         this.otherFunctions.put("eq", DBSPOpcode.EQ);
         this.otherFunctions.put("neq", DBSPOpcode.NEQ);
@@ -237,7 +237,8 @@ public class RustSqlRuntimeLibrary {
             tsuffixr = "";
             suffixl = "";
             suffixr = "";
-        } else if (opcode == DBSPOpcode.AGG_GTE || opcode == DBSPOpcode.AGG_LTE || opcode == DBSPOpcode.CONTROLLED_FILTER_COMPARE) {
+        } else if (opcode == DBSPOpcode.AGG_GTE || opcode == DBSPOpcode.AGG_LTE ||
+                opcode == DBSPOpcode.CONTROLLED_FILTER_GTE) {
             tsuffixl = "";
             tsuffixr = "";
         } else {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -67,8 +67,7 @@ public enum DBSPOpcode {
     // The left argument is the data compared, the right argument is the current waterline
     // A NULL on either side returns true.
     // Otherwise, this returns left >= right.
-    CONTROLLED_FILTER_COMPARE("cf_compare", true),
-
+    CONTROLLED_FILTER_GTE("cf_compare_gte", true),
     // Higher order operation: apply a function to every element of an array
     ARRAY_CONVERT("array_map", false)
     ;


### PR DESCRIPTION
Fixes #2775 
This uses a integrate_retain_keys operator for the WINDOW operator that is introduced for an emit_final annotation.