### PR TITLE
[SQL] Use UnimplementedException instead of NotImplementedException

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeFunction.java
@@ -23,7 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type.derived;
 
-import org.apache.commons.lang3.NotImplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -52,7 +52,7 @@ public class DBSPTypeFunction extends DBSPType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new NotImplementedException();
+        throw new UnimplementedException();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
@@ -23,7 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type.derived;
 
-import org.apache.commons.lang3.NotImplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
@@ -239,7 +239,7 @@ public class DBSPTypeStruct extends DBSPType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new NotImplementedException();
+        throw new UnimplementedException();
     }
 
     /** Generate a tuple type by ignoring the struct and field names, recursively. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeAny.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeAny.java
@@ -23,7 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type.primitive;
 
-import org.apache.commons.lang3.NotImplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
@@ -51,7 +51,7 @@ public class DBSPTypeAny extends DBSPType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new NotImplementedException();
+        throw new UnimplementedException();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeStream.java
@@ -23,7 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type.user;
 
-import org.apache.commons.lang3.NotImplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -50,7 +50,7 @@ public class DBSPTypeStream extends DBSPType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new NotImplementedException();
+        throw new UnimplementedException();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeUser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeUser.java
@@ -23,7 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type.user;
 
-import org.apache.commons.lang3.NotImplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
@@ -62,7 +62,7 @@ public class DBSPTypeUser extends DBSPType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new NotImplementedException();
+        throw new UnimplementedException();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
@@ -25,6 +25,8 @@ package org.dbsp.sqlCompiler.ir.type.user;
 
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.ICollectionType;
 
@@ -38,6 +40,11 @@ public class DBSPTypeVec extends DBSPTypeUser implements ICollectionType {
 
     public DBSPType getElementType() {
         return this.getTypeArg(0);
+    }
+
+    @Override
+    public DBSPExpression defaultValue() {
+        return new DBSPVecLiteral(this, false);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -15,6 +15,16 @@ import org.junit.Test;
 
 public class RegressionTests extends SqlIoTest {
     @Test
+    public void issue3063() {
+        this.getCCS("""
+                CREATE TABLE array_tbl(c1 INT ARRAY, c2 INT ARRAY);
+                CREATE MATERIALIZED VIEW v AS SELECT
+                ARG_MIN(c1, c2) AS arg_min,
+                ARG_MAX(c1, c2) AS arg_max
+                FROM array_tbl;""");
+    }
+
+    @Test
     public void issue3035() {
         this.compileRustTestCase("""
                 CREATE TABLE t0(c0 INT) with ('materialized' = 'true');


### PR DESCRIPTION
The code was using the wrong exception in several places, which led to a Compiler bug error instead of an error report.
This also adds a default value for arrays, which allows min and max computations for array values.