### PR TITLE
[Docs] Fix links to python docs with Docusaurus'es 'pathname://'

### DIFF
--- a/docs/connectors/sources/http.md
+++ b/docs/connectors/sources/http.md
@@ -131,4 +131,4 @@ For more information, see:
 * Data formats such as [JSON](/formats/json) and
   [CSV](/formats/csv)
 
-* [Python API documentation](/python/)
+* [Python API documentation](pathname:///python/)

--- a/docs/interact/index.mdx
+++ b/docs/interact/index.mdx
@@ -25,7 +25,7 @@ import Link from '@docusaurus/Link';
 <div className="card">
   <div className="card__body">
     <h3>
-      <Link to="/python/">Python SDK</Link>
+      <Link to="pathname:///python/">Python SDK</Link>
     </h3>
     <p>The Python SDK provides a convenient wrapper around our REST API. It allows you to programmatically define pipelines.</p>
   </div>

--- a/docs/sql/ad-hoc.md
+++ b/docs/sql/ad-hoc.md
@@ -47,19 +47,19 @@ Refer to [CLI docs](/reference/cli) for more details.
 
 ### Feldera Python SDK
 
-You can execute adhoc queries via the Python SDK using the [.query](/python/feldera.html#feldera.pipeline.Pipeline.query) method, which returns a generator of Python Dictionaries:
+You can execute adhoc queries via the Python SDK using the [.query](pathname:///python/feldera.html#feldera.pipeline.Pipeline.query) method, which returns a generator of Python Dictionaries:
 ```py
 gen_obj = pipeline.query("SELECT * FROM materialized_view;")
 output = list(gen_obj)
 ```
 
 There are variations of the `.query` method that return response in different formats:
-- [.query_tabular](/python/feldera.html#feldera.pipeline.Pipeline.query_tabular)
+- [.query_tabular](pathname:///python/feldera.html#feldera.pipeline.Pipeline.query_tabular)
   Returns a generator of `String`.
-- [.query_parquet](/python/feldera.html#feldera.pipeline.Pipeline.query_parquet)
+- [.query_parquet](pathname:///python/feldera.html#feldera.pipeline.Pipeline.query_parquet)
   Saves the output of this query to the parquet file.
 
-For `INSERT` and `DELETE` queries it is recommended to use the [.execute](/python/feldera.html#feldera.pipeline.Pipeline.execute) method:
+For `INSERT` and `DELETE` queries it is recommended to use the [.execute](pathname:///python/feldera.html#feldera.pipeline.Pipeline.execute) method:
 
 ```py
 pipeline.execute("INSERT INTO tbl VALUES(1, 2, 3);")

--- a/docs/sql/udf.md
+++ b/docs/sql/udf.md
@@ -136,7 +136,7 @@ base64 = "0.22.1"
 fda create udf_fda_test --udf-rs udf.rs --udf-toml udf.toml program.sql
 ```
 
-#### Using [Feldera Python SDK](/python/)
+#### Using [Feldera Python SDK](pathname:///python/)
 
 <details>
   <summary>Click to see how to create a pipeline with a Rust UDF using the Feldera Python SDK</summary>

--- a/docs/tutorials/basics/part1.md
+++ b/docs/tutorials/basics/part1.md
@@ -102,7 +102,7 @@ Click the Play <icon icon="bx:play" /> button to run the pipeline.
 
 ## Step 2. Insert data
 
-When the pipeline is running it can process incoming changes. The changes can be submitted to the pipeline in three ways: automatically via [input connectors](connectors/) attached to the pipeline tables, by sending HTTP ingress requests and by issuing `INSERT INTO ...` ad-hoc queries. You can use one of our tools - the [Python SDK](/python/feldera.html#feldera.pipeline.Pipeline.input_json), the [Feldera CLI tool](reference/cli), the Web Console or the [REST API](/api/push-data-to-a-sql-table) directly to leverage any of these methods. For simplicity, let us use the Web Console to run an `INSERT INTO ...` query.
+When the pipeline is running it can process incoming changes. The changes can be submitted to the pipeline in three ways: automatically via [input connectors](/connectors/) attached to the pipeline tables, by sending HTTP ingress requests and by issuing `INSERT INTO ...` ad-hoc queries. You can use one of our tools - the [Python SDK](pathname:///python/feldera.html#feldera.pipeline.Pipeline.input_json), the [Feldera CLI tool](/reference/cli), the Web Console or the [REST API](/api/push-data-to-a-sql-table) directly to leverage any of these methods. For simplicity, let us use the Web Console to run an `INSERT INTO ...` query.
 
 Open the "Ad-hoc query" tab and paste the following statement in the input field:
 

--- a/docs/use_cases/fraud_detection/fraud_detection.md
+++ b/docs/use_cases/fraud_detection/fraud_detection.md
@@ -17,7 +17,7 @@ will go through the following steps of building the application:
   seamlessly on streaming data for real-time inference.**
 
 The entire use case is implemented as a Python script written using the Feldera
-[Python SDK](/python/). It is available from our [github
+[Python SDK](pathname:///python/). It is available from our [github
 repository](https://github.com/feldera/feldera/blob/main/demo/project_demo10-FraudDetectionDeltaLake/run.py)
 and can be run from the command line or from your favorite Python notebook
 environment.
@@ -226,7 +226,7 @@ The following Python snippet connects to a Feldera service
 and creates a Feldera pipeline to read transaction and demographics
 data from Delta tables stored in S3 and evaluate the feature query
 defined above on this data. We use the
-[`listen`](/python/feldera.html#feldera.pipeline.Pipeline.listen)
+[`listen`](pathname:///python/feldera.html#feldera.pipeline.Pipeline.listen)
 API to read the computed features into a [Pandas](https://pandas.pydata.org/)
 dataframe. We split this dataframe into train and test sets. We
 use the former to train an XGBoost model and the latter to measure model


### PR DESCRIPTION
Docusaurus cannot resolve links to /python/... because they are generated separately, so need to be resolved as an absolute path. Rather than hardcoding docs.feldera.com, Docusaurus has special syntax for this : `pathname://`, e.g. `pathname:///python/...`