### PR TITLE
Fixes deadlocks with input stats RwLock.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1457,9 +1457,7 @@ impl BackpressureThread {
             };
 
             for (epid, ep) in controller.status.input_status().iter() {
-                let should_run = globally_running
-                    && !controller.status.input_endpoint_paused_by_user(epid)
-                    && !controller.status.input_endpoint_full(epid);
+                let should_run = globally_running && !ep.is_paused_by_user() && !ep.is_full();
                 match should_run {
                     true => {
                         if running_endpoints.insert(*epid) {

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -7,6 +7,7 @@ use crate::error::ManagerError;
 use crate::runner::error::RunnerError;
 use actix_web::{http::Method, web::Payload, HttpRequest, HttpResponse, HttpResponseBuilder};
 use reqwest::StatusCode;
+use std::sync::LazyLock;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
@@ -87,9 +88,9 @@ impl RunnerInteraction {
         query_string: &str,
         timeout: Option<Duration>, // If timeout is not specified, a default timeout is used
     ) -> Result<(String, reqwest::Response), ManagerError> {
-        let client = reqwest::Client::new();
+        static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
         let url = RunnerInteraction::format_pipeline_url(location, endpoint, query_string);
-        let response = client
+        let response = CLIENT
             .request(method, &url)
             .timeout(timeout.unwrap_or(Self::PIPELINE_HTTP_REQUEST_TIMEOUT))
             .send()


### PR DESCRIPTION
This was reported in #3139.

The problem boils down to re-entrant read() locking that leads to the 2nd read() call blocking when you have an outstanding writer. Consider this code that locks up as an example of what was happening:

```
use std::sync::RwLock;
use std::thread;
use std::time::Duration;

static LOCK: RwLock<i32> = RwLock::new(42);

fn main() {
    let r1 = LOCK.read().unwrap();
    thread::spawn(|| {
        let w1 = LOCK.write().unwrap();
    });
    thread::sleep(Duration::from_millis(100));
    let r2 = LOCK.read().unwrap();
}
```

The performance of http input is still terrible OTOH we made it a little bit better by reducing the timeout but it doesn't go beyond a 200req/s, probably thanks to all the overheads of creating separate endpoints/locking for each POST request.