### PR TITLE
[WebConsole] Fix Change Stream and Ad-Hoc Query tables flicker in Safari

### DIFF
--- a/web-console/src/lib/components/adhoc/Query.svelte
+++ b/web-console/src/lib/components/adhoc/Query.svelte
@@ -220,6 +220,9 @@
                   </tr>
                 {/if}
               {/snippet}
+              {#snippet emptyItem()}
+                <tr class="h-0"></tr>
+              {/snippet}
               {#snippet footer()}
                 <tr style="height: auto; ">
                   <td></td>

--- a/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
+++ b/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
@@ -20,6 +20,7 @@
   import { binarySearchMax } from '$lib/functions/common/array'
   let {
     item,
+    emptyItem,
     itemCount,
     itemSize,
     listContainer = defaultListContainer,
@@ -47,6 +48,10 @@
     onscroll?: OnScroll
     header?: Snippet
     item: Snippet<[Item]>
+    /**
+     * An empty item is rendered to preserve even-odd coloring of list items
+     */
+    emptyItem: Snippet
     listContainer?: Snippet<[Snippet, ListContainer, Snippet | undefined]>
     placeholder?: Snippet<[Item]>
     footer?: Snippet
@@ -110,7 +115,7 @@
   {@render header?.()}
   {#if indexOffset % 2 == 0}
     <!-- Preserve even-odd coloring of elements -->
-    <div></div>
+    {@render emptyItem()}
   {/if}
   {#if stickyRow !== undefined}
     {@render item({

--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -129,6 +129,9 @@
         </tr>
       {/if}
     {/snippet}
+    {#snippet emptyItem()}
+      <tr class="h-0"></tr>
+    {/snippet}
     {#snippet footer()}
       <tr style="height: auto; ">
         <td></td>

--- a/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ReverseScrollFixedList.svelte
@@ -8,6 +8,7 @@
     items,
     itemSize,
     item: renderItem,
+    emptyItem,
     listContainer,
     stickyIndices,
     class: _class = '',
@@ -17,6 +18,7 @@
   }: {
     items: Row[]
     item: Snippet<[item: Row, style?: string, padding?: string, isSticky?: boolean]>
+    emptyItem: Snippet
     listContainer?: Snippet<[Snippet, ListContainer, Snippet | undefined]>
     header?: Snippet
     footer?: Snippet
@@ -60,6 +62,7 @@
   {itemSize}
   {stickyIndices}
   {marginTop}
+  {emptyItem}
 >
   {#snippet item({ index, style, padding, isSticky })}
     {#if items[index]}


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/2999: scrolling in changestream not working