### PR TITLE
Use types that directly represent files, instead of file handles.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,7 +3628,6 @@ dependencies = [
  "crossbeam",
  "crossbeam-utils",
  "csv",
- "dashmap 5.5.3",
  "derive_more 1.0.0",
  "dyn-clone",
  "env_logger 0.11.5",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -70,7 +70,6 @@ feldera-types = { path = "../feldera-types", version = "0.31.2" }
 libc = "0.2.153"
 static_assertions = "1.1.0"
 lazy_static = "1.4.0"
-dashmap = "5"
 zip = "0.6.2"
 minitrace = "0.6"
 ouroboros = "0.18.4"

--- a/crates/dbsp/src/storage/backend/io_uring_impl/tests.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/tests.rs
@@ -2,144 +2,77 @@
 //!
 //! The main test makes sure we correspond to the model defined in
 //! [`InMemoryBackend`].
-use std::fs;
+use std::path::Path;
 
 use feldera_types::config::StorageCacheConfig;
-use pretty_assertions::assert_eq;
-use proptest::test_runner::Config;
-use proptest_state_machine::{prop_state_machine, ReferenceStateMachine, StateMachineTest};
-use tempfile::TempDir;
 
 use crate::storage::backend::io_uring_impl::IoUringBackend;
-use crate::storage::backend::tests::{InMemoryBackend, Transition, MAX_TRANSITIONS};
-use crate::storage::backend::{FileHandle, ImmutableFileHandle, Storage};
-use crate::storage::test::init_test_logger;
+use crate::storage::backend::tests::{random_sizes, test_backend};
+use crate::storage::backend::Backend;
 
-// Setup the state machine test using the `prop_state_machine!` macro
-prop_state_machine! {
-    #![proptest_config(Config {
-        verbose: 1,
-        .. Config::default()
-    })]
+fn create_iouring_backend(path: &Path) -> Backend {
+    Box::new(IoUringBackend::new(path, StorageCacheConfig::default()).unwrap())
+}
 
-    #[test]
-    fn io_uring_behaves_like_model(
-        sequential
-        1..MAX_TRANSITIONS
-        =>
-        IoUringBackend
+/// Write 10 MiB total in 1 KiB chunks.  `VectoredWrite` flushes its buffer when it
+/// reaches 1 MiB of sequential data, and we limit the amount of queued work
+/// to 4 MiB, so this has a chance to trigger both limits.
+#[test]
+fn sequential_1024() {
+    test_backend(
+        Box::new(create_iouring_backend),
+        &[1024; 1024 * 10],
+        true,
+        true,
+    )
+}
+
+/// Write 10 MiB total in 1 KiB chunks.  We skip over a chunk occasionally,
+/// which leaves a "hole" in the file that is all zeros and has the side effect
+/// of forcing `VectoredWrite` to flush its buffer.  Our actual btree writer
+/// never leaves holes but it seems best to test this anyhow.
+#[test]
+fn holes_1024() {
+    test_backend(
+        Box::new(create_iouring_backend),
+        &[1024; 1024 * 10],
+        false,
+        true,
+    )
+}
+
+/// Verify that files get deleted if not marked for a checkpoint.
+#[test]
+fn delete_1024() {
+    test_backend(
+        Box::new(create_iouring_backend),
+        &[1024; 1024 * 10],
+        true,
+        false,
+    )
+}
+
+#[test]
+fn sequential_random() {
+    test_backend(
+        Box::new(create_iouring_backend),
+        &random_sizes(),
+        true,
+        true,
     );
 }
 
-pub struct IoUringTest {
-    backend: IoUringBackend,
-    tmpdir: TempDir,
+#[test]
+fn holes_random() {
+    test_backend(
+        Box::new(create_iouring_backend),
+        &random_sizes(),
+        false,
+        true,
+    );
 }
 
-impl StateMachineTest for IoUringBackend {
-    type SystemUnderTest = IoUringTest;
-    type Reference = InMemoryBackend<true>;
-
-    fn init_test(
-        _ref_state: &<Self::Reference as ReferenceStateMachine>::State,
-    ) -> Self::SystemUnderTest {
-        init_test_logger();
-        let tmpdir = tempfile::tempdir().unwrap();
-        let backend = IoUringBackend::new(
-            tmpdir.path(),
-            StorageCacheConfig::default(),
-            Default::default(),
-            Default::default(),
-        )
-        .unwrap();
-
-        IoUringTest { backend, tmpdir }
-    }
-
-    fn apply(
-        state: Self::SystemUnderTest,
-        ref_state: &<Self::Reference as ReferenceStateMachine>::State,
-        transition: Transition,
-    ) -> Self::SystemUnderTest {
-        match transition {
-            Transition::Create => {
-                state.backend.create().expect("create failed");
-                state
-            }
-            Transition::DeleteMut(id) => {
-                state
-                    .backend
-                    .delete_mut(FileHandle(id))
-                    .expect("delete failed");
-                state
-            }
-            Transition::Write(id, offset, content) => {
-                let mut wb = state.backend.allocate_buffer(content.len());
-                wb.resize(content.len(), 0);
-                wb.copy_from_slice(content.as_bytes());
-                state
-                    .backend
-                    .write_block(&FileHandle(id), offset, wb)
-                    .expect("write failed");
-                state
-            }
-            Transition::Complete(id) => {
-                state
-                    .backend
-                    .complete(FileHandle(id))
-                    .expect("complete failed");
-                state
-            }
-            Transition::Read(id, offset, length) => {
-                let result_impl =
-                    state
-                        .backend
-                        .read_block(&ImmutableFileHandle(id), offset, length as usize);
-                let model_impl =
-                    ref_state.read_block(&ImmutableFileHandle(id), offset, length as usize);
-                assert_eq!(&model_impl, &result_impl);
-                state
-            }
-        }
-    }
-
-    fn check_invariants(
-        state: &Self::SystemUnderTest,
-        ref_state: &<Self::Reference as ReferenceStateMachine>::State,
-    ) {
-        // inv1: the immutable file contents of model and implementation must match
-
-        // We have to checkpoint to ensure that data in flight gets flushed.
-        state.backend.checkpoint().unwrap();
-
-        // inv2: we don't need more storage space than the in-memory implementation
-        let mem_bytes: usize = ref_state
-            .immutable_files
-            .borrow()
-            .values()
-            .map(|v| v.len())
-            .sum::<usize>()
-            + ref_state
-                .files
-                .borrow()
-                .values()
-                .map(|v| v.len())
-                .sum::<usize>();
-
-        let paths = fs::read_dir(&state.tmpdir).unwrap();
-        let files_bytes = paths
-            .into_iter()
-            .map(|p| {
-                if let Ok(p) = p {
-                    fs::metadata(p.path())
-                        .expect("Can't get metadata for {p}")
-                        .len() as usize
-                } else {
-                    0
-                }
-            })
-            .sum::<usize>();
-
-        assert_eq!(files_bytes, mem_bytes);
-    }
+#[test]
+fn empty() {
+    test_backend(Box::new(create_iouring_backend), &[], true, true);
 }

--- a/crates/dbsp/src/storage/backend/memory_impl.rs
+++ b/crates/dbsp/src/storage/backend/memory_impl.rs
@@ -7,129 +7,58 @@ use std::{
     collections::HashMap,
     io::{Error as IoError, ErrorKind},
     path::{Path, PathBuf},
-    rc::Rc,
-    sync::{Arc, RwLock},
+    sync::{Arc, LazyLock, RwLock},
 };
 
-use super::{AtomicIncrementOnlyI64, FileHandle, ImmutableFileHandle, Storage, StorageError};
+use super::{FileId, FileReader, FileWriter, HasFileId, Storage, StorageError};
 use crate::circuit::metrics::{
-    FILES_CREATED, FILES_DELETED, READS_FAILED, READS_SUCCESS, TOTAL_BYTES_READ,
-    TOTAL_BYTES_WRITTEN, WRITES_SUCCESS,
+    FILES_CREATED, READS_FAILED, READS_SUCCESS, TOTAL_BYTES_READ, TOTAL_BYTES_WRITTEN,
+    WRITES_SUCCESS,
 };
-use crate::storage::{backend::NEXT_FILE_HANDLE, buffer_cache::FBuf};
+use crate::storage::buffer_cache::FBuf;
 
-/// Meta-data we keep per file we created.
-#[derive(Default)]
-struct FileMetaData {
-    name: PathBuf,
+struct MemoryFile {
+    file_id: FileId,
+    path: PathBuf,
     blocks: HashMap<u64, Arc<FBuf>>,
     size: u64,
+}
+
+impl HasFileId for MemoryFile {
+    fn file_id(&self) -> FileId {
+        self.file_id
+    }
 }
 
 /// State of the backend needed to satisfy the storage APIs.
 pub struct MemoryBackend {
     /// Meta-data of all files we created so far.
-    files: RwLock<HashMap<i64, FileMetaData>>,
-    /// A global counter to get unique identifiers for file-handles.
-    next_file_id: Arc<AtomicIncrementOnlyI64>,
+    files: RwLock<HashMap<PathBuf, Arc<MemoryFile>>>,
 }
 
 impl MemoryBackend {
-    /// Instantiates a new backend.
-    ///
-    /// ## Parameters
-    /// - `next_file_id`: A counter to get unique identifiers for file-handles.
-    ///   Note that in case we use a global buffer cache, this counter should be
-    ///   shared among all instances of the backend.
-    pub fn new(next_file_id: Arc<AtomicIncrementOnlyI64>) -> Self {
-        Self {
-            files: RwLock::new(HashMap::new()),
-            next_file_id,
-        }
+    fn get() -> Arc<Self> {
+        static BACKEND: LazyLock<Arc<MemoryBackend>> = LazyLock::new(|| {
+            Arc::new(MemoryBackend {
+                files: RwLock::new(HashMap::new()),
+            })
+        });
+        Arc::clone(&BACKEND)
     }
 
-    /// See [`MemoryBackend::new`]. This function is a convenience function that
-    /// creates a new backend with global unique file-handle counter.
-    pub fn with_base<P: AsRef<Path>>(_base: P) -> Self {
-        Self::new(
-            NEXT_FILE_HANDLE
-                .get_or_init(|| Arc::new(Default::default()))
-                .clone(),
-        )
-    }
-
-    /// Helper function to delete (mutable and immutable) files.
-    fn delete_mut_inner(&self, fh: FileHandle) -> Result<(), StorageError> {
-        self.files.write().unwrap().remove(&fh.0).unwrap();
-        counter!(FILES_DELETED).increment(1);
-        Ok(())
-    }
-
-    /// Returns a thread-local default backend.
-    pub fn default_for_thread() -> Rc<Self> {
-        thread_local! {
-            pub static DEFAULT_BACKEND: Rc<MemoryBackend> = {
-                Rc::new(MemoryBackend::new(NEXT_FILE_HANDLE.get_or_init(|| {
-                    Arc::new(Default::default())
-                }).clone()))
-            };
-        }
-        DEFAULT_BACKEND.with(|rc| rc.clone())
+    fn insert(&self, mf: Arc<MemoryFile>) {
+        self.files.write().unwrap().insert(mf.path.clone(), mf);
     }
 }
 
-impl Storage for MemoryBackend {
-    fn create_named(&self, name: &Path) -> Result<FileHandle, StorageError> {
-        let file_counter = self.next_file_id.increment();
-        let mut files = self.files.write().unwrap();
-        files.insert(
-            file_counter,
-            FileMetaData {
-                name: name.to_path_buf(),
-                blocks: HashMap::new(),
-                size: 0,
-            },
-        );
-        counter!(FILES_CREATED).increment(1);
-
-        Ok(FileHandle(file_counter))
-    }
-
-    fn open(&self, name: &Path) -> Result<ImmutableFileHandle, StorageError> {
-        let files = self.files.read().unwrap();
-        let file_id = files
-            .iter()
-            .find(|(_, fm)| fm.name == name)
-            .map(|(id, _)| *id)
-            .ok_or(StorageError::StdIo(IoError::from(ErrorKind::NotFound)))?;
-
-        Ok(ImmutableFileHandle(file_id))
-    }
-
-    fn mark_for_checkpoint(&self, _fd: &ImmutableFileHandle) {}
-
-    fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
-        self.delete_mut_inner(fd)
-    }
-
-    fn base(&self) -> PathBuf {
-        todo!()
-    }
-
-    fn write_block(
-        &self,
-        fd: &FileHandle,
-        offset: u64,
-        data: FBuf,
-    ) -> Result<Arc<FBuf>, StorageError> {
+impl FileWriter for MemoryFile {
+    fn write_block(&mut self, offset: u64, data: FBuf) -> Result<Arc<FBuf>, StorageError> {
         let data = Arc::new(data);
-        let mut files = self.files.write().unwrap();
-        let fm = files.get_mut(&fd.0).unwrap();
-        fm.blocks.insert(offset, data.clone());
+        self.blocks.insert(offset, data.clone());
 
         let min_size = offset + data.len() as u64;
-        if min_size > fm.size {
-            fm.size = min_size;
+        if min_size > self.size {
+            self.size = min_size;
         }
 
         counter!(TOTAL_BYTES_WRITTEN).increment(data.len() as u64);
@@ -138,27 +67,19 @@ impl Storage for MemoryBackend {
         Ok(data)
     }
 
-    fn complete(&self, fd: FileHandle) -> Result<(ImmutableFileHandle, PathBuf), StorageError> {
-        let files = self.files.read().unwrap();
-        let fm = files.get(&fd.0).unwrap();
-        let path = fm.name.clone();
-
-        Ok((ImmutableFileHandle(fd.0), path))
+    fn complete(self: Box<Self>) -> Result<(Arc<dyn FileReader>, PathBuf), StorageError> {
+        let path = self.path.clone();
+        let file = Arc::from(*self);
+        MemoryBackend::get().insert(file.clone());
+        Ok((file, path))
     }
+}
 
-    fn prefetch(&self, _fd: &ImmutableFileHandle, _offset: u64, _size: usize) {
-        unimplemented!()
-    }
+impl FileReader for MemoryFile {
+    fn mark_for_checkpoint(&self) {}
 
-    fn read_block(
-        &self,
-        fd: &ImmutableFileHandle,
-        offset: u64,
-        size: usize,
-    ) -> Result<Arc<FBuf>, StorageError> {
-        let files = self.files.read().unwrap();
-        let fm = files.get(&fd.0).unwrap();
-        let block = fm.blocks.get(&offset);
+    fn read_block(&self, offset: u64, size: usize) -> Result<Arc<FBuf>, StorageError> {
+        let block = self.blocks.get(&offset);
         if let Some(block) = block {
             if size == block.len() {
                 counter!(TOTAL_BYTES_READ).increment(block.len() as u64);
@@ -170,9 +91,33 @@ impl Storage for MemoryBackend {
         Err(IoError::from(ErrorKind::UnexpectedEof).into())
     }
 
-    fn get_size(&self, fd: &ImmutableFileHandle) -> Result<u64, StorageError> {
+    fn get_size(&self) -> Result<u64, StorageError> {
+        Ok(self.size)
+    }
+}
+
+impl Storage for MemoryBackend {
+    fn create_named(&self, name: &Path) -> Result<Box<dyn FileWriter>, StorageError> {
+        let file_id = FileId::new();
+        let fm = MemoryFile {
+            file_id,
+            path: name.to_path_buf(),
+            blocks: HashMap::new(),
+            size: 0,
+        };
+        counter!(FILES_CREATED).increment(1);
+        Ok(Box::new(fm))
+    }
+
+    fn open(&self, name: &Path) -> Result<Arc<dyn FileReader>, StorageError> {
         let files = self.files.read().unwrap();
-        let fm = files.get(&fd.0).unwrap();
-        Ok(fm.size)
+        match files.get(name) {
+            Some(file) => Ok(file.clone()),
+            None => Err(StorageError::StdIo(IoError::from(ErrorKind::NotFound))),
+        }
+    }
+
+    fn base(&self) -> PathBuf {
+        todo!()
     }
 }

--- a/crates/dbsp/src/storage/backend/tests.rs
+++ b/crates/dbsp/src/storage/backend/tests.rs
@@ -4,273 +4,91 @@
 //! TODO: Currently only functional STM, should later be expanded to cover
 //! error/corner cases.
 
-use std::sync::Arc;
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    fmt::{self, Debug},
-    io::{Error as IoError, ErrorKind},
-    iter,
-    path::{Path, PathBuf},
-    sync::atomic::{AtomicI64, Ordering},
-};
+use std::path::Path;
 
-use proptest::prelude::*;
-use proptest_state_machine::ReferenceStateMachine;
+use rand::{thread_rng, Fill, Rng};
 
-use crate::storage::{
-    backend::{FileHandle, ImmutableFileHandle, Storage, StorageError},
-    buffer_cache::FBuf,
-};
+use crate::storage::{buffer_cache::FBuf, test::init_test_logger};
 
-/// Generates a "random" string to be written in a file.
-///
-/// The length is always a power of two in the range 2^9..=2^12.
-fn pow2_string() -> BoxedStrategy<String> {
-    (limited_pow2(), prop::char::range('a', 'z'))
-        .prop_map(|(length, c)| iter::repeat(c).take(length as usize).collect::<String>())
-        .boxed()
-}
+use super::{Backend, FileReader};
 
-/// Generates a power of two in the range 2^9..=2^12.
-fn limited_pow2() -> BoxedStrategy<u64> {
-    prop_oneof![Just(512), Just(1024), Just(2048), Just(4096)].boxed()
-}
-
-/// The maximum number of transitions to be generated for each test case.
-#[cfg(target_os = "linux")]
-pub(crate) const MAX_TRANSITIONS: usize = 20;
-
-/// How many files the test case try to read/write to.
-const MAX_FILES: i64 = 10;
-
-/// What the backend does, models the operations that the [`Storage`] trait
-/// provides.
-#[derive(Clone)]
-pub enum Transition {
-    Create,
-    DeleteMut(i64),
-    Write(i64, u64, String),
-    Complete(i64),
-    Read(i64, u64, u64),
-}
-
-impl Debug for Transition {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Transition::Create => write!(f, "Create"),
-            Transition::DeleteMut(id) => write!(f, "DeleteMut({})", id),
-            Transition::Write(id, offset, content) => {
-                write!(
-                    f,
-                    "Write({}, {}, {}*{})",
-                    id,
-                    offset,
-                    content.get(0..1).unwrap_or(""),
-                    content.len()
-                )
-            }
-            Transition::Complete(id) => write!(f, "Complete({})", id),
-            Transition::Read(id, offset, length) => {
-                write!(f, "Read({}, {}, {})", id, offset, length)
-            }
-        }
+fn test_read_block(reader: &dyn FileReader, data: &[u8], offset: usize) -> usize {
+    let remaining = data.len() - offset;
+    let mut length = 1 << thread_rng().gen_range(9..=20);
+    while length > remaining {
+        length /= 2;
     }
+    assert!(offset == data.len() || length > 0);
+    let block = reader.read_block(offset as u64, length).unwrap();
+    assert_eq!(block.as_slice(), &data[offset..offset + length]);
+    length
 }
 
-/// The in-memory backend that is used as a reference for the state machine
-/// tests.
-///
-/// Note that we have two modes of operation:
-/// - `ALLOW_OVERWRITE = true`: allows overwriting data in the file.
-/// - `ALLOW_OVERWRITE = false`: does not allow overwriting data in the file
-///   (returns an error on writes).
-///
-/// This ensures we can test the raw backend as well as the buffer cache (which
-/// does not allow overwrites).
-#[derive(Default, Debug)]
-pub struct InMemoryBackend<const ALLOW_OVERWRITE: bool> {
-    file_counter: AtomicI64,
-    /// All files we can currently write to.
-    pub(crate) files: RefCell<HashMap<i64, Vec<Option<u8>>>>,
-    /// All files which have transitioned to read-only.
-    pub(crate) immutable_files: RefCell<HashMap<i64, Vec<Option<u8>>>>,
-    /// Last encountered error, gets cleared on every transition.
-    pub(crate) error: Option<StorageError>,
-}
-
-impl<const ALLOW_OVERWRITE: bool> Clone for InMemoryBackend<ALLOW_OVERWRITE> {
-    fn clone(&self) -> Self {
-        Self {
-            files: self.files.clone(),
-            file_counter: AtomicI64::new(self.file_counter.load(Ordering::Relaxed)),
-            immutable_files: self.immutable_files.clone(),
-            error: Default::default(),
-        }
+fn test_read(reader: &dyn FileReader, data: &[u8]) {
+    let mut rng = thread_rng();
+    assert_eq!(reader.get_size().unwrap(), data.len() as u64);
+    let mut offset = 0;
+    while offset < data.len() {
+        offset += test_read_block(reader, data, offset);
     }
-}
-fn insert_slice_at_offset(
-    vec: &[Option<u8>],
-    offset: usize,
-    slice: &[u8],
-    allow_overwrite: bool,
-) -> Result<Vec<Option<u8>>, StorageError> {
-    // we clone the file so the write is 'atomic'. For this particular check
-    // (overlapping writes) this happens before any writes to the FS in the
-    // BufferCache implementation.
-    let mut new_vec = vec.to_owned();
-
-    if offset > vec.len() {
-        new_vec.resize(offset, None);
+    for _ in 0..100 {
+        test_read_block(reader, data, rng.gen_range(0..=data.len() / 512) * 512);
     }
+    reader.read_block(data.len() as u64, 512).unwrap_err();
+}
 
-    // Insert or overwrite the data at the specified offset
-    for (i, &byte) in slice.iter().enumerate() {
-        if offset + i < new_vec.len() {
-            if !allow_overwrite && vec[offset + i].is_some() {
-                return Err(StorageError::OverlappingWrites);
-            }
-            new_vec[offset + i] = Some(byte);
+pub(super) fn test_backend(
+    create_backend: Box<dyn FnOnce(&Path) -> Backend>,
+    writes: &[usize],
+    sequential: bool,
+    mark_for_checkpoint: bool,
+) {
+    init_test_logger();
+    let tmpdir = tempfile::tempdir().unwrap();
+    let backend = create_backend(tmpdir.path());
+    let mut rng = thread_rng();
+    let mut writer = backend.create().unwrap();
+    let mut data = Vec::new();
+    for (index, size) in writes.iter().copied().enumerate() {
+        if sequential || rng.gen_range(0..10) != 0 || index == writes.len() - 1 {
+            let mut block = FBuf::with_capacity(size);
+            block.resize(size, 0);
+            block.try_fill(&mut rng).unwrap();
+            let offset = data.len() as u64;
+            data.extend_from_slice(&block);
+            writer.write_block(offset, block).unwrap();
         } else {
-            new_vec.push(Some(byte));
+            // Occasionally skip over a block.
+            data.resize(data.len() + size, 0);
         }
     }
 
-    Ok(new_vec)
-}
-
-impl<const ALLOW_OVERWRITE: bool> Storage for InMemoryBackend<ALLOW_OVERWRITE> {
-    fn create_named(&self, _name: &Path) -> Result<FileHandle, StorageError> {
-        let file_counter = self.file_counter.fetch_add(1, Ordering::Relaxed);
-        self.files.borrow_mut().insert(file_counter, Vec::new());
-        Ok(FileHandle(file_counter))
+    let (reader, name) = writer.complete().unwrap();
+    test_read(reader.as_ref(), &data);
+    if mark_for_checkpoint {
+        reader.mark_for_checkpoint();
     }
+    drop(reader);
 
-    fn open(&self, _name: &Path) -> Result<ImmutableFileHandle, StorageError> {
-        unimplemented!()
-    }
-
-    fn mark_for_checkpoint(&self, _fd: &ImmutableFileHandle) {}
-
-    fn delete_mut(&self, fd: FileHandle) -> Result<(), StorageError> {
-        self.files.borrow_mut().remove(&fd.0);
-        Ok(())
-    }
-
-    fn base(&self) -> PathBuf {
-        PathBuf::from("")
-    }
-
-    fn write_block(
-        &self,
-        fd: &FileHandle,
-        offset: u64,
-        data: FBuf,
-    ) -> Result<Arc<FBuf>, StorageError> {
-        let mut files = self.files.borrow_mut();
-        let file = files.get(&fd.0).unwrap();
-        let new_file = insert_slice_at_offset(file, offset as usize, &data, ALLOW_OVERWRITE)?;
-        files.insert(fd.0, new_file);
-        Ok(Arc::new(data))
-    }
-
-    fn complete(&self, fd: FileHandle) -> Result<(ImmutableFileHandle, PathBuf), StorageError> {
-        let file = self.files.borrow_mut().remove(&fd.0).unwrap();
-        self.immutable_files.borrow_mut().insert(fd.0, file);
-        Ok((ImmutableFileHandle(fd.0), PathBuf::from("")))
-    }
-
-    fn prefetch(&self, _fd: &ImmutableFileHandle, _offset: u64, _size: usize) {}
-
-    fn read_block(
-        &self,
-        fd: &ImmutableFileHandle,
-        offset: u64,
-        size: usize,
-    ) -> Result<Arc<FBuf>, StorageError> {
-        let files = self.immutable_files.borrow();
-        let file = files.get(&fd.0).unwrap();
-        let offset = offset as usize;
-        if offset > file.len() || offset + size > file.len() {
-            return Err(IoError::from(ErrorKind::UnexpectedEof).into());
-        }
-        let end = offset + size;
-        debug_assert!(end <= file.len());
-
-        let mut buf = FBuf::with_capacity(end - offset);
-        // reads to unwritten regions will still return 0s
-        let slice: Vec<u8> = file[offset..end]
-            .iter()
-            .map(|x| x.unwrap_or_default())
-            .collect();
-        buf.extend_from_slice(&slice);
-        Ok(Arc::new(buf))
-    }
-
-    fn get_size(&self, fd: &ImmutableFileHandle) -> Result<u64, StorageError> {
-        let files = self.immutable_files.borrow();
-        let file = files.get(&fd.0).unwrap();
-        Ok(file.len() as u64)
-    }
-}
-
-impl<const ALLOW_OVERWRITE: bool> ReferenceStateMachine for InMemoryBackend<ALLOW_OVERWRITE> {
-    type State = Self;
-    type Transition = Transition;
-
-    fn init_state() -> BoxedStrategy<Self::State> {
-        Just(Default::default()).boxed()
-    }
-
-    fn transitions(_state: &Self::State) -> BoxedStrategy<Self::Transition> {
-        prop_oneof![
-            1 => Just(Transition::Create),
-            2 => (1..=MAX_FILES).prop_map(Transition::DeleteMut),
-            3 => (1..=MAX_FILES, limited_pow2(), pow2_string()).prop_map(|(ident, offset, content)| Transition::Write(ident, offset, content)),
-            4 => (1..=MAX_FILES).prop_map(Transition::Complete),
-            5 => (1..=MAX_FILES, limited_pow2(), limited_pow2()).prop_map(|(ident, offset, length)| Transition::Read(ident, offset, length)),
-        ]
-            .boxed()
-    }
-
-    fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
-        state.error = None;
-        match transition {
-            Transition::Create => {
-                let r = state.create();
-                state.error = r.err();
-            }
-            Transition::DeleteMut(id) => {
-                let r = state.delete_mut(FileHandle(*id));
-                state.error = r.err();
-            }
-            Transition::Write(id, offset, content) => {
-                let mut buf = state.allocate_buffer(content.len());
-                buf.resize(content.len(), 0);
-                buf.copy_from_slice(content.as_bytes());
-                let r = state.write_block(&FileHandle(*id), *offset, buf);
-                state.error = r.err()
-            }
-            Transition::Complete(id) => {
-                let r = state.complete(FileHandle(*id));
-                state.error = r.err();
-            }
-            Transition::Read(_ident, _offset, _length) => {}
+    if mark_for_checkpoint {
+        let reader = backend.open(&name).unwrap();
+        test_read(reader.as_ref(), &data);
+        drop(reader);
+    } else {
+        let Err(_) = backend.open(&name) else {
+            unreachable!()
         };
-        state
     }
+}
 
-    /// We currently avoid testing the error cases in the state-machine. This
-    /// can be added later by relaxing the preconditions.
-    fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
-        match transition {
-            Transition::Create => true,
-            Transition::DeleteMut(id) => state.files.borrow().contains_key(id),
-            Transition::Write(id, _offset, _content) => state.files.borrow().contains_key(id),
-            Transition::Complete(id) => state.files.borrow().contains_key(id),
-            Transition::Read(id, _offset, _length) => {
-                state.immutable_files.borrow().contains_key(id)
-            }
-        }
+pub(super) fn random_sizes() -> Vec<usize> {
+    let mut rng = thread_rng();
+    let mut blocks = Vec::new();
+    let mut total = 0;
+    while total < 1024 * 10 {
+        let size = 1 << rng.gen_range(9..=20);
+        blocks.push(size);
+        total += size;
     }
+    blocks
 }

--- a/crates/dbsp/src/storage/file/cache.rs
+++ b/crates/dbsp/src/storage/file/cache.rs
@@ -14,7 +14,7 @@ use binrw::{
 use lazy_static::lazy_static;
 
 use crate::storage::{
-    backend::ImmutableFileHandle,
+    backend::FileReader,
     buffer_cache::{BufferCache, CacheEntry, FBuf},
     file::BlockLocation,
 };
@@ -125,32 +125,32 @@ impl BufferCache<FileCacheEntry> {
     /// to `InnerDataBlock`.
     pub(super) fn read_data_block(
         &self,
-        fd: &ImmutableFileHandle,
+        file: &dyn FileReader,
         offset: u64,
         size: usize,
     ) -> Result<Arc<InnerDataBlock>, Error> {
-        self.read(fd, offset, size, FileCacheEntry::as_data_block)
+        self.read(file, offset, size, FileCacheEntry::as_data_block)
     }
 
     /// Reads a `size`-byte block at `offset` in `fd` and returns it converted
     /// to `InnerIndexBlock`.
     pub(super) fn read_index_block(
         &self,
-        fd: &ImmutableFileHandle,
+        file: &dyn FileReader,
         offset: u64,
         size: usize,
     ) -> Result<Arc<InnerIndexBlock>, Error> {
-        self.read(fd, offset, size, FileCacheEntry::as_index_block)
+        self.read(file, offset, size, FileCacheEntry::as_index_block)
     }
 
     /// Reads a `size`-byte file trailer block at `offset` in `fd` and returns
     /// it converted to `FileTrailer`.
     pub(super) fn read_file_trailer_block(
         &self,
-        fd: &ImmutableFileHandle,
+        file: &dyn FileReader,
         offset: u64,
         size: usize,
     ) -> Result<Arc<FileTrailer>, Error> {
-        self.read(fd, offset, size, FileCacheEntry::as_file_trailer)
+        self.read(file, offset, size, FileCacheEntry::as_file_trailer)
     }
 }

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -432,7 +432,7 @@ where
     type Builder: Builder<Self>;
 
     /// A type used to progressively merge batches.
-    type Merger: Merger<Self::Key, Self::Val, Self::Time, Self::R, Self> + Send + Sync;
+    type Merger: Merger<Self::Key, Self::Val, Self::Time, Self::R, Self>;
 
     /// Assemble an unordered vector of weighted items into a batch.
     #[allow(clippy::type_complexity)]

--- a/crates/dbsp/src/trace/spine_async/mod.rs
+++ b/crates/dbsp/src/trace/spine_async/mod.rs
@@ -357,8 +357,10 @@ where
             let state = Arc::clone(&state);
             let idle = Arc::clone(&idle);
             let no_backpressure = Arc::clone(&no_backpressure);
-            let mut mergers = std::array::from_fn(|_| None);
-            Box::new(move || Self::run(&mut mergers, &state, &idle, &no_backpressure))
+            Box::new(|| {
+                let mut mergers = std::array::from_fn(|_| None);
+                Box::new(move || Self::run(&mut mergers, &state, &idle, &no_backpressure))
+            })
         });
         Self {
             state,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - --mode dev-container
       # enable logs for debugging.
       - --default-log-level=error
-    image: docker.redpanda.com/vectorized/redpanda:v24.2.4
+    image: redpandadata/redpanda:v24.2.4
     ports:
       - 18081:18081
       - 18082:18082


### PR DESCRIPTION
Until now, the storage system has used a single `Storage` trait, which
had methods for creating and open files and reading and writing them.
`Storage` identified files with handles that were newtypes for integers.
This worked but it was not ideal because the handles could be passed
around in arbitrary ways, they had no useful behavior on drop, they
were not tied to their own `Storage` instance (that is, a handle for one
storage instance could be used with another, even though this was wrong),
they had possibly overlapping ranges for different `Storage` instances (so
sometimes using one with the wrong `Storage` would silently misbehave
rather than panicking), and lifetimes were confusing.

This commit fixes these problems by refactoring how things work.  Now,
`Storage` only has methods for opening and closing files.  An open writable
file is a `FileWriter`, an open readable file is a `FileReader`.  Dropping
one of these yields sensible results, every file is properly tied to its
own storage, and files can only be passsed around in correct ways (a
`FileWriter` is neither `Send` nor `Sync` and a `FileReader` is both).

The hope is that this will fix the periodic CI problems with storage
(https://github.com/feldera/feldera/issues/3100).