### PR TITLE
adapters: `Cache-Control` for GET endpoints

### DIFF
--- a/crates/adapters/src/adhoc/mod.rs
+++ b/crates/adapters/src/adhoc/mod.rs
@@ -82,6 +82,7 @@ pub async fn stream_adhoc_result(
     match args.format {
         AdHocResultFormat::Text => {
             Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
                 .content_type(mime::TEXT_PLAIN)
                 .streaming::<_, Infallible>(try_stream! {
                     let stream_exec = match execute_stream(df).await {
@@ -159,6 +160,7 @@ pub async fn stream_adhoc_result(
                 }))
         }
         AdHocResultFormat::Json => Ok(HttpResponse::Ok()
+            .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
             .content_type(mime::APPLICATION_JSON)
             .streaming::<_, Infallible>(try_stream! {
                 let stream_exec = match execute_stream(df).await {
@@ -228,6 +230,7 @@ pub async fn stream_adhoc_result(
             }.fuse());
 
             Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
                 .insert_header(header::ContentDisposition::attachment(file_name))
                 .content_type(mime::APPLICATION_OCTET_STREAM)
                 .streaming(stream! {

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -524,7 +524,9 @@ async fn start(state: WebData<ServerState>) -> impl Responder {
     match &*state.controller.lock().unwrap() {
         Some(controller) => {
             controller.start();
-            Ok(HttpResponse::Ok().json("The pipeline is running"))
+            Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
+                .json("The pipeline is running"))
         }
         None => Err(missing_controller_error(&state)),
     }
@@ -535,7 +537,9 @@ async fn pause(state: WebData<ServerState>) -> impl Responder {
     match &*state.controller.lock().unwrap() {
         Some(controller) => {
             controller.pause();
-            Ok(HttpResponse::Ok().json("Pipeline paused"))
+            Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
+                .json("Pipeline paused"))
         }
         None => Err(missing_controller_error(&state)),
     }
@@ -560,6 +564,7 @@ async fn stats(state: WebData<ServerState>) -> impl Responder {
         Some(controller) => {
             let json_string = serde_json::to_string(controller.status()).unwrap();
             Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
                 .content_type(mime::APPLICATION_JSON)
                 .body(json_string))
         }
@@ -580,6 +585,7 @@ async fn metrics(state: WebData<ServerState>) -> impl Responder {
             .metrics(controller)
         {
             Ok(metrics) => Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
                 .content_type(mime::TEXT_PLAIN)
                 .body(metrics)),
             Err(e) => Err(PipelineError::PrometheusError {
@@ -593,6 +599,7 @@ async fn metrics(state: WebData<ServerState>) -> impl Responder {
 #[get("/metadata")]
 async fn metadata(state: WebData<ServerState>) -> impl Responder {
     HttpResponse::Ok()
+        .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
         .content_type(mime::APPLICATION_JSON)
         .body(state.metadata.read().unwrap().clone())
 }
@@ -609,6 +616,7 @@ async fn heap_profile() -> impl Responder {
         }
         match prof_ctl.dump_pprof() {
             Ok(profile) => Ok(HttpResponse::Ok()
+                .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
                 .content_type("application/protobuf")
                 .body(profile)),
             Err(e) => Err(PipelineError::HeapProfilerError {
@@ -640,6 +648,7 @@ async fn dump_profile(state: WebData<ServerState>) -> impl Responder {
     let profile = receiver.await.unwrap()?;
 
     Ok(HttpResponse::Ok()
+        .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
         .insert_header(header::ContentType("application/zip".parse().unwrap()))
         .insert_header(header::ContentDisposition::attachment("profile.zip"))
         .body(profile.as_zip()))
@@ -683,7 +692,9 @@ async fn shutdown(state: WebData<ServerState>) -> impl Responder {
                 if let Err(e) = tokio::fs::remove_file(SERVER_PORT_FILE).await {
                     warn!("Failed to remove server port file: {e}");
                 }
-                Ok(HttpResponse::Ok().json("Pipeline terminated"))
+                Ok(HttpResponse::Ok()
+                    .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
+                    .json("Pipeline terminated"))
             }
             Err(e) => Err(e),
         }
@@ -960,7 +971,9 @@ async fn pause_input_endpoint(
         }
     };
 
-    Ok(HttpResponse::Ok())
+    Ok(HttpResponse::Ok()
+        .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
+        .finish())
 }
 
 #[get("/input_endpoints/{endpoint_name}/start")]
@@ -977,7 +990,9 @@ async fn start_input_endpoint(
         }
     };
 
-    Ok(HttpResponse::Ok())
+    Ok(HttpResponse::Ok()
+        .insert_header(header::CacheControl(vec![header::CacheDirective::NoStore]))
+        .finish())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds the `Cache-Control: no-store` HTTP header to the GET endpoints of the pipeline HTTP server. This should prevent any in-between cache from caching their responses, which is especially important for instance for status checks which should always be fresh.

For now, the strictest cache directive is used (`no-store`) for all GET endpoints. This might be relaxed in the future by fine-tuning it on a per-endpoint basis.