### PR TITLE
[dbsp] Strongly typed controlled filters.

### DIFF
--- a/crates/dbsp/src/operator/controlled_filter.rs
+++ b/crates/dbsp/src/operator/controlled_filter.rs
@@ -9,6 +9,21 @@ where
     C: Circuit,
     Z: IndexedZSet,
 {
+    /// A controlled filter operator that discards input keys by comparing them to a scalar
+    /// value in the `threshold` stream.
+    ///
+    /// This operator compares each key in the input indexed Z-set against the current value in
+    /// the `threshold` stream using `filter_func` and discards keys that don't pass the filter.
+    ///
+    /// Returns a pair of output streams.
+    ///
+    /// **Filtered output stream**: (key, value, weight) tuples whose key passes the filter
+    /// are sent to the first output stream unmodified.
+    ///
+    /// **Error stream**: Keys that don't pass the check are transformed by `report_func` and sent
+    /// to the second output stream. More precisely `report_func` is invoked for each (key, value, weight)
+    /// tuple whose key does not pass the filter and returns a value of type `E`, which is sent
+    /// with weight 1 to the error stream.
     pub fn controlled_key_filter<T, E, F, RF>(
         &self,
         threshold: &Stream<C, TypedBox<T, DynData>>,
@@ -38,6 +53,38 @@ where
         (output.typed(), error_stream.typed())
     }
 
+    /// Like [`Self::controlled_key_filter`], but values in the `threshold` stream are strongly typed
+    /// instead of having type `TypedBox`.
+    pub fn controlled_key_filter_typed<T, E, F, RF>(
+        &self,
+        threshold: &Stream<C, T>,
+        filter_func: F,
+        report_func: RF,
+    ) -> (Stream<C, Z>, Stream<C, OrdZSet<E>>)
+    where
+        E: DBData,
+        T: DBData,
+        F: Fn(&T, &Z::Key) -> bool + 'static,
+        RF: Fn(&T, &Z::Key, &Z::Val, ZWeight) -> E + 'static,
+    {
+        self.controlled_key_filter(&threshold.typed_box::<DynData>(), filter_func, report_func)
+    }
+
+    /// A controlled filter operator that discards input key/values pairs by comparing them to a scalar
+    /// value in the `threshold` stream.
+    ///
+    /// This operator compares each key/value pair in the input indexed Z-set against the current value in
+    /// the `threshold` stream using `filter_func` and discards tuples that don't pass the filter.
+    ///
+    /// Returns a pair of output streams.
+    ///
+    /// **Filtered putput stream**: (key, value, weight) tuples that pass the check are sent to the
+    /// first output stream unmodified.
+    ///
+    /// **Error stream**: Tuples that don't pass the check are transformed by `report_func` and sent
+    /// to the second output stream. More precisely `report_func` is invoked for each (key, value, weight)
+    /// tuple whose key and value do not pass the filter and returns a value of type `E`, which is sent
+    /// with weight 1 to the error stream.
     pub fn controlled_value_filter<T, E, F, RF>(
         &self,
         threshold: &Stream<C, TypedBox<T, DynData>>,
@@ -65,5 +112,22 @@ where
         );
 
         (output.typed(), error_stream.typed())
+    }
+
+    /// Like [`Self::controlled_value_filter`], but values in the `threshold` stream are strongly typed
+    /// instead of having type `TypedBox`.
+    pub fn controlled_value_filter_typed<T, E, F, RF>(
+        &self,
+        threshold: &Stream<C, T>,
+        filter_func: F,
+        report_func: RF,
+    ) -> (Stream<C, Z>, Stream<C, OrdZSet<E>>)
+    where
+        E: DBData,
+        T: DBData,
+        F: Fn(&T, &Z::Key, &Z::Val) -> bool + 'static,
+        RF: Fn(&T, &Z::Key, &Z::Val, ZWeight) -> E + 'static,
+    {
+        self.controlled_value_filter(&threshold.typed_box::<DynData>(), filter_func, report_func)
     }
 }

--- a/crates/dbsp/src/typed_batch.rs
+++ b/crates/dbsp/src/typed_batch.rs
@@ -642,3 +642,13 @@ impl<C: Circuit, T: DBData, D: DataTrait + ?Sized> Stream<C, TypedBox<T, D>> {
         self.apply(|typed_box| unsafe { typed_box.inner().downcast::<T>().clone() })
     }
 }
+
+impl<C: Circuit, T: DBData> Stream<C, T> {
+    pub fn typed_box<D>(&self) -> Stream<C, TypedBox<T, D>>
+    where
+        D: DataTrait + ?Sized,
+        T: Erase<D>,
+    {
+        self.apply(|x| TypedBox::new(x.clone()))
+    }
+}


### PR DESCRIPTION
Added versions of controlled filters that take strongly typed `threshold` stream instead of one that contains `TypedBox`.  This should make them easier to use in the SQL compiler.

Also added doc comments to these methods, which I somehow forgot in the original PR.