### PR TITLE
pipeline-manager: include git commit hash in platform version

### DIFF
--- a/crates/pipeline-manager/build.rs
+++ b/crates/pipeline-manager/build.rs
@@ -2,6 +2,7 @@ use change_detection::ChangeDetection;
 use static_files::{resource_dir, NpmBuild};
 use std::env;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 // These are touched during the build, so it would re-build every time if we
 // don't exclude them from change detection:
@@ -12,15 +13,31 @@ const EXCLUDE_LIST: [&str; 4] = [
     "../../web-console/pipeline-manager-",
 ];
 
-/// The build script has two modes:
+/// The build script has two features:
+/// 1. Generate the static files of the Web Console, which are served by the manager.
+/// 2. Identify the git commit hash, which is used in the platform version.
 ///
-/// - if `WEBCONSOLE_BUILD_DIR` we use that to serve in the manager
-/// - otherwise we build the web-console from web-console and serve it from the
-///   manager
+/// **Web Console build**
+///
+/// The Web Console build has two modes:
+/// - If `WEBCONSOLE_BUILD_DIR` we use that to serve in the manager
+/// - Otherwise, we build it from the ../../web-console directory and serve that
 ///
 /// The first mode is useful in CI builds to cache the website build so it
 /// doesn't get built many times due to changing rustc flags.
+///
+/// **Identify git commit hash**
+///
+/// The platform version must include the git commit hash, such that automatic
+/// upgrades take place not only between releases, but also between individual commits.
+///
+/// Identification has two modes:
+/// - If `FELDERA_BUILD_GIT_COMMIT_HASH` is set, use this
+/// - Otherwise, use `git rev-parse HEAD`
+///
+/// The first mode is useful when the crate was copied directly without the parent `.git` folder.
 fn main() {
+    // Web Console build
     if let Ok(webui_out_folder) = env::var("WEBCONSOLE_BUILD_DIR") {
         ChangeDetection::path(&webui_out_folder)
             .path("build.rs")
@@ -65,4 +82,39 @@ fn main() {
         let _ = resource_dir.with_generated_filename(out_dir.join("generated.rs"));
         resource_dir.build().expect("SvelteKit app failed to build")
     };
+
+    // Identify git commit hash
+    let git_commit_hash = env::var("FELDERA_BUILD_GIT_COMMIT_HASH").unwrap_or({
+        let output = Command::new("git")
+            .arg("rev-parse")
+            .arg("HEAD")
+            .stdout(Stdio::piped())
+            .output()
+            .expect("failed to execute 'git rev-parse HEAD'");
+        if !output.status.success() {
+            panic!(
+                "Command 'git rev-parse HEAD' returned unsuccessful status: {}",
+                output.status
+            )
+        }
+        String::from_utf8(output.stdout)
+            .expect("git commit hash should be valid UTF-8")
+            .trim()
+            .to_string()
+    });
+    assert_eq!(
+        git_commit_hash.len(),
+        40,
+        "expected git commit hash to be 40 characters long: {git_commit_hash}"
+    );
+    for c in git_commit_hash.chars() {
+        assert!(
+            c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_lowercase()),
+            "Invalid character '{c}' in git commit hash"
+        );
+    }
+    // TODO: is below check for .git necessary / too slow?
+    // println!("cargo:rerun-if-changed=../../.git/");
+    println!("cargo:rerun-if-env-changed=FELDERA_BUILD_GIT_COMMIT_HASH");
+    println!("cargo:rustc-env=FELDERA_BUILD_GIT_COMMIT_HASH={git_commit_hash}");
 }

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -10,10 +10,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// The default `platform_version`, which is retrieved from the
-/// environment variable `CARGO_PKG_VERSION` set by Cargo.
+/// The default `platform_version` is formed using two compilation environment variables:
+/// - `CARGO_PKG_VERSION` set by Cargo
+/// - `FELDERA_BUILD_GIT_COMMIT_HASH` set by the custom `build.rs` script
 fn default_platform_version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+    let package_version = env!("CARGO_PKG_VERSION").to_string();
+    let git_commit_hash = env!("FELDERA_BUILD_GIT_COMMIT_HASH").to_string();
+    format!("{package_version}+{git_commit_hash}")
 }
 
 /// Default working directory: ~/.feldera

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -23,6 +23,9 @@ RUN apt update --fix-missing && apt install \
   ca-certificates gnupg \
   # Required by the `metrics-exporter-tcp` crate
   protobuf-compiler
+  # TODO: decide on below
+  # # Required to retrieve the git commit hash
+  # git
 
 # Set UTF-8 locale. Needed for the Rust compiler to handle Unicode column names.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -87,6 +90,9 @@ COPY sql-to-dbsp-compiler/lib sql-to-dbsp-compiler/lib
 COPY --from=web-ui-builder /web-console/build web-console-build
 ENV WEBUI_BUILD_DIR=/app/web-console-out
 ENV WEBCONSOLE_BUILD_DIR=/app/web-console-build
+# TODO: decide on below
+# # Used to extract the git commit hash which will be included in the platform version
+# COPY .git .git
 RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --features=pg-embed
 
 # Java build can be performed in parallel


### PR DESCRIPTION
Open questions:
- Is it necessary to copy the whole `.git` folder in the Dockerfile? Alternative could be supplying an ARG, but then it needs to be explicitly set in advance before calling `docker build`.
- Should the `build.rs` do the git commit hash retrieval, or should it come from external?
- Another alternative could be that the manager at runtime looks over the arguments it gets (e.g., java compiler jar, dbsp folder, etc.) and uses that to create its checksum, getting rid of platform version altogether. Though this has its own downsides, as it would need to carefully cover everything that has an effect.