### PR TITLE
[SQL] Restrict the kinds of results that can be produced by date subtraction (#3132)

### DIFF
--- a/docs/sql/datetime.md
+++ b/docs/sql/datetime.md
@@ -90,6 +90,10 @@ For dates it always returns 0, since dates have no time component.
 Values of type `DATE` can be compared using `=`, `<>`, `!=`, `<`, `>`,
 `<=`, `>=`, `<=>`, `BETWEEN`; the result is a Boolean.
 
+`TIMESTAMPDIFF(<unit>, left, right)` computes the difference between
+two dates values and expresses the result in the specified time units.
+The result is a 32-bit integer.
+
 ## Times
 
 A time represents the time of day, a value between 0 and 24 hours
@@ -137,6 +141,10 @@ time)`.
 
 Values of type `TIME` can be compared using `=`, `<>`, `!=`, `<`, `>`,
 `<=`, `>=`, `<=>`, `BETWEEN`; the result is a Boolean.
+
+`TIMESTAMPDIFF(<unit>, left, right)` computes the difference between
+two time values and expresses the result in the specified time units.
+The result is a 32-bit integer.
 
 ## Timestamps
 
@@ -284,19 +292,21 @@ The following arithmetic operations are supported:
 | Operation                     | Result Type        | Explanation                                                      |
 |-------------------------------|--------------------|------------------------------------------------------------------|
 | `DATE` `+` `INTERVAL`         | `DATE`             | Add an interval to a date                                        |
+| (`DATE` `-` `DATE`) DAYS      | `INTERVAL`         | Compute the difference between two dates as a short interval     |
+| (`DATE` `-` `DATE`) MONTHS    | `INTERVAL`         | Compute the difference between two dates as a long interval      |
+| (`TIME` `-` `TIME`) SECONDS   | `INTERVAL`         | Compute the difference between two times as a short interval     |
 | `INTERVAL` `+` `INTERVAL`     | `INTERVAL`         | Add two intervals; both must have the same type                  |
 | `TIMESTAMP` `+` `INTERVAL`    | `TIMESTAMP`        | Add an interval to a timestamp                                   |
 | `TIME` `+` `INTERVAL`         | `TIME`             | Add an interval to a time. Performs wrapping addition.           |
 | `-` `INTERVAL`                | `INTERVAL`         | Negate an interval                                               |
 | `DATE` `-` `INTERVAL`         | `DATE`             | Subtract an interval from a date                                 |
-| (`TIME` `-` `TIME`) TIMEUNIT  | `INTERVAL` (short) | Compute the difference between two times                         |
 | `TIME` `-` `INTERVAL`         | `TIME`             | Subtract an interval from a time. Performs wrapping subtraction. |
 | `TIMESTAMP` `-` `INTERVAL`    | `TIMESTAMP`        | Subtract an interval from a timestamp                            |
+| (`TIMESTAMP` `-` `TIMESTAMP`) SECONDS | `INTERVAL` | Compute the difference between two timestamps as a short interval|
+| (`TIMESTAMP` `-` `TIMESTAMP`) MONTHS  | `INTERVAL` | Compute the difference between two timestamps as a long interval |
 | `INTERVAL` `-` `INTERVAL`     | `INTERVAL`         | Subtract two intervals                                           |
 | `INTERVAL` `*` `DOUBLE`       | `INTERVAL`         | Multiply an interval by a scalar                                 |
 | `INTERVAL` `/` `DOUBLE`       | `INTERVAL`         | Divide an interval by a scalar                                   |
-| (`DATE` `-` `DATE`) `TIMEUNIT`| `INTERVAL`         | Subtract two dates, generate an interval with the specified time units |
-| (`TIMESTAMP` `-` `TIMESTAMP`) `TIMEUNIT` | `INTERVAL` | Subtract two timestamps, generate an interval with the specified time units |
 
 Arithmetic involving a `TIME` value always produces a (positive)
 `TIME` value, between `00:00:00` (inclusive) and `24:00:00`
@@ -307,12 +317,9 @@ interval from a `TIME` value is supported, but always leaves the
 `TIME` value unchanged (since long intervals always consist of a whole
 number of days).
 
-Arithmetic between a DATE and an INTERVAL first converts the interval
-to a whole number days (rounding down) and then performs the
+Arithmetic between a `DATE` and an `INTERVAL` first converts the
+interval to a whole number days (rounding down) and then performs the
 computation on whole days.
-
-Subtraction between two dates, timestamps, or times must be followed
-by a TIMEUNIT qualifier: e.g., `(DATE '2024-01-01' - DATE '2023-12-31') DAYS`.
 
 `DATE_SUB` is a synonim for `DATE` - `INTERVAL`.  `DATE_ADD` is a
 synonim for `DATE` + `INTERVAL`.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampdiffTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampdiffTests.java
@@ -13,6 +13,13 @@ public class TimestampdiffTests extends SqlIoTest {
                 FROM time_tbl;""");
     }
 
+    @Test
+    public void issue3132() {
+        this.statementsFailingInCompilation(
+                "CREATE VIEW V AS SELECT (DATE '2020-01-01' - DATE '2019-01-01') YEAR",
+                "Unsupported interval: Interval type 'YEAR' not supported for difference operator");
+    }
+
     // Test data obtained from
     // https://github.com/mysql/mysql-server/blob/mysql-test/r/func_time.result#L715
     @Test
@@ -409,16 +416,39 @@ public class TimestampdiffTests extends SqlIoTest {
                  1 day
                 (1 row)
                 
-                 select (TIME '12:00:00' - TIME '10:00:00') MINUTES;
+                 select (TIME '12:00:00' - TIME '10:00:00') SECOND;
                  minutes
                 ---------
                  2 hours
                 (1 row)
                 
-                 select (TIMESTAMP '2024-01-01 12:00:00' - TIMESTAMP '2023-12-31 10:00:00') MINUTES;
+                 select (TIMESTAMP '2024-01-01 12:00:00' - TIMESTAMP '2023-12-31 10:00:00') SECOND;
                  minutes
                 ---------
                  1 day 2 hours
+                (1 row)""");
+    }
+
+    @Test
+    public void diffTests2() {
+        this.qs("""
+                select TIMESTAMPDIFF(DAY, DATE '2024-01-01', DATE '2023-12-31');
+                 days
+                ------
+                 -1
+                (1 row)
+                
+                select TIMESTAMPDIFF(MINUTE, TIME '12:00:00', TIME '10:00:00');
+                 minutes
+                ---------
+                 -120
+                (1 row)
+                
+                -- 24 * 60 + 120 = 1560
+                select TIMESTAMPDIFF(MINUTE, TIMESTAMP '2024-01-01 12:00:00', TIMESTAMP '2023-12-31 10:00:00');
+                 minutes
+                ---------
+                 -1560
                 (1 row)""");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/DateArithmeticTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/DateArithmeticTests.java
@@ -365,13 +365,13 @@ public class DateArithmeticTests extends SqlIoTest {
                  365 days
                 (1 row)
 
-                SELECT (date '2023-12-01' - date '2022-12-01') year;
+                SELECT (date '2023-12-01' - date '2022-12-01') month;
                  diff
                 ------
                  1 year
                 (1 row)
 
-                SELECT (date '2022-12-01' - date '2023-12-01') year;
+                SELECT (date '2022-12-01' - date '2023-12-01') month;
                  diff
                 ------
                  1 year ago

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -240,7 +240,7 @@ public class RegressionTests extends SqlIoTest {
                 CREATE TABLE timestamp_tbl(c1 TIMESTAMP, c2 TIMESTAMP);
                 
                 CREATE LOCAL VIEW atbl_interval AS SELECT
-                (c1 - c2) YEAR AS c1_minus_c2
+                (c1 - c2) MONTH AS c1_minus_c2
                 FROM timestamp_tbl;
                 
                 CREATE LOCAL VIEW interval_minus_interval AS SELECT
@@ -248,7 +248,7 @@ public class RegressionTests extends SqlIoTest {
                 FROM atbl_interval;
                 
                 CREATE MATERIALIZED VIEW interval_minus_interval_seconds AS SELECT
-                CAST((c1) AS BIGINT) AS f_c1
+                EXTRACT(MONTH FROM c1) AS f_c1
                 FROM interval_minus_interval;""");
     }
 
@@ -268,7 +268,7 @@ public class RegressionTests extends SqlIoTest {
                 CREATE TABLE time_tbl(c1 TIME, c2 TIME);
                 
                 CREATE LOCAL VIEW atbl_interval AS SELECT
-                (c1 - c2)MINUTE AS c1_minus_c2
+                (c1 - c2) SECOND AS c1_minus_c2
                 FROM time_tbl;
                 
                 CREATE MATERIALIZED VIEW interval_negation AS SELECT

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -211,7 +211,6 @@ public class BaseSQLTests {
         DBSPCompiler firstCompiler = testsToRun.get(0).ccs.compiler;
         RustFileWriter writer = new RustFileWriter(outputStream);
         int testNumber = 0;
-        String[] extraArgs = new String[0];
         for (TestCase test: testsToRun) {
             if (!test.ccs.compiler.options.same(firstCompiler.options))
                 throw new RuntimeException("Test " + Utilities.singleQuote(testsToRun.get(0).javaTestName) +
@@ -228,7 +227,7 @@ public class BaseSQLTests {
             testNumber++;
         }
         writer.writeAndClose(firstCompiler);
-        Utilities.compileAndTestRust(rustDirectory, true, extraArgs);
+        Utilities.compileAndTestRust(rustDirectory, true);
         testsToRun.clear();
     }
 


### PR DESCRIPTION
I will mark this as a draft for now.
A big problem is that merging this will invalidate many Python date arithmetic tests, and there is no easy way to rewrite them. These tests rely on the difference function to create INTERVAL values.

I have sent a question to the Calcite dev mailing list about the intended semantics of these operations.
I believe that most SQL dialects actually do not support this operation.