### PR TITLE
[SQL] Vec/Map/ZSet/Variant expressions are not always literals (#3164)

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNowOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNowOperator.java
@@ -7,7 +7,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 
@@ -18,7 +18,7 @@ import java.util.List;
 public final class DBSPNowOperator extends DBSPSimpleOperator {
     // zset!(Tup1::new(now()))
     static DBSPExpression createFunction(CalciteObject node) {
-        return new DBSPZSetLiteral(
+        return new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPApplyExpression(
                         "now", new DBSPTypeTimestamp(node, false))));
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToCsvVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToCsvVisitor.java
@@ -29,6 +29,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.*;
 import org.dbsp.util.Utilities;
 
@@ -173,13 +174,13 @@ public class ToCsvVisitor extends InnerVisitor {
     }
 
     @Override
-    public VisitDecision preorder(DBSPZSetLiteral literal) {
-        for (Map.Entry<DBSPExpression, Long> entry: literal.data.entrySet()) {
+    public VisitDecision preorder(DBSPZSetExpression expression) {
+        for (Map.Entry<DBSPExpression, Long> entry: expression.data.entrySet()) {
             DBSPExpression key = entry.getKey();
             long value = entry.getValue();
             if (value < 0)
                 throw new UnsupportedException("ZSet with negative weights is not representable as CSV",
-                        literal.getNode());
+                        expression.getNode());
             for (; value != 0; value--) {
                 key.accept(this);
                 this.appendable.append("\n");
@@ -191,12 +192,12 @@ public class ToCsvVisitor extends InnerVisitor {
     /**
      * Write a literal to a file as a csv format.
      * @param file        File to write to.
-     * @param literal     Literal to write.
+     * @param expression     Literal to write.
      */
-    public static File toCsv(DBSPCompiler compiler, File file, DBSPZSetLiteral literal) throws IOException {
+    public static File toCsv(DBSPCompiler compiler, File file, DBSPZSetExpression expression) throws IOException {
         StringBuilder builder = new StringBuilder();
         ToCsvVisitor visitor = new ToCsvVisitor(compiler, builder, () -> "");
-        visitor.apply(literal);
+        visitor.apply(expression);
         FileWriter writer = new FileWriter(file);
         writer.write(builder.toString());
         writer.close();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToSqlVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToSqlVisitor.java
@@ -14,7 +14,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.util.Utilities;
 
 import java.util.Map;
@@ -103,13 +103,13 @@ public class ToSqlVisitor extends InnerVisitor {
     }
 
     @Override
-    public VisitDecision preorder(DBSPZSetLiteral literal) {
-        for (Map.Entry<DBSPExpression, Long> entry: literal.data.entrySet()) {
+    public VisitDecision preorder(DBSPZSetExpression expression) {
+        for (Map.Entry<DBSPExpression, Long> entry: expression.data.entrySet()) {
             DBSPExpression key = entry.getKey();
             long value = entry.getValue();
             if (value < 0)
                 throw new UnsupportedException("ZSet with negative weights is not representable as SQL",
-                        literal.getNode());
+                        expression.getNode());
             for (; value != 0; value--) {
                 key.accept(this);
                 this.appendable.append("\n");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -95,9 +95,9 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.DBSPWindowBoundExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPISizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIndexedZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIndexedZSetExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStructItem;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStructWithHelperItem;
@@ -1509,11 +1509,11 @@ public class ToRustVisitor extends CircuitVisitor {
         operator.function.accept(this.innerVisitor);
         this.builder.append("} else {");
         if (operator.outputType.is(DBSPTypeZSet.class)) {
-            DBSPZSetLiteral empty = DBSPZSetLiteral.emptyWithElementType(
+            DBSPZSetExpression empty = DBSPZSetExpression.emptyWithElementType(
                     operator.getOutputZSetElementType());
             empty.accept(this.innerVisitor);
         } else {
-            assert operator.function.to(DBSPIndexedZSetLiteral.class).isEmpty();
+            assert operator.function.to(DBSPIndexedZSetExpression.class).isEmpty();
             operator.function.accept(this.innerVisitor);
         }
         this.builder.append("}));");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -59,7 +59,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.IsNumericType;
@@ -296,7 +296,7 @@ public class AggregateCompiler implements ICompilerComponent {
         boolean ignoreNulls = this.call.ignoreNulls();
         boolean distinct = this.call.isDistinct();
         DBSPType elementType = this.resultType.to(DBSPTypeVec.class).getElementType();
-        DBSPExpression zero = DBSPVecLiteral.emptyWithElementType(elementType, this.resultType.mayBeNull);
+        DBSPExpression zero = DBSPVecExpression.emptyWithElementType(elementType, this.resultType.mayBeNull);
         DBSPExpression aggregatedValue = this.getAggregatedValue();
         DBSPVariablePath accumulator = this.resultType.var();
         String functionName;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -172,9 +172,9 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.path.DBSPSimplePathSegment;
 import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
@@ -1570,7 +1570,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 assert elementType.sameType(flatten ? inputRowType.getFieldType(0) : inputRowType);
 
                 row = inputRowType.ref().var();
-                DBSPExpression zero = DBSPVecLiteral.emptyWithElementType(elementType, type.mayBeNull);
+                DBSPExpression zero = DBSPVecExpression.emptyWithElementType(elementType, type.mayBeNull);
                 DBSPVariablePath accumulator = vecType.var();
                 String functionName;
                 DBSPExpression[] arguments;
@@ -1598,7 +1598,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 assert valueType.sameType(inputRowType.getFieldType(1));
 
                 row = inputRowType.ref().var();
-                DBSPExpression zero = new DBSPMapLiteral(mapType, Linq.list());
+                DBSPExpression zero = new DBSPMapExpression(mapType, Linq.list());
                 DBSPVariablePath accumulator = mapType.var();
                 String functionName;
                 DBSPExpression[] arguments;
@@ -1648,7 +1648,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
             resultType = sourceType;
         }
 
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(resultType);
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(resultType);
         for (List<RexLiteral> t : values.getTuples()) {
             List<DBSPExpression> expressions = new ArrayList<>();
             if (t.size() != sourceType.size())
@@ -2860,7 +2860,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         CreateTableStatement def = this.tableContents.getTableDefinition(modify.tableName);
         this.modifyTableTranslation = new ModifyTableTranslation(
                 modify, def, targetColumnList, this.compiler);
-        DBSPZSetLiteral result;
+        DBSPZSetExpression result;
         if (modify.rel instanceof LogicalTableScan scan) {
             // Support for INSERT INTO table (SELECT * FROM otherTable)
             ProgramIdentifier sourceTable = Utilities.toIdentifier(scan.getTable().getQualifiedName());
@@ -3025,7 +3025,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         throw new UnsupportedException(statement.getCalciteObject());
     }
 
-    private DBSPZSetLiteral compileConstantProject(LogicalProject project) {
+    private DBSPZSetExpression compileConstantProject(LogicalProject project) {
         // Specialization of the visitor's visit method for LogicalProject
         // Does not produce a DBSPOperator, but only a literal.
         CalciteObject node = CalciteObject.create(project);
@@ -3034,7 +3034,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         DBSPType inputType = this.convertType(project.getInput().getRowType(), false);
         DBSPVariablePath row = inputType.ref().var();  // should not be used
         ExpressionCompiler expressionCompiler = new ExpressionCompiler(project, row, this.compiler);
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(outputElementType);
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(outputElementType);
 
         List<DBSPExpression> resultColumns = new ArrayList<>();
         int index = 0;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -76,14 +76,14 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPKeywordLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IsIntervalType;
@@ -751,11 +751,11 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         return s;
     }
 
-    DBSPVecLiteral arrayConstructor(CalciteObject node, DBSPType type, List<DBSPExpression> ops) {
+    DBSPVecExpression arrayConstructor(CalciteObject node, DBSPType type, List<DBSPExpression> ops) {
         DBSPTypeVec vec = type.to(DBSPTypeVec.class);
         DBSPType elemType = vec.getElementType();
         List<DBSPExpression> args = Linq.map(ops, o -> o.cast(elemType));
-        return new DBSPVecLiteral(node, type, args);
+        return new DBSPVecExpression(node, type, args);
     }
 
     /** Ensures that all the elements of array 'vec' are of the expectedType
@@ -1413,11 +1413,11 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 return this.arrayConstructor(node, type, ops);
             case MAP_VALUE_CONSTRUCTOR: {
                 DBSPTypeMap map = type.to(DBSPTypeMap.class);
-                List<DBSPExpression> keys = DBSPMapLiteral.getKeys(ops);
+                List<DBSPExpression> keys = DBSPMapExpression.getKeys(ops);
                 keys = Linq.map(keys, o -> o.cast(map.getKeyType()));
-                List<DBSPExpression> values = DBSPMapLiteral.getValues(ops);
+                List<DBSPExpression> values = DBSPMapExpression.getValues(ops);
                 values = Linq.map(values, o -> o.cast(map.getValueType()));
-                return new DBSPMapLiteral(map, keys, values);
+                return new DBSPMapExpression(map, keys, values);
             }
             case ITEM: {
                 if (call.operands.size() != 2)
@@ -1628,7 +1628,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     String warningMessage =
                             node + ": all elements are null; result is always an empty array";
                     this.compiler.reportWarning(node.getPositionRange(), "unnecessary function call", warningMessage);
-                    return new DBSPVecLiteral(arg0.getNode(), arg0.getType(), Linq.list());
+                    return new DBSPVecExpression(arg0.getNode(), arg0.getType(), Linq.list());
                 }
 
                 String method = getArrayOrMapCallName(call, arg0);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
@@ -34,7 +34,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateTableStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.TableModifyStatement;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
@@ -49,7 +49,7 @@ import java.util.Objects;
 class ModifyTableTranslation implements ICompilerComponent {
     /** Result of the VALUES expression. */
     @Nullable
-    private DBSPZSetLiteral valuesTranslation;
+    private DBSPZSetExpression valuesTranslation;
     /**
      * Maps each column index to the actual destination column index.
      * This handles SQL statements such as
@@ -96,7 +96,7 @@ class ModifyTableTranslation implements ICompilerComponent {
         }
     }
 
-    public DBSPZSetLiteral getTranslation() {
+    public DBSPZSetExpression getTranslation() {
         return Objects.requireNonNull(this.valuesTranslation);
     }
 
@@ -114,11 +114,11 @@ class ModifyTableTranslation implements ICompilerComponent {
         return new DBSPTupleExpression(columns);
     }
 
-    DBSPZSetLiteral permuteColumns(DBSPZSetLiteral source) {
+    DBSPZSetExpression permuteColumns(DBSPZSetExpression source) {
         assert this.resultType != null;
         if (this.columnPermutation == null)
             return source;
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(this.resultType);
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(this.resultType);
         for (Map.Entry<DBSPExpression, Long> e : source.data.entrySet()) {
             DBSPExpression perm = this.permuteColumns(e.getKey());
             result.add(perm, e.getValue());
@@ -126,7 +126,7 @@ class ModifyTableTranslation implements ICompilerComponent {
         return result;
     }
 
-    public void setResult(DBSPZSetLiteral literal) {
+    public void setResult(DBSPZSetExpression literal) {
         if (this.valuesTranslation != null)
             throw new InternalCompilerError("Overwriting logical value translation", CalciteObject.EMPTY);
         this.valuesTranslation = this.permuteColumns(literal);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TableContents.java
@@ -32,7 +32,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateTableStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.DropTableStatement;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.RelStatement;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
@@ -51,7 +51,7 @@ public class TableContents implements ICompilerComponent {
     final Map<ProgramIdentifier, CreateTableStatement> tableCreation = new HashMap<>();
     /** Keep track of the contents of each table. */
     @Nullable
-    final Map<ProgramIdentifier, DBSPZSetLiteral> tableContents;
+    final Map<ProgramIdentifier, DBSPZSetExpression> tableContents;
     final DBSPCompiler compiler;
 
     public TableContents(DBSPCompiler compiler, boolean trackTableContents) {
@@ -62,7 +62,7 @@ public class TableContents implements ICompilerComponent {
             this.tableContents = null;
     }
 
-    public DBSPZSetLiteral getTableContents(ProgramIdentifier tableName) {
+    public DBSPZSetExpression getTableContents(ProgramIdentifier tableName) {
         if (this.tableContents == null)
             throw new UnsupportedException("Not keeping track of table contents", CalciteObject.EMPTY);
         return Utilities.getExists(this.tableContents, tableName);
@@ -77,7 +77,7 @@ public class TableContents implements ICompilerComponent {
             this.tablesCreated.add(create.relationName);
             if (this.tableContents != null)
                 Utilities.putNew(this.tableContents, create.relationName,
-                        DBSPZSetLiteral.emptyWithElementType(
+                        DBSPZSetExpression.emptyWithElementType(
                                 create.getRowTypeAsTuple(this.compiler.getTypeCompiler())));
         } else if (statement.is(DropTableStatement.class)) {
             DropTableStatement drop = statement.to(DropTableStatement.class);
@@ -93,10 +93,10 @@ public class TableContents implements ICompilerComponent {
         return Utilities.getExists(this.tableCreation, tableName);
     }
 
-    public void addToTable(ProgramIdentifier tableName, DBSPZSetLiteral value) {
+    public void addToTable(ProgramIdentifier tableName, DBSPZSetExpression value) {
         if (this.tableContents == null)
             throw new UnsupportedException("Not keeping track of table contents", CalciteObject.EMPTY);
-        DBSPZSetLiteral table = this.tableContents.get(tableName);
+        DBSPZSetExpression table = this.tableContents.get(tableName);
         table.addUsingCast(value);
     }
 
@@ -120,8 +120,8 @@ public class TableContents implements ICompilerComponent {
     public void clear() {
         if (this.tableContents == null)
             return;
-        for (Map.Entry<ProgramIdentifier, DBSPZSetLiteral> entry: this.tableContents.entrySet()) {
-            entry.setValue(DBSPZSetLiteral.emptyWithElementType(entry.getValue().getElementType()));
+        for (Map.Entry<ProgramIdentifier, DBSPZSetExpression> entry: this.tableContents.entrySet()) {
+            entry.setValue(DBSPZSetExpression.emptyWithElementType(entry.getValue().getElementType()));
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
@@ -11,9 +11,9 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IsDateType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -74,7 +74,7 @@ public class ExpandCasts extends InnerRewriteVisitor {
                 DBSPExpression rec = field.cast(new DBSPTypeVariant(false));
                 values.add(rec);
             }
-            expression = new DBSPMapLiteral(type, keys, values);
+            expression = new DBSPMapExpression(type, keys, values);
         } else if (source.type.is(DBSPTypeVec.class)) {
             // Convert a vector by converting all elements to Variant
             DBSPTypeVec vecType = source.type.to(DBSPTypeVec.class);
@@ -150,7 +150,7 @@ public class ExpandCasts extends InnerRewriteVisitor {
             if (!type.getElementType().equals(sourceVecType.getElementType())) {
                 if (sourceVecType.getElementType().is(DBSPTypeAny.class)) {
                     // This can only happen if the source is an empty vector
-                    return new DBSPVecLiteral(type, false);
+                    return new DBSPVecExpression(type, false);
                 }
                 DBSPVariablePath var = sourceVecType.getElementType().ref().var();
                 DBSPExpression convert = var.deref();
@@ -165,7 +165,7 @@ public class ExpandCasts extends InnerRewriteVisitor {
             }
             return source.cast(type);
         } else if (sourceType.is(DBSPTypeNull.class)) {
-            return DBSPVecLiteral.none(type);
+            return new DBSPVecExpression(type, true);
         } else {
             this.unsupported(source, type);
             // unreachable

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -92,13 +92,13 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI8Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPISizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIndexedZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIndexedZSetExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPKeywordLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
@@ -110,10 +110,10 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU16Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.path.DBSPPathSegment;
 import org.dbsp.sqlCompiler.ir.path.DBSPSimplePathSegment;
@@ -677,20 +677,20 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder(node.to(DBSPLiteral.class));
     }
 
-    public VisitDecision preorder(DBSPVariantLiteral node) {
-        return this.preorder(node.to(DBSPLiteral.class));
+    public VisitDecision preorder(DBSPVariantExpression node) {
+        return this.preorder(node.to(DBSPExpression.class));
     }
 
     public VisitDecision preorder(DBSPVariantNullLiteral node) {
         return this.preorder(node.to(DBSPLiteral.class));
     }
 
-    public VisitDecision preorder(DBSPVecLiteral node) {
-        return this.preorder(node.to(DBSPLiteral.class));
+    public VisitDecision preorder(DBSPVecExpression node) {
+        return this.preorder(node.to(DBSPExpression.class));
     }
 
-    public VisitDecision preorder(DBSPMapLiteral node) {
-        return this.preorder(node.to(DBSPLiteral.class));
+    public VisitDecision preorder(DBSPMapExpression node) {
+        return this.preorder(node.to(DBSPExpression.class));
     }
 
     public VisitDecision preorder(DBSPTimestampLiteral node) {
@@ -725,12 +725,12 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder(node.to(DBSPLiteral.class));
     }
 
-    public VisitDecision preorder(DBSPZSetLiteral node) {
-        return this.preorder(node.to(DBSPLiteral.class));
+    public VisitDecision preorder(DBSPZSetExpression node) {
+        return this.preorder(node.to(DBSPExpression.class));
     }
 
-    public VisitDecision preorder(DBSPIndexedZSetLiteral node) {
-        return this.preorder(node.to(DBSPLiteral.class));
+    public VisitDecision preorder(DBSPIndexedZSetExpression node) {
+        return this.preorder(node.to(DBSPExpression.class));
     }
 
     public VisitDecision preorder(DBSPStrLiteral node) {
@@ -1261,20 +1261,20 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder(node.to(DBSPLiteral.class));
     }
 
-    public void postorder(DBSPVariantLiteral node) {
-        this.postorder(node.to(DBSPLiteral.class));
+    public void postorder(DBSPVariantExpression node) {
+        this.postorder(node.to(DBSPExpression.class));
     }
 
     public void postorder(DBSPVariantNullLiteral node) {
         this.postorder(node.to(DBSPLiteral.class));
     }
 
-    public void postorder(DBSPVecLiteral node) {
-        this.postorder(node.to(DBSPLiteral.class));
+    public void postorder(DBSPVecExpression node) {
+        this.postorder(node.to(DBSPExpression.class));
     }
 
-    public void postorder(DBSPMapLiteral node) {
-        this.postorder(node.to(DBSPLiteral.class));
+    public void postorder(DBSPMapExpression node) {
+        this.postorder(node.to(DBSPExpression.class));
     }
 
     public void postorder(DBSPFPLiteral node) {
@@ -1289,12 +1289,12 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder(node.to(DBSPLiteral.class));
     }
 
-    public void postorder(DBSPIndexedZSetLiteral node) {
-        this.postorder(node.to(DBSPLiteral.class));
+    public void postorder(DBSPIndexedZSetExpression node) {
+        this.postorder(node.to(DBSPExpression.class));
     }
 
-    public void postorder(DBSPZSetLiteral node) {
-        this.postorder(node.to(DBSPLiteral.class));
+    public void postorder(DBSPZSetExpression node) {
+        this.postorder(node.to(DBSPExpression.class));
     }
 
     public void postorder(DBSPStrLiteral node) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
@@ -20,7 +20,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPUnwrapCustomOrdExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnwrapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
@@ -313,7 +313,7 @@ public class Projection extends InnerVisitor {
     /** Compose this projection with a constant expression.
      * @param before Constant expression.
      * @return A new constant expression. */
-    public DBSPExpression applyAfter(DBSPZSetLiteral before) {
+    public DBSPExpression applyAfter(DBSPZSetExpression before) {
         Objects.requireNonNull(this.expression);
 
         Map<DBSPExpression, Long> result = new HashMap<>();
@@ -331,7 +331,7 @@ public class Projection extends InnerVisitor {
                 elementType = simplified.getType();
             result.put(simplified, entry.getValue());
         }
-        return new DBSPZSetLiteral(result, Objects.requireNonNull(elementType));
+        return new DBSPZSetExpression(result, Objects.requireNonNull(elementType));
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandAggregateZero.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandAggregateZero.java
@@ -12,7 +12,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.TypeCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.util.Linq;
 
 /** Replaces the {@link DBSPAggregateZeroOperator} with a graph;
@@ -35,7 +35,7 @@ public class ExpandAggregateZero extends CircuitCloneVisitor {
         DBSPSimpleOperator neg = new DBSPNegateOperator(node, map1.outputPort());
         this.addOperator(neg);
         DBSPSimpleOperator constant = new DBSPConstantOperator(
-                node, new DBSPZSetLiteral(emptySetResult), false, false);
+                node, new DBSPZSetExpression(emptySetResult), false, false);
         this.addOperator(constant);
         DBSPSimpleOperator sum = new DBSPSumOperator(node, Linq.list(constant.outputPort(), neg.outputPort(), input));
         this.map(operator, sum);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
@@ -28,7 +28,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
@@ -157,7 +157,7 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
         DBSPExpression arrayExpression;
         if (arrayType.mayBeNull) {
             DBSPExpression condition = statement.getVarReference().deref().is_null();
-            DBSPExpression empty = new DBSPVecLiteral(flatmap.getNode(), arrayType.withMayBeNull(false), Linq.list());
+            DBSPExpression empty = new DBSPVecExpression(flatmap.getNode(), arrayType.withMayBeNull(false), Linq.list());
             DBSPExpression contents = statement.getVarReference().deref().applyClone().unwrap();
             arrayExpression = new DBSPIfExpression(flatmap.getNode(), condition, empty, contents);
         } else {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjectionVisitor.java
@@ -19,7 +19,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeFunction;
 import org.dbsp.util.Maybe;
 
@@ -47,7 +47,7 @@ public class OptimizeProjectionVisitor extends CircuitCloneWithGraphsVisitor {
         if (projection.isProjection) {
             if (source.node().is(DBSPConstantOperator.class)) {
                 DBSPExpression newConstant = projection.applyAfter(
-                        source.node().to(DBSPConstantOperator.class).getFunction().to(DBSPZSetLiteral.class));
+                        source.node().to(DBSPConstantOperator.class).getFunction().to(DBSPZSetExpression.class));
                 DBSPSimpleOperator result = source.simpleNode().withFunction(newConstant, operator.outputType);
                 this.map(operator, result);
                 return;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
@@ -24,9 +24,8 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOper
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIndexedZSetLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIndexedZSetExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 
@@ -45,20 +44,20 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
     @Override
     public void postorder(DBSPConstantOperator operator) {
         DBSPExpression expression = operator.getFunction();
-        if (expression.is(DBSPZSetLiteral.class)) {
-            DBSPZSetLiteral lit = expression.to(DBSPZSetLiteral.class);
+        if (expression.is(DBSPZSetExpression.class)) {
+            DBSPZSetExpression lit = expression.to(DBSPZSetExpression.class);
             if (lit.isEmpty())
                 this.emptySources.add(operator);
         }
         super.postorder(operator);
     }
 
-    DBSPLiteral emptyLiteral(DBSPType type) {
+    DBSPExpression emptySet(DBSPType type) {
         if (type.is(DBSPTypeZSet.class)) {
             DBSPTypeZSet z = type.to(DBSPTypeZSet.class);
-            return DBSPZSetLiteral.emptyWithElementType(z.elementType);
+            return DBSPZSetExpression.emptyWithElementType(z.elementType);
         } else {
-            return new DBSPIndexedZSetLiteral(type.getNode(), type);
+            return new DBSPIndexedZSetExpression(type.getNode(), type);
         }
     }
 
@@ -66,7 +65,7 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
         OutputPort source = this.mapped(operator.input());
         if (this.emptySources.contains(source.node())) {
             DBSPType outputType = operator.getType();
-            DBSPLiteral value = this.emptyLiteral(outputType);
+            DBSPExpression value = this.emptySet(outputType);
             DBSPConstantOperator result = new DBSPConstantOperator(
                     operator.getNode(), value, false, operator.isMultiset);
             this.emptySources.add(result);
@@ -170,7 +169,7 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
             newSources.add(source);
         }
         if (newSources.isEmpty()) {
-            DBSPLiteral value = this.emptyLiteral(operator.getType());
+            DBSPExpression value = this.emptySet(operator.getType());
             DBSPConstantOperator result = new DBSPConstantOperator(
                     operator.getNode(), value, false, operator.isMultiset);
             this.emptySources.add(result);
@@ -189,7 +188,7 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
         OutputPort right = this.mapped(operator.inputs.get(1));
         if (this.emptySources.contains(right.node())) {
             if (this.emptySources.contains(left.node())) {
-                DBSPLiteral value = this.emptyLiteral(operator.getType());
+                DBSPExpression value = this.emptySet(operator.getType());
                 DBSPConstantOperator result = new DBSPConstantOperator(
                         operator.getNode(), value, false, operator.isMultiset);
                 this.emptySources.add(result);
@@ -207,7 +206,7 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
         for (OutputPort prev: operator.inputs) {
             OutputPort source = this.mapped(prev);
             if (this.emptySources.contains(source.node())) {
-                DBSPLiteral value = this.emptyLiteral(operator.getType());
+                DBSPExpression value = this.emptySet(operator.getType());
                 DBSPConstantOperator result = new DBSPConstantOperator(
                         operator.getNode(), value, false, operator.isMultiset);
                 this.emptySources.add(result);
@@ -223,7 +222,7 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
         for (OutputPort prev: operator.inputs) {
             OutputPort source = this.mapped(prev);
             if (this.emptySources.contains(source.node())) {
-                DBSPLiteral value = this.emptyLiteral(operator.getType());
+                DBSPExpression value = this.emptySet(operator.getType());
                 DBSPConstantOperator result = new DBSPConstantOperator(
                         operator.getNode(), value, false, operator.isMultiset);
                 this.emptySources.add(result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -83,7 +83,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -1619,7 +1619,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
             OutputPort collected;
             if (this.errorStreams.isEmpty()) {
                 DBSPSimpleOperator c = new DBSPConstantOperator(operator.getNode(),
-                        DBSPZSetLiteral.emptyWithElementType(operator.getOutputZSetElementType()), false, false);
+                        DBSPZSetExpression.emptyWithElementType(operator.getOutputZSetElementType()), false, false);
                 this.addOperator(c);
                 collected = c.outputPort();
             } else if (this.errorStreams.size() > 1) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
@@ -1,39 +1,42 @@
-package org.dbsp.sqlCompiler.ir.expression.literal;
+package org.dbsp.sqlCompiler.ir.expression;
 
-import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.IDBSPNode;
 import org.dbsp.sqlCompiler.ir.ISameValue;
-import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.IDBSPContainer;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.util.IIndentStream;
 
 import javax.annotation.Nullable;
 
-/** Represents a (constant) IndexedZSet described by its elements.
+/** Represents an IndexedZSet described by its elements.
  * An IndexedZSet is a map from keys to tuples to integer weights.
  * Currently, we only support empty indexed zsets since we found no
  * need for other constants yet. */
-public final class DBSPIndexedZSetLiteral extends DBSPLiteral implements IDBSPContainer {
+public final class DBSPIndexedZSetExpression extends DBSPExpression implements IDBSPContainer, ISameValue {
     public final DBSPTypeIndexedZSet indexedZSetType;
 
-    public DBSPIndexedZSetLiteral(CalciteObject node, DBSPType type) {
-        super(node, type, false);
+    public DBSPIndexedZSetExpression(CalciteObject node, DBSPType type) {
+        super(node, type);
         this.indexedZSetType = this.getType().to(DBSPTypeIndexedZSet.class);
     }
 
-    @Override
     public boolean isConstant() {
         return true;
     }
 
     @Override
     public DBSPExpression deepCopy() {
-        return new DBSPIndexedZSetLiteral(this.getNode(), this.type);
+        return new DBSPIndexedZSetExpression(this.getNode(), this.type);
+    }
+
+    @Override
+    public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
+        throw new UnimplementedException();
     }
 
     @Override
@@ -46,10 +49,8 @@ public final class DBSPIndexedZSetLiteral extends DBSPLiteral implements IDBSPCo
     }
 
     @Override
-    public DBSPLiteral getWithNullable(boolean mayBeNull) {
-        if (mayBeNull)
-            throw new InternalCompilerError("Null indexed zset");
-        return this;
+    public boolean sameFields(IDBSPNode other) {
+        return other.is(DBSPIndexedZSetExpression.class);
     }
 
     public boolean isEmpty() {
@@ -69,18 +70,13 @@ public final class DBSPIndexedZSetLiteral extends DBSPLiteral implements IDBSPCo
     public boolean sameValue(@Nullable ISameValue o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DBSPIndexedZSetLiteral that = (DBSPIndexedZSetLiteral) o;
+        DBSPIndexedZSetExpression that = (DBSPIndexedZSetExpression) o;
         return this.indexedZSetType.sameType(that.indexedZSetType);
     }
 
     @Override
     public IDBSPContainer add(DBSPExpression expression) {
         throw new UnimplementedException("Not yet implemented: IndexedZSet literals", expression);
-    }
-
-    @Override
-    public String toSqlString() {
-        throw new InternalCompilerError("Unreachable");
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -32,12 +32,15 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPNode;
 import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.primitive.*;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
-import org.dbsp.sqlCompiler.ir.type.primitive.*;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -102,9 +105,9 @@ public abstract class DBSPLiteral extends DBSPExpression implements ISameValue {
         } else if (type.is(DBSPTypeTime.class)) {
             return new DBSPTimeLiteral();
         } else if (type.is(DBSPTypeVec.class)) {
-            return new DBSPVecLiteral(type, true);
+            return new DBSPVecExpression(type, true);
         } else if (type.is(DBSPTypeMap.class)) {
-            return new DBSPMapLiteral(type.to(DBSPTypeMap.class), null, null);
+            return new DBSPMapExpression(type.to(DBSPTypeMap.class), null, null);
         } else if (type.is(DBSPTypeTuple.class)) {
             return DBSPTupleExpression.none(type.to(DBSPTypeTuple.class));
         } else if (type.is(DBSPTypeNull.class)) {
@@ -114,7 +117,7 @@ public abstract class DBSPLiteral extends DBSPExpression implements ISameValue {
         } else if (type.is(DBSPTypeBinary.class)) {
             return new DBSPBinaryLiteral(type.getNode(), type, null);
         } else if (type.is(DBSPTypeVariant.class)) {
-            return new DBSPVariantLiteral(null, type);
+            return new DBSPVariantExpression(null, type);
         }
         throw new InternalCompilerError("Unexpected type for NULL literal " + type, type);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeVariant.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeVariant.java
@@ -4,7 +4,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.util.IIndentStream;
@@ -35,7 +35,7 @@ public class DBSPTypeVariant extends DBSPTypeBaseType {
 
     @Override
     public DBSPExpression defaultValue() {
-        return DBSPVariantLiteral.sqlNull(this.mayBeNull);
+        return DBSPVariantExpression.sqlNull(this.mayBeNull);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
@@ -3,7 +3,7 @@ package org.dbsp.sqlCompiler.ir.type.user;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.Linq;
 
@@ -50,7 +50,7 @@ public class DBSPTypeMap extends DBSPTypeUser {
     public DBSPExpression defaultValue() {
         if (this.mayBeNull)
             return this.none();
-        return new DBSPMapLiteral(this, Linq.list());
+        return new DBSPMapExpression(this, Linq.list());
     }
 
     // sameType and hashCode inherited from TypeUser.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
@@ -26,7 +26,7 @@ package org.dbsp.sqlCompiler.ir.type.user;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.ICollectionType;
 
@@ -46,7 +46,7 @@ public class DBSPTypeVec extends DBSPTypeUser implements ICollectionType {
     public DBSPExpression defaultValue() {
         if (this.mayBeNull)
             return this.none();
-        return new DBSPVecLiteral(this, false);
+        return new DBSPVecExpression(this, false);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/TableValue.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/TableValue.java
@@ -12,7 +12,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
@@ -27,9 +27,9 @@ import java.util.Set;
 /** Represents the contents of a table as produced by INSERT and REMOVE statements */
 public class TableValue {
     public final ProgramIdentifier tableName;
-    public final DBSPZSetLiteral contents;
+    public final DBSPZSetExpression contents;
 
-    public TableValue(ProgramIdentifier tableName, DBSPZSetLiteral contents) {
+    public TableValue(ProgramIdentifier tableName, DBSPZSetExpression contents) {
         this.tableName = tableName;
         this.contents = contents;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
@@ -14,7 +14,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
@@ -32,7 +32,7 @@ public class UnusedFieldsTest {
         DBSPCompiler compiler = new DBSPCompiler(new CompilerOptions());
         Assert.assertEquals("None::<Vec<String>>",
                 ToRustInnerVisitor.toRustString(compiler, none, false));
-        DBSPZSetLiteral zset = new DBSPZSetLiteral(none);
+        DBSPZSetExpression zset = new DBSPZSetExpression(none);
         Assert.assertEquals("zset!((Vec<s>?)null => 1,)", zset.toString());
         Assert.assertEquals("zset!(None::<Vec<String>> => 1)",
                 ToRustInnerVisitor.toRustString(compiler, zset, false));
@@ -40,7 +40,7 @@ public class UnusedFieldsTest {
         Assert.assertEquals("Tup1::new((Vec<s>?)null, )", tup.toString());
         Assert.assertEquals("Tup1::new(None::<Vec<String>>)",
                 ToRustInnerVisitor.toRustString(compiler, tup, false));
-        DBSPZSetLiteral zset1 = new DBSPZSetLiteral(tup);
+        DBSPZSetExpression zset1 = new DBSPZSetExpression(tup);
         Assert.assertEquals("zset!(Tup1::new((Vec<s>?)null, ) => 1,)", zset1.toString());
         Assert.assertEquals("zset!(Tup1::new(None::<Vec<String>>) => 1)",
                 ToRustInnerVisitor.toRustString(compiler, zset1, false));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
@@ -18,7 +18,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDouble;
 import org.junit.Assert;
@@ -378,8 +378,8 @@ public class ComplexQueriesTest extends BaseSQLTests {
                     ON t1.cc_num = t2.cc_num);""";
         DBSPCompiler compiler = testCompiler();
         compiler.compileStatements(script);
-        DBSPZSetLiteral[] inputs = new DBSPZSetLiteral[] {
-                new DBSPZSetLiteral(new DBSPTupleExpression(
+        DBSPZSetExpression[] inputs = new DBSPZSetExpression[] {
+                new DBSPZSetExpression(new DBSPTupleExpression(
                         new DBSPDoubleLiteral(0.0),
                         new DBSPStringLiteral("First", true),
                         new DBSPStringLiteral("Male", true),
@@ -394,7 +394,7 @@ public class ComplexQueriesTest extends BaseSQLTests {
                         new DBSPStringLiteral("Job", true),
                         new DBSPStringLiteral("2020-02-20", true)
                         )),
-                new DBSPZSetLiteral(new DBSPTupleExpression(
+                new DBSPZSetExpression(new DBSPTupleExpression(
                         new DBSPTimestampLiteral("2020-02-20 10:00:00", false),
                         new DBSPDoubleLiteral(0.0, false),
                         new DBSPStringLiteral("Merchant", true),
@@ -438,8 +438,8 @@ public class ComplexQueriesTest extends BaseSQLTests {
                 FROM transactions AS t1;""";
         DBSPCompiler compiler = testCompiler();
         compiler.compileStatements(script);
-        DBSPZSetLiteral[] inputs = new DBSPZSetLiteral[] {
-                new DBSPZSetLiteral(new DBSPTupleExpression(
+        DBSPZSetExpression[] inputs = new DBSPZSetExpression[] {
+                new DBSPZSetExpression(new DBSPTupleExpression(
                         new DBSPI64Literal(0, false),
                         new DBSPDoubleLiteral(10.0, true),
                         new DBSPI32Literal(1000)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -55,7 +55,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -204,7 +204,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     @Test
     public void toCsvTest() {
         DBSPCompiler compiler = testCompiler();
-        DBSPZSetLiteral s = new DBSPZSetLiteral(EndToEndTests.E0, EndToEndTests.E1);
+        DBSPZSetExpression s = new DBSPZSetExpression(EndToEndTests.E0, EndToEndTests.E1);
         StringBuilder builder = new StringBuilder();
         ToCsvVisitor visitor = new ToCsvVisitor(compiler, builder, () -> "");
         visitor.apply(s);
@@ -219,7 +219,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     @Test
     public void rustCsvTest() throws IOException, InterruptedException {
         DBSPCompiler compiler = testCompiler();
-        DBSPZSetLiteral data = new DBSPZSetLiteral(EndToEndTests.E0, EndToEndTests.E1);
+        DBSPZSetExpression data = new DBSPZSetExpression(EndToEndTests.E0, EndToEndTests.E1);
         File file = File.createTempFile("test", ".csv", new File(BaseSQLTests.rustDirectory));
         file.deleteOnExit();
         ToCsvVisitor.toCsv(compiler, file, data);
@@ -244,7 +244,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     @Test
     public void rustCsvTest2() throws IOException, InterruptedException {
         DBSPCompiler compiler = this.testCompiler();
-        DBSPZSetLiteral data = new DBSPZSetLiteral(
+        DBSPZSetExpression data = new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(1, true)),
                 new DBSPTupleExpression(new DBSPI32Literal(2, true)),
                 new DBSPTupleExpression(DBSPI32Literal.none(
@@ -604,7 +604,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                 INSERT INTO T VALUES(1, 'x');
                 REMOVE FROM T VALUES(2, 'Y');
                 REMOVE FROM T VALUES(3, 'Z');""").simplify(compiler);
-        DBSPZSetLiteral expected = DBSPZSetLiteral.emptyWithElementType(
+        DBSPZSetExpression expected = DBSPZSetExpression.emptyWithElementType(
                 new DBSPTypeTuple(
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true),
                         DBSPTypeString.varchar(true)));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresDateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresDateTests.java
@@ -28,7 +28,7 @@ import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.util.Linq;
 import org.junit.Test;
 
@@ -929,8 +929,8 @@ public class PostgresDateTests extends SqlIoTest {
                 //-1475115L
         };
         // TODO: why is the output an integer instead of an interval in Postgres?
-        DBSPZSetLiteral result =
-                new DBSPZSetLiteral(Linq.map(results,
+        DBSPZSetExpression result =
+                new DBSPZSetExpression(Linq.map(results,
                         l -> new DBSPTupleExpression(new DBSPIntervalMillisLiteral(
                                 l * 86400 * 1000, true)), DBSPExpression.class));
         this.compare(query, result, true, results.length);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresNumericTests.java
@@ -29,7 +29,7 @@ import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.sql.tools.Change;
 import org.dbsp.sqlCompiler.compiler.sql.tools.InputOutputChange;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
@@ -519,7 +519,7 @@ public class PostgresNumericTests extends SqlIoTest {
         InputOutputChange change = new InputOutputChange(
                 this.getPreparedInputs(compiler),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(new DBSPTypeTuple(
+                        DBSPZSetExpression.emptyWithElementType(new DBSPTypeTuple(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,false),
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 64, true,false),
                                 new DBSPTypeDecimal(CalciteObject.EMPTY, WIDTH, 10, false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimestampTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimestampTests.java
@@ -34,7 +34,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.Linq;
 import org.junit.Test;
@@ -142,7 +142,7 @@ public class PostgresTimestampTests extends SqlIoTest {
         query = "CREATE VIEW V AS " + query;
         DBSPCompiler compiler = this.compileQuery(query, true);
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
-        DBSPZSetLiteral input = compiler.getTableContents().getTableContents(
+        DBSPZSetExpression input = compiler.getTableContents().getTableContents(
                 compiler.canonicalName("TIMESTAMP_TBL", false));
         InputOutputChange change = new InputOutputChange(new Change(input), expectedOutput);
         ccs.addChange(change);
@@ -559,7 +559,7 @@ public class PostgresTimestampTests extends SqlIoTest {
                         new DBSPI32Literal(-(int)(TableParser.shortIntervalToMilliseconds(d) / 60000), true)), DBSPExpression.class);
         String query = "SELECT TIMESTAMPDIFF(MINUTE, d1, timestamp '1997-01-02') AS diff\n" +
                 "   FROM TIMESTAMP_TBL WHERE d1 BETWEEN '1902-01-01' AND '2038-01-01'";
-        this.testQuery(query, new Change(new DBSPZSetLiteral(results)));
+        this.testQuery(query, new Change(new DBSPZSetExpression(results)));
     }
 
     @Test
@@ -662,7 +662,7 @@ public class PostgresTimestampTests extends SqlIoTest {
         DBSPExpression[] results = Linq.map(data, d ->
                 new DBSPTupleExpression(d == null ? DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)) :
                         new DBSPI32Literal(-(int)(TableParser.shortIntervalToMilliseconds(d)/1000), true)), DBSPExpression.class);
-        this.testQuery(query, new Change(new DBSPZSetLiteral(results)));
+        this.testQuery(query, new Change(new DBSPZSetExpression(results)));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
@@ -36,8 +36,8 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
@@ -83,8 +83,8 @@ public class ArrayTests extends BaseSQLTests {
                         Linq.list(new DBSPTypeInteger(CalciteObject.EMPTY, 64, true, false))
                 ), true);
         // null vector
-        Change input = new Change(new DBSPZSetLiteral(new DBSPTupleExpression(
-                Linq.list(new DBSPVecLiteral(vecType, true)), false)));
+        Change input = new Change(new DBSPZSetExpression(new DBSPTupleExpression(
+                Linq.list(new DBSPVecExpression(vecType, true)), false)));
         Change output = new Change();
         InputOutputChangeStream stream = new InputOutputChangeStream().addPair(input, output);
         this.testQuery(statements, query, stream);
@@ -104,11 +104,11 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testUnnest() {
         String query = "SELECT i*2 FROM UNNEST(ARRAY [1, 2, 3, 4, 5]) AS T(i)";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 6; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(new DBSPI32Literal(i * 2));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -120,11 +120,11 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testUnnestDuplicate() {
         String query = "SELECT * FROM UNNEST(ARRAY [1, 1, 1])";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 4; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(new DBSPI32Literal(1));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -136,11 +136,11 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testUnnestNull() {
         String query = "SELECT * FROM UNNEST(ARRAY [1, 2, 3, 4, NULL])";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 5; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(new DBSPI32Literal(i, true));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -153,13 +153,13 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testUnnestOrdinality() {
         String query = "SELECT * FROM UNNEST(ARRAY [1, 2, 3, 4, 5]) WITH ORDINALITY";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 6; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(
                     new DBSPI32Literal(i),
                     new DBSPI32Literal(i));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -170,13 +170,13 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testUnnestOrdinalityNull() {
         String query = "SELECT * FROM UNNEST(ARRAY [1, 2, 3, 4, 5, NULL]) WITH ORDINALITY";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 6; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(
                     new DBSPI32Literal(i, true),
                     new DBSPI32Literal(i));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -191,14 +191,14 @@ public class ArrayTests extends BaseSQLTests {
     @Test @Ignore("UNNEST with 2 arguments not yet implemented")
     public void testUnnest2() {
         String query = "SELECT * FROM UNNEST(ARRAY [1, 2, 3, 4, 5], ARRAY[3, 2, 1])";
-        DBSPZSetLiteral result = null;
+        DBSPZSetExpression result = null;
         for (int i = 1; i < 6; i++) {
             DBSPTupleExpression tuple = new DBSPTupleExpression(
                     new DBSPI32Literal(i),
                     i < 4 ? new DBSPI32Literal(4 - 1, true) :
                             DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)));
             if (i == 1)
-                result = new DBSPZSetLiteral(tuple);
+                result = new DBSPZSetExpression(tuple);
             else
                 Objects.requireNonNull(result).add(tuple);
         }
@@ -214,21 +214,21 @@ public class ArrayTests extends BaseSQLTests {
                 + "ID INTEGER NOT NULL)";
         String query = "SELECT VAL * 2, ID FROM " +
                 "ARR_TABLE, UNNEST(VALS) AS VAL";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
                         new DBSPI32Literal(6)),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
                         new DBSPI32Literal(7))
                 );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(2, true), new DBSPI32Literal(6)),
                 new DBSPTupleExpression(new DBSPI32Literal(4, true), new DBSPI32Literal(6)),
                 new DBSPTupleExpression(new DBSPI32Literal(6, true), new DBSPI32Literal(6)),
@@ -248,29 +248,29 @@ public class ArrayTests extends BaseSQLTests {
                 + "ID INTEGER NOT NULL)";
         String query = "SELECT VAL0, VAL1, ID FROM " +
                 "ARR_TABLE, UNNEST(VALS0) AS VAL0, UNNEST(VALS1) AS VAL1";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(4, true),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true)),
                         new DBSPI32Literal(7)),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(8, true),
                                 new DBSPI32Literal(9, true),
                                 new DBSPI32Literal(10, true)),
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(11, true),
                                 new DBSPI32Literal(12, true),
                                 new DBSPI32Literal(13, true)),
                         new DBSPI32Literal(14))
         );
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(
             new DBSPTypeTuple(
                     new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true),
                     new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true),
@@ -315,7 +315,7 @@ public class ArrayTests extends BaseSQLTests {
     public void testConstants() {
         String query = "SELECT ARRAY[2,3][2], CARDINALITY(ARRAY[2,3]), ELEMENT(ARRAY[2])";
         this.testQuery("", query, new InputOutputChange(new Change(),
-                new Change(new DBSPZSetLiteral(
+                new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPI32Literal(3, true),
                                 new DBSPI32Literal(2),
@@ -326,7 +326,7 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testElementNull() {
         this.testQuery("", "SELECT ELEMENT(NULL)", new InputOutputChange(new Change(),
-                new Change(new DBSPZSetLiteral(
+                new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPNullLiteral())))).toStream());
     }
 
@@ -339,30 +339,30 @@ public class ArrayTests extends BaseSQLTests {
     public void testArrayAppend() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY NOT NULL)";
 
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true),
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(
+                        new DBSPVecExpression(
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true),
@@ -377,30 +377,30 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testArrayAppendNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true),
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true),
@@ -415,25 +415,25 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testArrayAppendInnerNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY NULL)";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
@@ -441,7 +441,7 @@ public class ArrayTests extends BaseSQLTests {
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
@@ -457,21 +457,21 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testArrayMaxNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(3, true)
                 ),
@@ -487,14 +487,14 @@ public class ArrayTests extends BaseSQLTests {
     @Test
     public void testArraySubquery() {
         String ddl = "CREATE TABLE PAIRS(x INT NOT NULL, s VARCHAR NOT NULL);";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(10), new DBSPStringLiteral("hello")),
                 new DBSPTupleExpression(
                         new DBSPI32Literal(5), new DBSPStringLiteral("there")));
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                    new DBSPVecLiteral(
+                    new DBSPVecExpression(
                         new DBSPTupleExpression(
                             new DBSPI32Literal(5), new DBSPStringLiteral("there")),
                         new DBSPTupleExpression(
@@ -508,22 +508,22 @@ public class ArrayTests extends BaseSQLTests {
     public void testArrayMaxInnerNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
 
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 DBSPNullLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true)),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(3, true)
                 ),
@@ -540,21 +540,21 @@ public class ArrayTests extends BaseSQLTests {
     public void testArrayMinNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
 
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(1, true)
                 ),
@@ -571,22 +571,22 @@ public class ArrayTests extends BaseSQLTests {
     public void testArrayMinInnerNullable() {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
 
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 DBSPNullLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true)),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecLiteral(true,
+                        new DBSPVecExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
                 )
         );
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(1, true)
                 ),
@@ -606,7 +606,7 @@ public class ArrayTests extends BaseSQLTests {
                 (SELECT ARRAY[1, 2] a)""";
         this.testQuery("", sql,
                 new InputOutputChangeStream().addPair(new Change(),
-                        new Change(new DBSPZSetLiteral(
+                        new Change(new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPI32Literal(2, true),
                                         new DBSPI32Literal())))));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
@@ -36,7 +36,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.junit.Test;
 
@@ -60,7 +60,7 @@ public class CastTests extends SqlIoTest {
     }
 
     public Change createInput() {
-        return new Change(new DBSPZSetLiteral(new DBSPTupleExpression(
+        return new Change(new DBSPZSetExpression(new DBSPTupleExpression(
                 new DBSPI32Literal(10),
                 new DBSPDoubleLiteral(12.0),
                 new DBSPStringLiteral("100100"),
@@ -68,7 +68,7 @@ public class CastTests extends SqlIoTest {
                 new DBSPDecimalLiteral(tenFour, new BigDecimal(100103)))));
     }
 
-    public void testQuery(String query, DBSPZSetLiteral expectedOutput) {
+    public void testQuery(String query, DBSPZSetExpression expectedOutput) {
         query = "CREATE VIEW V AS " + query + ";";
         CompilerCircuitStream ccs = this.getCCS(query);
         InputOutputChange change = new InputOutputChange(this.createInput(), new Change(expectedOutput));
@@ -91,27 +91,27 @@ public class CastTests extends SqlIoTest {
     @Test
     public void intAndString() {
         String query = "SELECT '1' + 2";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(3))));
     }
 
     @Test
     public void intAndStringTable() {
         String query = "SELECT T.COL1 + T.COL3 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(100110))));
     }
 
     @Test
     public void castNull() {
         String query = "SELECT CAST(NULL AS INTEGER)";
-        this.testQuery(query, new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI32Literal())));
+        this.testQuery(query, new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI32Literal())));
     }
 
     @Test
     public void castFromFPTest() {
         String query = "SELECT T.COL1 + T.COL2 + T.COL3 + T.COL5 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPDoubleLiteral(200225.0))));
+        this.testQuery(query, new DBSPZSetExpression(new DBSPTupleExpression(new DBSPDoubleLiteral(200225.0))));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class CastTests extends SqlIoTest {
 
     @Test
     public void testFpCasts() {
-        this.testQuery("SELECT CAST(T.COL2 AS BIGINT) FROM T", new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI64Literal(12))));
+        this.testQuery("SELECT CAST(T.COL2 AS BIGINT) FROM T", new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI64Literal(12))));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -44,8 +44,8 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
@@ -90,14 +90,14 @@ public class EndToEndTests extends BaseSQLTests {
     }
 
     /** Use this function to test queries whose result does not change when table T is modified. */
-    void testConstantOutput(String query, DBSPZSetLiteral output) {
+    void testConstantOutput(String query, DBSPZSetExpression output) {
         this.testQueryBase(query, new InputOutputChange(createInput(), new Change(output)).toStream());
     }
 
     /** Use this function to test queries that compute aggregates */
     void testAggregate(String query,
-                       DBSPZSetLiteral firstOutput,
-                       DBSPZSetLiteral outputForEmptyInput) {
+                       DBSPZSetExpression firstOutput,
+                       DBSPZSetExpression outputForEmptyInput) {
         this.testQueryBase(query, new InputOutputChange(createInput(), new Change(firstOutput)).toStream());
     }
 
@@ -111,7 +111,7 @@ public class EndToEndTests extends BaseSQLTests {
      INSERT INTO T VALUES (10, 1e0, false, 'Hi', 1, 0e0);
      */
     static Change createInput() {
-        return new Change(new DBSPZSetLiteral(E0, E1));
+        return new Change(new DBSPZSetExpression(E0, E1));
     }
 
     public static final DBSPTypeDecimal D62 = new DBSPTypeDecimal(CalciteObject.EMPTY, 6, 2, true);
@@ -132,11 +132,11 @@ public class EndToEndTests extends BaseSQLTests {
             new DBSPDecimalLiteral(D62, BigDecimal.ZERO)
     );
 
-    static final DBSPZSetLiteral z0 = new DBSPZSetLiteral(E0);
-    static final DBSPZSetLiteral z1 = new DBSPZSetLiteral(E1);
-    static final DBSPZSetLiteral empty = DBSPZSetLiteral.emptyWithElementType(z0.getElementType());
+    static final DBSPZSetExpression z0 = new DBSPZSetExpression(E0);
+    static final DBSPZSetExpression z1 = new DBSPZSetExpression(E1);
+    static final DBSPZSetExpression empty = DBSPZSetExpression.emptyWithElementType(z0.getElementType());
 
-    public void testQuery(String query, DBSPZSetLiteral expectedOutput) {
+    public void testQuery(String query, DBSPZSetExpression expectedOutput) {
         this.testQuery(query, new Change(expectedOutput));
     }
 
@@ -148,7 +148,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableCompare() {
         String query = "SELECT T.COL5 > T.COL1 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true))));
     }
@@ -158,7 +158,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT ABS(T.COL2) FROM T";
         assert E0.fields != null;
         assert E1.fields != null;
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(E0.fields[1]),
                 new DBSPTupleExpression(E1.fields[1])));
     }
@@ -166,7 +166,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableCastCompare() {
         String query = "SELECT T.COL5 > T.COL2 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true))));
     }
@@ -174,7 +174,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableCastCompare2() {
         String query = "SELECT T.COL5 > T.COL6 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true, true))));
     }
@@ -182,7 +182,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableCompare2() {
         String query = "SELECT T.COL5 > 10 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true))));
     }
@@ -190,7 +190,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testBoolean() {
         String query = "SELECT T.COL3 OR T.COL1 > 10 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false))));
     }
@@ -198,7 +198,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableBoolean2() {
         String query = "SELECT T.COL5 > 10 AND T.COL3 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true))));
     }
@@ -206,7 +206,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testNullableBoolean3() {
         String query = "SELECT T.COL3 AND T.COL5 > 10 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true))));
     }
@@ -214,7 +214,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void overDecimalTest() {
         String query = "SELECT T.COL1, COUNT(*) OVER (ORDER BY T.COL6 RANGE UNBOUNDED PRECEDING) FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPI64Literal(1)),
                 new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPI64Literal(2))));
     }
@@ -223,20 +223,20 @@ public class EndToEndTests extends BaseSQLTests {
     public void overTest() {
         String query = "SELECT T.COL1, COUNT(*) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING) FROM T";
         DBSPExpression t = new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPI64Literal(2));
-        this.testQuery(query, new DBSPZSetLiteral(t, t));
+        this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
     @Test
     public void overSumTest() {
         String query = "SELECT T.COL1, SUM(T.COL2) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING) FROM T";
         DBSPExpression t = new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPDoubleLiteral(13.0));
-        this.testQuery(query, new DBSPZSetLiteral(t, t));
+        this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
     @Test
     public void lagTest() {
         String query = "SELECT T.COL1, LAG(T.COL1) OVER (ORDER BY T.COL1) FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(10),
                         DBSPLiteral.none(new DBSPTypeInteger(
@@ -250,41 +250,41 @@ public class EndToEndTests extends BaseSQLTests {
     public void testConcat() {
         String query = "SELECT T.COL4 || ' ' || T.COL4 FROM T";
         DBSPExpression lit = new DBSPTupleExpression(new DBSPStringLiteral("Hi Hi"));
-        this.testQuery(query, new DBSPZSetLiteral(lit, lit));
+        this.testQuery(query, new DBSPZSetExpression(lit, lit));
     }
 
     @Test
     public void testCast() {
         String query = "SELECT CAST(T.COL1 AS VARCHAR) FROM T";
         DBSPExpression lit = new DBSPTupleExpression(new DBSPStringLiteral("10"));
-        this.testQuery(query, new DBSPZSetLiteral(lit, lit));
+        this.testQuery(query, new DBSPZSetExpression(lit, lit));
     }
 
     @Test
     public void testArray() {
         String query = "SELECT ELEMENT(ARRAY [2])";
-        DBSPZSetLiteral result = new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI32Literal(2, true)));
+        DBSPZSetExpression result = new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI32Literal(2, true)));
         this.testConstantOutput(query, result);
     }
 
     @Test
     public void testNull() {
         String query = "SELECT NULL";
-        DBSPZSetLiteral result = new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPNullLiteral()));
+        DBSPZSetExpression result = new DBSPZSetExpression(new DBSPTupleExpression(new DBSPNullLiteral()));
         this.testConstantOutput(query, result);
     }
 
     @Test
     public void testArrayIndex() {
         String query = "SELECT (ARRAY [2])[1]";
-        DBSPZSetLiteral result = new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI32Literal(2, true)));
+        DBSPZSetExpression result = new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI32Literal(2, true)));
         this.testConstantOutput(query, result);
     }
 
     @Test
     public void testArrayIndexOutOfBounds() {
         String query = "SELECT (ARRAY [2])[3]";
-        DBSPZSetLiteral result = new DBSPZSetLiteral(new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))));
+        DBSPZSetExpression result = new DBSPZSetExpression(new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))));
         this.testConstantOutput(query, result);
     }
 
@@ -293,7 +293,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT T.COL4 || NULL FROM T";
         DBSPExpression lit = new DBSPTupleExpression(DBSPLiteral.none(
                 new DBSPTypeString(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, true)));
-        this.testQuery(query, new DBSPZSetLiteral(lit, lit));
+        this.testQuery(query, new DBSPZSetExpression(lit, lit));
     }
 
     @Test
@@ -301,7 +301,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT CONCAT(T.COL4, NULL) FROM T";
         DBSPExpression lit = new DBSPTupleExpression(DBSPLiteral.none(
                 new DBSPTypeString(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, true)));
-        this.testQuery(query, new DBSPZSetLiteral(lit, lit));
+        this.testQuery(query, new DBSPZSetExpression(lit, lit));
     }
 
     @Test
@@ -314,7 +314,7 @@ public class EndToEndTests extends BaseSQLTests {
                 SELECT T.COL1,
                 SUM(T.COL2) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING),
                 COUNT(*) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING) FROM T""";
-        this.testQuery(query, new DBSPZSetLiteral(t, t));
+        this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
     @Test
@@ -324,7 +324,7 @@ public class EndToEndTests extends BaseSQLTests {
                 new DBSPI64Literal(0));
         String query = "SELECT T.COL1, " +
                 "COUNT(*) OVER (ORDER BY T.COL1 RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(t, t));
+        this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
     @Test
@@ -337,7 +337,7 @@ public class EndToEndTests extends BaseSQLTests {
                 SELECT T.COL1,
                 SUM(T.COL2) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING),
                 COUNT(*) OVER (ORDER BY T.COL1 RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) FROM T""";
-        this.testQuery(query, new DBSPZSetLiteral(t, t));
+        this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
     @Test
@@ -348,10 +348,10 @@ public class EndToEndTests extends BaseSQLTests {
                 0.5 * (SELECT Sum(r1.COL5) FROM T r1) =
                 (SELECT Sum(r2.COL5) FROM T r2 WHERE r2.COL1 = r.COL1)""";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
 
@@ -368,9 +368,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void someTest() {
         String query = "SELECT SOME(T.COL3) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral())));
     }
 
@@ -378,9 +378,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void orTest() {
         String query = "SELECT LOGICAL_OR(T.COL3) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral())));
     }
 
@@ -388,9 +388,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void everyTest() {
         String query = "SELECT EVERY(T.COL3) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(false, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral())));
     }
 
@@ -398,7 +398,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void projectTest() {
         String query = "SELECT T.COL3 FROM T";
         this.testQuery(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))));
     }
@@ -407,7 +407,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void withTest() {
         String query = "WITH v AS (SELECT COL3 FROM T)\n" +
                 "SELECT * FROM v";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false))));
     }
@@ -417,7 +417,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT T.COL3, " +
                 "SUM(T.COL1) FILTER (WHERE T.COL1 > 20)\n" +
                 "FROM T GROUP BY T.COL3";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPBoolLiteral(true),
                         DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))
@@ -432,7 +432,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT T.COL3, " +
                 "COUNT(*) FILTER (WHERE T.COL1 > 20)\n" +
                 "FROM T GROUP BY T.COL3";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPBoolLiteral(true),
                         new DBSPI64Literal(0, false)
@@ -448,7 +448,7 @@ public class EndToEndTests extends BaseSQLTests {
                 SELECT T.COL3, COUNT(*) FILTER (WHERE T.COL1 > 20),
                 SUM(T.COL1) FILTER (WHERE T.COL1 > 20)
                 FROM T GROUP BY T.COL3""";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPBoolLiteral(true),
                         new DBSPI64Literal(0, false),
@@ -470,7 +470,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void plusNullTest() {
         String query = "SELECT T.COL1 + T.COL5 FROM T";
         this.testQuery(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(11, true)),
                         new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -479,7 +479,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void negateNullTest() {
         String query = "SELECT -T.COL5 FROM T";
         this.testQuery(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(-1, true)),
                         new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -489,7 +489,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT CAST(CAST(T.COL5 as VARIANT) AS INTEGER) FROM T";
         DBSPI32Literal one = new DBSPI32Literal(1, true);
         this.testQuery(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(one),
                         new DBSPTupleExpression(DBSPLiteral.none(one.getType()))));
     }
@@ -499,7 +499,7 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT T.COL5 FROM T";
         DBSPI32Literal one = new DBSPI32Literal(1, true);
         this.testQuery(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(one),
                         new DBSPTupleExpression(DBSPLiteral.none(one.getType()))));
     }
@@ -527,7 +527,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void joinTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral(false)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral(true)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true), new DBSPBoolLiteral(false)),
@@ -537,28 +537,28 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void joinFPTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 JOIN T AS T2 ON T1.COL2 = T2.COL6";
-        this.testQuery(query, DBSPZSetLiteral.emptyWithElementType(
+        this.testQuery(query, DBSPZSetExpression.emptyWithElementType(
                 new DBSPTypeTuple(DBSPTypeBool.create(false), DBSPTypeBool.create(false))));
     }
 
     @Test
     public void joinNullableTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 JOIN T AS T2 ON T1.COL1 = T2.COL5";
-        this.testQuery(query, DBSPZSetLiteral.emptyWithElementType(
+        this.testQuery(query, DBSPZSetExpression.emptyWithElementType(
                 new DBSPTypeTuple(DBSPTypeBool.create(false), DBSPTypeBool.create(false))));
     }
 
     @Test
     public void zero() {
         String query = "SELECT 0";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(0))));
     }
 
     @Test
     public void geoPointTest() {
         String query = "SELECT ST_POINT(0, 0)";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPGeoPointLiteral(CalciteObject.EMPTY,
                                 new DBSPDoubleLiteral(0),
@@ -568,14 +568,14 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void geoDistanceTest() {
         String query = "SELECT ST_DISTANCE(ST_POINT(0, 0), ST_POINT(0,1))";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPDoubleLiteral(1.0, true))));
     }
 
     @Test
     public void leftOuterJoinTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 LEFT JOIN T AS T2 ON T1.COL1 = T2.COL5";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false), new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true), new DBSPBoolLiteral())
         ));
@@ -584,7 +584,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void rightOuterJoinTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 RIGHT JOIN T AS T2 ON T1.COL1 = T2.COL5";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(), new DBSPBoolLiteral(false)),
                 new DBSPTupleExpression(new DBSPBoolLiteral(), new DBSPBoolLiteral(true))
         ));
@@ -593,7 +593,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void fullOuterJoinTest() {
         String query = "SELECT T1.COL3, T2.COL3 AS C3 FROM T AS T1 FULL OUTER JOIN T AS T2 ON T1.COL1 = T2.COL5";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBoolLiteral(false, true), new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(true, true), new DBSPBoolLiteral()),
                 new DBSPTupleExpression(new DBSPBoolLiteral(), new DBSPBoolLiteral(false, true)),
@@ -646,7 +646,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void whereExpressionTest() {
         String query = "SELECT * FROM T WHERE COL2 < 0";
-        this.testQuery(query, DBSPZSetLiteral.emptyWithElementType(z0.getElementType()));
+        this.testQuery(query, DBSPZSetExpression.emptyWithElementType(z0.getElementType()));
     }
 
     @Test
@@ -658,13 +658,13 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void constantFoldTest() {
         String query = "SELECT 1 + 2";
-        this.testConstantOutput(query, new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI32Literal(3))));
+        this.testConstantOutput(query, new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI32Literal(3))));
     }
 
     @Test
     public void groupByTest() {
         String query = "SELECT COL1 FROM T GROUP BY COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(10))));
     }
 
@@ -672,13 +672,13 @@ public class EndToEndTests extends BaseSQLTests {
     public void groupByCountTest() {
         String query = "SELECT COL1, COUNT(col2) FROM T GROUP BY COL1, COL3";
         DBSPExpression row =  new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPI64Literal(1));
-        this.testQuery(query, new DBSPZSetLiteral( row, row));
+        this.testQuery(query, new DBSPZSetExpression( row, row));
     }
 
     @Test
     public void groupBySumTest() {
         String query = "SELECT COL1, SUM(col2) FROM T GROUP BY COL1, COL3";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPDoubleLiteral(1)),
                 new DBSPTupleExpression(new DBSPI32Literal(10), new DBSPDoubleLiteral(12))));
     }
@@ -686,7 +686,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void divTest() {
         String query = "SELECT T.COL1 / T.COL5 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))),
                 new DBSPTupleExpression(new DBSPI32Literal(10, true))));
@@ -702,7 +702,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void decimalParse() {
         // This is the same as DECIMAL(N, 0), so the result is rounded down
         String query = "SELECT CAST('0.5' AS DECIMAL)";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPDecimalLiteral(new DBSPTypeDecimal(CalciteObject.EMPTY, DBSPTypeDecimal.MAX_PRECISION, 0, false), new BigDecimal("0")))));
     }
@@ -710,7 +710,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void decimalParseWithPrecisionScale() {
         String query = "SELECT CAST('0.5' AS DECIMAL(2, 1))";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPDecimalLiteral(new DBSPTypeDecimal(CalciteObject.EMPTY, 2, 1, false), new BigDecimal("0.5"))
                 )
@@ -720,7 +720,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void divIntTest() {
         String query = "SELECT T.COL5 / T.COL5 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))),
                 new DBSPTupleExpression(new DBSPI32Literal(1, true))));
@@ -729,7 +729,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void divTest2() {
         String query = "SELECT 5 / COUNT(*) - COUNT(*) FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI64Literal(0))));
     }
 
@@ -754,14 +754,14 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void testByteArray() {
         String query = "SELECT x'012345ab'";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPBinaryLiteral(new byte[]{ 0x01, 0x23, 0x45, (byte)0xAB }))));
     }
 
     @Test
     public void floatDivTest() {
         String query = "SELECT CAST(T.COL6 AS DOUBLE) / T.COL6 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(
                         new DBSPTypeDouble(CalciteObject.EMPTY,true))),
                 new DBSPTupleExpression(new DBSPDoubleLiteral(Double.NaN, true))));
@@ -771,16 +771,16 @@ public class EndToEndTests extends BaseSQLTests {
     public void countDistinctTest() {
         String query = "SELECT 100 + COUNT(DISTINCT - T.COL5) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPI64Literal(101))),
-                new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPI64Literal(100))));
+                new DBSPZSetExpression(new DBSPTupleExpression(new DBSPI64Literal(100))));
     }
 
     @Test
     public void writeLogTest() {
         String query = "SELECT WRITELOG('Hello %% message\n', COL1) FROM (SELECT DISTINCT T.COL1 FROM T)";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(10))));
     }
@@ -788,7 +788,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void distinctTest() {
         String query = "SELECT DISTINCT T.COL1 FROM T";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(10))));
     }
@@ -797,7 +797,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void nullDistinctTest() {
         String query = "SELECT DISTINCT 0 + NULL, T.COL1 FROM T";
         DBSPI32Literal ten = new DBSPI32Literal(10);
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(ten.getType().withMayBeNull(true)),
                         ten)));
     }
@@ -806,11 +806,11 @@ public class EndToEndTests extends BaseSQLTests {
     public void aggregateDistinctTest() {
         String query = "SELECT SUM(DISTINCT T.COL1), SUM(T.COL2) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPI32Literal(10, true),
                                 new DBSPDoubleLiteral(13.0, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 DBSPLiteral.none(new DBSPTypeDouble(CalciteObject.EMPTY,true)))));
@@ -820,9 +820,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void aggregateTest() {
         String query = "SELECT SUM(T.COL1) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(20, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -830,10 +830,10 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void aggregateTwiceTest() {
         String query = "SELECT COUNT(T.COL1), SUM(T.COL1) FROM T";
-        this.testAggregate(query, new DBSPZSetLiteral(
+        this.testAggregate(query, new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPI64Literal(2), new DBSPI32Literal(20, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI64Literal(0),
                                 DBSPLiteral.none(
                                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
@@ -843,12 +843,12 @@ public class EndToEndTests extends BaseSQLTests {
     public void linearNonLinearTest() {
         String query = "SELECT MAX(T.COL1), SUM(T.COL1) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPI32Literal(10, true),
                                 new DBSPI32Literal(20, true)
                         )),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true).none(),
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true).none())
@@ -859,9 +859,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void maxTest() {
         String query = "SELECT MAX(T.COL1) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(10, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -870,9 +870,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void maxConst() {
         String query = "SELECT MAX(6) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(6, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -880,7 +880,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void emptyAggregate() {
         String query = "SELECT COUNT(*), COUNT(DISTINCT COL1) FROM T WHERE COL1 > 10000";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI64Literal(0), new DBSPI64Literal(0))));
     }
@@ -888,7 +888,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void constAggregateExpression() {
         String query = "SELECT 34 / SUM (1) FROM T GROUP BY COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
                         new DBSPI32Literal(17))));
     }
@@ -897,9 +897,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void inTest() {
         String query = "SELECT 3 in (SELECT COL5 FROM T)";
         this.testAggregate(query,
-                new DBSPZSetLiteral(new DBSPTupleExpression(
+                new DBSPZSetExpression(new DBSPTupleExpression(
                         DBSPLiteral.none(new DBSPTypeBool(CalciteObject.EMPTY, true)))),
-                new DBSPZSetLiteral(new DBSPTupleExpression(
+                new DBSPZSetExpression(new DBSPTupleExpression(
                         new DBSPBoolLiteral(false, true)))
         );
     }
@@ -907,7 +907,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void constAggregateExpression2() {
         String query = "SELECT 34 / AVG (1) FROM T GROUP BY COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
                         new DBSPI32Literal(34))));
     }
@@ -915,7 +915,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void constAggregateDoubleExpression() {
         String query = "SELECT 34 / SUM (1), 20 / SUM(2) FROM T GROUP BY COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
                         new DBSPI32Literal(17), new DBSPI32Literal(5))));
     }
@@ -924,9 +924,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void aggregateFloatTest() {
         String query = "SELECT SUM(T.COL2) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPDoubleLiteral(13.0, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(new DBSPTypeDouble(CalciteObject.EMPTY,true)))));
     }
 
@@ -934,9 +934,9 @@ public class EndToEndTests extends BaseSQLTests {
     public void optionAggregateTest() {
         String query = "SELECT SUM(T.COL5) FROM T";
         this.testAggregate(query,
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPI32Literal(1, true))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(DBSPLiteral.none(
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -944,7 +944,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void aggregateFalseTest() {
         String query = "SELECT SUM(T.COL1) FROM T WHERE FALSE";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
                         DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -952,10 +952,10 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void averageTest() {
         String query = "SELECT AVG(T.COL1) FROM T";
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(10, true)));
-        this.testAggregate(query, output, new DBSPZSetLiteral(
+        this.testAggregate(query, output, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
     }
@@ -963,10 +963,10 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void averageFpTest() {
         String query = "SELECT AVG(T.COL2) FROM T";
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPDoubleLiteral(6.5, true)));
-        this.testAggregate(query, output, new DBSPZSetLiteral(
+        this.testAggregate(query, output, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(
                         new DBSPTypeDouble(CalciteObject.EMPTY, true)))));
     }
@@ -974,10 +974,10 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void averageNullableTest() {
         String query = "SELECT AVG(T.COL6) FROM T";
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPDecimalLiteral(D62, new BigDecimal(0))));
-        this.testAggregate(query, output, new DBSPZSetLiteral(
+        this.testAggregate(query, output, new DBSPZSetExpression(
                 new DBSPTupleExpression(DBSPLiteral.none(D62))));
     }
 
@@ -985,7 +985,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void cartesianTest() {
         String query = "SELECT * FROM T, T AS X";
         DBSPExpression inResult = DBSPTupleExpression.flatten(E0, E0);
-        DBSPZSetLiteral result = new DBSPZSetLiteral( inResult);
+        DBSPZSetExpression result = new DBSPZSetExpression( inResult);
         result.add(DBSPTupleExpression.flatten(E0, E1));
         result.add(DBSPTupleExpression.flatten(E1, E0));
         result.add(DBSPTupleExpression.flatten(E1, E1));
@@ -995,7 +995,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void foldTest() {
         String query = "SELECT + 91 + NULLIF ( + 93, + 38 )";
-        this.testConstantOutput(query, new DBSPZSetLiteral(
+        this.testConstantOutput(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
                 new DBSPI32Literal(184, true))));
     }
@@ -1003,16 +1003,16 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void orderbyTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2";
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPVecLiteral(E1, E0)
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPVecExpression(E1, E0)
         ));
     }
 
     @Test
     public void limitTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2 LIMIT 1";
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPVecLiteral(E1)
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPVecExpression(E1)
         ));
     }
 
@@ -1021,7 +1021,7 @@ public class EndToEndTests extends BaseSQLTests {
         // If the optimizer doesn't remove the inner ORDER BY this test
         // fails because the types don't match in Rust.
         String query = "SELECT COL1 FROM (SELECT * FROM T ORDER BY T.COL2)";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(10)),
                 new DBSPTupleExpression(new DBSPI32Literal(10))));
     }
@@ -1029,16 +1029,16 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void orderbyDescendingTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2 DESC";
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPVecLiteral(E0, E1)
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPVecExpression(E0, E1)
         ));
     }
 
     @Test
     public void orderby2Test() {
         String query = "SELECT * FROM T ORDER BY T.COL2, T.COL1";
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPVecLiteral(E1, E0)
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPVecExpression(E1, E0)
         ));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -27,6 +27,13 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue3164() {
+        this.getCCS("""
+             CREATE TABLE T(x INTEGER LATENESS 10);
+             CREATE VIEW V AS SELECT MAP['x', x] FROM T;""");
+    }
+
+    @Test
     public void issue3126() {
         this.getCCS("CREATE VIEW e AS SELECT * FROM error_view;");
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MapTests.java
@@ -9,9 +9,9 @@ import org.dbsp.sqlCompiler.compiler.sql.tools.InputOutputChange;
 import org.dbsp.sqlCompiler.compiler.sql.tools.InputOutputChangeStream;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
@@ -37,7 +37,7 @@ public class MapTests extends BaseSQLTests {
         this.addRustTestCase(ccs);
     }
 
-    private void testQuery(String query, DBSPZSetLiteral literal) {
+    private void testQuery(String query, DBSPZSetExpression literal) {
         this.testQuery("", query,
                 new InputOutputChangeStream().addChange(
                         new InputOutputChange(new Change(), new Change(literal))));
@@ -47,8 +47,8 @@ public class MapTests extends BaseSQLTests {
     public void mapLiteralTest() {
         String query = "SELECT MAP['hi',2]";
         DBSPType str = DBSPTypeString.varchar(false);
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPTupleExpression(new DBSPMapLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPTupleExpression(new DBSPMapExpression(
                         new DBSPTypeMap(
                                 str,
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false),
@@ -60,7 +60,7 @@ public class MapTests extends BaseSQLTests {
     @Test
     public void mapIndexTest() {
         String query = "SELECT MAP['hi',2]['hi'], MAP['hi',2]['x']";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(2, true),
                         new DBSPI32Literal())));
@@ -70,8 +70,8 @@ public class MapTests extends BaseSQLTests {
     public void mapBlackboxTest() {
         String query = "SELECT blackbox(MAP['hi',2])";
         DBSPType str = DBSPTypeString.varchar(false);
-        this.testQuery(query, new DBSPZSetLiteral(
-                new DBSPTupleExpression(new DBSPMapLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPTupleExpression(new DBSPMapExpression(
                         new DBSPTypeMap(
                                 str,
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, false),
@@ -83,7 +83,7 @@ public class MapTests extends BaseSQLTests {
     @Test
     public void mapCardinalityTest() {
         String query = "SELECT CARDINALITY(MAP['hi',2])";
-        this.testQuery(query, new DBSPZSetLiteral(
+        this.testQuery(query, new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPI32Literal(1))));
     }
@@ -92,7 +92,7 @@ public class MapTests extends BaseSQLTests {
     public void testMapSubquery() {
         String ddl = "CREATE TABLE T(v varchar, x int)";
         String query = "SELECT MAP(SELECT * FROM T)";
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPStringLiteral("hello", true),
                         new DBSPI32Literal(10, true)),
@@ -102,9 +102,9 @@ public class MapTests extends BaseSQLTests {
         DBSPTypeMap mapType = new DBSPTypeMap(
                 DBSPTypeString.varchar(true),
                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true ,true), false);
-        DBSPZSetLiteral result = new DBSPZSetLiteral(
+        DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPMapLiteral(
+                        new DBSPMapExpression(
                                 mapType,
                                 Linq.list(
                                         new DBSPStringLiteral("there", true),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MultiViewTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MultiViewTests.java
@@ -32,7 +32,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.junit.Test;
 
 /**
@@ -55,10 +55,10 @@ public class MultiViewTests extends BaseSQLTests {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         Change inputChange = EndToEndTests.createInput();
         Change outputChange = new Change(
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))),
-                new DBSPZSetLiteral(
+                new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPDoubleLiteral(12.0)),
                         new DBSPTupleExpression(new DBSPDoubleLiteral(1.0))));
         ccs.addPair(inputChange, outputChange);
@@ -81,10 +81,10 @@ public class MultiViewTests extends BaseSQLTests {
 
         InputOutputChange change = new InputOutputChange(
                 EndToEndTests.createInput(),
-                new Change(new DBSPZSetLiteral(
+                new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))),
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                                 new DBSPTupleExpression(new DBSPBoolLiteral(false))))
         );
@@ -108,10 +108,10 @@ public class MultiViewTests extends BaseSQLTests {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         InputOutputChange change = new InputOutputChange(
                 EndToEndTests.createInput(),
-                new Change(new DBSPZSetLiteral(
+                new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))),
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(new DBSPI32Literal(10))))
         );
         ccs.addChange(change);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
@@ -27,7 +27,7 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.tools.Change;
 import org.dbsp.sqlCompiler.compiler.sql.tools.InputOutputChangeStream;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ public class NaiveIncrementalTests extends EndToEndTests {
     }
 
     @Override
-    public void testQuery(String query, DBSPZSetLiteral firstOutput) {
+    public void testQuery(String query, DBSPZSetExpression firstOutput) {
         Change input = createInput();
         Change secondOutput = Change.singleEmptyWithElementType(firstOutput.getElementType());
         Change thirdOutput = new Change(secondOutput.getSet(0).minus(firstOutput));
@@ -54,7 +54,7 @@ public class NaiveIncrementalTests extends EndToEndTests {
     }
 
     @Override
-    void testConstantOutput(String query, DBSPZSetLiteral output) {
+    void testConstantOutput(String query, DBSPZSetExpression output) {
         Change input = createInput();
         Change e = Change.singleEmptyWithElementType(output.getElementType());
         this.invokeTestQueryBase(query,
@@ -66,8 +66,8 @@ public class NaiveIncrementalTests extends EndToEndTests {
 
     @Override
     void testAggregate(String query,
-                       DBSPZSetLiteral firstOutput,
-                       DBSPZSetLiteral outputForEmptyInput) {
+                       DBSPZSetExpression firstOutput,
+                       DBSPZSetExpression outputForEmptyInput) {
         Change input = createInput();
         Change secondOutput = Change.singleEmptyWithElementType(firstOutput.getElementType());
         Change thirdOutput = new Change(outputForEmptyInput.minus(firstOutput));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SerdeTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/SerdeTest.java
@@ -8,7 +8,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.junit.Test;
 
 public class SerdeTest extends SqlIoTest {
@@ -48,8 +48,8 @@ public class SerdeTest extends SqlIoTest {
         DBSPExpression person0 = new DBSPTupleExpression(
                 new DBSPI32Literal(2, true)
         );
-        DBSPZSetLiteral input = new DBSPZSetLiteral(address0, address1, invalid, invalidJson);
-        DBSPZSetLiteral output = new DBSPZSetLiteral(person0, person0);
+        DBSPZSetExpression input = new DBSPZSetExpression(address0, address1, invalid, invalidJson);
+        DBSPZSetExpression output = new DBSPZSetExpression(person0, person0);
         ccs.addPair(new Change(input), new Change(output));
         this.addRustTestCase(ccs);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/StructTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/StructTests.java
@@ -11,8 +11,8 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
@@ -80,8 +80,8 @@ public class StructTests extends SqlIoTest {
                 address0
         );
         DBSPExpression pair = new DBSPTupleExpression(person0, person0);
-        DBSPZSetLiteral input = new DBSPZSetLiteral(pair);
-        DBSPZSetLiteral output = new DBSPZSetLiteral(new DBSPTupleExpression(address0));
+        DBSPZSetExpression input = new DBSPZSetExpression(pair);
+        DBSPZSetExpression output = new DBSPZSetExpression(new DBSPTupleExpression(address0));
         ccs.addPair(new Change(input), new Change(output));
         this.addRustTestCase(ccs);
     }
@@ -115,8 +115,8 @@ public class StructTests extends SqlIoTest {
                 address0
         );
         DBSPExpression pair = new DBSPTupleExpression(person0, person0);
-        DBSPZSetLiteral input = new DBSPZSetLiteral(pair);
-        DBSPZSetLiteral output = new DBSPZSetLiteral(new DBSPTupleExpression(
+        DBSPZSetExpression input = new DBSPZSetExpression(pair);
+        DBSPZSetExpression output = new DBSPZSetExpression(new DBSPTupleExpression(
                 new DBSPTupleExpression(
                         new DBSPStringLiteral("Broadway", true),
                         new DBSPStringLiteral("New York", true),
@@ -138,12 +138,12 @@ public class StructTests extends SqlIoTest {
         compiler.compileStatements(ddl);
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPExpression pers = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                     new DBSPStringLiteral("Broadway", true),
                     new DBSPStringLiteral("5th Avenue", true),
                     new DBSPStringLiteral("1st Street", true)));
-        DBSPZSetLiteral input = new DBSPZSetLiteral(new DBSPTupleExpression(pers));
-        DBSPZSetLiteral output = new DBSPZSetLiteral(new DBSPTupleExpression(
+        DBSPZSetExpression input = new DBSPZSetExpression(new DBSPTupleExpression(pers));
+        DBSPZSetExpression output = new DBSPZSetExpression(new DBSPTupleExpression(
                         new DBSPStringLiteral("Broadway", true)));
         ccs.addPair(new Change(input), new Change(output));
         this.addRustTestCase(ccs);
@@ -158,12 +158,12 @@ public class StructTests extends SqlIoTest {
             CREATE VIEW V AS SELECT st FROM PERS, UNNEST(PERS.p0.street) AS st;""";
         CompilerCircuitStream ccs = this.getCCS(ddl);
         DBSPExpression pers = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPStringLiteral("Broadway", true),
                         new DBSPStringLiteral("5th Avenue", true),
                         new DBSPStringLiteral("1st Street", true)));
-        DBSPZSetLiteral input = new DBSPZSetLiteral(new DBSPTupleExpression(pers));
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(new DBSPTupleExpression(pers));
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(
                         new DBSPStringLiteral("Broadway", true)),
                 new DBSPTupleExpression(
@@ -184,7 +184,7 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = this.getCCS(ddl);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(0, true), t),
                         new DBSPTupleExpression(
@@ -192,17 +192,17 @@ public class StructTests extends SqlIoTest {
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(2, true), t)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(3, true), t),
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(4, true), t),
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(5, true), t)));
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(t0),
                 new DBSPTupleExpression(t1));
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(0, true), t),
                 new DBSPTupleExpression(new DBSPI32Literal(1, true), t),
                 new DBSPTupleExpression(new DBSPI32Literal(2, true), t),
@@ -225,19 +225,19 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(0, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(1, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(2, true), t), true)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(3, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(4, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(5, true), t), true)));
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(t0),
                 new DBSPTupleExpression(t1));
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(1, true)),
                 new DBSPTupleExpression(new DBSPI32Literal(2, true)),
                 new DBSPTupleExpression(new DBSPI32Literal(3, true)),
@@ -260,19 +260,19 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(0, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(1, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(2, true), t), true)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecLiteral(true,
+                new DBSPVecExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(3, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(4, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(5, true), t), true)));
-        DBSPZSetLiteral input = new DBSPZSetLiteral(
+        DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(t0),
                 new DBSPTupleExpression(t1));
-        DBSPZSetLiteral output = new DBSPZSetLiteral(
+        DBSPZSetExpression output = new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPI32Literal(1, true)),
                 new DBSPTupleExpression(new DBSPI32Literal(2, true)),
                 new DBSPTupleExpression(new DBSPI32Literal(3, true)),
@@ -310,11 +310,11 @@ public class StructTests extends SqlIoTest {
         DBSPExpression person0 = new DBSPTupleExpression(true,
                 new DBSPStringLiteral("Mike", true),
                 new DBSPStringLiteral("John", true),
-                new DBSPVecLiteral(true, address0, address0)
+                new DBSPVecExpression(true, address0, address0)
         );
         DBSPExpression data = new DBSPTupleExpression(person0);
-        DBSPZSetLiteral input = new DBSPZSetLiteral(data);
-        DBSPZSetLiteral output = new DBSPZSetLiteral(new DBSPTupleExpression(address0));
+        DBSPZSetExpression input = new DBSPZSetExpression(data);
+        DBSPZSetExpression output = new DBSPZSetExpression(new DBSPTupleExpression(address0));
         ccs.addPair(new Change(input), new Change(output));
         this.addRustTestCase(ccs);
     }
@@ -336,7 +336,7 @@ public class StructTests extends SqlIoTest {
                 DBSPTypeString.varchar(true)
         ).withMayBeNull(true);
         DBSPExpression address0 = tuple.none();
-        DBSPZSetLiteral input = new DBSPZSetLiteral(new DBSPTupleExpression(address0));
+        DBSPZSetExpression input = new DBSPZSetExpression(new DBSPTupleExpression(address0));
         ccs.addPair(new Change(input), new Change());
         this.addRustTestCase(ccs);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
@@ -37,7 +37,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.junit.Test;
@@ -58,14 +58,14 @@ public class TimeTests extends BaseSQLTests {
         query = "CREATE VIEW V AS " + query;
         DBSPCompiler compiler = this.compileQuery(query);
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
-        DBSPZSetLiteral expectedOutput = new DBSPZSetLiteral(new DBSPTupleExpression(fields));
+        DBSPZSetExpression expectedOutput = new DBSPZSetExpression(new DBSPTupleExpression(fields));
         InputOutputChange change = new InputOutputChange(this.createInput(), new Change(expectedOutput));
         ccs.addChange(change);
         this.addRustTestCase(ccs);
     }
 
     public Change createInput() {
-        return new Change(new DBSPZSetLiteral(new DBSPTupleExpression(new DBSPTimestampLiteral(100))));
+        return new Change(new DBSPZSetExpression(new DBSPTupleExpression(new DBSPTimestampLiteral(100))));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -21,11 +21,11 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDateLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPMapLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
@@ -1794,111 +1794,111 @@ public class StreamingTests extends StreamingTestBase {
         CompilerCircuitStream ccs = this.getCCS(sql);
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:00:00", false)))),
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPDateLiteral("2023-12-30", false))),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(error))));
         // Insert tuple before waterline, should be dropped
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-29 10:00:00", false)))),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(out),
-                        new DBSPZSetLiteral(
+                        DBSPZSetExpression.emptyWithElementType(out),
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPStringLiteral("series"),
                                         new DBSPStringLiteral("Late value"),
-                                        new DBSPVariantLiteral(
-                                                new DBSPMapLiteral(map,
+                                        new DBSPVariantExpression(
+                                                new DBSPMapExpression(map,
                                                         Linq.list(
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("distance")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPDoubleLiteral(10.0)
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("pickup")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPTimestampLiteral("2023-12-29 10:00:00", false)
                                                                 )))))))));
         // Insert tuple after waterline, should change average.
         // Waterline is advanced
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(20.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:10:00", false)))),
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(15.0, true),
                                         new DBSPDateLiteral("2023-12-30", false)))
                                 .add(
-                                        new DBSPZSetLiteral(
+                                        new DBSPZSetExpression(
                                                 new DBSPTupleExpression(
                                                         new DBSPDoubleLiteral(10.0, true),
                                                         new DBSPDateLiteral("2023-12-30", false))).negate()
                                 ),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(error))));
         // Insert tuple before last waterline, should be dropped
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-29 09:10:00", false)))),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(out),
-                        new DBSPZSetLiteral(
+                        DBSPZSetExpression.emptyWithElementType(out),
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPStringLiteral("series"),
                                         new DBSPStringLiteral("Late value"),
-                                        new DBSPVariantLiteral(
-                                                new DBSPMapLiteral(map,
+                                        new DBSPVariantExpression(
+                                                new DBSPMapExpression(map,
                                                         Linq.list(
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("distance")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPDoubleLiteral(10.0)
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("pickup")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPTimestampLiteral("2023-12-29 09:10:00", false)
                                                                 )))))))));
         // Insert tuple in the past, but before the last waterline
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:00:00", false)))),
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(13.333333333333334, true),
                                         new DBSPDateLiteral("2023-12-30", false)))
                                 .add(
-                                        new DBSPZSetLiteral(
+                                        new DBSPZSetExpression(
                                                 new DBSPTupleExpression(
                                                         new DBSPDoubleLiteral(15.0, true),
                                                         new DBSPDateLiteral("2023-12-30", false))).negate()
                                 ),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(error))));
         this.addRustTestCase(ccs);
     }
 
@@ -1926,92 +1926,92 @@ public class StreamingTests extends StreamingTestBase {
         CompilerCircuitStream ccs = this.getCCS(sql, Linq.list("series"), Linq.list("e", "error_view"));
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:00:00", false)))),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(e),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(e),
+                        DBSPZSetExpression.emptyWithElementType(error))));
         // Insert tuple before waterline, should be dropped
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-29 10:00:00", false)))),
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(new DBSPStringLiteral("Late value"))),
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPStringLiteral("series"),
                                         new DBSPStringLiteral("Late value"),
-                                        new DBSPVariantLiteral(
-                                                new DBSPMapLiteral(map,
+                                        new DBSPVariantExpression(
+                                                new DBSPMapExpression(map,
                                                         Linq.list(
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("distance")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPDoubleLiteral(10.0)
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("pickup")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPTimestampLiteral("2023-12-29 10:00:00", false)
                                                                 )))))))));
         // Insert tuple after waterline, should change average.
         // Waterline is advanced
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(20.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:10:00", false)))),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(e),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(e),
+                        DBSPZSetExpression.emptyWithElementType(error))));
         // Insert tuple before last waterline, should be dropped
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-29 09:10:00", false)))),
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(new DBSPStringLiteral("Late value"))),
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPStringLiteral("series"),
                                         new DBSPStringLiteral("Late value"),
-                                        new DBSPVariantLiteral(
-                                                new DBSPMapLiteral(map,
+                                        new DBSPVariantExpression(
+                                                new DBSPMapExpression(map,
                                                         Linq.list(
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("distance")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPDoubleLiteral(10.0)
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPStringLiteral("pickup")
                                                                 ),
-                                                                new DBSPVariantLiteral(
+                                                                new DBSPVariantExpression(
                                                                         new DBSPTimestampLiteral("2023-12-29 09:10:00", false)
                                                                 )))))))));
         // Insert tuple in the past, but before the last waterline
         ccs.addChange(new InputOutputChange(
                 new Change(
-                        new DBSPZSetLiteral(
+                        new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:00:00", false)))),
                 new Change(
-                        DBSPZSetLiteral.emptyWithElementType(e),
-                        DBSPZSetLiteral.emptyWithElementType(error))));
+                        DBSPZSetExpression.emptyWithElementType(e),
+                        DBSPZSetExpression.emptyWithElementType(error))));
         this.addRustTestCase(ccs);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/Change.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/Change.java
@@ -4,7 +4,7 @@ import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.Simplify;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Shuffle;
@@ -14,17 +14,17 @@ import java.util.List;
 /** A Change is a collection of Z-sets literals.
  * It represents an atomic change that is applied to a set of tables or views. */
 public class Change {
-    public final DBSPZSetLiteral[] sets;
+    public final DBSPZSetExpression[] sets;
 
-    public Change(DBSPZSetLiteral... sets) {
+    public Change(DBSPZSetExpression... sets) {
         this.sets = sets;
     }
 
     public Change(TableContents contents) {
-        this.sets = new DBSPZSetLiteral[contents.getTableCount()];
+        this.sets = new DBSPZSetExpression[contents.getTableCount()];
         int index = 0;
         for (ProgramIdentifier table: contents.tablesCreated) {
-            DBSPZSetLiteral data = contents.getTableContents(table);
+            DBSPZSetExpression data = contents.getTableContents(table);
             this.sets[index] = data;
             index++;
         }
@@ -32,23 +32,23 @@ public class Change {
 
     /** Return a change that has the sets in this one shuffled */
     public Change shuffle(Shuffle shuffle) {
-        List<DBSPZSetLiteral> data = Linq.list(this.sets);
+        List<DBSPZSetExpression> data = Linq.list(this.sets);
         data = shuffle.shuffle(data);
-        DBSPZSetLiteral[] shuffled = data.toArray(new DBSPZSetLiteral[0]);
+        DBSPZSetExpression[] shuffled = data.toArray(new DBSPZSetExpression[0]);
         return new Change(shuffled);
     }
 
     public Change simplify(DBSPCompiler compiler) {
         Simplify simplify = new Simplify(compiler);
-        DBSPZSetLiteral[] simplified = Linq.map(this.sets,
-                t -> simplify.apply(t).to(DBSPZSetLiteral.class), DBSPZSetLiteral.class);
+        DBSPZSetExpression[] simplified = Linq.map(this.sets,
+                t -> simplify.apply(t).to(DBSPZSetExpression.class), DBSPZSetExpression.class);
         return new Change(simplified);
     }
 
     /** Create a Change for a single ZSet, representing an empty ZSet
      * with the specified element type. */
     public static Change singleEmptyWithElementType(DBSPType elementType) {
-        return new Change(DBSPZSetLiteral.emptyWithElementType(elementType));
+        return new Change(DBSPZSetExpression.emptyWithElementType(elementType));
     }
 
     /** Number of Z-sets in this change */
@@ -56,14 +56,14 @@ public class Change {
         return this.sets.length;
     }
 
-    public DBSPZSetLiteral getSet(int index) {
+    public DBSPZSetExpression getSet(int index) {
         return this.sets[index];
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        for (DBSPZSetLiteral zset: this.sets) {
+        for (DBSPZSetExpression zset: this.sets) {
             builder.append(zset);
             builder.append(System.lineSeparator());
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -8,7 +8,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
@@ -91,11 +91,11 @@ public abstract class SqlIoTest extends BaseSQLTests {
      * (a, b) -> 4
      * (c, d) -> -1
      */
-    static DBSPZSetLiteral extractWeight(DBSPZSetLiteral data) {
+    static DBSPZSetExpression extractWeight(DBSPZSetExpression data) {
         DBSPTypeTuple rowType = data.getElementType().to(DBSPTypeTuple.class);
         int rowSize = rowType.size();
         DBSPType resultType = rowType.slice(0, rowSize - 1);
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(resultType);
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(resultType);
 
         for (Map.Entry<DBSPExpression, Long> entry: data.data.entrySet()) {
             Long weight = entry.getValue();
@@ -113,17 +113,17 @@ public abstract class SqlIoTest extends BaseSQLTests {
     }
 
     public Change getPreparedInputs(DBSPCompiler compiler) {
-        DBSPZSetLiteral[] inputs = new DBSPZSetLiteral[
+        DBSPZSetExpression[] inputs = new DBSPZSetExpression[
                 compiler.getTableContents().tablesCreated.size()];
         int index = 0;
         for (ProgramIdentifier table: compiler.getTableContents().tablesCreated) {
-            DBSPZSetLiteral data = compiler.getTableContents().getTableContents(table);
+            DBSPZSetExpression data = compiler.getTableContents().getTableContents(table);
             inputs[index++] = data;
         }
         return new Change(inputs);
     }
 
-    public void compare(String query, DBSPZSetLiteral expected, boolean optimize, int rowCount) {
+    public void compare(String query, DBSPZSetExpression expected, boolean optimize, int rowCount) {
         DBSPCompiler compiler = this.testCompiler(optimize);
         this.prepareInputs(compiler);
         compiler.compileStatement("CREATE VIEW VV AS " + query);
@@ -282,7 +282,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         DBSPCircuit circuit = ccs.circuit;
         DBSPType outputType = circuit.getSingleOutputType();
         Change result = new Change(
-                DBSPZSetLiteral.emptyWithElementType(outputType.to(DBSPTypeZSet.class).getElementType()));
+                DBSPZSetExpression.emptyWithElementType(outputType.to(DBSPTypeZSet.class).getElementType()));
         InputOutputChange ioChange = new InputOutputChange(
                 this.getPreparedInputs(compiler),
                 result

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -22,8 +22,8 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
@@ -302,7 +302,7 @@ public class TableParser {
             DBSPTypeVec vec = fieldType.to(DBSPTypeVec.class);
             // TODO: this does not handle nested arrays
             if (trimmed.equals("NULL")) {
-                result = new DBSPVecLiteral(fieldType, true);
+                result = new DBSPVecExpression(fieldType, true);
             } else {
                 if (!trimmed.startsWith("{") || !trimmed.endsWith("}"))
                     throw new UnimplementedException("Expected array constant to be bracketed: " + trimmed);
@@ -313,10 +313,10 @@ public class TableParser {
                     DBSPExpression[] fields;
                     fields = Linq.map(
                             parts, p -> parseValue(vec.getElementType(), p), DBSPExpression.class);
-                    result = new DBSPVecLiteral(fieldType.mayBeNull, fields);
+                    result = new DBSPVecExpression(fieldType.mayBeNull, fields);
                 } else {
                     // empty vector
-                    result = new DBSPVecLiteral(vec, false);
+                    result = new DBSPVecExpression(vec, false);
                 }
             }
         } else if (fieldType.is(DBSPTypeBinary.class)) {
@@ -387,13 +387,13 @@ public class TableParser {
         extraFields.add(new DBSPTypeInteger(CalciteObject.EMPTY, 64, true, false));
         DBSPType extraOutputType = new DBSPTypeTuple(extraFields);
         Change change = parseTable(table, new DBSPTypeZSet(extraOutputType), -1);
-        DBSPZSetLiteral[] extracted = Linq.map(change.sets, SqlIoTest::extractWeight, DBSPZSetLiteral.class);
+        DBSPZSetExpression[] extracted = Linq.map(change.sets, SqlIoTest::extractWeight, DBSPZSetExpression.class);
         return new Change(extracted);
     }
 
     public static Change parseTable(String table, DBSPType outputType, int rowCount) {
         DBSPTypeZSet zset = outputType.to(DBSPTypeZSet.class);
-        DBSPZSetLiteral result = DBSPZSetLiteral.emptyWithElementType(zset.elementType);
+        DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(zset.elementType);
         DBSPTypeTuple tuple = zset.elementType.to(DBSPTypeTuple.class);
 
         // We parse tables in three formats:

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -58,8 +58,8 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
@@ -215,19 +215,19 @@ public class DBSPExecutor extends SqlSltTestExecutor {
     }
 
     /** Convert a description of the data in the SLT format to a ZSet. */
-    public static DBSPZSetLiteral convert(@Nullable List<String> data, DBSPTypeZSet outputType) {
+    public static DBSPZSetExpression convert(@Nullable List<String> data, DBSPTypeZSet outputType) {
         if (data == null)
             data = Linq.list();
-        DBSPZSetLiteral result;
+        DBSPZSetExpression result;
         IDBSPContainer container;
         DBSPType elementType = outputType.elementType;
         if (elementType.is(DBSPTypeVec.class)) {
             elementType = elementType.to(DBSPTypeVec.class).getElementType();
-            DBSPVecLiteral vec = DBSPVecLiteral.emptyWithElementType(elementType, false);
+            DBSPVecExpression vec = DBSPVecExpression.emptyWithElementType(elementType, false);
             container = vec;
-            result = new DBSPZSetLiteral(vec);
+            result = new DBSPZSetExpression(vec);
         } else {
-            result = DBSPZSetLiteral.emptyWithElementType(outputType.getElementType());
+            result = DBSPZSetExpression.emptyWithElementType(outputType.getElementType());
             container = result;
         }
         DBSPTypeTuple outputElementType = elementType.to(DBSPTypeTuple.class);
@@ -304,7 +304,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
         }
         assert sink != null;
         DBSPTypeZSet outputType = sink.outputType.to(DBSPTypeZSet.class);
-        DBSPZSetLiteral expectedOutput = null;
+        DBSPZSetExpression expectedOutput = null;
         if (testQuery.outputDescription.hash == null) {
             expectedOutput = DBSPExecutor.convert(testQuery.outputDescription.getQueryResults(), outputType);
         }
@@ -429,7 +429,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             int outputNumber,
             DBSPFunction inputGeneratingFunction,
             TableContents contents,
-            @Nullable DBSPZSetLiteral output,
+            @Nullable DBSPZSetExpression output,
             SqlTestQueryOutputDescription description) {
         List<DBSPStatement> list = new ArrayList<>();
         DBSPExpression arg = new DBSPApplyExpression(

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
@@ -34,6 +34,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.*;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -79,11 +80,11 @@ public class DbspJdbcExecutor extends DBSPExecutor {
         return this.statementExecutor.getConnection();
     }
 
-    public DBSPZSetLiteral getTableContents(ProgramIdentifier table) throws SQLException {
+    public DBSPZSetExpression getTableContents(ProgramIdentifier table) throws SQLException {
         return getTableContents(this.getStatementExecutorConnection(), table);
     }
 
-    public static DBSPZSetLiteral getTableContents(Connection connection, ProgramIdentifier table) throws SQLException {
+    public static DBSPZSetExpression getTableContents(Connection connection, ProgramIdentifier table) throws SQLException {
         List<DBSPExpression> rows = new ArrayList<>();
         try (Statement stmt1 = connection.createStatement()) {
             ResultSet rs = stmt1.executeQuery("SELECT * FROM " + table);
@@ -149,8 +150,8 @@ public class DbspJdbcExecutor extends DBSPExecutor {
             }
             rs.close();
             if (rows.isEmpty())
-                return DBSPZSetLiteral.emptyWithElementType(new DBSPTypeTuple(colTypes));
-            return new DBSPZSetLiteral(rows.toArray(new DBSPExpression[0]));
+                return DBSPZSetExpression.emptyWithElementType(new DBSPTypeTuple(colTypes));
+            return new DBSPZSetExpression(rows.toArray(new DBSPExpression[0]));
         }
     }
 
@@ -159,7 +160,7 @@ public class DbspJdbcExecutor extends DBSPExecutor {
         TableValue[] result = new TableValue[this.tablesCreated.size()];
         int i = 0;
         for (ProgramIdentifier table: this.tablesCreated) {
-            DBSPZSetLiteral lit = this.getTableContents(table);
+            DBSPZSetExpression lit = this.getTableContents(table);
             result[i++] = new TableValue(table, lit);
         }
         return result;


### PR DESCRIPTION
Fixes #3164 

This is a cleanup which I wanted to do a long time ago. Since now it triggered a bug, it was a good time to do it.
Basically, expressions like DBSPMapLiteral were constructor invocations, and not necessarily literals, since some arguments may not be constant.