### PR TITLE
[SQL] Use 'cargo check' instead of 'cargo test' for tests that have no data

### DIFF
--- a/docs/connectors/sources/s3.md
+++ b/docs/connectors/sources/s3.md
@@ -8,7 +8,7 @@ about configuring input and output connectors.
 
 The S3 input connector is used to load data from an S3 bucket to a Feldera table.
 It can be configured to load a single object or multiple objects selected based on a
-common S3 prefix. By setting the `endpoint_url`, you can also read from non-AWS services 
+common S3 prefix. By setting the `endpoint_url`, you can also read from non-AWS services
 that offer S3 compatible APIs.
 
 :::tip

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -273,7 +273,7 @@ public class Utilities {
         runProcess(directory, new HashMap<>(), commands);
     }
 
-    static void compile(String directory, boolean quiet, String... extraArgs) throws IOException, InterruptedException {
+    static void compileAndTest(String directory, boolean quiet, String... extraArgs) throws IOException, InterruptedException {
         List<String> args = new ArrayList<>();
         args.add("cargo");
         args.add("test");
@@ -288,17 +288,27 @@ public class Utilities {
     }
 
     static final boolean retry = false;
+    /** Compile the rust code generated and run it using 'cargo test' */
     public static void compileAndTestRust(String directory, boolean quiet, String... extraArgs)
             throws IOException, InterruptedException {
         try {
-           compile(directory, quiet, extraArgs);
+           compileAndTest(directory, quiet, extraArgs);
         } catch (RuntimeException ex) {
             if (!retry)
                 throw ex;
             // Sometimes the rust compiler crashes; retry.
             runProcess(directory, "cargo", "clean");
-            compile(directory, quiet, extraArgs);
+            compileAndTest(directory, quiet, extraArgs);
         }
+    }
+
+    /** Compile the rust code generated and check it using 'cargo check' */
+    public static void compileAndCheckRust(String directory)
+            throws IOException, InterruptedException {
+        List<String> args = new ArrayList<>();
+        args.add("cargo");
+        args.add("check");
+        runProcess(directory, args.toArray(new String[0]));
     }
 
     public static <T> T last(List<T> data) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestListener.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestListener.java
@@ -1,13 +1,24 @@
 package org.dbsp.sqlCompiler.compiler;
 
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
+import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
 
 /** Invoked when all tests are finished. */
 public class TestListener extends RunListener {
+    long startTime = 0;
+
+    @Override
+    public void testRunStarted(Description description) {
+        this.startTime = System.currentTimeMillis();
+    }
+
     @Override
     public void testRunFinished(Result result) {
-        System.out.println("Executed " + BaseSQLTests.testsExecuted + " Rust tests");
+        long end = System.currentTimeMillis();
+        System.out.println("Executed " + BaseSQLTests.testsExecuted +
+                ", checked " + BaseSQLTests.testsChecked + " Rust tests in " +
+                (end - this.startTime)/1000 + "s");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TestCase.java
@@ -57,6 +57,10 @@ public class TestCase {
         this.message = message;
     }
 
+    boolean hasData() {
+        return !this.ccs.stream.changes.isEmpty();
+    }
+
     /**
      * Generates a Rust function which tests a {@link DBSPCircuit}.
      *


### PR DESCRIPTION
This may save 50% of the running time for Java tests.