### PR TITLE
[SQL] Refine long interval types

### DIFF
--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -423,6 +423,16 @@ impl LongInterval {
     pub fn months(&self) -> i32 {
         self.months
     }
+
+    /// Retrieve the number of years in the long interval.
+    pub fn years(&self) -> i32 {
+        let (mul, months) = if self.months() < 0 {
+            (-1, -self.months())
+        } else {
+            (1, self.months())
+        };
+        (months / 12) * mul
+    }
 }
 
 /// Multiply a `LongInterval` by an integer producing a `LongInterval`

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -172,7 +172,8 @@ public class RustSqlRuntimeLibrary {
             if (opcode == DBSPOpcode.TS_SUB || opcode == DBSPOpcode.TS_ADD) {
                 if (ltype.is(IsTimeRelatedType.class)) {
                     assert rtype != null;
-                    suffixReturn = "_" + expectedReturnType.baseTypeWithSuffix();
+                    suffixReturn = "_" + expectedReturnType.to(DBSPTypeBaseType.class).shortName()
+                            + expectedReturnType.nullableSuffix();
                     if (rtype.is(IsNumericType.class))
                         throw new CompilationError("Cannot apply operation " + Utilities.singleQuote(opcode.toString()) +
                                 " to arguments of type " + ltype.asSqlString() + " and " + rtype.asSqlString(), node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -131,6 +131,8 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeISize;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
@@ -813,9 +815,15 @@ public class ToRustInnerVisitor extends InnerVisitor {
             expression.source.accept(this);
             return VisitDecision.STOP;
         }
-
         functionName = "cast_to_" + destType.baseTypeWithSuffix() +
                 "_" + sourceType.baseTypeWithSuffix();
+
+        if ((sourceType.is(DBSPTypeMonthsInterval.class) && destType.is(DBSPTypeMonthsInterval.class)) ||
+            (sourceType.is(DBSPTypeMillisInterval.class) && destType.is(DBSPTypeMillisInterval.class))) {
+            DBSPTypeBaseType t = destType.to(DBSPTypeBaseType.class);
+            functionName = "cast_to_" + t.shortName() + destType.nullableSuffix() +
+                    "_" + t.shortName() + sourceType.nullableSuffix();
+        }
         this.builder.append(functionName).append("(");
         expression.source.accept(this);
         DBSPTypeDecimal dec = destType.as(DBSPTypeDecimal.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -245,9 +245,11 @@ public class TypeCompiler implements ICompilerComponent {
                     throw new UnimplementedException("Support for SQL type " + Utilities.singleQuote(tn.getName())
                             + " not yet implemented", node);
                 case INTERVAL_YEAR:
+                    return new DBSPTypeMonthsInterval(node, DBSPTypeMonthsInterval.Units.YEARS, nullable);
                 case INTERVAL_YEAR_MONTH:
+                    return new DBSPTypeMonthsInterval(node, DBSPTypeMonthsInterval.Units.YEARS_TO_MONTHS, nullable);
                 case INTERVAL_MONTH:
-                    return new DBSPTypeMonthsInterval(node, nullable);
+                    return new DBSPTypeMonthsInterval(node, DBSPTypeMonthsInterval.Units.MONTHS, nullable);
                 case INTERVAL_DAY:
                 case INTERVAL_DAY_HOUR:
                 case INTERVAL_DAY_MINUTE:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
@@ -15,10 +15,12 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.IsDateType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBinary;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeNull;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
@@ -206,6 +208,9 @@ public class ExpandCasts extends InnerRewriteVisitor {
             result = this.convertToStruct(source, type.to(DBSPTypeTuple.class));
         } else if (type.is(DBSPTypeMap.class)) {
             result = this.convertToMap(source, type.to(DBSPTypeMap.class));
+        } else if (type.is(IsDateType.class) && source.getType().is(DBSPTypeBinary.class)) {
+            throw new UnsupportedException(
+                    "Conversion of BINARY object to " + type.asSqlString() + " not supported", expression.getNode());
         }
         if (result == null)
             // Default implementation

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -179,7 +179,7 @@ public class Simplify extends InnerRewriteVisitor {
                     try {
                         TimeString ts = new TimeString(str.value);
                         result = new DBSPTimeLiteral(lit.getNode(), type, ts);
-                    } catch (DateTimeParseException ex) {
+                    } catch (DateTimeParseException | IllegalArgumentException ex) {
                         this.compiler.reportWarning(expression.getSourcePosition(), "Not a number",
                                 " String " + Utilities.singleQuote(str.value) +
                                         " cannot be interpreted as a time");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPIntervalMonthsLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPIntervalMonthsLiteral.java
@@ -46,19 +46,20 @@ public final class DBSPIntervalMonthsLiteral
 
     public DBSPIntervalMonthsLiteral(CalciteObject node, DBSPType type, @Nullable Integer value) {
         super(node, type, value == null);
+        assert type.is(DBSPTypeMonthsInterval.class);
         this.value = value;
     }
 
-    public DBSPIntervalMonthsLiteral(int value) {
-        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, false), value);
+    public DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units units, int value) {
+        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, units,false), value);
     }
 
-    public DBSPIntervalMonthsLiteral(int value, boolean mayBeNull) {
-        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, mayBeNull), value);
+    public DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units units, int value, boolean mayBeNull) {
+        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, units, mayBeNull), value);
     }
 
-    public DBSPIntervalMonthsLiteral() {
-        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, true), null);
+    public DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units units) {
+        this(CalciteObject.EMPTY, new DBSPTypeMonthsInterval(CalciteObject.EMPTY, units,true), null);
     }
 
     @Override
@@ -129,7 +130,7 @@ public final class DBSPIntervalMonthsLiteral
         if (value == null)
             return new DBSPIntervalMonthsLiteral(this.getNode(), this.type, null);
         BigInteger result = value.multiply(BigInteger.valueOf(this.value));
-        return new DBSPIntervalMonthsLiteral(result.intValueExact());
+        return new DBSPIntervalMonthsLiteral(this.getNode(), this.type, result.intValueExact());
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -96,7 +96,7 @@ public abstract class DBSPLiteral extends DBSPExpression implements ISameValue {
         } else if (type.is(DBSPTypeMillisInterval.class)) {
             return new DBSPIntervalMillisLiteral();
         } else if (type.is(DBSPTypeMonthsInterval.class)) {
-            return new DBSPIntervalMonthsLiteral();
+            return new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.MONTHS);
         } else if (type.is(DBSPTypeString.class)) {
             return new DBSPStringLiteral(CalciteObject.EMPTY, type, null, StandardCharsets.UTF_8);
         } else if (type.is(DBSPTypeTime.class)) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
@@ -42,8 +42,17 @@ import java.util.Objects;
 public class DBSPTypeMonthsInterval
         extends DBSPTypeBaseType
         implements IsTimeRelatedType, IHasZero, IsIntervalType {
-    public DBSPTypeMonthsInterval(CalciteObject node, boolean mayBeNull) {
+    public enum Units {
+        MONTHS,
+        YEARS,
+        YEARS_TO_MONTHS
+    };
+
+    public final Units units;
+
+    public DBSPTypeMonthsInterval(CalciteObject node, Units units, boolean mayBeNull) {
         super(node, DBSPTypeCode.INTERVAL_LONG, mayBeNull);
+        this.units = units;
     }
 
     @Override
@@ -57,19 +66,19 @@ public class DBSPTypeMonthsInterval
 
     @Override
     public DBSPExpression getMinValue() {
-        return new DBSPIntervalMonthsLiteral(Integer.MIN_VALUE, this.mayBeNull);
+        return new DBSPIntervalMonthsLiteral(this.units, Integer.MIN_VALUE, this.mayBeNull);
     }
 
     @Override
     public DBSPExpression getMaxValue() {
-        return new DBSPIntervalMonthsLiteral(Integer.MAX_VALUE, this.mayBeNull);
+        return new DBSPIntervalMonthsLiteral(this.units, Integer.MAX_VALUE, this.mayBeNull);
     }
 
     @Override
     public DBSPType withMayBeNull(boolean mayBeNull) {
         if (this.mayBeNull == mayBeNull)
             return this;
-        return new DBSPTypeMonthsInterval(this.getNode(), mayBeNull);
+        return new DBSPTypeMonthsInterval(this.getNode(), this.units, mayBeNull);
     }
 
     @Override
@@ -81,18 +90,26 @@ public class DBSPTypeMonthsInterval
     public DBSPExpression defaultValue() {
         if (this.mayBeNull)
             return this.none();
-        return new DBSPIntervalMonthsLiteral(0, this.mayBeNull);
+        return new DBSPIntervalMonthsLiteral(this.units, 0, this.mayBeNull);
     }
 
     @Override
     public DBSPLiteral getZero() {
-        return new DBSPIntervalMonthsLiteral(0, this.mayBeNull);
+        return new DBSPIntervalMonthsLiteral(this.units, 0, this.mayBeNull);
     }
 
     @Override
     public boolean sameType(DBSPType other) {
         if (!super.sameNullability(other))
             return false;
-        return other.is(DBSPTypeMonthsInterval.class);
+        DBSPTypeMonthsInterval otherType = other.as(DBSPTypeMonthsInterval.class);
+        if (otherType == null)
+            return false;
+        return this.units == otherType.units;
+    }
+
+    @Override
+    public String baseTypeWithSuffix() {
+        return this.shortName() + "_" + this.units.name() + this.nullableSuffix();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeString.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeString.java
@@ -41,10 +41,8 @@ public class DBSPTypeString extends DBSPTypeBaseType {
     /** If true the width is fixed, i.e., this is a CHAR type.
      * Otherwise, this is a VARCHAR. */
     public final boolean fixed;
-    /**
-     * Number of characters.  If UNLIMITED_PRECISION it means "unlimited".
-     * This is the size specified by CHAR or VARCHAR.
-     */
+    /** Number of characters.  If UNLIMITED_PRECISION it means "unlimited".
+     * This is the size specified by CHAR or VARCHAR. */
     public final int precision;
 
     public DBSPTypeString(CalciteObject node, int precision, boolean fixed, boolean mayBeNull) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresIntervalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresIntervalTests.java
@@ -506,4 +506,50 @@ public class PostgresIntervalTests extends SqlIoTest {
                       -1
                 (1 row)""");
     }
+
+    @Test
+    public void testCastString() {
+        // These are not from postgres
+        this.qs("""
+                SELECT CAST(INTERVAL 22 MONTHS AS VARCHAR);
+                 x
+                ---
+                 +22
+                (1 row)
+                
+                SELECT CAST(INTERVAL 1 YEARS AS VARCHAR);
+                 x
+                ---
+                 +1
+                (1 row)
+                
+                SELECT CAST(INTERVAL '1-10' YEARS TO MONTHS AS VARCHAR);
+                 x
+                ---
+                 +1-10
+                (1 row)""");
+    }
+
+    @Test
+    public void testCastToInterval() {
+        // These are not from postgres
+        this.qs("""
+                SELECT CAST(1 AS INTERVAL YEARS);
+                 x
+                ---
+                 1 years
+                (1 row)
+                
+                SELECT CAST(INTERVAL 22 MONTHS AS INTERVAL YEARS);
+                 x
+                ---
+                 22 months
+                (1 row)
+                
+                SELECT CAST(INTERVAL '1-10' YEAR TO MONTH AS INTERVAL YEARS);
+                 x
+                ---
+                 22 months
+                (1 row)""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -62,6 +62,20 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue3153() {
+        this.compileRustTestCase("""
+                CREATE TABLE timestamp_tbl(
+                c1 TIMESTAMP NOT NULL,
+                c2 TIMESTAMP);
+                CREATE LOCAL VIEW atbl_long_interval AS SELECT
+                (c1 - c2)MONTH AS months
+                FROM timestamp_tbl;
+                CREATE MATERIALIZED VIEW v AS SELECT
+                CAST(months AS VARCHAR) AS res
+                FROM atbl_long_interval;""");
+    }
+
+    @Test
     public void issue3119() {
         this.compileRustTestCase("""
                 CREATE TABLE row_tbl(id INT, c1 INT NOT NULL, c2 VARCHAR, c3 VARCHAR);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
@@ -38,6 +38,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.junit.Test;
 
@@ -93,11 +94,11 @@ public class TimeTests extends BaseSQLTests {
     @Test
     public void testInterval() {
         this.testQuery("SELECT INTERVAL '20' YEAR",
-                new DBSPIntervalMonthsLiteral(240));
+                new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.YEARS, 240));
         this.testQuery("SELECT INTERVAL '20-7' YEAR TO MONTH",
-                new DBSPIntervalMonthsLiteral(247));
+                new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.YEARS_TO_MONTHS, 247));
         this.testQuery("SELECT INTERVAL '10' MONTH",
-                new DBSPIntervalMonthsLiteral(10));
+                new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.MONTHS, 10));
         this.testQuery("SELECT INTERVAL '10' DAY",
                 new DBSPIntervalMillisLiteral(10L * 86400 * 1000, false));
         this.testQuery("SELECT INTERVAL '10 10' DAY TO HOUR",

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
@@ -31,6 +31,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
@@ -163,7 +164,7 @@ public class VariantTests extends BaseSQLTests {
                         new DBSPTypeTime(CalciteObject.EMPTY, false),
                         new TimeString("10:01:01"))));
         this.testQuery("SELECT CAST(INTERVAL '4-1' YEARS TO MONTHS AS VARIANT)",
-                new DBSPVariantLiteral(new DBSPIntervalMonthsLiteral(49)));
+                new DBSPVariantLiteral(new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.YEARS_TO_MONTHS, 49)));
         this.testQuery("SELECT CAST(INTERVAL '4 10:01' DAYS TO MINUTES AS VARIANT)",
                 new DBSPVariantLiteral(new DBSPIntervalMillisLiteral(1000L * (4 * 86400 + 10 * 3600 + 60), false)));
         this.testQuery("SELECT CAST(CAST(1 AS VARIANT) AS VARIANT)",

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -41,6 +41,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         options.languageOptions.generateInputForEveryTable = true;
         options.languageOptions.incrementalize = false;
         options.languageOptions.unrestrictedIOTypes = true;
+        options.ioOptions.verbosity = 1;
         return options;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -273,7 +273,7 @@ public class TableParser {
             result = new DBSPIntervalMillisLiteral(value, fieldType.mayBeNull);
         } else if (fieldType.is(DBSPTypeMonthsInterval.class)) {
             int months = longIntervalToMonths(trimmed);
-            result = new DBSPIntervalMonthsLiteral(months);
+            result = new DBSPIntervalMonthsLiteral(fieldType.to(DBSPTypeMonthsInterval.class).units, months);
         } else if (fieldType.is(DBSPTypeString.class)) {
             // If there is no space in front of the string, we expect a NULL.
             // This is how we distinguish empty strings from nulls.


### PR DESCRIPTION
Fixes #3153 

Previously the type system had one type of "long" interval. Now the type system recognizes 3 types of long intervals: YEARS, YEARS TO MONTHS, and MONTHS. At runtime these all have the same runtime type, LongInterval. However, the static type is important, because it affects the semantics of some operations. For example, casting an interval of 22 months to a string produces "22" if the interval is MONTHS, but it produces "1" if the interval is YEARS.

We will have to do a similar operation for short intervals, but there are many more of these (10 to be precise), so we leave this for a future PR.

We also introduced a test that exercises all the pairwise casts that are legal, to make sure they are implemented in the Rust runtime library. (We exercise only 1 of the 4 variants for each cast for now, without varying nullability)