### PR TITLE
Fixes a RwLock deadlock in manager.

### DIFF
--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -304,6 +304,7 @@ impl RunnerInteraction {
                     // transitions within the cache ttl of 5 secs).
                     let mut cache = self.endpoint_cache.write().unwrap();
                     cache.remove(&(tenant_id, pipeline_name.to_string()));
+                    drop(cache);
                     Box::pin(self.forward_http_request_to_pipeline_by_name(
                         tenant_id,
                         pipeline_name,


### PR DESCRIPTION
This is another instance of read after write lock that I added by accident which can cause the pipeline-manager to become unresponsive

FWIW I think we should just replace all our std RwLock instances with parking lot RwLock which panics when you attempt to do this

Fixes #3307 (I hope)