### PR TITLE
feldera-types: fix serialization of `SqlType`

### DIFF
--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -714,16 +714,19 @@ mod tests {
                 &sql_str_base.to_lowercase(), // lowercase
                 &sql_str_base.to_uppercase(), // UPPERCASE
             ] {
-                let value1: SqlType = serde_json::from_str(&format!("\"{}\"", sql_str)).expect(
-                    &format!("\"{sql_str}\" should deserialize into its SQL type"),
-                );
+                let value1: SqlType = serde_json::from_str(&format!("\"{}\"", sql_str))
+                    .unwrap_or_else(|_| {
+                        panic!("\"{sql_str}\" should deserialize into its SQL type")
+                    });
                 assert_eq!(value1, expected_value);
                 let serialized_str =
                     serde_json::to_string(&value1).expect("Value should serialize into JSON");
-                let value2: SqlType = serde_json::from_str(&serialized_str).expect(&format!(
-                    "{} should deserialize back into its SQL type",
-                    serialized_str
-                ));
+                let value2: SqlType = serde_json::from_str(&serialized_str).unwrap_or_else(|_| {
+                    panic!(
+                        "{} should deserialize back into its SQL type",
+                        serialized_str
+                    )
+                });
                 assert_eq!(value1, value2);
             }
         }

--- a/openapi.json
+++ b/openapi.json
@@ -2866,19 +2866,19 @@
         "type": "string",
         "description": "The specified units for SQL Interval types.\n\n`INTERVAL 1 DAY`, `INTERVAL 1 DAY TO HOUR`, `INTERVAL 1 DAY TO MINUTE`,\nwould yield `Day`, `DayToHour`, `DayToMinute`, as the `IntervalUnit` respectively.",
         "enum": [
-          "DAY",
-          "DAYTOHOUR",
-          "DAYTOMINUTE",
-          "DAYTOSECOND",
-          "HOUR",
-          "HOURTOMINUTE",
-          "HOURTOSECOND",
-          "MINUTE",
-          "MINUTETOSECOND",
-          "MONTH",
-          "SECOND",
-          "YEAR",
-          "YEARTOMONTH"
+          "Day",
+          "DayToHour",
+          "DayToMinute",
+          "DayToSecond",
+          "Hour",
+          "HourToMinute",
+          "HourToSecond",
+          "Minute",
+          "MinuteToSecond",
+          "Month",
+          "Second",
+          "Year",
+          "YearToMonth"
         ]
       },
       "JsonUpdateFormat": {
@@ -4074,105 +4074,105 @@
             "type": "string",
             "description": "SQL `BOOLEAN` type.",
             "enum": [
-              "BOOLEAN"
+              "Boolean"
             ]
           },
           {
             "type": "string",
             "description": "SQL `TINYINT` type.",
             "enum": [
-              "TINYINT"
+              "TinyInt"
             ]
           },
           {
             "type": "string",
             "description": "SQL `SMALLINT` or `INT2` type.",
             "enum": [
-              "SMALLINT"
+              "SmallInt"
             ]
           },
           {
             "type": "string",
             "description": "SQL `INTEGER`, `INT`, `SIGNED`, `INT4` type.",
             "enum": [
-              "INTEGER"
+              "Int"
             ]
           },
           {
             "type": "string",
             "description": "SQL `BIGINT` or `INT64` type.",
             "enum": [
-              "BIGINT"
+              "BigInt"
             ]
           },
           {
             "type": "string",
             "description": "SQL `REAL` or `FLOAT4` or `FLOAT32` type.",
             "enum": [
-              "REAL"
+              "Real"
             ]
           },
           {
             "type": "string",
             "description": "SQL `DOUBLE` or `FLOAT8` or `FLOAT64` type.",
             "enum": [
-              "DOUBLE"
+              "Double"
             ]
           },
           {
             "type": "string",
             "description": "SQL `DECIMAL` or `DEC` or `NUMERIC` type.",
             "enum": [
-              "DECIMAL"
+              "Decimal"
             ]
           },
           {
             "type": "string",
             "description": "SQL `CHAR(n)` or `CHARACTER(n)` type.",
             "enum": [
-              "CHAR"
+              "Char"
             ]
           },
           {
             "type": "string",
             "description": "SQL `VARCHAR`, `CHARACTER VARYING`, `TEXT`, or `STRING` type.",
             "enum": [
-              "VARCHAR"
+              "Varchar"
             ]
           },
           {
             "type": "string",
             "description": "SQL `BINARY(n)` type.",
             "enum": [
-              "BINARY"
+              "Binary"
             ]
           },
           {
             "type": "string",
             "description": "SQL `VARBINARY` or `BYTEA` type.",
             "enum": [
-              "VARBINARY"
+              "Varbinary"
             ]
           },
           {
             "type": "string",
             "description": "SQL `TIME` type.",
             "enum": [
-              "TIME"
+              "Time"
             ]
           },
           {
             "type": "string",
             "description": "SQL `DATE` type.",
             "enum": [
-              "DATE"
+              "Date"
             ]
           },
           {
             "type": "string",
             "description": "SQL `TIMESTAMP` type.",
             "enum": [
-              "TIMESTAMP"
+              "Timestamp"
             ]
           },
           {
@@ -4190,35 +4190,35 @@
             "type": "string",
             "description": "SQL `ARRAY` type.",
             "enum": [
-              "ARRAY"
+              "Array"
             ]
           },
           {
             "type": "string",
             "description": "A complex SQL struct type (`CREATE TYPE x ...`).",
             "enum": [
-              "STRUCT"
+              "Struct"
             ]
           },
           {
             "type": "string",
             "description": "SQL `MAP` type.",
             "enum": [
-              "MAP"
+              "Map"
             ]
           },
           {
             "type": "string",
             "description": "SQL `NULL` type.",
             "enum": [
-              "NULL"
+              "Null"
             ]
           },
           {
             "type": "string",
             "description": "SQL `VARIANT` type.",
             "enum": [
-              "VARIANT"
+              "Variant"
             ]
           }
         ],


### PR DESCRIPTION
A custom deserialization was implemented for `SqlType`, but its custom serialization counterpart was not implemented. This resulted in an error when deserializing the output of its own serialization for some of its variants (notably, interval types). This commit implements the custom serialization and adds a corresponding test. This also removes the `From` trait implementation, which is not used anywhere.

Fixes: https://github.com/feldera/feldera/issues/2947