### PR TITLE
[docs] Guide: Time Series Analysis with Feldera

### DIFF
--- a/demo/packaged/sql/06-time-series-tutorial.sql
+++ b/demo/packaged/sql/06-time-series-tutorial.sql
@@ -1,0 +1,161 @@
+-- Tutorial: Time Series Analysis with Feldera (time-series-tutorial)
+--
+-- Learn to effectively work with time series data in Feldera.
+--
+-- This program accompanies the guide to Time Series Analysis with Feldera: https://docs.feldera.com/tutorials/time-series
+--
+-- Each view definition demonstrates one concept from the guide.
+--
+-- Example inputs:
+-- Insert the following records in the `purchase` table and observe how
+-- the views change in response:
+--
+--    INSERT INTO purchase VALUES(1, '2020-01-01 01:00:00', 10);
+--    INSERT INTO purchase VALUES(1, '2020-01-01 02:00:00', 10);
+--    INSERT INTO purchase VALUES(1, '2020-01-02 00:00:00', 10);
+--    INSERT INTO purchase VALUES(1, '2020-01-02 01:00:00', 10);
+
+
+-- This table uses two time-series-related annotations:
+-- `LATENESS` - updates to this table can arrive no more than 1 hour out of order.
+-- `append_only` - records are only inserted to this table, but never deleted.
+CREATE TABLE purchase (
+   customer_id INT,
+   ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR,
+   amount BIGINT
+) WITH (
+    'materialized' = 'true',
+    'append_only' = 'true'
+);
+
+CREATE TABLE returns (
+    customer_id INT,
+    ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR,
+    amount BIGINT
+) WITH (
+    'materialized' = 'true'
+);
+
+CREATE TABLE customer (
+    customer_id INT,
+    ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 DAY,
+    address VARCHAR
+) WITH (
+    'materialized' = 'true'
+);
+
+-- Daily MAX purchase amount.
+CREATE MATERIALIZED VIEW daily_max AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    MAX(amount) AS max_amount
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+
+-- Daily total purchase amount.
+CREATE MATERIALIZED VIEW daily_total AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    SUM(amount) AS total
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+
+-- Like `daily_total`, but this view uses the 'emit_final' annotation to only
+-- produce the final value of the aggregate at the end of each day.
+CREATE MATERIALIZED VIEW daily_total_final
+WITH ('emit_final' = 'd')
+AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    SUM(amount) AS total
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+
+-- Daily MAX purchase amount computed using tumbling windows.
+CREATE MATERIALIZED VIEW daily_max_tumbling AS
+SELECT
+    window_start,
+    MAX(amount)
+FROM TABLE(
+  TUMBLE(
+    DATA => TABLE purchase,
+    TIMECOL => DESCRIPTOR(ts),
+    SIZE => INTERVAL 1 DAY))
+GROUP BY
+    window_start;
+
+-- Daily MAX purchase amount computed as a rolling aggregate.
+CREATE MATERIALIZED VIEW daily_max_rolling AS
+SELECT
+    ts,
+    amount,
+    MAX(amount) OVER window_1_day
+FROM purchase
+WINDOW window_1_day AS (ORDER BY ts RANGE BETWEEN INTERVAL 1 DAY PRECEDING AND CURRENT ROW);
+
+-- Use an OUTER JOIN to compute a daily transaction summary, including daily totals
+-- from `purchase` and `returns` tables.
+CREATE MATERIALIZED VIEW daily_totals AS
+WITH
+    purchase_totals AS (
+        SELECT
+            TIMESTAMP_TRUNC(purchase.ts, DAY) as purchase_date,
+            SUM(purchase.amount) as total_purchase_amount
+        FROM purchase
+        GROUP BY
+            TIMESTAMP_TRUNC(purchase.ts, DAY)
+    ),
+    return_totals AS (
+        SELECT
+            TIMESTAMP_TRUNC(returns.ts, DAY) as return_date,
+            SUM(returns.amount) as total_return_amount
+        FROM returns
+        GROUP BY
+            TIMESTAMP_TRUNC(returns.ts, DAY)
+    )
+SELECT
+    purchase_totals.purchase_date as d,
+    purchase_totals.total_purchase_amount,
+    return_totals.total_return_amount
+FROM
+    purchase_totals
+    FULL OUTER JOIN
+    return_totals
+ON
+    purchase_totals.purchase_date = return_totals.return_date;
+
+-- Use an ASOF JOIN to extract the customer’s address at the time of
+-- purchase from the `customer` table.
+CREATE MATERIALIZED VIEW purchase_with_address AS
+SELECT
+    purchase.ts,
+    purchase.customer_id,
+    customer.address
+FROM purchase
+LEFT ASOF JOIN customer MATCH_CONDITION(purchase.ts >= customer.ts)
+ON purchase.customer_id = customer.customer_id;
+
+-- Use LAG and LEAD operators to lookup previous and next purchase
+-- amounts for each record in the `purchase` table.
+CREATE MATERIALIZED VIEW purchase_with_prev_next AS
+SELECT
+    ts,
+    customer_id,
+    amount,
+    LAG(amount) OVER(PARTITION BY customer_id ORDER BY ts) as previous_amount,
+    LEAD(amount) OVER(PARTITION BY customer_id ORDER BY ts) as next_amount
+FROM
+    purchase;
+
+-- Temporal filter query that uses the current physical time (NOW())
+-- to compute transactions made in the last 7 days.
+CREATE MATERIALIZED VIEW recent_purchases AS
+SELECT * FROM purchase
+WHERE
+    ts >= NOW() - INTERVAL 7 DAYS;

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -92,6 +92,7 @@ const sidebars = {
                         },
                     ]
                 },
+                'tutorials/time-series',
                 'tutorials/rest_api/index',
                 'tutorials/monitoring/index',
             ]

--- a/docs/sql/streaming.md
+++ b/docs/sql/streaming.md
@@ -1,236 +1,22 @@
-# Streaming SQL extensions
+# Time-Series Extensions
 
-In order to implement features that are supported by streaming
-engines, we offer a few extensions to standard SQL.
+This section lists SQL extensions supported by Feldera for computing over
+time-series data.  A time series is a sequence of events, such as IoT sensor
+readings or financial transactions, where each event is associated with one or
+more timestamps.
 
-## Append-only tables
-
-By specifying the property `'append_only' = 'true'` on a table, the
-user instructs Feldera that the table will only receive `INSERT`
-updates (no deletions or updates).  This type of table is frequently
-used in streaming programs.  This usage pattern enables the compiler
-to apply additional optimizations.
-
-Example:
-
-```sql
-CREATE TABLE T (
-   ...
-) WITH (
-   'append_only' = 'true'
-);
-```
-
-::: warning
-
-Currently the runtime does not enforce the fact that such tables are
-append-only.  In the presence of updates or deletions in an
-append-only table, the behavior of the program is unspecified.  In
-particular, insertions in a table with a primary key may be
-implemented as a pair insert/delete if an item with the same key
-already exists.  Such tables are not append-only.
-
-:::
-
-## Waterlines
-
-Waterlines are a mechanism introduced by Feldera for reducing the
-memory use of streaming SQL programs.  Waterlines are an instance of a
-database statistic.  Waterlines are implemented in collaboration
-between the SQL compiler and the SQL runtime.
-
-Each intermediate relation in a SQL plan may have an attached
-waterline.  For a relation with schema S, a waterline is a single
-tuple T having the same schema S.  Consider the following example:
-
-```sql
-CREATE TABLE T(ID INT, TS TIMESTAMP);
-```
-
-A waterline for table `T` is represented by a tuple `T_waterline(ID
-INT, TS TIMESTAMP)`.
-
-If the field `T_waterline.TS` has a value X at runtime, it indicates
-that *all future updates* to table `T` will involve rows that have a
-value *larger* than X in column `TS`.
-
-The waterline of each relation is updated after each program execution
-step.
-
-The `LATENESS` annotation, described below can be used to help the
-compiler infer waterlines.  The `LATENESS` directly specifies how the
-waterline is computed for tables or views; starting from this
-information the SQL compiler may be able to infer waterlines for other
-collections.
+Refer to the
+[guide on time series analysis with Feldera](/tutorials/time-series)
+for a detailed description of these constructs and their usage.
 
 ## `LATENESS` expressions
 
-`LATENESS` is a property of the data in a column of a table or a view
-that is used for computing the table's (view's) waterline.  `LATENESS`
-is described by an expression that evaluates to a constant value.  The
-expression must have a type that can be subtracted from the column
-type.  For example, a column of type `TIMESTAMP` may have a lateness
-specified as an `INTERVAL` type.
+Lateness is a constant bound associated with a timestamp column in a
+table or view, such that updates to the table are not allowed to arrive more than
+lateness time units out of order.
 
-To specify `LATENESS` for a table column, the column declaration can
-be annotated in the `CREATE TABLE` statement, as in this example:
-
-```sql
-CREATE TABLE order_pickup (
-   when TIMESTAMP NOT NULL LATENESS INTERVAL '1:00' HOURS TO MINUTES,
-   location VARCHAR
-);
-```
-
-To specify `LATENESS` for a view, the SQL statement `LATENESS` must be
-used.  The statement specifies a view, a column of the view, and an
-expression for the latness value.  For example:
-
-```sql
-LATENESS V.COL1 INTERVAL '1' HOUR;
-CREATE VIEW V AS SELECT T.COL1, T.COL2 FROM T;
-```
-
-The `LATENESS` property of a column allows values that are too much
-"out of order" to be ignored.  The runtime will compute the
-[*waterline*](streaming.md#waterlines) of the view as the maximum of
-all values ever encountered minus the specified lateness.  A value X
-is "out of order" if it is below the computed waterline.  Such values
-will be logged and discarded.
-
-For example, consider the table above, and a sequence of insertions,
-each as a separate transaction:
-
-```sql
--- initially T_waterline = (-infinity, NULL)
-INSERT INTO T VALUES('2020-01-01 00:00:00', 'home');
--- after this insertion T_waterline = (2019-12-12 23:00:00, NULL)
-
-INSERT INTO T VALUES('2020-01-01 01:00:00', 'office');
--- T_waterline = (2020-01-01 00:00:00, NULL)
-
--- next row is late (before the previous row), but not too late (it is after the waterline)
-INSERT INTO T VALUES('2020-01-01 00:10:00', 'shop');
--- T_waterline = (2020-01-01 00:00:00, NULL), unchanged
-
-INSERT INTO T VALUES('2020-01-01 02:00:00', 'home');
--- T_waterline = (2020-01-01 01:00:00, NULL)
-
--- next row is too late (before the waterline), and it will be ignored
-INSERT INTO T VALUES('2020-01-01 00:20:00', 'friend');
--- T_waterline = (2020-01-01 01:00:00, NULL) is unchanged
-```
-
-The second insertion is not out of order, since its timestamp is
-larger than the timestamp of the first insertion.  The first insertion
-sets the waterline of the table to the inserted timestamp minus one hour.
-
-The third insertion is out of order, since its timestamp value is
-smaller than the second insertion.  But the third insertion is *not*
-too late, since it is only 50 minutes late, whereas the specified
-column lateness is 1 hour, and thus is is before the
-
-waterline.  The fifth row is too late, though, since it is 100 minutes
-late with respect to the fourth row, and it is before the waterline
-computed after the fourth row.
-
-Lateness is used to instruct the data processing system to ignore the
-rows that are too much out of order; the system behaves as if such
-insertions never took place.  The computed waterline used to decide if
-a value is late, is updated only *after* the current program step.  So
-if all 5 insertions above are executed within one step, all five will
-take place.  If they are executed as 5 steps, only the first 4 will
-take place.
-
-The `LATENESS` annotation ensures that some computed results that
-reflect past data may not be updated due to very late coming data.
-This also enables the runtime system to avoid maintaining very old
-state, which may never impact future results.
-
-A table or view can have any number of columns annotated with
-lateness.  An inserted row is considered "too late" if any of its
-annotated columns is too late.
-
-## `emit_final` views
-
-:::warning
-
-The `emit_final` feature is still experimental, and it may be removed
-or substantially modified in the future.
-
-:::
-
-By default, Feldera updates SQL views incrementally whenever new
-inputs arrive. Such incremental updates include deleting previously
-added rows and inserting new rows into the view.  By monitoring these
-updates, the user can observe the most up-to-date results of the
-computation.  However, some applications only need to observe the
-final outputs of the computation, i.e., rows that are guaranteed to
-never be deleted or updated.  For instance, the application may need
-to know the value of an aggregate over a [tumbling
-window](table.md#tumble) only after the content of the window has been
-finalized.  Furthermore, some applications may not be able to handle
-intermediate updates.  Typical reasons for this are:
-
-* **The application is unable to process row deletions.** Some
-    databases and database connectors cannot ingest deletions
-    efficiently or at all.
-
-* **The application cannot handle a large volume of incremental
-    updates.** Frequent small input changes can generate many
-    incremental output updates. These updates often cancel out, as
-    rows are inserted and later deleted and replaced with new
-    values. Hence the volume of intermediate updates can be much
-    larger than the final output.
-
-* **The application is only allowed to act on the final
-    output**. Consider an application that raises an alarm, sends an
-    email, or performs some other irreversible action based on the
-    output or the view. Such actions should only be taken when the
-    output is final. Having to handle intermediate outputs can
-    complicate the logic of such applications, as the application may
-    not be able to reliably identify and discard intermediate values.
-
-The `emit_final` attribute instructs Feldera to only output final rows
-of a view, as in the following example:
-
-```sql
-CREATE VIEW V WITH (
-  'emit_final' = 'ts'
-) AS SELECT ... as ts, .... FROM ...
-```
-
-This property is modeled after the Kafka [emit on
-close](https://kafka.apache.org/33/javadoc/org/apache/kafka/streams/kstream/EmitStrategy.html#onWindowClose())
-property.
-
-The `emit_final` property must specify either a column name that
-exists in the view, or a column number, where 0 is the leftmost view
-column.
-
-The `emit_final` annotation causes the view to emit only the rows that
-have a value in the specified column that is before the view's current
-[waterline](streaming.md#waterline), i.e., these rows will never be
-updated.  If the compiler cannot infer a waterline for the specified
-column of the view, it will emit an error at compilation time.
-
-Currently this annotation is only allowed on views that are not
-`LOCAL`.  This annotation takes effect only for the view used as
-output.  If the view is used in defining other views, these derived
-views will receive the non-delayed data.
-
-Be careful when using this annotation: some kinds of computations may
-require delaying outputs for very long periods of time.  Consider an
-example like:
-
-```sql
-CREATE VIEW W AS
-SELECT YEAR(timestamp), ... FROM T
-GROUP BY YEAR(timestamp)
-```
-
-This program will need to buffer outputs for a whole year before
-emitting the results.
+See the [Time Series Analysis Guide](/tutorials/time-series#timestamp-columns-and-lateness)
+for details.
 
 ## `WATERMARK` expressions
 
@@ -241,42 +27,31 @@ or substantially modified in the future.
 
 :::
 
-`WATERMARK` is an annotation on the data in a column of a table that
-is relevant for the case of stream processing.  `WATERMARK` is
-described by an expression that evaluates to a constant value.  The
-expression must have a type that can be subtracted from the column
-type.  For example, a column of type `TIMESTAMP` may have a watermark
-specified as an `INTERVAL` type.
+`WATERMARK` is an annotation on a column of a table that delays the processing
+of the input rows by a constant amount of time.
 
-To specify `WATERMARK` for a table column, the column declaration can
-be annotated in the `CREATE TABLE` statement.  For example:
+See the [Time Series Analysis Guide](/tutorials/time-series#delaying-inputs-with-watermark)
+for details.
 
-```sql
-CREATE TABLE order_pickup (
-   pickup_time TIMESTAMP NOT NULL WATERMARK INTERVAL '1:00' HOURS TO MINUTES,
-   location VARCHAR
-);
-```
+## `append_only` tables
 
-The effect of the `WATERMARK` is to delay the processing of the input
-rows until they are less likely to arrive out of order with respect to
-other rows.  More precisely, the system maintains the largest value
-encountered so far in any input row for the columns that have a
-watermark.  Given a `WATERMARK` annotation with value W, an input row
-with a value X for a watermarked column will be "held up" until an
-input row with a value X + W has been received.  The program will
-behave as if the row with value X has only just been received.
-Similar to `LATENESS`, the effect of the `WATERMARK` is visible in the
-*next* circuit step; an event that changes the watermark in step 2 of
-the circuit will only make "visible" the eligible events inserted up
-to step 1.
+The `append_only` annotation on a table instructs Feldera that the table will
+only receive `INSERT` updates.
 
-If a table has multiple columns annotated with `WATERMARK` values, a
-row is released only when *all* the delays have been exceeded.
+See the [Time Series Analysis Guide](/tutorials/time-series#append-only-tables)
+for details.
+
+## `emit_final` views
 
 :::warning
 
-The current version of the compiler does not support multiple
-`WATERMARK` columns in a single table.
+The `emit_final` feature is still experimental, and it may be removed
+or substantially modified in the future.
 
 :::
+
+The `emit_final` annotation on a view instructs Feldera to only output its final rows,
+i.e., rows that are guaranteed to never get deleted or updated.
+
+See the [Time Series Analysis Guide](/tutorials/time-series#emitting-final-values-of-a-view-with-emit_final)
+for details.

--- a/docs/tutorials/time-series.md
+++ b/docs/tutorials/time-series.md
@@ -1,0 +1,766 @@
+# Time Series Analysis with Feldera
+
+This guide covers concepts required to effectively process **time series**
+data with Feldera.  A time series is a sequence of events, such as IoT sensor
+readings or financial transactions, where each event is associated with one or
+more timestamps.  Time series data is inherently dynamic, changing continuously
+as new events arrive in real-time.  Feldera is designed to
+efficiently compute over changing data, making it well-suited for time series
+analytics.
+
+:::tip
+
+Most examples in this guide are available as a pre-packaged demo "Time Series Analysis with Feldera"
+that ships with the
+[Feldera Docker container](https://docs.feldera.com/docker) and the
+[online sandbox](https://try.feldera.com).
+
+:::
+
+**Time series data is not special**.  The most important thing to know about
+time series processing in Feldera is that for most intents and purposes time
+series are handled in the same way as any other input data, in particular:
+
+  * Time series inputs are modeled as SQL tables with [input connectors](/connectors)
+    attached to them.
+
+  * Time series tables support inserts, deletes, and upserts.
+
+  * **All** SQL operators apply to time series and non-time-series data with
+    identical semantics, i.e., given the same inputs, Feldera produces the exact
+    same outputs.
+
+**Feldera optimizes time series processing**.  While Feldera offers the same
+expressive power for time series and non-time-series data, it can evaluate some
+classes of time series queries faster and/or using less memory:
+
+  * It takes advantage of the fact that timestamps in a time series grow monotonically or
+    almost monotonically.  This allows discarding old data no longer needed to compute outputs
+    for new data points. In order to apply this optimization the query engine needs
+    to know which columns in the input time series contain (almost) monotonically growing
+    timestamp values.  This requires
+    [`LATENESS` annotations](#timestamp-columns-and-lateness), described below.
+
+  * Time series data is often append-only: once an event has been appended to the
+    series, it cannot be deleted or modified.  Feldera implements an optimized version
+    of several operators for append-only collections.  In order to enable these
+    optimizations, the query engine needs to know which inputs are append-only.  The user
+    can provide this information to the engine using [`append_only` annotations](#append-only-tables).
+
+As a user, you do not need to understand the intricate details of time series
+processing in order to take advantage of these optimizations. Your simply
+communicate information about the input data to the query engine using
+annotations.  Feldera uses this information to apply optimizations automatically
+in a way that does not affect the output of the queries.  **Assuming that user
+annotations are correct, the optimized query plan produces the same outputs as
+the unoptimized plan.**
+
+**Users can control the timing of the output of time series queries**.  Users
+can further take advantage of the monotonicity of time series inputs to control
+**when** the output of a query is produced by Feldera using
+[`emit_final`](#emitting-final-values-of-a-view-with-emit_final)
+annotations.
+
+In the rest of this guide, we discuss these concepts in more detail.
+
+## Timestamp columns and lateness
+
+A timestamp column is a column in a SQL table or view that indicates a specific
+point in time associated with each row.
+
+  * There can be any number of timestamp columns in a table. For instance, a
+    table that describes taxi rides can store the time when the ride order was
+    received, pickup time, dropoff time, and the time when the payment was
+    processed.
+
+  * Timestamp columns can have any temporal (`TIMESTAMP`, `DATE`, `TIME`) or
+    numeric type.
+
+**A timestamp column can grow monotonically or almost monotonically**. Time
+series data often arrives ordered by timestamp, i.e., every event has the same
+or larger timestamp than the previous event.  In some cases, events can get
+reordered and delayed, but this delay is bounded, e.g., it may not exceed 1
+hour.  We refer to this bound as **lateness**.
+
+**Lateness** is a constant bound `L` associated with a timestamp column in a
+table or view, such that if the table contains a record with timestamp equal to
+`TS`, then any future records inserted to or removed from the table will have
+timestamps greater than or equal to `TS - L`.  In other words, updates to the
+table cannot arrive more than `L` time units out of order.
+
+The Feldera query engine uses lateness information to optimize the execution of
+queries.
+
+### Specifying lateness for tables and views
+
+To specify lateness for a table column, the column declaration is annotated with
+the `LATENESS` attribute:
+
+```sql
+CREATE TABLE purchase (
+   customer_id INT,
+   ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOURS,
+   amount BIGINT
+);
+```
+
+The value of the `LATENESS` attribute is an expression that evaluates to a
+constant value.  The expression must have a type that can be subtracted from the
+column type.  In the above example, lateness for a column of type `TIMESTAMP` is
+specified as an `INTERVAL` type.
+
+**Views can have lateness too**. Lateness is a property of input data; however
+it is not always possible to associate a lateness annotation with an input table
+column.  For instance, input data can arrive as JSON strings, which must be
+[parsed](/sql/json/#parse_json) to extract the actual payload fields, including
+timestamps.  In such situations, columns with lateness appear in intermediate
+views.  To specify lateness for a view, the `LATENESS` statement must be used.
+The statement specifies a view, a column of the view, and an expression for the
+lateness value.  The statement may appear before or after the view declaration:
+
+```sql
+CREATE VIEW v AS SELECT t.col1, t.col2 FROM t;
+LATENESS v.col1 INTERVAL 1 HOUR;
+```
+
+### Guidelines for writing lateness annotations
+
+Keep in mind the following guidelines when choosing lateness annotations for
+tables and views:
+
+* **Lateness is NOT time-to-live**.  Lateness should not be confused with
+  time-to-live annotations used by some stream processing systems.  Declaring
+  a column with `LATENESS` 1 hour does not mean that the data will be discarded
+  after an hour. The compiler decides what data to store and for how long by
+  analyzing the entire SQL program.  `LATENESS` annotations simply inform this
+  analysis.
+
+* **LATENESS does not affect the output of the program**.  Assuming lateness
+  annotations are accurate, i.e., input records do not arrive more than lateness
+  time units out of order, the output of the program with lateness annotations
+  is guaranteed to be identical to outputs of the same program without annotations.
+
+* **Inputs that violate lateness are discarded.**  When a program receives a record
+  that is more than lateness time units behind the most recent timestamp value
+  previously observed in the same column, the pipeline will drop such a record.
+
+We recommend choosing conservative `LATENESS` values, leaving sufficient time for any
+delayed inputs to arrive.  In practice, this may require accounting for potential
+upstream failures, such as an IoT devices losing cloud connectivity.
+
+### Lateness example
+
+Consider the `purchase` table declared above with 1-hour lateness on the `ts` column
+and the following sequence of inserts into this table:
+
+```sql
+INSERT INTO purchase VALUES(1, '2020-01-01 00:00:00', 10);
+
+INSERT INTO purchase VALUES(1, '2020-01-01 01:00:00', 20);
+
+-- Late row, but within the lateness bound.
+INSERT INTO purchase VALUES(1,'2020-01-01 00:10:00', 15);
+
+INSERT INTO purchase VALUES(1, '2020-01-01 02:00:00', 12);
+
+-- Late row that violates lateness.
+INSERT INTO purchase VALUES(1, '2020-01-01 00:20:00', 65);
+```
+
+The second insertion arrives in order, since its timestamp is
+larger than the timestamp of the first insertion.  The third insertion
+is out of order, since its timestamp is smaller than the second
+insertion.  But it does not violate lateness, since it is
+only 50 minutes late, whereas the specified lateness is 1 hour.
+The fifth row violates lateness, since it is 100 minutes late with
+respect to the fourth row, and will be discarded.
+
+Note that lateness is a soft bound.  A pipeline is guaranteed to
+accept any records that arrive within the bound; but can also accept
+late records for a short period of time.  The reason for this is that
+Feldera ingests input records in chunks and advances the cutoff timestamp,
+below which inputs are discarded, after processing the whole chunk.
+
+## How Feldera garbage collects old state
+
+Consider the `purchase` table from before.  As new purchase records are added
+over time, the table will keep growing.  How much of its history do we need to
+store?  A conventional database, serving as a system of record, must store every
+record added to it, until it is deleted by the user, so that it can answer
+queries over this data on-demand.  In contrast, the Feldera query engine
+incrementally maintains a set of views defined ahead of time and
+only keeps state needed by those views.
+
+:::note
+
+Feldera also supports on-demand queries (also know as **ad hoc queries**) for
+materialized tables and views.  See [documentation](/sql/materialized#ad-hoc-queries) for details.
+
+:::
+
+Let’s assume the `purchase` table is used to compute a single view that tracks
+the daily maximum purchase amount:
+
+```sql
+CREATE VIEW daily_max AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    MAX(amount) AS max_amount
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+```
+
+If the `purchase` table did not have the `LATENESS` annotation,
+the query engine would assume that records can be inserted and deleted
+with arbitrary timestamps, e.g., it would be possible to delete a year-old
+record.  Deleting an old record requires re-computing the daily maximum
+for the corresponding date.  This in turn requires storing the entire
+purchase history permanently.
+
+**We can do better with `LATENESS`**.  The `LATENESS` annotation guarantees
+that changes to the table cannot get delayed by more than one hour relative
+to each other.  Hence, daily maxima can only change for the current and, possibly,
+previous day.  Since we will never need to reevaluate the query for earlier dates,
+we do not need to store older data.
+
+To make this more precise, we need two new concepts:
+
+1. **Stream time** of a relation (a table or view) with respect to a timestamp column
+   is the highest timestamp value of any record that has ever been added to the relation.
+   Stream time can only move forward; removing the latest timestamp from the relation
+   does not cause it to revert. This concept enables reasoning about recent vs old
+   records without depending on a physical clock.
+
+2. **Waterline** of a relation with respect to a timestamp column is a timestamp value
+   `W`, such that all future additions or deletions in the relation will have timestamps
+   greater than or equal to `W`.
+
+### The data retention algorithm
+
+Feldera uses the following procedure to identify and discard unused
+data:
+
+1. **Compute waterlines of all program relations** through a combination of compile-time
+   and runtime dataflow analysis:
+
+   * Given a SQL table with a timestamp column with the current stream time
+     `T` and lateness `L`, waterline `W` for this column is computed as: `W = T - L`.
+
+   * The waterline of a view column is derived from the waterlines
+     of all its inputs based on the semantics of the view
+     query.  In our example, the waterline of the `daily_max.d` column is
+     computed as `W = TIMESTAMP_TRUNC(Wp, DAY)`, where `Wp` is the waterline
+     of the `purchase.ts` column.
+
+     Not all SQL operators produce outputs monotonic in the input timestamp (and
+     hence have waterlines).  In our example, the `daily_max.d` column has a waterline
+     because the `GROUP BY` clause of the query uses a monotonic function
+     (`TIMESTAMP_TRUNC`) over an input column with a waterline.
+
+2. **Compute state retention bounds**. For each view in the program, the query engine
+   determines how much state it needs to maintain in order to evaluate the view incrementally.
+   Some queries, such as simple projections and filters, do not require keeping any state.
+   Others, such as joins and aggregates, may require storing the state of their input
+   relations.  In this case, the query engine determines **how long the state
+   should be retained** based on the semantics of the query and the waterlines
+   computed at the previous step.
+
+   In our example, the engine infers that the `daily_max` view needs to access
+   records in the `purchase` table only until the `purchase.ts` waterline rolls
+   over a date boundary, after which records for the past date can be discarded.
+   More precisrly, it retains `purchase` records where
+   `TIMESTAMP_TRUNC(purchase.ts) >= TIMESTAMP_TRUNC(Wp)`.
+
+3. **Discard old records**. Feldera continuously runs background jobs that garbage
+   collect old records that fall below retention bounds.
+
+**Not all queries support discarding old inputs**. We list the operators for which
+Feldera implements garbage collection, along with the conditions under which it is
+applied [below](#sql-for-time-series-analysis).
+
+**Relations can have multiple waterlines**. The query engine can derive waterlines
+for multiple columns in a table or view. All these waterlines can be utilized for
+garbage collection. For example, if the `purchase` table included an additional
+timestamp column that recorded the time when payment was received, and this column
+had its own `LATENESS` attribute, we could create a view computing daily totals
+based on this column, and garbage collection would work for this view as well.
+
+**Discarding old records is not equivalent to deleting them**. These are
+fundamentally different operations.  Deleting a record means that any outputs
+derived from it should be updated.  For example, deleting a year-old purchase
+requires recomputing the `daily_max` query for the corresponding date.
+In contrast, a discarded record is conceptually still part of the relation;
+however it will not participate in computing any future incremental updates
+and therefore does not need to be stored.
+
+:::warning
+
+Feldera does not automatically garbage collect [materialized tables and views](/sql/materialized),
+as well as tables declared with a primary key.
+
+When a table or view is declared as materialized, it indicates an explicit user
+request to store its entire contents, making it accessible for
+[ad hoc queries](/sql/materialized/#ad-hoc-queries).
+However, if the materialized table contains an unbounded time series, it will
+continue to consume storage without limit, even if the associated views only
+require storing a bounded portion of the time series.
+
+Similarly Feldera stores the entire contents of tables declared with a primary key.
+This is necessary to correctly implement the upsert operation for such tables.
+
+:::
+
+
+## Emitting final values of a view with `emit_final`
+
+:::warning
+
+The `emit_final` feature is still experimental, and it may be removed
+or substantially modified in the future.
+
+:::
+
+By default, Feldera updates SQL views incrementally whenever new
+inputs arrive. Such incremental updates include deleting existing
+rows and inserting new rows into the view.  By monitoring these
+updates, the user can observe the most up-to-date results of the
+computation.  However, some applications only need to observe its
+final outputs, i.e., rows that are guaranteed to
+never get deleted or updated.
+
+Consider the following query that computes the sum of all purchases
+for each day.
+
+```sql
+CREATE VIEW daily_total AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    SUM(amount) AS total
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+```
+
+Suppose that a new `purchase` record arrives every second.  In response,
+Feldera updates the `daily_total` value for the current date,
+deleting the old value and inserting a new one.  The user may observe
+86400 such updates per day.  In some cases this is precisely what the user
+wants--to keep track of the latest value of the aggregate with low latency.
+But if the application only requires the final value of the aggregate at
+the end of the day, handling all the intermediate updates may introduce
+unnecessary overheads. Some applications may not be able to handle
+intermediate updates at all.  Typical reasons for this are:
+
+* **The application is unable to process row deletions**. Some
+    databases and database connectors cannot ingest deletions
+    efficiently or at all.
+
+* **The application cannot handle a large volume of incremental
+    updates.**  As we see in this example, the volume of intermediate
+    updates can be much larger than the final output, potentially
+    overwhelming the application.
+
+* **The application is only allowed to act on the final
+    output**. Consider an application that sends an
+    email, approves a stock trade or performs some other irreversible
+    action based on the output or the view. Such actions should only
+    be taken when the output is final. Handling intermediate outputs can
+    complicate the logic of the application, as the application may
+    not be able to reliably identify and discard intermediate values.
+
+The `emit_final` attribute instructs Feldera to only output final rows
+of a view, as in the following example:
+
+```sql
+CREATE VIEW daily_total_final
+WITH ('emit_final' = 'd')
+AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    SUM(amount) AS total
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+```
+
+The `emit_final` annotation causes the view to emit only the rows that
+have a value in the specified column that is before the view's current
+waterline.  Let us insert some records in the `purchase` table and
+observe how this affects the waterlines and the output of the view
+with and without `emit_final` annotations.
+
+| `INSERT INTO purchase`                 | `purchase.ts` stream time  |  `purchase.ts` waterline     | `daily_total.d` waterline    | Output without `emit_final`                     | Output with `emit_final`    |
+|----------------------------------------|----------------------------|------------------------------|------------------------------|-------------------------------------------------|-----------------------------|
+| `VALUES(1, '2020-01-01 01:00:00', 10)` | '2020-01-01 01:00:00'      | '2020-01-01 00:00:00'        | '2020-01-01 00:00:00'        | `insert: {"d":"2020-01-01 00:00:00","total":10}`|                             |
+| `VALUES(1, '2020-01-01 02:00:00', 10)` | '2020-01-01 02:00:00'      | '2020-01-01 01:00:00'        | '2020-01-01 00:00:00'        | `delete: {"d":"2020-01-01 00:00:00","total":10}`|                             |
+|                                        |                            |                              |                              | `insert: {"d":"2020-01-01 00:00:00","total":20}`|                             |
+| `VALUES(1, '2020-01-02 00:00:00', 10)` | '2020-01-02 00:00:00'      | '2020-01-01 23:00:00'        | '2020-01-01 00:00:00'        | `insert: {"d":"2020-01-02 00:00:00","total":10}`|                             |
+| `VALUES(1, '2020-01-02 01:00:00', 10)` | '2020-01-02 01:00:00'      | '2020-01-02 00:00:00'        | '2020-01-02 00:00:00'        | `delete: {"d":"2020-01-02 00:00:00","total":10}`| `insert: {"d":"2020-01-01 00:00:00","total":20}`|
+|                                        |                            |                              |                              | `insert: {"d":"2020-01-02 00:00:00","total":20}`|                             |
+
+Explanation:
+
+* The `purchase.ts` waterline trails one hour behind stream time due
+  to the `LATENESS` annotation on the `purchase` table.
+
+* The `daily_total.d` waterline is obtained by rounding the `purchase.ts`
+  waterline down to start of day using `TIMESTAMP_TRUNC()`.
+
+* Without `emit_final`, every input update produces an output update,
+  deleting any outdated records and inserting new records instead.
+
+* With `emit_final` only outputs below the current waterline are
+  produced. In this example, the waterline of the `daily_total.d`
+  timestamp column remains at '2020-01-01 00:00:00' until the last
+  `INSERT`, which moves the stream time to '2020-01-02 01:00:00'.
+  At this point, we know that no new inputs will have a timestamp
+  `< 2020-01-02 00:00:00` and can output the final aggregate value
+  for `2020-01-01`.
+
+The `emit_final` property must specify either a column name that
+exists in the view, or a column number, where 0 is the leftmost view
+column.
+
+Note that using `emit_final` can significantly delay the output of a view.
+In the example above, the aggregation is performed over a 1-day window,
+resulting in a 1-day delay before the output is produced. If the aggregation
+window were extended to 1 year, the view would not produce any outputs for
+an entire year.
+
+The use of `emit_final` is subject to the following restrictions:
+
+* If the query engine cannot infer a waterline for the specified
+  column of the view, it will emit an error at compilation time.
+
+* Currently this annotation is only allowed on views that are not
+  [`LOCAL`](/sql/grammar/#creating-views).  It takes effect only
+  for the view used as output.  If the view is used in defining
+  other views, these derived views will receive the non-delayed data.
+
+## Delaying inputs with `WATERMARK`
+
+:::warning
+
+The `WATERMARK` feature is still experimental, and it may be removed
+or substantially modified in the future.
+
+:::
+
+Feldera can process data received either in-order or out-of-order.  In both
+scenarios, it continuously maintains query results computed based on the inputs
+received so far, updating these results as new data arrives.  However, some
+applications may not be able to handle results derived from out-of-order data
+correctly and prefer to wait until all out-of-order events have been delivered.
+
+`WATERMARK` is an annotation on a column of a table that delays the processing
+of the input rows by a specified amount of time.  More precisely, given a `WATERMARK` annotation with value `WM`,
+an input row with a value `X` for the watermarked column will be "held up" until
+the stream time of the table reaches `X + WM`, at which point the program will
+behave as if the row with value `X` has only just been received.
+
+This delay allows `WM` time units for out-of-order data to arrive.
+For a column with a `LATENESS` annotation, setting `WATERMARK` to be equal
+to `LATENESS` ensures that all received data is processed in-order.
+
+`WATERMARK` is specified as an expression that evaluates to a constant value.
+The expression must have a type that can be subtracted from the column
+type.  For example, a column of type `TIMESTAMP` may have a watermark
+specified as an `INTERVAL` type:
+
+```sql
+CREATE TABLE purchase_watermark (
+   customer_id INT,
+   ts TIMESTAMP NOT NULL WATERMARK INTERVAL 1 HOURS,
+   amount BIGINT
+);
+```
+
+:::warning
+
+The current version of the SQL compiler does not support multiple
+`WATERMARK` columns in a single table.
+
+:::
+
+## Append-only tables
+
+Time series tables are often append-only: once an event has been received, it
+cannot be modified or deleted.  Feldera is able to leverage this property to
+optimize certain types of queries. Consider the `daily_max` view from above:
+
+```sql
+CREATE VIEW daily_max AS
+SELECT
+    TIMESTAMP_TRUNC(ts, DAY) as d,
+    MAX(amount) AS max_amount
+FROM
+    purchase
+GROUP BY
+    TIMESTAMP_TRUNC(ts, DAY);
+```
+
+Maintaining the `MAX` aggregate incrementally requires permanently storing the
+entire contents of the `purchase` table (ignoring the `LATENESS` annotation on
+`purchase.ts`).  However, if the table is append-only, then the `MAX` aggregate
+can only increase monotonically as new records are added to the table, and we
+only need to store the current largest value for each 1-day window.
+
+The `append_only` annotation on a table instructs Feldera that the table will
+only receive `INSERT` updates, enabling this and other optimizations:
+
+```sql
+CREATE TABLE purchase (
+   customer_id INT,
+   ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOURS,
+   amount BIGINT
+) WITH (
+    'append_only' = 'true'
+);
+```
+
+Note that `append_only` annotations are only supported for tables; however
+the Feldera query engine automatically derives it for views that depend on
+append-only tables.
+
+## SQL for time series analytics
+
+In this section, we present a catalog of SQL operators and patterns frequently used in
+time series analysis. Although these operators are applicable to both time-series and
+non-time-series data, they are particularly beneficial when working with time series.
+
+Feldera offers efficient incremental implementations of these constructs and
+supports garbage collection for most of them, meaning that they can be evaluated
+efficiently in both time and space.
+
+### Aggregating Time Series Data Over Fixed-Size Time Intervals
+
+A common practice in time series analysis is to segment the timeline into fixed-size
+intervals—such as minutes, hours, days, or years—and aggregate the data within each
+segment. Earlier, we encountered two examples of such queries: `daily_max` and
+`daily_sum`, which apply the `MAX` and `SUM` aggregation functions over 1-day
+intervals.
+
+#### Garbage collection
+
+The incremental implementation of aggregation operators stores both
+the input and output of the operator.  Feldera applies various optimizations to
+optimize storage, for example linear aggregation functions, such as
+`SUM`, `COUNT`, `AVG`, `STDDEV`, do not require storing the input relation;
+`MIN` and `MAX` aggregates over [append-only](#append-only-tables) collections
+only store one value per group, etc.  On top of these optimizations, the GC
+mechanism can discard old records under the following conditions:
+
+* Old input records get discarded if at least one of the expressions in the
+  `GROUP BY` clause is a monotonic function of a timestamp column, for which the query
+  engine can establish a waterline.  For instance, in the `daily_max` view,
+  `TIMESTAMP_TRUNC` is a monotonic function over the `purchase.ts` column.
+
+* Old output records get discarded if at least one of the output columns
+  has a waterline.  In the `daily_max` view, the `TIMESTAMP_TRUNC(ts, DAY) as d`
+  column has a waterline.
+
+### Tumbling and hopping windows
+
+[Tumbling](/sql/table/#tumble) and [hopping](/sql/table/#tumble) window operators
+provide a more idiomatic way to slice the timeline into non-overlapping or
+overlapping windows.  These operators do not maintain any state and therefore do
+not require GC.  The `daily_max` view can be expressed using the `TUMBLE` operator
+as follows:
+
+```sql
+CREATE VIEW daily_max_tumbling AS
+SELECT
+    window_start,
+    MAX(amount)
+FROM TABLE(
+  TUMBLE(
+    DATA => TABLE purchase,
+    TIMECOL => DESCRIPTOR(ts),
+    SIZE => INTERVAL 1 DAY))
+GROUP BY
+    window_start;
+```
+
+### Rolling aggregates
+
+[Rolling aggregates](https://www.feldera.com/blog/rolling-aggregates) offer a
+different way to define time windows. For each data point in a time series, they
+compute an aggregate over a fixed time frame (such as a day, an hour, or a
+month) preceding this data point.  Rolling aggregates can be expressed in SQL using
+[window aggregate functions](/sql/aggregates#window-aggregate-functions).
+Here is a version of `daily_max` that computes `MAX` over the 1-day window
+preceding each event:
+
+```sql
+CREATE VIEW daily_max_rolling AS
+SELECT
+    ts,
+    amount,
+    MAX(amount) OVER window_1_day
+FROM purchase
+WINDOW window_1_day AS (ORDER BY ts RANGE BETWEEN INTERVAL 1 DAY PRECEDING AND CURRENT ROW);
+```
+
+Rolling aggregates provide an accurate summary of recent event history for each data
+point in the dataset. They are more expensive than
+[tumbling and hopping windows](#tumbling-and-hopping-windows), since they instantiate as many
+individual windows as there are data points in the table.
+Feldera features an efficient incremental implementation of the rolling aggregate operator,
+that is capable of evaluating millions of individual windows per second on
+a laptop.
+
+#### Garbage collection
+
+GC for rolling aggregates works similar to regular aggregates (see [above](#aggregating-time-series-data-over-fixed-size-time-intervals)):
+
+* Old input records are discarded if the `ORDER BY` expression is a monotonic function
+  of a timestamp column, for which the query engine can establish a waterline.  For
+  instance, in the `rolling_daily_max` view above, the `purchase.ts` column, used in the
+  `ORDER BY` clause, has a waterline.
+
+* Old output records get discarded if at least one of the output columns
+  has a waterline.  In the `rolling_daily_max` view, the `ts` column copied
+  from the input table has a waterline.
+
+### Join over timestamp columns
+
+The following query computes daily totals over the `purchase` and `returns`
+tables and joins the results by date in order to construct a daily summary
+combining both totals for each given day in a single view:
+
+```sql
+CREATE VIEW daily_totals AS
+WITH
+    purchase_totals AS (
+        SELECT
+            TIMESTAMP_TRUNC(purchase.ts, DAY) as purchase_date,
+            SUM(purchase.amount) as total_purchase_amount
+        FROM purchase
+        GROUP BY
+            TIMESTAMP_TRUNC(purchase.ts, DAY)
+    ),
+    return_totals AS (
+        SELECT
+            TIMESTAMP_TRUNC(returns.ts, DAY) as return_date,
+            SUM(returns.amount) as total_return_amount
+        FROM returns
+        GROUP BY
+            TIMESTAMP_TRUNC(returns.ts, DAY)
+    )
+SELECT
+    purchase_totals.purchase_date as d,
+    purchase_totals.total_purchase_amount,
+    return_totals.total_return_amount
+FROM
+    purchase_totals
+    FULL OUTER JOIN
+    return_totals
+ON
+    purchase_totals.purchase_date = return_totals.return_date;
+```
+
+#### Garbage collection
+
+The join operator stores both of its input relations.  If at least one pair of
+columns being joined on has waterlines (in this case, both `purchase_totals.purchase_date`
+and `return_totals.return_date` have waterlines), the operator discards old records
+below the smaller of the two waterlines.
+
+### As-of joins
+
+The [`ASOF JOIN`](https://www.feldera.com/blog/asof-join) operator is a specialized
+type of JOIN used between two relations with comparable timestamp columns. It is
+used to answer questions such as "What was the stock price at
+the exact moment of the transaction?" or "What was the account balance just before
+the money transfer?"
+
+For each row in the left input relation, the as-of join operator identifies at most
+one row in the right input with the closest timestamp that is no greater than the
+timestamp in the left row. The example below demonstrates how an as-of join can be
+used to extract the customer’s address at the time of purchase from the `customer`
+table.
+
+```sql
+CREATE VIEW purchase_with_address AS
+SELECT
+    purchase.ts,
+    purchase.customer_id,
+    customer.address
+FROM purchase
+LEFT ASOF JOIN customer MATCH_CONDITION(purchase.ts >= customer.ts)
+ON purchase.customer_id = customer.customer_id;
+```
+
+#### Garbage collection
+
+The incremental as-of join operator stores both of its input relations.  Feldera
+currently implements GC for the left input only: if both timestamp columns
+in the `MATCH_CONDITION` have waterlines, the operator will discard old records
+below the smaller of the two waterlines.
+
+GC for the right input is on our [roadmap](https://github.com/feldera/feldera/issues/1850).
+[Let us know](https://github.com/feldera/feldera/issues/new/) if you are interested in this feature.
+
+### `LAG` and `LEAD`
+
+[`LAG` and `LEAD`](/sql/aggregates#window-aggregate-functions) SQL window functions allow access
+to a previous or following row in a relation.  When used with a window ordered by a timestamp
+column, they refer to earlier or later data points in a time series. The following view computes
+previous and next purchase amounts for each record in the `purchase` table:
+
+```sql
+CREATE VIEW purchase_with_prev_next AS
+SELECT
+    ts,
+    customer_id,
+    amount,
+    LAG(amount) OVER(PARTITION BY customer_id ORDER BY ts) as previous_amount,
+    LEAD(amount) OVER(PARTITION BY customer_id ORDER BY ts) as next_amount
+FROM
+    purchase;
+```
+
+#### Garbage collection
+
+GC for `LAG` and `LEAD` functions has not been implemented yet (see our
+GC feature [roadmap](https://github.com/feldera/feldera/issues/1850)).
+[Let us know](https://github.com/feldera/feldera/issues/new/) if you are interested in this feature.
+
+## `NOW()` and temporal filters
+
+All features discussed so far evaluate SQL queries over time series data without
+referring to the current physical time.  When the notion of "current time"
+was needed, stream time served the purpose.  Feldera allows using the current
+physical time in queries via the [`NOW()`](/sql/datetime/#the-now-function) function.  The primary use of this
+function is in implementing **temporal filters**, i.e., queries that filter
+records based on the current time values, e.g.:
+
+```sql
+CREATE VIEW recent_purchases AS
+SELECT * FROM purchase
+WHERE
+    ts >= NOW() - INTERVAL 7 DAYS;
+```
+
+`NOW()` is the only construct in Feldera that can cause the pipeline to produce
+outputs without receiving any new input.  In the above example, the pipeline will
+output deletions for records that fall outside the 7-day window as the physical
+clock ticks forward.
+
+See [`NOW()`](/sql/datetime/#the-now-function) documentation for more details.
+
+#### Garbage collection
+
+Feldera implements garbage collection for temporal filters by discarding records older
+than the left window bound (e.g., records more than 7 days old in the above example).
+This optimization is sound because `NOW()` grows monotonically, and not _not_ require
+the timestamp column to have a waterline.
+
+
+## Further reading
+
+* [Blog post: LATENESS in streaming programs](https://www.feldera.com/blog/lateness-in-streaming-programs)


### PR DESCRIPTION
A guide that systematically introduces concepts around GC and time series processing, the various SQL extensions we support for time seris analytics, as well as standard SQL that works well for time series (and that's GC'able).

Removed most text from the "Streaming extensions" section in the SQL reference, just keeping the list of features with pointers to corresponding sections of the guide.

I am still working on SQL examples.  I will combine them all in one program and will add it as a pre-packaged demo accompanying the guide.