### PR TITLE
pipeline-manager: reserialize `runtime_config` and `program_config`

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -202,7 +202,7 @@ impl Into<ProgramConfig> for Profile {
     fn into(self) -> ProgramConfig {
         ProgramConfig {
             profile: Some(self.into()),
-            cache: None,
+            cache: true,
         }
     }
 }

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -105,7 +105,7 @@ impl TemporaryCacheDisable {
     ) {
         let pc = if disable {
             let mut disabled_cache_pc = original_pc.clone();
-            disabled_cache_pc.cache = Some(false);
+            disabled_cache_pc.cache = false;
             disabled_cache_pc
         } else {
             original_pc.clone()
@@ -1292,7 +1292,7 @@ async fn program(format: OutputFormat, action: ProgramAction, client: Client) {
                 udf_toml: None,
                 program_config: Some(ProgramConfig {
                     profile: Some(profile.into()),
-                    cache: None,
+                    cache: true,
                 }),
                 runtime_config: None,
             };

--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -78,6 +78,12 @@ pub enum DBError {
         value: serde_json::Value,
         error: String,
     },
+    FailedToSerializeRuntimeConfig {
+        error: String,
+    },
+    FailedToSerializeProgramConfig {
+        error: String,
+    },
     FailedToSerializeErrorResponse {
         error: String,
     },
@@ -408,6 +414,12 @@ impl Display for DBError {
             DBError::InvalidErrorResponse { value, error } => {
                 write!(f, "JSON for 'deployment_error' field:\n{value:#}\n\n... is not valid due to: {error}")
             }
+            DBError::FailedToSerializeRuntimeConfig { error } => {
+                write!(f, "Unable to serialize runtime configuration for 'runtime_config' field as JSON due to: {error}")
+            }
+            DBError::FailedToSerializeProgramConfig { error } => {
+                write!(f, "Unable to serialize program configuration for 'program_config' field as JSON due to: {error}")
+            }
             DBError::FailedToSerializeErrorResponse { error } => {
                 write!(f, "Unable to serialize error response for 'deployment_error' field as JSON due to: {error}")
             }
@@ -555,6 +567,12 @@ impl DetailedError for DBError {
             Self::InvalidProgramInfo { .. } => Cow::from("InvalidProgramInfo"),
             Self::InvalidDeploymentConfig { .. } => Cow::from("InvalidDeploymentConfig"),
             Self::InvalidErrorResponse { .. } => Cow::from("InvalidErrorResponse"),
+            Self::FailedToSerializeRuntimeConfig { .. } => {
+                Cow::from("FailedToSerializeRuntimeConfig")
+            }
+            Self::FailedToSerializeProgramConfig { .. } => {
+                Cow::from("FailedToSerializeProgramConfig")
+            }
             Self::FailedToSerializeErrorResponse { .. } => {
                 Cow::from("FailedToSerializeErrorResponse")
             }
@@ -622,6 +640,8 @@ impl ResponseError for DBError {
             Self::InvalidProgramInfo { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidDeploymentConfig { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidErrorResponse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::FailedToSerializeRuntimeConfig { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::FailedToSerializeProgramConfig { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::FailedToSerializeErrorResponse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::UniqueKeyViolation { .. } => StatusCode::INTERNAL_SERVER_ERROR, // UUID conflict
             Self::DuplicateKey { .. } => StatusCode::INTERNAL_SERVER_ERROR, // This error should never bubble up till here

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -507,15 +507,15 @@ async fn pipeline_creation() {
     let new_descriptor = PipelineDescr {
         name: "test1".to_string(),
         description: "Test description".to_string(),
-        runtime_config: json!({}),
+        runtime_config: json!({
+            "workers": 123
+        }),
         program_code: "".to_string(),
         udf_rust: "".to_string(),
         udf_toml: "".to_string(),
-        program_config: serde_json::to_value(ProgramConfig {
-            profile: Some(CompilationProfile::Unoptimized),
-            cache: false,
-        })
-        .unwrap(),
+        program_config: json!({
+            "profile": "unoptimized"
+        }),
     };
     let new_result = handle
         .db
@@ -530,9 +530,21 @@ async fn pipeline_creation() {
     // Core fields
     assert_eq!(actual.name, new_descriptor.name);
     assert_eq!(actual.description, new_descriptor.description);
-    assert_eq!(actual.runtime_config, new_descriptor.runtime_config);
+    assert_eq!(
+        actual.runtime_config,
+        serde_json::to_value(
+            serde_json::from_value::<RuntimeConfig>(new_descriptor.runtime_config).unwrap()
+        )
+        .unwrap()
+    );
     assert_eq!(actual.program_code, new_descriptor.program_code);
-    assert_eq!(actual.program_config, new_descriptor.program_config);
+    assert_eq!(
+        actual.program_config,
+        serde_json::to_value(
+            serde_json::from_value::<ProgramConfig>(new_descriptor.program_config).unwrap()
+        )
+        .unwrap()
+    );
 
     // Core metadata fields
     // actual.id

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -252,13 +252,9 @@ pub fn validate_program_status_transition(
     }
 }
 
-/// Default value for program configuration: cache.
-fn default_program_config_cache() -> bool {
-    true
-}
-
 /// Program configuration.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
 pub struct ProgramConfig {
     /// Compilation profile.
     /// If none is specified, the compiler default compilation profile is used.
@@ -268,8 +264,16 @@ pub struct ProgramConfig {
     /// already exists, the output of that (i.e., binary) is used.
     /// Set `false` to always trigger a new compilation, which might take longer
     /// and as well can result in overriding an existing binary.
-    #[serde(default = "default_program_config_cache")]
     pub cache: bool,
+}
+
+impl Default for ProgramConfig {
+    fn default() -> Self {
+        Self {
+            profile: None,
+            cache: true,
+        }
+    }
 }
 
 #[derive(ThisError, Serialize, Deserialize, Debug, ToSchema)]

--- a/openapi.json
+++ b/openapi.json
@@ -3602,7 +3602,8 @@
         "properties": {
           "cache": {
             "type": "boolean",
-            "description": "If `true` (default), when a prior compilation with the same checksum\nalready exists, the output of that (i.e., binary) is used.\nSet `false` to always trigger a new compilation, which might take longer\nand as well can result in overriding an existing binary."
+            "description": "If `true` (default), when a prior compilation with the same checksum\nalready exists, the output of that (i.e., binary) is used.\nSet `false` to always trigger a new compilation, which might take longer\nand as well can result in overriding an existing binary.",
+            "default": true
           },
           "profile": {
             "allOf": [
@@ -3610,6 +3611,7 @@
                 "$ref": "#/components/schemas/CompilationProfile"
               }
             ],
+            "default": null,
             "nullable": true
           }
         }

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -2092,7 +2092,8 @@ export const $ProgramConfig = {
       description: `If \`true\` (default), when a prior compilation with the same checksum
 already exists, the output of that (i.e., binary) is used.
 Set \`false\` to always trigger a new compilation, which might take longer
-and as well can result in overriding an existing binary.`
+and as well can result in overriding an existing binary.`,
+      default: true
     },
     profile: {
       allOf: [
@@ -2100,6 +2101,7 @@ and as well can result in overriding an existing binary.`
           $ref: '#/components/schemas/CompilationProfile'
         }
       ],
+      default: null,
       nullable: true
     }
   }


### PR DESCRIPTION
Currently, the `runtime_config` and `program_config` fields are stored as the direct JSON that was supplied for them. As a consequence, they do not have any defaults set when supplied during POST, PUT or PATCH. As such, currently it is needed to look at the OpenAPI specification or the documentation generated from it to discover which parameters can be set and what their default values are. This is too inconvenient for the user at this moment, especially in the Web Console. In the future this might be sufficiently mitigated by linking to documentation and providing autocomplete.

This commit adds back the reserialization of `runtime_config` and `program_config`.

To illustrate, when a user supplies the following JSON for the `program_config`:
```
{
  "profile": "unoptimized"
}
```

The back-end will receive the JSON, deserialize it as `ProgramConfig` and then serialize that as JSON again, ending up with the following stored in the database:
```
{
  "profile": "unoptimized",
  "cache": true
}
```

Note that what is additionally stored in the database will only include the defaults of the fields that exist at that moment. Suppose in the future another field called `example` is added with default value 123, it will not be present in the program configuration JSON stored in the database by prior versions of the platform. It will also not be in the JSON of `program_config` when it is returned, because during GET the direct JSON value stored in the database is returned (there is no reserialization).

If a backward incompatible change has occurred for any of the struct fields and the pipeline is retrieved, an error will now be printed in the log.