### PR TITLE
[SQL] Add missing cast functions to variant (#3140)

### DIFF
--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -1741,6 +1741,14 @@ where
 }
 
 #[doc(hidden)]
+pub fn cast_to_VN_vec<T>(vec: Vec<T>) -> Option<Variant>
+where
+    Variant: From<T>,
+{
+    Some(vec.into())
+}
+
+#[doc(hidden)]
 pub fn cast_to_V_vecN<T>(vec: Option<Vec<T>>) -> Variant
 where
     Variant: From<T>,
@@ -1749,6 +1757,14 @@ where
         None => Variant::SqlNull,
         Some(vec) => vec.into(),
     }
+}
+
+#[doc(hidden)]
+pub fn cast_to_VN_vecN<T>(vec: Option<Vec<T>>) -> Option<Variant>
+where
+    Variant: From<T>,
+{
+    Some(cast_to_V_vecN(vec))
 }
 
 #[doc(hidden)]

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -141,6 +141,14 @@ public class RegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue3140() {
+        this.compileRustTestCase("""
+                CREATE TABLE variant_tbl(c1 INT ARRAY);
+                CREATE MATERIALIZED VIEW atbl_variant AS SELECT
+                CAST(c1 AS VARIANT) AS c1 FROM variant_tbl;""");
+    }
+
+    @Test
     public void issue3072() {
         this.compileRustTestCase("""
                 CREATE TABLE t0(c0 VARCHAR);


### PR DESCRIPTION
I initially thought these functions are not necessary, since VARIANTs can never be null when produced by casts, but the type inference of Calcite requires them anyway, since it doesn't know this fact.