### PR TITLE
[adapters] Optimize loading delta tables with lateness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -316,8 +316,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -354,8 +354,8 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -883,7 +883,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1030,8 +1030,8 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -1047,8 +1047,8 @@ version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -2034,8 +2034,8 @@ dependencies = [
  "lazycell",
  "log",
  "prettyplease",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
@@ -2062,8 +2062,8 @@ checksum = "cb515fdd6f8d3a357c8e19b8ec59ef53880807864329b1cb1cba5c53bf76557e"
 dependencies = [
  "either",
  "owo-colors",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2168,8 +2168,8 @@ checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
  "syn_derive",
 ]
@@ -2242,8 +2242,8 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2268,8 +2268,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -2377,7 +2377,7 @@ checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.13.4",
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2389,8 +2389,8 @@ checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.14.4",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2609,8 +2609,8 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2621,8 +2621,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -3012,7 +3012,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3060,8 +3060,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -3074,8 +3074,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -3088,8 +3088,8 @@ checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "strsim 0.11.1",
  "syn 2.0.90",
 ]
@@ -3101,7 +3101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3112,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3123,7 +3123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
- "quote 1.0.37",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -3662,7 +3662,7 @@ dependencies = [
  "pretty_assertions",
  "priority-queue",
  "proptest",
- "proptest-derive 0.5.0",
+ "proptest-derive",
  "proptest-state-machine",
  "ptr_meta 0.2.0",
  "rand",
@@ -3756,8 +3756,7 @@ dependencies = [
  "parquet",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.3.0",
- "proptest-derive 0.5.0",
+ "proptest-derive",
  "psutil",
  "rand",
  "rdkafka",
@@ -3912,8 +3911,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fe89c064f509a4a00c00c895af4b966e4b592e7ddf6a476eae856a9b883623"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -4087,8 +4086,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -4099,8 +4098,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 2.0.90",
 ]
@@ -4120,10 +4119,10 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
- "unicode-xid 0.2.6",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4205,8 +4204,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -4275,8 +4274,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4342,8 +4341,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -4355,8 +4354,8 @@ checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint",
  "num-traits",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -4655,7 +4654,7 @@ dependencies = [
  "libc",
  "log",
  "proptest",
- "proptest-derive 0.5.0",
+ "proptest-derive",
  "rust_decimal_macros",
  "serde",
  "serde_json",
@@ -4728,8 +4727,8 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8f0de9daf465d763422866d0538f07be1596e05623e120b37b4f715f5585200"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4886,8 +4885,8 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -5622,8 +5621,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6270,8 +6269,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14efd4b574325fcb981bce1ac700b9ccf071ec2eb94f7a6a6b583a84f228ba47"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6335,8 +6334,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -6479,8 +6478,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -6570,8 +6569,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6582,8 +6581,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate 3.2.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -6677,8 +6676,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -6836,9 +6835,9 @@ checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.12.1",
- "proc-macro2 1.0.92",
+ "proc-macro2",
  "proc-macro2-diagnostics",
- "quote 1.0.37",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -7114,8 +7113,8 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -7170,7 +7169,7 @@ dependencies = [
  "pg-embed",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.5.0",
+ "proptest-derive",
  "rand",
  "refinery",
  "regex",
@@ -7389,7 +7388,7 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
- "proc-macro2 1.0.92",
+ "proc-macro2",
  "syn 2.0.90",
 ]
 
@@ -7429,8 +7428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7441,18 +7440,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -7470,8 +7460,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
  "version_check",
  "yansi",
@@ -7515,8 +7505,8 @@ dependencies = [
  "http 0.2.12",
  "indexmap 2.6.0",
  "openapiv3",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "regex",
  "schemars",
  "serde",
@@ -7534,9 +7524,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6243da5bffaaef639c32a8a1d630625131c7b0afd8f82b9151c733366676f0ed"
 dependencies = [
  "openapiv3",
- "proc-macro2 1.0.92",
+ "proc-macro2",
  "progenitor-impl",
- "quote 1.0.37",
+ "quote",
  "schemars",
  "serde",
  "serde_json",
@@ -7567,23 +7557,12 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -7624,8 +7603,8 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7637,8 +7616,8 @@ checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -7694,8 +7673,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7705,8 +7684,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7806,20 +7785,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
- "proc-macro2 1.0.92",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -8044,8 +8014,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd81f69687fe8a1fa10995108b3ffc7cdbd63e682a4f8fbfd1020130780d7e17"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "refinery-core",
  "regex",
  "syn 2.0.90",
@@ -8284,8 +8254,8 @@ version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8384,8 +8354,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -8416,8 +8386,8 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "rust-embed-utils",
  "syn 2.0.90",
  "walkdir",
@@ -8459,7 +8429,7 @@ version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "rust_decimal",
 ]
 
@@ -8735,8 +8705,8 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "serde_derive_internals",
  "syn 2.0.90",
 ]
@@ -8861,8 +8831,8 @@ version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -8872,8 +8842,8 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -8904,8 +8874,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "serde",
  "syn 2.0.90",
 ]
@@ -8947,8 +8917,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.10",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -8999,8 +8969,8 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9010,8 +8980,8 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9138,8 +9108,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9195,8 +9165,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9266,8 +9236,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9339,8 +9309,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 2.0.90",
 ]
@@ -9376,23 +9346,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -9402,8 +9361,8 @@ version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -9414,8 +9373,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9475,8 +9434,8 @@ checksum = "bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9527,8 +9486,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -9629,8 +9588,8 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9640,8 +9599,8 @@ version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -9786,8 +9745,8 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -10064,8 +10023,8 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -10118,7 +10077,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -10153,8 +10112,8 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -10191,8 +10150,8 @@ checksum = "93bbb24e990654aff858d80fee8114f4322f7d7a1b1ecb45129e2fcb0d0ad5ae"
 dependencies = [
  "heck 0.5.0",
  "log",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "regress",
  "schemars",
  "semver",
@@ -10209,8 +10168,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e6491896e955692d68361c68db2b263e3bec317ec0b684e0e2fa882fb6e31e"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "schemars",
  "semver",
  "serde",
@@ -10288,12 +10247,6 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
@@ -10367,8 +10320,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "regex",
  "syn 2.0.90",
  "uuid",
@@ -10438,8 +10391,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 
@@ -10466,8 +10419,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -10530,8 +10483,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
@@ -10554,7 +10507,7 @@ version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
- "quote 1.0.37",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -10564,8 +10517,8 @@ version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -10991,8 +10944,8 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.92",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.90",
 ]
 

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -57,8 +57,8 @@ log = "0.4.20"
 size-of = { version = "0.1.5", package = "feldera-size-of", features = ["time-std", "ordered-float"], optional = true }
 futures = { version = "0.3.28" }
 futures-util = { version = "0.3.28" }
-proptest = { version = "1.0.0", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
+proptest = { version = "1.5.0", optional = true }
+proptest-derive = { version = "0.5.0", optional = true }
 env_logger = "0.10.0"
 clap = { version = "4.0.32", features = ["derive"] }
 tokio = { version = "1.25.0", features = ["sync", "macros", "fs", "rt"] }

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -238,7 +238,8 @@ impl Arbitrary for TestStruct2 {
             i64::arbitrary(),
             String::arbitrary(),
             bool::arbitrary(),
-            u32::arbitrary(),
+            // Generate timestamps within a 1-year range
+            1704070800u32..1735693200,
             0u32..100_000,
             // (0u64..24 * 60 * 60 * 1_000_000),
             EmbeddedStruct::arbitrary_with(()),
@@ -369,6 +370,27 @@ impl TestStruct2 {
                 ColumnType::map(false, ColumnType::varchar(false), ColumnType::bigint(false)),
             ),
         ]
+    }
+
+    pub fn schema_with_lateness() -> Vec<Field> {
+        let mut fields = vec![
+            Field::new("id".into(), ColumnType::bigint(false)).with_lateness("1000"),
+            Field::new("name".into(), ColumnType::varchar(true)),
+            Field::new("b".into(), ColumnType::boolean(false)),
+            Field::new("ts".into(), ColumnType::timestamp(false))
+                .with_lateness("interval '10 days'"),
+            Field::new("dt".into(), ColumnType::date(false)),
+            Field::new(
+                "es".into(),
+                ColumnType::structure(false, &[Field::new("a".into(), ColumnType::boolean(false))]),
+            ),
+            Field::new(
+                "m".into(),
+                ColumnType::map(false, ColumnType::varchar(false), ColumnType::bigint(false)),
+            ),
+        ];
+
+        fields
     }
 
     pub fn relation_schema() -> Relation {

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -5,7 +5,7 @@ use arrow::array::{
 use arrow::datatypes::{DataType, Schema, TimeUnit};
 use dbsp::utils::Tup2;
 use feldera_sqllib::{Date, Timestamp};
-use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier, SqlType};
+use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
 use feldera_types::{
     deserialize_table_record, deserialize_without_context, serialize_struct, serialize_table_record,
 };
@@ -51,58 +51,10 @@ impl TestStruct {
     }
     pub fn schema() -> Vec<Field> {
         vec![
-            Field {
-                name: "id".into(),
-                columntype: ColumnType {
-                    typ: SqlType::BigInt,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "b".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Boolean,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "i".into(),
-                columntype: ColumnType {
-                    typ: SqlType::BigInt,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "s".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
+            Field::new("id".into(), ColumnType::bigint(false)),
+            Field::new("b".into(), ColumnType::boolean(false)),
+            Field::new("i".into(), ColumnType::bigint(true)),
+            Field::new("s".into(), ColumnType::varchar(false)),
         ]
     }
 
@@ -403,120 +355,19 @@ impl TestStruct2 {
 
     pub fn schema() -> Vec<Field> {
         vec![
-            Field {
-                name: "id".into(),
-                columntype: ColumnType {
-                    typ: SqlType::BigInt,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "name".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "b".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Boolean,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "ts".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Timestamp,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "dt".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Date,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            /*Field {
-                name: "t".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Time,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                },
-            },*/
-            Field {
-                name: "es".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Struct,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: Some(vec![Field {
-                        name: "a".into(),
-                        columntype: ColumnType {
-                            typ: SqlType::Boolean,
-                            nullable: false,
-                            precision: None,
-                            scale: None,
-                            component: None,
-                            fields: None,
-                            key: None,
-                            value: None,
-                        },
-                    }]),
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "m".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Map,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: Some(Box::new(ColumnType::varchar(false))),
-                    value: Some(Box::new(ColumnType::bigint(false))),
-                },
-            },
+            Field::new("id".into(), ColumnType::bigint(false)),
+            Field::new("name".into(), ColumnType::varchar(true)),
+            Field::new("b".into(), ColumnType::boolean(false)),
+            Field::new("ts".into(), ColumnType::timestamp(false)),
+            Field::new("dt".into(), ColumnType::date(false)),
+            Field::new(
+                "es".into(),
+                ColumnType::structure(false, &[Field::new("a".into(), ColumnType::boolean(false))]),
+            ),
+            Field::new(
+                "m".into(),
+                ColumnType::map(false, ColumnType::varchar(false), ColumnType::bigint(false)),
+            ),
         ]
     }
 
@@ -642,110 +493,14 @@ pub struct DatabricksPeople {
 impl DatabricksPeople {
     pub fn schema() -> Vec<Field> {
         vec![
-            Field {
-                name: "id".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Int,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "firstName".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "middleName".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "lastName".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "gender".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "birthDate".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Timestamp,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "ssn".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Varchar,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "salary".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Int,
-                    nullable: true,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
+            Field::new("id".into(), ColumnType::int(false)),
+            Field::new("firstName".into(), ColumnType::varchar(true)),
+            Field::new("middleName".into(), ColumnType::varchar(true)),
+            Field::new("lastName".into(), ColumnType::varchar(true)),
+            Field::new("gender".into(), ColumnType::varchar(true)),
+            Field::new("birthDate".into(), ColumnType::timestamp(true)),
+            Field::new("ssn".into(), ColumnType::varchar(true)),
+            Field::new("salary".into(), ColumnType::int(true)),
         ]
     }
 }

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -373,7 +373,7 @@ impl TestStruct2 {
     }
 
     pub fn schema_with_lateness() -> Vec<Field> {
-        let mut fields = vec![
+        let fields = vec![
             Field::new("id".into(), ColumnType::bigint(false)).with_lateness("1000"),
             Field::new("name".into(), ColumnType::varchar(true)),
             Field::new("b".into(), ColumnType::boolean(false)),

--- a/crates/adapters/src/test/datagen.rs
+++ b/crates/adapters/src/test/datagen.rs
@@ -6,7 +6,7 @@ use dbsp::algebra::F64;
 use feldera_sqllib::binary::ByteArray;
 use feldera_sqllib::{Date, Time, Timestamp};
 use feldera_types::config::{InputEndpointConfig, TransportConfig};
-use feldera_types::program_schema::{ColumnType, Field, Relation, SqlType};
+use feldera_types::program_schema::{ColumnType, Field, Relation};
 use feldera_types::serde_with_context::{DeserializeWithContext, SqlSerdeConfig};
 use feldera_types::transport::datagen::GenerationPlan;
 use feldera_types::{deserialize_table_record, serialize_table_record};
@@ -40,19 +40,7 @@ struct ByteStruct {
 
 impl ByteStruct {
     pub fn schema() -> Vec<Field> {
-        vec![Field {
-            name: "bs".into(),
-            columntype: ColumnType {
-                typ: SqlType::Varbinary,
-                nullable: false,
-                precision: None,
-                scale: None,
-                component: None,
-                fields: None,
-                key: None,
-                value: None,
-            },
-        }]
+        vec![Field::new("bs".into(), ColumnType::varbinary(false))]
     }
 }
 serialize_table_record!(ByteStruct[1]{
@@ -87,19 +75,7 @@ struct RealStruct {
 
 impl RealStruct {
     pub fn schema() -> Vec<Field> {
-        vec![Field {
-            name: "double".into(),
-            columntype: ColumnType {
-                typ: SqlType::Double,
-                nullable: false,
-                precision: None,
-                scale: None,
-                component: None,
-                fields: None,
-                key: None,
-                value: None,
-            },
-        }]
+        vec![Field::new("double".into(), ColumnType::double(false))]
     }
 }
 serialize_table_record!(RealStruct[1]{
@@ -608,45 +584,9 @@ struct TimeStuff {
 impl TimeStuff {
     pub fn schema() -> Vec<Field> {
         vec![
-            Field {
-                name: "ts".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Timestamp,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "dt".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Date,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
-            Field {
-                name: "\"t\"".into(),
-                columntype: ColumnType {
-                    typ: SqlType::Time,
-                    nullable: false,
-                    precision: None,
-                    scale: None,
-                    component: None,
-                    fields: None,
-                    key: None,
-                    value: None,
-                },
-            },
+            Field::new("ts".into(), ColumnType::timestamp(false)),
+            Field::new("dt".into(), ColumnType::date(false)),
+            Field::new("\"t\"".into(), ColumnType::time(false)),
         ]
     }
 }

--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -978,6 +978,9 @@ impl<'a> RecordGenerator<'a> {
             let arr_field = Field {
                 name: SqlIdentifier::from("array_element"),
                 columntype,
+                lateness: None,
+                watermark: None,
+                default: None,
             };
 
             if let Some(nl) = Self::maybe_null(field, settings, rng) {

--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -240,6 +240,11 @@ impl Field {
             watermark: None,
         }
     }
+
+    pub fn with_lateness(mut self, lateness: &str) -> Self {
+        self.lateness = Some(lateness.to_string());
+        self
+    }
 }
 
 /// Thanks to the brain-dead Calcite schema, if we are deserializing a field, the type options

--- a/crates/feldera-types/src/transport/delta_table.rs
+++ b/crates/feldera-types/src/transport/delta_table.rs
@@ -83,17 +83,28 @@ pub struct DeltaTableReaderConfig {
 
     /// Table column that serves as an event timestamp.
     ///
-    ///
     /// When this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,
-    /// the snapshot of the table is ingested in the timestamp order.  This setting is required
-    /// for tables declared with the
-    /// [`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions) attribute
-    /// in Feldera SQL. It impacts the performance of the connector, since data must be sorted
-    /// before pushing it to the pipeline; therefore it is not recommended to use this
-    /// settings for tables without `LATENESS`.
-    // TODO: The above semantics is expensive and unnecessary.  What is really needed is to maintain
-    // the `LATENESS` guarantee of the column, for which it is sufficient to ingest rows sorted up
-    // to lateness by issuing a series of queries for lateness-width time ranges to the table.
+    /// table rows are ingested in the timestamp order, respecting the
+    /// [`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions)
+    /// property of the column: each ingested row has a timestamp no more than `LATENESS`
+    /// time units earlier than the most recent timestamp of any previously ingested row.
+    /// The ingestion is performed by partitioning the table into timestamp ranges of width
+    /// `LATENESS`. Each range is processed sequentially, in increasing timestamp order.
+    ///
+    /// # Example
+    ///
+    /// Consider a table with timestamp column of type `TIMESTAMP` and lateness attribute
+    /// `INTERVAL 1 DAY`. Assuming that the oldest timestamp in the table is
+    /// `2024-01-01T00:00:00``, the connector will fetch all records with timestamps
+    /// from `2024-01-01`, then all records for `2024-01-02`, `2024-01-03`, etc., until all records
+    /// in the table have been ingested.
+    ///
+    /// # Requirements
+    ///
+    /// * The timestamp column must be of a supported type: integer, `DATE`, or `TIMESTAMP`.
+    /// * The timestamp column must be declared with non-zero `LATENESS`.
+    /// * For efficient ingest, the table must be optimized for timestamp-based
+    ///   queries using partitioning, Z-ordering, or liquid clustering.
     pub timestamp_column: Option<String>,
 
     /// Optional row filter.
@@ -105,7 +116,7 @@ pub struct DeltaTableReaderConfig {
     /// the `where` clause of the `select * from snapshot where ...` query.
     ///
     /// This option can be used to specify the range of event times to include in the snapshot,
-    /// e.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.
+    /// e.g.: `ts BETWEEN TIMESTAMP '2005-01-01 00:00:00' AND TIMESTAMP '2010-12-31 23:59:59'`.
     pub snapshot_filter: Option<String>,
 
     /// Optional table version.

--- a/demo/project_demo10-FraudDetectionDeltaLake/notebook.ipynb
+++ b/demo/project_demo10-FraudDetectionDeltaLake/notebook.ipynb
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "e6724c8f",
    "metadata": {},
    "outputs": [],
@@ -102,7 +102,7 @@
     "        category STRING,\n",
     "        amt DOUBLE,\n",
     "        trans_num STRING,\n",
-    "        unix_time BIGINT,\n",
+    "        unix_time BIGINT LATENESS 3600 * 24 * 30,\n",
     "        merch_lat DOUBLE,\n",
     "        merch_long DOUBLE,\n",
     "        is_fraud BIGINT\n",
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "16e0d435",
    "metadata": {},
    "outputs": [],
@@ -251,22 +251,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "17619d5d",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'feldera'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[3], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mpandas\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mpd\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mjson\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mfeldera\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m PipelineBuilder, FelderaClient\n\u001b[1;32m      5\u001b[0m DATA_URI \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124ms3://feldera-fraud-detection-data\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      7\u001b[0m \u001b[38;5;66;03m# Load DEMOGRAPHICS data from a Delta table stored in an S3 bucket.\u001b[39;00m\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'feldera'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "from feldera import PipelineBuilder, FelderaClient\n",
@@ -519,9 +507,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
-   "name": "python3"
+   "name": "venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -533,7 +521,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/demo/project_demo10-FraudDetectionDeltaLake/run.py
+++ b/demo/project_demo10-FraudDetectionDeltaLake/run.py
@@ -273,7 +273,7 @@ def build_program(
         category STRING,
         amt DOUBLE,
         trans_num STRING,
-        unix_time BIGINT,
+        unix_time BIGINT LATENESS 3600 * 24 * 30,
         merch_lat DOUBLE,
         merch_long DOUBLE,
         is_fraud BIGINT

--- a/docs/connectors/sources/delta.md
+++ b/docs/connectors/sources/delta.md
@@ -15,61 +15,20 @@ tolerance](..#fault-tolerance).
 
 ## Delta Lake input connector configuration
 
-### Required parameters
+| Property                    | Type   | Default    | Description   |
+|-----------------------------|--------|------------|---------------|
+| `uri`*                      | string |            | Table URI, e.g., "s3://feldera-fraud-detection-data/demographics_train"|
+| `mode`*                     | enum   |            | Table read mode. Three options are available: <ul> <li>`snapshot` - read a snapshot of the table and stop.</li> <li>`follow` - follow the changelog of the table, only ingesting changes (new and deleted rows)</li> <li>`snapshot_and_follow` - Read a snapshot of the table before switching to the `follow` mode.  This mode implements the backfill pattern where we load historical data for the table before ingesting the stream of real-time updates.</li> </ul>|
+| `timestamp_column`          | string |            | Table column that serves as an event timestamp. When this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`, table rows are ingested in the timestamp order, respecting the [`LATENESS`](/sql/streaming#lateness-expressions) property of the column: each ingested row has a timestamp no more than `LATENESS` time units earlier than the most recent timestamp of any previously ingested row.  See details [below](#ingesting-time-series-data-from-a-delta-lake). |
+| `snapshot_filter`           | string |            | <p>Optional row filter.  This option is only valid when `mode` is set to `snapshot` or `snapshot_and_follow`.  When specified, only rows that satisfy the filter condition are included in the snapshot.  The condition must be a valid SQL Boolean expression that can be used in the `where` clause of the `select * from snapshot where ..` query.</p><p> This option can be used to specify the range of event times to include in the snapshot, e.g.: `ts BETWEEN TIMESTAMP '2005-01-01 00:00:00' AND TIMESTAMP '2010-12-31 23:59:59'`.</p>
+| `version`                   | integer|            | <p>Optional table version.  When this option is set, the connector finds and opens the specified version of the table. In `snapshot` and `snapshot_and_follow` modes, it retrieves the snapshot of this version of the table.  In `follow` and `snapshot_and_follow` modes, it follows transaction log records **after** this version.</p><p>Note: at most one of `version` and `datetime` options can be specified.  When neither of the two options is specified, the latest committed version of the table is used.</p>
+| `datetime`                  | string |            | <p>Optional timestamp for the snapshot in the ISO-8601/RFC-3339 format, e.g., "2024-12-09T16:09:53+00:00". When this option is set, the connector finds and opens the version of the table as of the specified point in time (based on the server time recorded in the transaction log, not the event time encoded in the data).  In `snapshot` and `snapshot_and_follow` modes, it retrieves the snapshot of this version of the table.  In `follow` and `snapshot_and_follow` modes, it follows transaction log records **after** this version.</p><p> Note: at most one of `version` and `datetime` options can be specified.  When neither of the two options is specified, the latest committed version of the table is used.</p>|
 
-* `uri` - Table URI, e.g., "s3://feldera-fraud-detection-data/demographics_train"
-* `mode` - Table read mode.  Three options are available:
-  * `snapshot` - read a snapshot of the table and stop.
-  * `follow` - follow the changelog of the table, only ingesting changes (new and deleted rows)
-  * `snapshot_and_follow` - Read a snapshot of the table before switching to the `follow` mode.
-    This mode implements the backfill pattern where we load historical data for the table
-    before ingesting the stream of real-time updates.
-
-### Optional parameters
-
-* `timestamp_column` - Table column that serves as an event timestamp.  When this option is
-   specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,
-   the snapshot of the table is ingested in the timestamp order.  This setting is required
-   for tables declared with the
-   [`LATENESS`](/sql/streaming#lateness-expressions) attribute
-   in Feldera SQL.  It impacts the performance of the connector, since data must be sorted
-   before pushing it to the pipeline; therefore it is not recommended to use this
-   settings for tables without `LATENESS`.
-
-* `snapshot_filter` - Optional row filter.  This option is only valid when `mode` is set to
-  `snapshot` or `snapshot_and_follow`.  When specified, only rows that satisfy the filter
-   condition are included in the snapshot.  The condition must be a valid SPARK SQL Boolean
-   expression that can be used in the `where` clause of the `select * from snapshot where ..`
-   query.
-
-   This option can be used for example to specify the range of event times to
-   include in the snapshot, e.g.: `ts BETWEEN '2005-01-01 00:00:00' AND
-   '2010-12-31 23:59:59'`.
-
-* `version` - Optional table version.  When this option is set, the connector finds and
-   opens the specified version of the table. In `snapshot` and `snapshot_and_follow` modes,
-   it retrieves the snapshot of this version of the table.  In `follow` and
-   `snapshot_and_follow` modes, it follows transaction log records **after** this version.
-
-   Note: at most one of `version` and `datetime` options can be specified.
-   When neither of the two options is specified, the latest committed version of the table
-   is used.
-
-* `datetime` - Optional timestamp for the snapshot in the ISO-8601/RFC-3339 format, e.g.,
-   "2024-12-09T16:09:53+00:00". When this option is set, the connector finds and opens the
-   version of the table as of the specified point in time (based on the server time recorded
-   in the transaction log, not the event time encoded in the data).  In `snapshot` and
-   `snapshot_and_follow` modes, it retrieves the snapshot of this version of the table.
-   In `follow` and `snapshot_and_follow` modes, it follows transaction log records
-   **after** this version.
-
-   Note: at most one of `version` and `datetime` options can be specified.
-   When neither of the two options is specified, the latest committed version of the table
-   is used.
+[*]: Required fields
 
 ### Storage parameters
 
-Along with the parameters mentioned above, there are additional configuration options for
+Along with the parameters listed above, there are additional configuration options for
 specific storage backends.  Refer to backend-specific documentation for details:
 
 * [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
@@ -77,29 +36,117 @@ specific storage backends.  Refer to backend-specific documentation for details:
 * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
 
 
-## Example usage
+## Ingesting time series data from a Delta Lake
 
-Create a Delta Lake input connector that reads a snapshot of a table from a public S3 bucket.
-Note the `aws_skip_signature` flag, required to read from the bucket without authentcation.  The
-snapshot will be sorted by the `unix_time` column.
+Feldera is optimized to efficiently process time series data by taking advantage
+of the fact that such data often arrives ordered by timestamp, i.e., every event
+has the same or larger timestamp than the previous event. In some cases, events
+can get reordered and delayed, but this delay is bounded, e.g., it may not
+exceed 1 hour. We refer to this bound as **lateness** and specify it by
+attaching the [`LATENESS`](/sql/streaming#lateness-expressions) attribute to the
+timestamp column of the table declaraion.  See our [Time Series Analysis
+Guide](/tutorials/time-series) for more details.
+
+When reading from a Delta Table that contains time series data, the user must
+ensure that the initial snapshot of the table is ingested respecting the
+`LATENESS` annotation, e.g., if the table contains one year worth of data, and
+its lateness is equal to 1 month, then the connector must ingest all data for the
+first month before moving to the second month, and so on.  If this requirement
+is violated, the pipeline will drop records that arrive more that `LATENESS` out
+of order.
+
+This can be achieved using the `timestamp_column` property, which specifies the table column
+that serves as an event timestamp. When this property is set, and `mode` is
+one of `snapshot` or `snapshot_and_follow`, table rows are ingested in the timestamp
+order, respecting the `LATENESS` annotation on the column: each ingested row has a
+timestamp no more than `LATENESS` time units earlier than the most recent timestamp
+of any previously ingested row.  The ingestion is performed by partitioning the table
+into timestamp ranges of width `LATENESS`. Each range is processed sequentially,
+in increasing timestamp order.
+
+Requirements:
+* The timestamp column must be of a supported type: integer, `DATE`, or `TIMESTAMP`.
+* The timestamp column must be declared with non-zero `LATENESS`.
+* `LATENESS` must be a valid constant expression in the [DataFusion
+  SQL dialect](https://datafusion.apache.org/). The reason for this is that Feldera
+  uses the Apache Datafusion engine to query Delta Lake.  In practice, most
+  valid Feldera SQL expressions are accepted by DataFusion.
+* For efficient ingest, the Delta table must be optimized for timestamp-based queries
+  using partitioning, Z-ordering, or liquid clustering.
+
+Note that the `timestamp_column` property only controls the initial table snapshot.
+When `mode` is set to `follow` or `snapshot_and_follow` and the connector is following
+the transaction log of the table, it ingests changes in the order they appear in the
+log.  It is the responsibility of the application that writes to the table
+to ensure that changes it applies to the table respect the `LATENESS` annotations.
+
+### Example
+
+The following table contains a timestamp column of type `TIMESTAMP` with `LATENESS` equal
+to `INTERVAL 30 days`. Assuming that the oldest timestamp in the table is `2024-01-01T00:00:00`,
+the connector will fetch all records with timestamps from `2024-01-01`, then all records for
+`2024-01-02`, `2024-01-03`, etc., until all rcords in the table have been ingested.
 
 ```sql
-CREATE TABLE INPUT (
-   ... -- columns omitted
+CREATE TABLE transaction(
+    trans_date_trans_time TIMESTAMP NOT NULL LATENESS INTERVAL 1 day,
+    cc_num BIGINT,
+    merchant STRING,
+    category STRING,
+    amt DOUBLE,
+    trans_num STRING,
+    unix_time BIGINT,
+    merch_lat DOUBLE,
+    merch_long DOUBLE,
+    is_fraud BIGINT
 ) WITH (
-  'connectors' = '[
-    {
-      "transport": {
-        "name": "delta_table_input",
-        "config": {
-          "uri": "s3://feldera-fraud-detection-data/transaction_train",
-          "mode": "snapshot",
-          "aws_skip_signature": "true",
-          "timestamp_column": "unix_time"
-        }
+  'connectors' = '[{
+    "transport": {
+      "name": "delta_table_input",
+      "config": {
+        "uri": "s3://feldera-fraud-detection-data/transaction_train",
+        "mode": "snapshot",
+        "aws_skip_signature": "true",
+        "timestamp_column": "trans_date_trans_time"
       }
-    }]'
-)
+    }
+  }
+]');
+```
+
+## Additional examples
+
+Create a Delta Lake input connector to read a snapshot of a table from a public S3 bucket, using
+`unix_time` as the timestamp column.  The column stores event time in seconds since UNIX epoch
+and has lateness equal to 30 days (3600 seconds/hour * 24 hours/day * 30 days).
+Note the `aws_skip_signature` flag, required to read from the bucket without authentcation,
+
+
+```sql
+CREATE TABLE transaction(
+    trans_date_trans_time TIMESTAMP,
+    cc_num BIGINT,
+    merchant STRING,
+    category STRING,
+    amt DOUBLE,
+    trans_num STRING,
+    unix_time BIGINT LATENESS 3600 * 24 * 30,
+    merch_lat DOUBLE,
+    merch_long DOUBLE,
+    is_fraud BIGINT
+) WITH (
+  'connectors' = '[{
+    "transport": {
+      "name": "delta_table_input",
+      "config": {
+        "uri": "s3://feldera-fraud-detection-data/transaction_train",
+        "mode": "snapshot",
+        "aws_skip_signature": "true",
+        "timestamp_column": "unix_time"
+      }
+    }
+  }
+]');
 ```
 
 Read a full snapshot of version 10 of the table before ingesting the stream of

--- a/openapi.json
+++ b/openapi.json
@@ -2407,12 +2407,12 @@
           },
           "snapshot_filter": {
             "type": "string",
-            "description": "Optional row filter.\n\nThis option is only valid when `mode` is set to `snapshot` or `snapshot_and_follow`.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.",
+            "description": "Optional row filter.\n\nThis option is only valid when `mode` is set to `snapshot` or `snapshot_and_follow`.\n\nWhen specified, only rows that satisfy the filter condition are included in the\nsnapshot.  The condition must be a valid SQL Boolean expression that can be used in\nthe `where` clause of the `select * from snapshot where ...` query.\n\nThis option can be used to specify the range of event times to include in the snapshot,\ne.g.: `ts BETWEEN TIMESTAMP '2005-01-01 00:00:00' AND TIMESTAMP '2010-12-31 23:59:59'`.",
             "nullable": true
           },
           "timestamp_column": {
             "type": "string",
-            "description": "Table column that serves as an event timestamp.\n\n\nWhen this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,\nthe snapshot of the table is ingested in the timestamp order.  This setting is required\nfor tables declared with the\n[`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions) attribute\nin Feldera SQL. It impacts the performance of the connector, since data must be sorted\nbefore pushing it to the pipeline; therefore it is not recommended to use this\nsettings for tables without `LATENESS`.",
+            "description": "Table column that serves as an event timestamp.\n\nWhen this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,\ntable rows are ingested in the timestamp order, respecting the\n[`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions)\nproperty of the column: each ingested row has a timestamp no more than `LATENESS`\ntime units earlier than the most recent timestamp of any previously ingested row.\nThe ingestion is performed by partitioning the table into timestamp ranges of width\n`LATENESS`. Each range is processed sequentially, in increasing timestamp order.\n\n# Example\n\nConsider a table with timestamp column of type `TIMESTAMP` and lateness attribute\n`INTERVAL 1 DAY`. Assuming that the oldest timestamp in the table is\n`2024-01-01T00:00:00``, the connector will fetch all records with timestamps\nfrom `2024-01-01`, then all records for `2024-01-02`, `2024-01-03`, etc., until all records\nin the table have been ingested.\n\n# Requirements\n\n* The timestamp column must be of a supported type: integer, `DATE`, or `TIMESTAMP`.\n* The timestamp column must be declared with non-zero `LATENESS`.\n* For efficient ingest, the table must be optimized for timestamp-based\nqueries using partitioning, Z-ordering, or liquid clustering.",
             "nullable": true
           },
           "uri": {
@@ -2786,6 +2786,18 @@
             "properties": {
               "columntype": {
                 "$ref": "#/components/schemas/ColumnType"
+              },
+              "default": {
+                "type": "string",
+                "nullable": true
+              },
+              "lateness": {
+                "type": "string",
+                "nullable": true
+              },
+              "watermark": {
+                "type": "string",
+                "nullable": true
               }
             }
           }


### PR DESCRIPTION
When loading a snapshot of a Delta table with lateness the connector must
satisfy the lateness constraint. Until now, we achieved
this by sorting the table by timestamp by issuing a snapshot query of
the form `select * from snapshot order by ts`, which is very
inefficient for large tables, as it involves storing and sorting the
entire dataset inside the pipeline. This is also unnecessary in most
cases, since lateness allows out-of-order ingest as long as it doesn't
exceed the specified lateness bound.

This commit implements a more efficient strategy, which, instead of
issuing a single expensive snapshot query, generates a sequence of
queries for lateness-width timestamp ranges. Assuming the input table is
optimized for timestamp queries, e.g., partitioned, Z-ordered, or liquid
clustered by time (which it usually will be in any reasonable real-world
situation), such range queries can be very efficient (I am getting 1M
records/s over wifi on a laptop when downloading from S3).

The tricky part of this commit is the handling of arithmetics on SQL
expressions.  We don't have a good way to parse and manipulate SQL
expressions that represent the timestamp in Rust, so we delegate all
this to datafusion by using it as a calculator for  queries like
`select cast({start_time} + {lateness} as string)`.
