### PR TITLE
Fix banner display in docker form factor.

### DIFF
--- a/crates/pipeline-manager/src/api/mod.rs
+++ b/crates/pipeline-manager/src/api/mod.rs
@@ -453,7 +453,7 @@ pub async fn run(db: Arc<Mutex<StoragePostgres>>, api_config: ApiServerConfig) -
         }
     };
 
-    let banner = if theme(Duration::from_millis(500)).unwrap_or(Theme::Dark) == Theme::Dark {
+    let banner = if theme(Duration::from_millis(500)).unwrap_or(Theme::Light) == Theme::Dark {
         include_str!("../../light-banner.ascii")
     } else {
         include_str!("../../dark-banner.ascii")


### PR DESCRIPTION
If no bg theme can be detected in the terminal, we chose the wrong banner instead of the one that is background agnostic.

Fixes https://github.com/feldera/feldera/issues/2837