### PR TITLE
[SQL] Emit extra metadata information in JSON: default value, lateness, watermark

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteRelNode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteObject/CalciteRelNode.java
@@ -2,8 +2,12 @@ package org.dbsp.sqlCompiler.compiler.frontend.calciteObject;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
+import org.apache.calcite.rel.rel2sql.SqlImplementor;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
 
 public class CalciteRelNode extends CalciteObject {
     final RelNode relNode;
@@ -33,5 +37,14 @@ public class CalciteRelNode extends CalciteObject {
     @Override
     public String toInternalString() {
         return this.relNode.toString();
+    }
+
+    /** Convert a closed expression into SQL. */
+    public static String toSqlString(RexNode node) {
+        SqlImplementor.SimpleContext context = new SqlImplementor.SimpleContext(CalciteRelNode.DIALECT,
+                // This function should never be called
+                x -> new SqlIdentifier("", SqlParserPos.ZERO));
+        SqlNode sql = context.toSql(null, node);
+        return sql.toString();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/IHasSchema.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/IHasSchema.java
@@ -13,6 +13,7 @@ import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.TypeCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RelColumnMetadata;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
 import org.dbsp.sqlCompiler.compiler.frontend.parser.PropertyList;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
@@ -75,6 +76,15 @@ public interface IHasSchema extends IHasCalciteObject, ICastable {
                 column.set("columntype", repr);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
+            }
+            if (col.defaultValue != null) {
+                column.put("default", CalciteRelNode.toSqlString(col.defaultValue));
+            }
+            if (col.lateness != null) {
+                column.put("lateness", CalciteRelNode.toSqlString(col.lateness));
+            }
+            if (col.watermark != null) {
+                column.put("watermark", CalciteRelNode.toSqlString(col.watermark));
             }
         }
         if (hasKey)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -706,10 +706,11 @@ public class MetadataTests extends BaseSQLTests {
         String sql = """
                 CREATE TABLE T (
                 COL1 INT NOT NULL
-                , COL2 DOUBLE NOT NULL FOREIGN KEY REFERENCES S(COL0)
+                , COL2 DOUBLE NOT NULL FOREIGN KEY REFERENCES S(COL0) DEFAULT 1e0
                 , COL3 VARCHAR(3) NOT NULL PRIMARY KEY
                 , COL4 VARCHAR(3) ARRAY
                 , COL5 MAP<INT, INT>
+                , COL6 TIMESTAMP LATENESS INTERVAL '5 10:10' DAYS TO MINUTES
                 );
                 CREATE VIEW V AS SELECT COL1 AS "xCol" FROM T;
                 CREATE VIEW V1 ("yCol") AS SELECT COL1 FROM T;""";
@@ -748,7 +749,8 @@ public class MetadataTests extends BaseSQLTests {
                       "columntype" : {
                         "nullable" : false,
                         "type" : "DOUBLE"
-                      }
+                      },
+                      "default" : "1.0E0"
                     }, {
                       "name" : "col3",
                       "case_sensitive" : false,
@@ -784,6 +786,15 @@ public class MetadataTests extends BaseSQLTests {
                           "type" : "INTEGER"
                         }
                       }
+                    }, {
+                      "name" : "col6",
+                      "case_sensitive" : false,
+                      "columntype" : {
+                        "nullable" : true,
+                        "precision" : 0,
+                        "type" : "TIMESTAMP"
+                      },
+                      "lateness" : "INTERVAL '5 10:10' DAY TO MINUTE"
                     } ],
                     "primary_key" : [ "col3" ],
                     "materialized" : false,


### PR DESCRIPTION
The metadata will be emitted as a legal SQL expression.
See the test case for an example.