### PR TITLE
[dbsp] API to GC linear aggregates.

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -78,6 +78,33 @@ public final class DBSPCircuit extends DBSPNode
         this.allOperators.sort(comparator);
     }
 
+    /** Sort the nodes to be compatible with a topological order
+     * on the specified graph.
+     * @param graph Topological order to enforce.
+     *              Mutated by the method. */
+    public void resort(CircuitGraph graph) {
+        this.allOperators.clear();
+        DBSPOperator previous = null;
+        for (DBSPSourceTableOperator source: this.sourceOperators.values()) {
+            if (previous != null) {
+                // Preserve the input order
+                graph.addEdge(previous, source, 0);
+            }
+            previous = source;
+        }
+
+        previous = null;
+        for (DBSPSinkOperator sink: this.sinkOperators.values()) {
+            if (previous != null) {
+                // Preserve the output order
+                graph.addEdge(previous, sink, 0);
+            }
+            previous = sink;
+        }
+        for (DBSPOperator op: graph.sort())
+            this.allOperators.add(op);
+    }
+
     /** @return the names of the input tables.
      * The order of the tables corresponds to the inputs of the generated circuit. */
     public Set<ProgramIdentifier> getInputTables() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateLinearPostprocessRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAggregateLinearPostprocessRetainKeysOperator.java
@@ -1,0 +1,69 @@
+package org.dbsp.sqlCompiler.circuit.operator;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class DBSPAggregateLinearPostprocessRetainKeysOperator extends DBSPBinaryOperator {
+    public final DBSPClosureExpression postProcess;
+    public final DBSPClosureExpression retainKeysFunction;
+
+    // This operator is incremental-only
+    public DBSPAggregateLinearPostprocessRetainKeysOperator(
+            CalciteObject node,
+            DBSPTypeIndexedZSet outputType,
+            DBSPExpression function,
+            DBSPClosureExpression postProcess,
+            DBSPClosureExpression retainKeysFunction,
+            OutputPort left, OutputPort right) {
+        super(node, "aggregate_linear_postprocess_retain_keys",
+                function, outputType, false, left, right);
+        this.postProcess = postProcess;
+        this.retainKeysFunction = retainKeysFunction;
+    }
+
+    @Override
+    public void accept(CircuitVisitor visitor) {
+        visitor.push(this);
+        VisitDecision decision = visitor.preorder(this);
+        if (!decision.stop())
+            visitor.postorder(this);
+        visitor.pop(this);
+    }
+
+    @Override
+    public DBSPSimpleOperator withFunction(@Nullable DBSPExpression expression, DBSPType outputType) {
+        throw new InternalCompilerError("Should not be called");
+    }
+
+    @Override
+    public DBSPSimpleOperator withInputs(List<OutputPort> newInputs, boolean force) {
+        if (force || this.inputsDiffer(newInputs))
+            return new DBSPAggregateLinearPostprocessRetainKeysOperator(
+                    this.getNode(), this.outputType.to(DBSPTypeIndexedZSet.class),
+                    this.getFunction(), this.postProcess, this.retainKeysFunction,
+                    newInputs.get(0), newInputs.get(1))
+                    .copyAnnotations(this);
+        return this;
+    }
+
+    @Override
+    public boolean equivalent(DBSPOperator other) {
+        if (!super.equivalent(other))
+            return false;
+        DBSPAggregateLinearPostprocessRetainKeysOperator agg =
+                other.to(DBSPAggregateLinearPostprocessRetainKeysOperator.class);
+        return this.getFunction().equivalent(agg.getFunction()) &&
+                this.postProcess.equivalent(agg.postProcess) &&
+                this.retainKeysFunction.equivalent(agg.retainKeysFunction);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
@@ -138,4 +138,13 @@ public final class DBSPControlledKeyFilterOperator extends DBSPOperatorWithError
                 .append(this.error)
                 .append(");");
     }
+
+    @Override
+    public String toString() {
+        return this.getClass()
+                .getSimpleName()
+                .replace("DBSP", "")
+                .replace("Operator", "")
+                + " " + this.getIdString();
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -462,12 +462,14 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
                     this.messages.reportError((BaseCompilerException) e.getCause());
                 } else {
                     this.messages.reportError(e);
+                    this.rethrow(new RuntimeException(e), SqlParserPos.ZERO);
                 }
             } catch (CalciteException e) {
                 this.messages.reportError(e);
+                this.rethrow(e, SqlParserPos.ZERO);
             } catch (Throwable e) {
                 this.messages.reportError(e);
-                this.printMessages(SqlParserPos.ZERO);
+                this.rethrow(new RuntimeException(e), SqlParserPos.ZERO);
                 parsed.clear();
             }
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -409,6 +409,11 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
     }
 
     @Override
+    public void postorder(DBSPAggregateLinearPostprocessRetainKeysOperator operator) {
+        this.replace(operator);
+    }
+
+    @Override
     public void postorder(DBSPDeindexOperator operator) { this.replace(operator); }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraph.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraph.java
@@ -6,6 +6,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.util.IHasId;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.ToIndentableString;
+import org.dbsp.util.graph.DFSOrder;
 import org.dbsp.util.graph.DiGraph;
 import org.dbsp.util.graph.Port;
 import org.dbsp.util.Utilities;
@@ -47,7 +48,7 @@ public class CircuitGraph implements DiGraph<DBSPOperator>, IHasId, ToIndentable
         assert this.circuit.contains(node);
     }
 
-    void addEdge(DBSPOperator source, DBSPOperator dest, int input) {
+    public void addEdge(DBSPOperator source, DBSPOperator dest, int input) {
         if (!this.nodeSet.contains(source)) {
             throw new RuntimeException(
                     "Adding edge from node " + source + " to " + dest +
@@ -117,5 +118,11 @@ public class CircuitGraph implements DiGraph<DBSPOperator>, IHasId, ToIndentable
             }
         }
         return builder.decrease().append("}");
+    }
+
+    /** Return a topological sort of this graph */
+    public Iterable<DBSPOperator> sort() {
+        DFSOrder<DBSPOperator> dfs = new DFSOrder<>(this);
+        return dfs.reversePost();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -95,9 +95,10 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         passes.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
         passes.add(new MonotoneAnalyzer(compiler));
         passes.add(new RemoveTable(compiler, DBSPCompiler.ERROR_TABLE_NAME));
-
         // The circuit is complete here, start optimizing for real.
         // Doing this after the monotone analysis only
+
+        passes.add(new LinearPostprocessRetainKeys(compiler));
         if (!options.ioOptions.emitHandles)
             passes.add(new IndexedInputs(compiler));
         passes.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -24,6 +24,7 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
@@ -315,6 +316,31 @@ public class CircuitRewriter extends CircuitCloneVisitor {
                 || function != operator.function) {
             result = new DBSPAggregateLinearPostprocessOperator(operator.getNode(),
                     outputType.to(DBSPTypeIndexedZSet.class), function, postProcess.to(DBSPClosureExpression.class), input)
+                    .copyAnnotations(operator);
+        }
+        this.map(operator, result);
+    }
+
+    @Override
+    public void postorder(DBSPAggregateLinearPostprocessRetainKeysOperator operator) {
+        DBSPType outputType = this.transform(operator.outputType);
+        DBSPExpression function = this.transform(operator.getFunction());
+        DBSPExpression postProcess = this.transform(operator.postProcess);
+        DBSPExpression retainKeysFunction = this.transform(operator.retainKeysFunction);
+        OutputPort left = this.mapped(operator.left());
+        OutputPort right = this.mapped(operator.right());
+        DBSPSimpleOperator result = operator;
+        if (!outputType.sameType(operator.outputType)
+                || !left.equals(operator.left())
+                || !right.equals(operator.right())
+                || postProcess != operator.postProcess
+                || retainKeysFunction != operator.retainKeysFunction
+                || function != operator.function) {
+            result = new DBSPAggregateLinearPostprocessRetainKeysOperator(operator.getNode(),
+                    outputType.to(DBSPTypeIndexedZSet.class), function,
+                    postProcess.to(DBSPClosureExpression.class),
+                    retainKeysFunction.to(DBSPClosureExpression.class),
+                    left, right)
                     .copyAnnotations(operator);
         }
         this.map(operator, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -227,6 +227,10 @@ public abstract class CircuitVisitor
         return this.preorder((DBSPUnaryOperator) node);
     }
 
+    public VisitDecision preorder(DBSPAggregateLinearPostprocessRetainKeysOperator node) {
+        return this.preorder((DBSPBinaryOperator) node);
+    }
+
     public VisitDecision preorder(DBSPPartitionedRollingAggregateOperator node) {
         return this.preorder((DBSPAggregateOperatorBase) node);
     }
@@ -480,6 +484,10 @@ public abstract class CircuitVisitor
 
     public void postorder(DBSPAggregateLinearPostprocessOperator node) {
         this.postorder((DBSPUnaryOperator) node);
+    }
+
+    public void postorder(DBSPAggregateLinearPostprocessRetainKeysOperator node) {
+        this.postorder((DBSPBinaryOperator) node);
     }
 
     public void postorder(DBSPPartitionedRollingAggregateOperator node) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LinearPostprocessRetainKeys.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LinearPostprocessRetainKeys.java
@@ -1,0 +1,106 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.apache.calcite.util.Pair;
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.util.IWritesLogs;
+import org.dbsp.util.graph.Port;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Replaces the following pattern:
+ * {@link org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator} followed by
+ * {@link org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator} by a
+ * {@link org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator} operator
+ * followed by the same integrator.
+ *
+ * <P>This is harder than it looks, because the operators in the result graph must be
+ * sorted in topological order, which may not be the same as in the original graph.
+ * In the result graph there is an edge from the waterline of the RetainKeys operator
+ * to the Aggregate operator, which does not exist in the original graph. */
+public class LinearPostprocessRetainKeys implements CircuitTransform, IWritesLogs {
+    final DBSPCompiler compiler;
+
+    public LinearPostprocessRetainKeys(DBSPCompiler compiler) {
+        this.compiler = compiler;
+    }
+
+    /** Does the actual replacement work */
+    static class ReplaceLinear extends CircuitCloneWithGraphsVisitor {
+        ReplaceLinear(DBSPCompiler compiler, CircuitGraphs graphs) {
+            super(compiler, graphs, false);
+        }
+
+        @Override
+        public void postorder(DBSPAggregateLinearPostprocessOperator operator) {
+            List<Port<DBSPOperator>> destinations = this.getGraph().getSuccessors(operator);
+            for (Port<DBSPOperator> port : destinations) {
+                if (port.node().is(DBSPIntegrateTraceRetainKeysOperator.class)) {
+                    DBSPIntegrateTraceRetainKeysOperator integrator = port.node()
+                            .to(DBSPIntegrateTraceRetainKeysOperator.class);
+                    OutputPort left = this.mapped(operator.input());
+                    // Because we sorted the graph we know that this has already been processed
+                    OutputPort right = this.mapped(integrator.right());
+                    DBSPAggregateLinearPostprocessRetainKeysOperator replacement =
+                            new DBSPAggregateLinearPostprocessRetainKeysOperator(operator.getNode(),
+                                    operator.getOutputIndexedZSetType(),
+                                    operator.getFunction(),
+                                    operator.postProcess,
+                                    integrator.getClosureFunction(),
+                                    left, right);
+                    this.map(operator, replacement);
+                    return;
+                }
+            }
+            super.postorder(operator);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "LinearPostprocessRetainKeys";
+    }
+
+    @Override
+    public DBSPCircuit apply(DBSPCircuit circuit) {
+        Graph graphs = new Graph(this.compiler);
+        graphs.apply(circuit);
+        CircuitGraph graph = graphs.graphs.getGraph(circuit);
+
+        // We are not doing recursive components now
+        List<Pair<DBSPOperator, DBSPOperator>> toAdd = new ArrayList<>();
+        for (DBSPOperator op: circuit.allOperators) {
+            List<Port<DBSPOperator>> destinations = graph.getSuccessors(op);
+            if (op.is(DBSPAggregateLinearPostprocessOperator.class)) {
+                for (Port<DBSPOperator> port : destinations) {
+                    if (port.node().is(DBSPIntegrateTraceRetainKeysOperator.class)) {
+                        DBSPIntegrateTraceRetainKeysOperator integrator = port.node()
+                                .to(DBSPIntegrateTraceRetainKeysOperator.class);
+                        // Place a dependence in the graph between the integrator's right input
+                        // and the aggregate node.  We cannot modify the graph while we iterate on it.
+                        toAdd.add(new Pair<>(integrator.right().node(), op));
+                    }
+                }
+            }
+        }
+
+        for (var p: toAdd)
+            graph.addEdge(p.left, p.right, 0);
+        circuit.resort(graph);
+
+        graphs.apply(circuit);
+        ReplaceLinear replace = new ReplaceLinear(this.compiler, graphs.getGraphs());
+        return replace.apply(circuit);
+    }
+
+    @Override
+    public String toString() {
+        return this.getName();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RemoveTable.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RemoveTable.java
@@ -30,6 +30,6 @@ public class RemoveTable extends CircuitCloneVisitor {
 
     @Override
     public String toString() {
-        return super.toString() + " " + this.tableName.singleQuote();
+        return super.toString() + "-" + this.tableName;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/ExpandOperators.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer.expansion;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
@@ -38,6 +39,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitCloneVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity.KeyPropagation;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
@@ -219,6 +221,12 @@ public class ExpandOperators extends CircuitCloneVisitor {
     public void postorder(DBSPAggregateLinearPostprocessOperator operator) {
         // This is not true, but we don't care here about the internal structure
         this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAggregateLinearPostprocessRetainKeysOperator operator) {
+        throw new UnsupportedException("These operators should not have been introduced yet",
+                operator.getNode());
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DFSOrder.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DFSOrder.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 /** Computes depth-first order of a graph */
-class DFSOrder<Node> {
+public class DFSOrder<Node> {
     final Set<Node> marked;
     final Map<Node, Integer> post;
     final List<Node> preorder;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -125,21 +125,21 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         String str = circuit.toString();
         String expected = """
                 Circuit circuit {
-                    // DBSPSourceMultisetOperator s0
+                    // DBSPConstantOperator s0
+                    let s0: stream<WSet<Tup3<s, s, VARIANT>>> = (zset!());
+                    // DBSPSourceMultisetOperator s1
                     // CREATE TABLE `t` (`col1` INTEGER NOT NULL, `col2` DOUBLE NOT NULL, `col3` BOOLEAN NOT NULL, `col4` VARCHAR NOT NULL, `col5` INTEGER, `col6` DOUBLE)
-                    let s0 = t();
-                    // DBSPMapOperator s1
-                    let s1: stream<WSet<Tup1<b>>> = s0.map((|t_3: &Tup6<i32, d, b, s, i32?, d?>| Tup1::new(((*t_3).2), )));
+                    let s1 = t();
+                    // DBSPMapOperator s2
+                    let s2: stream<WSet<Tup1<b>>> = s1.map((|t_3: &Tup6<i32, d, b, s, i32?, d?>| Tup1::new(((*t_3).2), )));
                     // CREATE VIEW `v` AS
                     // SELECT `t`.`col3`
                     // FROM `schema`.`t` AS `t`
-                    let s2: stream<WSet<Tup1<b>>> = s1;
-                    // DBSPConstantOperator s3
-                    let s3: stream<WSet<Tup3<s, s, VARIANT>>> = (zset!());
+                    let s3: stream<WSet<Tup1<b>>> = s2;
                     // CREATE VIEW `error_view` AS
                     // SELECT `error_table`.`table_or_view_name`, `error_table`.`message`, `error_table`.`metadata`
                     // FROM `schema`.`error_table` AS `error_table`
-                    let s4: stream<WSet<Tup3<s, s, VARIANT>>> = s3;
+                    let s4: stream<WSet<Tup3<s, s, VARIANT>>> = s0;
                 }
                 """;
         Assert.assertEquals(expected, str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -1702,7 +1702,7 @@ public class RegressionTests extends SqlIoTest {
                 CAST((c2) AS VARCHAR) AS c2
                 FROM double_tbl;""");
         ccs.step("""
-                INSERT INTO double_tbl values(" +
+                INSERT INTO double_tbl values(
                    (-34567891.312, 98765432.12),
                    (8765432.147, -2344579.923));""", """
                  c1            |            c2 | weight

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
@@ -867,7 +867,8 @@ INSERT INTO auction VALUES(101, 'item-name', 'description', 5, 10, '2020-01-01 0
         CircuitVisitor v = new CircuitVisitor(ccs.compiler) {
             @Override
             public VisitDecision preorder(DBSPSimpleOperator node) {
-                assert !node.operation.contains("aggregate") || node.operation.equals("aggregate_linear_postprocess");
+                assert !node.operation.contains("aggregate") ||
+                       node.operation.equals("aggregate_linear_postprocess_retain_keys");
                 return super.preorder(node);
             }
         };


### PR DESCRIPTION
Fixes #3344.

Linear aggregation operators create an internal integral of the weighted stream, which is not exposed outside the operator and therefore cannot get GC'd using `integrate_trace_retain_keys`. This integral is usually small, but if the number of groups grows over time, it can keep growing unbounded. To fix this, we add a version of linear aggregation operators that take waterline as an extra argument and apply it to the internal aggregate.