### PR TITLE
[dbsp] Disable incorrect test.

### DIFF
--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1290,9 +1290,13 @@ mod tests {
         generic_checkpoint_restore(batches, mkcircuit);
     }
 
+    // TODO: fix this test. The circuit uses integrate_trace_with_bounds,
+    // which applied bounds lazily; however the correctness check assumes
+    // that bounds are applied instantly.
     /// Make sure we can take checkpoints of a spine with a trace bound and
     /// restore them.
     #[test]
+    #[ignore]
     fn commit_restore_bounds() {
         let _r = env_logger::try_init();
         let batches: Vec<Vec<Tup2<i32, Tup2<i32, i64>>>> = vec![


### PR DESCRIPTION
Disabled `commit_restore_bounds` test, which was failing in CI. The test assumes that `integrate_trace_with_bounds` applies bounds eagerly, which is not the case.

Fixes #2801 