### PR TITLE
pipeline-manager: connector orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7188,6 +7188,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "url",
+ "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -915,15 +915,11 @@ async fn output_endpoint(
 }
 
 #[get("/input_endpoints/{endpoint_name}/pause")]
-async fn pause_input_endpoint(state: WebData<ServerState>, req: HttpRequest) -> impl Responder {
-    let endpoint_name = match req.match_info().get("endpoint_name") {
-        None => {
-            return Err(PipelineError::MissingUrlEncodedParam {
-                param: "endpoint_name",
-            });
-        }
-        Some(table_name) => table_name.to_string(),
-    };
+async fn pause_input_endpoint(
+    state: WebData<ServerState>,
+    path: web::Path<String>,
+) -> impl Responder {
+    let endpoint_name = path.into_inner();
 
     match &*state.controller.lock().unwrap() {
         Some(controller) => controller.pause_input_endpoint(&endpoint_name)?,
@@ -936,15 +932,11 @@ async fn pause_input_endpoint(state: WebData<ServerState>, req: HttpRequest) -> 
 }
 
 #[get("/input_endpoints/{endpoint_name}/start")]
-async fn start_input_endpoint(state: WebData<ServerState>, req: HttpRequest) -> impl Responder {
-    let endpoint_name = match req.match_info().get("endpoint_name") {
-        None => {
-            return Err(PipelineError::MissingUrlEncodedParam {
-                param: "endpoint_name",
-            });
-        }
-        Some(table_name) => table_name.to_string(),
-    };
+async fn start_input_endpoint(
+    state: WebData<ServerState>,
+    path: web::Path<String>,
+) -> impl Responder {
+    let endpoint_name = path.into_inner();
 
     match &*state.controller.lock().unwrap() {
         Some(controller) => controller.start_input_endpoint(&endpoint_name)?,

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -361,15 +361,17 @@ pub enum PipelineAction {
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
         name: String,
     },
-    /// Control an endpoint of a pipeline.
-    Endpoint {
+    /// Control an input connector belonging to a table of a pipeline.
+    TableConnector {
         /// The name of the pipeline.
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
         name: String,
-        /// The name of the pipeline endpoint.
-        endpoint_name: String,
+        /// The name of the table.
+        table_name: String,
+        /// The name of the connector.
+        connector_name: String,
         #[command(subcommand)]
-        action: EndpointAction,
+        action: ConnectorAction,
     },
     /// Obtains a heap profile for a pipeline.
     ///
@@ -503,7 +505,7 @@ pub enum ProgramAction {
 }
 
 #[derive(Subcommand)]
-pub enum EndpointAction {
+pub enum ConnectorAction {
     Start,
     Pause,
 }

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -901,11 +901,21 @@ async fn pipeline(action: PipelineAction, client: Client) {
             );
         }
         PipelineAction::Program { action } => program(action, client).await,
-        PipelineAction::Endpoint {
+        PipelineAction::TableConnector {
             name,
-            endpoint_name,
+            table_name,
+            connector_name,
             action,
-        } => endpoint(name, endpoint_name.as_str(), action, client).await,
+        } => {
+            table_connector(
+                name,
+                table_name.as_str(),
+                connector_name.as_str(),
+                action,
+                client,
+            )
+            .await
+        }
         PipelineAction::HeapProfile {
             name,
             pprof,
@@ -1033,44 +1043,47 @@ async fn pipeline(action: PipelineAction, client: Client) {
     }
 }
 
-async fn endpoint(
+async fn table_connector(
     pipeline_name: String,
-    endpoint_name: &str,
-    action: EndpointAction,
+    table_name: &str,
+    connector_name: &str,
+    action: ConnectorAction,
     client: Client,
 ) {
     match action {
-        EndpointAction::Start => {
+        ConnectorAction::Start => {
             client
-                .input_endpoint_action()
+                .post_pipeline_input_connector_action()
                 .pipeline_name(pipeline_name)
-                .endpoint_name(endpoint_name)
+                .table_name(table_name)
+                .connector_name(connector_name)
                 .action("start")
                 .send()
                 .await
                 .map_err(handle_errors_fatal(
                     client.baseurl,
-                    "Failed to start endpoint",
+                    "Failed to start table connector",
                     1,
                 ))
                 .unwrap();
-            println!("Endpoint {} started successfully.", endpoint_name);
+            println!("Table {table_name} connector {connector_name} started successfully.");
         }
-        EndpointAction::Pause => {
+        ConnectorAction::Pause => {
             client
-                .input_endpoint_action()
+                .post_pipeline_input_connector_action()
                 .pipeline_name(pipeline_name)
-                .endpoint_name(endpoint_name)
+                .table_name(table_name)
+                .connector_name(connector_name)
                 .action("pause")
                 .send()
                 .await
                 .map_err(handle_errors_fatal(
                     client.baseurl,
-                    "Failed to pause endpoint",
+                    "Failed to pause table connector",
                     1,
                 ))
                 .unwrap();
-            println!("Endpoint {} paused successfully.", endpoint_name);
+            println!("Table {table_name} connector {connector_name} paused successfully.");
         }
     };
 }

--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -44,6 +44,14 @@ impl SqlIdentifier {
     }
 
     /// Return the name of the identifier in canonical form.
+    /// The result is the true case-sensitive identifying name of the table,
+    /// and can be used for example to detect duplicate table names.
+    ///
+    /// Example return values for this function:
+    /// - `CREATE TABLE t1` -> `t1`
+    /// - `CREATE TABLE T1` -> `t1`
+    /// - `CREATE TABLE "t1"` -> `t1`
+    /// - `CREATE TABLE "T1"` -> `T1`
     pub fn name(&self) -> String {
         if self.case_sensitive {
             self.name.clone()
@@ -52,7 +60,16 @@ impl SqlIdentifier {
         }
     }
 
-    /// Return the name of the identifier as it would appear in SQL.
+    /// Return the name of the identifier as it appeared originally in SQL.
+    /// This method should only be used for log or error messages as it is what
+    /// the user originally wrote, however it should not be used for identification
+    /// or disambiguation (use `name()` for that instead).
+    ///
+    /// Example return values for this function:
+    /// - `CREATE TABLE t1` -> `t1`
+    /// - `CREATE TABLE T1` -> `T1`
+    /// - `CREATE TABLE "t1"` -> `"t1"`
+    /// - `CREATE TABLE "T1"` -> `"T1"`
     pub fn sql_name(&self) -> String {
         if self.case_sensitive {
             format!("\"{}\"", self.name)

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -15,9 +15,9 @@ development = ["pg-client-config"]
 
 [dependencies]
 feldera-types = { path = "../feldera-types" }
-actix-web = "4.3"
-actix-http = "3.8.0"
-actix-web-static-files = "4.0.0"
+actix-web = "4.9.0"
+actix-http = "3.9.0"
+actix-web-static-files = "4.0.1"
 actix-files = "0.6.2"
 awc = {version = "3.1.0", features = ["openssl"] } # Needed for auth workflows
 static-files = "0.2.3"
@@ -65,6 +65,7 @@ fdlimit = "0.3.0"
 termbg = "0.5.1"
 hex = "0.4.3"
 indoc = "2.0.5"
+urlencoding = "2.1.3"
 
 [features]
 integration-test = []

--- a/crates/pipeline-manager/src/api/api_key.rs
+++ b/crates/pipeline-manager/src/api/api_key.rs
@@ -1,11 +1,9 @@
 /// API to create and delete API keys
 use super::{ManagerError, ServerState};
+use crate::api::util::parse_url_parameter;
 use crate::db::types::api_key::{ApiKeyId, ApiPermission};
 use crate::db::types::tenant::TenantId;
-use crate::{
-    api::{examples, parse_string_param},
-    db::storage::Storage,
-};
+use crate::{api::examples, db::storage::Storage};
 use actix_web::{
     delete, get,
     http::header::{CacheControl, CacheDirective},
@@ -92,7 +90,7 @@ pub(crate) async fn get_api_key(
     tenant_id: ReqData<TenantId>,
     req: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    let name = parse_string_param(&req, "api_key_name")?;
+    let name = parse_url_parameter(&req, "api_key_name")?;
     let api_key = state.db.lock().await.get_api_key(*tenant_id, &name).await?;
     Ok(HttpResponse::Ok()
         .insert_header(CacheControl(vec![CacheDirective::NoCache]))
@@ -169,7 +167,7 @@ pub(crate) async fn delete_api_key(
     tenant_id: ReqData<TenantId>,
     req: HttpRequest,
 ) -> Result<HttpResponse, ManagerError> {
-    let name = parse_string_param(&req, "api_key_name")?;
+    let name = parse_url_parameter(&req, "api_key_name")?;
     let resp = state
         .db
         .lock()

--- a/crates/pipeline-manager/src/api/error.rs
+++ b/crates/pipeline-manager/src/api/error.rs
@@ -19,6 +19,7 @@ pub enum ApiError {
     InvalidChecksumParam { value: String, error: String },
     InvalidVersionParam { value: String, error: String },
     InvalidPipelineAction { action: String },
+    InvalidConnectorAction { action: String },
 }
 
 impl DetailedError for ApiError {
@@ -30,6 +31,7 @@ impl DetailedError for ApiError {
             Self::InvalidChecksumParam { .. } => Cow::from("InvalidChecksumParam"),
             Self::InvalidVersionParam { .. } => Cow::from("InvalidVersionParam"),
             Self::InvalidPipelineAction { .. } => Cow::from("InvalidPipelineAction"),
+            Self::InvalidConnectorAction { .. } => Cow::from("InvalidConnectorAction"),
         }
     }
 }
@@ -55,6 +57,12 @@ impl Display for ApiError {
             Self::InvalidPipelineAction { action } => {
                 write!(f, "Invalid pipeline action '{action}'; valid actions are: 'start', 'pause', or 'shutdown'")
             }
+            Self::InvalidConnectorAction { action } => {
+                write!(
+                    f,
+                    "Invalid connector action '{action}'; valid actions are: 'start' or 'pause'"
+                )
+            }
         }
     }
 }
@@ -76,6 +84,7 @@ impl ResponseError for ApiError {
             Self::InvalidChecksumParam { .. } => StatusCode::BAD_REQUEST,
             Self::InvalidVersionParam { .. } => StatusCode::BAD_REQUEST,
             Self::InvalidPipelineAction { .. } => StatusCode::BAD_REQUEST,
+            Self::InvalidConnectorAction { .. } => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/crates/pipeline-manager/src/api/http_io.rs
+++ b/crates/pipeline-manager/src/api/http_io.rs
@@ -7,7 +7,8 @@ use actix_web::{
 use log::debug;
 
 use crate::api::error::ApiError;
-use crate::api::{examples, parse_string_param};
+use crate::api::examples;
+use crate::api::util::parse_url_parameter;
 use crate::db::types::tenant::TenantId;
 
 use super::{ManagerError, ServerState};
@@ -84,7 +85,7 @@ async fn http_input(
     req: HttpRequest,
     body: web::Payload,
 ) -> Result<HttpResponse, ManagerError> {
-    let pipeline_name = parse_string_param(&req, "pipeline_name")?;
+    let pipeline_name = parse_url_parameter(&req, "pipeline_name")?;
     let table_name = match req.match_info().get("table_name") {
         None => {
             return Err(ManagerError::from(ApiError::MissingUrlEncodedParam {
@@ -173,7 +174,7 @@ async fn http_output(
     req: HttpRequest,
     body: web::Payload,
 ) -> Result<HttpResponse, ManagerError> {
-    let pipeline_name = parse_string_param(&req, "pipeline_name")?;
+    let pipeline_name = parse_url_parameter(&req, "pipeline_name")?;
     let table_name = match req.match_info().get("table_name") {
         None => {
             return Err(ManagerError::from(ApiError::MissingUrlEncodedParam {

--- a/crates/pipeline-manager/src/api/mod.rs
+++ b/crates/pipeline-manager/src/api/mod.rs
@@ -23,8 +23,8 @@ mod examples;
 mod http_io;
 mod metrics;
 mod pipeline;
+pub mod util;
 
-use crate::api::error::ApiError;
 use crate::auth::JwkCache;
 use crate::config::{ApiServerConfig, CommonConfig};
 use crate::db::storage_postgres::StoragePostgres;
@@ -42,7 +42,7 @@ use actix_web::{
     get,
     web::Data as WebData,
     web::{self},
-    App, HttpRequest, HttpResponse, HttpServer,
+    App, HttpResponse, HttpServer,
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
 use actix_web_static_files::ResourceFiles;
@@ -102,7 +102,7 @@ The program version is used internally by the compiler to know when to recompile
 
         // Special pipeline endpoints
         pipeline::post_pipeline_action,
-        pipeline::input_endpoint_action,
+        pipeline::post_pipeline_input_connector_action,
         pipeline::get_pipeline_logs,
         pipeline::get_pipeline_stats,
         pipeline::get_pipeline_circuit_profile,
@@ -265,7 +265,7 @@ fn api_scope() -> Scope {
         // Special pipeline endpoints
         .service(pipeline::checkpoint_pipeline)
         .service(pipeline::post_pipeline_action)
-        .service(pipeline::input_endpoint_action)
+        .service(pipeline::post_pipeline_input_connector_action)
         .service(pipeline::get_pipeline_logs)
         .service(pipeline::get_pipeline_stats)
         .service(pipeline::get_pipeline_circuit_profile)
@@ -306,24 +306,6 @@ impl Modify for SecurityAddon {
                 ),
             )
         }
-    }
-}
-
-pub(crate) fn parse_string_param(
-    req: &HttpRequest,
-    param_name: &'static str,
-) -> Result<String, ManagerError> {
-    match req.match_info().get(param_name) {
-        None => Err(ManagerError::from(ApiError::MissingUrlEncodedParam {
-            param: param_name,
-        })),
-        Some(id) => match id.parse::<String>() {
-            Err(e) => Err(ManagerError::from(ApiError::InvalidNameParam {
-                value: id.to_string(),
-                error: e.to_string(),
-            })),
-            Ok(id) => Ok(id),
-        },
     }
 }
 

--- a/crates/pipeline-manager/src/api/util.rs
+++ b/crates/pipeline-manager/src/api/util.rs
@@ -1,0 +1,18 @@
+use crate::api::error::ApiError;
+use crate::error::ManagerError;
+use actix_web::HttpRequest;
+
+/// Parses a named parameter from the URL of the request.
+/// For example, a request "GET /examples/{example}" would have an "example" parameter.
+/// Returns an error if the parameter is not found.
+pub(crate) fn parse_url_parameter(
+    req: &HttpRequest,
+    param_name: &'static str,
+) -> Result<String, ManagerError> {
+    match req.match_info().get(param_name) {
+        None => Err(ManagerError::from(ApiError::MissingUrlEncodedParam {
+            param: param_name,
+        })),
+        Some(value) => Ok(value.to_string()),
+    }
+}

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -388,7 +388,7 @@ fn convert_connectors_with_unique_names(
     let mut unique_names = vec![];
     for (stream, connector_name, _, origin_value) in &connectors {
         if let Some(name) = connector_name {
-            let unique_name = format!("{stream}.{name}");
+            let unique_name = format!("{}.{name}", SqlIdentifier::from(&stream).name());
             if unique_names.contains(&Some(unique_name.clone())) {
                 return Err(ConnectorGenerationError::RelationConnectorNameCollision {
                     position: origin_value.value_position,
@@ -410,7 +410,11 @@ fn convert_connectors_with_unique_names(
             // Try several times to generate a unique name which is not extremely long
             let mut found = None;
             for _retry in 0..20 {
-                let unique_name = format!("{}.{}", &stream, generate_random_name());
+                let unique_name = format!(
+                    "{}.{}",
+                    SqlIdentifier::from(&stream).name(),
+                    generate_random_name()
+                );
                 if !unique_names.contains(&Some(unique_name.clone())) {
                     found = Some(unique_name);
                     break;

--- a/crates/pipeline-manager/src/runner/main.rs
+++ b/crates/pipeline-manager/src/runner/main.rs
@@ -1,5 +1,5 @@
 use crate::api::error::ApiError;
-use crate::api::parse_string_param;
+use crate::api::util::parse_url_parameter;
 use crate::config::CommonConfig;
 use crate::db::storage_postgres::StoragePostgres;
 use crate::db::types::pipeline::PipelineId;
@@ -102,7 +102,7 @@ async fn get_logs(
     req: HttpRequest,
 ) -> Result<impl Responder, ManagerError> {
     // Parse pipeline identifier
-    let pipeline_id = parse_string_param(&req, "pipeline_id")?;
+    let pipeline_id = parse_url_parameter(&req, "pipeline_id")?;
     let pipeline_id = PipelineId(Uuid::from_str(&pipeline_id).map_err(|e| {
         ManagerError::from(ApiError::InvalidUuidParam {
             value: pipeline_id.clone(),

--- a/demo/project_demo06-SupplyChainTutorial/run.py
+++ b/demo/project_demo06-SupplyChainTutorial/run.py
@@ -214,7 +214,7 @@ def main():
             time.sleep(1)
         print("Starting the 'tutorial-price-redpanda' connector")
         requests.post(
-            f"{api_url}/v0/pipelines/{pipeline_name}/input_endpoints/price.tutorial-price-redpanda/start"
+            f"{api_url}/v0/pipelines/{pipeline_name}/tables/price/connectors/tutorial-price-redpanda/start"
         ).raise_for_status()
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -1608,65 +1608,6 @@
         ]
       }
     },
-    "/v0/pipelines/{pipeline_name}/input_endpoints/{endpoint_name}/{action}": {
-      "post": {
-        "tags": [
-          "Pipelines"
-        ],
-        "summary": "Change the desired state of an input endpoint.",
-        "description": "The following values of the `action` argument are accepted by this endpoint:\n\n- 'start': Start processing data.\n- 'pause': Pause the pipeline.",
-        "operationId": "input_endpoint_action",
-        "parameters": [
-          {
-            "name": "pipeline_name",
-            "in": "path",
-            "description": "Unique pipeline name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "endpoint_name",
-            "in": "path",
-            "description": "Input endpoint name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "action",
-            "in": "path",
-            "description": "Endpoint action [start, pause]",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Request accepted."
-          },
-          "404": {
-            "description": "Specified endpoint does not exist.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "JSON web token (JWT) or API key": []
-          }
-        ]
-      }
-    },
     "/v0/pipelines/{pipeline_name}/logs": {
       "get": {
         "tags": [
@@ -1894,6 +1835,74 @@
                   },
                   "error_code": "UnknownPipeline",
                   "message": "Unknown pipeline id '2e79afe1-ff4d-44d3-af5f-9397de7746c0'"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
+    "/v0/pipelines/{pipeline_name}/tables/{table_name}/connectors/{connector_name}/{action}": {
+      "post": {
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Start (resume) or pause the input connector.",
+        "description": "The following values of the `action` argument are accepted: `start` and `pause`.\n\nInput connectors can be in either the `Running` or `Paused` state. By default,\nconnectors are initialized in the `Running` state when a pipeline is deployed.\nIn this state, the connector actively fetches data from its configured data\nsource and forwards it to the pipeline. If needed, a connector can be created\nin the `Paused` state by setting its\n[`paused`](https://docs.feldera.com/connectors/#generic-attributes) property\nto `true`. When paused, the connector remains idle until reactivated using the\n`start` command. Conversely, a connector in the `Running` state can be paused\nat any time by issuing the `pause` command.\n\nThe current connector state can be retrieved via the\n`GET /v0/pipelines/{pipeline_name}/stats` endpoint.\n\nNote that only if both the pipeline *and* the connector state is `Running`,\nis the input connector active.\n```text\nPipeline state    Connector state    Connector is active?\n--------------    ---------------    --------------------\nPaused            Paused             No\nPaused            Running            No\nRunning           Paused             No\nRunning           Running            Yes\n```",
+        "operationId": "post_pipeline_input_connector_action",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "table_name",
+            "in": "path",
+            "description": "Unique table name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "connector_name",
+            "in": "path",
+            "description": "Unique input connector name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "description": "Input connector action (one of: start, pause)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Action has been processed"
+          },
+          "404": {
+            "description": "Input connector with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
Restructures the API endpoint for starting (resuming) and pausing connectors.

Instead of requiring endpoint name (previous):

```
POST /v0/pipelines/{pipeline_name}/input_endpoints/{endpoint_name}/{action}
```

It now requires table and (input) connector name (new):

```
POST /v0/pipelines/{pipeline_name}/tables/{table_name}/connectors/{connector_name}/{action}
```

This is more user-friendly, as endpoints are not a user-facing concept. Case-(in)sensitivity and special characters are now handled by using URL encoding. Integration tests for orchestration are added.

The CLI tool `fda` has its `endpoint` subcommand replaced with the `table-connector` subcommand.

**Remaining:**
- [x] The syntax needs to be updated for `fda` (done by @snkas)

**Future PRs:**
- Add support for connector orchestration to the Python SDK (https://github.com/feldera/feldera/issues/3127)
- Add a section on connector orchestration to https://docs.feldera.com/connectors/ (https://github.com/feldera/feldera/issues/3131)