### PR TITLE
docker: remove stale default origins

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -139,4 +139,4 @@ ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 # Run the precompile phase to speed up Rust compilations during deployment
 RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler --dbsp-override-path=/home/feldera/lib --precompile
 ENV BANNER_ADDR=localhost
-ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--dbsp-override-path=/home/feldera/lib", "--allowed-origins", "https://www.feldera.com", "--allowed-origins", "http://localhost:8080", "--demos-dir", "/home/feldera/demos"]
+ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--dbsp-override-path=/home/feldera/lib", "--demos-dir", "/home/feldera/demos"]


### PR DESCRIPTION
We needed this when the REST API was more complex and users needed
the swagger-ui / docs website to learn how the API works. These two
mechanisms have become somehwat stale.

The swagger-ui isn't easily discoverable by users anymore (we've stopped
showing it on the UI). The docs website does not allow users to
configure servers either.

This defaults to allowing all origins, which is appropriate for this
developer build.

Signed-off-by: Lalith Suresh <lalith@feldera.com>
