### PR TITLE
[tests] re-enable SQL aggregate tests for decimals

### DIFF
--- a/python/tests/aggregate_tests/main.py
+++ b/python/tests/aggregate_tests/main.py
@@ -40,9 +40,9 @@ from tests.aggregate_tests.test_date_max import *  # noqa: F403
 from tests.aggregate_tests.test_date_min import *  # noqa: F403
 from tests.aggregate_tests.test_date_tbl import *  # noqa: F403
 
-# from tests.aggregate_tests.test_decimal_avg import *  # noqa: F403
-# from tests.aggregate_tests.test_decimal_sum import *  # noqa: F403
-# from tests.aggregate_tests.test_decimal_table import *  # noqa: F403
+from tests.aggregate_tests.test_decimal_avg import *  # noqa: F403
+from tests.aggregate_tests.test_decimal_sum import *  # noqa: F403
+from tests.aggregate_tests.test_decimal_table import *  # noqa: F403
 from tests.aggregate_tests.test_every import *  # noqa: F403
 from tests.aggregate_tests.test_int_table import *  # noqa: F403
 from tests.aggregate_tests.test_max import *  # noqa: F403

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Re-enables the python based SQL aggregate tests for DECIMAL as #2667 has been fixed.