### PR TITLE
Revert "[adapters] Workaround for datafusion regression."

### DIFF
--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -20,8 +20,6 @@ rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1" 
 serde_json = { version = "1.0.127", features = ["arbitrary_precision"] }
 rkyv = { version = "0.7.45", default-features = false, features = ["std", "size_64"] }
 lazy_static = { version = "1.4.0" }
-# Temporary workaround for https://github.com/apache/datafusion/issues/13686
-lexical-write-integer = "=1.0.2"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5.4", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }


### PR DESCRIPTION
The issue was solver in lexical-write-integer 1.0.5.

This reverts commit 43b8d0ef8faeab173316a46e3ff9e3b5c074f86f.