### PR TITLE
[manager] Quote case-sensitive table names.

### DIFF
--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -500,7 +500,7 @@ pub fn generate_program_info(
                 }
             }
             input_connectors.push((
-                input_relation.name.name(),
+                input_relation.name.sql_name(),
                 connector.name,
                 connector.config,
                 origin_value,
@@ -545,7 +545,7 @@ pub fn generate_program_info(
                 }
             }
             output_connectors.push((
-                output_relation.name.name(),
+                output_relation.name.sql_name(),
                 connector.name,
                 connector.config,
                 origin_value,


### PR DESCRIPTION
Resolves https://github.com/feldera/feldera/issues/2972

When encoding table name in connector configuration, pipeline manager did not quote case-sensitive names.  On the pipeline side, the config decodes the name as SqlIdentifier, treating it as case-insensitive, so it no longer matches table name.