### PR TITLE
Multiple WebConsole fixes and improvements

### DIFF
--- a/web-console/src/lib/components/adhoc/Query.svelte
+++ b/web-console/src/lib/components/adhoc/Query.svelte
@@ -1,10 +1,8 @@
 <script lang="ts" module>
   import { useSkeletonTheme } from '$lib/compositions/useSkeletonTheme.svelte'
-  import { getCaseIndependentName } from '$lib/functions/felderaRelation'
   import type { SQLValueJS } from '$lib/functions/sqlValue'
   import type { Field } from '$lib/services/manager'
   import { Progress } from '@skeletonlabs/skeleton-svelte'
-  import JSONbig from 'true-json-bigint'
 
   export type Row = { cells: SQLValueJS[] } | { error: string } | { warning: string }
 
@@ -42,8 +40,9 @@
 
 <script lang="ts">
   import SqlValue from '$lib/components/relationData/SQLValue.svelte'
-  import SqlColumnHeader from '../relationData/SQLColumnHeader.svelte'
+  import SqlColumnHeader from '$lib/components/relationData/SQLColumnHeader.svelte'
   import { usePopoverTooltip } from '$lib/compositions/common/usePopoverTooltip.svelte'
+  import ReverseScrollFixedList from '$lib/components/pipelines/editor/ReverseScrollFixedList.svelte'
 
   let {
     query = $bindable(),
@@ -70,10 +69,12 @@
 </script>
 
 <div
-  class="bg-white-black absolute m-0 w-max max-w-lg -translate-x-[5px] -translate-y-[3.5px] whitespace-break-spaces break-words border border-surface-500 px-2 py-1 text-surface-950-50"
+  class="bg-white-black absolute m-0 w-max max-w-lg -translate-x-[4.5px] -translate-y-[2.5px] whitespace-break-spaces break-words border border-surface-500 px-2 py-1 text-surface-950-50"
   popover="manual"
   bind:this={popupRef}
-  style={tooltip.data ? `left: ${tooltip.data.x}px; top: ${tooltip.data.y}px` : ''}
+  style={tooltip.data
+    ? `left: ${tooltip.data.x}px; top: ${tooltip.data.y}px; min-width: ${tooltip.data.targetWidth + 8}px`
+    : ''}
 >
   {tooltip.data?.text}
 </div>
@@ -140,43 +141,76 @@
     </div>
 
     {#if result}
-      <div class="mr-4 max-h-64 w-fit max-w-full overflow-auto scrollbar">
-        <table>
-          {#if result.columns.length}
-            <thead class="bg-white-black sticky top-0 !mb-0">
-              <tr>
-                {#each result.columns as column}
-                  <SqlColumnHeader {column}></SqlColumnHeader>
+      <div class="relative mr-4">
+        <ReverseScrollFixedList
+          itemSize={28}
+          items={result.rows}
+          class="overflow-scroll scrollbar"
+          stickyIndices={[]}
+          marginTop={28}
+        >
+          {#snippet listContainer(children, { height, onscroll, onresize, setref })}
+            {@const _height = {
+              set current(x: number) {
+                onresize({ clientHeight: x })
+              }
+            }}
+            {@const ref = {
+              set current(el: HTMLElement) {
+                setref(el)
+              }
+            }}
+            <div
+              class="h-full max-h-64 max-w-full overflow-auto scrollbar"
+              {onscroll}
+              bind:clientHeight={_height.current}
+              bind:this={ref.current}
+            >
+              <table style:height>
+                {#if result.columns.length}
+                  <thead class="bg-white-black sticky top-0 z-10 !mb-0 h-7">
+                    <tr>
+                      {#each result.columns as column}
+                        <SqlColumnHeader {column}></SqlColumnHeader>
+                      {/each}
+                    </tr>
+                  </thead>
+                {/if}
+                <tbody>
+                  {@render children()}
+                </tbody>
+              </table>
+            </div>
+          {/snippet}
+          {#snippet item(row, style, padding, isSticky)}
+            {#if 'cells' in row}
+              <tr {style} class="h-7 whitespace-nowrap even:bg-surface-50-950">
+                {#each row.cells as value}
+                  <SqlValue
+                    {value}
+                    props={(format) => ({
+                      onclick: tooltip.showTooltip(format(value)),
+                      onmouseleave: tooltip.onmouseleave
+                    })}
+                  ></SqlValue>
                 {/each}
               </tr>
-            </thead>
-          {/if}
-          <tbody>
-            {#each result.rows as row}
-              {#if 'cells' in row}
-                <tr class="whitespace-nowrap even:bg-surface-50-950">
-                  {#each row.cells as value}
-                    <SqlValue
-                      {value}
-                      props={(text) => ({
-                        onmouseenter: tooltip.onmouseenter(text),
-                        onmouseleave: tooltip.onmouseleave
-                      })}
-                    ></SqlValue>
-                  {/each}
-                </tr>
-              {:else if 'error' in row}
-                <tr>
-                  <td colspan="99999999" class="px-2 preset-tonal-error">{row.error}</td>
-                </tr>
-              {:else}
-                <tr>
-                  <td colspan="99999999" class="px-2 preset-tonal-warning">{row.warning}</td>
-                </tr>
-              {/if}
-            {/each}
-          </tbody>
-        </table>
+            {:else if 'error' in row}
+              <tr {style} class="h-7">
+                <td colspan="99999999" class="px-2 preset-tonal-error">{row.error}</td>
+              </tr>
+            {:else}
+              <tr {style} class="h-7">
+                <td colspan="99999999" class="px-2 preset-tonal-warning">{row.warning}</td>
+              </tr>
+            {/if}
+          {/snippet}
+          {#snippet footer()}
+            <tr style="height: auto; ">
+              <td></td>
+            </tr>
+          {/snippet}
+        </ReverseScrollFixedList>
       </div>
     {/if}
   </div>

--- a/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
+++ b/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
@@ -28,7 +28,8 @@
     stickyIndices = [],
     onscroll: _onscroll,
     overScan = 0,
-    marginTop = 0
+    marginTop = 0,
+    children
   }: {
     itemCount: number
     itemSize: number
@@ -46,10 +47,11 @@
     onscroll?: OnScroll
     header?: Snippet
     item: Snippet<[Item]>
-    listContainer?: Snippet<[Snippet, ListContainer]>
+    listContainer?: Snippet<[Snippet, ListContainer, Snippet | undefined]>
     placeholder?: Snippet<[Item]>
     footer?: Snippet
     marginTop?: number
+    children?: Snippet
   } = $props()
 
   export function scrollToBottom() {
@@ -61,8 +63,8 @@
 
   let scrollTop = $state(0)
   let clientHeight = $state(0)
-  let indexOffset = $derived(Math.max(Math.round(scrollTop / itemSize) - overScan, 0))
-  let visibleCount = $derived(Math.round(clientHeight / itemSize) + 1 + 2 * overScan)
+  let indexOffset = $derived(Math.max(Math.round(scrollTop / itemSize) - overScan - 1, 0))
+  let visibleCount = $derived(Math.round(clientHeight / itemSize) + 2 + 2 * overScan)
 
   let stickyRow = $derived(
     ((i) => (i === -1 ? undefined : stickyIndices[i]))(
@@ -83,21 +85,26 @@
 </script>
 
 {#snippet defaultListContainer(
-  children: Snippet,
+  items: Snippet,
   { width, height }: { height: string; width: string }
 )}
   <div style:width style:height>
-    {@render children()}
+    {@render items()}
+    {@render children?.()}
   </div>
 {/snippet}
 
-{@render listContainer(listBody, {
-  height: `${itemCount * itemSize + marginTop}px`,
-  width: '100%',
-  onscroll,
-  onresize,
-  setref: (v) => (containerRef = v)
-})}
+{@render listContainer(
+  listBody,
+  {
+    height: `${itemCount * itemSize + marginTop}px`,
+    width: '100%',
+    onscroll,
+    onresize,
+    setref: (v) => (containerRef = v)
+  },
+  children
+)}
 
 {#snippet listBody()}
   {@render header?.()}

--- a/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
+++ b/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
@@ -26,7 +26,9 @@
     header,
     footer,
     stickyIndices = [],
-    onscroll: _onscroll
+    onscroll: _onscroll,
+    overScan = 0,
+    marginTop = 0
   }: {
     itemCount: number
     itemSize: number
@@ -47,20 +49,21 @@
     listContainer?: Snippet<[Snippet, ListContainer]>
     placeholder?: Snippet<[Item]>
     footer?: Snippet
+    marginTop?: number
   } = $props()
 
   export function scrollToBottom() {
-    if (!setref) {
+    if (!containerRef) {
       return
     }
-    setref.scrollTo({ top: setref.scrollHeight })
+    containerRef.scrollTo({ top: containerRef.scrollHeight })
   }
 
   let scrollTop = $state(0)
   let clientHeight = $state(0)
-  const overscan = 1
-  let indexOffset = $derived(Math.max(Math.round(scrollTop / itemSize) - overscan, 0))
-  let visibleCount = $derived(Math.round(clientHeight / itemSize) + overscan)
+  let indexOffset = $derived(Math.max(Math.round(scrollTop / itemSize) - overScan, 0))
+  let visibleCount = $derived(Math.round(clientHeight / itemSize) + 1 + 2 * overScan)
+
   let stickyRow = $derived(
     ((i) => (i === -1 ? undefined : stickyIndices[i]))(
       binarySearchMax(stickyIndices, indexOffset + 1)
@@ -76,7 +79,7 @@
   const onresize = (event: { clientHeight: number }) => {
     clientHeight = event.clientHeight
   }
-  let setref = $state<Element>()
+  let containerRef = $state<Element>()
 </script>
 
 {#snippet defaultListContainer(
@@ -89,11 +92,11 @@
 {/snippet}
 
 {@render listContainer(listBody, {
-  height: `${itemCount * itemSize}px`,
+  height: `${itemCount * itemSize + marginTop}px`,
   width: '100%',
   onscroll,
   onresize,
-  setref: (v) => (setref = v)
+  setref: (v) => (containerRef = v)
 })}
 
 {#snippet listBody()}

--- a/web-console/src/lib/components/dialogs/JSONDialog.svelte
+++ b/web-console/src/lib/components/dialogs/JSONDialog.svelte
@@ -4,6 +4,7 @@
   import { isMonacoEditorDisabled } from '$lib/functions/common/monacoEditor'
   import type { Snippet } from 'svelte'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import { useSkeletonTheme } from '$lib/compositions/useSkeletonTheme.svelte'
   let {
     json,
     onApply,
@@ -17,6 +18,7 @@
     title: Snippet
     disabled?: boolean
   } = $props()
+  const theme = useSkeletonTheme()
   const mode = useDarkMode()
   let value = $state(json)
   $effect(() => {
@@ -46,7 +48,9 @@
         })
       }}
       options={{
-        theme: mode.darkMode.value === 'light' ? 'vs' : 'vs-dark',
+        fontFamily: theme.config.monospaceFontFamily,
+        fontSize: 16,
+        theme: mode.darkMode.value === 'dark' ? 'feldera-dark' : 'feldera-light',
         automaticLayout: true,
         lineNumbersMinChars: 2,
         overviewRulerLanes: 0,

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -17,7 +17,7 @@
   import { humanSize } from '$lib/functions/common/string'
   import WarningBanner from '$lib/components/pipelines/editor/WarningBanner.svelte'
   import ReverseScrollFixedList from '$lib/components/pipelines/editor/ReverseScrollFixedList.svelte'
-  import SqlValue from '$lib/components/relationData/SQLValue.svelte'
+  import SQLValue from '$lib/components/relationData/SQLValue.svelte'
   import type { Field } from '$lib/services/manager'
   import SqlColumnHeader from '$lib/components/relationData/SQLColumnHeader.svelte'
   import { usePopoverTooltip } from '$lib/compositions/common/usePopoverTooltip.svelte'
@@ -101,27 +101,30 @@
         {@const data = 'insert' in row ? row.insert : row.delete}
         <tr
           style="{style} {padding}"
-          class={`h-7 whitespace-nowrap even:bg-surface-50-950`}
+          class="h-7 select-none whitespace-nowrap even:bg-surface-50-950"
           oncopy={(e) => {
-            e.clipboardData!.setData('text/plain', JSONbig.stringify(item))
+            e.clipboardData!.setData('text/plain', JSONbig.stringify(row))
             e.preventDefault()
           }}
         >
           {#if 'insert' in row}
-            <td class="block h-7 w-8 bg-opacity-30 pt-1 text-center font-mono bg-success-100-900"
-              >+</td
+            <td class="block h-7 w-20 bg-opacity-30 pt-1 text-center font-mono bg-success-100-900"
+              >Insert</td
             >
           {:else}
-            <td class="block h-7 w-8 bg-opacity-30 text-center font-mono bg-error-100-900">-</td>
+            <td class="block h-7 w-20 bg-opacity-30 text-center font-mono bg-error-100-900"
+              >Delete</td
+            >
           {/if}
           {#each Object.values(data) as value}
-            <SqlValue
+            <SQLValue
               {value}
+              class="cursor-pointer"
               props={(format) => ({
                 onclick: tooltip.showTooltip(format(value)),
                 onmouseleave: tooltip.onmouseleave
               })}
-            ></SqlValue>
+            ></SQLValue>
           {/each}
         </tr>
       {/if}

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -16,7 +16,7 @@
 
   import { humanSize } from '$lib/functions/common/string'
   import WarningBanner from '$lib/components/pipelines/editor/WarningBanner.svelte'
-  import ReverseScrollFixedList from './ReverseScrollFixedList.svelte'
+  import ReverseScrollFixedList from '$lib/components/pipelines/editor/ReverseScrollFixedList.svelte'
   import SqlValue from '$lib/components/relationData/SQLValue.svelte'
   import type { Field } from '$lib/services/manager'
   import SqlColumnHeader from '$lib/components/relationData/SQLColumnHeader.svelte'
@@ -33,10 +33,12 @@
 </script>
 
 <div
-  class="bg-white-black absolute m-0 w-max max-w-lg -translate-x-[4.5px] -translate-y-[3px] whitespace-break-spaces break-words border border-surface-500 px-2 py-1 text-surface-950-50"
+  class="bg-white-black absolute m-0 w-max max-w-lg -translate-x-[4.5px] -translate-y-[2.5px] whitespace-break-spaces break-words border border-surface-500 px-2 py-1 text-right text-surface-950-50"
   popover="manual"
   bind:this={popupRef}
-  style={tooltip.data ? `left: ${tooltip.data.x}px; top: ${tooltip.data.y}px` : ''}
+  style={tooltip.data
+    ? `left: ${tooltip.data.x}px; top: ${tooltip.data.y}px; min-width: ${tooltip.data.targetWidth + 8}px`
+    : ''}
 >
   {tooltip.data?.text}
 </div>
@@ -55,22 +57,22 @@
     class="overflow-scroll scrollbar"
     stickyIndices={changeStream.headers}
   >
-    {#snippet listContainer(children, { width, height, onscroll, onresize, setref })}
-      {@const z = {
-        set num(x: number) {
+    {#snippet listContainer(children, { height, onscroll, onresize, setref })}
+      {@const _height = {
+        set current(x: number) {
           onresize({ clientHeight: x })
         }
       }}
       {@const ref = {
-        set value(el: HTMLElement) {
+        set current(el: HTMLElement) {
           setref(el)
         }
       }}
       <div
         class="h-full overflow-auto scrollbar"
         {onscroll}
-        bind:clientHeight={z.num}
-        bind:this={ref.value}
+        bind:clientHeight={_height.current}
+        bind:this={ref.current}
       >
         <table style:height>
           <tbody>
@@ -88,11 +90,11 @@
         </tr>
       {:else if 'columns' in row}
         <tr class="h-7" style="{style} {padding}">
-          <th class=" font-normal {isSticky ? 'bg-white-black sticky top-0 z-10' : ''}"
+          <th class="pl-2 font-normal {isSticky ? 'bg-white-black sticky top-0 z-10' : ''}"
             >{row.relationName}</th
           >
           {#each row.columns as column}
-            <SqlColumnHeader {column} {isSticky} class="bg-white-black"></SqlColumnHeader>
+            <SqlColumnHeader {column} {isSticky} class="bg-white-black px-2"></SqlColumnHeader>
           {/each}
         </tr>
       {:else}
@@ -115,8 +117,8 @@
           {#each Object.values(data) as value}
             <SqlValue
               {value}
-              props={(text) => ({
-                onmouseenter: tooltip.onmouseenter(text),
+              props={(format) => ({
+                onclick: tooltip.showTooltip(format(value)),
                 onmouseleave: tooltip.onmouseleave
               })}
             ></SqlValue>

--- a/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
+++ b/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
@@ -279,7 +279,7 @@
     <div class="flex flex-wrap">
       {#each files as file}
         <button
-          class="py-1 pl-3 pr-8 {file.name === currentFileName
+          class="px-3 py-1 {file.name === currentFileName
             ? 'bg-white-black'
             : 'hover:!bg-opacity-50 hover:bg-surface-100-900'}"
           onclick={() => (currentFileName = file.name)}

--- a/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
+++ b/web-console/src/lib/components/pipelines/editor/InteractionsPanel.svelte
@@ -130,12 +130,11 @@
   {/snippet}
 
   {#snippet content()}
-    {#each tabs as [tabName, , TabComponent]}
-      <Tabs.Panel value={tabName} classes="h-full overflow-y-auto relative scrollbar">
-        <div class="absolute h-full w-full">
-          <TabComponent {pipeline} {metrics} {errors}></TabComponent>
-        </div>
-      </Tabs.Panel>
-    {/each}
+    {@const TabComponent = tabs.find((tab) => tab[0] === currentTab.value)![2]!}
+    <div class="relative h-full">
+      <div class="absolute h-full w-full">
+        <TabComponent {pipeline} {metrics} {errors}></TabComponent>
+      </div>
+    </div>
   {/snippet}
 </Tabs>

--- a/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
@@ -12,7 +12,8 @@
     stickyIndices,
     class: _class = '',
     header,
-    footer
+    footer,
+    marginTop
   }: {
     items: Row[]
     item: Snippet<[item: Row, style?: string, padding?: string, isSticky?: boolean]>
@@ -22,6 +23,7 @@
     itemSize: number
     stickyIndices?: number[]
     class?: string
+    marginTop?: number
   } = $props()
 
   let ref = $state<ReturnType<typeof List>>(undefined!)
@@ -56,6 +58,7 @@
   {listContainer}
   {itemSize}
   {stickyIndices}
+  {marginTop}
 >
   {#snippet item({ index, style, padding, isSticky })}
     {#if items[index]}

--- a/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
@@ -17,7 +17,7 @@
   }: {
     items: Row[]
     item: Snippet<[item: Row, style?: string, padding?: string, isSticky?: boolean]>
-    listContainer?: Snippet<[Snippet, ListContainer]>
+    listContainer?: Snippet<[Snippet, ListContainer, Snippet | undefined]>
     header?: Snippet
     footer?: Snippet
     itemSize: number
@@ -66,6 +66,7 @@
     {/if}
   {/snippet}
 </List>
+
 {#if !stickToBottom}
   <button
     transition:scale={{ duration: 200 }}

--- a/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
@@ -81,7 +81,7 @@
                 return
               }
               adhocQueries[pipelineName].queries[i].result?.rows.push({
-                warning: `The query result contains more rows, but only the first ${bufferSize} are shown`
+                warning: `The result contains more rows, but only the first ${bufferSize} are shown`
               })
               getAdhocQueries = () => adhocQueries
               adhocQueries[pipelineName].queries[i].result?.endResultStream()
@@ -131,7 +131,7 @@
 
 <div class="bg-white-black flex h-full min-h-full flex-col gap-6 overflow-y-auto p-2 scrollbar">
   {#if isIdle}
-    <WarningBanner class="sticky top-0 z-10 -m-2">
+    <WarningBanner class="sticky top-0 z-10 -mx-2 -mb-4 -translate-y-2">
       Start the pipeline to be able to execute queries
     </WarningBanner>
   {/if}

--- a/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
@@ -129,7 +129,7 @@
   }
 </script>
 
-<div class="bg-white-black flex min-h-full flex-col gap-6 p-2">
+<div class="bg-white-black flex h-full min-h-full flex-col gap-6 overflow-y-auto p-2 scrollbar">
   {#if isIdle}
     <WarningBanner class="sticky top-0 z-10 -m-2">
       Start the pipeline to be able to execute queries

--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -17,7 +17,7 @@
 </script>
 
 {#if global}
-  <div class="flex flex-col gap-4 p-2">
+  <div class="flex h-full flex-col gap-4 overflow-y-auto p-2 scrollbar">
     <div class="flex w-full flex-col-reverse gap-2 lg:flex-row">
       <div class="mr-auto">
         <div class="mb-auto flex flex-col">

--- a/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
@@ -7,8 +7,8 @@
   const theme = useSkeletonTheme()
 </script>
 
-<div class=" h-full">
-  <div class="{errors.length ? 'bg-white-black' : ''} flex min-h-full flex-col p-2">
+<div class="{errors.length ? 'bg-white-black' : ''} h-full overflow-y-auto scrollbar">
+  <div class=" flex min-h-full flex-col p-2">
     {#each errors as systemError}
       <div class=" whitespace-nowrap">
         <a class="" href={systemError.cause.source}>

--- a/web-console/src/lib/components/pipelines/editor/TabQueryData.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabQueryData.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-  let { pipelineName }: { pipelineName: string } = $props()
-</script>
-
-TabQueryData

--- a/web-console/src/lib/components/relationData/SQLValue.svelte
+++ b/web-console/src/lib/components/relationData/SQLValue.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { SQLValueJS } from '$lib/functions/sqlValue'
+  import BigNumber from 'bignumber.js'
+  import { format } from 'd3-format'
   import type { HTMLTdAttributes } from 'svelte/elements'
   import JSONbig from 'true-json-bigint'
 
@@ -9,17 +11,40 @@
     class: _class,
     ...rest
   }: { value: SQLValueJS } & {
-    props?: (text: string | null) => HTMLTdAttributes
+    props?: (formatter: (value: SQLValueJS) => string) => HTMLTdAttributes
   } & HTMLTdAttributes = $props()
-  let text = $derived(
+  let thumb = $derived(
     value === null
-      ? null
+      ? 'NULL'
+      : typeof value === 'string'
+        ? value.slice(0, 37) + (value.length >= 37 ? '...' : '')
+        : BigNumber.isBigNumber(value)
+          ? value.toFixed(3, BigNumber.ROUND_DOWN).replace(/\.0+$/, '')
+          : JSONbig.stringify(value, undefined, 1)
+  )
+  let displayValue = (value: SQLValueJS) => {
+    return value === null
+      ? 'NULL'
       : typeof value === 'string'
         ? value
-        : JSONbig.stringify(value, undefined, 1)
-  )
+        : BigNumber.isBigNumber(value)
+          ? value.toFixed()
+          : JSONbig.stringify(value, undefined, 1)
+  }
+  //   let thumb = $derived(
+  //     text === null
+  //       ? 'NULL'
+  //       : text.slice(0, 37).replace(/\.0+$/, '') + (text.length >= 37 ? '...' : '')
+  //   )
 </script>
 
-<td {...props?.(text)} class:italic={text === null} class="px-1 {_class}" {...rest}>
-  {text === null ? 'NULL' : text.slice(0, 37)}{text && text.length > 36 ? '...' : ''}
+<td
+  {...props?.(displayValue)}
+  class:italic={thumb === null}
+  class="px-1 {typeof value === 'number' || BigNumber.isBigNumber(value)
+    ? 'text-right'
+    : ''} {_class}"
+  {...rest}
+>
+  {thumb}
 </td>

--- a/web-console/src/lib/components/relationData/SQLValue.svelte
+++ b/web-console/src/lib/components/relationData/SQLValue.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { SQLValueJS } from '$lib/functions/sqlValue'
   import BigNumber from 'bignumber.js'
-  import { format } from 'd3-format'
   import type { HTMLTdAttributes } from 'svelte/elements'
   import JSONbig from 'true-json-bigint'
 
@@ -19,7 +18,7 @@
       : typeof value === 'string'
         ? value.slice(0, 37) + (value.length >= 37 ? '...' : '')
         : BigNumber.isBigNumber(value)
-          ? value.toFixed(3, BigNumber.ROUND_DOWN).replace(/\.0+$/, '')
+          ? value.toFixed(3, BigNumber.ROUND_DOWN).replace(/\.?0+$/, '')
           : JSONbig.stringify(value, undefined, 1)
   )
   let displayValue = (value: SQLValueJS) => {
@@ -31,11 +30,6 @@
           ? value.toFixed()
           : JSONbig.stringify(value, undefined, 1)
   }
-  //   let thumb = $derived(
-  //     text === null
-  //       ? 'NULL'
-  //       : text.slice(0, 37).replace(/\.0+$/, '') + (text.length >= 37 ? '...' : '')
-  //   )
 </script>
 
 <td

--- a/web-console/src/lib/compositions/common/usePopoverTooltip.svelte.ts
+++ b/web-console/src/lib/compositions/common/usePopoverTooltip.svelte.ts
@@ -2,7 +2,7 @@ import { untrack } from 'svelte'
 
 export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined) => {
   let tooltipDetails: { element: HTMLElement; value: any } | undefined = $state()
-  let popupData: { x: number; y: number; text: string } | undefined = $state()
+  let popupData: { x: number; y: number; targetWidth: number; text: string } | undefined = $state()
   let hoverCount = $state(0)
   $effect(() => {
     if (hoverCount > 3) {
@@ -62,6 +62,7 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
     popupData = {
       x: 0,
       y: 0,
+      targetWidth: 0,
       text
     }
     el.showPopover()
@@ -70,6 +71,7 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
       popupData = {
         x: Math.min(Math.max(0, rect.left), window.innerWidth - rect2.width),
         y: Math.min(rect.top, window.innerHeight - rect2.height),
+        targetWidth: tooltipDetails!.element.clientWidth,
         text
       }
     })
@@ -77,11 +79,11 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
   type CustomMouseEvent = MouseEvent & {
     currentTarget: EventTarget & HTMLTableCellElement
   }
-  const handleTargetHoverImpl = (e: CustomMouseEvent, value: any) => {
+  const showTooltipWith = (e: CustomMouseEvent, value: any) => {
     tooltipDetails = { element: e.currentTarget, value }
     ++hoverCount
   }
-  const onmouseenter = (value: any) => (e: CustomMouseEvent) => handleTargetHoverImpl(e, value)
+  const showTooltipCb = (value: any) => (e: CustomMouseEvent) => showTooltipWith(e, value)
   const onmouseleave = (e: CustomMouseEvent) => {
     requestAnimationFrame(() => {
       hoverCount -= hoverCount > 0 ? 1 : 0
@@ -91,7 +93,8 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
     get data() {
       return popupData
     },
-    onmouseenter,
-    onmouseleave
+    showTooltip: showTooltipCb,
+    onmouseleave,
+    onclick
   }
 }

--- a/web-console/src/lib/compositions/layout/useDrawer.svelte.ts
+++ b/web-console/src/lib/compositions/layout/useDrawer.svelte.ts
@@ -4,7 +4,7 @@ import { useIsMobile } from './useIsMobile.svelte'
 export const useDrawer = () => {
   const isMobile = useIsMobile()
 
-  const showDrawer = useLocalStorage('layout/drawer', true)
+  const showDrawer = useLocalStorage('layout/drawer', !isMobile)
   return {
     get value() {
       return showDrawer.value

--- a/web-console/src/routes/(authenticated)/+layout.svelte
+++ b/web-console/src/routes/(authenticated)/+layout.svelte
@@ -43,7 +43,7 @@
     </div>
   </Drawer>
   <div class="flex h-full w-full flex-col">
-    <div class="flex justify-between p-1">
+    <div class=" flex justify-between p-1">
       <div class="flex">
         <button
           class="btn-icon"
@@ -68,7 +68,6 @@
             <span class="hidden xl:block">{item.title}</span>
           </a>
         {/each}
-        <!-- <HealthPopup></HealthPopup> -->
         <button
           onclick={toggleDarkMode}
           class="preset-grayout-surface btn-icon text-[24px]

--- a/web-console/src/routes/(authenticated)/+page.svelte
+++ b/web-console/src/routes/(authenticated)/+page.svelte
@@ -20,19 +20,19 @@
   </button>
 {/snippet}
 
-<div class="flex flex-col gap-8 self-center py-8">
-  {#if data.demos.length}
-    <span class="h5 inline px-8 text-[0px] font-normal leading-8">
-      <span class="text-base"> Try running one of our examples below </span>
-      {#if isMobile.current}
-        <span class=" text-base">, or&nbsp;</span>
-        <span class="-my-2 inline-block">
-          {@render createNewPipeline()}
-        </span>
-      {:else}
-        <span class="text-base">:</span>
-      {/if}
-    </span>
+{#if data.demos.length}
+  <div class="h5 block px-8 py-4 text-[0px] font-normal leading-8">
+    <span class="text-base"> Try running one of our examples below </span>
+    {#if isMobile.current}
+      <span class=" text-base">, or&nbsp;</span>
+      <span class="-my-2 inline-block">
+        {@render createNewPipeline()}
+      </span>
+    {:else}
+      <span class="text-base">:</span>
+    {/if}
+  </div>
+  <div class="h-full overflow-y-auto pb-8 scrollbar">
     <div
       class="grid max-w-[1390px] grid-cols-1 gap-8 px-8 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
     >
@@ -46,14 +46,14 @@
         </div>
       {/each}
     </div>
-  {:else}
-    <div class="h5 px-8 font-normal">
-      Write a new SQL query from scratch:
-      {@render creatyeNewPipeline()}
-    </div>
-    <div class="px-8 text-lg text-surface-600-400">
-      There are no demo pipelines available at this time. Please refer to documentation for examples
-      of SQL queries.
-    </div>
-  {/if}
-</div>
+  </div>
+{:else}
+  <div class="h5 px-8 font-normal">
+    Write a new SQL query from scratch:
+    {@render createNewPipeline()}
+  </div>
+  <div class="px-8 text-lg text-surface-600-400">
+    There are no demo pipelines available at this time. Please refer to documentation for examples
+    of SQL queries.
+  </div>
+{/if}

--- a/web-console/src/routes/(authenticated)/+page.svelte
+++ b/web-console/src/routes/(authenticated)/+page.svelte
@@ -1,17 +1,38 @@
 <script lang="ts">
   import { goto, preloadCode } from '$app/navigation'
   import { base } from '$app/paths'
+  import { useIsMobile } from '$lib/compositions/layout/useIsMobile.svelte'
   import { useTryPipeline } from '$lib/compositions/pipelines/useTryPipeline'
 
   preloadCode(`${base}/pipelines/*`)
 
   let { data } = $props()
   const tryPipeline = useTryPipeline()
+  const isMobile = useIsMobile()
 </script>
 
-<div class="self-center">
+{#snippet createNewPipeline()}
+  <button
+    class="btn mt-auto self-end text-sm preset-filled-primary-500"
+    onclick={() => goto('#new')}
+  >
+    CREATE NEW PIPELINE
+  </button>
+{/snippet}
+
+<div class="flex flex-col gap-8 self-center py-8">
   {#if data.demos.length}
-    <div class="h5 px-8 py-8 font-normal">Try running one of our examples below.</div>
+    <span class="h5 inline px-8 text-[0px] font-normal leading-8">
+      <span class="text-base"> Try running one of our examples below </span>
+      {#if isMobile.current}
+        <span class=" text-base">, or&nbsp;</span>
+        <span class="-my-2 inline-block">
+          {@render createNewPipeline()}
+        </span>
+      {:else}
+        <span class="text-base">:</span>
+      {/if}
+    </span>
     <div
       class="grid max-w-[1390px] grid-cols-1 gap-8 px-8 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
     >
@@ -26,14 +47,9 @@
       {/each}
     </div>
   {:else}
-    <div class="h5 px-8 py-8 font-normal">
+    <div class="h5 px-8 font-normal">
       Write a new SQL query from scratch:
-      <button
-        class="btn mt-auto self-end text-sm preset-filled-primary-500"
-        onclick={() => goto('#new')}
-      >
-        CREATE NEW PIPELINE
-      </button>
+      {@render creatyeNewPipeline()}
     </div>
     <div class="px-8 text-lg text-surface-600-400">
       There are no demo pipelines available at this time. Please refer to documentation for examples


### PR DESCRIPTION
Hide drawer when WebConsole is first opened on mobile
Make SQL value popup appear on click instead of on hover in data tables
Make numbers right-aligned in data tables, add truncation of insignificant decimal digits
Display 'create new pipeline' button on home page above demos on mobile
Reduce right padding of file tabs so that they fit on mobile in one line
Use virtual list for better performance of Ad-hoc query results table
Improve scrollbar on examples page
Spell 'Insert' and 'Delete' instead of '+' and '-' in Change Stream
Other minor fixes

![image](https://github.com/user-attachments/assets/1dd588a7-9ebe-432d-a83a-5ddf54f0da55)
![image](https://github.com/user-attachments/assets/e7e37018-210c-47d7-aa51-a53fb604e661)
![image](https://github.com/user-attachments/assets/01d31bb8-15ee-426f-82ab-b03b8c8590c5)

