### PR TITLE
[docs] Improve SQL doc structure.

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -135,17 +135,20 @@ const sidebars = {
                 {
                     type: 'category',
                     label: 'Feldera SQL',
+                    link: {
+                        type: 'doc',
+                        id: 'sql/index'
+                    },
                     items: [
                         'sql/grammar',
                         'sql/identifiers',
+                        'sql/types',
+                        'sql/casts',
                         'sql/operators',
                         'sql/aggregates',
-                        'sql/casts',
-                        'sql/types',
                         'sql/boolean',
                         'sql/comparisons',
                         'sql/integer',
-                        'sql/json',
                         'sql/float',
                         'sql/decimal',
                         'sql/string',
@@ -153,6 +156,7 @@ const sidebars = {
                         'sql/array',
                         'sql/map',
                         'sql/datetime',
+                        'sql/json',
                         'sql/materialized',
                         'sql/recursion',
                         'sql/ad-hoc',

--- a/docs/sql/ad-hoc.md
+++ b/docs/sql/ad-hoc.md
@@ -1,4 +1,4 @@
-# Ad-hoc SQL queries
+# Ad-hoc SQL Queries
 
 You can run ad-hoc SQL queries on a running or paused pipeline. Unlike Feldera SQL programs that define pipelines and
 are evaluated incrementally, ad-hoc queries are evaluated in batch mode,

--- a/docs/sql/aggregates.md
+++ b/docs/sql/aggregates.md
@@ -1,4 +1,4 @@
-# Aggregate operations
+# Aggregate Operations
 
 ## Standard aggregate operations
 

--- a/docs/sql/binary.md
+++ b/docs/sql/binary.md
@@ -1,4 +1,4 @@
-# Binary (byte array) operations
+# Binary (Byte Array) Operations
 
 The `BINARY` and `VARBINARY` data types allows storage of binary strings.
 

--- a/docs/sql/casts.md
+++ b/docs/sql/casts.md
@@ -1,4 +1,4 @@
-# Data type conversions
+# Data Type Conversions
 
 SQL expressions can mix data of different types in the same
 expression.  Most operations, however, require operands to have either

--- a/docs/sql/datetime.md
+++ b/docs/sql/datetime.md
@@ -1,4 +1,4 @@
-# Date- and time-related operations
+# Date- and Time-Related Operations
 
 ## Time units
 

--- a/docs/sql/decimal.md
+++ b/docs/sql/decimal.md
@@ -1,4 +1,4 @@
-# Decimal data type
+# Operations on Decimals
 
 A synonym for the ``decimal`` type is ``numeric``.
 

--- a/docs/sql/float.md
+++ b/docs/sql/float.md
@@ -1,4 +1,4 @@
-# Floating point types
+# Floating Point Operations
 
 We support standard IEEE 754 floating point types.
 

--- a/docs/sql/function-index.md
+++ b/docs/sql/function-index.md
@@ -1,4 +1,4 @@
-# Index of functions and SQL constructs supported in Feldera SQL
+# Index of Functions and SQL Constructs Supported in Feldera SQL
 
 * `%`: [operators](operators.md)
 * `*`: [operators](operators.md)

--- a/docs/sql/index.mdx
+++ b/docs/sql/index.mdx
@@ -1,0 +1,7 @@
+# Feldera SQL
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/docs/sql/json.md
+++ b/docs/sql/json.md
@@ -1,4 +1,4 @@
-# Dynamically-typed values and JSON support
+# Dynamically-Typed Values and JSON Support
 
 ## The `VARIANT` type
 

--- a/docs/sql/recursion.mdx
+++ b/docs/sql/recursion.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Mutually-recursive queries
+# Mutually-Recursive Queries
 
 :::warning
 

--- a/docs/sql/string.md
+++ b/docs/sql/string.md
@@ -1,4 +1,4 @@
-# String operations
+# String Operations
 
 SQL defines two primary character types: `character varying(n)` and
 `character(n)`, where n is a positive integer.  Both of these types

--- a/docs/sql/system.md
+++ b/docs/sql/system.md
@@ -1,4 +1,4 @@
-# System views
+# System Views
 
 The Feldera runtime comes with some built-in views.  These views are
 built-in.  Their contents is pre-populated by the runtime.

--- a/docs/sql/table.md
+++ b/docs/sql/table.md
@@ -1,4 +1,4 @@
-# Table functions
+# Table Functions
 
 A table function is a function that returns data of a table type.  The
 table-valued function can be used wherever a relation can be used.

--- a/docs/sql/types.md
+++ b/docs/sql/types.md
@@ -1,4 +1,4 @@
-# Built-in Data Types
+# Data Types
 
 The compiler supports the following SQL data types:
 

--- a/docs/sql/udf.md
+++ b/docs/sql/udf.md
@@ -1,4 +1,4 @@
-# User-defined functions
+# User-Defined Functions
 
 The SQL statement `CREATE FUNCTION` can be used to declare new
 functions.  Functions can be implemented either in SQL or in Rust.


### PR DESCRIPTION
- Create a top-level page that we can link to directly instead of linking to one of the subsections.

- Reorder sections in a more logical way

- Consistent page names.