### PR TITLE
[SQL] Migrate to Calcite 1.38

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>19</maven.compiler.source>
         <maven.compiler.target>19</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <calcite.version>1.38.0</calcite.version>
+        <calcite.version>1.39.0</calcite.version>
         <jackson.version>2.17.1</jackson.version>
         <janino.version>3.1.12</janino.version>
     </properties>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -965,6 +965,9 @@ data: {
     includeAdditionalDeclarations: false
     includeParsingStringLiteralAsArrayLiteral: true
 
+    # Method for parsing "SET [OR RESET]" calls.
+    setOptionParserMethod: "SqlSetOption"
+
     implementationFiles: [
       "ddl.ftl"
       "parserImpls.ftl"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
@@ -192,4 +192,11 @@ public class CompilerMessages {
         }
         return result;
     }
+
+    /** Print the messages on stdout, if any */
+    public void print() {
+        if (this.messages.isEmpty())
+            return;
+        System.out.println(this);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -1321,10 +1321,10 @@ public class CalciteToDBSPCompiler extends RelVisitor
         RexNode leftOver = decomposition.getLeftOver();
         assert leftOver == null;
 
-        int leftTsIndex;  // Index of "timestamp" column in left input
-        int rightTsIndex;
         SqlKind comparison;  // Comparison operation, with left table column always on the left
 
+        int leftTsIndex;  // Index of "timestamp" column in left input
+        int rightTsIndex;
         {
             // Analyze match condition.  We know it's always a simple comparison between
             // two columns (enforced by the Validator).

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -174,7 +174,7 @@ public class MetadataTests extends BaseSQLTests {
         File file = createInputScript(sql);
         CompilerMessages messages = CompilerMain.execute("--unquotedCasing", "lower",
                 "-q", "-o", BaseSQLTests.testFilePath, file.getPath());
-        System.out.println(messages);
+        messages.print();
         Assert.assertEquals(0, messages.errorCount());
         Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, true);
     }
@@ -329,7 +329,7 @@ public class MetadataTests extends BaseSQLTests {
                 CREATE VIEW V AS SELECT COL1 FROM T;""";
         File file = createInputScript(sql);
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
-        System.err.println(messages);
+        messages.print();
         Assert.assertEquals(0, messages.errorCount());
         Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -340,8 +340,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                 String path = subdir.getPath() + "/" + sqlFile;
                 CompilerMessages messages = CompilerMain.execute(
                         "-i", "--alltables", "-o", BaseSQLTests.testFilePath, path);
-                if (!messages.isEmpty())
-                    System.out.println(messages);
+                messages.print();
                 Assert.assertEquals(0, messages.errorCount());
             }
             Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
@@ -409,7 +408,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                 CREATE VIEW V AS SELECT COL1 FROM T;""";
         File file = createInputScript(sql);
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, file.getPath());
-        System.err.println(messages);
+        messages.print();
         Assert.assertEquals(0, messages.exitCode);
         Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -29,7 +29,7 @@ public class ProfilingTests extends StreamingTestBase {
         CompilerMessages messages = CompilerMain.execute(
                 "-o", BaseSQLTests.testFilePath, "--handles", "-i",
                 script.getPath());
-        System.out.println(messages);
+        messages.print();
         Assert.assertEquals(0, messages.errorCount());
 
         String mainFilePath = rustDirectory + "/main.rs";

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # This script builds the SQL compiler
 # it has an optional argument which specifies whether to build
@@ -19,10 +19,10 @@ else
     # hasn't been merged yet
     CALCITE_REPO="https://github.com/mihaibudiu/calcite.git"
     CALCITE_BRANCH="variant"
-    CALCITE_NEXT_COMMIT="9eb0fe74380e0cb5f916a4ae88834ad989a66d7e"
+    CALCITE_NEXT_COMMIT="9b88b5b8807eeee4b728def3983e4c2a505319a3"
 fi
-CALCITE_NEXT="1.38.0"
-CALCITE_CURRENT="1.37.0"
+CALCITE_NEXT="1.39.0"
+CALCITE_CURRENT="1.38.0"
 
 usage() {
     echo "This script builds the sql-to-dbsp compiler"

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # This script builds the SQL compiler
 # it has an optional argument which specifies whether to build


### PR DESCRIPTION
The new Calcite is a bit more finicky with respect to casts, so some ASOF joins that used to compile will now report some rather obscure errors. An error may look like this:

```
(no input file):261:4: error: Error in SQL statement: ASOF JOIN condition must be a conjunction of equality comparisons
  261|ON B.mod = S.key;
         ^^^^^^^^^^^^^
```

This comparison looks right. But the problem is that in the compiler this looks like `CAST(B.mod as BIGINT) = S.key`, which is not a simple comparison.

I have filed https://issues.apache.org/jira/browse/CALCITE-6641 to track this issue, and I will try to implement a solution. 
For now the solution is to edit the SQL and to to insert the casts manually before invoking the join.