### PR TITLE
Send attributes that are null as part of JSON response.

### DIFF
--- a/crates/pipeline-manager/src/integration_test.rs
+++ b/crates/pipeline-manager/src/integration_test.rs
@@ -1087,7 +1087,7 @@ async fn json_ingress() {
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 10, "c2": true}, {"c1": 20, "c3": "foo"}])
+        json!([{"c1": 10, "c2": true, "c3": null}, {"c1": 20, "c2": null, "c3": "foo"}])
     );
 
     // Push more data using insert/delete format.
@@ -1108,7 +1108,7 @@ async fn json_ingress() {
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 20, "c3": "foo"}, {"c1": 30, "c3": "bar"}])
+        json!([{"c1": 20, "c2": null, "c3": "foo"}, {"c1": 30, "c2": null, "c3": "bar"}])
     );
 
     // Format data as json array.
@@ -1136,7 +1136,7 @@ async fn json_ingress() {
                 "select * from T1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 20, "c3": "foo"}, {"c1": 30, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
+        json!([{"c1": 20, "c2": null, "c3": "foo"}, {"c1": 30, "c2": null, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
     );
 
     // Trigger parse errors.
@@ -1160,7 +1160,7 @@ async fn json_ingress() {
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 20, "c3": "foo"}, {"c1": 30, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
+        json!([{"c1": 20, "c2": null, "c3": "foo"}, {"c1": 30, "c2": null, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
     );
 
     let mut response = config
@@ -1183,7 +1183,7 @@ async fn json_ingress() {
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 20, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
+        json!([{"c1": 20, "c2": null, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c2": null, "c3": "bar"}, {"c1": 50, "c2": true, "c3": ""}])
     );
 
     // Debezium CDC format
@@ -1203,7 +1203,7 @@ async fn json_ingress() {
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 20, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c3": "bar"}, {"c1": 60, "c2": true, "c3": "hello"}])
+        json!([{"c1": 20, "c2": null, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c2": null, "c3": "bar"}, {"c1": 60, "c2": true, "c3": "hello"}])
     );
 
     // Push some CSV data (the second record is invalid, but the other two should
@@ -1229,7 +1229,7 @@ not_a_number,true,ΑαΒβΓγΔδ
                 "select * from t1 order by c1, c2, c3;"
             )
             .await,
-        json!([{"c1": 15, "c2": true, "c3": "foo"}, {"c1": 16, "c2": false, "c3": "unicode🚲"}, {"c1": 20, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c3": "bar"}, {"c1": 60, "c2": true, "c3": "hello"}])
+        json!([{"c1": 15, "c2": true, "c3": "foo"}, {"c1": 16, "c2": false, "c3": "unicode🚲"}, {"c1": 20, "c2": null, "c3": "foo"}, {"c1": 25, "c2": true, "c3": ""}, {"c1": 30, "c2": null, "c3": "bar"}, {"c1": 60, "c2": true, "c3": "hello"}])
     );
 
     // Shutdown the pipeline
@@ -1279,7 +1279,7 @@ async fn map_column() {
         config
             .adhoc_query_json("/v0/pipelines/test/query", "select * from t1 order by c1;")
             .await,
-        json!([{"c1": 10, "c2": true, "c3": {"bar": "2", "foo": "1"}}, {"c1": 20}])
+        json!([{"c1": 10, "c2": true, "c3": {"bar": "2", "foo": "1"}}, {"c1": 20, "c2": null, "c3": null}])
     );
 
     // Shutdown the pipeline

--- a/python/tests/aggregate_tests/aggtst_base.py
+++ b/python/tests/aggregate_tests/aggtst_base.py
@@ -100,7 +100,6 @@ class View(SqlObject):
         """Check that the data received matches the expected data"""
         data = list(pipeline.query(f"SELECT * FROM {self.name};"))
         expected = self.get_data()
-        expected = [{k: v for k, v in d.items() if v is not None} for d in expected]
 
         tc = unittest.TestCase()
         tc.assertCountEqual(

--- a/python/tests/aggregate_tests/test_varcharn_argmin.py
+++ b/python/tests/aggregate_tests/test_varcharn_argmin.py
@@ -22,7 +22,10 @@ class aggtst_varcharn_argmin_value_diff(TstView):
 class aggtst_varcharn_argmin_gby(TstView):
     def __init__(self):
         # checked manually
-        self.data = [{"id": 0, "c2": "fred"}, {"id": 1, "c1": "hello", "c2": "varia"}]
+        self.data = [
+            {"id": 0, "c1": None, "c2": "fred"},
+            {"id": 1, "c1": "hello", "c2": "varia"},
+        ]
         self.sql = """CREATE MATERIALIZED VIEW varcharn_argmin_gby AS SELECT
                       id, ARG_MIN(f_c1, f_c2) AS c1, ARG_MIN(f_c2, f_c1) AS c2
                       FROM atbl_varcharn
@@ -41,7 +44,10 @@ class aggtst_varcharn_argmin_distinct(TstView):
 class aggtst_varcharn_argmin_distinct_gby(TstView):
     def __init__(self):
         # checked manually
-        self.data = [{"id": 0, "c2": "fred"}, {"id": 1, "c1": "hello", "c2": "varia"}]
+        self.data = [
+            {"id": 0, "c1": None, "c2": "fred"},
+            {"id": 1, "c1": "hello", "c2": "varia"},
+        ]
         self.sql = """CREATE MATERIALIZED VIEW varcharn_argmin_distinct_gby AS SELECT
                       id, ARG_MIN(DISTINCT f_c1, f_c2) AS c1, ARG_MIN(DISTINCT f_c2, f_c1) AS c2
                       FROM atbl_varcharn


### PR DESCRIPTION
Otherwise it's hard for clients to figure out which fields a query returns.

Fixes #2839