### PR TITLE
[dbsp] Fix antijoin for indexed z-sets.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -216,7 +216,7 @@ where
                 self.stream_id(),
                 sharding_policy(self.circuit()),
             )))
-            .map_or(false, |sharded| sharded.ptr_eq(self))
+            .is_some_and(|sharded| sharded.ptr_eq(self))
     }
 
     /// Marks `self` as sharded if `input` has a sharded version of itself

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -91,7 +91,7 @@ where
     pub fn is_distinct(&self) -> bool {
         self.circuit()
             .cache_get(&DistinctIncrementalId::new(self.stream_id()))
-            .map_or(false, |value: Stream<C, D>| value.ptr_eq(self))
+            .is_some_and(|value: Stream<C, D>| value.ptr_eq(self))
     }
 
     /// Returns the distinct version of the stream if it exists

--- a/crates/dbsp/src/operator/join.rs
+++ b/crates/dbsp/src/operator/join.rs
@@ -343,11 +343,11 @@ where
     pub fn antijoin<I2>(&self, other: &Stream<C, I2>) -> Stream<C, I1>
     where
         I2: IndexedZSet<Key = I1::Key, DynK = I1::DynK>,
-        I2::InnerBatch: Send,
+        I2::InnerBatch: Send + DynFilterMap,
         Box<I1::DynK>: Clone,
         Box<I1::DynV>: Clone,
     {
-        let factories = AntijoinFactories::new::<I1::Key, I1::Val, I2::Val>();
+        let factories = AntijoinFactories::new::<I1::Key, I1::Val>();
 
         self.inner()
             .dyn_antijoin(&factories, &other.inner())


### PR DESCRIPTION
The implementation of `antijoin` did not account for the fact that the
right collection could have multiple values per key.  It called
`distinct` on the original collection, which only made values distinct.
With more than one value per key, the subsequent join could end up
returning entries with weights greater than the weight of the left
input, so that `minus` ended up creating outputs with negative weights.

The fix is to convert the right input into a z-set by projecting away
the value before joining.

Fixes https://github.com/feldera/feldera/issues/3365
