### PR TITLE
[SQL/SLT] SLT tests were broken when the error view was introduced

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -211,9 +211,7 @@ public class BaseSQLTests {
 
     public static int testsExecuted = 0;
 
-    /**
-     * Collect here all the tests to run and execute them using a single Rust compilation.
-     */
+    /** Collect here all the tests to run and execute them using a single Rust compilation. */
     static final List<TestCase> testsToRun = new ArrayList<>();
 
     @BeforeClass

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
@@ -3,7 +3,6 @@ package org.dbsp.sqlCompiler.compiler.sql.tools;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
-import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.DBSPFunction;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;


### PR DESCRIPTION
The code was assuming that the generated circuit always has a single output.
This fix should restore the nightly CI tests.