### PR TITLE
[SQL] Fix typo in visitor implementation; ExpressionTree class for debugging help

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -1054,7 +1054,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId {
     // Expressions
 
     public void postorder(DBSPFlatmap node) {
-        this.preorder(node.to(DBSPExpression.class));
+        this.postorder(node.to(DBSPExpression.class));
     }
 
     public void postorder(DBSPSortExpression node) {
@@ -1138,7 +1138,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId {
     }
 
     public void postorder(DBSPUnwrapExpression node) {
-        this.preorder(node.to(DBSPExpression.class));
+        this.postorder(node.to(DBSPExpression.class));
     }
 
     public void postorder(DBSPPathExpression node) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/RepeatedExpressions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/RepeatedExpressions.java
@@ -4,6 +4,8 @@ import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.util.IHasId;
+import org.dbsp.util.Linq;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -28,6 +30,10 @@ public class RepeatedExpressions extends InnerVisitor {
         this.onlyExpressions = expressions;
         this.visited = new HashSet<>();
         this.duplicate = null;
+    }
+
+    void printContext() {
+        System.out.println(Linq.map(this.context, IHasId::getId));
     }
 
     @Override
@@ -67,13 +73,13 @@ public class RepeatedExpressions extends InnerVisitor {
                     .append(this.duplicate)
                     .append(" ")
                     .append(this.duplicate.getId())
-                    .append(" context ");
+                    .append(" context:\n");
             Collections.reverse(this.duplicateContext);
             for (IDBSPInnerNode parent: this.duplicateContext) {
                 builder.append(parent.getId())
                         .append(" ")
                         .append(parent)
-                        .append(" ");
+                        .append("\n");
             }
             throw new RuntimeException(builder.toString());
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/ExpressionTree.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/ExpressionTree.java
@@ -1,0 +1,52 @@
+package org.dbsp.sqlCompiler.ir.expression;
+
+import org.dbsp.util.IIndentStream;
+import org.dbsp.util.IndentStream;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Use reflection to print an expression as a tree */
+public class ExpressionTree {
+    static List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        while (clazz != null) {
+            Collections.addAll(fields, clazz.getDeclaredFields());
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
+
+    private static void asTree(DBSPExpression expression, IIndentStream stream) throws IllegalAccessException {
+        Class<?> clazz = expression.getClass();
+        stream.append(expression.id)
+                .append(" ")
+                .append(clazz.getSimpleName())
+                .increase();
+        for (Field field : getAllFields(clazz)) {
+            if (DBSPExpression.class.isAssignableFrom(field.getType())) {
+                asTree((DBSPExpression) field.get(expression), stream);
+            } else if (field.getType().isArray()) {
+                Object[] values = (Object[])field.get(expression);
+                for (Object obj: values) {
+                    if (obj instanceof DBSPExpression)
+                        asTree((DBSPExpression) obj, stream);
+                }
+            }
+        }
+        stream.decrease();
+    }
+
+    public static String asTree(DBSPExpression expression) {
+        try {
+            StringBuilder builder = new StringBuilder();
+            IndentStream stream = new IndentStream(builder);
+            asTree(expression, stream);
+            return stream.toString();
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/ExpressionTreeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/ExpressionTreeTests.java
@@ -1,0 +1,31 @@
+package org.dbsp.sqlCompiler.compiler.ir;
+
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.ExpressionTree;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExpressionTreeTests {
+    @Test
+    public void testTree() throws IllegalAccessException {
+        DBSPType i32 = new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true);
+        DBSPExpression expression =
+                new DBSPTupleExpression(
+                        new DBSPI32Literal(20),
+                        new DBSPBinaryExpression(
+                                CalciteObject.EMPTY,
+                                i32,
+                                DBSPOpcode.ADD,
+                                i32.var(),
+                                new DBSPI32Literal(6)));
+        String tree = ExpressionTree.asTree(expression);
+        Assert.assertTrue(tree.contains("DBSPBinaryExpression"));
+    }
+}


### PR DESCRIPTION
There were two typos in the visitor implementation for expressions.
It is a bit unfortunate that there is no easy way to catch such bugs except through visual inspection.
To help debug this problem I created a new class ExpressionTree.