### PR TITLE
[SQL] Fix bug in implementation of XOR aggregate

### DIFF
--- a/crates/sqllib/src/aggregates.rs
+++ b/crates/sqllib/src/aggregates.rs
@@ -1,9 +1,10 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::let_and_return)]
+#![allow(clippy::unnecessary_cast)]
 
 use crate::binary::ByteArray;
-use crate::{FromInteger, ToInteger};
+use crate::{FromInteger, ToInteger, Weight};
 use dbsp::algebra::{FirstLargeValue, HasOne, HasZero, SignedPrimInt, UnsignedPrimInt, F32, F64};
 use num::PrimInt;
 use num_traits::CheckedAdd;
@@ -377,6 +378,30 @@ where
 
 for_all_int_aggregate!(agg_xor, agg_xor);
 
+// Helper function for XOR
+#[doc(hidden)]
+#[inline]
+pub fn right_xor_weigh<T>(right: T, w: Weight) -> T
+where
+    T: PrimInt,
+{
+    if ((w as i64) % 2) == 0 {
+        T::zero()
+    } else {
+        right
+    }
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn right_xor_weighN<T>(right: Option<T>, w: Weight) -> Option<T>
+where
+    T: PrimInt,
+{
+    let right = right?;
+    Some(right_xor_weigh(right, w))
+}
+
 #[doc(hidden)]
 pub fn agg_and_bytes(left: ByteArray, right: ByteArray) -> ByteArray {
     left.and(&right)
@@ -394,6 +419,23 @@ some_aggregate!(agg_or_bytes, agg_or, bytes, ByteArray);
 #[doc(hidden)]
 pub fn agg_xor_bytes(left: ByteArray, right: ByteArray) -> ByteArray {
     left.xor(&right)
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn right_xor_weigh_bytes(right: ByteArray, w: Weight) -> ByteArray {
+    if ((w as i64) % 2) == 0 {
+        ByteArray::zero(right.length())
+    } else {
+        right
+    }
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn right_xor_weigh_bytesN(right: Option<ByteArray>, w: Weight) -> Option<ByteArray> {
+    let right = right?;
+    Some(right_xor_weigh_bytes(right, w))
 }
 
 some_aggregate!(agg_xor_bytes, agg_xor, bytes, ByteArray);

--- a/crates/sqllib/src/binary.rs
+++ b/crates/sqllib/src/binary.rs
@@ -60,6 +60,12 @@ impl ByteArray {
         Self { data: d.to_vec() }
     }
 
+    pub fn zero(size: usize) -> Self {
+        Self {
+            data: vec![0; size],
+        }
+    }
+
     /// Create a ByteArray from a Vector of bytes
     pub fn from_vec(d: Vec<u8>) -> Self {
         Self { data: d }

--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -4,7 +4,7 @@
 
 use std::cmp::Ordering;
 
-use crate::{binary::ByteArray, geopoint::*, interval::*, timestamp::*, variant::*};
+use crate::{binary::ByteArray, geopoint::*, interval::*, timestamp::*, variant::*, Weight};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use dbsp::algebra::{HasOne, HasZero, F32, F64};
 use num::{FromPrimitive, One, ToPrimitive, Zero};
@@ -1365,6 +1365,13 @@ cast_to_i!(u16);
 cast_to_i!(u32);
 cast_to_i!(u64);
 cast_to_i!(u128);
+
+#[doc(hidden)]
+#[inline]
+#[allow(clippy::unnecessary_cast)]
+pub fn cast_to_i64_Weight(w: Weight) -> i64 {
+    w as i64
+}
 
 #[doc(hidden)]
 #[inline]

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -64,9 +64,8 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitOptimizer;
 import org.dbsp.sqlCompiler.ir.DBSPFunction;
 import org.dbsp.sqlCompiler.ir.DBSPNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeUser;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWeight;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
@@ -154,8 +153,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         this.sources = new SourceFileContents();
         this.circuit = null;
         this.typeCompiler = new TypeCompiler(this);
-        this.weightVar = new DBSPTypeUser(CalciteObject.EMPTY, DBSPTypeCode.USER, "Weight", false)
-                .var();
+        this.weightVar = DBSPTypeWeight.INSTANCE.var();
         this.start();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -55,9 +55,11 @@ public enum DBSPOpcode {
     // arithmetic operations, following SQL semantics.
     AGG_AND("agg_and", true),
     AGG_OR("agg_or", true),
+    // Operation which combines an accumulator and a *weighted* value
     AGG_XOR("agg_xor", true),
     AGG_MAX("agg_max", true),
     AGG_MIN("agg_min", true),
+    // Operation which combines an accumulator and a *weighted* value
     AGG_ADD("agg_plus", true),
     // > used in aggregation, for computing ARG_MAX.
     // NULL compares in a special way, since it means "uninitialized"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBinary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBinary.java
@@ -10,9 +10,7 @@ import org.dbsp.util.IIndentStream;
 
 import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.BYTES;
 
-/**
- * Represents a byte array.
- */
+/** Represents a byte array. */
 public class DBSPTypeBinary extends DBSPTypeBaseType {
     public static final int UNLIMITED_PRECISION = -1;
 
@@ -77,4 +75,3 @@ public class DBSPTypeBinary extends DBSPTypeBaseType {
                 .append(this.mayBeNull ? "?" : "");
     }
 }
-

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeWeight.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeWeight.java
@@ -1,0 +1,15 @@
+package org.dbsp.sqlCompiler.ir.type.user;
+
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
+
+/** Represents the DBSP ZWeight type as TypeUser. */
+public final class DBSPTypeWeight extends DBSPTypeUser {
+    public static final DBSPTypeWeight INSTANCE = new DBSPTypeWeight();
+
+    private DBSPTypeWeight() {
+        super(CalciteObject.EMPTY, DBSPTypeCode.USER, "Weight", false);
+    }
+
+    // sameType and hashCode inherited from TypeUser.
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
@@ -1717,4 +1717,27 @@ public class AggScottTests extends ScottBaseTests {
                 +-----------------------+----------------------+---------------+-------------------+
                 (1 row)""");
     }
+
+    @Test
+    public void bitTests() {
+        this.qs("""
+                -- BIT_AND, BIT_OR, BIT_XOR aggregate functions
+                select bit_and(deptno), bit_or(deptno), bit_xor(deptno) from emp;
+                +--------+--------+--------+
+                | EXPR$0 | EXPR$1 | EXPR$2 |
+                +--------+--------+--------+
+                |      0 |     30 |     30 |
+                +--------+--------+--------+
+                (1 row)
+                
+                select deptno, bit_and(empno), bit_or(empno), bit_xor(empno) from emp group by deptno;
+                +--------+--------+--------+--------+
+                | DEPTNO | EXPR$1 | EXPR$2 | EXPR$3 |
+                +--------+--------+--------+--------+
+                |     10 |   7686 |   7935 |   7687 |
+                |     20 |   7168 |   8191 |   7985 |
+                |     30 |   7168 |   8191 |    934 |
+                +--------+--------+--------+--------+
+                (3 rows)""");
+    }
 }


### PR DESCRIPTION
The weight of the item was ignored when computing XOR.
The new implementation uses the item when the weight is odd, and zero when the weight is even.

