### PR TITLE
pipeline-manager: pipeline unreachable status code 503 instead of 500

### DIFF
--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -384,7 +384,7 @@ impl ResponseError for RunnerError {
             Self::PipelineShutdownTimeout { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::PortFileParseError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::BinaryFetchError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::PipelineUnreachable { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::PipelineUnreachable { .. } => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 


### PR DESCRIPTION
The service is not available (503) rather than that an internal error (500) occurred.