### PR TITLE
Fault tolerance fixes and improvements

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.81.0
+          toolchain: 1.82.0
           components: rustfmt clippy
       - uses: actions/setup-python@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    rust: 1.81.0
+    rust: 1.82.0
 repos:
 -   repo: local
     hooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "url",
  "utoipa",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4462,6 +4463,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4484,6 +4486,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-googleapis",
  "google-cloud-pubsub",
+ "governor 0.7.0",
  "home",
  "indexmap 2.6.0",
  "jemalloc_pprof",
@@ -3668,6 +3669,7 @@ dependencies = [
  "minitrace",
  "minitrace-jaeger",
  "mockall",
+ "nonzero_ext",
  "num-bigint",
  "once_cell",
  "ordered-float 4.3.0",
@@ -4473,7 +4475,7 @@ dependencies = [
  "fake",
  "feldera-adapterlib",
  "feldera-types",
- "governor",
+ "governor 0.6.3",
  "num-traits",
  "rand",
  "rand_distr",
@@ -5017,6 +5019,27 @@ dependencies = [
  "dashmap 5.5.3",
  "futures",
  "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if",
+ "dashmap 6.1.0",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=$HOME/.rustup
 ENV CARGO_HOME=$HOME/.cargo
 # Adds python and rust binaries to the path
 ENV PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-ENV RUST_VERSION=1.81.0
+ENV RUST_VERSION=1.82.0
 ENV RUST_BUILD_MODE='' # set to --release for release builds
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV DEBIAN_FRONTEND=noninteractive

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -25,6 +25,7 @@ bytemuck = "1.16.3"
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 tokio = { version = "1.25.0", features = ["sync"] }
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 
 [package.metadata.cargo-machete]
 ignored = ["num-traits"]

--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -574,6 +574,9 @@ pub enum ControllerError {
 
     /// Controller terminated before command could be executed.
     ControllerExit,
+
+    /// Enterprise-only feature.
+    EnterpriseFeature(&'static str),
 }
 
 impl ResponseError for ControllerError {
@@ -589,6 +592,7 @@ impl ResponseError for ControllerError {
             Self::UnknownInputEndpoint { .. } => StatusCode::NOT_FOUND,
             Self::ParseError { .. } => StatusCode::BAD_REQUEST,
             Self::NotSupported { .. } => StatusCode::BAD_REQUEST,
+            Self::EnterpriseFeature(_) => StatusCode::NOT_IMPLEMENTED,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -690,6 +694,7 @@ impl DbspDetailedError for ControllerError {
             Self::DbspPanic => Cow::from("DbspPanic"),
             Self::ControllerPanic => Cow::from("ControllerPanic"),
             Self::ControllerExit => Cow::from("ControllerExit"),
+            Self::EnterpriseFeature(_) => Cow::from("EnterpriseFeature"),
         }
     }
 }
@@ -720,6 +725,7 @@ impl DetailedError for ControllerError {
             Self::DbspPanic => Cow::from("DbspPanic"),
             Self::ControllerPanic => Cow::from("ControllerPanic"),
             Self::ControllerExit => Cow::from("ControllerExit"),
+            Self::EnterpriseFeature(_) => Cow::from("EnterpriseFeature"),
         }
     }
 }
@@ -814,8 +820,14 @@ impl Display for ControllerError {
             Self::ControllerPanic => {
                 write!(f, "Panic inside the DBSP controller")
             }
-            ControllerError::ControllerExit => {
+            Self::ControllerExit => {
                 write!(f, "Controller exited before command could be executed")
+            }
+            Self::EnterpriseFeature(feature) => {
+                write!(
+                    f,
+                    "Cannot use enterprise-only feature ({feature}) in Feldera community edition."
+                )
             }
         }
     }

--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -511,6 +511,9 @@ pub enum ControllerError {
     /// Unexpected step number.
     UnexpectedStep { actual: Step, expected: Step },
 
+    /// Step replay failure.
+    ReplayFailure { error: String },
+
     /// Feature is not supported.
     NotSupported { error: String },
 
@@ -685,6 +688,7 @@ impl DbspDetailedError for ControllerError {
             Self::RestoreInProgress => Cow::from("RestoreInProgress"),
             Self::StepError { .. } => Cow::from("StepError"),
             Self::UnexpectedStep { .. } => Cow::from("UnexpectedStep"),
+            Self::ReplayFailure { .. } => Cow::from("ReplayFailure"),
             Self::IrParseError { .. } => Cow::from("IrParseError"),
             Self::CliArgsError { .. } => Cow::from("ControllerCliArgsError"),
             Self::Config { config_error } => {
@@ -717,6 +721,7 @@ impl DetailedError for ControllerError {
             Self::RestoreInProgress => Cow::from("RestoreInProgress"),
             Self::StepError { .. } => Cow::from("StepError"),
             Self::UnexpectedStep { .. } => Cow::from("UnexpectedStep"),
+            Self::ReplayFailure { .. } => Cow::from("ReplayFailure"),
             Self::IrParseError { .. } => Cow::from("IrParseError"),
             Self::CliArgsError { .. } => Cow::from("ControllerCliArgsError"),
             Self::Config { config_error } => {
@@ -765,6 +770,9 @@ impl Display for ControllerError {
             Self::StepError(error) => write!(f, "Error with persistent input steps: {error}"),
             Self::UnexpectedStep { actual, expected } => {
                 write!(f, "Read step {actual}, expected {expected}")
+            }
+            Self::ReplayFailure { error } => {
+                write!(f, "{error}")
             }
             Self::IrParseError { error } => {
                 write!(f, "Error parsing program IR: {error}")

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -26,6 +26,7 @@ pubsub-emulator-test = []
 # Run Pub/Sub connector tests agains a GCP account.
 # Google Cloud Application Default Credentials (ADC) must be configured. See `pubsub/test.rs`.
 pubsub-gcp-test = []
+feldera-enterprise = []
 
 [dependencies]
 feldera-types = { path = "../feldera-types" }

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -107,6 +107,8 @@ indexmap = "2.6.0"
 rmp-serde = "1.3.0"
 rmpv = { version = "1.3.0", features = ["with-serde"] }
 serde_bytes = "0.11.15"
+governor = "0.7.0"
+nonzero_ext = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -109,6 +109,7 @@ rmpv = { version = "1.3.0", features = ["with-serde"] }
 serde_bytes = "0.11.15"
 governor = "0.7.0"
 nonzero_ext = "0.3.0"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"

--- a/crates/adapters/src/controller/metadata.rs
+++ b/crates/adapters/src/controller/metadata.rs
@@ -22,6 +22,7 @@ pub struct Checkpoint {
     pub circuit: CheckpointMetadata,
     pub step: Step,
     pub config: PipelineConfig,
+    pub processed_records: u64,
 }
 
 impl Checkpoint {

--- a/crates/adapters/src/controller/metadata.rs
+++ b/crates/adapters/src/controller/metadata.rs
@@ -364,7 +364,14 @@ pub struct StepMetadata {
     pub step: Step,
     pub remove_inputs: HashSet<String>,
     pub add_inputs: HashMap<String, InputEndpointConfig>,
-    pub input_logs: HashMap<String, RmpValue>,
+    pub input_logs: HashMap<String, InputLog>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct InputLog {
+    pub value: RmpValue,
+    pub num_records: u64,
+    pub hash: u64,
 }
 
 #[cfg(test)]

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -115,15 +115,15 @@ where
 }
 
 impl GlobalControllerMetrics {
-    fn new() -> Self {
+    fn new(processed_records: u64) -> Self {
         Self {
             state: Atomic::new(PipelineState::Paused),
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             rss_bytes: Some(AtomicU64::new(0)),
             cpu_msecs: Some(AtomicU64::new(0)),
             buffered_input_records: AtomicU64::new(0),
-            total_input_records: AtomicU64::new(0),
-            total_processed_records: AtomicU64::new(0),
+            total_input_records: AtomicU64::new(processed_records),
+            total_processed_records: AtomicU64::new(processed_records),
             pipeline_complete: AtomicBool::new(false),
             step_requested: AtomicBool::new(false),
         }
@@ -391,10 +391,10 @@ impl Serialize for ControllerMetric {
 }
 
 impl ControllerStatus {
-    pub fn new(pipeline_config: PipelineConfig) -> Self {
+    pub fn new(pipeline_config: PipelineConfig, processed_records: u64) -> Self {
         Self {
             pipeline_config,
-            global_metrics: GlobalControllerMetrics::new(),
+            global_metrics: GlobalControllerMetrics::new(processed_records),
             inputs: ShardedLock::new(BTreeMap::new()),
             outputs: ShardedLock::new(BTreeMap::new()),
             metrics: Mutex::new(Vec::new()),

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -605,11 +605,17 @@ impl ControllerStatus {
         };
     }
 
-    pub fn completed(&self, endpoint_id: EndpointId, num_records: u64, metadata: Option<RmpValue>) {
+    pub fn completed(
+        &self,
+        endpoint_id: EndpointId,
+        num_records: u64,
+        hash: u64,
+        metadata: Option<RmpValue>,
+    ) {
         let inputs = self.inputs.read().unwrap();
         self.global_metrics.consume_buffered_inputs(num_records);
         if let Some(endpoint_stats) = inputs.get(&endpoint_id) {
-            endpoint_stats.completed(num_records, metadata);
+            endpoint_stats.completed(num_records, hash, metadata);
         };
     }
 
@@ -795,6 +801,7 @@ pub enum StepProgress {
     Started,
     Complete {
         num_records: u64,
+        hash: u64,
         metadata: Option<RmpValue>,
     },
 }
@@ -888,9 +895,10 @@ impl InputEndpointStatus {
         }
     }
 
-    fn completed(&self, num_records: u64, metadata: Option<RmpValue>) {
+    fn completed(&self, num_records: u64, hash: u64, metadata: Option<RmpValue>) {
         *self.progress.lock().unwrap() = StepProgress::Complete {
             num_records,
+            hash,
             metadata,
         };
         self.metrics

--- a/crates/adapters/src/format/avro/input.rs
+++ b/crates/adapters/src/format/avro/input.rs
@@ -439,7 +439,7 @@ impl Parser for AvroParser {
     }
     fn parse(&mut self, data: &[u8]) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
         let errors = self.input(data).map_or_else(|e| vec![e], |_| Vec::new());
-        let buffer = self.input_stream.as_mut().and_then(|avro| avro.take());
+        let buffer = self.input_stream.as_mut().and_then(|avro| avro.take_all());
         (buffer, errors)
     }
 

--- a/crates/adapters/src/format/avro/test.rs
+++ b/crates/adapters/src/format/avro/test.rs
@@ -328,7 +328,7 @@ where
         for (avro, expected_errors) in test.input_batches {
             let (mut buffer, errors) = parser.parse(&avro);
             assert_eq!(&errors, &expected_errors);
-            buffer.flush_all();
+            buffer.flush();
         }
         assert_eq!(&test.expected_output, &outputs.state().flushed);
     }

--- a/crates/adapters/src/format/avro/test.rs
+++ b/crates/adapters/src/format/avro/test.rs
@@ -27,7 +27,7 @@ use feldera_types::{
 use proptest::prelude::*;
 use proptest::proptest;
 use serde::Serialize;
-use std::{borrow::Cow, collections::HashMap, fmt::Debug};
+use std::{borrow::Cow, collections::HashMap, fmt::Debug, hash::Hash};
 use std::{iter::repeat, sync::Arc};
 
 #[derive(Debug)]
@@ -314,7 +314,13 @@ where
 
 fn run_parser_test<T>(test_cases: Vec<TestCase<T>>)
 where
-    T: Debug + Eq + for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
+    T: Debug
+        + Eq
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + 'static,
 {
     for test in test_cases {
         let format_config = FormatConfig {

--- a/crates/adapters/src/format/csv.rs
+++ b/crates/adapters/src/format/csv.rs
@@ -139,7 +139,7 @@ impl Parser for CsvParser {
         if !data.is_empty() {
             self.parse_record(data, &mut errors);
         }
-        (self.input_stream.take(), errors)
+        (self.input_stream.take_all(), errors)
     }
 }
 

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -394,9 +394,9 @@ mod test {
         serde_with_context::{DeserializeWithContext, SqlSerdeConfig},
     };
     use log::trace;
-    use std::{borrow::Cow, fmt::Debug, panic::Location};
+    use std::{borrow::Cow, fmt::Debug, hash::Hash, panic::Location};
 
-    #[derive(PartialEq, Debug, Eq)]
+    #[derive(PartialEq, Debug, Eq, Hash)]
     struct TestStruct {
         b: bool,
         i: i32,
@@ -427,7 +427,7 @@ mod test {
         }
     }
 
-    #[derive(PartialEq, Debug, Eq)]
+    #[derive(PartialEq, Debug, Eq, Hash)]
     struct TestStructUpd {
         b: Option<bool>,
         i: i32,
@@ -469,12 +469,14 @@ mod test {
         T: Debug
             + Eq
             + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+            + Hash
             + Send
             + Sync
             + 'static,
         U: Debug
             + Eq
             + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+            + Hash
             + Send
             + Sync
             + 'static,

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -367,7 +367,7 @@ impl Parser for JsonParser {
             }
         }
 
-        (self.input_stream.take(), errors)
+        (self.input_stream.take_all(), errors)
     }
 
     fn fork(&self) -> Box<dyn Parser> {
@@ -493,7 +493,7 @@ mod test {
             for (json, expected_errors) in test.input_batches {
                 let (mut buffer, errors) = parser.parse(json.as_bytes());
                 assert_eq!(&errors, &expected_errors);
-                buffer.flush_all();
+                buffer.flush();
             }
             consumer.eoi();
             assert_eq!(&test.expected_output, &outputs.state().flushed);

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -70,15 +70,13 @@ pub fn get_output_format(name: &str) -> Option<&'static dyn OutputFormat> {
 pub struct EmptyInputBuffer;
 
 impl InputBuffer for EmptyInputBuffer {
-    fn flush(&mut self, _n: usize) -> usize {
-        0
-    }
+    fn flush(&mut self) {}
 
     fn len(&self) -> usize {
         0
     }
 
-    fn take(&mut self) -> Option<Box<dyn InputBuffer>> {
+    fn take_some(&mut self, _n: usize) -> Option<Box<dyn InputBuffer>> {
         None
     }
 }

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -2,6 +2,7 @@ use crate::format::parquet::{ParquetInputFormat, ParquetOutputFormat};
 #[cfg(feature = "with-avro")]
 use avro::input::AvroInputFormat;
 use once_cell::sync::Lazy;
+use std::hash::Hasher;
 use std::ops::Range;
 use std::{
     cmp::max,
@@ -71,6 +72,8 @@ pub struct EmptyInputBuffer;
 
 impl InputBuffer for EmptyInputBuffer {
     fn flush(&mut self) {}
+
+    fn hash(&self, _hasher: &mut dyn Hasher) {}
 
     fn len(&self) -> usize {
         0

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -151,7 +151,7 @@ impl Parser for ParquetParser {
                 )),
             )],
         };
-        (self.input_stream.take(), errors)
+        (self.input_stream.take_all(), errors)
     }
 
     fn fork(&self) -> Box<dyn Parser> {

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -524,7 +524,7 @@ impl DeltaTableInputEndpointInner {
                 },
                 |()| Vec::new(),
             );
-            self.queue.push((input_stream.take(), errors), bytes);
+            self.queue.push((input_stream.take_all(), errors), bytes);
         }
     }
 

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -519,8 +519,8 @@ async fn query(state: WebData<ServerState>, args: Query<AdhocQueryArgs>) -> impl
         controller.as_ref().map(|c| c.session_context())
     };
 
-    match session_ctxt {
-        Some(session) => stream_adhoc_result(args.into_inner(), session).await,
+    match session_ctxt.transpose()? {
+        Some(session) => Ok(stream_adhoc_result(args.into_inner(), session).await),
         None => Err(missing_controller_error(&state)),
     }
 }

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -498,7 +498,7 @@ mod test {
         input_stream_handle
             .insert(br#"{"id": 2, "b": true, "s": "2"}"#)
             .unwrap();
-        input_stream_handle.flush_all();
+        input_stream_handle.flush();
 
         circuit.step().unwrap();
 
@@ -515,7 +515,7 @@ mod test {
         input_stream_handle
             .insert(br#"{"id": 1, "b": true, "s": "1-modified"}"#)
             .unwrap();
-        input_stream_handle.flush_all();
+        input_stream_handle.flush();
 
         circuit.step().unwrap();
 
@@ -530,7 +530,7 @@ mod test {
         // Step 3: delete an entry.
 
         input_stream_handle.delete(br#"2"#).unwrap();
-        input_stream_handle.flush_all();
+        input_stream_handle.flush();
 
         circuit.step().unwrap();
 

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -12,12 +12,14 @@ use anyhow::{anyhow, bail, Result as AnyResult};
 #[cfg(feature = "with-avro")]
 use apache_avro::types::Value as AvroValue;
 use arrow::array::RecordBatch;
+use dbsp::dynamic::Data;
 use dbsp::{
     algebra::HasOne, operator::Update, utils::Tup2, DBData, InputHandle, MapHandle, SetHandle,
     ZSetHandle, ZWeight,
 };
 use feldera_types::serde_with_context::{DeserializeWithContext, SqlSerdeConfig};
 use serde_arrow::Deserializer as ArrowDeserializer;
+use std::hash::Hasher;
 use std::{collections::VecDeque, marker::PhantomData, mem::swap, ops::Neg};
 
 /// A deserializer that parses byte arrays into a strongly typed representation.
@@ -361,6 +363,12 @@ where
         self.handle.append(&mut self.updates);
     }
 
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        for update in &self.updates {
+            hasher.write_u64(update.default_hash())
+        }
+    }
+
     fn len(&self) -> usize {
         self.updates.len()
     }
@@ -466,6 +474,10 @@ where
         self.buffer.len()
     }
 
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
+    }
+
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
     }
@@ -534,6 +546,10 @@ where
 
     fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 }
 
@@ -607,6 +623,10 @@ where
 
     fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 }
 
@@ -708,6 +728,12 @@ where
 
     fn len(&self) -> usize {
         self.updates.len()
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        for update in &self.updates {
+            hasher.write_u64(update.default_hash())
+        }
     }
 
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
@@ -812,6 +838,10 @@ where
         self.buffer.len()
     }
 
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
+    }
+
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
     }
@@ -876,6 +906,10 @@ where
 
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 
     fn len(&self) -> usize {
@@ -949,6 +983,10 @@ where
 
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 
     fn len(&self) -> usize {
@@ -1122,6 +1160,12 @@ where
         self.updates.len()
     }
 
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        for update in &self.updates {
+            hasher.write_u64(update.default_hash())
+        }
+    }
+
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         if !self.updates.is_empty() {
             Some(Box::new(DeMapStreamBuffer {
@@ -1266,6 +1310,10 @@ where
         self.buffer.len()
     }
 
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
+    }
+
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
     }
@@ -1357,6 +1405,10 @@ where
 
     fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
         self.buffer.take_some(n)
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 
     fn len(&self) -> usize {
@@ -1466,6 +1518,10 @@ where
 
     fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.buffer.hash(hasher)
     }
 }
 

--- a/crates/adapters/src/test/datagen.rs
+++ b/crates/adapters/src/test/datagen.rs
@@ -12,6 +12,7 @@ use feldera_types::transport::datagen::GenerationPlan;
 use feldera_types::{deserialize_table_record, serialize_table_record};
 use size_of::SizeOf;
 use std::collections::BTreeMap;
+use std::hash::Hash;
 use std::time::Duration;
 use std::{env, thread};
 
@@ -114,8 +115,8 @@ fn mk_pipeline<T, U>(
     fields: Vec<Field>,
 ) -> AnyResult<(Box<dyn InputReader>, MockInputConsumer, MockDeZSet<T, U>)>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
 {
     let relation = Relation::new("test_input".into(), fields, true, BTreeMap::new());
     let (endpoint, consumer, _parser, zset) =

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -300,7 +300,7 @@ impl BufferConsumer {
                             };
 
                             if let Some(payload) = message.payload() {
-                                parser.parse(payload).0.flush_all();
+                                parser.parse(payload).0.flush();
                             }
                         }
                     }

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -102,9 +102,9 @@ impl InputConsumer for MockInputConsumer {
 
     fn buffered(&self, _num_records: usize, _num_bytes: usize) {}
 
-    fn replayed(&self, _num_records: usize) {}
+    fn replayed(&self, _num_records: usize, _hash: u64) {}
 
-    fn extended(&self, _num_records: usize, _metadata: RmpValue) {
+    fn extended(&self, _num_records: usize, _hash: u64, _metadata: RmpValue) {
         self.state().n_extended += 1;
     }
 }

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -17,6 +17,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::{read_dir, File};
+use std::hash::Hash;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::{
@@ -104,8 +105,8 @@ pub fn mock_parser_pipeline<T, U>(
     config: &FormatConfig,
 ) -> AnyResult<(MockInputConsumer, MockInputParser, MockDeZSet<T, U>)>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
 {
     let input_handle = <MockDeZSet<T, U>>::new();
     let consumer = MockInputConsumer::new();
@@ -139,8 +140,8 @@ pub fn mock_input_pipeline<T, U>(
     MockDeZSet<T, U>,
 )>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
 {
     let default_format = FormatConfig {
         name: Cow::from("json"),

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -3,12 +3,12 @@
 #![allow(clippy::type_complexity)]
 
 use crate::{
-    controller::InputEndpointConfig, format::InputBuffer, transport::InputReader, Catalog,
-    CircuitCatalog, FormatConfig,
+    controller::InputEndpointConfig, transport::InputReader, Catalog, CircuitCatalog, FormatConfig,
 };
 use anyhow::Result as AnyResult;
 use dbsp::{DBData, DBSPHandle, OrdZSet, Runtime};
 use env_logger::Env;
+use feldera_adapterlib::format::InputBuffer;
 use feldera_types::serde_with_context::{
     DeserializeWithContext, SerializeWithContext, SqlSerdeConfig,
 };
@@ -261,7 +261,7 @@ where
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes).unwrap();
     let (mut parsed_buffers, errors) = parser.parse(&bytes);
-    parsed_buffers.flush_all();
+    parsed_buffers.flush();
 
     // Use assert_eq, so errors are printed in case of a failure.
     assert_eq!(errors, vec![]);

--- a/crates/adapters/src/transport/adhoc.rs
+++ b/crates/adapters/src/transport/adhoc.rs
@@ -123,7 +123,7 @@ impl AdHocInputEndpoint {
         arrow_inserter: &mut Box<dyn ArrowStream>,
     ) -> AnyResult<u64> {
         arrow_inserter.insert(&batch)?;
-        let buffer = arrow_inserter.take();
+        let buffer = arrow_inserter.take_all();
         let num_records = buffer.len();
         if !buffer.is_empty() {
             let mut aux = Vec::new();
@@ -270,7 +270,8 @@ impl InputReader for AdHocInputEndpoint {
                     let (mut buffer, errors) = details.parser.parse(&chunk);
                     details.consumer.buffered(buffer.len(), !chunk.len());
                     details.consumer.parse_errors(errors);
-                    num_records += buffer.flush_all();
+                    num_records += buffer.len();
+                    buffer.flush();
                 }
                 details.consumer.replayed(num_records);
             }

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -122,7 +122,7 @@ impl FileInputReader {
                                 None => Some(offsets),
                             };
                             total += buffer.len();
-                            buffer.flush_all();
+                            buffer.flush();
                             if total >= limit {
                                 break;
                             }
@@ -159,7 +159,8 @@ impl FileInputReader {
                                 let (mut buffer, errors) = parser.parse(chunk);
                                 consumer.parse_errors(errors);
                                 consumer.buffered(buffer.len(), chunk.len());
-                                num_records += buffer.flush_all();
+                                num_records += buffer.len();
+                                buffer.flush();
                             }
                         }
                         consumer.replayed(num_records);

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -273,7 +273,7 @@ mod test {
     use std::{io::Write, thread::sleep, time::Duration};
     use tempfile::NamedTempFile;
 
-    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+    #[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
     pub struct TestStruct {
         s: String,
         b: bool,

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -274,7 +274,8 @@ impl InputReader for HttpInputEndpoint {
                     let (mut buffer, errors) = details.parser.parse(&chunk);
                     details.consumer.buffered(buffer.len(), chunk.len());
                     details.consumer.parse_errors(errors);
-                    num_records += buffer.flush_all();
+                    num_records += buffer.len();
+                    buffer.flush();
                 }
                 details.consumer.replayed(num_records);
             }

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -172,7 +172,7 @@ impl KafkaFtInputReaderInner {
                             ReplayAction::Replay => {
                                 consumer.parse_errors(msg.errors);
                                 total_records += msg.buffer.len();
-                                msg.buffer.flush_all()
+                                msg.buffer.flush()
                             }
                             ReplayAction::Defer => unreachable!(
                                 "`replay_messages` was split so that this couldn't happen."
@@ -200,7 +200,7 @@ impl KafkaFtInputReaderInner {
                             ReplayAction::Replay => {
                                 consumer.parse_errors(errors);
                                 total_records += buffer.len();
-                                buffer.flush_all();
+                                buffer.flush();
                             }
                             ReplayAction::Defer => {
                                 // Message is after the step we're replaying.
@@ -240,7 +240,8 @@ impl KafkaFtInputReaderInner {
                                 for (partition, buf) in partitions.iter_mut().enumerate() {
                                     if let Some((offset, mut msg)) = buf.messages.pop_first() {
                                         consumer.parse_errors(msg.errors);
-                                        total += msg.buffer.flush_all();
+                                        total += msg.buffer.len();
+                                        msg.buffer.flush();
                                         empty = false;
 
                                         let range = &mut ranges[topic][partition];

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -15,6 +15,7 @@ use env_logger::Env;
 use feldera_types::program_schema::Relation;
 use log::info;
 use rmpv::Value as RmpValue;
+use std::hash::Hasher;
 use std::ops::Range;
 use std::sync::atomic::AtomicUsize;
 use std::{
@@ -314,6 +315,8 @@ impl InputBuffer for DummyInputBuffer {
     fn len(&self) -> usize {
         self.data.as_ref().map_or(0, |_| 1)
     }
+
+    fn hash(&self, _hasher: &mut dyn Hasher) {}
 
     fn take_some(&mut self, _n: usize) -> Option<Box<dyn InputBuffer>> {
         self.data.take().map(|data| {

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -304,13 +304,10 @@ struct DummyInputBuffer {
 }
 
 impl InputBuffer for DummyInputBuffer {
-    fn flush(&mut self, _n: usize) -> usize {
+    fn flush(&mut self) {
         if let Some(s) = self.data.take() {
             info!("flushing {:?}", s);
             self.receiver.flushed.lock().unwrap().push(s);
-            1
-        } else {
-            0
         }
     }
 
@@ -318,7 +315,7 @@ impl InputBuffer for DummyInputBuffer {
         self.data.as_ref().map_or(0, |_| 1)
     }
 
-    fn take(&mut self) -> Option<Box<dyn InputBuffer>> {
+    fn take_some(&mut self, _n: usize) -> Option<Box<dyn InputBuffer>> {
         self.data.take().map(|data| {
             Box::new(Self {
                 receiver: self.receiver.clone(),

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -496,11 +496,11 @@ impl InputConsumer for DummyInputConsumer {
         }
     }
 
-    fn replayed(&self, num_records: usize) {
+    fn replayed(&self, num_records: usize, _hash: u64) {
         self.called(ConsumerCall::Replayed { num_records });
     }
 
-    fn extended(&self, num_records: usize, metadata: RmpValue) {
+    fn extended(&self, num_records: usize, _hash: u64, metadata: RmpValue) {
         self.called(ConsumerCall::Extended {
             num_records,
             metadata,

--- a/crates/adapters/src/transport/nexmark.rs
+++ b/crates/adapters/src/transport/nexmark.rs
@@ -298,7 +298,8 @@ fn worker_thread(
         barrier.wait();
         let mut total = 0;
         for (_events, mut buffer) in queue.lock().unwrap().drain(..) {
-            total += buffer.flush_all();
+            total += buffer.len();
+            buffer.flush();
         }
         consumers[NexmarkTable::Bid].replayed(total);
         next_event_id = event_ids.end;
@@ -334,7 +335,8 @@ fn worker_thread(
                             Some(events) => Some(events.start..range.end),
                             None => Some(range),
                         };
-                        total += buffer.flush_all();
+                        total += buffer.len();
+                        buffer.flush();
                     }
                 }
                 consumers[NexmarkTable::Bid].extended(

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -267,7 +267,8 @@ impl S3InputReader {
                                 let (mut buffer, errors) = parser.parse(chunk);
                                 consumer.parse_errors(errors);
                                 consumer.buffered(buffer.len(), chunk.len());
-                                num_records += buffer.flush_all();
+                                num_records += buffer.len();
+                                buffer.flush();
                             }
                         }
                     }
@@ -356,7 +357,8 @@ impl S3InputReader {
                                 let Some(QueuedBuffer { key, start_offset, end_offset, mut buffer }) = queue.pop_front() else {
                                     break
                                 };
-                                total += buffer.flush_all();
+                                total += buffer.len();
+                                buffer.flush();
                                 offsets.entry(key)
                                     .and_modify(|value| value.1 = end_offset)
                                     .or_insert((start_offset, end_offset));

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -502,7 +502,7 @@ mod test {
     use serde::{Deserialize, Serialize};
     use std::sync::Arc;
 
-    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+    #[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
     struct TestStruct {
         i: i64,
     }

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -15,15 +15,22 @@ use feldera_types::program_schema::Relation;
 use feldera_types::transport::url::UrlInputConfig;
 use futures::{future::OptionFuture, StreamExt};
 use serde::{Deserialize, Serialize};
-use xxhash_rust::xxh3::Xxh3Default;
 use std::{
-    cmp::{min, Ordering}, collections::VecDeque, hash::Hasher, ops::Range, str::FromStr, sync::Arc, thread::spawn, time::Duration
+    cmp::{min, Ordering},
+    collections::VecDeque,
+    hash::Hasher,
+    ops::Range,
+    str::FromStr,
+    sync::Arc,
+    thread::spawn,
+    time::Duration,
 };
 use tokio::{
     select,
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     time::{sleep_until, Instant},
 };
+use xxhash_rust::xxh3::Xxh3Default;
 
 pub(crate) struct UrlInputEndpoint {
     config: Arc<UrlInputConfig>,

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -403,7 +403,7 @@ mod test {
         time::Duration,
     };
 
-    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+    #[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
     struct TestStruct {
         s: String,
         b: bool,

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -260,7 +260,8 @@ impl UrlInputReader {
                     let (mut buffer, errors) = parser.parse(chunk);
                     consumer.parse_errors(errors);
                     consumer.buffered(buffer.len(), chunk.len());
-                    num_records += buffer.flush_all();
+                    num_records += buffer.len();
+                    buffer.flush();
                 }
             }
             consumer.replayed(num_records);
@@ -311,7 +312,7 @@ impl UrlInputReader {
                                     None => Some(offsets),
                                 };
                                 total += buffer.len();
-                                buffer.flush_all();
+                                buffer.flush();
                                 if total >= limit {
                                     break;
                                 }

--- a/crates/datagen/Cargo.toml
+++ b/crates/datagen/Cargo.toml
@@ -20,3 +20,4 @@ rmpv = { version = "1.3.0", features = ["with-serde"] }
 serde = { version = "1.0", features = ["derive"] }
 async-channel = "2.3.1"
 range-set = "0.0.11"
+xxhash-rust = { version = "0.8.6", features = ["xxh3"] }

--- a/crates/dbsp/src/dynamic/data.rs
+++ b/crates/dbsp/src/dynamic/data.rs
@@ -77,6 +77,19 @@ impl<T: DBData> Data for T {
     }
 }
 
+/// This test ensures that the underlying hash function stays the same from one
+/// build to the next. If the hash function changes, then restoring from a
+/// checkpoint will fail because data hashes will change.
+///
+/// We only test this on little-endian platforms. Big-endian platforms will
+/// compute a different hash value, which means that checkpoints won't be
+/// exchangeable between big- and little-endian platforms.
+#[cfg(all(test, target_endian = "little"))]
+#[test]
+fn test_default_hash() {
+    assert_eq!(1.default_hash(), 15781232456890734344);
+}
+
 /// Strongly typed data.
 ///
 /// A trait that includes the concrete type behind the given trait object in its type signature.

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -150,6 +150,7 @@ pub enum RuntimeConfigKey {
     Workers,
     Storage,
     FaultTolerance,
+    CheckpointInterval,
     CpuProfiler,
     Tracing,
     TracingEndpointJaeger,

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -510,9 +510,8 @@ async fn pipeline(action: PipelineAction, client: Client) {
         }
         PipelineAction::Checkpoint { name } => {
             let response = client
-                .post_pipeline_action()
+                .checkpoint_pipeline()
                 .pipeline_name(name.clone())
-                .action("checkpoint")
                 .send()
                 .await
                 .map_err(handle_errors_fatal(

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -6,7 +6,7 @@ use std::io::{ErrorKind, Read, Write};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use feldera_types::config::RuntimeConfig;
+use feldera_types::config::{FtConfig, RuntimeConfig};
 use feldera_types::error::ErrorResponse;
 use futures_util::StreamExt;
 use log::{debug, error, info, trace, warn};
@@ -236,10 +236,15 @@ fn patch_runtime_config(
             rc.storage = value.parse().map_err(|_| ())?;
         }
         RuntimeConfigKey::FaultTolerance => {
-            rc.fault_tolerance = match value {
-                "" => None,
-                _ => Some(value.parse().map_err(|_| ())?),
+            let enable: bool = value.parse().map_err(|_| ())?;
+            rc.fault_tolerance = match enable {
+                false => None,
+                true => Some(FtConfig::default()),
             }
+        }
+        RuntimeConfigKey::CheckpointInterval => {
+            let ft = rc.fault_tolerance.get_or_insert_with(FtConfig::default);
+            ft.checkpoint_interval_secs = value.parse().map_err(|_| ())?;
         }
         RuntimeConfigKey::CpuProfiler => {
             rc.cpu_profiler = value.parse().map_err(|_| ())?;

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -66,6 +66,7 @@ termbg = "0.5.1"
 
 [features]
 integration-test = []
+feldera-enterprise = []
 
 [build-dependencies]
 change-detection = "1.2"

--- a/crates/pipeline-manager/src/compiler.rs
+++ b/crates/pipeline-manager/src/compiler.rs
@@ -384,7 +384,13 @@ inherits = "release"
         project_toml_code = project_toml_code
             .replace(
                 "dbsp_adapters = { path = \"../../crates/adapters\", default-features = false }",
-                "dbsp_adapters = { path = \"../../crates/adapters\" }",
+                {
+                    #[cfg(not(feature = "feldera-enterprise"))]
+                    { r#"dbsp_adapters = { path = "../../crates/adapters" }"# }
+
+                    #[cfg(feature = "feldera-enterprise")]
+                    { r#"dbsp_adapters = { path = "../../crates/adapters", features = ["feldera-enterprise"] }"# }
+                },
             )
             .replace("../../crates", &format!("{p}/crates"))
             .replace("../lib", &format!("{}", config.sql_lib_path().display()));

--- a/crates/pipeline-manager/src/error.rs
+++ b/crates/pipeline-manager/src/error.rs
@@ -81,6 +81,7 @@ pub enum ManagerError {
     RustCompilerError {
         error: String,
     },
+    EnterpriseFeature(&'static str),
 }
 
 impl ManagerError {
@@ -185,6 +186,12 @@ impl Display for ManagerError {
             Self::RustCompilerError { error } => {
                 write!(f, "Error compiling generated Rust code: {error}")
             }
+            Self::EnterpriseFeature(feature) => {
+                write!(
+                    f,
+                    "Cannot use enterprise-only feature ({feature}) in Feldera community edition."
+                )
+            }
         }
     }
 }
@@ -205,6 +212,7 @@ impl ResponseError for ManagerError {
             Self::IoError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidProgramSchema { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::RustCompilerError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::EnterpriseFeature(_) => StatusCode::NOT_IMPLEMENTED,
         }
     }
 
@@ -229,6 +237,7 @@ impl DetailedError for ManagerError {
             Self::IoError { .. } => Cow::from("ManagerIoError"),
             Self::InvalidProgramSchema { .. } => Cow::from("InvalidProgramSchema"),
             Self::RustCompilerError { .. } => Cow::from("RustCompilerError"),
+            Self::EnterpriseFeature(_) => Cow::from("EnterpriseFeature"),
         }
     }
 }

--- a/docs/connectors/index.mdx
+++ b/docs/connectors/index.mdx
@@ -163,12 +163,13 @@ for an example of configuring the output buffer.
 
 ## Fault tolerance
 
-As a preview feature, Feldera supports fault tolerance, meaning that
-it can gracefully restart from the exact point of an abrupt shutdown
-or crash, picking up from where it left off without dropping or
-duplicating input or output.  To enable fault tolerance on a pipeline,
-set `"fault_tolerance": "latest_checkpoint"` in the pipeline
-configuration.
+As a preview feature in the enterprise edition only, Feldera supports
+fault tolerance, meaning that it can gracefully restart from the exact
+point of an abrupt shutdown or crash, picking up from where it left
+off without dropping or duplicating input or output.  To enable fault
+tolerance on a pipeline, set `"fault_tolerance": {}` in the pipeline
+configuration (optional configuration for fault tolerance may be
+specified inside `{}`).
 
 When a fault-tolerant pipeline restarts, it loads its state from the
 most recent checkpoint, then it replays any data from input connectors

--- a/openapi.json
+++ b/openapi.json
@@ -2780,12 +2780,17 @@
         }
       },
       "FtConfig": {
-        "type": "string",
+        "type": "object",
         "description": "Fault-tolerance configuration for runtime startup.",
-        "enum": [
-          "initial_state",
-          "latest_checkpoint"
-        ]
+        "properties": {
+          "checkpoint_interval_secs": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Interval between automatic checkpoints, in seconds.\n\nThe default is 60 seconds.  A value of 0 disables automatic\ncheckpointing.",
+            "default": 60,
+            "minimum": 0
+          }
+        }
       },
       "GenerationPlan": {
         "type": "object",

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -488,7 +488,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                     persons_stream
                         .insert(b"Tom,20,false")
                         .expect("Failed to insert data");  // Insert twice
-                    persons_stream.flush_all();
+                    persons_stream.flush();
                     // Execute the circuit on these inputs
                     circuit
                         .step()

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -940,9 +940,20 @@ endpoint or to encode data sent to the endpoint.`,
 } as const
 
 export const $FtConfig = {
-  type: 'string',
+  type: 'object',
   description: 'Fault-tolerance configuration for runtime startup.',
-  enum: ['initial_state', 'latest_checkpoint']
+  properties: {
+    checkpoint_interval_secs: {
+      type: 'integer',
+      format: 'int64',
+      description: `Interval between automatic checkpoints, in seconds.
+
+The default is 60 seconds.  A value of 0 disables automatic
+checkpointing.`,
+      default: 60,
+      minimum: 0
+    }
+  }
 } as const
 
 export const $GenerationPlan = {

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -634,7 +634,15 @@ export type FormatConfig = {
 /**
  * Fault-tolerance configuration for runtime startup.
  */
-export type FtConfig = 'initial_state' | 'latest_checkpoint'
+export type FtConfig = {
+  /**
+   * Interval between automatic checkpoints, in seconds.
+   *
+   * The default is 60 seconds.  A value of 0 disables automatic
+   * checkpointing.
+   */
+  checkpoint_interval_secs?: number
+}
 
 /**
  * A random generation plan for a table that generates either a limited amount of rows or runs continuously.


### PR DESCRIPTION
These commits:
* Checkpoint automatically every so often (by default, every minute).
* Speed up checkpointing.
* Prevent operations with side effects while replaying from a checkpoint.
* Verify that replaying inputs the same records that were originally input, using a count and a hash.
* Restore the number of processed records from a checkpoint, instead of starting again from 0.
* Fix a few other bugs.