### PR TITLE
Print root-cause for input/output errors.

### DIFF
--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -793,8 +793,9 @@ impl Display for ControllerError {
             } => {
                 write!(
                     f,
-                    "{}error on input endpoint '{endpoint_name}': {error}",
-                    if *fatal { "FATAL " } else { "" }
+                    "{}error on input endpoint '{endpoint_name}': {}",
+                    if *fatal { "FATAL " } else { "" },
+                    error.root_cause()
                 )
             }
             Self::OutputTransportError {
@@ -804,8 +805,9 @@ impl Display for ControllerError {
             } => {
                 write!(
                     f,
-                    "{}error on output endpoint '{endpoint_name}': {error}",
-                    if *fatal { "FATAL " } else { "" }
+                    "{}error on output endpoint '{endpoint_name}': {}",
+                    if *fatal { "FATAL " } else { "" },
+                    error.root_cause()
                 )
             }
             Self::ParseError {


### PR DESCRIPTION
Can't really tell if it's an overall net benefit.
We don't have a good way to test/see error messages side-by-side before and after this change. But it does improve the errors reported by the S3 connector.