### PR TITLE
[SQL] Monotonicity analysis for subtract and negate operators

### DIFF
--- a/crates/dbsp/src/operator/dynamic/time_series/window.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/window.rs
@@ -260,6 +260,7 @@ where
         //  region 3: [e0 .. e1)
 
         let (start1, end1) = bounds.into_owned();
+        // println!("{:?}-{:?}", start1, end1);
         let trace = trace.as_ref();
         let batch = batch.as_ref();
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
@@ -17,6 +17,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
@@ -26,6 +27,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSubtractOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUpsertFeedbackOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPViewOperator;
@@ -74,6 +76,16 @@ public class ExpandOperators extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPSumOperator operator) {
+        this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPSubtractOperator operator) {
+        this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPNegateOperator operator) {
         this.identity(operator);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -1007,7 +1007,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
                 return left;
             } else {
                 return ExpressionCompiler.makeBinaryExpression(left.getNode(),
-                        left.getType(), DBSPOpcode.MAX, left, right);
+                        left.getType(), DBSPOpcode.AGG_MAX, left, right);
             }
         } else if (leftProjection.is(PartiallyMonotoneTuple.class)) {
             PartiallyMonotoneTuple l = leftProjection.to(PartiallyMonotoneTuple.class);
@@ -1174,7 +1174,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
     }
 
     public static DBSPClosureExpression timestampMax(CalciteObject node, DBSPTypeTupleBase type) {
-        return type.pairwiseOperation(node, DBSPOpcode.MAX);
+        return type.pairwiseOperation(node, DBSPOpcode.AGG_MAX);
     }
 
     /** Generate an expression that compares two other expressions for equality */
@@ -1426,7 +1426,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         assert left.getType().sameTypeIgnoringNullability(right.getType());
         if (left.getType().is(DBSPTypeBaseType.class)) {
             return ExpressionCompiler.makeBinaryExpression(
-                    left.getNode(), left.getType(), DBSPOpcode.MIN, left, right);
+                    left.getNode(), left.getType(), DBSPOpcode.AGG_MIN, left, right);
         } else if (left.getType().is(DBSPTypeTupleBase.class)) {
             DBSPTypeTupleBase lt = left.getType().to(DBSPTypeTupleBase.class);
             DBSPExpression[] mins = new DBSPExpression[lt.size()];

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -14,6 +14,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPHopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
@@ -23,6 +24,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSubtractOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUpsertFeedbackOperator;
@@ -443,8 +445,7 @@ public class Monotonicity extends CircuitVisitor {
         this.set(node, result);
     }
 
-    @Override
-    public void postorder(DBSPSumOperator node) {
+    void sumOrDifference(DBSPOperator node) {
         List<MonotoneExpression> inputFunctions = Linq.map(node.inputs, this::getMonotoneExpression);
         // All the inputs must be monotone for the result to have a chance of being monotone
         if (inputFunctions.contains(null))
@@ -464,6 +465,15 @@ public class Monotonicity extends CircuitVisitor {
         this.set(node, result);
     }
 
+    @Override
+    public void postorder(DBSPSumOperator node) {
+        this.sumOrDifference(node);
+    }
+
+    @Override
+    public void postorder(DBSPSubtractOperator node) {
+        this.sumOrDifference(node);
+    }
 
     @Override
     public void postorder(DBSPDeindexOperator node) {
@@ -506,6 +516,11 @@ public class Monotonicity extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPNoopOperator node) {
+        this.identity(node);
+    }
+
+    @Override
+    public void postorder(DBSPNegateOperator node) {
         this.identity(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -46,6 +46,24 @@ public class StreamingTests extends StreamingTestBase {
                 AS SELECT t1.ts
                 FROM t1 FULL OUTER JOIN t2 on t1.ts = t2.ts;""";
         var ccs = this.getCCS(sql);
+        ccs.step("insert into t1 values (1, '2020-01-01 00:00:00');",
+                """
+                         ts | weight
+                        --------------""");
+        ccs.step("insert into t2 values (1, '2020-01-01 00:00:00');",
+                """
+                         ts | weight
+                        --------------""");
+        ccs.step("""
+                        insert into t1 values (1, '2020-01-02 00:00:00');
+                        insert into t2 values (1, '2020-01-02 00:00:00');
+                        """,
+                """
+                         ts | weight
+                        --------------
+                         2020-01-01 00:00:00 | 1""");
+
+
         this.addRustTestCase(ccs);
         CircuitVisitor visitor = new CircuitVisitor(new StderrErrorReporter()) {
             int window = 0;
@@ -61,6 +79,7 @@ public class StreamingTests extends StreamingTestBase {
                 Assert.assertEquals(1, this.window);
             }
         };
+        visitor.apply(ccs.circuit);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -29,6 +29,7 @@ import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.LowerCircuitVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity.MonotoneAnalyzer;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.Logger;
@@ -64,14 +65,22 @@ public class BaseSQLTests {
         return new CompilerCircuitStream(compiler);
     }
 
+    @SuppressWarnings("unused")
     protected void showPlan() {
         Logger.INSTANCE.setLoggingLevel(CalciteCompiler.class, 2);
     }
 
+    @SuppressWarnings("unused")
+    protected void instrumentApply() {
+        Logger.INSTANCE.setLoggingLevel(LowerCircuitVisitor.class, 2);
+    }
+
+    @SuppressWarnings("unused")
     protected void showMonotone() {
         Logger.INSTANCE.setLoggingLevel(MonotoneAnalyzer.class, 2);
     }
 
+    @SuppressWarnings("unused")
     protected void showFinal() {
         Logger.INSTANCE.setLoggingLevel(DBSPCompiler.class, 2);
     }


### PR DESCRIPTION
Fixes #2846

Outer joins are decomposed into regular joins and some subtractions. This PR implements monotonicity analysis for subtract and negate, and thus enables propagation of such information through outer joins.

The fact that the test program even compiles is a proof that the analysis works, otherwise the program would be rejected, since it has an emit_final annotation.
