### PR TITLE
[SQL] Support for the regexp_replace function

### DIFF
--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -9,6 +9,7 @@ use crate::{
 use like::{Escape, Like};
 use regex::Regex;
 
+#[doc(hidden)]
 pub fn concat_s_s(mut left: String, right: String) -> String {
     left.reserve(right.len());
     left.push_str(&right);
@@ -17,6 +18,7 @@ pub fn concat_s_s(mut left: String, right: String) -> String {
 
 some_polymorphic_function2!(concat, s, String, s, String, String);
 
+#[doc(hidden)]
 pub fn substring3___(value: String, left: i32, count: i32) -> String {
     if count < 0 {
         String::new()
@@ -33,6 +35,7 @@ pub fn substring3___(value: String, left: i32, count: i32) -> String {
 
 some_function3!(substring3, String, i32, i32, String);
 
+#[doc(hidden)]
 pub fn substring2__(value: String, left: i32) -> String {
     // character indexes in SQL start at 1
     let start = if left < 1 { 0 } else { left - 1 };
@@ -41,6 +44,7 @@ pub fn substring2__(value: String, left: i32) -> String {
 
 some_function2!(substring2, String, i32, String);
 
+#[doc(hidden)]
 pub fn trim_both_s_s(remove: String, value: String) -> String {
     // 'remove' always has exactly 1 character
     let chr = remove.chars().next().unwrap();
@@ -49,6 +53,7 @@ pub fn trim_both_s_s(remove: String, value: String) -> String {
 
 some_polymorphic_function2!(trim_both, s, String, s, String, String);
 
+#[doc(hidden)]
 pub fn trim_leading_s_s(remove: String, value: String) -> String {
     // 'remove' always has exactly 1 character
     let chr = remove.chars().next().unwrap();
@@ -57,6 +62,7 @@ pub fn trim_leading_s_s(remove: String, value: String) -> String {
 
 some_polymorphic_function2!(trim_leading, s, String, s, String, String);
 
+#[doc(hidden)]
 pub fn trim_trailing_s_s(remove: String, value: String) -> String {
     // 'remove' always has exactly 1 character
     let chr = remove.chars().next().unwrap();
@@ -65,12 +71,14 @@ pub fn trim_trailing_s_s(remove: String, value: String) -> String {
 
 some_polymorphic_function2!(trim_trailing, s, String, s, String, String);
 
+#[doc(hidden)]
 pub fn like2__(value: String, pattern: String) -> bool {
     Like::<false>::like(value.as_str(), pattern.as_str()).unwrap()
 }
 
 some_function2!(like2, String, String, bool);
 
+#[doc(hidden)]
 pub fn rlike__(value: String, pattern: String) -> bool {
     let re = Regex::new(&pattern).ok();
     rlikeC__(value, &re)
@@ -80,6 +88,7 @@ pub fn rlike__(value: String, pattern: String) -> bool {
 // re is None when the regular expression expression is malformed,
 // In this case the result is false and not None.
 // The regular expression cannot be null - the compiler would detect that.
+#[doc(hidden)]
 pub fn rlikeC__(value: String, re: &Option<Regex>) -> bool {
     match re {
         None => false,
@@ -87,6 +96,7 @@ pub fn rlikeC__(value: String, re: &Option<Regex>) -> bool {
     }
 }
 
+#[doc(hidden)]
 pub fn rlikeCN_(value: Option<String>, re: &Option<Regex>) -> Option<bool> {
     let value = value?;
     Some(rlikeC__(value, re))
@@ -94,6 +104,7 @@ pub fn rlikeCN_(value: Option<String>, re: &Option<Regex>) -> Option<bool> {
 
 some_function2!(rlike, String, String, bool);
 
+#[doc(hidden)]
 pub fn like3___(value: String, pattern: String, escape: String) -> bool {
     let escaped = pattern.as_str().escape(escape.as_str()).unwrap();
     Like::<true>::like(value.as_str(), escaped.as_str()).unwrap()
@@ -101,6 +112,7 @@ pub fn like3___(value: String, pattern: String, escape: String) -> bool {
 
 some_function3!(like3, String, String, String, bool);
 
+#[doc(hidden)]
 pub fn ilike2__(value: String, pattern: String) -> bool {
     // Convert both the value and the pattern to lowercase for case-insensitive comparison
     Like::<false>::like(
@@ -112,6 +124,7 @@ pub fn ilike2__(value: String, pattern: String) -> bool {
 
 some_function2!(ilike2, String, String, bool);
 
+#[doc(hidden)]
 pub fn position__(needle: String, haystack: String) -> i32 {
     let pos = haystack.find(needle.as_str());
     match pos {
@@ -122,16 +135,19 @@ pub fn position__(needle: String, haystack: String) -> i32 {
 
 some_function2!(position, String, String, i32);
 
+#[doc(hidden)]
 pub fn char_length_(value: String) -> i32 {
     value.chars().count() as i32
 }
 
 some_function1!(char_length, String, i32);
 
+#[doc(hidden)]
 pub fn char_length_ref(value: &str) -> i32 {
     value.chars().count() as i32
 }
 
+#[doc(hidden)]
 pub fn ascii_(value: String) -> i32 {
     if value.is_empty() {
         0
@@ -142,6 +158,7 @@ pub fn ascii_(value: String) -> i32 {
 
 some_function1!(ascii, String, i32);
 
+#[doc(hidden)]
 pub fn chr_(code: i32) -> String {
     if code < 0 {
         String::default()
@@ -156,6 +173,7 @@ pub fn chr_(code: i32) -> String {
 
 some_function1!(chr, i32, String);
 
+#[doc(hidden)]
 pub fn repeat__(value: String, count: i32) -> String {
     if count <= 0 {
         String::default()
@@ -166,6 +184,7 @@ pub fn repeat__(value: String, count: i32) -> String {
 
 some_function2!(repeat, String, i32, String);
 
+#[doc(hidden)]
 pub fn overlay3___(source: String, replacement: String, position: i32) -> String {
     let len = char_length_ref(&replacement);
     overlay4____(source, replacement, position, len)
@@ -173,6 +192,7 @@ pub fn overlay3___(source: String, replacement: String, position: i32) -> String
 
 some_function3!(overlay3, String, String, i32, String);
 
+#[doc(hidden)]
 pub fn overlay4____(source: String, replacement: String, position: i32, remove: i32) -> String {
     let mut remove = remove;
     if remove < 0 {
@@ -192,18 +212,21 @@ pub fn overlay4____(source: String, replacement: String, position: i32, remove: 
 
 some_function4!(overlay4, String, String, i32, i32, String);
 
+#[doc(hidden)]
 pub fn lower_(source: String) -> String {
     source.to_lowercase()
 }
 
 some_function1!(lower, String, String);
 
+#[doc(hidden)]
 pub fn upper_(source: String) -> String {
     source.to_uppercase()
 }
 
 some_function1!(upper, String, String);
 
+#[doc(hidden)]
 pub fn initcap_(source: String) -> String {
     let mut result = String::with_capacity(source.len());
     let mut capitalize_next = true;
@@ -230,18 +253,21 @@ pub fn initcap_(source: String) -> String {
 
 some_function1!(initcap, String, String);
 
+#[doc(hidden)]
 pub fn replace___(haystack: String, needle: String, replacement: String) -> String {
     haystack.replace(&needle, &replacement)
 }
 
 some_function3!(replace, String, String, String, String);
 
+#[doc(hidden)]
 pub fn left__(source: String, size: i32) -> String {
     substring3___(source, 1, size)
 }
 
 some_function2!(left, String, i32, String);
 
+#[doc(hidden)]
 pub fn split2__(source: String, separators: String) -> Vec<String> {
     if separators.is_empty() {
         return vec![source];
@@ -254,12 +280,14 @@ pub fn split2__(source: String, separators: String) -> Vec<String> {
 
 some_function2!(split2, String, String, Vec<String>);
 
+#[doc(hidden)]
 pub fn split1_(source: String) -> Vec<String> {
     split2__(source, ",".to_string())
 }
 
 some_function1!(split1, String, Vec<String>);
 
+#[doc(hidden)]
 pub fn split_part___(s: String, delimiter: String, n: i32) -> String {
     let parts: Vec<String> = split2__(s, delimiter);
     let part_count = parts.len() as i32;
@@ -276,12 +304,14 @@ pub fn split_part___(s: String, delimiter: String, n: i32) -> String {
 
 some_function3!(split_part, String, String, i32, String);
 
+#[doc(hidden)]
 pub fn array_to_string2_vec__(value: Vec<String>, separator: String) -> String {
     value.join(&separator)
 }
 
 some_function2!(array_to_string2_vec, Vec<String>, String, String);
 
+#[doc(hidden)]
 pub fn array_to_string2Nvec__(value: Vec<Option<String>>, separator: String) -> String {
     let capacity = value
         .iter()
@@ -307,6 +337,7 @@ pub fn array_to_string2Nvec__(value: Vec<Option<String>>, separator: String) -> 
 
 some_function2!(array_to_string2Nvec, Vec<Option<String>>, String, String);
 
+#[doc(hidden)]
 pub fn array_to_string3_vec___(
     value: Vec<String>,
     separator: String,
@@ -317,6 +348,7 @@ pub fn array_to_string3_vec___(
 
 some_function3!(array_to_string3_vec, Vec<String>, String, String, String);
 
+#[doc(hidden)]
 pub fn array_to_string3Nvec___(
     value: Vec<Option<String>>,
     separator: String,
@@ -351,6 +383,7 @@ some_function3!(
     String
 );
 
+#[doc(hidden)]
 pub fn writelog<T: std::fmt::Display>(format: String, argument: T) -> T {
     let format_arg = format!("{}", argument);
     let formatted = format.replace("%%", &format_arg);
@@ -358,6 +391,7 @@ pub fn writelog<T: std::fmt::Display>(format: String, argument: T) -> T {
     argument
 }
 
+#[doc(hidden)]
 pub fn parse_json_s(value: String) -> Variant {
     match serde_json::from_str::<Variant>(&value) {
         Ok(v) => v,
@@ -365,12 +399,14 @@ pub fn parse_json_s(value: String) -> Variant {
     }
 }
 
+#[doc(hidden)]
 pub fn parse_json_nullN(_value: Option<()>) -> Option<Variant> {
     None
 }
 
 some_polymorphic_function1!(parse_json, s, String, Variant);
 
+#[doc(hidden)]
 pub fn to_json_V(value: Variant) -> Option<String> {
     match value.to_json_string() {
         Ok(s) => Some(s),
@@ -378,11 +414,78 @@ pub fn to_json_V(value: Variant) -> Option<String> {
     }
 }
 
+#[doc(hidden)]
 pub fn to_json_VN(value: Option<Variant>) -> Option<String> {
     let value = value?;
     to_json_V(value)
 }
 
+#[doc(hidden)]
 pub fn to_json_nullN(_value: Option<()>) -> Option<String> {
     None
+}
+
+#[doc(hidden)]
+pub fn regexp_replace3___(str: String, re: String, repl: String) -> String {
+    let re = Regex::new(&re).ok();
+    regexp_replaceC3___(str, &re, repl)
+}
+
+some_function3!(regexp_replace3, String, String, String, String);
+
+#[doc(hidden)]
+pub fn regexp_replace2__(str: String, re: String) -> String {
+    regexp_replace3___(str, re, "".to_string())
+}
+
+some_function2!(regexp_replace2, String, String, String);
+
+#[doc(hidden)]
+pub fn regexp_replaceC3___(str: String, re: &Option<Regex>, repl: String) -> String {
+    match re {
+        None => str,
+        Some(re) => re.replace_all(&str, repl).to_string(),
+    }
+}
+
+#[doc(hidden)]
+pub fn regexp_replaceC3N__(
+    str: Option<String>,
+    re: &Option<Regex>,
+    repl: String,
+) -> Option<String> {
+    let str = str?;
+    Some(regexp_replaceC3___(str, re, repl))
+}
+
+#[doc(hidden)]
+pub fn regexp_replaceC3__N(
+    str: String,
+    re: &Option<Regex>,
+    repl: Option<String>,
+) -> Option<String> {
+    let repl = repl?;
+    Some(regexp_replaceC3___(str, re, repl))
+}
+
+#[doc(hidden)]
+pub fn regexp_replaceC3N_N(
+    str: Option<String>,
+    re: &Option<Regex>,
+    repl: Option<String>,
+) -> Option<String> {
+    let str = str?;
+    let repl = repl?;
+    Some(regexp_replaceC3___(str, re, repl))
+}
+
+#[doc(hidden)]
+pub fn regexp_replaceC2__(str: String, re: &Option<Regex>) -> String {
+    regexp_replaceC3___(str, re, "".to_string())
+}
+
+#[doc(hidden)]
+pub fn regexp_replaceC2N_(str: Option<String>, re: &Option<Regex>) -> Option<String> {
+    let str = str?;
+    Some(regexp_replaceC3___(str, re, "".to_string()))
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ProgramMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ProgramMetadata.java
@@ -3,6 +3,8 @@ package org.dbsp.sqlCompiler.compiler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPViewDeclarationOperator;
+import org.dbsp.sqlCompiler.compiler.frontend.statements.DeclareViewStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.IHasSchema;
 import org.dbsp.util.Utilities;
 
@@ -22,8 +24,11 @@ public class ProgramMetadata {
     public ObjectNode asJson() {
         ObjectMapper mapper = Utilities.deterministicObjectMapper();
         ArrayNode inputs = mapper.createArrayNode();
-        for (IHasSchema input: this.inputTables.values())
+        for (IHasSchema input: this.inputTables.values()) {
+            if (input.is(DeclareViewStatement.class))
+                continue;
             inputs.add(input.asJson());
+        }
         ArrayNode outputs = mapper.createArrayNode();
         for (IHasSchema output: this.outputViews.values())
             outputs.add(output.asJson());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -140,7 +140,7 @@ public class TypeCompiler implements ICompilerComponent {
                     if (this.compiler().options.languageOptions.lenient)
                         // If we are not lenient and names are duplicated
                         // we will get an exception below where we create the struct.
-                        fieldName = fieldNameGen.freshName(fieldName);
+                        fieldName = fieldNameGen.freshName(fieldName, true);
                     fields.add(new DBSPTypeStruct.Field(
                             CalciteObject.create(dt), fieldName, index++, type, false));
                 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/IHasSchema.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/IHasSchema.java
@@ -17,13 +17,14 @@ import org.dbsp.sqlCompiler.compiler.frontend.parser.PropertyList;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.util.ICastable;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 /** An interface implemented by objects which have a name and a schema */
-public interface IHasSchema extends IHasCalciteObject {
+public interface IHasSchema extends IHasCalciteObject, ICastable {
     /** The name of this object */
     String getName();
     /** True if the name is quoted */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/FreshName.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/FreshName.java
@@ -25,35 +25,31 @@ package org.dbsp.util;
 
 import java.util.Set;
 
-/**
- * Generates a fresh name that does not appear in a set of used names.
+/** Generates a fresh name that does not appear in a set of used names.
  * The name is a legal identifier in many languages if the prefix supplied to
- * 'freshName' also is.  The names are composed only of the prefix, underscores, and digits.
- */
+ * 'freshName' also is.  The names are composed only of the prefix, underscores, and digits. */
 public class FreshName {
     final Set<String> used;
 
-    /**
-     * @param used Keep track of the used names in this set.
-     *             The used set is modified every time a new name is generated.
-     */
+    /** @param used Keep track of the used names in this set.  */
     public FreshName(Set<String> used) {
         this.used = used;
     }
 
     /**
      * Generate a fresh name starting with the specified prefix.
-     * Add the generated name to the set of used names.
+     *
      * @param prefix  Prefix for the new name.
-     */
-    public String freshName(String prefix) {
+     * @param remember If true, add the generated name to the set of used names. */
+    public String freshName(String prefix, boolean remember) {
         String name = prefix;
         long counter = 0;
         while (this.used.contains(name)) {
             name = prefix + "_" + counter;
             counter++;
         }
-        this.used.add(name);
+        if (remember)
+            this.used.add(name);
         return name;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NameGen.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NameGen.java
@@ -28,9 +28,7 @@ package org.dbsp.util;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Used to generate new names during a program execution.
- */
+/** Used to generate new names during a program execution. */
 public class NameGen {
     private final String prefix;
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -40,6 +40,15 @@ public class CatalogTests extends BaseSQLTests {
     }
 
     @Test
+    public void duplicateViewExplicitColumnName() {
+        String sql = """
+                CREATE TABLE T(id int);
+                CREATE VIEW V AS SELECT id as col0, cast(id AS BIGINT) as col0 FROM T;""";
+        var ccs = this.getCCS(sql);
+        assert ccs.compiler.messages.messages.isEmpty();
+    }
+
+    @Test
     public void issue2949() {
         String sql = """
                 CREATE TABLE t4(c0 BOOLEAN, c1 DOUBLE, c2 VARCHAR);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/BigQueryTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/BigQueryTests.java
@@ -1,0 +1,40 @@
+package org.dbsp.sqlCompiler.compiler.sql.quidem;
+
+import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
+import org.junit.Test;
+
+/** Tests from babel/src/test/resources/sql/big-query.iq */
+public class BigQueryTests extends SqlIoTest {
+    @Test
+    public void testRegexpReplace() {
+        this.qs("""
+                -- REGEXP_REPLACE(value, regexp, replacement)
+                --
+                -- Returns a STRING where all substrings of value that match regexp are replaced with replacement.
+                -- Supports backslashed-escaped digits in replacement argument for corresponding capturing groups
+                -- in regexp. Returns an exception if regex is invalid.
+                SELECT REGEXP_REPLACE('qw1e1rt1y', '1', 'X');
+                +----------+
+                | EXPR$0   |
+                +----------+
+                | qwXeXrtXy|
+                +----------+
+                (1 row)
+                
+                SELECT REGEXP_REPLACE('a0b1c2d3', 'a|d', 'X');
+                +---------+
+                | EXPR$0  |
+                +---------+
+                | X0b1c2X3|
+                +---------+
+                (1 row)
+                
+                SELECT REGEXP_REPLACE('1=00--20=0', '(-)', '#');
+                +-----------+
+                | EXPR$0    |
+                +-----------+
+                | 1=00##20=0|
+                +-----------+
+                (1 row)""");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/RedshiftTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/RedshiftTests.java
@@ -31,4 +31,26 @@ public class RedshiftTests extends ScottBaseTests {
                 (6 rows)
                 """, false);
     }
+
+    @Test
+    public void testRegexpReplace() {
+        this.qs("""
+                select regexp_replace('DonecFri@semperpretiumneque.com', '@.*\\.(org|gov|com)$');
+                 result
+                --------
+                 DonecFri
+                (1 row)
+                
+                SELECT regexp_replace('abcabc', 'b') AS x;
+                 X
+                ----
+                 acac
+                (1 row)
+                
+                SELECT regexp_replace('abc def GHI', '[a-z]+', 'X') AS x;
+                 X
+                --------
+                 X X GHI
+                (1 row)""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -11,6 +11,35 @@ import org.junit.Test;
 /** Tests with recursive queries */
 public class RecursiveTests extends BaseSQLTests {
     @Test
+    public void testFibonacci() {
+        String sql = """
+                create recursive view fibonacci(n INT, value INT);
+                create table input (x int);
+                
+                create view fibonacci AS
+                (
+                    -- Base case: first two Fibonacci numbers
+                    select 0 as n, 0 as value
+                    union all
+                    select 1 as n, 1 as value
+                )
+                union all
+                (
+                    -- Compute F(n)=F(n-1)+F(n-2)
+                    select
+                        prev.n + 1 as n,
+                        (prev.value + curr.value) as value
+                    from fibonacci as curr
+                    join fibonacci as prev
+                    on prev.n = curr.n - 1
+                    where curr.n < 10 and prev.n < 10
+                );
+                
+                create view fib_outputs as select * from fibonacci;""";
+        var ccs = this.getCCS(sql);
+    }
+
+    @Test
     public void issue2979() {
         String sql = """
                 -- Given a cell value as a formula (e.g., =A0+B0), and a context with cell values

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -11,35 +11,6 @@ import org.junit.Test;
 /** Tests with recursive queries */
 public class RecursiveTests extends BaseSQLTests {
     @Test
-    public void testFibonacci() {
-        String sql = """
-                create recursive view fibonacci(n INT, value INT);
-                create table input (x int);
-                
-                create view fibonacci AS
-                (
-                    -- Base case: first two Fibonacci numbers
-                    select 0 as n, 0 as value
-                    union all
-                    select 1 as n, 1 as value
-                )
-                union all
-                (
-                    -- Compute F(n)=F(n-1)+F(n-2)
-                    select
-                        prev.n + 1 as n,
-                        (prev.value + curr.value) as value
-                    from fibonacci as curr
-                    join fibonacci as prev
-                    on prev.n = curr.n - 1
-                    where curr.n < 10 and prev.n < 10
-                );
-                
-                create view fib_outputs as select * from fibonacci;""";
-        var ccs = this.getCCS(sql);
-    }
-
-    @Test
     public void issue2979() {
         String sql = """
                 -- Given a cell value as a formula (e.g., =A0+B0), and a context with cell values

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CalciteSqlOperatorTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CalciteSqlOperatorTest.java
@@ -1,0 +1,163 @@
+package org.dbsp.sqlCompiler.compiler.sql.simple;
+
+import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
+import org.junit.Test;
+
+/** Tests taken from Calcite SqlOperatorTest */
+public class CalciteSqlOperatorTest extends SqlIoTest {
+    @Test
+    public void testRegexReplace2Func() {
+        this.qs("""
+                select regexp_replace('a b c', 'b');
+                 r
+                ---
+                 a  c
+                (1 row)
+
+                select regexp_replace('abc1 def2 ghi3', '[a-z]+');
+                 r
+                ---
+                 1 2 3
+                (1 row)
+
+                select regexp_replace('100-200', '(\\d+)');
+                 r
+                ---
+                 -
+                (1 row)
+
+                select regexp_replace('100-200', '(-)');
+                 r
+                ---
+                 100200
+                (1 row)""");
+    }
+
+    @Test
+    public void testRegexReplace3Func() {
+        this.qs("""
+                select regexp_replace('a b c', 'b', 'X');
+                 r
+                ---
+                 a X c
+                (1 row)
+                
+                select regexp_replace('abc def ghi', '[a-z]+', 'X');
+                 r
+                ---
+                 X X X
+                (1 row)
+                
+                select regexp_replace('100-200', '(\\d+)', 'num');
+                 r
+                ---
+                 num-num
+                (1 row)
+                
+                select regexp_replace('100-200', '(-)', '###');
+                 r
+                ---
+                 100###200
+                (1 row)
+                
+                select regexp_replace(cast(null as varchar), '(-)', '###');
+                 r
+                ---
+                NULL
+                (1 row)
+                
+                select regexp_replace('100-200', cast(null as varchar), '###');
+                 r
+                ---
+                NULL
+                (1 row)
+                
+                select regexp_replace('100-200', '(-)', cast(null as varchar));
+                 r
+                ---
+                NULL
+                (1 row)
+                
+                select regexp_replace('abc\t
+                def\t
+                ghi', '\t', '+');
+                 r
+                ---
+                 abc+\\ndef+\\nghi
+                (1 row)
+                
+                select regexp_replace('abc\t\ndef\t\nghi', '\t\n', '+');
+                 r
+                ---
+                 abc+def+ghi
+                (1 row)
+                
+                select regexp_replace('abc\t\ndef\t\nghi', '\\w+', '+');
+                 r
+                ---
+                 +\t\\n+\t\\n+
+                (1 row)""");
+    }
+
+    @Test public void testRegexpReplaceCapture() {
+        // modified from BigQuery, which uses a different syntax for capture groups.
+        this.qs("""
+                select regexp_replace('abc16', 'b(.*)(\\d)', '$2${1}X');
+                 r
+                ---
+                 a6c1X
+                (1 row)
+                
+                select regexp_replace('a\\bc56a\\bc37', 'b(.)(\\d)', '$2${0}X');
+                 r
+                ----
+                 a\\5bc5X6a\\3bc3X7
+                (1 row)
+                
+                select regexp_replace('abcdefghijabc', 'abc(.)', '$$123xyz');
+                 r
+                ---
+                 $123xyzefghijabc
+                (1 row)
+                
+                select regexp_replace('abcdefghijabc', 'abc(.)', '\1xy');
+                 r
+                ---
+                 \1xyefghijabc
+                (1 row)
+                
+                select regexp_replace('abc123', 'b(.*)(\\d)', '\\$ $\\');
+                 r
+                ---
+                 a\\$ $\\
+                (1 row)""");
+    }
+
+    @Test
+    public void testDocs() {
+        this.qs("""
+                select regexp_replace('1078910', '[^01]');
+                 r
+                -----
+                 1010
+                (1 row)
+                
+                select regexp_replace('deep fried', '(?<first>\\w+)\\s+(?<second>\\w+)', '${first}_$second');
+                 r
+                ---
+                 deep_fried
+                (1 row)
+                
+                select regexp_replace('Springsteen, Bruce', '([^,\\s]+),\\s+(\\S+)', '$2 $1');
+                 r
+                ----
+                 Bruce Springsteen
+                (1 row)
+                
+                select regexp_replace('Springsteen, Bruce', '(?<last>[^,\\s]+),\\s+(?<first>\\S+)', '$first $last');
+                 r
+                ---
+                 Bruce Springsteen
+                (1 row)""");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -162,10 +162,21 @@ public abstract class SqlIoTest extends BaseSQLTests {
         int index = 0;
         for (String line: lines) {
             line = line.trim();
-            int comment = line.indexOf("--");
-            if (comment >= 0) {
-                line = line.substring(0, comment);
-                lines[index] = line;
+            boolean inString = false;
+            for (int i = 0; i < line.length(); i++) {
+                String c = line.substring(i, i + 1);
+                if (c.equals("'")) {
+                    inString = !inString;
+                }
+                if (inString)
+                    continue;
+                if (i < line.length() - 2) {
+                    String two = line.substring(i, i + 2);
+                    if (two.equals("--")) {
+                        line = line.substring(0, i);
+                        lines[index] = line;
+                    }
+                }
             }
             index++;
             if (line.contains(";"))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -280,7 +280,9 @@ public class TableParser {
                     throw new RuntimeException("Expected NULL or a space: " +
                             Utilities.singleQuote(data));
             } else {
+                // replace \\n with \n, otherwise we can't represent it
                 data = data.substring(1);
+                data = data.replace("\\n", "\n");
                 result = new DBSPStringLiteral(CalciteObject.EMPTY, fieldType, data, StandardCharsets.UTF_8);
             }
         } else if (fieldType.is(DBSPTypeBool.class)) {


### PR DESCRIPTION
This implementation uses the Rust function replace_all.
Thus the syntax for regular expressions matches Rust, including capture groups, which are denoted with `$0`, `$1`, etc.
This differs from other SQL dialects.

The PR also fixes a bug which prevented SLT tests from running when a view has two columns with the same name.
