### PR TITLE
Revert "Add debug = true to Cargo workspace for pipelines."

### DIFF
--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -645,11 +645,9 @@ async fn prepare_workspace(
         opt-level = 0
         lto = \"off\"
         codegen-units = 256
-        debug = \"line-tables-only\"
 
         [profile.optimized]
         inherits = \"release\"
-        debug = \"line-tables-only\"
     "};
     let cargo_toml_file_path = config
         .working_dir()


### PR DESCRIPTION
This turned out to result in very large binaries (up to 1 GiB), so we decided to revert the change again.

This reverts commit 50b1491e8e3bc509ee6f4ad53f283b42226433f8.