### PR TITLE
[deploy] Upgrade debezium container to 2.7.3.Final

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -192,7 +192,7 @@ RUN apt update && apt install pkg-config \
 CMD bash
 
 # Kafka connect with all Debezium connectors + the Snowflake connector.
-FROM debezium/connect:2.7 AS kafka-connect
+FROM debezium/connect:2.7.3.Final AS kafka-connect
 RUN mkdir /kafka/connect/snowflake-kafka-connector
 RUN cd /kafka/connect/snowflake-kafka-connector \
   && curl -LO https://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/2.1.0/snowflake-kafka-connector-2.1.0.jar \


### PR DESCRIPTION
Looks like the version of the container we've been using has been yanked. Upgraded to the latest release in the 2.7 series.