### PR TITLE
[SQL] implement blackbox function

### DIFF
--- a/crates/sqllib/src/operators.rs
+++ b/crates/sqllib/src/operators.rs
@@ -349,3 +349,7 @@ where
 }
 
 for_all_compare!(min, T, T where Ord);
+
+pub fn blackbox<T>(value: T) -> T {
+    value
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -1219,6 +1219,9 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         for (int i = 0; i < ops.size(); i++)
                             this.ensureInteger(ops, i, 32);
                         return compileFunction(call, node, type, ops, 2);
+                    case "blackbox":
+                        assert ops.size() == 1: "expected one argument for blackbox function";
+                        return new DBSPApplyExpression(node, "blackbox", ops.get(0).type, ops.toArray(new DBSPExpression[0]));
                     case "regexp_replace": {
                         validateArgCount(node, operationName, ops.size(), 2, 3);
                         for (int i = 0; i < ops.size(); i++)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
@@ -41,6 +41,7 @@ public class CustomFunctions {
         this.initial.add(NowFunction.INSTANCE);
         this.initial.add(ParseJsonFunction.INSTANCE);
         this.initial.add(ToJsonFunction.INSTANCE);
+        this.initial.add(BlackboxFunction.INSTANCE);
         this.udf = new HashMap<>();
     }
 
@@ -178,6 +179,17 @@ public class CustomFunctions {
         }
 
         public static final ToIntFunction INSTANCE = new ToIntFunction();
+    }
+
+    public static class BlackboxFunction extends NonOptimizedFunction {
+        private BlackboxFunction() {
+            super("BLACKBOX",
+                    ReturnTypes.ARG0,
+                    OperandTypes.ANY,
+                    SqlFunctionCategory.USER_DEFINED_FUNCTION);
+        }
+
+        public static final BlackboxFunction INSTANCE = new BlackboxFunction();
     }
 
     /**

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/PredefinedFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/PredefinedFunctions.java
@@ -37,7 +37,8 @@ public class PredefinedFunctions implements FunctionDocumentation.FunctionRegist
                 new PredefinedFunction(CustomFunctions.ToIntFunction.INSTANCE, "binary"),
                 new PredefinedFunction(CustomFunctions.NowFunction.INSTANCE, "datetime"),
                 new PredefinedFunction(CustomFunctions.ParseJsonFunction.INSTANCE, "json"),
-                new PredefinedFunction(CustomFunctions.ToJsonFunction.INSTANCE, "json")
+                new PredefinedFunction(CustomFunctions.ToJsonFunction.INSTANCE, "json"),
+                new PredefinedFunction(CustomFunctions.BlackboxFunction.INSTANCE, "blackbox")
         );
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -1992,4 +1992,53 @@ public class FunctionsTest extends SqlIoTest {
                 """
         );
     }
+
+    @Test
+    public void testBlackboxFunction() {
+        this.qs("""
+                SELECT blackbox(1);
+                 blackbox
+                ----------
+                 1
+                (1 row)
+                
+                SELECT blackbox('blah');
+                 blackbox
+                ----------
+                 blah
+                (1 row)
+                
+                SELECT blackbox(true);
+                 blackbox
+                ----------
+                 true
+                (1 row)
+                
+                SELECT blackbox(1e0);
+                 blackbox
+                ----------
+                 1e0
+                (1 row)
+                
+                SELECT blackbox(1.0);
+                 blackbox
+                ----------
+                 1.0
+                (1 row)
+                
+                SELECT blackbox(vals) from arr_table;
+                 blackbox
+                ----------
+                 {1,2,3}
+                 {1,2,3}
+                (2 rows)
+                
+                SELECT blackbox(1.0) as c0, blackbox(true) as c1;
+                  c0 | c1
+                -----+-----
+                 1.0 | true
+                (1 row)
+                """
+        );
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
@@ -70,6 +70,20 @@ public class MapTests extends BaseSQLTests {
     }
 
     @Test
+    public void mapBlackboxTest() {
+        String query = "SELECT blackbox(MAP['hi',2])";
+        DBSPType str = DBSPTypeString.varchar(false);
+        this.testQuery(query, new DBSPZSetLiteral(
+                new DBSPTupleExpression(new DBSPMapLiteral(
+                        new DBSPTypeMap(
+                                str,
+                                new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false),
+                                false),
+                        Linq.list(new DBSPStringLiteral(CalciteObject.EMPTY, str, "hi", Charset.defaultCharset()),
+                                new DBSPI32Literal(2))))));
+    }
+
+    @Test
     public void mapCardinalityTest() {
         String query = "SELECT CARDINALITY(MAP['hi',2])";
         this.testQuery(query, new DBSPZSetLiteral(


### PR DESCRIPTION
Adds the function `blackbox(T) -> T`, so that we can force Calcite to skip making optimizations.