### PR TITLE
dbsp: Use xxh3 default hasher instead of custom.

### DIFF
--- a/crates/dbsp/src/hash.rs
+++ b/crates/dbsp/src/hash.rs
@@ -1,13 +1,11 @@
 //! Hashing utilities.
 
 use std::hash::{Hash, Hasher};
-use xxhash_rust::xxh3::Xxh3;
-
-const SEED: u64 = 0x7f95_ef85_be33_c337u64;
+use xxhash_rust::xxh3::Xxh3Default;
 
 /// Default hashing function used to shard records across workers.
 pub fn default_hash<T: Hash>(x: &T) -> u64 {
-    let mut hasher = Xxh3::with_seed(SEED);
+    let mut hasher = Xxh3Default::new();
     x.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION
`Xxh3::with_seed()` computes 192 bytes of a custom "secret" on every invocation, and stores that secret in the `Xxh3`, which makes the hasher bigger and slower.  We don't really need a custom secret, so switch to `Xxh3Default`, which is over 192 bytes smaller and does not compute a secret at initialization time, making it faster.

I did not measure performance.

Fixes https://github.com/feldera/feldera/issues/2975.