### PR TITLE
Delete files that are no longer part of a spine.

### DIFF
--- a/crates/dbsp/src/storage/backend/memory_impl.rs
+++ b/crates/dbsp/src/storage/backend/memory_impl.rs
@@ -59,8 +59,8 @@ impl MemoryBackend {
     }
 
     /// Helper function to delete (mutable and immutable) files.
-    fn delete_inner(&self, fd: i64) -> Result<(), StorageError> {
-        self.files.write().unwrap().remove(&fd).unwrap();
+    fn delete_mut_inner(&self, fh: FileHandle) -> Result<(), StorageError> {
+        self.files.write().unwrap().remove(&fh.0).unwrap();
         counter!(FILES_DELETED).increment(1);
         Ok(())
     }
@@ -106,12 +106,10 @@ impl Storage for MemoryBackend {
         Ok(ImmutableFileHandle(file_id))
     }
 
-    fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
-        self.delete_inner(fd.0)
-    }
+    fn mark_for_checkpoint(&self, _fd: &ImmutableFileHandle) {}
 
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
-        self.delete_inner(fd.0)
+        self.delete_mut_inner(fd)
     }
 
     fn base(&self) -> PathBuf {

--- a/crates/dbsp/src/storage/backend/tests.rs
+++ b/crates/dbsp/src/storage/backend/tests.rs
@@ -150,10 +150,7 @@ impl<const ALLOW_OVERWRITE: bool> Storage for InMemoryBackend<ALLOW_OVERWRITE> {
         unimplemented!()
     }
 
-    fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
-        self.immutable_files.borrow_mut().remove(&fd.0);
-        Ok(())
-    }
+    fn mark_for_checkpoint(&self, _fd: &ImmutableFileHandle) {}
 
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
         self.files.borrow_mut().remove(&fd.0);

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -307,13 +307,15 @@ where
     fn create_named(&self, name: &Path) -> Result<FileHandle, StorageError> {
         Self::backend().create_named(name)
     }
+
     fn open(&self, name: &Path) -> Result<ImmutableFileHandle, StorageError> {
         Self::backend().open(name)
     }
-    fn delete(&self, fd: ImmutableFileHandle) -> Result<(), StorageError> {
-        self.inner.lock().unwrap().delete_file((&fd).into());
-        Self::backend().delete(fd)
+
+    fn mark_for_checkpoint(&self, fd: &ImmutableFileHandle) {
+        Self::backend().mark_for_checkpoint(fd);
     }
+
     fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
         self.inner.lock().unwrap().delete_file((&fd).into());
         Self::backend().delete_mut(fd)

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -1070,6 +1070,14 @@ impl ImmutableFileRef {
         let file_handle = cache.open(path)?;
         Ok(Self::new(cache, file_handle, path.to_path_buf()))
     }
+
+    pub fn mark_for_checkpoint(&self) {
+        if let Some(file_handle) = self.file_handle.as_ref() {
+            self.cache.mark_for_checkpoint(file_handle);
+        } else {
+            log::error!("file_handle was None?")
+        }
+    }
 }
 
 struct ReaderInner<T> {
@@ -1196,6 +1204,11 @@ where
             columns: (0..T::n_columns()).map(|_| Column::empty()).collect(),
             _phantom: PhantomData,
         })))
+    }
+
+    /// Marks the file of the reader as being part of a checkpoint.
+    pub fn mark_for_checkpoint(&self) {
+        self.0.file.mark_for_checkpoint();
     }
 
     /// Instantiates a reader given an existing path.

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -52,7 +52,6 @@ pub mod spine_async;
 pub use spine_async::{Spine, SpineSnapshot};
 
 mod spine_fueled;
-pub use spine_fueled::Spine as OldSpine;
 #[cfg(test)]
 pub mod test;
 
@@ -568,7 +567,11 @@ where
         None
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    /// This functions returns a path to a file that can be used by the checkpoint
+    /// mechanism to find the batch again on re-start.
+    ///
+    /// If the batch can not be persisted, this function returns None.
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         None
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -397,10 +397,10 @@ where
         }
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         match &self.inner {
-            Inner::Vec(vec) => vec.persistent_id(),
-            Inner::File(file) => file.persistent_id(),
+            Inner::Vec(vec) => vec.checkpoint_path(),
+            Inner::File(file) => file.checkpoint_path(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -326,10 +326,10 @@ where
         }
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         match &self.inner {
-            Inner::Vec(vec) => vec.persistent_id(),
-            Inner::File(file) => file.persistent_id(),
+            Inner::Vec(vec) => vec.checkpoint_path(),
+            Inner::File(file) => file.checkpoint_path(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -336,10 +336,10 @@ where
         }
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         match &self.inner {
-            Inner::Vec(vec) => vec.persistent_id(),
-            Inner::File(file) => file.persistent_id(),
+            Inner::Vec(vec) => vec.checkpoint_path(),
+            Inner::File(file) => file.checkpoint_path(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -393,10 +393,10 @@ where
         }
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         match &self.inner {
-            Inner::Vec(vec) => vec.persistent_id(),
-            Inner::File(file) => file.persistent_id(),
+            Inner::Vec(vec) => vec.checkpoint_path(),
+            Inner::File(file) => file.checkpoint_path(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -413,7 +413,8 @@ where
 
     fn recede_to(&mut self, _frontier: &()) {}
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
+        self.file.mark_for_checkpoint();
         Some(self.file.path())
     }
 

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -313,7 +313,8 @@ where
         }
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
+        self.file.mark_for_checkpoint();
         Some(self.file.path())
     }
 

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -378,7 +378,8 @@ where
         })
     }
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
+        self.file.mark_for_checkpoint();
         Some(self.file.path())
     }
 

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -409,7 +409,8 @@ where
 
     fn recede_to(&mut self, _frontier: &()) {}
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
+        self.file.mark_for_checkpoint();
         Some(self.file.path())
     }
 

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -334,7 +334,7 @@ where
     type Builder = VecKeyBuilder<K, T, R, O>;
     type Merger = VecKeyMerger<K, T, R, O>;
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         unimplemented!()
     }
 

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -402,7 +402,7 @@ where
     type Builder = VecValBuilder<K, V, T, R, O>;
     type Merger = VecValMerger<K, V, T, R, O>;
 
-    fn persistent_id(&self) -> Option<PathBuf> {
+    fn checkpoint_path(&self) -> Option<PathBuf> {
         unimplemented!()
     }
 

--- a/crates/dbsp/src/trace/spine_async/mod.rs
+++ b/crates/dbsp/src/trace/spine_async/mod.rs
@@ -1037,7 +1037,7 @@ where
             .iter()
             .map(|batch| {
                 batch
-                    .persistent_id()
+                    .checkpoint_path()
                     .expect("The batch should have been persisted")
                     .to_string_lossy()
                     .to_string()

--- a/crates/dbsp/src/trace/spine_fueled.rs
+++ b/crates/dbsp/src/trace/spine_fueled.rs
@@ -128,7 +128,7 @@ impl<B: Batch + Send + Sync> From<&Spine<B>> for CommittedSpine<B> {
         let mut batches = vec![];
         value.map_batches(|b| {
             batches.push(
-                b.persistent_id()
+                b.checkpoint_path()
                     .expect("Persistent spine needs an identifier")
                     .to_string_lossy()
                     .to_string(),


### PR DESCRIPTION
When we run with storage, we didn't delete files that got replaced with new ones by merging.

This PR removes the explicit delete in the storage backend as it's hard to know when it's safe to delete files. Instead we delete files automatically in the drop handle for ImmutableFile. This is good as long as the file isn't part of a checkpoint, when we can no longer do that. For this case we add a new method, mark_for_checkpoint that, when called stops deleting on drop.

After mark_for_checkpoint is called, the Checkpointer becomes responsible to remove files that are no longer reachable from any checkpoint.