### PR TITLE
[sql] Don't generate serde traits for structs.

### DIFF
--- a/crates/feldera-types/src/serde_with_context/serialize.rs
+++ b/crates/feldera-types/src/serde_with_context/serialize.rs
@@ -38,7 +38,7 @@ use std::{
 
 /// Similar to [`Serialize`], but takes an extra `context` argument and
 /// threads it through all nested structures.
-pub trait SerializeWithContext<C>: Sized + Serialize {
+pub trait SerializeWithContext<C>: Sized {
     fn serialize_with_context<S>(&self, serializer: S, context: &C) -> Result<S::Ok, S::Error>
     where
         S: Serializer;
@@ -372,7 +372,7 @@ macro_rules! serialize_struct {
         #[allow(unused_mut)]
         impl<C, $($arg),*> $crate::serde_with_context::SerializeWithContext<C> for $struct<$($arg),*>
         where
-            $($arg: $crate::serde_with_context::SerializeWithContext<C> + serde::Serialize),*
+            $($arg: $crate::serde_with_context::SerializeWithContext<C>),*
             $($($arg : $bound,)?),*
         {
             fn serialize_with_context<S>(&self, serializer: S, context: &C) -> Result<S::Ok, S::Error>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -1547,17 +1547,13 @@ public class ToRustInnerVisitor extends InnerVisitor {
 
     @Override
     public VisitDecision preorder(DBSPStructItem item) {
-        this.builder.append("#[derive(Clone, Debug, Eq, PartialEq, Default, serde::Serialize, serde::Deserialize)]")
+        this.builder.append("#[derive(Clone, Debug, Eq, PartialEq, Default)]")
                 .newline();
         builder.append("struct ")
                     .append(Objects.requireNonNull(item.type.sanitizedName))
                 .append(" {")
                 .increase();
         for (DBSPTypeStruct.Field field: item.type.fields.values()) {
-            builder.append("#[serde(rename = \"")
-                    .append(Utilities.escape(
-                            this.options.canonicalName(field.name)))
-                    .append("\")]\n");
             field.accept(this);
             this.builder.append(",")
                     .newline();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -326,18 +326,6 @@ public class CatalogTests extends BaseSQLTests {
         this.addRustTestCase(ccs);
     }
 
-    // Test for https://github.com/feldera/feldera/issues/1666
-    @Test
-    public void viewColumnsTest() {
-        String sql = """
-                CREATE TABLE t(v INT);
-                CREATE VIEW V (sum) AS SELECT SUM(v) FROM T;
-                """;
-        CompilerCircuitStream ccs = this.getCCS(sql);
-        String string = ToRustVisitor.toRustString(new StderrErrorReporter(), ccs.circuit, ccs.compiler.options);
-        Assert.assertTrue(string.contains("serde(rename = \"sum\")"));
-    }
-
     // Test for https://github.com/feldera/feldera/issues/1151
     @Test
     public void primaryKeyTest() {


### PR DESCRIPTION
Auto-generated Rust structs only need to implement `(De)SerializeWithContext`, and not the standard serde `Serialize/Deserialize` traits.

Turns out, `SerializeWithContext` derived `serde::Serialize`, but it was completely unnecessary, so I removed the derivation and changed Java code not to auto-derive serde traits.

I don't think this improves compilation speed.  The serde traits weren't actually used and ended up getting compiled away.