### PR TITLE
[SQL] Support for SAFE_CAST

### DIFF
--- a/crates/sqllib/src/decimal.rs
+++ b/crates/sqllib/src/decimal.rs
@@ -14,7 +14,9 @@ use std::str::FromStr;
 #[inline(always)]
 pub fn new_decimal(s: &str, precision: u32, scale: u32) -> Option<Decimal> {
     let value = Decimal::from_str(s).ok()?;
-    Some(cast_to_decimal_decimal(value, precision, scale))
+    Some(unwrap_cast(cast_to_decimal_decimal(
+        value, precision, scale,
+    )))
 }
 
 #[doc(hidden)]

--- a/crates/sqllib/src/error.rs
+++ b/crates/sqllib/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+/// Error that may be produced by a function at runtime
+#[derive(Error, Debug)]
+pub enum SqlRuntimeError {
+    #[error("{0}")]
+    CustomError(String),
+}
+
+impl SqlRuntimeError {
+    /// Create a Boxed SqlRuntimeError from a message string
+    pub fn from_string(message: String) -> Box<Self> {
+        Box::new(SqlRuntimeError::CustomError(message))
+    }
+
+    /// Create a Boxed SqlRuntimeError from a message slice
+    pub fn from_strng(message: &str) -> Box<Self> {
+        Box::new(SqlRuntimeError::CustomError(message.to_string()))
+    }
+}
+
+pub type SqlResult<T> = Result<T, Box<SqlRuntimeError>>;
+
+#[doc(hidden)]
+// Convert a SqlResult<T> into a SqlResult<Option<T>>
+pub(crate) fn r2o<T>(result: SqlResult<T>) -> SqlResult<Option<T>> {
+    match result {
+        Err(e) => Err(e),
+        Ok(value) => Ok(Some(value)),
+    }
+}

--- a/crates/sqllib/src/geopoint.rs
+++ b/crates/sqllib/src/geopoint.rs
@@ -80,7 +80,10 @@ some_polymorphic_function2!(make_geopoint, d, F64, d, F64, GeoPoint);
 
 #[doc(hidden)]
 pub fn make_geopoint_decimal_decimal(left: Decimal, right: Decimal) -> GeoPoint {
-    GeoPoint::new(cast_to_d_decimal(left), cast_to_d_decimal(right))
+    GeoPoint::new(
+        cast_to_d_decimal(left).unwrap(),
+        cast_to_d_decimal(right).unwrap(),
+    )
 }
 
 some_polymorphic_function2!(make_geopoint, decimal, Decimal, decimal, Decimal, GeoPoint);

--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -10,6 +10,8 @@ pub mod casts;
 #[doc(hidden)]
 pub mod decimal;
 #[doc(hidden)]
+pub mod error;
+#[doc(hidden)]
 pub mod geopoint;
 pub mod interval;
 #[doc(hidden)]

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -351,7 +351,7 @@ polymorphic_return_function2!(
 
 #[doc(hidden)]
 pub fn plus_Date_ShortInterval_Timestamp(left: Date, right: ShortInterval) -> Timestamp {
-    plus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left), right)
+    plus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left).unwrap(), right)
 }
 
 polymorphic_return_function2!(
@@ -403,7 +403,7 @@ polymorphic_return_function2!(
 
 #[doc(hidden)]
 pub fn minus_Date_ShortInterval_Timestamp(left: Date, right: ShortInterval) -> Timestamp {
-    minus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left), right)
+    minus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left).unwrap(), right)
 }
 
 polymorphic_return_function2!(
@@ -521,7 +521,7 @@ polymorphic_return_function2!(
 
 #[doc(hidden)]
 pub fn minus_Date_Timestamp_LongInterval(left: Date, right: Timestamp) -> LongInterval {
-    minus_Timestamp_Timestamp_LongInterval(cast_to_Timestamp_Date(left), right)
+    minus_Timestamp_Timestamp_LongInterval(cast_to_Timestamp_Date(left).unwrap(), right)
 }
 
 polymorphic_return_function2!(
@@ -536,7 +536,7 @@ polymorphic_return_function2!(
 
 #[doc(hidden)]
 pub fn minus_Timestamp_Date_LongInterval(left: Timestamp, right: Date) -> LongInterval {
-    minus_Timestamp_Timestamp_LongInterval(left, cast_to_Timestamp_Date(right))
+    minus_Timestamp_Timestamp_LongInterval(left, cast_to_Timestamp_Date(right).unwrap())
 }
 
 polymorphic_return_function2!(

--- a/docs/sql/casts.md
+++ b/docs/sql/casts.md
@@ -50,3 +50,10 @@ For example, the following statment is legal:
 ```sql
 SELECT cast(row(1, 2) as row(a integer, b tinyint)) as r;
 ```
+
+## Safe casts
+
+The `SAFE_CAST` function has the same syntax as `CAST`.  `SAFE_CAST`
+produces the same result as `CAST` for all legal inputs.  The main
+difference is that `SAFE_CAST` never produces a runtime error,
+producing a `NULL` value when a conversion is illegal.

--- a/docs/sql/function-index.md
+++ b/docs/sql/function-index.md
@@ -181,6 +181,7 @@
 * `ROUND`: [float](float.md#round), [float](float.md#round2), [decimal](decimal.md#round), [decimal](decimal.md#round2)
 * `ROW`: [types](types.md#row_constructor)
 * `ROW_NUMBER` (aggregate): [aggregates](aggregates.md#row_number)
+* `SAFE_CAST`: [casts](casts.md#safe-casts)
 * `SEC`: [float](float.md#sec)
 * `SECH`: [float](float.md#sech)
 * `SECOND`: [datetime](datetime.md#date_second), [datetime](datetime.md#time_second), [datetime](datetime.md#timestamp_second)

--- a/python/tests/aggregate_tests/test_empty_set.py
+++ b/python/tests/aggregate_tests/test_empty_set.py
@@ -140,12 +140,14 @@ class aggtst_some_emp_test_row(TstView):
                       SOME(c1 > SAFE_CAST(c2 AS INT)) AS sme
                       FROM row_tbl"""
 
+
 class aggtst_every_emp_test_row(TstView):
     def __init__(self):
         self.data = [{"evry": None}]
         self.sql = """CREATE MATERIALIZED VIEW every_emp_row AS SELECT
                       EVERY(c1 > SAFE_CAST(c2 AS INT)) AS evry
                       FROM row_tbl"""
+
 
 # Map
 class aggtst_count_emp_test_map(TstView):

--- a/python/tests/aggregate_tests/test_empty_set.py
+++ b/python/tests/aggregate_tests/test_empty_set.py
@@ -137,17 +137,15 @@ class aggtst_some_emp_test_row(TstView):
     def __init__(self):
         self.data = [{"sme": None}]
         self.sql = """CREATE MATERIALIZED VIEW some_emp_row AS SELECT
-                      SOME(c1 > c2) AS sme
+                      SOME(c1 > SAFE_CAST(c2 AS INT)) AS sme
                       FROM row_tbl"""
-
 
 class aggtst_every_emp_test_row(TstView):
     def __init__(self):
         self.data = [{"evry": None}]
         self.sql = """CREATE MATERIALIZED VIEW every_emp_row AS SELECT
-                      EVERY(c1 > c2) AS evry
+                      EVERY(c1 > SAFE_CAST(c2 AS INT)) AS evry
                       FROM row_tbl"""
-
 
 # Map
 class aggtst_count_emp_test_map(TstView):

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -767,13 +767,17 @@ public class ToRustInnerVisitor extends InnerVisitor {
         DBSPTypeVec destVecType = destType.as(DBSPTypeVec.class);
         String functionName;
 
+        if (expression.safe)
+            this.builder.append("unwrap_safe_cast(");
+        else
+            this.builder.append("unwrap_cast(");
         if (destVecType != null) {
             if (sourceType.is(DBSPTypeVariant.class)) {
                 // Cast variant to vec
                 functionName = "cast_to_vec" + destType.nullableSuffix() + "_" + sourceType.baseTypeWithSuffix();
                 this.builder.append(functionName).append("(").increase();
                 expression.source.accept(this);
-                this.builder.decrease().append(")");
+                this.builder.decrease().append("))");
                 return VisitDecision.STOP;
             }
         }
@@ -789,7 +793,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                         .append("(")
                         .increase();
                 expression.source.accept(this);
-                this.builder.decrease().append(")");
+                this.builder.decrease().append("))");
                 return VisitDecision.STOP;
             }
 
@@ -810,7 +814,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 functionName = "cast_to_map" + destType.nullableSuffix() + "_" + sourceType.baseTypeWithSuffix();
                 this.builder.append(functionName).append("(").increase();
                 expression.source.accept(this);
-                this.builder.decrease().append(")");
+                this.builder.decrease().append("))");
                 return VisitDecision.STOP;
             }
             this.unimplementedCast(expression);
@@ -820,7 +824,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 functionName = "cast_to_" + destType.baseTypeWithSuffix() + "_map" + sourceType.nullableSuffix();
                 this.builder.append(functionName).append("(").increase();
                 expression.source.accept(this);
-                this.builder.decrease().append(")");
+                this.builder.decrease().append("))");
                 return VisitDecision.STOP;
             }
             this.unimplementedCast(expression);
@@ -833,7 +837,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
             // we are dumping DOT
             this.builder.append("(");
             expression.type.accept(this);
-            this.builder.append(")");
+            this.builder.append("))");
             expression.source.accept(this);
             return VisitDecision.STOP;
         }
@@ -844,7 +848,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
             // we are dumping DOT
             this.builder.append("(");
             expression.type.accept(this);
-            this.builder.append(")");
+            this.builder.append("))");
             expression.source.accept(this);
             return VisitDecision.STOP;
         }
@@ -881,8 +885,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
             this.builder.append(",")
                     .append(binary.precision);
         }
-
-        this.builder.append(")");
+        this.builder.append("))");
         return VisitDecision.STOP;
     }
 
@@ -937,7 +940,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 DBSPExpression sub1 = ExpressionCompiler.makeBinaryExpression(
                         expression.getNode(), indexType, DBSPOpcode.SUB,
                         expression.right, indexType.to(IsNumericType.class).getOne());
-                sub1 = sub1.cast(new DBSPTypeISize(CalciteObject.EMPTY, indexType.mayBeNull));
+                sub1 = sub1.cast(new DBSPTypeISize(CalciteObject.EMPTY, indexType.mayBeNull), false);
                 sub1.accept(this);
                 this.builder.append(")");
                 break;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -1202,7 +1202,7 @@ public class ToRustVisitor extends CircuitVisitor {
                 }
                 this.builder.append(">(");
         DBSPExpression cast = operator.limit.cast(
-                new DBSPTypeUSize(CalciteObject.EMPTY, operator.limit.getType().mayBeNull));
+                new DBSPTypeUSize(CalciteObject.EMPTY, operator.limit.getType().mayBeNull), false);
         cast.accept(this.innerVisitor);
         if (operator.outputProducer != null) {
             if (operator.numbering != DBSPIndexedTopKOperator.TopKNumbering.ROW_NUMBER) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -218,7 +218,7 @@ public class AggregateCompiler implements ICompilerComponent {
         }
 
         // TODO: should this be looking at the filter argument?
-        DBSPExpression increment = new DBSPI64Literal(result).cast(this.nullableResultType);
+        DBSPExpression increment = new DBSPI64Literal(result).cast(this.nullableResultType, false);
         DBSPVariablePath accumulator = this.nullableResultType.var();
         DBSPType semigroup = new DBSPTypeUser(CalciteObject.EMPTY, SEMIGROUP, "UnimplementedSemigroup",
                 false, accumulator.getType());
@@ -348,15 +348,15 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPVariablePath accumulator = zeroType.var();
         DBSPExpression ge = new DBSPBinaryExpression(
                 node, DBSPTypeBool.create(false), compareOpcode,
-                tuple.fields[1].cast(currentType).applyCloneIfNeeded(),
+                tuple.fields[1].cast(currentType, false).applyCloneIfNeeded(),
                 accumulator.field(1).applyCloneIfNeeded());
         if (this.filterArgument >= 0) {
             ge = ExpressionCompiler.makeBinaryExpression(
                     node, ge.getType(), DBSPOpcode.AND, ge, Objects.requireNonNull(this.filterArgument()));
         }
         DBSPTupleExpression aggArgCast = new DBSPTupleExpression(
-                tuple.fields[0].cast(this.resultType).applyCloneIfNeeded(),
-                tuple.fields[1].cast(currentType).applyCloneIfNeeded());
+                tuple.fields[0].cast(this.resultType, false).applyCloneIfNeeded(),
+                tuple.fields[1].cast(currentType, false).applyCloneIfNeeded());
         DBSPExpression increment = new DBSPIfExpression(node, ge, aggArgCast, accumulator.applyCloneIfNeeded());
         DBSPType semigroup = new DBSPTypeUser(node, SEMIGROUP, "UnimplementedSemigroup",
                 false, aggArgCast.getType());
@@ -397,13 +397,13 @@ public class AggregateCompiler implements ICompilerComponent {
         if (!leftType.withMayBeNull(rightType.mayBeNull).sameType(rightType)) {
             if (!rightType.is(DBSPTypeBaseType.class)) {
                 // These can also be different DECIMAL types
-                right = right.cast(leftType.withMayBeNull(rightType.mayBeNull));
+                right = right.cast(leftType.withMayBeNull(rightType.mayBeNull), false);
             }
         }
 
         DBSPExpression binOp = new DBSPConditionalAggregateExpression(
                 node, op, resultType, left.applyCloneIfNeeded(), right.applyCloneIfNeeded(), filter);
-        return binOp.cast(type);
+        return binOp.cast(type, false);
     }
 
     void processMinMax(SqlMinMaxAggFunction function) {
@@ -466,7 +466,7 @@ public class AggregateCompiler implements ICompilerComponent {
                 condition = agg;
             DBSPExpression first = new DBSPIfExpression(
                     node, condition,
-                    this.getAggregatedValue().cast(typedZero.getType()),
+                    this.getAggregatedValue().cast(typedZero.getType(), false),
                     typedZero);
             DBSPExpression second = new DBSPIfExpression(node, condition, one, realZero);
             DBSPExpression mapBody = new DBSPTupleExpression(first, second, one);
@@ -475,7 +475,7 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPExpression postBody = new DBSPIfExpression(node,
                     ExpressionCompiler.makeBinaryExpression(node,
                             DBSPTypeBool.create(false), DBSPOpcode.NEQ, postVar.field(1), realZero),
-                    postVar.field(0).cast(this.nullableResultType), zero);
+                    postVar.field(0).cast(this.nullableResultType, false), zero);
             post = postBody.closure(postVar);
             map = mapBody.closure(this.v);
             this.setResult(new LinearAggregate(node, map, post, zero));
@@ -518,7 +518,7 @@ public class AggregateCompiler implements ICompilerComponent {
             else
                 condition = agg;
             DBSPExpression first = new DBSPIfExpression(
-                    node, condition, this.getAggregatedValue().cast(zero.getType()), zero);
+                    node, condition, this.getAggregatedValue().cast(zero.getType(), false), zero);
             DBSPExpression mapBody = new DBSPTupleExpression(first, one);
             DBSPVariablePath postVar = mapBody.getType().var();
             // post = |x| x.0
@@ -589,7 +589,7 @@ public class AggregateCompiler implements ICompilerComponent {
                 condition = agg;
             DBSPExpression first = new DBSPIfExpression(
                     node, condition,
-                    this.getAggregatedValue().cast(typedZero.getType()),
+                    this.getAggregatedValue().cast(typedZero.getType(), false),
                     typedZero);
             DBSPExpression second = new DBSPIfExpression(node, condition, one, typedZero);
             DBSPExpression mapBody = new DBSPTupleExpression(first, second, one);
@@ -600,7 +600,7 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPExpression postBody = new DBSPIfExpression(node,
                     ExpressionCompiler.makeBinaryExpression(node,
                             DBSPTypeBool.create(false), DBSPOpcode.NEQ, postVar.field(1), typedZero),
-                    div.cast(this.nullableResultType), postZero);
+                    div.cast(this.nullableResultType, false), postZero);
             post = postBody.closure(postVar);
             map = mapBody.closure(this.v);
             return new LinearAggregate(node, map, post, postZero);
@@ -616,7 +616,7 @@ public class AggregateCompiler implements ICompilerComponent {
             final int countIndex = 1;
             DBSPExpression countAccumulator = accumulator.field(countIndex);
             DBSPExpression sumAccumulator = accumulator.field(sumIndex);
-            DBSPExpression aggregatedValue = this.getAggregatedValue().cast(intermediateResultType);
+            DBSPExpression aggregatedValue = this.getAggregatedValue().cast(intermediateResultType, false);
             DBSPType intermediateResultTypeNonNull = intermediateResultType.withMayBeNull(false);
             DBSPExpression plusOne = intermediateResultTypeNonNull.to(IsNumericType.class).getOne();
 
@@ -642,7 +642,7 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPExpression divide = ExpressionCompiler.makeBinaryExpression(
                     node, this.resultType, DBSPOpcode.DIV,
                     a.field(sumIndex), a.field(countIndex));
-            divide = divide.cast(this.nullableResultType);
+            divide = divide.cast(this.nullableResultType, false);
             DBSPClosureExpression post = new DBSPClosureExpression(
                     node, divide, a.asParameter());
             DBSPType semigroup = new DBSPTypeUser(node, SEMIGROUP, "PairSemigroup", false,
@@ -677,7 +677,7 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression sumAccumulator = accumulator.field(sumIndex);
         DBSPExpression sumSquaresAccumulator = accumulator.field(sumSquaresIndex);
 
-        DBSPExpression aggregatedValue = this.getAggregatedValue().cast(intermediateResultType);
+        DBSPExpression aggregatedValue = this.getAggregatedValue().cast(intermediateResultType, false);
         DBSPType intermediateResultTypeNonNull = intermediateResultType.withMayBeNull(false);
         DBSPExpression plusOne = intermediateResultTypeNonNull.to(IsNumericType.class).getOne();
 
@@ -726,14 +726,14 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPType sqrtType = new DBSPTypeDouble(node, this.nullableResultType.mayBeNull);
         DBSPExpression div = ExpressionCompiler.makeBinaryExpression(
                 node, this.nullableResultType, DBSPOpcode.DIV_NULL,
-                sub, denom).cast(sqrtType);
+                sub, denom).cast(sqrtType, false);
         // Prevent sqrt from negative values if computations are unstable
         DBSPExpression max = ExpressionCompiler.makeBinaryExpression(
                 node, sqrtType, DBSPOpcode.MAX,
                 div, sqrtType.to(IsNumericType.class).getZero());
         DBSPExpression sqrt = ExpressionCompiler.compilePolymorphicFunction(
                 "sqrt", node, sqrtType, Linq.list(max), 1);
-        sqrt = sqrt.cast(this.nullableResultType);
+        sqrt = sqrt.cast(this.nullableResultType, false);
         DBSPClosureExpression post = new DBSPClosureExpression(node, sqrt, a.asParameter());
         DBSPExpression postZero = DBSPLiteral.none(this.nullableResultType);
         DBSPType semigroup = new DBSPTypeUser(node, SEMIGROUP, "TripleSemigroup", false,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
@@ -248,6 +248,7 @@ public class CalciteFunctions implements FunctionDocumentation.FunctionRegistry 
             new Func(SqlLibraryOperators.SPLIT_PART, "SPLIT_PART", SqlLibrary.POSTGRESQL, "string#split_part", false),
             new Func(SqlLibraryOperators.GREATEST, "GREATEST", SqlLibrary.BIG_QUERY, "comparisons#greatest", false),
             new Func(SqlLibraryOperators.LEAST, "LEAST", SqlLibrary.BIG_QUERY, "comparisons#least", false),
+            new Func(SqlLibraryOperators.SAFE_CAST, "SAFE_CAST", SqlLibrary.BIG_QUERY, "casts#safe-casts", false),
 
             new Func(SqlLibraryOperators.REGEXP_REPLACE_2, "REGEXP_REPLACE", SqlLibrary.REDSHIFT, "string#regexp_replace", false),
             new Func(SqlLibraryOperators.REGEXP_REPLACE_3, "REGEXP_REPLACE", SqlLibrary.REDSHIFT, "string#regexp_replace", false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
@@ -199,9 +199,9 @@ public class ExternalFunction extends SqlFunction {
             DBSPType functionType = functionBody.getType();
             if (!returnType.sameType(functionType)) {
                 if (returnType.is(DBSPTypeString.class)) {
-                    functionBody = functionBody.cast(returnType);
+                    functionBody = functionBody.cast(returnType, false);
                 } else if (returnType.sameType(functionType.withMayBeNull(true))) {
-                    functionBody = functionBody.cast(returnType);
+                    functionBody = functionBody.cast(returnType, false);
                 } else {
                     throw new CompilationError("Function " + Utilities.singleQuote(this.getName()) +
                             " should return " + Utilities.singleQuote(this.returnType.getFullTypeString()) +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandWriteLog.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandWriteLog.java
@@ -66,8 +66,7 @@ public class ExpandWriteLog extends InnerRewriteVisitor {
                         if (castToStr == null) {
                             DBSPTypeString stringType = new DBSPTypeString(
                                     CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_PRECISION, false, type.mayBeNull);
-                            castToStr = new DBSPCastExpression(
-                                    expression.getNode(), arguments[1], stringType);
+                            castToStr = arguments[1].cast(stringType, false);
                             // do not print argument first time around the loop
                         } else {
                             String printFunction = type.mayBeNull ? "print_opt" : "print";

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -847,7 +847,7 @@ public abstract class InnerRewriteVisitor
         DBSPExpression source = this.transform(expression.source);
         DBSPType type = this.transform(expression.getType());
         this.pop(expression);
-        DBSPExpression result = source.cast(type);
+        DBSPExpression result = source.cast(type, expression.safe);
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -140,7 +140,7 @@ public class Simplify extends InnerRewriteVisitor {
         DBSPExpression source = this.transform(expression.source);
         this.pop(expression);
         DBSPType type = expression.getType();
-        DBSPExpression result = source.cast(type);
+        DBSPExpression result = source.cast(type, expression.safe);
         DBSPLiteral lit = source.as(DBSPLiteral.class);
         if (lit != null) {
             DBSPType litType = lit.getType();
@@ -455,7 +455,7 @@ public class Simplify extends InnerRewriteVisitor {
                 }
             }
         }
-        this.map(expression, result.cast(expression.getType()));
+        this.map(expression, result.cast(expression.getType(), false));
         return VisitDecision.STOP;
     }
 
@@ -542,7 +542,7 @@ public class Simplify extends InnerRewriteVisitor {
                     IsNumericType iLeftType = leftType.to(IsNumericType.class);
                     if (iLeftType.isOne(leftLit)) {
                         // This works even for null
-                        result = right.cast(expression.getType());
+                        result = right.cast(expression.getType(), false);
                     } else if (iLeftType.isZero(leftLit) && !rightMayBeNull) {
                         // This is not true for null values
                         result = left;
@@ -597,7 +597,7 @@ public class Simplify extends InnerRewriteVisitor {
         } catch (ArithmeticException unused) {
             // ignore, defer to runtime
         }
-        this.map(expression, result.cast(expression.getType()));
+        this.map(expression, result.cast(expression.getType(), false));
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/monotone/MonotoneTransferFunctions.java
@@ -579,10 +579,10 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
             if (!lm) {
                 reduced = right.getReducedExpression()
                         // must preserve type
-                        .cast(expression.getType());
+                        .cast(expression.getType(), false);
             } else if (!rm) {
                 reduced = left.getReducedExpression()
-                        .cast(expression.getType());
+                        .cast(expression.getType(), false);
             } else {
                 reduced = expression.replaceSources(
                         left.getReducedExpression(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
@@ -692,7 +692,7 @@ public class ImplementNow extends Passes {
             // Index input by timestamp
             DBSPClosureExpression indexFunction =
                     new DBSPRawTupleExpression(
-                            bounds.common.cast(commonType.withMayBeNull(false)),
+                            bounds.common.cast(commonType.withMayBeNull(false), false),
                             param.asVariable().deref().applyClone()).closure(param);
             DBSPTypeIndexedZSet ix = new DBSPTypeIndexedZSet(operator.getNode(),
                     commonType.withMayBeNull(false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
@@ -92,7 +92,7 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
             e0plus1 = new DBSPBinaryExpression(flatmap.getNode(),
                     new DBSPTypeUSize(CalciteObject.EMPTY, false), DBSPOpcode.ADD,
                     e.field(0),
-                    new DBSPUSizeLiteral(1)).cast(flatmap.ordinalityIndexType);
+                    new DBSPUSizeLiteral(1)).cast(flatmap.ordinalityIndexType, false);
         }
 
         if (flatmap.rightProjections != null) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MinMaxOptimize.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/MinMaxOptimize.java
@@ -124,7 +124,7 @@ public class MinMaxOptimize extends Passes {
 
             DBSPVariablePath inputVar = new DBSPTypeTuple(aggregationInputType).ref().var();
             DBSPClosureExpression init = new DBSPTupleExpression(
-                    inputVar.deref().field(0).applyCloneIfNeeded().cast(resultType))
+                    inputVar.deref().field(0).applyCloneIfNeeded().cast(resultType, false))
                     .closure(inputVar, this.weightVar);
 
             DBSPVariablePath acc = new DBSPTypeTuple(resultType).var();
@@ -132,7 +132,7 @@ public class MinMaxOptimize extends Passes {
                     new DBSPTupleExpression(new DBSPBinaryExpression(operator.getNode(),
                             resultType, code, acc.field(0).applyCloneIfNeeded(),
                             inputVar.deref().field(0).applyCloneIfNeeded())
-                            .cast(resultType))
+                            .cast(resultType, false))
                             .closure(acc, inputVar, this.weightVar);
 
             DBSPSimpleOperator chain = new DBSPChainAggregateOperator(operator.getNode(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -1394,7 +1394,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         DBSPClosureExpression error = new DBSPTupleExpression(
                 new DBSPStringLiteral(tableOrViewName.toString()),
                 new DBSPStringLiteral(DBSPControlledKeyFilterOperator.LATE_ERROR),
-                dataArg.cast(new DBSPTypeVariant(false))).closure(
+                dataArg.cast(new DBSPTypeVariant(false), false)).closure(
                         controlArg.asParameter(), dataParam, valArg.asParameter(), weightArg.asParameter());
         DBSPControlledKeyFilterOperator result = new DBSPControlledKeyFilterOperator(node, closure, error, data, control);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -36,15 +36,19 @@ import org.dbsp.util.IIndentStream;
  * It represents a cast of an expression to a given type. */
 public final class DBSPCastExpression extends DBSPExpression {
     public final DBSPExpression source;
+    /** If true this is a safe cast */
+    public final boolean safe;
 
-    public DBSPCastExpression(CalciteObject node, DBSPExpression source, DBSPType to) {
+    public DBSPCastExpression(CalciteObject node, DBSPExpression source, DBSPType to, boolean safe) {
         super(node, to);
         this.source = source;
+        this.safe = safe;
+        assert !safe || to.mayBeNull;
     }
 
     public DBSPCastExpression replaceSource(DBSPExpression source) {
         assert source.getType().sameType(this.source.getType());
-        return new DBSPCastExpression(this.getNode(), source, this.type);
+        return new DBSPCastExpression(this.getNode(), source, this.type, this.safe);
     }
 
     @Override
@@ -64,6 +68,7 @@ public final class DBSPCastExpression extends DBSPExpression {
         if (o == null)
             return false;
         return this.source == o.source &&
+                this.safe == o.safe &&
                 this.hasSameType(o);
     }
 
@@ -78,7 +83,7 @@ public final class DBSPCastExpression extends DBSPExpression {
 
     @Override
     public DBSPExpression deepCopy() {
-        return new DBSPCastExpression(this.getNode(), this.source.deepCopy(), this.getType());
+        return new DBSPCastExpression(this.getNode(), this.source.deepCopy(), this.getType(), this.safe);
     }
 
     @Override
@@ -87,6 +92,7 @@ public final class DBSPCastExpression extends DBSPExpression {
         if (otherExpression == null)
             return false;
         return context.equivalent(this.source, otherExpression.source) &&
+                this.safe == otherExpression.safe &&
                 this.hasSameType(other);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -171,7 +171,7 @@ public abstract class DBSPExpression
         return new DBSPApplyMethodExpression(method, resultType, this, arguments);
     }
 
-    public DBSPExpression cast(DBSPType to, boolean force) {
+    public DBSPExpression cast(DBSPType to, boolean force, boolean safe) {
         DBSPType fromType = this.getType();
         // Still, do not insert a cast if the source is a cast to the exact same type
         if (this.is(DBSPCastExpression.class)
@@ -180,21 +180,21 @@ public abstract class DBSPExpression
         if (fromType.sameType(to) && !force) {
             return this;
         }
-        return new DBSPCastExpression(this.getNode(), this, to);
+        return new DBSPCastExpression(this.getNode(), this, to, safe);
     }
 
     /** Cast an expression to its own type, but nullable */
     public DBSPExpression castToNullable() {
         if (this.getType().mayBeNull)
             return this;
-        return this.cast(this.getType().withMayBeNull(true));
+        return this.cast(this.getType().withMayBeNull(true), false);
     }
 
-    public DBSPExpression cast(DBSPType to) {
+    public DBSPExpression cast(DBSPType to, boolean safe) {
         boolean force = type.is(DBSPTypeDecimal.class);
         // Computations on decimal values in Rust do not produce the correct result type,
         // so they must be always cast
-        return this.cast(to, force);
+        return this.cast(to, force, safe);
     }
 
     public DBSPExpression applyCloneIfNeeded() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
@@ -131,7 +131,7 @@ public final class DBSPTupleExpression extends DBSPBaseTupleExpression {
                     + " to " + destType + " with " + destType.size() + " fields", this);
         return new DBSPTupleExpression(
                 Linq.zip(Objects.requireNonNull(this.fields), destType.tupFields,
-                        DBSPExpression::cast, DBSPExpression.class));
+                        (e, t) -> e.cast(t, false), DBSPExpression.class));
     }
 
     public DBSPTupleExpression slice(int start, int endExclusive) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
@@ -137,7 +137,7 @@ public final class DBSPZSetExpression extends DBSPExpression
 
     public DBSPExpression castRecursive(DBSPExpression expression, DBSPType type) {
         if (type.is(DBSPTypeBaseType.class)) {
-            return expression.cast(type);
+            return expression.cast(type, false);
         } else if (type.is(DBSPTypeVec.class)) {
             DBSPTypeVec vec = type.to(DBSPTypeVec.class);
             DBSPVecExpression vecLit = expression.to(DBSPVecExpression.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
@@ -173,7 +173,7 @@ public abstract class DBSPType extends DBSPNode implements IDBSPInnerNode {
     }
 
     /** Returns a lambda which casts the current type to the specified type. */
-    public DBSPClosureExpression caster(DBSPType to) {
+    public DBSPClosureExpression caster(DBSPType to, boolean safe) {
         if (this.sameType(to)) {
             DBSPVariablePath var = this.ref().var();
             return var.deref().applyCloneIfNeeded().closure(var);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRawTuple.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRawTuple.java
@@ -112,16 +112,16 @@ public class DBSPTypeRawTuple extends DBSPTypeTupleBase {
      * @return A closure that casts every member of a tuple to
      * generate a raw tuple of this type. */
     @Override
-    public DBSPClosureExpression caster(DBSPType to) {
+    public DBSPClosureExpression caster(DBSPType to, boolean safe) {
         if (!to.is(DBSPTypeRawTuple.class))
-            return super.caster(to);  // throw
+            return super.caster(to, safe);  // throw
         DBSPTypeRawTuple tuple = to.to(DBSPTypeRawTuple.class);
         if (tuple.size() != this.size())
-            return super.caster(to);  // throw
+            return super.caster(to, safe);  // throw
         DBSPVariablePath var = this.ref().var();
         DBSPExpression[] casts = new DBSPExpression[this.tupFields.length];
         for (int i = 0; i < this.tupFields.length; i++) {
-            casts[i] = this.tupFields[i].caster(tuple.tupFields[i]);
+            casts[i] = this.tupFields[i].caster(tuple.tupFields[i], safe);
             casts[i] = casts[i].call(var.deref().field(i));
         }
         return new DBSPRawTupleExpression(casts).closure(var);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
@@ -135,16 +135,16 @@ public class DBSPTypeTuple extends DBSPTypeTupleBase {
     /** Returns a lambda which casts every field of a tuple
      * to the corresponding field of this type. */
     @Override
-    public DBSPClosureExpression caster(DBSPType to) {
+    public DBSPClosureExpression caster(DBSPType to, boolean safe) {
         if (!to.is(DBSPTypeTuple.class))
-            return super.caster(to);  // throw
+            return super.caster(to, safe);  // throw
         DBSPTypeTuple tuple = to.to(DBSPTypeTuple.class);
         if (tuple.size() != this.size())
-            return super.caster(to);  // throw
+            return super.caster(to, safe);  // throw
         DBSPVariablePath var = this.ref().var();
         DBSPExpression[] casts = new DBSPExpression[this.tupFields.length];
         for (int i = 0; i < this.tupFields.length; i++) {
-            casts[i] = this.tupFields[i].caster(tuple.tupFields[i]);
+            casts[i] = this.tupFields[i].caster(tuple.tupFields[i], safe);
             casts[i] = casts[i].call(var.deepCopy().deref().field(i));
         }
         return new DBSPTupleExpression(casts).closure(var);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
@@ -45,9 +45,9 @@ public abstract class DBSPTypeBaseType extends DBSPType {
     }
 
     @Override
-    public DBSPClosureExpression caster(DBSPType to) {
+    public DBSPClosureExpression caster(DBSPType to, boolean safe) {
         DBSPVariablePath var = this.var();
-        return var.cast(to).applyCloneIfNeeded().closure(var);
+        return var.cast(to, safe).applyCloneIfNeeded().closure(var);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -182,13 +182,14 @@ public class FunctionsTest extends SqlIoTest {
 
     @Test
     public void issue1180() {
-        this.runtimeConstantFail("SELECT '1_000'::INT4", "Could not parse");
+        this.runtimeConstantFail("SELECT '1_000'::INT4",
+                "invalid digit found in string");
     }
 
     @Test
     public void issue1192() {
-        this.runtimeConstantFail("select '-9223372036854775809'::int64", "Could not parse");
-        this.runtimeConstantFail("select '9223372036854775808'::int64", "Could not parse");
+        this.runtimeConstantFail("select '-9223372036854775809'::int64", "number too small to fit in target type");
+        this.runtimeConstantFail("select '9223372036854775808'::int64", "number too large to fit in target type");
     }
 
     // this is an edge case for negative integer modulo
@@ -511,18 +512,18 @@ public class FunctionsTest extends SqlIoTest {
     @Test
     public void testDecimalErrors() {
         this.runtimeConstantFail("select cast(1234.1234 AS DECIMAL(6, 3))",
-                "cannot represent 1234.123 as DECIMAL(6, 3): precision of DECIMAL type too small to represent value");
+                "Cannot represent 1234.123 as DECIMAL(6, 3): precision of DECIMAL type too small to represent value");
         this.runtimeConstantFail("select cast(1234.1236 AS DECIMAL(6, 3))",
-                "cannot represent 1234.123 as DECIMAL(6, 3): precision of DECIMAL type too small to represent value");
+                "Cannot represent 1234.123 as DECIMAL(6, 3): precision of DECIMAL type too small to represent value");
         this.runtimeConstantFail("select cast(143.481 as decimal(2, 1))",
-                "cannot represent 143.4 as DECIMAL(2, 1): precision of DECIMAL type too small to represent value");
+                "Cannot represent 143.4 as DECIMAL(2, 1): precision of DECIMAL type too small to represent value");
         this.q("""
                 select cast(99.6 as decimal(2, 0));
                  result
                 --------
                  99""");
         this.runtimeConstantFail("select cast(-13.4 as decimal(2,1))",
-                "cannot represent -13.4 as DECIMAL(2, 1)");
+                "Cannot represent -13.4 as DECIMAL(2, 1)");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/DateFormatsTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/DateFormatsTests.java
@@ -85,7 +85,7 @@ public class DateFormatsTests extends SqlIoTest {
     public void testIncorrectOrder() {
         // Returns NULL in MySQL
         this.runtimeConstantFail("SELECT format_date(1151414896, '%Y-%m-%d %H:%i:%s')",
-                "Could not parse string '%Y-%m-%d %H:%i:%s' as a Date");
+                "input contains invalid characters");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresFloat8Tests.java
@@ -857,8 +857,8 @@ FROM (SELECT 10*cosd(a), 10*sind(a)
 
     @Test
     public void castToInt() {
-        this.qf("SELECT '32768.6'::double::int2", "out of range");
-        this.qf("SELECT '-9223372036854780000'::float8::int8", "out of range");
+        this.qf("SELECT '32768.6'::double::int2", "Cannot convert");
+        this.qf("SELECT '-9223372036854780000'::float8::int8", "Cannot convert");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt8Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresInt8Tests.java
@@ -539,19 +539,20 @@ public class PostgresInt8Tests extends SqlIoTest {
 
     @Test
     public void testOutOfRangeCast() {
-        this.runtimeConstantFail("select '-9223372036854775809'::int64", "Could not parse");
-        this.runtimeConstantFail("select '9223372036854775808'::int64", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('4567890123456789' AS int4)", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('4567890123456789' AS int2)", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('+4567890123456789' AS int4)", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('+4567890123456789' AS int2)", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('-4567890123456789' AS int4)", "Could not parse");
-        this.runtimeConstantFail("SELECT CAST('-4567890123456789' AS int2)", "Could not parse");
+        this.runtimeConstantFail("select '-9223372036854775809'::int64", "number too small to fit");
+        this.runtimeConstantFail("select '9223372036854775808'::int64", "number too large to fit");
+        this.runtimeConstantFail("SELECT CAST('4567890123456789' AS int4)", "number too large to fit");
+        this.runtimeConstantFail("SELECT CAST('4567890123456789' AS int2)", "number too large to fit");
+        this.runtimeConstantFail("SELECT CAST('+4567890123456789' AS int4)", "number too large to fit");
+        this.runtimeConstantFail("SELECT CAST('+4567890123456789' AS int2)", "number too large to fit");
+        this.runtimeConstantFail("SELECT CAST('-4567890123456789' AS int4)", "number too small to fit");
+        this.runtimeConstantFail("SELECT CAST('-4567890123456789' AS int2)", "number too small to fit");
     }
 
     @Test
     public void issue1199() {
-        this.runtimeConstantFail("SELECT CAST('922337203685477580700.0'::float8 AS int64)", "out of range for type");
+        this.runtimeConstantFail("SELECT CAST('922337203685477580700.0'::float8 AS int64)",
+                "Cannot convert 922337203685477600000 to BIGINT");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
@@ -79,8 +79,7 @@ public class CastTests extends SqlIoTest {
 
     @Test
     public void testTinyInt() {
-        String query = "SELECT CAST(256 AS TINYINT)";
-        this.runtimeConstantFail(query, "Value '256' out of range for type");
+        this.runtimeConstantFail("SELECT CAST(256 AS TINYINT)", "out of range integral type conversion attempted");
     }
 
     @Test
@@ -118,7 +117,7 @@ public class CastTests extends SqlIoTest {
     @Test
     public void decimalOutOfRange() {
         this.runtimeFail("SELECT CAST(100103123 AS DECIMAL(10, 4))",
-                "cannot represent 100103123 as DECIMAL(10, 4)",
+                "Cannot represent 100103123 as DECIMAL(10, 4)",
                 this.streamWithEmptyChanges());
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -742,7 +742,7 @@ public class EndToEndTests extends BaseSQLTests {
     @Test
     public void divZero0() {
         String query = "SELECT 'Infinity' / 0";
-        this.runtimeConstantFail(query, "Could not parse");
+        this.runtimeConstantFail(query, "invalid digit found in string");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -72,7 +72,7 @@ public class ProfilingTests extends StreamingTestBase {
                 use feldera_sqllib::{
                     append_to_collection_handle,
                     read_output_handle,
-                    casts::cast_to_Timestamp_s,
+                    casts::{cast_to_Timestamp_s,unwrap_cast},
                 };
 
                 use std::{
@@ -177,7 +177,7 @@ public class ProfilingTests extends StreamingTestBase {
         // Rust program which profiles the circuit.
         String main = this.createMain("""
                     // Initial data value for timestamp
-                    let mut timestamp = cast_to_Timestamp_s("2024-01-10 10:10:10".to_string());
+                    let mut timestamp = unwrap_cast(cast_to_Timestamp_s("2024-01-10 10:10:10".to_string()));
                     for i in 0..1000000 {
                         let value = Some(F64::new(i.into()));
                         timestamp = timestamp.add(20000);
@@ -236,7 +236,7 @@ public class ProfilingTests extends StreamingTestBase {
         // Rust program which profiles the circuit.
         String main = this.createMain("""
                     // Initial data value for timestamp
-                    let mut timestamp = cast_to_Timestamp_s("2024-01-10 10:10:10".to_string());
+                    let mut timestamp = unwrap_cast(cast_to_Timestamp_s("2024-01-10 10:10:10".to_string()));
                     for i in 0..1000000 {
                         let expire = timestamp.add(1000000);
                         timestamp = timestamp.add(20000);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -276,6 +276,7 @@ public class BaseSQLTests {
         options.languageOptions.generateInputForEveryTable = true;
         options.ioOptions.quiet = true;
         options.ioOptions.emitHandles = true;
+        options.ioOptions.verbosity = 1;
         options.languageOptions.incrementalize = incremental;
         options.languageOptions.unrestrictedIOTypes = true;
         options.languageOptions.optimizationLevel = optimize ? 2 : 1;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
@@ -156,7 +156,8 @@ public class TestCase {
                     for (int index = 0; index < tuple.size(); index++) {
                         DBSPType fieldType = tuple.getFieldType(index);
                         if (fieldType.is(DBSPTypeFP.class)) {
-                            converted[index] = var.deref().field(index).cast(DBSPTypeString.varchar(fieldType.mayBeNull));
+                            converted[index] = var.deref().field(index)
+                                    .cast(DBSPTypeString.varchar(fieldType.mayBeNull), false);
                             foundFp = true;
                         } else {
                             converted[index] = var.deref().field(index).applyCloneIfNeeded();

--- a/sql-to-dbsp-compiler/lib/sltsqlvalue/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sltsqlvalue/src/lib.rs
@@ -243,7 +243,9 @@ impl SqlLogicTestFormat for SltSqlValue {
             (SltSqlValue::OptStr(None), 'T') => String::from("NULL"),
             (SltSqlValue::OptStr(Some(x)), 'T') => slt_translate_string(x),
             (SltSqlValue::OptStr(None), 'I') => String::from("NULL"),
-            (SltSqlValue::OptStr(Some(x)), 'I') => format!("{}", cast_to_i32_s(x.clone())),
+            (SltSqlValue::OptStr(Some(x)), 'I') => {
+                format!("{}", unwrap_cast(cast_to_i32_s(x.clone())))
+            }
 
             (SltSqlValue::OptBool(None), _) => String::from("NULL"),
             (SltSqlValue::Bool(b), _) => format!("{}", b),

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -255,7 +255,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             else
                 throw new RuntimeException("Unexpected type " + colType);
             if (!colType.sameType(field.getType()))
-                field = field.cast(colType);
+                field = field.cast(colType, false);
             fields.add(field);
             col++;
             if (col == outputElementType.size()) {


### PR DESCRIPTION
This implements the `SAFE_CAST` SQL construct, which never crashes the program when a cast cannot be performed, but returns `NULL` instead.

This is a very large PR, because it touches all the cast library functions, and there are perhaps 1000 of them.
After this change, the difference between a standard cast and a safe cast is that the standard cast unwraps the Result (using `unwrap_cast` library function), whereas the safe cast converts Err into None (using `unwrap_safe_cast`. (By definition all safe casts must return nullable values).

The cast library functions are all changed to return `Result<T, Error>` instead of `T` (which is now defined as being `SqlResult<T>`)
This is a necessary step towards making programs never crash at runtime.
When we implement the non-crash behavior we also have to 
- change all other library functions to return `SqlResult<T>`
- change all library functions (including the casts that have been changed now) to also take `SqlResult<T>` as arguments.