### PR TITLE
[RFC][WebConsole] collapse 'connectors' =... declaration when the file is first opened

### DIFF
--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -93,7 +93,8 @@
         markers: ((errors) =>
           errors ? { [felderaCompilerMarkerSource]: extractErrorMarkers(errors) } : undefined)(
           programErrors['program.sql']
-        )
+        ),
+        foldRangeIf: (line: string) => /'connectors' =/.test(line)
       },
       {
         name: `stubs.rs`,

--- a/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
+++ b/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
@@ -118,7 +118,8 @@
   let isReadonly = $derived(editDisabled || isReadonlyProperty(file.access, 'current'))
 
   let filePath = $derived(path + '/' + file.name)
-  let previousFilePath = $state<string | undefined>(undefined)
+  /* svelte-ignore state_referenced_locally */
+  let previousFilePath = $state(filePath)
 
   $effect.pre(() => {
     if (openFiles[filePath]) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5066823c-c5f5-4606-b950-65fe51514f61)
![image](https://github.com/user-attachments/assets/5fbc36f2-bff4-483c-8956-ca11765de60d)

If you expand the connector declaration, switch to another pipeline and come back - the declaration will remain expanded. If you reload the page the declaration will get collapsed again