### PR TITLE
pipeline-manager: runner version guard

### DIFF
--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -129,6 +129,10 @@ pub enum DBError {
         outdated_version: Version,
         latest_version: Version,
     },
+    OutdatedPipelineVersion {
+        outdated_version: Version,
+        latest_version: Version,
+    },
     StartFailedDueToFailedCompilation {
         compiler_error: String,
     },
@@ -477,6 +481,15 @@ impl Display for DBError {
                     "Program version ({outdated_version}) is outdated by latest ({latest_version})"
                 )
             }
+            DBError::OutdatedPipelineVersion {
+                outdated_version,
+                latest_version,
+            } => {
+                write!(
+                    f,
+                    "Pipeline version ({outdated_version}) is outdated by latest ({latest_version})"
+                )
+            }
             DBError::StartFailedDueToFailedCompilation { .. } => {
                 write!(
                     f,
@@ -570,6 +583,7 @@ impl DetailedError for DBError {
                 Cow::from("CannotRenameNonExistingPipeline")
             }
             Self::OutdatedProgramVersion { .. } => Cow::from("OutdatedProgramVersion"),
+            Self::OutdatedPipelineVersion { .. } => Cow::from("OutdatedPipelineVersion"),
             Self::StartFailedDueToFailedCompilation { .. } => {
                 Cow::from("StartFailedDueToFailedCompilation")
             }
@@ -626,6 +640,7 @@ impl ResponseError for DBError {
             Self::CannotDeleteNonShutdownPipeline { .. } => StatusCode::BAD_REQUEST,
             Self::CannotRenameNonExistingPipeline { .. } => StatusCode::BAD_REQUEST,
             Self::OutdatedProgramVersion { .. } => StatusCode::CONFLICT,
+            Self::OutdatedPipelineVersion { .. } => StatusCode::CONFLICT,
             Self::StartFailedDueToFailedCompilation { .. } => StatusCode::BAD_REQUEST,
             Self::TransitionRequiresCompiledProgram { .. } => StatusCode::INTERNAL_SERVER_ERROR, // Runner error
             Self::InvalidProgramStatusTransition { .. } => StatusCode::INTERNAL_SERVER_ERROR, // Compiler error

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -277,6 +277,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_config: serde_json::Value,
     ) -> Result<(), DBError>;
 
@@ -285,6 +286,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_location: &str,
     ) -> Result<(), DBError>;
 
@@ -293,6 +295,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError>;
 
     /// Transitions deployment status to `Paused`.
@@ -300,6 +303,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError>;
 
     /// Transitions deployment status to `Unavailable`.
@@ -307,6 +311,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError>;
 
     /// Transitions deployment status to `ShuttingDown`.
@@ -314,6 +319,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError>;
 
     /// Transitions deployment status to `Shutdown`.
@@ -321,6 +327,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError>;
 
     /// Transitions deployment status to `Failed`.
@@ -328,6 +335,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_error: &ErrorResponse,
     ) -> Result<(), DBError>;
 

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -638,6 +638,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_config: serde_json::Value,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
@@ -646,6 +647,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Provisioning,
             None,
             Some(deployment_config),
@@ -660,6 +662,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_location: &str,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
@@ -668,6 +671,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Initializing,
             None,
             None,
@@ -682,6 +686,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -689,6 +694,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Running,
             None,
             None,
@@ -703,6 +709,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -710,6 +717,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Paused,
             None,
             None,
@@ -724,6 +732,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -731,6 +740,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Unavailable,
             None,
             None,
@@ -745,6 +755,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -752,6 +763,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::ShuttingDown,
             None,
             None,
@@ -766,6 +778,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -773,6 +786,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Shutdown,
             None,
             None,
@@ -787,6 +801,7 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_id: PipelineId,
+        version_guard: Version,
         deployment_error: &ErrorResponse,
     ) -> Result<(), DBError> {
         let mut client = self.pool.get().await?;
@@ -795,6 +810,7 @@ impl Storage for StoragePostgres {
             &txn,
             tenant_id,
             pipeline_id,
+            version_guard,
             PipelineStatus::Failed,
             Some(deployment_error.clone()),
             None,


### PR DESCRIPTION
In the transition from `Shutdown` to `Provisioning`, there is a particular concurrency scenario:
1. User calls `/start` on pipeline (v1)
2. Runner picks up that desired state is `Running` and creates the deployment configuration (v1), but it has not yet stored it in the database
3. User calls `/shutdown`, making the pipeline editable again
4. User edits pipeline (e.g., runtime configuration) to become (v2)
5. User calls `/start`
6. The runner stores the transition to `Provisioning` in the database with deployment configuration (v1)

The above is unlikely to happen given the exact timing required. Nevertheless, this fixes it by adding a version guard such that at step (6) the runner does not transition but instead tries again next cycle.