### PR TITLE
[docs] Fix typo in Kafka input connector docs

### DIFF
--- a/docs/connectors/sources/kafka.md
+++ b/docs/connectors/sources/kafka.md
@@ -34,7 +34,7 @@ Message 2:
 CREATE TABLE INPUT (
    ... -- columns omitted
 ) WITH (
-  'connectors = '[
+  'connectors' = '[
     {
       "transport": {
           "name": "kafka_input",


### PR DESCRIPTION
Fix small WITH syntax error.
<img width="402" alt="image" src="https://github.com/user-attachments/assets/1fd6c0be-fdb7-45df-b186-fe9e27131695">
