### PR TITLE
[SQL] Correctly implement outer joins

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
@@ -95,7 +95,7 @@ public abstract class DBSPOperator extends DBSPNode implements IDBSPOuterNode {
                 throw new InternalCompilerError("Comparing operator with " + this.inputs.size() +
                         " inputs with a list of " + newInputs.size() + " inputs", this);
             else
-                return false;
+                return true;
         }
         for (boolean b: Linq.zip(this.inputs, newInputs, (l, r) -> !l.equals(r))) {
             if (b)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAntiJoinOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAntiJoinOperator.java
@@ -11,8 +11,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 
-/** Currently there is no corespondent operator in DBSP, so an attempt to generate
- * Rust for this operator will fail. */
+/** Currently there is no corespondent operator in DBSP. */
 public final class DBSPStreamAntiJoinOperator extends DBSPBinaryOperator {
     public DBSPStreamAntiJoinOperator(CalciteObject node, OutputPort left, OutputPort right) {
         super(node, "stream_antijoin", null, left.outputType(), left.isMultiset(), left, right);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamJoinIndexOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamJoinIndexOperator.java
@@ -13,9 +13,8 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 
-/** Currently there is no corespondent operator in DBSP, so an attempt to generate
- * Rust for this operator will fail.   See {@link DBSPJoinIndexOperator} for
- * the function signature. */
+/** Currently there is no corespondent operator in DBSP.
+ * See {@link DBSPJoinIndexOperator} for the function signature. */
 public final class DBSPStreamJoinIndexOperator extends DBSPJoinBaseOperator {
     public DBSPStreamJoinIndexOperator(
             CalciteObject node, DBSPTypeIndexedZSet outputType,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -743,7 +743,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                     columnName +
                     " - " + value +
                     " FROM TMP;\n";
-            Logger.INSTANCE.belowLevel(this, 2)
+            Logger.INSTANCE.belowLevel(this, 4)
                     .newline()
                     .append(sql)
                     .newline();
@@ -799,7 +799,7 @@ public class SqlToRelCompiler implements IWritesLogs {
               CREATE VIEW V AS SELECT expression;
               and validate it. */
             String sql = "CREATE VIEW V AS SELECT " + value.toSqlString(OracleSqlDialect.DEFAULT) + ";";
-            Logger.INSTANCE.belowLevel(this, 2)
+            Logger.INSTANCE.belowLevel(this, 4)
                     .newline()
                     .append(sql)
                     .newline();
@@ -1168,7 +1168,7 @@ public class SqlToRelCompiler implements IWritesLogs {
             builder.append("\nFROM TMP;");
 
             String sql = builder.toString();
-            Logger.INSTANCE.belowLevel(this, 2)
+            Logger.INSTANCE.belowLevel(this, 4)
                     .newline()
                     .append(sql)
                     .newline();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -95,6 +95,8 @@ import org.dbsp.sqlCompiler.ir.statement.DBSPStructWithHelperItem;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeFunction;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
@@ -295,6 +297,24 @@ public abstract class InnerRewriteVisitor
         DBSPType[] args = this.transform(type.typeArgs);
         this.pop(type);
         DBSPType result = new DBSPTypeUser(type.getNode(), type.code, type.name, type.mayBeNull, args);
+        this.map(type, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPTypeMonthsInterval type) {
+        this.push(type);
+        this.pop(type);
+        DBSPType result = new DBSPTypeMonthsInterval(type.getNode(), type.units, type.mayBeNull);
+        this.map(type, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPTypeMillisInterval type) {
+        this.push(type);
+        this.pop(type);
+        DBSPType result = new DBSPTypeMillisInterval(type.getNode(), type.mayBeNull);
         this.map(type, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -136,9 +136,9 @@ public class Simplify extends InnerRewriteVisitor {
     public VisitDecision preorder(DBSPCastExpression expression) {
         this.push(expression);
         DBSPExpression source = this.transform(expression.source);
-        DBSPType type = this.transform(expression.getType());
-        DBSPExpression result = source.cast(type);
         this.pop(expression);
+        DBSPType type = expression.getType();
+        DBSPExpression result = source.cast(type);
         DBSPLiteral lit = source.as(DBSPLiteral.class);
         if (lit != null) {
             DBSPType litType = lit.getType();
@@ -332,9 +332,7 @@ public class Simplify extends InnerRewriteVisitor {
                 }
             }
         }
-        assert expression.getType().mayBeNull == result.getType().mayBeNull :
-                "Nullability of " + expression + " has changed " +
-                " from " + expression.getType() + " to " + result.getType();
+        assert expression.getType().sameType(result.getType());
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -72,6 +72,7 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         if (options.languageOptions.outputsAreSets)
             passes.add(new EnsureDistinctOutputs(compiler));
         passes.add(new UnusedFields(compiler));
+        passes.add(new CSE(compiler));
         passes.add(new MinMaxOptimize(compiler, compiler.weightVar));
         passes.add(new ExpandAggregateZero(compiler));
         passes.add(new MergeSums(compiler));
@@ -127,6 +128,8 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         passes.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
         // Beta reduction after implementing aggregates.
         passes.add(new BetaReduction(compiler).getCircuitVisitor(false));
+        passes.add(new ExpandJoins(compiler));
+        passes.add(new CSE(compiler));
         passes.add(new RemoveViewOperators(compiler, true));
         passes.add(new CompactNames(compiler));
         return new Passes("optimize", compiler, passes);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandJoins.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandJoins.java
@@ -1,0 +1,57 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.util.Linq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Expands joins that do not have DBSP implementations, such as
+ * {@link DBSPStreamAntiJoinOperator} and {@link DBSPStreamJoinIndexOperator}.
+ * These are implemented using differentiators and integrators around a non-stream operator.
+ * These operators should not appear in incremental circuits. */
+public class ExpandJoins extends CircuitCloneVisitor {
+    public ExpandJoins(DBSPCompiler compiler) {
+        super(compiler, false);
+    }
+
+    @Override
+    public void postorder(DBSPStreamAntiJoinOperator operator) {
+        var inputs = Linq.map(operator.inputs, this::mapped);
+        List<OutputPort> diffs = new ArrayList<>(operator.inputs.size());
+        for (OutputPort in: inputs) {
+            DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(operator.getNode(), in);
+            this.addOperator(diff);
+            diffs.add(diff.outputPort());
+        }
+        DBSPAntiJoinOperator join = new DBSPAntiJoinOperator(operator.getNode(), diffs.get(0), diffs.get(1));
+        this.addOperator(join);
+        DBSPIntegrateOperator integ = new DBSPIntegrateOperator(operator.getNode(), join.outputPort());
+        this.map(operator, integ);
+    }
+
+    @Override
+    public void postorder(DBSPStreamJoinIndexOperator operator) {
+        var inputs = Linq.map(operator.inputs, this::mapped);
+        List<OutputPort> diffs = new ArrayList<>(operator.inputs.size());
+        for (OutputPort in: inputs) {
+            DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(operator.getNode(), in);
+            this.addOperator(diff);
+            diffs.add(diff.outputPort());
+        }
+        DBSPJoinIndexOperator join = new DBSPJoinIndexOperator(
+                operator.getNode(), operator.getOutputIndexedZSetType(), operator.getFunction(),
+                operator.isMultiset, diffs.get(0), diffs.get(1));
+        this.addOperator(join);
+        DBSPIntegrateOperator integ = new DBSPIntegrateOperator(operator.getNode(), join.outputPort());
+        this.map(operator, integ);
+    }
+
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer.expansion;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
@@ -26,6 +27,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSubtractOperator;
@@ -131,6 +133,16 @@ public class ExpandOperators extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPViewOperator operator) {
+        this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAntiJoinOperator operator) {
+        this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPStreamAntiJoinOperator operator) {
         this.identity(operator);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApply2Operator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
@@ -34,6 +35,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOper
 import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateWithWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSubtractOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
@@ -308,6 +310,19 @@ public class InsertLimiters extends CircuitCloneVisitor {
             this.nonMonotone(represented);
         else
             this.addBounds(represented, expanded.replacement, 0);
+    }
+
+
+    @Override
+    public void postorder(DBSPStreamAntiJoinOperator operator) {
+        this.addBoundsForNonExpandedOperator(operator);
+        super.postorder(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAntiJoinOperator operator) {
+        this.addBoundsForNonExpandedOperator(operator);
+        super.postorder(operator);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
@@ -25,6 +26,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPPrimitiveAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSubtractOperator;
@@ -438,6 +440,26 @@ public class Monotonicity extends CircuitVisitor {
     @Override
     public void postorder(DBSPStreamJoinIndexOperator node) {
         this.processJoinBase(node);
+    }
+
+    @Override
+    public void postorder(DBSPAntiJoinOperator node) {
+        // Preserve monotonicity of left input
+        MonotoneExpression input = this.getMonotoneExpression(node.left());
+        if (input == null)
+            return;
+        MonotoneExpression output = this.identity(node, getBodyType(input), true);
+        this.set(node, output);
+    }
+
+    @Override
+    public void postorder(DBSPStreamAntiJoinOperator node) {
+        // Preserve monotonicity of left input
+        MonotoneExpression input = this.getMonotoneExpression(node.left());
+        if (input == null)
+            return;
+        MonotoneExpression output = this.identity(node, getBodyType(input), true);
+        this.set(node, output);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -37,6 +37,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.*;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
@@ -99,7 +100,7 @@ public abstract class DBSPLiteral extends DBSPExpression implements ISameValue {
         } else if (type.is(DBSPTypeMillisInterval.class)) {
             return new DBSPIntervalMillisLiteral();
         } else if (type.is(DBSPTypeMonthsInterval.class)) {
-            return new DBSPIntervalMonthsLiteral(DBSPTypeMonthsInterval.Units.MONTHS);
+            return new DBSPIntervalMonthsLiteral(type.getNode(), type, null);
         } else if (type.is(DBSPTypeString.class)) {
             return new DBSPStringLiteral(CalciteObject.EMPTY, type, null, StandardCharsets.UTF_8);
         } else if (type.is(DBSPTypeTime.class)) {
@@ -118,6 +119,8 @@ public abstract class DBSPLiteral extends DBSPExpression implements ISameValue {
             return new DBSPBinaryLiteral(type.getNode(), type, null);
         } else if (type.is(DBSPTypeVariant.class)) {
             return new DBSPVariantExpression(null, type);
+        } else if (type.is(DBSPTypeStruct.class)) {
+            return type.to(DBSPTypeStruct.class).toTuple().none();
         }
         throw new InternalCompilerError("Unexpected type for NULL literal " + type, type);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
@@ -217,7 +217,7 @@ public class DBSPTypeStruct extends DBSPType {
     /** Generate a tuple type by ignoring the struct and field names. */
     public DBSPTypeTuple toTuple() {
         List<DBSPType> types = Linq.list(Linq.map(this.fields.values(), f -> f.type));
-        return new DBSPTypeTuple(this.getNode(), false, this, types);
+        return new DBSPTypeTuple(this.getNode(), this.mayBeNull, this, types);
     }
 
     private static DBSPType toTupleDeep(DBSPType type) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
@@ -112,4 +112,22 @@ public class DBSPTypeMonthsInterval
     public String baseTypeWithSuffix() {
         return this.shortName() + "_" + this.units.name() + this.nullableSuffix();
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LongInterval(");
+        builder.append(switch (this.units) {
+            case YEARS_TO_MONTHS -> "Y";
+            case YEARS -> "Y";
+            default -> "";
+        });
+        builder.append(switch (this.units) {
+            case YEARS_TO_MONTHS -> "M";
+            case MONTHS -> "Y";
+            default -> "";
+        });
+        builder.append(")");
+        return builder.toString();
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -389,7 +389,7 @@ public class RegressionTests extends SqlIoTest {
         this.compileRustTestCase(sql);
     }
 
-    @Test @Ignore("https://github.com/feldera/feldera/issues/3154")
+    @Test
     public void testOuterDuplicate() {
         // Validated on Postgres
         String sql = """


### PR DESCRIPTION
Fixes #3154 

The previous implementation was only correct for joins on sets. The previous implementation used DISTINCT and EXCEPT (DBSP subtract) to compute the left and right sets that are added to an INNER JOIN when implementing an OUTER JOIN.

This implementation uses Anti Joins, a primitive DBSP operator, to correctly compute the correct "difference" between multisets.

The optimization that trims unused fields does not currently work with the code generated for an outer join, but this will be fixed in a future PR.