### PR TITLE
Improve logging for adapter messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3471,7 +3471,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "paste",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3644,7 +3644,6 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "libc",
- "log",
  "metrics",
  "mimalloc-rust-sys",
  "minitrace",
@@ -3680,6 +3679,7 @@ dependencies = [
  "thiserror 1.0.64",
  "time",
  "tokio",
+ "tracing",
  "typedmap",
  "uuid",
  "xxhash-rust",
@@ -3720,7 +3720,6 @@ dependencies = [
  "dbsp_nexmark",
  "deltalake",
  "enum-map",
- "env_logger 0.10.2",
  "erased-serde",
  "feldera-adapterlib",
  "feldera-datagen",
@@ -3740,7 +3739,6 @@ dependencies = [
  "indexmap 2.6.0",
  "jemalloc_pprof",
  "lazy_static",
- "log",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
@@ -3779,6 +3777,8 @@ dependencies = [
  "test_bin",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "utoipa",
  "uuid",
@@ -6123,6 +6123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6430,6 +6439,16 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -6845,6 +6864,12 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -7549,7 +7574,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -8030,7 +8055,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.8",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8038,6 +8063,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
 
 [[package]]
 name = "regex-automata"
@@ -8047,7 +8075,7 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -8055,6 +8083,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -10039,6 +10073,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10057,9 +10102,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -53,13 +53,11 @@ aws-types = "1.1.7"
 actix = "0.13.1"
 actix-web = { version = "4.4.0", default-features = false, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
 mime = "0.3.16"
-log = "0.4.20"
 size-of = { version = "0.1.5", package = "feldera-size-of", features = ["time-std", "ordered-float"], optional = true }
 futures = { version = "0.3.28" }
 futures-util = { version = "0.3.28" }
 proptest = { version = "1.5.0", optional = true }
 proptest-derive = { version = "0.5.0", optional = true }
-env_logger = "0.10.0"
 clap = { version = "4.0.32", features = ["derive"] }
 tokio = { version = "1.25.0", features = ["sync", "macros", "fs", "rt"] }
 utoipa = "4.1"
@@ -110,6 +108,8 @@ serde_bytes = "0.11.15"
 governor = "0.7.0"
 nonzero_ext = "0.3.0"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"

--- a/crates/adapters/src/adhoc/table.rs
+++ b/crates/adapters/src/adhoc/table.rs
@@ -39,6 +39,7 @@ use serde_arrow::schema::SerdeArrowSchema;
 use serde_arrow::ArrayBuilder;
 use serde_yaml::Value as YamlValue;
 use tokio::sync::mpsc::Sender;
+use tracing::{info_span, Instrument};
 use uuid::Uuid;
 
 pub const fn datafusion_arrow_serde_config() -> &'static SqlSerdeConfig {
@@ -282,6 +283,7 @@ impl DataSink for AdHocTableSink {
         // Call endpoint to complete request.
         let result = endpoint
             .complete_request(data, arrow_inserter, &self.schema)
+            .instrument(info_span!("adhoc_output"))
             .await
             .map_err(|e| DataFusionError::External(e.into()));
         drop(endpoint);

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -43,7 +43,6 @@ use feldera_types::format::json::JsonLines;
 use governor::DefaultDirectRateLimiter;
 use governor::Quota;
 use governor::RateLimiter;
-use log::{debug, error, info, trace, warn};
 use metadata::Checkpoint;
 use metadata::InputLog;
 use metadata::StepMetadata;
@@ -78,6 +77,7 @@ use std::{
 };
 use tokio::sync::oneshot;
 use tokio::sync::Mutex as TokioMutex;
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 mod error;

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -37,7 +37,6 @@ use atomic::Atomic;
 use crossbeam::sync::{ShardedLock, ShardedLockReadGuard, Unparker};
 use feldera_adapterlib::transport::InputReader;
 use feldera_types::config::PipelineConfig;
-use log::error;
 use metrics::{KeyName, SharedString as MetricString, Unit as MetricUnit};
 use metrics_util::{
     debugging::{DebugValue, Snapshot},
@@ -58,6 +57,7 @@ use std::{
     },
     time::Duration,
 };
+use tracing::error;
 
 #[derive(Default, Serialize)]
 pub struct GlobalControllerMetrics {

--- a/crates/adapters/src/format/avro/input.rs
+++ b/crates/adapters/src/format/avro/input.rs
@@ -17,7 +17,6 @@ use feldera_types::{
         DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat,
     },
 };
-use log::{debug, info};
 use schema_registry_converter::blocking::schema_registry::{get_schema_by_id, SrSettings};
 use serde::Deserialize;
 use serde_urlencoded::Deserializer as UrlDeserializer;
@@ -27,6 +26,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
+use tracing::{debug, info};
 
 // TODO: Error handling here is a bit of a mess. Schema parsing and validation happens
 // as part of message processing; however since input_XXX methods must return `ParseError`,

--- a/crates/adapters/src/format/avro/output.rs
+++ b/crates/adapters/src/format/avro/output.rs
@@ -10,7 +10,6 @@ use erased_serde::Serialize as ErasedSerialize;
 use feldera_types::config::{ConnectorConfig, TransportConfig};
 use feldera_types::format::avro::{AvroEncoderConfig, AvroUpdateFormat, SubjectNameStrategy};
 use feldera_types::program_schema::{Relation, SqlIdentifier};
-use log::{debug, error};
 use schema_registry_converter::blocking::schema_registry::post_schema;
 use schema_registry_converter::blocking::schema_registry::SrSettings;
 use schema_registry_converter::schema_registry_common::{SchemaType, SuppliedSchema};
@@ -18,6 +17,7 @@ use serde::Deserialize;
 use serde_urlencoded::Deserializer as UrlDeserializer;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use tracing::{debug, error};
 
 // TODOs:
 // - Add options to specify schema by id or subject name and retrieve it from the registry.

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -489,8 +489,8 @@ mod test {
         program_schema::Relation,
         serde_with_context::{DeserializeWithContext, SqlSerdeConfig},
     };
-    use log::trace;
     use std::{borrow::Cow, fmt::Debug, hash::Hash, panic::Location};
+    use tracing::trace;
 
     use super::JsonSplitter;
 

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -437,12 +437,12 @@ mod test {
     use dbsp::{utils::Tup2, OrdZSet};
     use feldera_types::format::json::JsonUpdateFormat;
     use feldera_types::program_schema::Relation;
-    use log::trace;
     use proptest::prelude::*;
     use serde::Deserialize;
     use serde_json::json;
     use std::collections::BTreeMap;
     use std::{cell::RefCell, fmt::Debug, rc::Rc, sync::Arc};
+    use tracing::trace;
 
     trait OutputUpdate: Debug + for<'de> Deserialize<'de> + Eq + Ord {
         type Val;

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -32,7 +32,6 @@ use deltalake::protocol::SaveMode;
 use deltalake::table::builder::ensure_table_uri;
 use deltalake::table::PeekCommit;
 use deltalake::{datafusion, DeltaTable, DeltaTableBuilder, Path};
-use env_logger::builder;
 use feldera_adapterlib::format::ParseError;
 use feldera_types::config::InputEndpointConfig;
 use feldera_types::format::json::JsonFlavor;
@@ -41,7 +40,6 @@ use feldera_types::transport::delta_table::{DeltaTableIngestMode, DeltaTableRead
 use feldera_types::transport::s3::S3InputConfig;
 use futures::TryFutureExt;
 use futures_util::StreamExt;
-use log::{debug, error, info, trace};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::format;
@@ -53,6 +51,8 @@ use tokio::sync::mpsc;
 use tokio::sync::watch::{channel, Receiver, Sender};
 use tokio::time::sleep;
 use tokio_util::time;
+use tracing::{debug, error, info, trace};
+use tracing_subscriber::fmt::fmt;
 use url::Url;
 use utoipa::ToSchema;
 

--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -22,12 +22,12 @@ use deltalake::protocol::{DeltaOperation, SaveMode};
 use deltalake::DeltaTable;
 use feldera_types::transport::delta_table::DeltaTableWriteMode;
 use feldera_types::{program_schema::Relation, transport::delta_table::DeltaTableWriterConfig};
-use log::{debug, error, info, trace};
 use serde_arrow::schema::SerdeArrowSchema;
 use serde_arrow::ArrayBuilder;
 use std::cmp::min;
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tracing::{debug, error, info, trace};
 
 struct DeltaTableWriterInner {
     endpoint_id: EndpointId,

--- a/crates/adapters/src/server/error.rs
+++ b/crates/adapters/src/server/error.rs
@@ -39,14 +39,13 @@
 //! [`PipelineError`], which allows [`PipelineError`] to be returned as an error
 //! type by HTTP endpoints.
 
-use crate::{ControllerError, ParseError};
+use crate::{dyn_event, ControllerError, ParseError};
 use actix_web::{
     body::BoxBody, http::StatusCode, HttpResponse, HttpResponseBuilder, ResponseError,
 };
 use anyhow::Error as AnyError;
 use datafusion::error::DataFusionError;
 use dbsp::DetailedError;
-use log::{error, log, warn, Level};
 use parquet::errors::ParquetError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
@@ -56,6 +55,7 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     sync::Arc,
 };
+use tracing::{error, warn, Level};
 use utoipa::ToSchema;
 
 pub const MAX_REPORTED_PARSE_ERRORS: usize = 1_000;
@@ -105,7 +105,7 @@ impl ErrorResponse {
     {
         let result = Self::from_error_nolog(error);
 
-        log!(
+        dyn_event!(
             error.log_level(),
             "[HTTP error response] {}: {}",
             result.error_code,
@@ -270,10 +270,10 @@ impl DetailedError for PipelineError {
 
     fn log_level(&self) -> Level {
         match self {
-            Self::Initializing => Level::Info,
-            Self::Terminating => Level::Info,
+            Self::Initializing => Level::INFO,
+            Self::Terminating => Level::INFO,
             Self::ControllerError { error } => error.log_level(),
-            _ => Level::Error,
+            _ => Level::ERROR,
         }
     }
 }

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -48,7 +48,7 @@ use tokio::{
         oneshot,
     },
 };
-use tracing::{debug, error, info, trace, warn, Level, Subscriber};
+use tracing::{debug, error, info, info_span, trace, warn, Instrument, Level, Subscriber};
 use tracing_subscriber::fmt::format::Format;
 use tracing_subscriber::fmt::{FormatEvent, FormatFields};
 use tracing_subscriber::layer::SubscriberExt;
@@ -773,7 +773,10 @@ async fn input_endpoint(
     };
 
     // Call endpoint to complete request.
-    let response = endpoint.complete_request(payload).await;
+    let response = endpoint
+        .complete_request(payload)
+        .instrument(info_span!("http_input"))
+        .await;
     drop(endpoint);
 
     // Delete endpoint on completion/error.

--- a/crates/adapters/src/test/http.rs
+++ b/crates/adapters/src/test/http.rs
@@ -7,7 +7,7 @@ use awc::{error::PayloadError, ClientRequest};
 use csv::ReaderBuilder as CsvReaderBuilder;
 use csv::WriterBuilder as CsvWriterBuilder;
 use futures::{Stream, StreamExt};
-use log::trace;
+use tracing::trace;
 
 pub struct TestHttpSender;
 pub struct TestHttpReceiver;

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -10,7 +10,6 @@ use feldera_types::program_schema::Relation;
 use feldera_types::transport::kafka::default_redpanda_server;
 use futures::executor::block_on;
 use lazy_static::lazy_static;
-use log::{error, info};
 use rdkafka::message::BorrowedMessage;
 use rdkafka::{
     admin::{AdminClient, AdminOptions, NewPartitions, NewTopic, TopicReplication},
@@ -31,6 +30,7 @@ use std::{
     thread::{sleep, JoinHandle},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use tracing::{error, info};
 
 static MAX_TOPIC_PROBE_TIMEOUT: Duration = Duration::from_millis(20_000);
 

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -7,7 +7,6 @@ use crate::{InputBuffer, Parser};
 use anyhow::{bail, Error as AnyError, Result as AnyResult};
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::file::{FileInputConfig, FileOutputConfig};
-use log::error;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::hash::Hasher;
@@ -17,6 +16,7 @@ use std::thread::{self, Thread};
 use std::{fs::File, io::Write, thread::spawn, time::Duration};
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::error;
 use xxhash_rust::xxh3::Xxh3Default;
 
 const SLEEP: Duration = Duration::from_millis(200);

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -13,7 +13,6 @@ use circular_queue::CircularQueue;
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::http::HttpInputConfig;
 use futures_util::StreamExt;
-use log::debug;
 use rmpv::Value as RmpValue;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -26,6 +25,7 @@ use tokio::{
     sync::watch,
     time::{sleep, timeout},
 };
+use tracing::debug;
 use xxhash_rust::xxh3::Xxh3Default;
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -25,7 +25,7 @@ use tokio::{
     sync::watch,
     time::{sleep, timeout},
 };
-use tracing::debug;
+use tracing::{debug, info_span};
 use xxhash_rust::xxh3::Xxh3Default;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -265,6 +265,7 @@ impl TransportInputEndpoint for HttpInputEndpoint {
 
 impl InputReader for HttpInputEndpoint {
     fn request(&self, command: InputReaderCommand) {
+        let _guard = info_span!("http_input").entered();
         match command {
             InputReaderCommand::Seek(_) => (),
             InputReaderCommand::Replay(metadata) => {

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -16,7 +16,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::timeout,
 };
-use tracing::{debug, error};
+use tracing::{debug, error, info_span};
 
 // TODO: make this configurable via endpoint config.
 const MAX_BUFFERS: usize = 100;
@@ -273,6 +273,7 @@ impl OutputEndpoint for HttpOutputEndpoint {
     }
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
+        let _guard = info_span!("http_output").entered();
         self.inner
             .push_buffer(Some(buffer), self.inner.backpressure)
     }

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -3,8 +3,6 @@ use actix_web::{http::header::ContentType, web::Bytes, HttpResponse};
 use anyhow::{anyhow, bail, Result as AnyResult};
 use async_stream::stream;
 use crossbeam::sync::ShardedLock;
-use log::debug;
-use log::error;
 use serde::{ser::SerializeStruct, Serializer};
 use serde_json::value::RawValue;
 use std::{
@@ -18,6 +16,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::timeout,
 };
+use tracing::{debug, error};
 
 // TODO: make this configurable via endpoint config.
 const MAX_BUFFERS: usize = 100;

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -15,7 +15,6 @@ use feldera_adapterlib::transport::{InputEndpoint, InputReaderCommand};
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::kafka::KafkaInputConfig;
 use indexmap::IndexSet;
-use log::debug;
 use rdkafka::config::RDKafkaLogLevel;
 use rdkafka::{
     config::FromClientConfigAndContext,
@@ -38,6 +37,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::debug;
 use xxhash_rust::xxh3::Xxh3Default;
 
 /// Poll timeout must be low, as it bounds the amount of time it takes to resume the connector.

--- a/crates/adapters/src/transport/kafka/ft/mod.rs
+++ b/crates/adapters/src/transport/kafka/ft/mod.rs
@@ -10,7 +10,6 @@ mod output;
 
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
 use feldera_types::transport::kafka::{default_redpanda_server, KafkaLogLevel};
-use log::{debug, error, warn};
 use rdkafka::{
     client::Client as KafkaClient,
     config::RDKafkaLogLevel,
@@ -30,6 +29,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 pub use input::KafkaFtInputEndpoint;

--- a/crates/adapters/src/transport/kafka/ft/output.rs
+++ b/crates/adapters/src/transport/kafka/ft/output.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context, Error as AnyError, Result as AnyResult};
 use feldera_types::transport::kafka::KafkaOutputConfig;
-use log::{debug, info, warn};
 use rdkafka::message::OwnedHeaders;
 use rdkafka::{
     config::FromClientConfigAndContext,
@@ -17,6 +16,7 @@ use rdkafka::{
 };
 use serde::{Deserialize, Serialize};
 use std::{cmp::max, sync::RwLock, time::Duration};
+use tracing::{debug, info, warn};
 
 use super::{count_partitions_in_topic, CommonConfig, Ctp, DataConsumerContext};
 

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Error as AnyError, Result as AnyResult};
 use feldera_types::transport::kafka::{KafkaHeader, KafkaLogLevel};
-use log::warn;
 use parquet::data_type::AsBytes;
 use rdkafka::message::{Header, OwnedHeaders, ToBytes};
 use rdkafka::producer::{BaseRecord, ProducerContext, ThreadedProducer};
@@ -18,6 +17,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+use tracing::warn;
 
 pub use ft::{KafkaFtInputEndpoint, KafkaFtOutputEndpoint};
 pub use nonft::{KafkaInputEndpoint, KafkaOutputEndpoint};
@@ -164,7 +164,7 @@ impl DeferredLogging {
         *self.0.lock().unwrap() = Some(Vec::new());
         let r = f();
         for (level, fac, message) in self.0.lock().unwrap().take().unwrap().drain(..) {
-            log::info!("{level:?} {fac} {message}");
+            tracing::info!("{level:?} {fac} {message}");
         }
         r
     }
@@ -211,19 +211,19 @@ impl DeferredLogging {
             | RDKafkaLogLevel::Alert
             | RDKafkaLogLevel::Critical
             | RDKafkaLogLevel::Error => {
-                log::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Warning => {
-                log::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Notice => {
-                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Info => {
-                log::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
             RDKafkaLogLevel::Debug => {
-                log::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+                tracing::debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
             }
         }
     }

--- a/crates/adapters/src/transport/kafka/nonft/input.rs
+++ b/crates/adapters/src/transport/kafka/nonft/input.rs
@@ -14,7 +14,6 @@ use atomic::Atomic;
 use crossbeam::queue::ArrayQueue;
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::kafka::KafkaInputConfig;
-use log::debug;
 use rdkafka::config::RDKafkaLogLevel;
 use rdkafka::{
     config::FromClientConfigAndContext,
@@ -33,6 +32,7 @@ use std::{
 };
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::debug;
 
 /// Poll timeout must be low, as it bounds the amount of time it takes to resume the connector.
 const POLL_TIMEOUT: Duration = Duration::from_millis(5);

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -174,11 +174,7 @@ impl OutputEndpoint for KafkaOutputEndpoint {
         }
 
         record = record.headers(self.headers.clone());
-
-        self.kafka_producer
-            .send(record)
-            .map_err(|(err, _record)| err)?;
-        Ok(())
+        kafka_send(&self.kafka_producer, &self.config.topic, record)
     }
 
     fn is_fault_tolerant(&self) -> bool {

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -5,7 +5,6 @@ use crate::transport::secret_resolver::resolve_secret;
 use crate::{AsyncErrorCallback, OutputEndpoint};
 use anyhow::{anyhow, bail, Error as AnyError, Result as AnyResult};
 use feldera_types::transport::kafka::KafkaOutputConfig;
-use log::debug;
 use rdkafka::message::OwnedHeaders;
 use rdkafka::{
     config::FromClientConfigAndContext,
@@ -15,6 +14,7 @@ use rdkafka::{
     ClientConfig, ClientContext,
 };
 use std::{sync::RwLock, time::Duration};
+use tracing::debug;
 
 const DEFAULT_MAX_MESSAGE_SIZE: usize = 1_000_000;
 

--- a/crates/adapters/src/transport/kafka/nonft/test.rs
+++ b/crates/adapters/src/transport/kafka/nonft/test.rs
@@ -8,7 +8,6 @@ use crate::{
     Controller, PipelineConfig,
 };
 use feldera_types::program_schema::Relation;
-use log::info;
 use parquet::data_type::AsBytes;
 use proptest::prelude::*;
 use rdkafka::message::{BorrowedMessage, Header, Headers};
@@ -21,6 +20,7 @@ use std::{
     thread::sleep,
     time::Duration,
 };
+use tracing::info;
 
 #[test]
 fn test_kafka_output_errors() {

--- a/crates/adapters/src/transport/pubsub/input.rs
+++ b/crates/adapters/src/transport/pubsub/input.rs
@@ -22,7 +22,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
+use tracing::{debug, info_span, Instrument};
 
 pub struct PubSubInputEndpoint {
     config: Arc<PubSubInputConfig>,
@@ -71,13 +71,15 @@ impl PubSubReader {
         consumer: Box<dyn InputConsumer>,
         parser: Box<dyn Parser>,
     ) -> AnyResult<Self> {
+        let span = info_span!("pub_sub_input", subscription = config.subscription.clone());
         let (state_sender, state_receiver) = unbounded_channel();
-        let subscription = TOKIO.block_on(Self::subscribe(&config))?;
+        let subscription = TOKIO.block_on(Self::subscribe(&config).instrument(span.clone()))?;
         thread::spawn({
             move || {
                 let consumer_clone = consumer.clone();
                 TOKIO.block_on(async {
                     Self::worker_task(subscription, consumer_clone, parser, state_receiver)
+                        .instrument(span)
                         .await
                         .unwrap_or_else(|e| consumer.error(true, e));
                 })

--- a/crates/adapters/src/transport/pubsub/input.rs
+++ b/crates/adapters/src/transport/pubsub/input.rs
@@ -12,7 +12,6 @@ use google_cloud_pubsub::{
     client::{google_cloud_auth::credentials::CredentialsFile, Client, ClientConfig},
     subscription::{SeekTo, Subscription},
 };
-use log::debug;
 use std::{
     sync::Arc,
     thread,
@@ -23,6 +22,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
 pub struct PubSubInputEndpoint {
     config: Arc<PubSubInputConfig>,

--- a/crates/adapters/src/transport/pubsub/test.rs
+++ b/crates/adapters/src/transport/pubsub/test.rs
@@ -15,9 +15,9 @@ use google_cloud_pubsub::{
     subscription::SubscriptionConfig,
     topic::Topic,
 };
-use log::info;
 use proptest::prelude::*;
 use serde::Serialize;
+use tracing::info;
 
 static EMULATOR_PROJECT_ID: &str = "feldera-test";
 

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -14,9 +14,9 @@ use crate::{
 use anyhow::{bail, Result as AnyResult};
 use dbsp::circuit::tokio::TOKIO;
 use feldera_types::program_schema::Relation;
-use log::error;
 #[cfg(test)]
 use mockall::automock;
+use tracing::error;
 
 use crate::transport::InputEndpoint;
 use feldera_types::transport::s3::S3InputConfig;

--- a/crates/adapters/src/transport/secret_resolver.rs
+++ b/crates/adapters/src/transport/secret_resolver.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use anyhow::{anyhow, Result as AnyResult};
 use feldera_types::secret_ref::MaybeSecretRef;
-use log::debug;
 use regex::Regex;
+use tracing::debug;
 
 /// Enumeration which holds a simple string or a resolved secret's string.
 ///

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -30,6 +30,7 @@ use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     time::{sleep_until, Instant},
 };
+use tracing::info_span;
 use xxhash_rust::xxh3::Xxh3Default;
 
 pub(crate) struct UrlInputEndpoint {
@@ -213,6 +214,7 @@ impl UrlInputReader {
         spawn({
             let config = config.clone();
             move || {
+                let _guard = info_span!("url_input", path = config.path.clone()).entered();
                 System::new().block_on(async move {
                     if let Err(error) =
                         Self::worker_thread(config, &mut parser, receiver, consumer.as_ref()).await

--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -37,3 +37,18 @@ where
 
     Ok(())
 }
+
+/// For logging with a non-constant level.  From
+/// <https://github.com/tokio-rs/tracing/issues/2730>
+#[macro_export]
+macro_rules! dyn_event {
+    ($lvl:expr, $($arg:tt)+) => {
+        match $lvl {
+            ::tracing::Level::TRACE => ::tracing::trace!($($arg)+),
+            ::tracing::Level::DEBUG => ::tracing::debug!($($arg)+),
+            ::tracing::Level::INFO => ::tracing::info!($($arg)+),
+            ::tracing::Level::WARN => ::tracing::warn!($($arg)+),
+            ::tracing::Level::ERROR => ::tracing::error!($($arg)+),
+        }
+    };
+}

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -62,7 +62,6 @@ clap = { version = "4.4.14", features = ["derive", "env", "wrap_help"] }
 fdlimit = { version = "0.3.0" }
 # metrics won't display if it doesn't match the adapters metrics version!
 metrics = { version = "0.23.0" }
-log = { version = "0.4", features = [] }
 rlimit = "0.10.1"
 serde = { version = "1.0", features = ["derive"] }
 ptr_meta = "0.2.0"
@@ -73,6 +72,7 @@ lazy_static = "1.4.0"
 zip = "0.6.2"
 minitrace = "0.6"
 ouroboros = "0.18.4"
+tracing = "0.1.40"
 
 
 [dependencies.time]

--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -121,15 +121,15 @@ impl Checkpointer {
             ) || path.is_dir()
             {
                 if path.is_dir() {
-                    log::debug!("Removing unused directory '{}'", path.display());
+                    tracing::debug!("Removing unused directory '{}'", path.display());
                     fs::remove_dir_all(path)?;
                 } else {
                     match fs::remove_file(path) {
                         Ok(_) => {
-                            log::debug!("Removed unused file '{}'", path.display());
+                            tracing::debug!("Removed unused file '{}'", path.display());
                         }
                         Err(e) => {
-                            log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", path.display(), e);
+                            tracing::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", path.display(), e);
                         }
                     }
                 }
@@ -243,10 +243,10 @@ impl Checkpointer {
             );
             match fs::remove_file(file) {
                 Ok(_) => {
-                    log::debug!("Removed file {}", file.as_ref().display());
+                    tracing::debug!("Removed file {}", file.as_ref().display());
                 }
                 Err(e) => {
-                    log::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", file.as_ref().display(), e);
+                    tracing::warn!("Unable to remove old-checkpoint file {}: {} (the pipeline will try to delete the file again on a restart)", file.as_ref().display(), e);
                 }
             }
         }
@@ -259,7 +259,7 @@ impl Checkpointer {
         assert_ne!(cpm.uuid, Uuid::nil());
         let checkpoint_dir = self.storage_path.join(cpm.uuid.to_string());
         if !checkpoint_dir.exists() {
-            log::warn!(
+            tracing::warn!(
                 "Tried to remove a checkpoint directory '{}' that doesn't exist.",
                 checkpoint_dir.display()
             );

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -52,7 +52,6 @@ use crate::{
     Error as DbspError, Error, Runtime,
 };
 use anyhow::Error as AnyError;
-use log::info;
 use serde::Serialize;
 use std::{
     any::type_name_of_val,
@@ -67,6 +66,7 @@ use std::{
     thread::panicking,
     time::{Duration, Instant},
 };
+use tracing::info;
 use typedmap::{TypedMap, TypedMapKey};
 use uuid::Uuid;
 

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -687,7 +687,7 @@ impl RuntimeHandle {
         match st {
             StorageLocation::Temporary(path) => {
                 if std::thread::panicking() || did_runtime_panic {
-                    log::info!("Preserved runtime storage at: {:?} due to panic", path);
+                    tracing::info!("Preserved runtime storage at: {:?} due to panic", path);
                 } else {
                     let _ = std::fs::remove_dir_all(path);
                 }

--- a/crates/dbsp/src/error.rs
+++ b/crates/dbsp/src/error.rs
@@ -1,6 +1,5 @@
 use crate::{storage::backend::StorageError, RuntimeError, SchedulerError};
 use anyhow::Error as AnyError;
-use log::Level;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     borrow::Cow,
@@ -8,11 +7,12 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     io::Error as IOError,
 };
+use tracing::Level;
 
 pub trait DetailedError: StdError + Serialize {
     fn error_code(&self) -> Cow<'static, str>;
     fn log_level(&self) -> Level {
-        Level::Error
+        Level::ERROR
     }
 }
 

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -10,7 +10,6 @@
 #![warn(missing_docs)]
 
 use feldera_types::config::StorageCacheConfig;
-use log::{trace, warn};
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
     fs::OpenOptions,
@@ -22,6 +21,7 @@ use std::{
 };
 use tempfile::TempDir;
 use thiserror::Error;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use crate::storage::buffer_cache::FBuf;

--- a/crates/dbsp/src/storage/backend/posixio_impl.rs
+++ b/crates/dbsp/src/storage/backend/posixio_impl.rs
@@ -1,7 +1,6 @@
 //! Implementation of the storage backend ([`Storage`] APIs using POSIX I/O.
 
 use feldera_types::config::StorageCacheConfig;
-use log::warn;
 use metrics::{counter, histogram};
 use std::{
     fs::{self, remove_file, File, OpenOptions},
@@ -15,6 +14,7 @@ use std::{
     },
     time::Instant,
 };
+use tracing::warn;
 
 use super::{
     append_to_path, tempdir_for_thread, FileId, FileReader, FileWriter, HasFileId, Storage,

--- a/crates/dbsp/src/storage/dirlock/mod.rs
+++ b/crates/dbsp/src/storage/dirlock/mod.rs
@@ -4,7 +4,6 @@
 //! using the same data directory.
 
 use libc::{c_int, c_short};
-use log::{error, info};
 use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{Error as IoError, ErrorKind};
@@ -15,6 +14,7 @@ use std::process;
 use std::sync::{LazyLock, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+use tracing::{error, info};
 
 use crate::storage::backend::StorageError;
 

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -1086,7 +1086,7 @@ impl ImmutableFileRef {
         if let Some(file_handle) = self.file_handle.as_ref() {
             file_handle.mark_for_checkpoint();
         } else {
-            log::error!("file_handle was None?")
+            tracing::error!("file_handle was None?")
         }
     }
 }

--- a/crates/dbsp/src/storage/mod.rs
+++ b/crates/dbsp/src/storage/mod.rs
@@ -11,10 +11,10 @@ pub mod file;
 mod test;
 
 use fdlimit::{raise_fd_limit, Outcome::LimitRaised};
-use log::{info, warn};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use tracing::{info, warn};
 
 use crate::{Error, Runtime};
 use std::sync::Once;


### PR DESCRIPTION
The final commit is the important one:

> dbsp_adapters: Annotate adapter logging with tracing spans.
> 
> We have a lot of input and output adapters and pipelines can have more than
> one of each.  Log messages aren't always clear about which one they're
> talking about.
> 
> This commit helps by adding tracing spans that give the name of the adapter
> and in many cases a bit more detail (a file name, a URL, a Kafka topic,
> etc.).  These will appear in every message from that adapter with the
> default log settings.  This should make what's going on clearer.
> 
> Fixes: https://github.com/feldera/feldera/issues/3023
> 