### PR TITLE
[SQL] Support for OVER without ROWS, RANK, or ORDER BY

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDot.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDot.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.backend.dot;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitTransform;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.util.IndentStream;
 import org.dbsp.util.Logger;
@@ -14,7 +15,7 @@ import java.io.PrintWriter;
 
 /** Dump a graph in the graphviz dot format */
 public class ToDot {
-    public static void dump(String fileName, @Nullable String outputFormat,
+    public static void customDump(String fileName, @Nullable String outputFormat,
                             DBSPCircuit circuit,
                             ToDotEdgesVisitor.VisitorConstructor nodesVisitor,
                             ToDotEdgesVisitor.VisitorConstructor edgesVisitor) {
@@ -56,10 +57,27 @@ public class ToDot {
         }
     }
 
-    public static void dump(DBSPCompiler reporter, String fileName, int details,
+    public static void dump(DBSPCompiler compiler, String fileName, int details,
                             @Nullable String outputFormat, DBSPCircuit circuit) {
-        dump(fileName, outputFormat, circuit,
-                stream -> new ToDotNodesVisitor(reporter, stream, details),
-                stream -> new ToDotEdgesVisitor(reporter, stream, details));
+        customDump(fileName, outputFormat, circuit,
+                stream -> new ToDotNodesVisitor(compiler, stream, details),
+                stream -> new ToDotEdgesVisitor(compiler, stream, details));
+    }
+
+    /** Returns a circuit transform which can be inserted in the CircuitOptimizer to dump the
+     * circuit at some point */
+    public static CircuitTransform dumper(DBSPCompiler compiler, String file, int details) {
+        return new CircuitTransform() {
+            @Override
+            public String getName() {
+                return "toDot";
+            }
+
+            @Override
+            public DBSPCircuit apply(DBSPCircuit circuit) {
+                ToDot.dump(compiler, file, details, "png", circuit);
+                return circuit;
+            }
+        };
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -498,7 +498,8 @@ public class AggregateCompiler implements ICompilerComponent {
                         node, DBSPTypeBool.create(false), DBSPOpcode.AND, filter, agg);
             else
                 condition = agg;
-            DBSPExpression first = new DBSPIfExpression(node, condition, this.getAggregatedValue(), zero);
+            DBSPExpression first = new DBSPIfExpression(
+                    node, condition, this.getAggregatedValue().cast(zero.getType()), zero);
             DBSPExpression mapBody = new DBSPTupleExpression(first, one);
             DBSPVariablePath postVar = mapBody.getType().var();
             // post = |x| x.0

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
@@ -90,7 +90,6 @@ public class OptimizeProjectionVisitor extends CircuitCloneWithGraphsVisitor {
         super.postorder(operator);
     }
 
-
     @Override
     public void postorder(DBSPMapIndexOperator operator) {
         OutputPort source = this.mapped(operator.input());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
@@ -83,7 +83,7 @@ public class MonotoneAnalyzer implements CircuitTransform, IWritesLogs {
         Monotonicity monotonicity = new Monotonicity(this.compiler);
         expanded = monotonicity.apply(expanded);
         if (debug)
-            ToDot.dump("expanded.png", "png", expanded,
+            ToDot.customDump("expanded.png", "png", expanded,
                     stream -> new ToDotNodesVisitor(compiler, stream, details),
                     stream -> new MonotoneDot(compiler, stream, details, monotonicity.info));
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeString.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeString.java
@@ -38,10 +38,8 @@ import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.STRING;
 public class DBSPTypeString extends DBSPTypeBaseType {
     public static final int UNLIMITED_PRECISION = -1;
 
-    /**
-     * If true the width is fixed, i.e., this is a CHAR type.
-     * Otherwise, this is a VARCHAR.
-     */
+    /** If true the width is fixed, i.e., this is a CHAR type.
+     * Otherwise, this is a VARCHAR. */
     public final boolean fixed;
     /**
      * Number of characters.  If UNLIMITED_PRECISION it means "unlimited".

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
@@ -970,6 +970,11 @@ public class PostgresStringTests extends SqlIoTest {
     public void testConcatConversions() {
         // In Postgres concatenation converts to text, whereas Calcite does not.
         this.q("""
+                SELECT 'text'::text || ' and characters'::char(20) || 'x' AS "Concat text to char";
+                 Concat text to char
+                ---------------------
+                 text and characters     x""");
+        this.q("""
                 SELECT 'unknown' || ' and unknown' AS "Concat unknown types";
                  Concat unknown types
                 ----------------------
@@ -984,11 +989,6 @@ public class PostgresStringTests extends SqlIoTest {
                  Concat char to unknown type
                 -----------------------------
                  characters           and text""");
-        this.q("""
-                SELECT 'text'::text || ' and characters'::char(20) AS "Concat text to char";
-                 Concat text to char
-                ---------------------
-                 text and characters    \s""");
         this.q("""
                 SELECT 'text'::text || ' and varchar'::varchar AS "Concat text to varchar";
                  Concat text to varchar

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresWindowTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresWindowTests.java
@@ -109,12 +109,13 @@ public class PostgresWindowTests extends SqlIoTest {
         this.insertFromResource("tenk1_2_small", compiler);
     }
 
-    @Test @Ignore("Requires ORDER BY")
+    @Test
     public void testWindow() {
         this.qs("""
                 SELECT depname, empno, salary, sum(salary)
                 OVER (PARTITION BY depname)
-                FROM empsalary ORDER BY depname, salary;
+                FROM empsalary -- ORDER BY depname, salary
+                ;
                   depname  | empno | salary |  sum
                 -----------+-------+--------+-------
                  develop   |     7 |   4200 | 25100

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggScottTests.java
@@ -59,24 +59,24 @@ public class AggScottTests extends ScottBaseTests {
                 +--------+-----------+----+---+---+---+
                 | DEPTNO | JOB       | C  | D | J | X |
                 +--------+-----------+----+---+---+---+
-                |     10 | CLERK|       1 | 0 | 0 | 0 |
-                |     10 | MANAGER|     1 | 0 | 0 | 0 |
-                |     10 | PRESIDENT|   1 | 0 | 0 | 0 |
-                |     10 |NULL|         3 | 0 | 1 | 1 |
-                |     20 | ANALYST|     2 | 0 | 0 | 0 |
-                |     20 | CLERK|       2 | 0 | 0 | 0 |
-                |     20 | MANAGER|     1 | 0 | 0 | 0 |
-                |     20 |NULL|         5 | 0 | 1 | 1 |
-                |     30 | CLERK|       1 | 0 | 0 | 0 |
-                |     30 | MANAGER|     1 | 0 | 0 | 0 |
-                |     30 | SALESMAN|    4 | 0 | 0 | 0 |
-                |     30 |NULL|         6 | 0 | 1 | 1 |
-                |        | ANALYST|     2 | 1 | 0 | 2 |
-                |        | CLERK|       4 | 1 | 0 | 2 |
-                |        | MANAGER|     3 | 1 | 0 | 2 |
-                |        | PRESIDENT|   1 | 1 | 0 | 2 |
-                |        | SALESMAN|    4 | 1 | 0 | 2 |
-                |        |NULL|        14 | 1 | 1 | 3 |
+                |     10 | CLERK     |  1 | 0 | 0 | 0 |
+                |     10 | MANAGER   |  1 | 0 | 0 | 0 |
+                |     10 | PRESIDENT |  1 | 0 | 0 | 0 |
+                |     10 |NULL       |  3 | 0 | 1 | 1 |
+                |     20 | ANALYST   |  2 | 0 | 0 | 0 |
+                |     20 | CLERK     |  2 | 0 | 0 | 0 |
+                |     20 | MANAGER   |  1 | 0 | 0 | 0 |
+                |     20 |NULL       |  5 | 0 | 1 | 1 |
+                |     30 | CLERK     |  1 | 0 | 0 | 0 |
+                |     30 | MANAGER   |  1 | 0 | 0 | 0 |
+                |     30 | SALESMAN  |  4 | 0 | 0 | 0 |
+                |     30 |NULL       |  6 | 0 | 1 | 1 |
+                |        | ANALYST   |  2 | 1 | 0 | 2 |
+                |        | CLERK     |  4 | 1 | 0 | 2 |
+                |        | MANAGER   |  3 | 1 | 0 | 2 |
+                |        | PRESIDENT |  1 | 1 | 0 | 2 |
+                |        | SALESMAN  |  4 | 1 | 0 | 2 |
+                |        |NULL       | 14 | 1 | 1 | 3 |
                 +--------+-----------+----+---+---+---+
                 (18 rows)""");
     }
@@ -173,33 +173,33 @@ public class AggScottTests extends ScottBaseTests {
                 +--------+-----------+-------+--------+----------+-----------------------------------+
                 | DEPTNO | JOB       | EMPNO | ENAME  | SUMSAL   | GR_TEXT                           |
                 +--------+-----------+-------+--------+----------+-----------------------------------+
-                |     10 | CLERK|       7934 | MILLER|   1300.00 | grouped by deptno,job,empno,ename|
-                |     10 | CLERK|            |NULL|      1300.00 | grouped by deptno,job|
-                |     10 | MANAGER|     7782 | CLARK|    2450.00 | grouped by deptno,job,empno,ename|
-                |     10 | MANAGER|          |NULL|      2450.00 | grouped by deptno,job|
-                |     10 | PRESIDENT|   7839 | KING|     5000.00 | grouped by deptno,job,empno,ename|
-                |     10 | PRESIDENT|        |NULL|      5000.00 | grouped by deptno,job|
-                |     10 |NULL|              |NULL|      8750.00 | grouped by deptno|
-                |     20 | ANALYST|     7788 | SCOTT|    3000.00 | grouped by deptno,job,empno,ename|
-                |     20 | ANALYST|     7902 | FORD|     3000.00 | grouped by deptno,job,empno,ename|
-                |     20 | ANALYST|          |NULL|      6000.00 | grouped by deptno,job|
-                |     20 | CLERK|       7369 | SMITH|     800.00 | grouped by deptno,job,empno,ename|
-                |     20 | CLERK|       7876 | ADAMS|    1100.00 | grouped by deptno,job,empno,ename|
-                |     20 | CLERK|            |NULL|      1900.00 | grouped by deptno,job|
-                |     20 | MANAGER|     7566 | JONES|    2975.00 | grouped by deptno,job,empno,ename|
-                |     20 | MANAGER|          |NULL|      2975.00 | grouped by deptno,job|
-                |     20 |NULL|              |NULL|     10875.00 | grouped by deptno|
-                |     30 | CLERK|       7900 | JAMES|     950.00 | grouped by deptno,job,empno,ename|
-                |     30 | CLERK|            |NULL|       950.00 | grouped by deptno,job|
-                |     30 | MANAGER|     7698 | BLAKE|    2850.00 | grouped by deptno,job,empno,ename|
-                |     30 | MANAGER|          |NULL|      2850.00 | grouped by deptno,job|
-                |     30 | SALESMAN|    7499 | ALLEN|    1600.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|    7521 | WARD|     1250.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|    7654 | MARTIN|   1250.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|    7844 | TURNER|   1500.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|         |NULL|      5600.00 | grouped by deptno,job|
-                |     30 |NULL|              |NULL|      9400.00 | grouped by deptno|
-                |        |NULL|              |NULL|     29025.00 | grouped by ()|
+                |     10 | CLERK     |  7934 | MILLER |  1300.00 | grouped by deptno,job,empno,ename |
+                |     10 | CLERK     |       |NULL    |  1300.00 | grouped by deptno,job             |
+                |     10 | MANAGER   |  7782 | CLARK  |  2450.00 | grouped by deptno,job,empno,ename |
+                |     10 | MANAGER   |       |NULL    |  2450.00 | grouped by deptno,job             |
+                |     10 | PRESIDENT |  7839 | KING   |  5000.00 | grouped by deptno,job,empno,ename |
+                |     10 | PRESIDENT |       |NULL    |  5000.00 | grouped by deptno,job             |
+                |     10 |NULL       |       |NULL    |  8750.00 | grouped by deptno                 |
+                |     20 | ANALYST   |  7788 | SCOTT  |  3000.00 | grouped by deptno,job,empno,ename |
+                |     20 | ANALYST   |  7902 | FORD   |  3000.00 | grouped by deptno,job,empno,ename |
+                |     20 | ANALYST   |       |NULL    |  6000.00 | grouped by deptno,job             |
+                |     20 | CLERK     |  7369 | SMITH  |   800.00 | grouped by deptno,job,empno,ename |
+                |     20 | CLERK     |  7876 | ADAMS  |  1100.00 | grouped by deptno,job,empno,ename |
+                |     20 | CLERK     |       |NULL    |  1900.00 | grouped by deptno,job             |
+                |     20 | MANAGER   |  7566 | JONES  |  2975.00 | grouped by deptno,job,empno,ename |
+                |     20 | MANAGER   |       |NULL    |  2975.00 | grouped by deptno,job             |
+                |     20 |NULL       |       |NULL    | 10875.00 | grouped by deptno                 |
+                |     30 | CLERK     |  7900 | JAMES  |   950.00 | grouped by deptno,job,empno,ename |
+                |     30 | CLERK     |       |NULL    |   950.00 | grouped by deptno,job             |
+                |     30 | MANAGER   |  7698 | BLAKE  |  2850.00 | grouped by deptno,job,empno,ename |
+                |     30 | MANAGER   |       |NULL    |  2850.00 | grouped by deptno,job             |
+                |     30 | SALESMAN  |  7499 | ALLEN  |  1600.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7521 | WARD   |  1250.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7654 | MARTIN |  1250.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7844 | TURNER |  1500.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |       |NULL    |  5600.00 | grouped by deptno,job             |
+                |     30 |NULL       |       |NULL    |  9400.00 | grouped by deptno                 |
+                |        |NULL       |       |NULL    | 29025.00 | grouped by ()                     |
                 +--------+-----------+-------+--------+----------+-----------------------------------+
                 (27 rows)
 
@@ -230,37 +230,37 @@ public class AggScottTests extends ScottBaseTests {
                 +--------+-----------+-------+--------+----------+-----------------------------------+
                 | DEPTNO | JOB       | EMPNO | ENAME  | SUMSAL   | GR_TEXT                           |
                 +--------+-----------+-------+--------+----------+-----------------------------------+
-                |     10 | CLERK|       7934 | MILLER|   1300.00 | grouped by deptno,job,empno,ename|
-                |     10 | CLERK|            |NULL|      1300.00 | grouped by deptno,job|
-                |     10 | MANAGER|     7782 | CLARK|    2450.00 | grouped by deptno,job,empno,ename|
-                |     10 | MANAGER|          |NULL|      2450.00 | grouped by deptno,job|
-                |     10 | PRESIDENT|   7839 | KING|     5000.00 | grouped by deptno,job,empno,ename|
-                |     10 | PRESIDENT|        |NULL|      5000.00 | grouped by deptno,job|
-                |     10 |NULL|              |NULL|      8750.00 | grouped by deptno, grouping set 3|
-                |     10 |NULL|              |NULL|      8750.00 | grouped by deptno, grouping set 4|
-                |     20 | ANALYST|     7788 | SCOTT|    3000.00 | grouped by deptno,job,empno,ename|
-                |     20 | ANALYST|     7902 | FORD|     3000.00 | grouped by deptno,job,empno,ename|
-                |     20 | ANALYST|          |NULL|      6000.00 | grouped by deptno,job|
-                |     20 | CLERK|  7369      | SMITH|     800.00 | grouped by deptno,job,empno,ename|
-                |     20 | CLERK|  7876      | ADAMS|    1100.00 | grouped by deptno,job,empno,ename|
-                |     20 | CLERK|            |NULL|      1900.00 | grouped by deptno,job|
-                |     20 | MANAGER|  7566    | JONES|    2975.00 | grouped by deptno,job,empno,ename|
-                |     20 | MANAGER|          |NULL|      2975.00 | grouped by deptno,job|
-                |     20 |NULL|              |NULL|     10875.00 | grouped by deptno, grouping set 3|
-                |     20 |NULL|              |NULL|     10875.00 | grouped by deptno, grouping set 4|
-                |     30 | CLERK|  7900      | JAMES|     950.00 | grouped by deptno,job,empno,ename|
-                |     30 | CLERK|            |NULL|       950.00 | grouped by deptno,job|
-                |     30 | MANAGER|  7698    | BLAKE|    2850.00 | grouped by deptno,job,empno,ename|
-                |     30 | MANAGER|          |NULL|      2850.00 | grouped by deptno,job|
-                |     30 | SALESMAN|  7499   | ALLEN|    1600.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|  7521   | WARD|     1250.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|  7654   | MARTIN|   1250.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|  7844   | TURNER|   1500.00 | grouped by deptno,job,empno,ename|
-                |     30 | SALESMAN|         |NULL|      5600.00 | grouped by deptno,job|
-                |     30 |NULL|              |NULL|      9400.00 | grouped by deptno, grouping set 3|
-                |     30 |NULL|              |NULL|      9400.00 | grouped by deptno, grouping set 4|
-                |        |NULL|              |NULL|     29025.00 | grouped by (), grouping set 5|
-                |        |NULL|              |NULL|     29025.00 | grouped by (), grouping set 6|
+                |     10 | CLERK     |  7934 | MILLER |  1300.00 | grouped by deptno,job,empno,ename |
+                |     10 | CLERK     |       |NULL    |  1300.00 | grouped by deptno,job             |
+                |     10 | MANAGER   |  7782 | CLARK  |  2450.00 | grouped by deptno,job,empno,ename |
+                |     10 | MANAGER   |       |NULL    |  2450.00 | grouped by deptno,job             |
+                |     10 | PRESIDENT |  7839 | KING   |  5000.00 | grouped by deptno,job,empno,ename |
+                |     10 | PRESIDENT |       |NULL    |  5000.00 | grouped by deptno,job             |
+                |     10 |NULL       |       |NULL    |  8750.00 | grouped by deptno, grouping set 3 |
+                |     10 |NULL       |       |NULL    |  8750.00 | grouped by deptno, grouping set 4 |
+                |     20 | ANALYST   |  7788 | SCOTT  |  3000.00 | grouped by deptno,job,empno,ename |
+                |     20 | ANALYST   |  7902 | FORD   |  3000.00 | grouped by deptno,job,empno,ename |
+                |     20 | ANALYST   |       |NULL    |  6000.00 | grouped by deptno,job             |
+                |     20 | CLERK     |  7369 | SMITH  |   800.00 | grouped by deptno,job,empno,ename |
+                |     20 | CLERK     |  7876 | ADAMS  |  1100.00 | grouped by deptno,job,empno,ename |
+                |     20 | CLERK     |       |NULL    |  1900.00 | grouped by deptno,job             |
+                |     20 | MANAGER   |  7566 | JONES  |  2975.00 | grouped by deptno,job,empno,ename |
+                |     20 | MANAGER   |       |NULL    |  2975.00 | grouped by deptno,job             |
+                |     20 |NULL       |       |NULL    | 10875.00 | grouped by deptno, grouping set 3 |
+                |     20 |NULL       |       |NULL    | 10875.00 | grouped by deptno, grouping set 4 |
+                |     30 | CLERK     |  7900 | JAMES  |   950.00 | grouped by deptno,job,empno,ename |
+                |     30 | CLERK     |       |NULL    |   950.00 | grouped by deptno,job             |
+                |     30 | MANAGER   |  7698 | BLAKE  |  2850.00 | grouped by deptno,job,empno,ename |
+                |     30 | MANAGER   |       |NULL    |  2850.00 | grouped by deptno,job             |
+                |     30 | SALESMAN  |  7499 | ALLEN  |  1600.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7521 | WARD   |  1250.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7654 | MARTIN |  1250.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |  7844 | TURNER |  1500.00 | grouped by deptno,job,empno,ename |
+                |     30 | SALESMAN  |       |NULL    |  5600.00 | grouped by deptno,job             |
+                |     30 |NULL       |       |NULL    |  9400.00 | grouped by deptno, grouping set 3 |
+                |     30 |NULL       |       |NULL    |  9400.00 | grouped by deptno, grouping set 4 |
+                |        |NULL       |       |NULL    | 29025.00 | grouped by (), grouping set 5     |
+                |        |NULL       |       |NULL    | 29025.00 | grouped by (), grouping set 6     |
                 +--------+-----------+-------+--------+----------+-----------------------------------+
                 (31 rows)
 
@@ -388,38 +388,38 @@ public class AggScottTests extends ScottBaseTests {
                   group by grouping sets ((job, deptno, comm is null),
                     (job, deptno), (job, comm is null), (job, comm is null))
                   order by g, i, s desc;
-                  +----+---+---+---------+---+---+
-                  |  D | C | J | S       | G | I |
-                  +----+---+---+---------+---+---+
-                  | 20 | T | ANALYST| 6000.00 | 0 | 0 |
-                  | 30 | F | SALESMAN| 5600.00 | 0 | 0 |
-                  | 10 | T | PRESIDENT| 5000.00 | 0 | 0 |
-                  | 20 | T | MANAGER| 2975.00 | 0 | 0 |
-                  | 30 | T | MANAGER| 2850.00 | 0 | 0 |
-                  | 10 | T | MANAGER| 2450.00 | 0 | 0 |
-                  | 20 | T | CLERK| 1900.00 | 0 | 0 |
-                  | 10 | T | CLERK| 1300.00 | 0 | 0 |
-                  | 30 | T | CLERK|  950.00 | 0 | 0 |
-                  |    | T | MANAGER| 8275.00 | 2 | 1 |
-                  |    | T | ANALYST| 6000.00 | 2 | 1 |
-                  |    | F | SALESMAN| 5600.00 | 2 | 1 |
-                  |    | T | PRESIDENT| 5000.00 | 2 | 1 |
-                  |    | T | CLERK| 4150.00 | 2 | 1 |
-                  | 20 |   | ANALYST| 6000.00 | 1 | 0 |
-                  | 30 |   | SALESMAN| 5600.00 | 1 | 0 |
-                  | 10 |   | PRESIDENT| 5000.00 | 1 | 0 |
-                  | 20 |   | MANAGER| 2975.00 | 1 | 0 |
-                  | 30 |   | MANAGER| 2850.00 | 1 | 0 |
-                  | 10 |   | MANAGER| 2450.00 | 1 | 0 |
-                  | 20 |   | CLERK| 1900.00 | 1 | 0 |
-                  | 10 |   | CLERK| 1300.00 | 1 | 0 |
-                  | 30 |   | CLERK|  950.00 | 1 | 0 |
-                  |    | T | MANAGER| 8275.00 | 2 | 0 |
-                  |    | T | ANALYST| 6000.00 | 2 | 0 |
-                  |    | F | SALESMAN| 5600.00 | 2 | 0 |
-                  |    | T | PRESIDENT| 5000.00 | 2 | 0 |
-                  |    | T | CLERK| 4150.00 | 2 | 0 |
-                  +----+---+---------+---+---+
+                  +----+---+-----------+---------+---+---+
+                  |  D | C |         J | S       | G | I |
+                  +----+---+-----------+---------+---+---+
+                  | 20 | T | ANALYST   | 6000.00 | 0 | 0 |
+                  | 30 | F | SALESMAN  | 5600.00 | 0 | 0 |
+                  | 10 | T | PRESIDENT | 5000.00 | 0 | 0 |
+                  | 20 | T | MANAGER   | 2975.00 | 0 | 0 |
+                  | 30 | T | MANAGER   | 2850.00 | 0 | 0 |
+                  | 10 | T | MANAGER   | 2450.00 | 0 | 0 |
+                  | 20 | T | CLERK     | 1900.00 | 0 | 0 |
+                  | 10 | T | CLERK     | 1300.00 | 0 | 0 |
+                  | 30 | T | CLERK     |  950.00 | 0 | 0 |
+                  |    | T | MANAGER   | 8275.00 | 2 | 1 |
+                  |    | T | ANALYST   | 6000.00 | 2 | 1 |
+                  |    | F | SALESMAN  | 5600.00 | 2 | 1 |
+                  |    | T | PRESIDENT | 5000.00 | 2 | 1 |
+                  |    | T | CLERK     | 4150.00 | 2 | 1 |
+                  | 20 |   | ANALYST   | 6000.00 | 1 | 0 |
+                  | 30 |   | SALESMAN  | 5600.00 | 1 | 0 |
+                  | 10 |   | PRESIDENT | 5000.00 | 1 | 0 |
+                  | 20 |   | MANAGER   | 2975.00 | 1 | 0 |
+                  | 30 |   | MANAGER   | 2850.00 | 1 | 0 |
+                  | 10 |   | MANAGER   | 2450.00 | 1 | 0 |
+                  | 20 |   | CLERK     | 1900.00 | 1 | 0 |
+                  | 10 |   | CLERK     | 1300.00 | 1 | 0 |
+                  | 30 |   | CLERK     |  950.00 | 1 | 0 |
+                  |    | T | MANAGER   | 8275.00 | 2 | 0 |
+                  |    | T | ANALYST   | 6000.00 | 2 | 0 |
+                  |    | F | SALESMAN  | 5600.00 | 2 | 0 |
+                  |    | T | PRESIDENT | 5000.00 | 2 | 0 |
+                  |    | T | CLERK     | 4150.00 | 2 | 0 |
+                  +----+---+-----------+---------+---+---+
                   (28 rows)""");
     }
 
@@ -1399,7 +1399,7 @@ public class AggScottTests extends ScottBaseTests {
                 +-------+-------+
                 | MI    | MA    |
                 +-------+-------+
-                | MILLER| WARD|
+                | MILLER| WARD  |
                 +-------+-------+
                 (1 row)
 
@@ -1409,7 +1409,7 @@ public class AggScottTests extends ScottBaseTests {
                 +-------+-------+
                 | MI    | MA    |
                 +-------+-------+
-                | MILLER| WARD|
+                | MILLER| WARD  |
                 +-------+-------+
                 (1 row)
 
@@ -1420,7 +1420,7 @@ public class AggScottTests extends ScottBaseTests {
                 +-------+-------+
                 | MI    | MA    |
                 +-------+-------+
-                | MILLER| SMITH|
+                | MILLER| SMITH |
                 +-------+-------+
                 (1 row)
 
@@ -1443,9 +1443,9 @@ public class AggScottTests extends ScottBaseTests {
                 +--------+-------+--------+
                 | DEPTNO | MI    | MA     |
                 +--------+-------+--------+
-                |     10 | CLARK| MILLER|
-                |     20 | ADAMS| SMITH|
-                |     30 | ALLEN| WARD|
+                |     10 | CLARK| MILLER  |
+                |     20 | ADAMS| SMITH   |
+                |     30 | ALLEN| WARD    |
                 +--------+-------+--------+
                 (3 rows)
 
@@ -1482,19 +1482,19 @@ public class AggScottTests extends ScottBaseTests {
                    +--------+-----------+----+
                    | DEPTNO | JOB       | C  |
                    +--------+-----------+----+
-                   |     10 | CLERK|  1 |
-                   |     10 | MANAGER|  1 |
-                   |     10 | PRESIDENT|  1 |
-                   |     10 |NULL|  3 |
-                   |     20 | ANALYST|  2 |
-                   |     20 | CLERK|  2 |
-                   |     20 | MANAGER|  1 |
-                   |     20 |NULL|  5 |
-                   |     30 | CLERK|  1 |
-                   |     30 | MANAGER|  1 |
-                   |     30 | SALESMAN|  4 |
-                   |     30 |NULL|  6 |
-                   |        |NULL| 14 |
+                   |     10 | CLERK     |  1 |
+                   |     10 | MANAGER   |  1 |
+                   |     10 | PRESIDENT |  1 |
+                   |     10 |NULL       |  3 |
+                   |     20 | ANALYST   |  2 |
+                   |     20 | CLERK     |  2 |
+                   |     20 | MANAGER   |  1 |
+                   |     20 |NULL       |  5 |
+                   |     30 | CLERK     |  1 |
+                   |     30 | MANAGER   |  1 |
+                   |     30 | SALESMAN  |  4 |
+                   |     30 |NULL       |  6 |
+                   |        |NULL       | 14 |
                    +--------+-----------+----+
                    (13 rows)
 
@@ -1560,7 +1560,7 @@ public class AggScottTests extends ScottBaseTests {
                 | 29025.00 |                    3 |     8750.00 |    10875.00 |         6 |         0 |           |           |              |           14 |         5 |
                 +----------+----------------------+-------------+-------------+-----------+-----------+-----------+-----------+--------------+--------------+-----------+
                 (1 row)
-                
+
                 -- Check that SUM produces NULL on empty set, COUNT produces 0.
                 select
                  sum(sal) as sum_sal,
@@ -1584,7 +1584,7 @@ public class AggScottTests extends ScottBaseTests {
                 |         |                    0 |             |             |           |         0 |           |           |              |              |         0 |
                 +---------+----------------------+-------------+-------------+-----------+-----------+-----------+-----------+--------------+--------------+-----------+
                 (1 row)
-                
+
                 -- [CALCITE-4609] AggregateRemoveRule throws while handling AVG
                 -- Note that the outer GROUP BY is a no-op, and therefore
                 -- AggregateRemoveRule kicks in.
@@ -1603,7 +1603,7 @@ public class AggScottTests extends ScottBaseTests {
                 | SALESMAN|  1400.00  |
                 +----------+----------+
                 (3 rows)
-                
+
                 -- Same, using WITH
                 WITH EmpAnalytics AS (
                     SELECT deptno, job, AVG(sal) AS avg_sal
@@ -1634,7 +1634,7 @@ public class AggScottTests extends ScottBaseTests {
                 |     14 |     14 | 800.00 | 5000.00 |
                 +--------+--------+--------+---------+
                 (1 row)
-                
+
                 -- [CALCITE-1930] AggregateExpandDistinctAggregateRules should handle multiple aggregate calls with same input ref
                 select count(distinct DEPTNO), COUNT(JOB), MIN(SAL), MAX(SAL) from emp;
                 +--------+--------+--------+---------+
@@ -1643,7 +1643,7 @@ public class AggScottTests extends ScottBaseTests {
                 |      3 |     14 | 800.00 | 5000.00 |
                 +--------+--------+--------+---------+
                 (1 row)
-                
+
                 -- [CALCITE-1930] AggregateExpandDistinctAggregateRules should handle multiple aggregate calls with same input ref
                 select MGR, count(distinct DEPTNO), COUNT(JOB), MIN(SAL), MAX(SAL) from emp group by MGR;
                 +------+--------+--------+---------+---------+
@@ -1658,7 +1658,7 @@ public class AggScottTests extends ScottBaseTests {
                 |      |      1 |      1 | 5000.00 | 5000.00 |
                 +------+--------+--------+---------+---------+
                 (7 rows)
-                
+
                 -- [CALCITE-1930] AggregateExpandDistinctAggregateRules should handle multiple aggregate calls with same input ref
                 select MGR, count(distinct DEPTNO, JOB), MIN(SAL), MAX(SAL) from emp group by MGR;
                 +------+--------+---------+---------+
@@ -1688,7 +1688,7 @@ public class AggScottTests extends ScottBaseTests {
                 |                     4 |                     14 |
                 +-----------------------+------------------------+
                 (1 row)
-                
+
                 -- [CALCITE-1776, CALCITE-2402] REGR_SXX, REGR_SXY, REGR_SYY
                 SELECT
                   regr_sxx(COMM, SAL) as "REGR_SXX(COMM, SAL)",
@@ -1702,7 +1702,7 @@ public class AggScottTests extends ScottBaseTests {
                 |          95000.0000 |        1090000.0000 |        1090000.0000 |          95000.0000 |
                 +---------------------+---------------------+---------------------+---------------------+
                 (1 row)
-                
+
                 -- [CALCITE-1776, CALCITE-2402] COVAR_POP, COVAR_SAMP, VAR_SAMP, VAR_POP
                 SELECT
                   covar_pop(COMM, COMM) as "COVAR_POP(COMM, COMM)",
@@ -1729,7 +1729,7 @@ public class AggScottTests extends ScottBaseTests {
                 |      0 |     30 |     30 |
                 +--------+--------+--------+
                 (1 row)
-                
+
                 select deptno, bit_and(empno), bit_or(empno), bit_xor(empno) from emp group by deptno;
                 +--------+--------+--------+--------+
                 | DEPTNO | EXPR$1 | EXPR$2 | EXPR$3 |

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/AggTests.java
@@ -11,15 +11,15 @@ public class AggTests extends PostBaseTests {
                 SELECT ENAME, ENAME in ('Adam', 'Alice', 'Eve') FROM EMP;
                  ename | expr
                 --------------
-                 Adam| true
-                 Alice| true
-                 Bob| false
-                 Eric| false
-                 Eve| true
-                 Grace| false
-                 Jane| false
-                 Susan| false
-                 Wilma| false
+                 Adam  | true
+                 Alice | true
+                 Bob   | false
+                 Eric  | false
+                 Eve   | true
+                 Grace | false
+                 Jane  | false
+                 Susan | false
+                 Wilma | false
                 ---------------
                 (9 rows)""");
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HRWinAggTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HRWinAggTests.java
@@ -53,4 +53,19 @@ public class HRWinAggTests extends HrBaseTests {
                 +-------+--------+------------+-----+-----+
                 (4 rows)""");
     }
+
+    @Test
+    public void test1() {
+        this.qs("""
+                select * from (
+                  select "empid", count(*) over () c
+                    from "emps"
+                ) where "empid"=100;
+                +-------+---+
+                | empid | C |
+                +-------+---+
+                |   100 | 4 |
+                +-------+---+
+                (1 row)""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -93,6 +93,16 @@ public class RegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue457() {
+        String sql = """
+                create table t (id int, x int);
+                create view v as
+                select max(t.x) OVER (PARTITION BY t.id)
+                from t;""";
+        this.compileRustTestCase(sql);
+    }
+
+    @Test
     public void issue3031() {
         this.compileRustTestCase("""
                 CREATE TABLE time_tbl(c1 TIME, c2 TIME);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpcDsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpcDsTest.java
@@ -10,18 +10,13 @@ import java.io.IOException;
 
 public class TpcDsTest extends BaseSQLTests {
     // TODO: Disabled in the SQL code the following views
-    // q12: OVER without ORDER BY https://github.com/feldera/feldera/issues/457
-    // q20: OVER without ORDER BY
     // q36: OVER and RANK
-    // q47: OVER without ORDER BY
+    // q47: OVER and RANK
     // q49: OVER and RANK
     // q51: OVER with ROWS aggregate
-    // q53: OVER without ORDER BY
-    // q57: OVER without ORDER BY
-    // q63: OVER without ORDER BY
+    // q57: OVER and RANK
     // q70: OVER and RANK (this should probably work)
     // q86: OVER and RANK
-    // q89: OVER without ORDER BY
     @Test
     public void compileTpcds() throws IOException {
         String tpcds = TestUtil.readStringFromResourceFile("tpcds.sql");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -278,7 +278,7 @@ public class TableParser {
             // If there is no space in front of the string, we expect a NULL.
             // This is how we distinguish empty strings from nulls.
             if (!data.startsWith(" ")) {
-                if (data.equals("NULL"))
+                if (data.startsWith("NULL"))
                     result = DBSPLiteral.none(fieldType);
                 else
                     throw new RuntimeException("Expected NULL or a space: " +
@@ -287,6 +287,9 @@ public class TableParser {
                 // replace \\n with \n, otherwise we can't represent it
                 data = data.substring(1);
                 data = data.replace("\\n", "\n");
+                DBSPTypeString type = fieldType.to(DBSPTypeString.class);
+                if (!type.fixed)
+                    data = Utilities.trimRight(data);
                 result = new DBSPStringLiteral(CalciteObject.EMPTY, fieldType, data, StandardCharsets.UTF_8);
             }
         } else if (fieldType.is(DBSPTypeBool.class)) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/tpcds.sql
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/tpcds.sql
@@ -1224,7 +1224,7 @@ with year_total as (
  limit 100
 ;
 
-/* sql_12.sql
+/* sql_12.sql */
 CREATE VIEW sql_12 AS
 select i_item_id
       ,i_item_desc
@@ -1258,7 +1258,6 @@ order by
         ,revenueratio
 limit 100
 ;
-*/
 
 /* sql_13.sql */
 CREATE VIEW sql_13 AS
@@ -1676,7 +1675,7 @@ select i_brand_id brand_id, i_brand brand, i_manufact_id, i_manufact,
  limit 100
  ;
 
-/* sql_20.sql
+/* sql_20.sql */
 CREATE VIEW sql_20 AS
 select i_item_id
        ,i_item_desc
@@ -1706,7 +1705,6 @@ select i_item_id
          ,revenueratio
  limit 100
 ;
-*/
 
 /* sql_21.sql */
 CREATE VIEW sql_21 AS
@@ -3041,7 +3039,7 @@ select dt.d_year
  limit 100
  ;
 
-/* sql_53.sql
+/* sql_53.sql */
 CREATE VIEW sql_53 AS
 select * from
 (select i_manufact_id,
@@ -3069,7 +3067,6 @@ order by avg_quarterly_sales,
 	 i_manufact_id
 limit 100
 ;
-*/
 
 /* sql_54.sql */
 CREATE VIEW sql_54 AS
@@ -3533,7 +3530,7 @@ order by substring(w_warehouse_name,1,20)
 limit 100
 ;
 
-/* sql_63.sql
+/* sql_63.sql */
 CREATE VIEW sql_63 AS
 select *
 from (select i_manager_id
@@ -3562,7 +3559,6 @@ order by i_manager_id
         ,sum_sales
 limit 100
 ;
-*/
 
 /* sql_64.sql */
 CREATE VIEW sql_64 AS
@@ -5025,7 +5021,7 @@ from
      and store.s_store_name = 'ese') s8
 ;
 
-/* sql_89.sql
+/* sql_89.sql */
 CREATE VIEW sql_89 AS
 select *
 from(
@@ -5053,7 +5049,6 @@ where case when (avg_monthly_sales <> 0) then (abs(sum_sales - avg_monthly_sales
 order by sum_sales - avg_monthly_sales, s_store_name
 limit 100
 ;
-*/
 
 /* sql_90.sql */
 CREATE VIEW sql_90 AS


### PR DESCRIPTION
We used to reject this query:
```sql
create view v as
select max(t.x) OVER (PARTITION BY t.id)
from t;
```

This PR implements such queries in terms of standard aggregates followed by joins.
There are still a few patterns not supported for OVER, but this eliminates some of them.
Part of #457

