### PR TITLE
python: account for status `SqlCompiled` in program compilation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ following command:
 docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:0.31.1
 ```
 
-Once the container image downloads and you see the Feldera logo on your terminal, visit 
+Once the container image downloads and you see the Feldera logo on your terminal, visit
 the WebConsole at [http://localhost:8080](http://localhost:8080).
 We suggest going through our [tutorial](https://docs.feldera.com/tutorials/basics/) next.
 
-We also have instructions to run Feldera using [Docker Compose](https://docs.feldera.com/get-started), 
-if you'd like to experiment with Kafka and other auxiliary services. 
+We also have instructions to run Feldera using [Docker Compose](https://docs.feldera.com/get-started),
+if you'd like to experiment with Kafka and other auxiliary services.
 
 ## ⚙️ Running Feldera from sources
 

--- a/benchmark/feldera-sql/run.py
+++ b/benchmark/feldera-sql/run.py
@@ -409,6 +409,7 @@ def main():
             elif (
                 status != "Pending"
                 and status != "CompilingRust"
+                and status != "SqlCompiled"
                 and status != "CompilingSql"
             ):
                 raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/project_demo01-TimeSeriesEnrich/run.py
+++ b/demo/project_demo01-TimeSeriesEnrich/run.py
@@ -105,6 +105,7 @@ def prepare_feldera(api_url, start_pipeline):
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/project_demo03-GreenTrip/run.py
+++ b/demo/project_demo03-GreenTrip/run.py
@@ -87,6 +87,7 @@ def prepare_feldera(api_url, start_pipeline):
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/project_demo04-SimpleSelect/run.py
+++ b/demo/project_demo04-SimpleSelect/run.py
@@ -81,6 +81,7 @@ def prepare_feldera(api_url, start_pipeline):
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/project_demo06-SupplyChainTutorial/run.py
+++ b/demo/project_demo06-SupplyChainTutorial/run.py
@@ -168,6 +168,7 @@ def main():
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/project_demo07-SnowflakeSink/run.py
+++ b/demo/project_demo07-SnowflakeSink/run.py
@@ -191,6 +191,7 @@ def prepare_feldera(api_url):
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/demo/steady/demo.py
+++ b/demo/steady/demo.py
@@ -76,6 +76,7 @@ def main():
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")

--- a/scripts/compilation_speed_benchmark.py
+++ b/scripts/compilation_speed_benchmark.py
@@ -102,6 +102,7 @@ def compile(program_name, program, headers):
         elif (
             status != "Pending"
             and status != "CompilingRust"
+            and status != "SqlCompiled"
             and status != "CompilingSql"
         ):
             raise RuntimeError(f"Failed program compilation with status {status}")


### PR DESCRIPTION
There are demo and benchmark Python scripts which use direct API calls for program compilation. Some of them do not yet account for the new status `SqlCompiled` that was introduced in the compiler rework, and fail as a result. This failure is nondeterministic, as when there is only one program, it would relatively quickly transition to `CompilingRust` and as such there is only a chance of the script observing the new status. This fixes it by adding an extra condition for `SqlCompiled` in the check of whether compilation is still ongoing.