### PR TITLE
pipeline-manager: revert reuse of reqwest client

### DIFF
--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -7,7 +7,6 @@ use crate::error::ManagerError;
 use crate::runner::error::RunnerError;
 use actix_web::{http::Method, web::Payload, HttpRequest, HttpResponse, HttpResponseBuilder};
 use reqwest::StatusCode;
-use std::sync::LazyLock;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
@@ -88,9 +87,9 @@ impl RunnerInteraction {
         query_string: &str,
         timeout: Option<Duration>, // If timeout is not specified, a default timeout is used
     ) -> Result<(String, reqwest::Response), ManagerError> {
-        static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+        let client = reqwest::Client::new();
         let url = RunnerInteraction::format_pipeline_url(location, endpoint, query_string);
-        let response = CLIENT
+        let response = client
             .request(method, &url)
             .timeout(timeout.unwrap_or(Self::PIPELINE_HTTP_REQUEST_TIMEOUT))
             .send()


### PR DESCRIPTION
There seems to be a bug in reqwest that either caches or mixes up prior GET requests from the same client. This is a temporary fix, as the client should ideally be reused to improve performance.