### PR TITLE
[SQL] Trim unused fields backwards from joins

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -182,6 +182,7 @@ build-manager:
 test-sql:
     # SQL-generated code imports adapters crate.
     FROM +build-adapters
+    COPY --dir demo/packaged demo/packaged
     RUN cd "sql-to-dbsp-compiler" && ./build.sh && mvn test --no-transfer-progress -q -B -pl SQL-compiler -Dsurefire.failIfNoSpecifiedTests=false
 
 test-slt:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
@@ -256,30 +256,15 @@ public class CalciteOptimizer implements IWritesLogs {
                 CoreRules.INTERSECT_MERGE);
         // this.addStep(merge); -- messes up the shape of uncollect
 
-        this.addStep(new BaseOptimizerStep("Move projections", level) {
-            @Override
-            HepProgram getProgram(RelNode node, int level) {
-                this.addRules(2,
-                        // Rule is unsound: https://issues.apache.org/jira/browse/CALCITE-6681
-                        // CoreRules.PROJECT_CORRELATE_TRANSPOSE,
-                        CoreRules.PROJECT_WINDOW_TRANSPOSE,
-                        CoreRules.PROJECT_SET_OP_TRANSPOSE,
-                        CoreRules.FILTER_PROJECT_TRANSPOSE
-                );
-                /*
-                // Rule is unsound, hopefully it works if there are no correlates
-                // Moreover, rule interferes with temporal filters optimization
-                // Should be made obsolete when we add multijoins.
-                CorrelateFinder finder = new CorrelateFinder();
-                finder.run(node);
-                if (!finder.found) {
-                    this.addRules(level, CoreRules.PROJECT_JOIN_TRANSPOSE);
-                }
-                */
-                this.builder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
-                return this.builder.build();
-            }
-        });
+        this.addStep(new SimpleOptimizerStep("Move projections", 0,
+                // Rule is unsound: https://issues.apache.org/jira/browse/CALCITE-6681
+                // CoreRules.PROJECT_CORRELATE_TRANSPOSE,
+                CoreRules.PROJECT_WINDOW_TRANSPOSE,
+                CoreRules.PROJECT_SET_OP_TRANSPOSE,
+                CoreRules.FILTER_PROJECT_TRANSPOSE
+                // Rule is unsound, replaced with NarrowJoins done later.
+                //CoreRules.PROJECT_JOIN_TRANSPOSE
+        ));
 
         this.addStep(merge);
         this.addStep(new SimpleOptimizerStep("Remove dead code", 0,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -73,7 +73,7 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
             passes.add(new DeadCode(reporter, true, false));
             passes.add(new Simplify(reporter).circuitRewriter());
             passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeProjectionVisitor(reporter, g)));
-            passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
+            passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, true, g)));
             passes.add(new OptimizeWithGraph(reporter, g -> new FilterJoinVisitor(reporter, g)));
             if (options.languageOptions.incrementalize) {
                 // Monotonicity analysis only makes sense for incremental programs
@@ -99,7 +99,7 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         if (options.languageOptions.optimizationLevel >= 2) {
             passes.add(new OptimizeWithGraph(reporter, g -> new FilterMapVisitor(reporter, g)));
             // optimize the maps introduced by the deindex removal
-            passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
+            passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, false, g)));
             passes.add(new SimplifyWaterline(reporter)
                     .circuitRewriter(node -> node.hasAnnotation(a -> a.is(Waterline.class))));
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -75,11 +75,11 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
             passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeProjectionVisitor(reporter, g)));
             passes.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
             passes.add(new OptimizeWithGraph(reporter, g -> new FilterJoinVisitor(reporter, g)));
-            passes.add(new NarrowJoins(reporter));
             if (options.languageOptions.incrementalize) {
                 // Monotonicity analysis only makes sense for incremental programs
                 passes.add(new MonotoneAnalyzer(reporter));
             }
+            passes.add(new NarrowJoins(reporter));
             // Doing this after the monotone analysis only
             if (!options.ioOptions.emitHandles)
                 passes.add(new IndexedInputs(reporter));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
@@ -51,7 +51,7 @@ public class NarrowJoins extends Repeat {
             this.add(new RemoveJoinFields(reporter));
             this.add(new DeadCode(reporter, true, false));
             // Merges projections into other joins if possible
-            this.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
+            this.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, false, g)));
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/NarrowJoins.java
@@ -1,9 +1,11 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
 import org.dbsp.sqlCompiler.compiler.frontend.TypeCompiler;
@@ -37,9 +39,20 @@ import java.util.List;
 import java.util.Map;
 
 /** Find and remove unused fields in Join operators. */
-public class NarrowJoins extends CircuitCloneVisitor {
+public class NarrowJoins extends Repeat {
     public NarrowJoins(IErrorReporter reporter) {
-        super(reporter, false);
+        super(reporter, new OnePass(reporter));
+    }
+
+    static class OnePass extends Passes {
+        OnePass(IErrorReporter reporter) {
+            super(reporter);
+            // Moves projections from joins to their inputs
+            this.add(new RemoveJoinFields(reporter));
+            this.add(new DeadCode(reporter, true, false));
+            // Merges projections into other joins if possible
+            this.add(new OptimizeWithGraph(reporter, g -> new OptimizeMaps(reporter, g)));
+        }
     }
 
     /** Rewrite variable and field accesses */
@@ -115,85 +128,105 @@ public class NarrowJoins extends CircuitCloneVisitor {
         }
     }
 
-    DBSPMapIndexOperator getProjection(CalciteObject node, List<Integer> fields, DBSPOperator input) {
-        DBSPType inputType = input.getOutputIndexedZSetType().getKVRefType();
-        DBSPVariablePath var = inputType.var();
-        List<DBSPExpression> resultFields = Linq.map(fields,
-                f -> var.deepCopy().field(1).deref().field(f).applyCloneIfNeeded());
-        DBSPRawTupleExpression raw = new DBSPRawTupleExpression(
-                var.deepCopy().field(0).deref().applyClone(),
-                new DBSPTupleExpression(resultFields, false));
-        DBSPClosureExpression projection = raw.closure(var);
+    static class RemoveJoinFields extends CircuitCloneVisitor {
+        RemoveJoinFields(IErrorReporter reporter) {
+            super(reporter, false);
+        }
 
-        DBSPOperator source = this.mapped(input);
-        DBSPTypeIndexedZSet ix = TypeCompiler.makeIndexedZSet(projection.getResultType().to(DBSPTypeRawTuple.class));
-        DBSPMapIndexOperator map = new DBSPMapIndexOperator(node, projection, ix, source);
-        this.addOperator(map);
-        return map;
-    }
+        DBSPMapIndexOperator getProjection(CalciteObject node, List<Integer> fields, DBSPOperator input) {
+            DBSPType inputType = input.getOutputIndexedZSetType().getKVRefType();
+            DBSPVariablePath var = inputType.var();
+            List<DBSPExpression> resultFields = Linq.map(fields,
+                    f -> var.deepCopy().field(1).deref().field(f).applyCloneIfNeeded());
+            DBSPRawTupleExpression raw = new DBSPRawTupleExpression(
+                    DBSPTupleExpression.flatten(var.deepCopy().field(0).deref()),
+                    new DBSPTupleExpression(resultFields, false));
+            DBSPClosureExpression projection = raw.closure(var);
 
-    boolean processJoin(DBSPJoinBaseOperator join) {
-        Projection projection = new Projection(this.errorReporter);
-        projection.apply(join.getFunction());
-        if (!projection.hasIoMap()) return false;
-        DBSPClosureExpression joinFunction = join.getClosureFunction();
-        int leftSize = joinFunction.parameters[1].getType().deref().to(DBSPTypeTupleBase.class).size();
-        int rightSize = joinFunction.parameters[2].getType().deref().to(DBSPTypeTupleBase.class).size();
+            DBSPOperator source = this.mapped(input);
+            DBSPTypeIndexedZSet ix = TypeCompiler.makeIndexedZSet(projection.getResultType().to(DBSPTypeRawTuple.class));
+            DBSPMapIndexOperator map = new DBSPMapIndexOperator(node, projection, ix, source);
+            this.addOperator(map);
+            return map;
+        }
 
-        // Create a projection map for each input which has unused fields
-        Projection.IOMap outputMap = projection.getIoMap();
-        List<Integer> leftInputs = outputMap.getFieldsOfInput(1);
-        List<Integer> rightInputs = outputMap.getFieldsOfInput(2);
-        // If all the fields are used there is no point in optimizing this
-        if (leftInputs.size() == leftSize && rightInputs.size() == rightSize)
-            return false;
-        DBSPOperator leftMap = getProjection(join.getNode(), leftInputs, join.left());
-        DBSPOperator rightMap = getProjection(join.getNode(), rightInputs, join.right());
+        boolean processJoin(DBSPJoinBaseOperator join) {
+            Projection projection = new Projection(this.errorReporter, true);
+            projection.apply(join.getFunction());
+            if (!projection.hasIoMap()) return false;
+            DBSPClosureExpression joinFunction = join.getClosureFunction();
+            int leftSize = joinFunction.parameters[1].getType().deref().to(DBSPTypeTupleBase.class).size();
+            int rightSize = joinFunction.parameters[2].getType().deref().to(DBSPTypeTupleBase.class).size();
 
-        Map<Integer, Integer> leftRemap = new HashMap<>();
-        for (int i = 0; i < leftInputs.size(); i++)
-            // This "compresses" the indexes in the join function, omitting the ones
-            // that are no longer present in the inputs
-            leftRemap.put(leftInputs.get(i), i);
-        Map<Integer, Integer> rightRemap = new HashMap<>();
-        for (int i = 0; i < rightInputs.size(); i++)
-            rightRemap.put(rightInputs.get(i), i);
+            // Create a projection map for each input which has unused fields
+            Projection.IOMap outputMap = projection.getIoMap();
+            List<Integer> leftInputs = outputMap.getFieldsOfInput(1);
+            List<Integer> rightInputs = outputMap.getFieldsOfInput(2);
+            // If all the fields are used there is no point in optimizing this
+            if (leftInputs.size() == leftSize && rightInputs.size() == rightSize)
+                return false;
+            DBSPOperator leftMap = getProjection(join.getNode(), leftInputs, join.left());
+            DBSPOperator rightMap = getProjection(join.getNode(), rightInputs, join.right());
 
-        assert joinFunction.parameters.length == 3;
-        Substitution<DBSPParameter, DBSPParameter> subst = new Substitution<>();
-        subst.substituteNew(
-                joinFunction.parameters[0],
-                join.left().getOutputIndexedZSetType().keyType.ref().var().asParameter());
-        subst.substitute(
-                joinFunction.parameters[1],
-                leftMap.getOutputIndexedZSetType().elementType.ref().var().asParameter());
-        subst.substitute(
-                joinFunction.parameters[2],
-                rightMap.getOutputIndexedZSetType().elementType.ref().var().asParameter());
+            Map<Integer, Integer> leftRemap = new HashMap<>();
+            for (int i = 0; i < leftInputs.size(); i++)
+                // This "compresses" the indexes in the join function, omitting the ones
+                // that are no longer present in the inputs
+                leftRemap.put(leftInputs.get(i), i);
+            Map<Integer, Integer> rightRemap = new HashMap<>();
+            for (int i = 0; i < rightInputs.size(); i++)
+                rightRemap.put(rightInputs.get(i), i);
 
-        Map<DBSPParameter, Map<Integer, Integer>> remap = new HashMap<>();
-        Utilities.putNew(remap, joinFunction.parameters[1], leftRemap);
-        Utilities.putNew(remap, joinFunction.parameters[2], rightRemap);
+            assert joinFunction.parameters.length == 3;
+            Substitution<DBSPParameter, DBSPParameter> subst = new Substitution<>();
+            subst.substituteNew(
+                    joinFunction.parameters[0],
+                    join.left().getOutputIndexedZSetType().keyType.ref().var().asParameter());
+            subst.substitute(
+                    joinFunction.parameters[1],
+                    leftMap.getOutputIndexedZSetType().elementType.ref().var().asParameter());
+            subst.substitute(
+                    joinFunction.parameters[2],
+                    rightMap.getOutputIndexedZSetType().elementType.ref().var().asParameter());
 
-        RewriteFields rw = new RewriteFields(this.errorReporter, subst, remap);
-        DBSPExpression newJoinFunction = rw.apply(join.getFunction()).to(DBSPExpression.class);
-        DBSPOperator replacement = join.withFunction(newJoinFunction, join.outputType)
-                .withInputs(Linq.list(leftMap, rightMap), true);
-        this.map(join, replacement);
-        return true;
-    }
+            Map<DBSPParameter, Map<Integer, Integer>> remap = new HashMap<>();
+            Utilities.putNew(remap, joinFunction.parameters[1], leftRemap);
+            Utilities.putNew(remap, joinFunction.parameters[2], rightRemap);
 
-    @Override
-    public void postorder(DBSPStreamJoinOperator join) {
-        boolean done = this.processJoin(join);
-        if (!done)
-            super.postorder(join);
-    }
+            RewriteFields rw = new RewriteFields(this.errorReporter, subst, remap);
+            DBSPExpression newJoinFunction = rw.apply(join.getFunction()).to(DBSPExpression.class);
+            DBSPOperator replacement = join.withFunction(newJoinFunction, join.outputType)
+                    .withInputs(Linq.list(leftMap, rightMap), true);
+            this.map(join, replacement);
+            return true;
+        }
 
-    @Override
-    public void postorder(DBSPJoinOperator join) {
-        boolean done = this.processJoin(join);
-        if (!done)
-            super.postorder(join);
+        @Override
+        public void postorder(DBSPJoinIndexOperator join) {
+            boolean done = this.processJoin(join);
+            if (!done)
+                super.postorder(join);
+        }
+
+        @Override
+        public void postorder(DBSPStreamJoinIndexOperator join) {
+            boolean done = this.processJoin(join);
+            if (!done)
+                super.postorder(join);
+        }
+
+        @Override
+        public void postorder(DBSPStreamJoinOperator join) {
+            boolean done = this.processJoin(join);
+            if (!done)
+                super.postorder(join);
+        }
+
+        @Override
+        public void postorder(DBSPJoinOperator join) {
+            boolean done = this.processJoin(join);
+            if (!done)
+                super.postorder(join);
+        }
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
@@ -1,21 +1,27 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.IErrorReporter;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
 import org.dbsp.util.Linq;
 
 import java.util.ArrayList;
@@ -31,7 +37,6 @@ import java.util.List;
  */
 public class OptimizeMaps extends CircuitCloneVisitor {
     final CircuitGraph graph;
-    public static boolean testIssue2228 = false;
 
     public OptimizeMaps(IErrorReporter reporter, CircuitGraph graph) {
         super(reporter, false);
@@ -41,6 +46,7 @@ public class OptimizeMaps extends CircuitCloneVisitor {
     @Override
     public void postorder(DBSPMapIndexOperator operator) {
         DBSPOperator source = this.mapped(operator.input());
+        int inputFanout = this.graph.getFanout(operator.input());
         if (source.is(DBSPMapOperator.class)) {
             // mapindex(map) = mapindex
             DBSPClosureExpression expression = source.getClosureFunction();
@@ -50,6 +56,36 @@ public class OptimizeMaps extends CircuitCloneVisitor {
                     operator.getNode(), newFunction, operator.getOutputIndexedZSetType(), source.inputs.get(0));
             this.map(operator, result);
             return;
+        } else if (source.is(DBSPMapIndexOperator.class)) {
+            // mapindex(mapindex) = mapindex
+            DBSPClosureExpression sourceFunction = source.getClosureFunction();
+            DBSPClosureExpression thisFunction = operator.getClosureFunction();
+            if (thisFunction.parameters.length != 1)
+                throw new InternalCompilerError("Expected closure with 1 parameter", operator);
+            DBSPExpression argument = new DBSPRawTupleExpression(
+                    sourceFunction.body.field(0).borrow(),
+                    sourceFunction.body.field(1).borrow());
+            DBSPExpression apply = thisFunction.call(argument);
+            DBSPClosureExpression newFunction = apply.closure(sourceFunction.parameters)
+                    .reduce(errorReporter).to(DBSPClosureExpression.class);
+            DBSPOperator result = new DBSPMapIndexOperator(
+                    operator.getNode(), newFunction, operator.getOutputIndexedZSetType(), source.inputs.get(0));
+            this.map(operator, result);
+            return;
+        } else if (inputFanout == 1) {
+            if (source.is(DBSPJoinOperator.class)
+                    || source.is(DBSPStreamJoinOperator.class)) {
+                DBSPOperator result = OptimizeProjectionVisitor.mapIndexAfterJoin(
+                        this.errorReporter, source.to(DBSPJoinBaseOperator.class), operator);
+                this.map(operator, result);
+                return;
+            } else if (source.is(DBSPJoinIndexOperator.class)
+                    || source.is(DBSPStreamJoinIndexOperator.class)) {
+                DBSPOperator result = OptimizeProjectionVisitor.mapIndexAfterJoinIndex(
+                        this.errorReporter, source.to(DBSPJoinBaseOperator.class), operator);
+                this.map(operator, result);
+                return;
+            }
         }
         super.postorder(operator);
     }
@@ -66,10 +102,6 @@ public class OptimizeMaps extends CircuitCloneVisitor {
     }
 
     public void postorder(DBSPApplyOperator operator) {
-        if (testIssue2228) {
-            super.postorder(operator);
-            return;
-        }
         DBSPOperator source = this.mapped(operator.input());
         int inputFanout = this.graph.getFanout(operator.input());
         if (source.is(DBSPApplyOperator.class) && inputFanout == 1) {
@@ -103,13 +135,18 @@ public class OptimizeMaps extends CircuitCloneVisitor {
                     jfm.filter, newMap, operator.isMultiset, jfm.left(), jfm.right())
                     .copyAnnotations(operator).copyAnnotations(source);
             this.map(operator, result);
-        } else if ((source.is(DBSPStreamJoinOperator.class) || source.is(DBSPJoinOperator.class)) &&
+        } else if ((source.is(DBSPStreamJoinOperator.class) ||
+                source.is(DBSPAsofJoinOperator.class) ||
+                source.is(DBSPJoinOperator.class)) &&
                 // We have to look up the original operator input, not source
                 inputFanout == 1) {
-            DBSPClosureExpression expression = source.getClosureFunction();
-            DBSPClosureExpression newFunction = operator.getClosureFunction()
-                    .applyAfter(this.errorReporter, expression);
-            DBSPOperator result = source.withFunction(newFunction, operator.outputType);
+            DBSPOperator result = OptimizeProjectionVisitor.mapAfterJoin(
+                    this.errorReporter, source.to(DBSPJoinBaseOperator.class), operator);
+            this.map(operator, result);
+        } else if (source.is(DBSPJoinIndexOperator.class) ||
+                   source.is(DBSPStreamJoinIndexOperator.class) && inputFanout == 1) {
+            DBSPOperator result = OptimizeProjectionVisitor.mapAfterJoinIndex(
+                    this.errorReporter, source.to(DBSPJoinBaseOperator.class), operator);
             this.map(operator, result);
         } else if (source.is(DBSPMapOperator.class)) {
             DBSPClosureExpression expression = source.getClosureFunction();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeWithGraph.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeWithGraph.java
@@ -20,7 +20,7 @@ public class OptimizeWithGraph extends Repeat {
     }
 
     public OptimizeWithGraph(IErrorReporter reporter,
-                               Function<CircuitGraph, CircuitTransform> optimizerFactory) {
+                             Function<CircuitGraph, CircuitTransform> optimizerFactory) {
         super(reporter, createOnePass(reporter, optimizerFactory));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -596,7 +596,7 @@ public class Monotonicity extends CircuitVisitor {
         IMaybeMonotoneType keyMonoType = leftKeyMonoType.union(rightKeyMonoType);
 
         // We expect ASOF joins to look like projections.
-        Projection projection = new Projection(this.errorReporter);
+        Projection projection = new Projection(this.errorReporter, true);
         DBSPClosureExpression function = node.getClosureFunction();
         projection.apply(function);
         assert projection.isProjection && projection.hasIoMap();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -835,8 +835,8 @@ public class RegressionTests extends SqlIoTest {
 
             @Override
             public void endVisit() {
-                // We expect 9 MapIndex operators instead of 11 if CSE works
-                Assert.assertEquals(9, this.mapIndex);
+                // We expect 7 MapIndex operators instead of 11 if CSE works
+                Assert.assertEquals(7, this.mapIndex);
             }
         };
         visitor.apply(circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -1,11 +1,9 @@
 package org.dbsp.sqlCompiler.compiler.sql.streaming;
 
 import org.dbsp.sqlCompiler.CompilerMain;
-import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
-import org.dbsp.sqlCompiler.compiler.visitors.outer.OptimizeMaps;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
@@ -262,7 +260,6 @@ public class ProfilingTests extends StreamingTestBase {
 
     @Test
     public void issue2228() throws SQLException, IOException, InterruptedException {
-        OptimizeMaps.testIssue2228 = true;
         String sql = """
                 CREATE TABLE transaction (
                     id int NOT NULL,
@@ -286,6 +283,5 @@ public class ProfilingTests extends StreamingTestBase {
                 let _ = circuit.step().expect("could not run circuit");
                 """);
         this.measure(sql, main);
-        OptimizeMaps.testIssue2228 = false;
     }
 }


### PR DESCRIPTION
This optimization replaces the unsound Calcite optimization PROJECT_JOIN_TRANSPOSE.
The optimization essentially moves projections backwards through the plan, pushing projections at the output of a join to the inputs of the join.
This optimization was disabled in our compiler a while ago, but the lack of this optimization caused some SLT tests to fail, since the plans they were generating we very inefficient.
