### PR TITLE
Show compilation errors for pipeline in fda.

### DIFF
--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -458,7 +458,22 @@ async fn wait_for_status(
 
         if wait_for != PipelineStatus::Shutdown && pc.deployment_status == PipelineStatus::Failed {
             if let Some(deployment_error) = &pc.deployment_error {
-                eprintln!("{}", deployment_error.message);
+                if deployment_error.error_code == "StartFailedDueToFailedCompilation" {
+                    eprintln!("Pipeline failed to start due to the following compilation error:");
+                    eprintln!();
+                    eprintln!(
+                        "{}",
+                        deployment_error
+                            .details
+                            .as_object()
+                            .unwrap_or(&serde_json::Map::new())
+                            .get("compiler_error")
+                            .and_then(|e| e.as_str())
+                            .unwrap_or_default()
+                    );
+                } else {
+                    eprintln!("{}", deployment_error.message);
+                }
             } else {
                 eprintln!("Pipeline failed to reach status {:?}", wait_for);
             }

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -204,7 +204,10 @@ pub(crate) fn error_pipeline_not_running_or_paused() -> ErrorResponse {
 }
 
 pub(crate) fn error_program_failed_compilation() -> ErrorResponse {
-    ErrorResponse::from_error_nolog(&DBError::StartFailedDueToFailedCompilation)
+    ErrorResponse::from_error_nolog(&DBError::StartFailedDueToFailedCompilation {
+        compiler_error: "error: failed to compile: error: linking with `cc` failed: exit code: 1"
+            .to_string(),
+    })
 }
 
 pub(crate) fn error_invalid_pipeline_action() -> ErrorResponse {

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -13,7 +13,7 @@ use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::string::ParseError;
 use thiserror::Error as ThisError;
@@ -99,6 +99,19 @@ pub struct SqlCompilerMessage {
     pub(crate) error_type: String,
     message: String,
     snippet: Option<String>,
+}
+
+impl Display for SqlCompilerMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{error_type}: {message} (line {start_line_number}, column {start_column})",
+            error_type = self.error_type,
+            message = self.message,
+            start_line_number = self.start_line_number,
+            start_column = self.start_column
+        )
+    }
 }
 
 impl SqlCompilerMessage {

--- a/openapi.json
+++ b/openapi.json
@@ -1956,7 +1956,9 @@
                   "Program failed compilation": {
                     "description": "Program failed compilation",
                     "value": {
-                      "details": null,
+                      "details": {
+                        "compiler_error": "error: failed to compile: error: linking with `cc` failed: exit code: 1"
+                      },
                       "error_code": "StartFailedDueToFailedCompilation",
                       "message": "Not possible to start the pipeline because the program failed to compile"
                     }


### PR DESCRIPTION
We add the compiler message to the corresponding error type in the manager to do that.

Fixes #3214 