### PR TITLE
[adapters] Typo in `push_with_aux`.

### DIFF
--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -212,7 +212,7 @@ impl<A> InputQueue<A> {
                 queue.push_back((buffer, aux));
                 self.consumer.buffered(num_records, num_bytes);
             }
-            _ => self.consumer.buffered(num_bytes, 0),
+            _ => self.consumer.buffered(0, num_bytes),
         }
     }
 


### PR DESCRIPTION
`push_with_aux` swapped arguments to consumer.buffered(), which messed up the buffered records accounting, and caused #2845.

Fixes #2845 