### PR TITLE
Support custom CSV delimiters

### DIFF
--- a/benchmark/feldera-sql/benchmarks/tpc-h/generate.bash
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/generate.bash
@@ -1,28 +1,12 @@
-#!/bin/bash
-
-set -e
+#!/bin/sh -e
 
 echo "running tpc-h/generate.bash"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-pushd ${THIS_DIR}
+cd "${THIS_DIR}"
 
-rewrite_csv() {
-    for i in `ls *.csv`; do
-        csvformat -d"|" $i >x && mv x ${i}
-    done
-}
-
-if [[ ! -d "data-large" ]]; then
+if test ! -d "data-large"; then
     git clone --quiet https://github.com/dbtoaster/dbtoaster-experiments-data.git
     mv dbtoaster-experiments-data/tpch/big data-large
-    cd data-large
-    rewrite_csv
-    cd ..
     mv dbtoaster-experiments-data/tpch/standard data-medium
-    cd data-medium
-    rewrite_csv
-    cd ..
     rm -rf dbtoaster-experiments-data
 fi
-
-popd

--- a/benchmark/feldera-sql/benchmarks/tpc-h/table.sql
+++ b/benchmark/feldera-sql/benchmarks/tpc-h/table.sql
@@ -23,7 +23,8 @@ CREATE TABLE LINEITEM (
         "config": {{ "path": "{folder}/data-large/lineitem.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -43,7 +44,8 @@ CREATE TABLE ORDERS  (
         "config": {{ "path": "{folder}/data-large/orders.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -63,7 +65,8 @@ CREATE TABLE PART (
         "config": {{ "path": "{folder}/data-large/part.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -82,7 +85,8 @@ CREATE TABLE CUSTOMER (
         "config": {{ "path": "{folder}/data-large/customer.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -100,7 +104,8 @@ CREATE TABLE SUPPLIER (
         "config": {{ "path": "{folder}/data-large/supplier.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -116,7 +121,8 @@ CREATE TABLE PARTSUPP (
         "config": {{ "path": "{folder}/data-large/partsupp.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -131,7 +137,8 @@ CREATE TABLE NATION  (
         "config": {{ "path": "{folder}/data-large/nation.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 
@@ -145,7 +152,8 @@ CREATE TABLE REGION  (
         "config": {{ "path": "{folder}/data-large/region.csv" }}
     }},
     "format": {{
-        "name": "csv"
+        "name": "csv",
+        "config": {{ "delimiter": "|" }}
     }}
 }}]');
 

--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -8,6 +8,7 @@ use anyhow::Result as AnyResult;
 use apache_avro::{schema::NamesRef, types::Value as AvroValue, Schema as AvroSchema};
 use arrow::record_batch::RecordBatch;
 use dyn_clone::DynClone;
+use feldera_types::format::csv::CsvParserConfig;
 use feldera_types::format::json::JsonFlavor;
 use feldera_types::program_schema::{Relation, SqlIdentifier};
 use feldera_types::serde_with_context::SqlSerdeConfig;
@@ -28,7 +29,7 @@ pub enum RecordFormat {
     // raw encoding of this column only.  This is particularly useful for
     // tables that store raw JSON or binary data to be parsed using SQL.
     Json(JsonFlavor),
-    Csv,
+    Csv(CsvParserConfig),
     Parquet(SerdeArrowSchema),
     #[cfg(feature = "with-avro")]
     Avro,

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -329,6 +329,9 @@ transport:
         buffer_size_bytes: 5
 format:
     name: csv
+    config:
+        delimiter: "|"
+        headers: true
 "#,
             temp_file.path().to_str().unwrap()
         );
@@ -336,7 +339,8 @@ format:
         println!("Config:\n{}", config_str);
 
         let mut writer = CsvWriterBuilder::new()
-            .has_headers(false)
+            .has_headers(true)
+            .delimiter(b'|')
             .from_writer(temp_file.as_file());
         for val in test_data.iter().cloned() {
             writer.serialize(val).unwrap();

--- a/crates/feldera-types/src/format/csv.rs
+++ b/crates/feldera-types/src/format/csv.rs
@@ -1,18 +1,78 @@
+use std::fmt::Debug;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, ToSchema)]
-pub struct CsvParserConfig {}
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+#[serde(default)]
+pub struct CsvParserConfig {
+    /// Field delimiter (default `','`).
+    ///
+    /// This must be an ASCII character.
+    pub delimiter: char,
 
-#[derive(Deserialize, Serialize, ToSchema)]
+    /// Whether the input begins with a header line (which is ignored).
+    pub headers: bool,
+}
+
+impl CsvParserConfig {
+    pub fn delimiter(&self) -> CsvDelimiter {
+        self.delimiter.into()
+    }
+}
+
+impl Default for CsvParserConfig {
+    fn default() -> Self {
+        Self {
+            delimiter: CsvDelimiter::default().0.into(),
+            headers: false,
+        }
+    }
+}
+
+/// A delimiter between CSV records, typically `b','`.
+#[derive(Copy, Clone)]
+pub struct CsvDelimiter(pub u8);
+
+impl CsvDelimiter {
+    pub const DEFAULT: CsvDelimiter = CsvDelimiter(b',');
+}
+
+impl Default for CsvDelimiter {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl Debug for CsvDelimiter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CsvDelimiter")
+            .field(&char::from(self.0))
+            .finish()
+    }
+}
+
+impl From<char> for CsvDelimiter {
+    fn from(value: char) -> Self {
+        Self(value.try_into().unwrap_or(b','))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 #[serde(default)]
 pub struct CsvEncoderConfig {
+    /// Field delimiter (default `','`).
+    ///
+    /// This must be an ASCII character.
+    pub delimiter: char,
+
     pub buffer_size_records: usize,
 }
 
 impl Default for CsvEncoderConfig {
     fn default() -> Self {
         Self {
+            delimiter: CsvDelimiter::default().0.into(),
             buffer_size_records: 10_000,
         }
     }

--- a/docs/formats/csv.md
+++ b/docs/formats/csv.md
@@ -145,3 +145,36 @@ for ingress.
 The CSV format does not have native support for arrays. Arrays are expected to
 be represented in the form of a string that is a valid JSON array. e.g., a value
 for `ARRAY BIGINT` can be expressed as `'[1,2,3]'`.
+
+## Configuring CSV event streams
+
+### Configure connectors
+
+When adding a new input or output connector on a table or view,
+the data format is specified in the `format` field of the connector configuration:
+
+```sql
+create table FAILED_BANKS (
+  name varchar,
+  city varchar,
+  state varchar,
+  cert bigint,
+  acquirer varchar,
+  closing varchar,   -- needs to be translated from 'DD-MMM-YY' format
+  fund bigint
+) with (
+  'connectors' = '[{
+    "transport": {
+        "name": "url_input",
+        "config": { "path": "https://www.fdic.gov/system/files/2024-07/banklist.csv" }
+    },
+    "format": {
+        "name": "csv",
+        "config": { "headers": true }
+    }
+}]'
+);
+```
+
+- `delimiter`: A single character that delimits fields. The default is `","`.
+- `headers`: Whether the first line of input is a header line. If this is set to true, Feldera ignores the first line. This applies only to input connectors (Feldera never writes a header line for CSV output). The default is `false`.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -494,7 +494,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                         .expect("Failed to get input collection handle");
                     let mut persons_stream = persons
                         .handle
-                        .configure_deserializer(RecordFormat::Csv)
+                        .configure_deserializer(RecordFormat::Csv(Default::default()))
                         .expect("Failed to configure deserializer");
                     persons_stream
                         .insert(b"Bob,12,true")

--- a/sql-to-dbsp-compiler/using.md
+++ b/sql-to-dbsp-compiler/using.md
@@ -382,7 +382,7 @@ pub fn test() {
         .input_collection_handle(&SqlIdentifier::from("PERSON"))
         .expect("Failed to get input collection handle");
     let mut persons_stream = persons
-        .configure_deserializer(RecordFormat::Csv)
+        .configure_deserializer(RecordFormat::Csv(Default::default())
         .expect("Failed to configure deserializer");
     persons_stream
         .insert(b"Bob,12,true")

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -361,20 +361,34 @@ export type DeltaTableReaderConfig = {
    * the `where` clause of the `select * from snapshot where ...` query.
    *
    * This option can be used to specify the range of event times to include in the snapshot,
-   * e.g.: `ts BETWEEN '2005-01-01 00:00:00' AND '2010-12-31 23:59:59'`.
+   * e.g.: `ts BETWEEN TIMESTAMP '2005-01-01 00:00:00' AND TIMESTAMP '2010-12-31 23:59:59'`.
    */
   snapshot_filter?: string | null
   /**
    * Table column that serves as an event timestamp.
    *
-   *
    * When this option is specified, and `mode` is one of `snapshot` or `snapshot_and_follow`,
-   * the snapshot of the table is ingested in the timestamp order.  This setting is required
-   * for tables declared with the
-   * [`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions) attribute
-   * in Feldera SQL. It impacts the performance of the connector, since data must be sorted
-   * before pushing it to the pipeline; therefore it is not recommended to use this
-   * settings for tables without `LATENESS`.
+   * table rows are ingested in the timestamp order, respecting the
+   * [`LATENESS`](https://docs.feldera.com/sql/streaming#lateness-expressions)
+   * property of the column: each ingested row has a timestamp no more than `LATENESS`
+   * time units earlier than the most recent timestamp of any previously ingested row.
+   * The ingestion is performed by partitioning the table into timestamp ranges of width
+   * `LATENESS`. Each range is processed sequentially, in increasing timestamp order.
+   *
+   * # Example
+   *
+   * Consider a table with timestamp column of type `TIMESTAMP` and lateness attribute
+   * `INTERVAL 1 DAY`. Assuming that the oldest timestamp in the table is
+   * `2024-01-01T00:00:00``, the connector will fetch all records with timestamps
+   * from `2024-01-01`, then all records for `2024-01-02`, `2024-01-03`, etc., until all records
+   * in the table have been ingested.
+   *
+   * # Requirements
+   *
+   * * The timestamp column must be of a supported type: integer, `DATE`, or `TIMESTAMP`.
+   * * The timestamp column must be declared with non-zero `LATENESS`.
+   * * For efficient ingest, the table must be optimized for timestamp-based
+   * queries using partitioning, Z-ordering, or liquid clustering.
    */
   timestamp_column?: string | null
   /**
@@ -591,6 +605,9 @@ export type ExtendedPipelineDescrOptionalCode = {
  */
 export type Field = SqlIdentifier & {
   columntype: ColumnType
+  default?: string | null
+  lateness?: string | null
+  watermark?: string | null
 }
 
 /**
@@ -2347,6 +2364,10 @@ export type $OpenApiTs = {
          * Pipeline successfully created
          */
         '201': ExtendedPipelineDescr
+        /**
+         * Invalid name specified
+         */
+        '400': ErrorResponse
         /**
          * Cannot create pipeline as the name already exists
          */


### PR DESCRIPTION
TPC-H uses `|` instead of `,` and I'm sure that other datasets use other characters too.