### PR TITLE
dbsp: Improved trace compaction

### DIFF
--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -16,6 +16,7 @@ use binrw::{
     io::{Cursor, NoSeek},
     BinWrite,
 };
+#[cfg(debug_assertions)]
 use dyn_clone::clone_box;
 
 use crate::storage::{

--- a/crates/dbsp/src/time/mod.rs
+++ b/crates/dbsp/src/time/mod.rs
@@ -42,7 +42,6 @@
 //! sorting.
 
 mod antichain;
-//mod nested_ts32;
 mod product;
 
 use crate::{

--- a/crates/dbsp/src/trace/layers/mod.rs
+++ b/crates/dbsp/src/trace/layers/mod.rs
@@ -185,7 +185,7 @@ pub trait MergeBuilder: Builder {
     ///
     /// Optionally applies `map_func` to each key in the leaf of the trie.
     /// This is used to implement timestamp compaction where multiple timestamps
-    /// are merged into one during merging.  This function does not
+    /// are merged into one during merging.  `map_func` does not
     /// have to be monotonic and therefore requires sorting and consolidating
     /// items in the leaf.
     fn push_merge<'a>(

--- a/crates/dbsp/src/trace/layers/mod.rs
+++ b/crates/dbsp/src/trace/layers/mod.rs
@@ -161,9 +161,13 @@ pub trait MergeBuilder: Builder {
     fn keys(&self) -> usize;
 
     /// Copy a range of `other` into this collection.
-    fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
-        self.copy_range_retain_keys(other, lower, upper, &|_| true)
-    }
+    fn copy_range(
+        &mut self,
+        other: &Self::Trie,
+        lower: usize,
+        upper: usize,
+        map_func: Option<&dyn Fn(&mut <<Self as Builder>::Trie as Trie>::LeafKey)>,
+    );
 
     /// Copy a range of `other` into this collection, only retaining
     /// entries whose keys satisfy the `filter` condition.
@@ -173,6 +177,7 @@ pub trait MergeBuilder: Builder {
         lower: usize,
         upper: usize,
         filter: &F,
+        map_func: Option<&dyn Fn(&mut <<Self as Builder>::Trie as Trie>::LeafKey)>,
     ) where
         F: Fn(&<<Self::Trie as Trie>::Cursor<'a> as Cursor<'a>>::Key) -> bool;
 
@@ -328,7 +333,14 @@ impl MergeBuilder for () {
         0
     }
 
-    fn copy_range(&mut self, _other: &Self::Trie, _lower: usize, _upper: usize) {}
+    fn copy_range(
+        &mut self,
+        _other: &Self::Trie,
+        _lower: usize,
+        _upper: usize,
+        _map_func: Option<&dyn Fn(&mut <<Self as Builder>::Trie as Trie>::LeafKey)>,
+    ) {
+    }
 
     fn copy_range_retain_keys<'a, F>(
         &mut self,
@@ -336,6 +348,7 @@ impl MergeBuilder for () {
         _lower: usize,
         _upper: usize,
         _filter: &F,
+        _map_func: Option<&dyn Fn(&mut <<Self as Builder>::Trie as Trie>::LeafKey)>,
     ) where
         F: Fn(&<<Self::Trie as Trie>::Cursor<'a> as Cursor<'a>>::Key) -> bool,
     {

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -52,7 +52,6 @@ pub mod ord;
 pub mod spine_async;
 pub use spine_async::{Spine, SpineSnapshot};
 
-// mod spine_fueled;
 #[cfg(test)]
 pub mod test;
 

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -466,7 +466,7 @@ where
 
     // Like `merge_times`, but additionally applied `map_func` to each timestamp.
     // Sorts and consolidates the resulting array of time/diff pairs.
-    fn merge_map_times<'a>(
+    fn map_and_merge_times<'a>(
         &mut self,
         cursor1: &mut FileKeyCursor<'a, K, T, R>,
         cursor2: &mut FileKeyCursor<'a, K, T, R>,
@@ -582,7 +582,12 @@ where
                 Ordering::Equal => {
                     if filter(key_filter, cursor1.key.as_ref()) {
                         let non_zero = if let Some(time_map_func) = &time_map_func {
-                            self.merge_map_times(&mut cursor1, &mut cursor2, time_map_func, fuel)
+                            self.map_and_merge_times(
+                                &mut cursor1,
+                                &mut cursor2,
+                                time_map_func,
+                                fuel,
+                            )
                         } else {
                             self.merge_times(&mut cursor1, &mut cursor2, &mut sum, fuel)
                         };


### PR DESCRIPTION
A recent commit introduced lazy compaction of traces by bumping
timestamps up to the frontier. In that commit compaction was only
applied when merging identical values from the two input batches, but
not when simply copying values from one of the inputs to the output
batch. The thinking was that individual batches are always compacted,
so there is nothing else to compact. However, this is not true, since
individual batches are only compacted when the are first generated, but
as the frontier moves forward over time, compacted batches can become no
longer compacted. This may not sound too bad, but can lead to unbounded
inflation of memory/storage in some scenarios.  In particular, this
happens when the batch contains a value that was inserted and deleted and
that never occurs again in any future updates (and hence never gets
compacted).  Such values can accumulate over time.

This commit addresses this issue by performing compaction while copying
values. We do it in memory-based and file-based batch builders, as well as
in the generic builder.