### PR TITLE
pipeline-manager: pipeline GET selector and allow missing in POST/PUT

### DIFF
--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -1,10 +1,12 @@
 // Example errors for use in OpenAPI docs.
 use crate::api::error::ApiError;
-use crate::api::pipeline::{ExtendedPipelineDescrOptionalCode, PatchPipeline};
+use crate::api::pipeline::{
+    PatchPipeline, PipelineFieldSelector, PipelineInfo, PipelineSelectedInfo, PostPutPipeline,
+};
 use crate::db::error::DBError;
 use crate::db::types::common::Version;
 use crate::db::types::pipeline::{
-    ExtendedPipelineDescr, PipelineDescr, PipelineDesiredStatus, PipelineId, PipelineStatus,
+    ExtendedPipelineDescr, PipelineDesiredStatus, PipelineId, PipelineStatus,
 };
 use crate::db::types::program::{CompilationProfile, ProgramConfig, ProgramStatus};
 use crate::error::ManagerError;
@@ -46,26 +48,26 @@ pub(crate) fn error_stream_terminated() -> ErrorResponse {
     })
 }
 
-pub(crate) fn pipeline_1() -> PipelineDescr {
-    PipelineDescr {
+pub(crate) fn pipeline_post_put() -> PostPutPipeline {
+    PostPutPipeline {
         name: "example1".to_string(),
-        description: "Description of the pipeline example1".to_string(),
-        runtime_config: RuntimeConfig {
+        description: Some("Description of the pipeline example1".to_string()),
+        runtime_config: Some(RuntimeConfig {
             workers: 16,
             tracing_endpoint_jaeger: "".to_string(),
             ..RuntimeConfig::default()
-        },
+        }),
         program_code: "CREATE TABLE table1 ( col1 INT );".to_string(),
-        udf_rust: "".to_string(),
-        udf_toml: "".to_string(),
-        program_config: ProgramConfig {
+        udf_rust: None,
+        udf_toml: None,
+        program_config: Some(ProgramConfig {
             profile: Some(CompilationProfile::Optimized),
             cache: true,
-        },
+        }),
     }
 }
 
-pub(crate) fn extended_pipeline_1() -> ExtendedPipelineDescr {
+fn extended_pipeline_1() -> ExtendedPipelineDescr {
     ExtendedPipelineDescr {
         id: PipelineId(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8")),
         name: "example1".to_string(),
@@ -101,7 +103,7 @@ pub(crate) fn extended_pipeline_1() -> ExtendedPipelineDescr {
     }
 }
 
-pub(crate) fn extended_pipeline_2() -> ExtendedPipelineDescr {
+fn extended_pipeline_2() -> ExtendedPipelineDescr {
     ExtendedPipelineDescr {
         id: PipelineId(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c9")),
         name: "example2".to_string(),
@@ -152,11 +154,20 @@ pub(crate) fn extended_pipeline_2() -> ExtendedPipelineDescr {
     }
 }
 
-pub(crate) fn list_extended_pipeline_optional_code() -> Vec<ExtendedPipelineDescrOptionalCode> {
-    vec![
-        ExtendedPipelineDescrOptionalCode::new(extended_pipeline_1(), false),
-        ExtendedPipelineDescrOptionalCode::new(extended_pipeline_2(), false),
-    ]
+pub(crate) fn pipeline_1_info() -> PipelineInfo {
+    PipelineInfo::new(&extended_pipeline_1())
+}
+
+pub(crate) fn pipeline_1_selected_info() -> PipelineSelectedInfo {
+    PipelineSelectedInfo::new(&extended_pipeline_1(), &PipelineFieldSelector::All)
+}
+
+pub(crate) fn pipeline_2_selected_info() -> PipelineSelectedInfo {
+    PipelineSelectedInfo::new(&extended_pipeline_2(), &PipelineFieldSelector::All)
+}
+
+pub(crate) fn list_pipeline_selected_info() -> Vec<PipelineSelectedInfo> {
+    vec![pipeline_1_selected_info(), pipeline_2_selected_info()]
 }
 
 pub(crate) fn patch_pipeline() -> PatchPipeline {

--- a/crates/pipeline-manager/src/api/mod.rs
+++ b/crates/pipeline-manager/src/api/mod.rs
@@ -49,6 +49,7 @@ use actix_web_static_files::ResourceFiles;
 use anyhow::{Error as AnyError, Result as AnyResult};
 use futures_util::FutureExt;
 use log::{error, log, trace, Level};
+pub use pipeline::PipelineFieldSelector;
 use std::io::Write;
 use std::time::Duration;
 use std::{env, io, net::TcpListener, sync::Arc};
@@ -141,13 +142,14 @@ The program version is used internally by the compiler to know when to recompile
 
         // Pipeline
         crate::db::types::pipeline::PipelineId,
-        crate::db::types::pipeline::PipelineDescr,
-        crate::db::types::pipeline::ExtendedPipelineDescr,
         crate::db::types::pipeline::PipelineStatus,
         crate::db::types::pipeline::PipelineDesiredStatus,
-        crate::api::pipeline::ListPipelinesQueryParameters,
+        crate::api::pipeline::PipelineInfo,
+        crate::api::pipeline::PipelineSelectedInfo,
+        crate::api::pipeline::PipelineFieldSelector,
+        crate::api::pipeline::GetPipelineParameters,
+        crate::api::pipeline::PostPutPipeline,
         crate::api::pipeline::PatchPipeline,
-        crate::api::pipeline::ExtendedPipelineDescrOptionalCode,
 
         // Demo
         crate::demo::Demo,

--- a/crates/pipeline-manager/src/compiler/util.rs
+++ b/crates/pipeline-manager/src/compiler/util.rs
@@ -22,6 +22,9 @@ pub async fn create_new_file_with_content(
     file.write_all(content.as_bytes())
         .await
         .map_err(|e| CommonError::io_error(format!("writing file '{}'", file_path.display()), e))?;
+    file.flush().await.map_err(|e| {
+        CommonError::io_error(format!("flushing file '{}'", file_path.display()), e)
+    })?;
     Ok(())
 }
 
@@ -41,6 +44,9 @@ pub async fn recreate_file_with_content(
     file.write_all(content.as_bytes())
         .await
         .map_err(|e| CommonError::io_error(format!("writing file '{}'", file_path.display()), e))?;
+    file.flush().await.map_err(|e| {
+        CommonError::io_error(format!("flushing file '{}'", file_path.display()), e)
+    })?;
     Ok(())
 }
 

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -82,13 +82,13 @@ impl Display for PipelineId {
 /// in the diagram.
 ///
 /// The user can monitor the current state of the pipeline via the
-/// `GET /v0/pipelines/{name}` endpoint, which returns an object of type
-/// `ExtendedPipelineDescr`. In a typical scenario, the user first sets
-/// the desired state, e.g., by invoking the `/start` endpoint, and
-/// then polls the `GET /v0/pipelines/{name}` endpoint to monitor the
-/// actual status of the pipeline until its `deployment_status` attribute
-/// changes to "running" indicating that the pipeline has been successfully
-/// initialized and is processing data, or "failed", indicating an error.
+/// `GET /v0/pipelines/{name}` endpoint. In a typical scenario,
+/// the user first sets the desired state, e.g., by invoking the
+/// `/start` endpoint, and then polls the `GET /v0/pipelines/{name}`
+/// endpoint to monitor the actual status of the pipeline until its
+/// `deployment_status` attribute changes to `Running` indicating
+/// that the pipeline has been successfully initialized and is
+/// processing data, or `Failed`, indicating an error.
 #[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone, Copy)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum PipelineStatus {
@@ -364,7 +364,7 @@ pub fn validate_deployment_desired_status_transition(
 }
 
 /// Pipeline descriptor.
-#[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct PipelineDescr {
     /// Pipeline name.
     pub name: String,
@@ -379,11 +379,9 @@ pub struct PipelineDescr {
     pub program_code: String,
 
     /// Rust code for UDFs.
-    #[serde(default)]
     pub udf_rust: String,
 
     /// Rust dependencies in the TOML format.
-    #[serde(default)]
     pub udf_toml: String,
 
     /// Program compilation configuration.
@@ -392,7 +390,7 @@ pub struct PipelineDescr {
 
 /// Pipeline descriptor which besides the basic fields in direct regular control of the user
 /// also has all additional fields generated and maintained by the back-end.
-#[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub struct ExtendedPipelineDescr {
     /// Assigned globally unique pipeline identifier.
     pub id: PipelineId,

--- a/openapi.json
+++ b/openapi.json
@@ -332,16 +332,16 @@
           "Pipelines"
         ],
         "summary": "Retrieve the list of pipelines.",
-        "description": "Inclusion of program code is configured with by the `code` boolean query parameter.",
+        "description": "Configure which fields are included using the `selector` query parameter.",
         "operationId": "list_pipelines",
         "parameters": [
           {
-            "name": "code",
+            "name": "selector",
             "in": "query",
-            "description": "Whether to include program code in the response (default: `true`).\nPassing `false` reduces the response size, which is particularly handy\nwhen frequently monitoring the endpoint over low bandwidth connections.",
+            "description": "The `selector` parameter limits which fields are returned for a pipeline.\nLimiting which fields is particularly handy for instance when frequently\nmonitoring over low bandwidth connections while being only interested\nin pipeline status.",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "$ref": "#/components/schemas/PipelineFieldSelector"
             }
           }
         ],
@@ -353,26 +353,21 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ExtendedPipelineDescrOptionalCode"
+                    "$ref": "#/components/schemas/PipelineSelectedInfo"
                   }
                 },
                 "example": [
                   {
                     "created_at": "1970-01-01T00:00:00Z",
-                    "deployment_config": null,
                     "deployment_desired_status": "Shutdown",
                     "deployment_error": null,
-                    "deployment_location": null,
                     "deployment_status": "Shutdown",
                     "deployment_status_since": "1970-01-01T00:00:00Z",
                     "description": "Description of the pipeline example1",
                     "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                     "name": "example1",
                     "platform_version": "v0",
-                    "program_binary_integrity_checksum": null,
-                    "program_binary_source_checksum": null,
-                    "program_binary_url": null,
-                    "program_code": null,
+                    "program_code": "CREATE TABLE table1 ( col1 INT );",
                     "program_config": {
                       "cache": true,
                       "profile": "optimized"
@@ -401,26 +396,21 @@
                       "tracing_endpoint_jaeger": "",
                       "workers": 16
                     },
-                    "udf_rust": null,
-                    "udf_toml": null,
+                    "udf_rust": "",
+                    "udf_toml": "",
                     "version": 4
                   },
                   {
                     "created_at": "1970-01-01T00:00:00Z",
-                    "deployment_config": null,
                     "deployment_desired_status": "Shutdown",
                     "deployment_error": null,
-                    "deployment_location": null,
                     "deployment_status": "Shutdown",
                     "deployment_status_since": "1970-01-01T00:00:00Z",
                     "description": "Description of the pipeline example2",
                     "id": "67e55044-10b1-426f-9247-bb680e5fe0c9",
                     "name": "example2",
                     "platform_version": "v0",
-                    "program_binary_integrity_checksum": null,
-                    "program_binary_source_checksum": null,
-                    "program_binary_url": null,
-                    "program_code": null,
+                    "program_code": "CREATE TABLE table2 ( col2 VARCHAR );",
                     "program_config": {
                       "cache": true,
                       "profile": "unoptimized"
@@ -449,8 +439,8 @@
                       "tracing_endpoint_jaeger": "",
                       "workers": 10
                     },
-                    "udf_rust": null,
-                    "udf_toml": null,
+                    "udf_rust": "",
+                    "udf_toml": "",
                     "version": 1
                   }
                 ]
@@ -484,7 +474,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PipelineDescr"
+                "$ref": "#/components/schemas/PostPutPipeline"
               },
               "example": {
                 "description": "Description of the pipeline example1",
@@ -514,8 +504,8 @@
                   "tracing_endpoint_jaeger": "",
                   "workers": 16
                 },
-                "udf_rust": "",
-                "udf_toml": ""
+                "udf_rust": null,
+                "udf_toml": null
               }
             }
           },
@@ -527,23 +517,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPipelineDescr"
+                  "$ref": "#/components/schemas/PipelineInfo"
                 },
                 "example": {
                   "created_at": "1970-01-01T00:00:00Z",
-                  "deployment_config": null,
                   "deployment_desired_status": "Shutdown",
                   "deployment_error": null,
-                  "deployment_location": null,
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "description": "Description of the pipeline example1",
                   "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "name": "example1",
                   "platform_version": "v0",
-                  "program_binary_integrity_checksum": null,
-                  "program_binary_source_checksum": null,
-                  "program_binary_url": null,
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "program_config": {
                     "cache": true,
@@ -626,6 +611,7 @@
           "Pipelines"
         ],
         "summary": "Retrieve a pipeline.",
+        "description": "Configure which fields are included using the `selector` query parameter.",
         "operationId": "get_pipeline",
         "parameters": [
           {
@@ -636,6 +622,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "selector",
+            "in": "query",
+            "description": "The `selector` parameter limits which fields are returned for a pipeline.\nLimiting which fields is particularly handy for instance when frequently\nmonitoring over low bandwidth connections while being only interested\nin pipeline status.",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PipelineFieldSelector"
+            }
           }
         ],
         "responses": {
@@ -644,23 +639,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPipelineDescr"
+                  "$ref": "#/components/schemas/PipelineSelectedInfo"
                 },
                 "example": {
                   "created_at": "1970-01-01T00:00:00Z",
-                  "deployment_config": null,
                   "deployment_desired_status": "Shutdown",
                   "deployment_error": null,
-                  "deployment_location": null,
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "description": "Description of the pipeline example1",
                   "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "name": "example1",
                   "platform_version": "v0",
-                  "program_binary_integrity_checksum": null,
-                  "program_binary_source_checksum": null,
-                  "program_binary_url": null,
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "program_config": {
                     "cache": true,
@@ -742,7 +732,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PipelineDescr"
+                "$ref": "#/components/schemas/PostPutPipeline"
               },
               "example": {
                 "description": "Description of the pipeline example1",
@@ -772,8 +762,8 @@
                   "tracing_endpoint_jaeger": "",
                   "workers": 16
                 },
-                "udf_rust": "",
-                "udf_toml": ""
+                "udf_rust": null,
+                "udf_toml": null
               }
             }
           },
@@ -785,23 +775,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPipelineDescr"
+                  "$ref": "#/components/schemas/PipelineInfo"
                 },
                 "example": {
                   "created_at": "1970-01-01T00:00:00Z",
-                  "deployment_config": null,
                   "deployment_desired_status": "Shutdown",
                   "deployment_error": null,
-                  "deployment_location": null,
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "description": "Description of the pipeline example1",
                   "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "name": "example1",
                   "platform_version": "v0",
-                  "program_binary_integrity_checksum": null,
-                  "program_binary_source_checksum": null,
-                  "program_binary_url": null,
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "program_config": {
                     "cache": true,
@@ -843,23 +828,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPipelineDescr"
+                  "$ref": "#/components/schemas/PipelineInfo"
                 },
                 "example": {
                   "created_at": "1970-01-01T00:00:00Z",
-                  "deployment_config": null,
                   "deployment_desired_status": "Shutdown",
                   "deployment_error": null,
-                  "deployment_location": null,
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "description": "Description of the pipeline example1",
                   "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "name": "example1",
                   "platform_version": "v0",
-                  "program_binary_integrity_checksum": null,
-                  "program_binary_source_checksum": null,
-                  "program_binary_url": null,
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "program_config": {
                     "cache": true,
@@ -1035,23 +1015,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPipelineDescr"
+                  "$ref": "#/components/schemas/PipelineInfo"
                 },
                 "example": {
                   "created_at": "1970-01-01T00:00:00Z",
-                  "deployment_config": null,
                   "deployment_desired_status": "Shutdown",
                   "deployment_error": null,
-                  "deployment_location": null,
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "description": "Description of the pipeline example1",
                   "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
                   "name": "example1",
                   "platform_version": "v0",
-                  "program_binary_integrity_checksum": null,
-                  "program_binary_source_checksum": null,
-                  "program_binary_url": null,
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "program_config": {
                     "cache": true,
@@ -2531,257 +2506,6 @@
           }
         }
       },
-      "ExtendedPipelineDescr": {
-        "type": "object",
-        "description": "Pipeline descriptor which besides the basic fields in direct regular control of the user\nalso has all additional fields generated and maintained by the back-end.",
-        "required": [
-          "id",
-          "name",
-          "description",
-          "created_at",
-          "version",
-          "platform_version",
-          "runtime_config",
-          "program_code",
-          "udf_rust",
-          "udf_toml",
-          "program_config",
-          "program_version",
-          "program_status",
-          "program_status_since",
-          "deployment_status",
-          "deployment_status_since",
-          "deployment_desired_status"
-        ],
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Timestamp when the pipeline was originally created."
-          },
-          "deployment_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PipelineConfig"
-              }
-            ],
-            "nullable": true
-          },
-          "deployment_desired_status": {
-            "$ref": "#/components/schemas/PipelineDesiredStatus"
-          },
-          "deployment_error": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorResponse"
-              }
-            ],
-            "nullable": true
-          },
-          "deployment_location": {
-            "type": "string",
-            "description": "Location where the pipeline can be reached at runtime\n(e.g., a TCP port number or a URI).",
-            "nullable": true
-          },
-          "deployment_status": {
-            "$ref": "#/components/schemas/PipelineStatus"
-          },
-          "deployment_status_since": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Time when the pipeline was assigned its current status\nof the pipeline."
-          },
-          "description": {
-            "type": "string",
-            "description": "Pipeline description."
-          },
-          "id": {
-            "$ref": "#/components/schemas/PipelineId"
-          },
-          "name": {
-            "type": "string",
-            "description": "Pipeline name."
-          },
-          "platform_version": {
-            "type": "string",
-            "description": "Pipeline platform version."
-          },
-          "program_binary_integrity_checksum": {
-            "type": "string",
-            "description": "Checksum of the binary file itself.",
-            "nullable": true
-          },
-          "program_binary_source_checksum": {
-            "type": "string",
-            "description": "Combined checksum of all the inputs that influenced Rust compilation to a binary.",
-            "nullable": true
-          },
-          "program_binary_url": {
-            "type": "string",
-            "description": "URL where to download the program binary from.",
-            "nullable": true
-          },
-          "program_code": {
-            "type": "string",
-            "description": "Program SQL code."
-          },
-          "program_config": {
-            "$ref": "#/components/schemas/ProgramConfig"
-          },
-          "program_info": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ProgramInfo"
-              }
-            ],
-            "nullable": true
-          },
-          "program_status": {
-            "$ref": "#/components/schemas/ProgramStatus"
-          },
-          "program_status_since": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Timestamp when the current program status was set."
-          },
-          "program_version": {
-            "$ref": "#/components/schemas/Version"
-          },
-          "runtime_config": {
-            "$ref": "#/components/schemas/RuntimeConfig"
-          },
-          "udf_rust": {
-            "type": "string",
-            "description": "Rust code for UDFs."
-          },
-          "udf_toml": {
-            "type": "string",
-            "description": "Rust dependencies in the TOML format."
-          },
-          "version": {
-            "$ref": "#/components/schemas/Version"
-          }
-        }
-      },
-      "ExtendedPipelineDescrOptionalCode": {
-        "type": "object",
-        "description": "Extended pipeline descriptor with code being optionally included.",
-        "required": [
-          "id",
-          "name",
-          "description",
-          "created_at",
-          "version",
-          "platform_version",
-          "runtime_config",
-          "program_config",
-          "program_version",
-          "program_status",
-          "program_status_since",
-          "deployment_status",
-          "deployment_status_since",
-          "deployment_desired_status"
-        ],
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "deployment_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PipelineConfig"
-              }
-            ],
-            "nullable": true
-          },
-          "deployment_desired_status": {
-            "$ref": "#/components/schemas/PipelineDesiredStatus"
-          },
-          "deployment_error": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorResponse"
-              }
-            ],
-            "nullable": true
-          },
-          "deployment_location": {
-            "type": "string",
-            "nullable": true
-          },
-          "deployment_status": {
-            "$ref": "#/components/schemas/PipelineStatus"
-          },
-          "deployment_status_since": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "description": {
-            "type": "string"
-          },
-          "id": {
-            "$ref": "#/components/schemas/PipelineId"
-          },
-          "name": {
-            "type": "string"
-          },
-          "platform_version": {
-            "type": "string"
-          },
-          "program_binary_integrity_checksum": {
-            "type": "string",
-            "nullable": true
-          },
-          "program_binary_source_checksum": {
-            "type": "string",
-            "nullable": true
-          },
-          "program_binary_url": {
-            "type": "string",
-            "nullable": true
-          },
-          "program_code": {
-            "type": "string",
-            "nullable": true
-          },
-          "program_config": {
-            "$ref": "#/components/schemas/ProgramConfig"
-          },
-          "program_info": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ProgramInfo"
-              }
-            ],
-            "nullable": true
-          },
-          "program_status": {
-            "$ref": "#/components/schemas/ProgramStatus"
-          },
-          "program_status_since": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "program_version": {
-            "$ref": "#/components/schemas/Version"
-          },
-          "runtime_config": {
-            "$ref": "#/components/schemas/RuntimeConfig"
-          },
-          "udf_rust": {
-            "type": "string",
-            "nullable": true
-          },
-          "udf_toml": {
-            "type": "string",
-            "nullable": true
-          },
-          "version": {
-            "$ref": "#/components/schemas/Version"
-          }
-        }
-      },
       "Field": {
         "allOf": [
           {
@@ -2915,6 +2639,15 @@
           }
         },
         "additionalProperties": false
+      },
+      "GetPipelineParameters": {
+        "type": "object",
+        "description": "Query parameters to GET a pipeline or a list of pipelines.",
+        "properties": {
+          "selector": {
+            "$ref": "#/components/schemas/PipelineFieldSelector"
+          }
+        }
       },
       "HttpInputConfig": {
         "type": "object",
@@ -3154,16 +2887,6 @@
           }
         }
       },
-      "ListPipelinesQueryParameters": {
-        "type": "object",
-        "description": "Query parameters for GET the list of pipelines.",
-        "properties": {
-          "code": {
-            "type": "boolean",
-            "description": "Whether to include program code in the response (default: `true`).\nPassing `false` reduces the response size, which is particularly handy\nwhen frequently monitoring the endpoint over low bandwidth connections."
-          }
-        }
-      },
       "NewApiKeyRequest": {
         "type": "object",
         "description": "Request to create a new API key.",
@@ -3308,7 +3031,7 @@
       },
       "PatchPipeline": {
         "type": "object",
-        "description": "Patch (partially) update the pipeline.\n\nNote that the patching only applies to the main fields, not subfields.\nFor instance, it is not possible to update only the number of workers;\nit is required to again pass the whole runtime configuration with the\nchange.",
+        "description": "Partially update the pipeline (PATCH).\n\nNote that the patching only applies to the main fields, not subfields.\nFor instance, it is not possible to update only the number of workers;\nit is required to again pass the whole runtime configuration with the\nchange.",
         "properties": {
           "description": {
             "type": "string",
@@ -3474,45 +3197,6 @@
         ],
         "description": "Pipeline deployment configuration.\nIt represents configuration entries directly provided by the user\n(e.g., runtime configuration) and entries derived from the schema\nof the compiled program (e.g., connectors). Storage configuration,\nif applicable, is set by the runner."
       },
-      "PipelineDescr": {
-        "type": "object",
-        "description": "Pipeline descriptor.",
-        "required": [
-          "name",
-          "description",
-          "runtime_config",
-          "program_code",
-          "program_config"
-        ],
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Pipeline description."
-          },
-          "name": {
-            "type": "string",
-            "description": "Pipeline name."
-          },
-          "program_code": {
-            "type": "string",
-            "description": "Program SQL code."
-          },
-          "program_config": {
-            "$ref": "#/components/schemas/ProgramConfig"
-          },
-          "runtime_config": {
-            "$ref": "#/components/schemas/RuntimeConfig"
-          },
-          "udf_rust": {
-            "type": "string",
-            "description": "Rust code for UDFs."
-          },
-          "udf_toml": {
-            "type": "string",
-            "description": "Rust dependencies in the TOML format."
-          }
-        }
-      },
       "PipelineDesiredStatus": {
         "type": "string",
         "enum": [
@@ -3521,14 +3205,219 @@
           "Running"
         ]
       },
+      "PipelineFieldSelector": {
+        "type": "string",
+        "enum": [
+          "all",
+          "status"
+        ]
+      },
       "PipelineId": {
         "type": "string",
         "format": "uuid",
         "description": "Pipeline identifier."
       },
+      "PipelineInfo": {
+        "type": "object",
+        "description": "Pipeline information.",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created_at",
+          "version",
+          "platform_version",
+          "runtime_config",
+          "program_code",
+          "udf_rust",
+          "udf_toml",
+          "program_config",
+          "program_version",
+          "program_status",
+          "program_status_since",
+          "deployment_status",
+          "deployment_status_since",
+          "deployment_desired_status"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployment_desired_status": {
+            "$ref": "#/components/schemas/PipelineDesiredStatus"
+          },
+          "deployment_error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            ],
+            "nullable": true
+          },
+          "deployment_status": {
+            "$ref": "#/components/schemas/PipelineStatus"
+          },
+          "deployment_status_since": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/PipelineId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platform_version": {
+            "type": "string"
+          },
+          "program_code": {
+            "type": "string"
+          },
+          "program_config": {
+            "$ref": "#/components/schemas/ProgramConfig"
+          },
+          "program_info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgramInfo"
+              }
+            ],
+            "nullable": true
+          },
+          "program_status": {
+            "$ref": "#/components/schemas/ProgramStatus"
+          },
+          "program_status_since": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "program_version": {
+            "$ref": "#/components/schemas/Version"
+          },
+          "runtime_config": {
+            "$ref": "#/components/schemas/RuntimeConfig"
+          },
+          "udf_rust": {
+            "type": "string"
+          },
+          "udf_toml": {
+            "type": "string"
+          },
+          "version": {
+            "$ref": "#/components/schemas/Version"
+          }
+        }
+      },
+      "PipelineSelectedInfo": {
+        "type": "object",
+        "description": "Pipeline information which has a selected subset of optional fields.\nIf an optional field is not selected (i.e., is `None`), it will not be serialized.",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "created_at",
+          "version",
+          "platform_version",
+          "program_version",
+          "program_status",
+          "program_status_since",
+          "deployment_status",
+          "deployment_status_since",
+          "deployment_desired_status"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployment_desired_status": {
+            "$ref": "#/components/schemas/PipelineDesiredStatus"
+          },
+          "deployment_error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorResponse"
+              }
+            ],
+            "nullable": true
+          },
+          "deployment_status": {
+            "$ref": "#/components/schemas/PipelineStatus"
+          },
+          "deployment_status_since": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/PipelineId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platform_version": {
+            "type": "string"
+          },
+          "program_code": {
+            "type": "string",
+            "nullable": true
+          },
+          "program_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgramConfig"
+              }
+            ],
+            "nullable": true
+          },
+          "program_info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgramInfo"
+              }
+            ],
+            "nullable": true
+          },
+          "program_status": {
+            "$ref": "#/components/schemas/ProgramStatus"
+          },
+          "program_status_since": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "program_version": {
+            "$ref": "#/components/schemas/Version"
+          },
+          "runtime_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeConfig"
+              }
+            ],
+            "nullable": true
+          },
+          "udf_rust": {
+            "type": "string",
+            "nullable": true
+          },
+          "udf_toml": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "$ref": "#/components/schemas/Version"
+          }
+        }
+      },
       "PipelineStatus": {
         "type": "string",
-        "description": "Pipeline status.\n\nThis type represents the state of the pipeline tracked by the pipeline\nrunner and observed by the API client via the `GET /v0/pipelines/{name}` endpoint.\n\n### The lifecycle of a pipeline\n\nThe following automaton captures the lifecycle of the pipeline.\nIndividual states and transitions of the automaton are described below.\n\n* States labeled with the hourglass symbol (⌛) are **timed** states. The\nautomaton stays in timed state until the corresponding operation completes\nor until it transitions to become failed after the pre-defined timeout\nperiod expires.\n\n* State transitions labeled with API endpoint names (`/start`, `/pause`,\n`/shutdown`) are triggered by invoking corresponding endpoint,\ne.g., `POST /v0/pipelines/{name}/start`. Note that these only express\ndesired state, and are applied asynchronously by the automata.\n\n```text\nShutdown◄────────────────────┐\n│                        │\n/start or /pause│                    ShuttingDown ◄────── Failed\n│                        ▲                  ▲\n▼              /shutdown │                  │\n⌛Provisioning ──────────────────┤        Shutdown, Provisioning,\n│                        │        Initializing, Paused,\n│                        │         Running, Unavailable\n▼                        │    (all states except ShuttingDown\n⌛Initializing ──────────────────┤      can transition to Failed)\n│                        │\n┌─────────┼────────────────────────┴─┐\n│         ▼                          │\n│       Paused  ◄──────► Unavailable │\n│       │    ▲                ▲      │\n│ /start│    │/pause          │      │\n│       ▼    │                │      │\n│      Running ◄──────────────┘      │\n└────────────────────────────────────┘\n```\n\n### Desired and actual status\n\nWe use the desired state model to manage the lifecycle of a pipeline.\nIn this model, the pipeline has two status attributes associated with\nit at runtime: the **desired** status, which represents what the user\nwould like the pipeline to do, and the **current** status, which\nrepresents the actual state of the pipeline.  The pipeline runner\nservice continuously monitors both fields and steers the pipeline\ntowards the desired state specified by the user.\nOnly three of the states in the pipeline automaton above can be\nused as desired statuses: `Paused`, `Running`, and `Shutdown`.\nThese statuses are selected by invoking REST endpoints shown\nin the diagram.\n\nThe user can monitor the current state of the pipeline via the\n`GET /v0/pipelines/{name}` endpoint, which returns an object of type\n`ExtendedPipelineDescr`. In a typical scenario, the user first sets\nthe desired state, e.g., by invoking the `/start` endpoint, and\nthen polls the `GET /v0/pipelines/{name}` endpoint to monitor the\nactual status of the pipeline until its `deployment_status` attribute\nchanges to \"running\" indicating that the pipeline has been successfully\ninitialized and is processing data, or \"failed\", indicating an error.",
+        "description": "Pipeline status.\n\nThis type represents the state of the pipeline tracked by the pipeline\nrunner and observed by the API client via the `GET /v0/pipelines/{name}` endpoint.\n\n### The lifecycle of a pipeline\n\nThe following automaton captures the lifecycle of the pipeline.\nIndividual states and transitions of the automaton are described below.\n\n* States labeled with the hourglass symbol (⌛) are **timed** states. The\nautomaton stays in timed state until the corresponding operation completes\nor until it transitions to become failed after the pre-defined timeout\nperiod expires.\n\n* State transitions labeled with API endpoint names (`/start`, `/pause`,\n`/shutdown`) are triggered by invoking corresponding endpoint,\ne.g., `POST /v0/pipelines/{name}/start`. Note that these only express\ndesired state, and are applied asynchronously by the automata.\n\n```text\nShutdown◄────────────────────┐\n│                        │\n/start or /pause│                    ShuttingDown ◄────── Failed\n│                        ▲                  ▲\n▼              /shutdown │                  │\n⌛Provisioning ──────────────────┤        Shutdown, Provisioning,\n│                        │        Initializing, Paused,\n│                        │         Running, Unavailable\n▼                        │    (all states except ShuttingDown\n⌛Initializing ──────────────────┤      can transition to Failed)\n│                        │\n┌─────────┼────────────────────────┴─┐\n│         ▼                          │\n│       Paused  ◄──────► Unavailable │\n│       │    ▲                ▲      │\n│ /start│    │/pause          │      │\n│       ▼    │                │      │\n│      Running ◄──────────────┘      │\n└────────────────────────────────────┘\n```\n\n### Desired and actual status\n\nWe use the desired state model to manage the lifecycle of a pipeline.\nIn this model, the pipeline has two status attributes associated with\nit at runtime: the **desired** status, which represents what the user\nwould like the pipeline to do, and the **current** status, which\nrepresents the actual state of the pipeline.  The pipeline runner\nservice continuously monitors both fields and steers the pipeline\ntowards the desired state specified by the user.\nOnly three of the states in the pipeline automaton above can be\nused as desired statuses: `Paused`, `Running`, and `Shutdown`.\nThese statuses are selected by invoking REST endpoints shown\nin the diagram.\n\nThe user can monitor the current state of the pipeline via the\n`GET /v0/pipelines/{name}` endpoint. In a typical scenario,\nthe user first sets the desired state, e.g., by invoking the\n`/start` endpoint, and then polls the `GET /v0/pipelines/{name}`\nendpoint to monitor the actual status of the pipeline until its\n`deployment_status` attribute changes to `Running` indicating\nthat the pipeline has been successfully initialized and is\nprocessing data, or `Failed`, indicating an error.",
         "enum": [
           "Shutdown",
           "Provisioning",
@@ -3539,6 +3428,50 @@
           "Failed",
           "ShuttingDown"
         ]
+      },
+      "PostPutPipeline": {
+        "type": "object",
+        "description": "Create a new pipeline (POST), or fully update an existing pipeline (PUT).\nLeft-out fields will be set to their default value.",
+        "required": [
+          "name",
+          "program_code"
+        ],
+        "properties": {
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "program_code": {
+            "type": "string"
+          },
+          "program_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgramConfig"
+              }
+            ],
+            "nullable": true
+          },
+          "runtime_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeConfig"
+              }
+            ],
+            "nullable": true
+          },
+          "udf_rust": {
+            "type": "string",
+            "nullable": true
+          },
+          "udf_toml": {
+            "type": "string",
+            "nullable": true
+          }
+        }
       },
       "ProgramConfig": {
         "type": "object",

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -179,7 +179,7 @@ export const patchPipeline = async (pipeline_name: string, pipeline: Partial<Pip
 }
 
 export const getPipelines = async (): Promise<PipelineThumb[]> => {
-  const pipelines = await handled(listPipelines)({ query: { code: false } })
+  const pipelines = await handled(listPipelines)({ query: { selector: 'status' } })
   return pipelines.map(toPipelineThumb)
 }
 


### PR DESCRIPTION
The `code` query parameter for the retrieval of a list of pipelines is replaced because it is not descriptive enough and its boolean value is not expressive enough. It is replaced by the `selector` query parameter, which can be set to `status` for only status-related information or `all` (default) for all fields. The internal fields of the pipeline descriptor are no longer included in the API response.

When POST or PUT a pipeline, currently the API requires supplying a value for all fields. This commit instead allows the `description`, `runtime_config`, `udf_rust`, `udf_toml`, and `program_config` to not be specified (or `null`). Fields `name` and `program_code` remain required.

This commit includes edits to the CLI client `fda` and the Web Console to handle the aforementioned API changes.