### PR TITLE
Fixes 2 bugs found by Sqlancer and 1 bug found by SLT

### DIFF
--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -877,38 +877,53 @@ pub fn wrap_bool(b: Option<bool>) -> bool {
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn or_b_b(left: bool, right: bool) -> bool {
-    left || right
+pub fn or_b_b<F>(left: bool, right: F) -> bool
+where
+    F: Fn() -> bool,
+{
+    left || right()
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn or_bN_b(left: Option<bool>, right: bool) -> Option<bool> {
-    match (left, right) {
-        (Some(l), r) => Some(l || r),
-        (_, true) => Some(true),
-        (_, _) => None::<bool>,
+pub fn or_bN_b<F>(left: Option<bool>, right: F) -> Option<bool>
+where
+    F: Fn() -> bool,
+{
+    match left {
+        Some(l) => Some(l || right()),
+        None => match right() {
+            true => Some(true),
+            _ => None,
+        },
     }
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn or_b_bN(left: bool, right: Option<bool>) -> Option<bool> {
-    match (left, right) {
-        (l, Some(r)) => Some(l || r),
-        (true, _) => Some(true),
-        (_, _) => None::<bool>,
+pub fn or_b_bN<F>(left: bool, right: F) -> Option<bool>
+where
+    F: Fn() -> Option<bool>,
+{
+    match left {
+        false => right(),
+        true => Some(true),
     }
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn or_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool> {
-    match (left, right) {
-        (Some(l), Some(r)) => Some(l || r),
-        (Some(true), _) => Some(true),
-        (_, Some(true)) => Some(true),
-        (_, _) => None::<bool>,
+pub fn or_bN_bN<F>(left: Option<bool>, right: F) -> Option<bool>
+where
+    F: Fn() -> Option<bool>,
+{
+    match left {
+        None => match right() {
+            Some(true) => Some(true),
+            _ => None,
+        },
+        Some(false) => right(),
+        Some(true) => Some(true),
     }
 }
 
@@ -916,38 +931,54 @@ pub fn or_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool> {
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn and_b_b(left: bool, right: bool) -> bool {
-    left && right
+pub fn and_b_b<F>(left: bool, right: F) -> bool
+where
+    F: Fn() -> bool,
+{
+    left && right()
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn and_bN_b(left: Option<bool>, right: bool) -> Option<bool> {
-    match (left, right) {
-        (Some(l), r) => Some(l && r),
-        (_, false) => Some(false),
-        (_, _) => None::<bool>,
+pub fn and_bN_b<F>(left: Option<bool>, right: F) -> Option<bool>
+where
+    F: Fn() -> bool,
+{
+    match left {
+        Some(false) => Some(false),
+        Some(true) => Some(right()),
+        None => match right() {
+            false => Some(false),
+            _ => None,
+        },
     }
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn and_b_bN(left: bool, right: Option<bool>) -> Option<bool> {
-    match (left, right) {
-        (l, Some(r)) => Some(l && r),
-        (false, _) => Some(false),
-        (_, _) => None::<bool>,
+pub fn and_b_bN<F>(left: bool, right: F) -> Option<bool>
+where
+    F: Fn() -> Option<bool>,
+{
+    match left {
+        false => Some(false),
+        true => right(),
     }
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn and_bN_bN(left: Option<bool>, right: Option<bool>) -> Option<bool> {
-    match (left, right) {
-        (Some(l), Some(r)) => Some(l && r),
-        (Some(false), _) => Some(false),
-        (_, Some(false)) => Some(false),
-        (_, _) => None::<bool>,
+pub fn and_bN_bN<F>(left: Option<bool>, right: F) -> Option<bool>
+where
+    F: Fn() -> Option<bool>,
+{
+    match left {
+        Some(false) => Some(false),
+        Some(true) => right(),
+        None => match right() {
+            Some(false) => Some(false),
+            _ => None,
+        },
     }
 }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -930,6 +930,22 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 this.builder.append(")");
                 break;
             }
+            case OR:
+            case AND: {
+                String function = RustSqlRuntimeLibrary.INSTANCE.getFunctionName(
+                        expression.getNode(),
+                        expression.opcode,
+                        expression.getType(),
+                        expression.left.getType(),
+                        expression.right.getType());
+                this.builder.append(function).append("(");
+                expression.left.accept(this);
+                // lazy in the right argument, make it a closure
+                this.builder.append(", || (");
+                expression.right.accept(this);
+                this.builder.append("))");
+                break;
+            }
             default: {
                 String function = RustSqlRuntimeLibrary.INSTANCE.getFunctionName(
                         expression.getNode(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -362,10 +362,10 @@ public class ToRustVisitor extends CircuitVisitor {
     }
 
     void generateOperator(DBSPOperator operator) {
-        /*
-        String str = operator.getNode().toInternalString();
-        this.writeComments(str);
-         */
+        if (this.compiler.options.ioOptions.verbosity > 0) {
+            String str = operator.getNode().toInternalString();
+            this.writeComments(str);
+        }
         operator.accept(this);
         this.builder.newline();
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -324,8 +324,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     return left.withMayBeNull(anyNull);
             }
             if (rd != null) {
-                // FLOAT op DECIMAL, convert to FLOAT
-                return lf;
+                // FLOAT op DECIMAL, convert to DOUBLE
+                return new DBSPTypeDouble(left.getNode(), anyNull);
             }
         }
         if (ld != null) {
@@ -335,8 +335,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         Math.max(ln.getPrecision(), rn.getPrecision()), ld.scale, anyNull);
             }
             if (rf != null) {
-                // DECIMAL op FLOAT, convert to FLOAT
-                return rf;
+                // DECIMAL op FLOAT, convert to DOUBLE
+                return new DBSPTypeDouble(right.getNode(), anyNull);
             }
             // DECIMAL op DECIMAL does not convert to a common type.
         }
@@ -441,6 +441,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     opcode == DBSPOpcode.SUB || opcode == DBSPOpcode.MUL) {
                 // Use the inferred Calcite type for the output as the common type
                 commonBase = typeWithNull;
+                expressionResultType = commonBase;
             }
             if (opcode.isComparison()) {
                 expressionResultType = DBSPTypeBool.create(anyNull);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MinMaxOptimize.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MinMaxOptimize.java
@@ -124,13 +124,14 @@ public class MinMaxOptimize extends Passes {
 
             DBSPVariablePath inputVar = new DBSPTypeTuple(aggregationInputType).ref().var();
             DBSPClosureExpression init = new DBSPTupleExpression(
-                    inputVar.deref().field(0).cast(resultType))
+                    inputVar.deref().field(0).applyCloneIfNeeded().cast(resultType))
                     .closure(inputVar, this.weightVar);
 
             DBSPVariablePath acc = new DBSPTypeTuple(resultType).var();
             DBSPClosureExpression comparison =
                     new DBSPTupleExpression(new DBSPBinaryExpression(operator.getNode(),
-                            resultType, code, acc.field(0), inputVar.deref().field(0))
+                            resultType, code, acc.field(0).applyCloneIfNeeded(),
+                            inputVar.deref().field(0).applyCloneIfNeeded())
                             .cast(resultType))
                             .closure(acc, inputVar, this.weightVar);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -1159,4 +1159,19 @@ public class RegressionTests extends SqlIoTest {
         visitor.apply(circuit);
         this.compileRustTestCase(sql);
     }
+
+    @Test
+    public void issue3093() {
+        this.compileRustTestCase("""
+                CREATE TABLE t1(c0 REAL);
+                CREATE VIEW v0 AS
+                SELECT t1.c0 + 0.42331, t1.c0 * 0.42331, .42331 * t1.c0 FROM t1;""");
+    }
+
+    @Test
+    public void issue3094() {
+        this.compileRustTestCase("""
+                CREATE TABLE t1(c0 REAL, c1 VARCHAR, c2 CHAR);
+                CREATE VIEW v2_optimized AS SELECT MIN(t1.c1) FROM t1 WHERE (1 IS NOT DISTINCT FROM 2);""");
+    }
 }

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -596,6 +596,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                 compilerOptions.languageOptions.throwOnError = options.stopAtFirstError;
                 compilerOptions.languageOptions.lenient = true;
                 compilerOptions.languageOptions.generateInputForEveryTable = true;
+                compilerOptions.ioOptions.verbosity = options.verbosity;
                 DBSPExecutor result = new DBSPExecutor(options, compilerOptions);
                 result.skip(skip.get());
                 Set<String> bugs = options.readBugsFile();


### PR DESCRIPTION
There are separate commits.
Fixes #3093 
Fixes #3094 
The SLT bug is interesting: it is caused by a multiplication that produces an overflow. The multiplication is in a NOT BETWEEN statement. Postgres and sqlite convert the NOT BETWEEN to an OR, which evaluates lazily the right input. The SQL standard does *not* mandate lazy evaluation for OR or BETWEEN, but it does not prohibit it either. So this choice essentially will make fewer programs fail at runtime.