### PR TITLE
s3: pass an endpoint_url argument to interact with non-AWS services

### DIFF
--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -478,8 +478,13 @@ impl<T> BufferedReceiver<T> {
 }
 
 fn to_s3_config(config: &Arc<S3InputConfig>) -> aws_sdk_s3::Config {
-    let config_builder =
-        aws_sdk_s3::Config::builder().region(aws_types::region::Region::new(config.region.clone()));
+    let config_builder = if let Some(endpoint) = &config.endpoint_url {
+        aws_sdk_s3::Config::builder()
+            .region(aws_types::region::Region::new(config.region.clone()))
+            .endpoint_url(endpoint)
+    } else {
+        aws_sdk_s3::Config::builder().region(aws_types::region::Region::new(config.region.clone()))
+    };
     if config.no_sign_request {
         config_builder.build()
     } else {

--- a/crates/feldera-types/src/transport/s3.rs
+++ b/crates/feldera-types/src/transport/s3.rs
@@ -25,4 +25,8 @@ pub struct S3InputConfig {
 
     /// S3 bucket name to access.
     pub bucket_name: String,
+
+    /// The endpoint URL used to communicate with this service. Can be used to make this connector
+    /// talk to non-AWS services with an S3 API.
+    pub endpoint_url: Option<String>,
 }

--- a/docs/connectors/sources/s3.md
+++ b/docs/connectors/sources/s3.md
@@ -1,4 +1,4 @@
-# AWS S3 input connector
+# S3 input connector
 
 :::note
 This page describes configuration options specific to the S3 input connector.
@@ -6,9 +6,10 @@ See [top-level connector documentation](/connectors/) for general information
 about configuring input and output connectors.
 :::
 
-The AWS S3 input connector is used to load data from an S3 bucket to a Feldera table.
+The S3 input connector is used to load data from an S3 bucket to a Feldera table.
 It can be configured to load a single object or multiple objects selected based on a
-common S3 prefix.
+common S3 prefix. By setting the `endpoint_url`, you can also read from non-AWS services 
+that offer S3 compatible APIs.
 
 :::tip
 When accessing an S3 bucket that stores data in the Delta Lake or Iceberg format, consider
@@ -29,6 +30,7 @@ The S3 input connector supports [fault tolerance](..#fault-tolerance).
 | `prefix`                      | string |            | Read all objects whose keys match a prefix. Set to an empty string to read all objects in the bucket. Either this property or the `key` property must be set. |
 | `region`*                     | string |            | AWS region. |
 | `bucket_name`*                | string |            | S3 bucket name. |
+| `endpoint_url`                | string |            | The endpoint URL used to communicate with this service. Explicitly set it to connect to non-AWS services. For example, use `https://storage.googleapis.com` to interact with Google Cloud Storage. |
 | `streaming`                   | bool   | `false`    | Determines how the connector ingests an individual S3 object. When `true`, the connector pushes the object to the pipeline chunk-by-chunk, so that the pipeline can parse and process initial chunks of the object before the entire object has been retrieved. This mode is suitable for streaming formats such as newline-delimited JSON. When `false`, the connector buffers the entire object in memory and pushes it to the pipeline as a single chunk. Appropriate for formats like Parquet that cannot be streamed.|
 
 *Fields marked with an asterisk are required.
@@ -72,6 +74,33 @@ CREATE TABLE vendor (
             "aws_secret_access_key": "YOUR_SECRET_ACCESS_KEY",
             "bucket_name": "feldera-basics-tutorial",
             "region": "us-west-1"
+        }
+    },
+    "format": { "name": "json" }
+}]');
+```
+
+To connect to Google Cloud Storage, [explicitly set](https://cloud.google.com/storage/docs/interoperability) the `endpoint_url`. You also
+need to configure an [HMAC
+key](https://cloud.google.com/storage/docs/authentication/hmackeys) to get an
+Access ID and Secret. You will also need to grant the corresponding Principal
+access to the bucket.
+
+```sql
+CREATE TABLE vendor (
+    id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR,
+    address VARCHAR
+) WITH ('connectors' = '[{
+    "transport": {
+        "name": "s3_input",
+        "config": {
+            "key": "vendor.json",
+            "aws_access_key_id": "YOUR_ACCESS_KEY_ID",
+            "aws_secret_access_key": "YOUR_SECRET_ACCESS_KEY",
+            "bucket_name": "my-bucket",
+            "region": "us-west1",
+            "endpoint_url": "https://storage.googleapis.com"
         }
     },
     "format": { "name": "json" }

--- a/openapi.json
+++ b/openapi.json
@@ -4202,6 +4202,11 @@
             "type": "string",
             "description": "S3 bucket name to access."
           },
+          "endpoint_url": {
+            "type": "string",
+            "description": "The endpoint URL used to communicate with this service. Can be used to make this connector\ntalk to non-AWS services with an S3 API.",
+            "nullable": true
+          },
           "key": {
             "type": "string",
             "description": "Read a single object specified by a key.",


### PR DESCRIPTION
Tested against GCS.