### PR TITLE
pipeline-manager: reduce monitoring overhead

### DIFF
--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -1,8 +1,6 @@
 // Example errors for use in OpenAPI docs.
 use crate::api::error::ApiError;
-use crate::api::pipeline::{
-    PatchPipeline, PipelineFieldSelector, PipelineInfo, PipelineSelectedInfo, PostPutPipeline,
-};
+use crate::api::pipeline::{PatchPipeline, PipelineInfo, PipelineSelectedInfo, PostPutPipeline};
 use crate::db::error::DBError;
 use crate::db::types::common::Version;
 use crate::db::types::pipeline::{
@@ -159,11 +157,11 @@ pub(crate) fn pipeline_1_info() -> PipelineInfo {
 }
 
 pub(crate) fn pipeline_1_selected_info() -> PipelineSelectedInfo {
-    PipelineSelectedInfo::new(&extended_pipeline_1(), &PipelineFieldSelector::All)
+    PipelineSelectedInfo::new_all(&extended_pipeline_1())
 }
 
 pub(crate) fn pipeline_2_selected_info() -> PipelineSelectedInfo {
-    PipelineSelectedInfo::new(&extended_pipeline_2(), &PipelineFieldSelector::All)
+    PipelineSelectedInfo::new_all(&extended_pipeline_2())
 }
 
 pub(crate) fn list_pipeline_selected_info() -> Vec<PipelineSelectedInfo> {

--- a/crates/pipeline-manager/src/api/metrics.rs
+++ b/crates/pipeline-manager/src/api/metrics.rs
@@ -36,7 +36,12 @@ pub(crate) async fn get_metrics(
     state: WebData<ServerState>,
     tenant_id: ReqData<TenantId>,
 ) -> Result<HttpResponse, ManagerError> {
-    let pipelines = state.db.lock().await.list_pipelines(*tenant_id).await?;
+    let pipelines = state
+        .db
+        .lock()
+        .await
+        .list_pipelines_for_monitoring(*tenant_id)
+        .await?;
 
     const NEWLINE: u8 = b'\n';
     let mut result = Vec::new();

--- a/crates/pipeline-manager/src/compiler/main.rs
+++ b/crates/pipeline-manager/src/compiler/main.rs
@@ -150,6 +150,9 @@ pub async fn compiler_precompile(
     )
     .await
     .map_err(|e| match e {
+        SqlCompilationError::NoLongerExists => CompilerError::PrecompilationError {
+            error: "SQL compilation no longer relevant as pipeline no longer exists".to_string(),
+        },
         SqlCompilationError::Outdated => CompilerError::PrecompilationError {
             error: "Outdated SQL compilation".to_string(),
         },
@@ -179,6 +182,9 @@ pub async fn compiler_precompile(
     )
     .await
     .map_err(|e| match e {
+        RustCompilationError::NoLongerExists => CompilerError::PrecompilationError {
+            error: "Rust compilation no longer relevant as pipeline no longer exists".to_string(),
+        },
         RustCompilationError::Outdated => CompilerError::PrecompilationError {
             error: "Outdated Rust compilation".to_string(),
         },

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -438,7 +438,7 @@ pub struct ExtendedPipelineDescr {
 
     /// Program information which includes schema, input connectors and output connectors.
     /// It is set once SQL compilation has been successfully completed
-    /// (i.e., the `program_status` field reaches >= `ProgramStatus::CompilingRust`).
+    /// (i.e., the `program_status` field reaches >= `ProgramStatus::SqlCompiled`).
     pub program_info: Option<ProgramInfo>,
 
     /// Combined checksum of all the inputs that influenced Rust compilation to a binary.
@@ -473,5 +473,29 @@ pub struct ExtendedPipelineDescr {
 
     /// Location where the pipeline can be reached at runtime
     /// (e.g., a TCP port number or a URI).
+    pub deployment_location: Option<String>,
+}
+
+/// Pipeline descriptor which includes the fields relevant to system monitoring.
+/// The advantage of this descriptor over the [`ExtendedPipelineDescr`] is that it
+/// excludes fields which can be quite large (e.g., the generated Rust code stored
+/// in `program_info` can become several MiB in size). This is particularly relevant
+/// for monitoring in which the pipeline tuple is retrieved very frequently, which would
+/// result in high CPU usage to retrieve large fields that are not of interest.
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct ExtendedPipelineDescrMonitoring {
+    pub id: PipelineId,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub version: Version,
+    pub platform_version: String,
+    pub program_version: Version,
+    pub program_status: ProgramStatus,
+    pub program_status_since: DateTime<Utc>,
+    pub deployment_status: PipelineStatus,
+    pub deployment_status_since: DateTime<Utc>,
+    pub deployment_desired_status: PipelineDesiredStatus,
+    pub deployment_error: Option<ErrorResponse>,
     pub deployment_location: Option<String>,
 }

--- a/crates/pipeline-manager/src/metrics.rs
+++ b/crates/pipeline-manager/src/metrics.rs
@@ -71,7 +71,9 @@ async fn metrics(
 ) -> Result<impl Responder, ManagerError> {
     let mut buffer = String::new();
     let db = db.lock().await;
-    let pipelines = db.list_pipelines_across_all_tenants().await?;
+    let pipelines = db
+        .list_pipelines_across_all_tenants_for_monitoring()
+        .await?;
     for (_tenant_id, pipeline) in pipelines {
         // Get the metrics for all running pipelines,
         // don't write anything if the request fails.

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -1,7 +1,7 @@
 use crate::config::ApiServerConfig;
 use crate::db::storage::Storage;
 use crate::db::storage_postgres::StoragePostgres;
-use crate::db::types::pipeline::{ExtendedPipelineDescr, PipelineId, PipelineStatus};
+use crate::db::types::pipeline::{ExtendedPipelineDescrMonitoring, PipelineId, PipelineStatus};
 use crate::db::types::tenant::TenantId;
 use crate::error::ManagerError;
 use crate::runner::error::RunnerError;
@@ -37,12 +37,12 @@ impl RunnerInteraction {
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(ExtendedPipelineDescr, String), ManagerError> {
+    ) -> Result<(ExtendedPipelineDescrMonitoring, String), ManagerError> {
         let pipeline = self
             .db
             .lock()
             .await
-            .get_pipeline(tenant_id, pipeline_name)
+            .get_pipeline_for_monitoring(tenant_id, pipeline_name)
             .await?;
 
         match pipeline.deployment_status {
@@ -294,7 +294,7 @@ impl RunnerInteraction {
             .db
             .lock()
             .await
-            .get_pipeline(tenant_id, pipeline_name)
+            .get_pipeline_for_monitoring(tenant_id, pipeline_name)
             .await?;
 
         // Build request to the runner

--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -289,7 +289,7 @@ impl PipelineExecutor for LocalRunner {
     type Config = LocalRunnerConfig;
 
     // Provisioning is over once the pipeline port file has been detected.
-    const PROVISIONING_TIMEOUT: Duration = Duration::from_millis(10_000);
+    const PROVISIONING_TIMEOUT: Duration = Duration::from_millis(20_000);
     const PROVISIONING_POLL_PERIOD: Duration = Duration::from_millis(250);
 
     // Shutdown is over once the process has exited.


### PR DESCRIPTION
The manager currently retrieves all columns when retrieving a pipeline irrespective of which ones are needed, and only applies a filter at API endpoints. This becomes an issue when pipelines fields become very large, which in particular can occur for `program_code` and `program_info`. This results in unnecessarily high CPU usage.

This commit adds new and modifies some existing database operations to retrieve pipeline descriptors with only the fields relevant to monitoring. These operations are then used both internally when monitoring pipelines (e.g., by the SQL compiler, Rust compiler, and runners), as well as by the API endpoints when possible (e.g., when the field selector is `status`).