### PR TITLE
pipeline-manager: remove `main_rust` from API GET endpoints

### DIFF
--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -1,6 +1,6 @@
 // Example errors for use in OpenAPI docs.
 use crate::api::endpoints::pipeline_management::{
-    PatchPipeline, PipelineInfo, PipelineInfoInternal, PipelineSelectedInfo,
+    PartialProgramInfo, PatchPipeline, PipelineInfo, PipelineInfoInternal, PipelineSelectedInfo,
     PipelineSelectedInfoInternal, PostPutPipeline,
 };
 use crate::api::error::ApiError;
@@ -167,7 +167,14 @@ fn pipeline_info_internal_to_external(pipeline: PipelineInfoInternal) -> Pipelin
         program_status: pipeline.program_status,
         program_status_since: pipeline.program_status_since,
         program_info: pipeline.program_info.map(|v| {
-            validate_program_info(&v).expect("example must have a valid program_info if specified")
+            let program_info = validate_program_info(&v)
+                .expect("example must have a valid program_info if specified");
+            PartialProgramInfo {
+                schema: program_info.schema,
+                udf_stubs: program_info.udf_stubs,
+                input_connectors: program_info.input_connectors,
+                output_connectors: program_info.output_connectors,
+            }
         }),
         deployment_status: pipeline.deployment_status,
         deployment_status_since: pipeline.deployment_status_since,
@@ -177,7 +184,7 @@ fn pipeline_info_internal_to_external(pipeline: PipelineInfoInternal) -> Pipelin
 }
 
 pub(crate) fn pipeline_1_info() -> PipelineInfo {
-    pipeline_info_internal_to_external(PipelineInfoInternal::new(&extended_pipeline_1()))
+    pipeline_info_internal_to_external(PipelineInfoInternal::new(extended_pipeline_1()))
 }
 
 /// Converts the actual serialized type [`PipelineSelectedInfoInternal`] to the type the endpoint
@@ -207,8 +214,14 @@ fn pipeline_selected_info_internal_to_external(
         program_status_since: pipeline.program_status_since,
         program_info: pipeline.program_info.map(|v| {
             v.map(|v| {
-                validate_program_info(&v)
-                    .expect("example must have a valid program_info if specified")
+                let program_info = validate_program_info(&v)
+                    .expect("example must have a valid program_info if specified");
+                PartialProgramInfo {
+                    schema: program_info.schema,
+                    udf_stubs: program_info.udf_stubs,
+                    input_connectors: program_info.input_connectors,
+                    output_connectors: program_info.output_connectors,
+                }
             })
         }),
         deployment_status: pipeline.deployment_status,
@@ -220,13 +233,13 @@ fn pipeline_selected_info_internal_to_external(
 
 pub(crate) fn pipeline_1_selected_info() -> PipelineSelectedInfo {
     pipeline_selected_info_internal_to_external(PipelineSelectedInfoInternal::new_all(
-        &extended_pipeline_1(),
+        extended_pipeline_1(),
     ))
 }
 
 pub(crate) fn pipeline_2_selected_info() -> PipelineSelectedInfo {
     pipeline_selected_info_internal_to_external(PipelineSelectedInfoInternal::new_all(
-        &extended_pipeline_2(),
+        extended_pipeline_2(),
     ))
 }
 

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -126,7 +126,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         crate::db::types::program::SqlCompilerMessage,
         crate::db::types::program::ProgramStatus,
         crate::db::types::program::ProgramConfig,
-        crate::db::types::program::ProgramInfo,
+        crate::api::endpoints::pipeline_management::PartialProgramInfo,
 
         // API key
         crate::db::types::api_key::ApiKeyId,

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -457,7 +457,7 @@ fn convert_connectors_with_unique_names(
 ///
 /// It includes information needed for Rust compilation (e.g., generated Rust code)
 /// as well as only for runtime (e.g., schema, input/output connectors).
-#[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 pub struct ProgramInfo {
     /// Schema of the compiled SQL.
     pub schema: ProgramSchema,

--- a/openapi.json
+++ b/openapi.json
@@ -3142,6 +3142,39 @@
         ],
         "description": "Describes an output connector configuration"
       },
+      "PartialProgramInfo": {
+        "type": "object",
+        "description": "Program information is the result of the SQL compilation.",
+        "required": [
+          "schema",
+          "udf_stubs",
+          "input_connectors",
+          "output_connectors"
+        ],
+        "properties": {
+          "input_connectors": {
+            "type": "object",
+            "description": "Input connectors derived from the schema.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InputEndpointConfig"
+            }
+          },
+          "output_connectors": {
+            "type": "object",
+            "description": "Output connectors derived from the schema.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/OutputEndpointConfig"
+            }
+          },
+          "schema": {
+            "$ref": "#/components/schemas/ProgramSchema"
+          },
+          "udf_stubs": {
+            "type": "string",
+            "description": "Generated user defined function (UDF) stubs Rust code: stubs.rs"
+          }
+        }
+      },
       "PatchPipeline": {
         "type": "object",
         "description": "Partially update the pipeline (PATCH).\n\nNote that the patching only applies to the main fields, not subfields.\nFor instance, it is not possible to update only the number of workers;\nit is required to again pass the whole runtime configuration with the\nchange.",
@@ -3396,7 +3429,7 @@
           "program_info": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProgramInfo"
+                "$ref": "#/components/schemas/PartialProgramInfo"
               }
             ],
             "nullable": true
@@ -3492,7 +3525,7 @@
           "program_info": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProgramInfo"
+                "$ref": "#/components/schemas/PartialProgramInfo"
               }
             ],
             "nullable": true
@@ -3603,42 +3636,6 @@
             ],
             "default": null,
             "nullable": true
-          }
-        }
-      },
-      "ProgramInfo": {
-        "type": "object",
-        "description": "Program information is the output of the SQL compiler.\n\nIt includes information needed for Rust compilation (e.g., generated Rust code)\nas well as only for runtime (e.g., schema, input/output connectors).",
-        "required": [
-          "schema",
-          "input_connectors",
-          "output_connectors"
-        ],
-        "properties": {
-          "input_connectors": {
-            "type": "object",
-            "description": "Input connectors derived from the schema.",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/InputEndpointConfig"
-            }
-          },
-          "main_rust": {
-            "type": "string",
-            "description": "Generated main program Rust code: main.rs"
-          },
-          "output_connectors": {
-            "type": "object",
-            "description": "Output connectors derived from the schema.",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/OutputEndpointConfig"
-            }
-          },
-          "schema": {
-            "$ref": "#/components/schemas/ProgramSchema"
-          },
-          "udf_stubs": {
-            "type": "string",
-            "description": "Generated user defined function (UDF) stubs Rust code: stubs.rs"
           }
         }
       },

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -1528,6 +1528,35 @@ connected to.`
   description: 'Describes an output connector configuration'
 } as const
 
+export const $PartialProgramInfo = {
+  type: 'object',
+  description: 'Program information is the result of the SQL compilation.',
+  required: ['schema', 'udf_stubs', 'input_connectors', 'output_connectors'],
+  properties: {
+    input_connectors: {
+      type: 'object',
+      description: 'Input connectors derived from the schema.',
+      additionalProperties: {
+        $ref: '#/components/schemas/InputEndpointConfig'
+      }
+    },
+    output_connectors: {
+      type: 'object',
+      description: 'Output connectors derived from the schema.',
+      additionalProperties: {
+        $ref: '#/components/schemas/OutputEndpointConfig'
+      }
+    },
+    schema: {
+      $ref: '#/components/schemas/ProgramSchema'
+    },
+    udf_stubs: {
+      type: 'string',
+      description: 'Generated user defined function (UDF) stubs Rust code: stubs.rs'
+    }
+  }
+} as const
+
 export const $PatchPipeline = {
   type: 'object',
   description: `Partially update the pipeline (PATCH).
@@ -1825,7 +1854,7 @@ It both includes fields which are user-provided and system-generated.`,
     program_info: {
       allOf: [
         {
-          $ref: '#/components/schemas/ProgramInfo'
+          $ref: '#/components/schemas/PartialProgramInfo'
         }
       ],
       nullable: true
@@ -1924,7 +1953,7 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
     program_info: {
       allOf: [
         {
-          $ref: '#/components/schemas/ProgramInfo'
+          $ref: '#/components/schemas/PartialProgramInfo'
         }
       ],
       nullable: true
@@ -2103,42 +2132,6 @@ and as well can result in overriding an existing binary.`,
       ],
       default: null,
       nullable: true
-    }
-  }
-} as const
-
-export const $ProgramInfo = {
-  type: 'object',
-  description: `Program information is the output of the SQL compiler.
-
-It includes information needed for Rust compilation (e.g., generated Rust code)
-as well as only for runtime (e.g., schema, input/output connectors).`,
-  required: ['schema', 'input_connectors', 'output_connectors'],
-  properties: {
-    input_connectors: {
-      type: 'object',
-      description: 'Input connectors derived from the schema.',
-      additionalProperties: {
-        $ref: '#/components/schemas/InputEndpointConfig'
-      }
-    },
-    main_rust: {
-      type: 'string',
-      description: 'Generated main program Rust code: main.rs'
-    },
-    output_connectors: {
-      type: 'object',
-      description: 'Output connectors derived from the schema.',
-      additionalProperties: {
-        $ref: '#/components/schemas/OutputEndpointConfig'
-      }
-    },
-    schema: {
-      $ref: '#/components/schemas/ProgramSchema'
-    },
-    udf_stubs: {
-      type: 'string',
-      description: 'Generated user defined function (UDF) stubs Rust code: stubs.rs'
     }
   }
 } as const
@@ -2795,6 +2788,12 @@ export const $S3InputConfig = {
     bucket_name: {
       type: 'string',
       description: 'S3 bucket name to access.'
+    },
+    endpoint_url: {
+      type: 'string',
+      description: `The endpoint URL used to communicate with this service. Can be used to make this connector
+talk to non-AWS services with an S3 API.`,
+      nullable: true
     },
     key: {
       type: 'string',

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -368,19 +368,21 @@ export const postPipelineInputConnectorAction = (
 }
 
 /**
- * Start, pause or shutdown a pipeline.
- * The endpoint returns immediately after performing initial request validation
- * (e.g., upon start checking the program is compiled) and initiating the relevant
- * procedure (e.g., informing the runner or the already running pipeline).
- * The state changes completely asynchronously. On error, the pipeline
- * transitions to the `Failed` state. The user can monitor the current status
- * of the pipeline by polling the `GET /pipelines` and
- * `GET /pipelines/{pipeline_name}` endpoint.
+ * Sets the desired deployment state of a pipeline.
+ * The desired state is set based on the `action` path parameter:
+ * - `/start` sets desired state to `Running`
+ * - `/pause` sets desired state to `Paused`
+ * - `/shutdown` sets desired state to `Shutdown`
  *
- * The following values of the `action` argument are accepted:
- * - `start`: Start the pipeline
- * - `pause`: Pause the pipeline
- * - `shutdown`: Terminate the pipeline
+ * The endpoint returns immediately after setting the desired state.
+ * The relevant procedure to get to the desired state is performed asynchronously,
+ * and, as such, progress should be monitored by polling the pipeline using the
+ * `GET` endpoints.
+ *
+ * Note the following:
+ * - A shutdown pipeline can be started through calling either `/start` or `/pause`
+ * - Both starting as running and resuming a pipeline is done by calling `/start`
+ * - Both starting as paused and pausing a pipeline is done by calling `/pause`
  */
 export const postPipelineAction = (options: Options<PostPipelineActionData>) => {
   return (options?.client ?? client).post<PostPipelineActionResponse, PostPipelineActionError>({

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1174,6 +1174,29 @@ export type OutputEndpointConfig = ConnectorConfig & {
 }
 
 /**
+ * Program information is the result of the SQL compilation.
+ */
+export type PartialProgramInfo = {
+  /**
+   * Input connectors derived from the schema.
+   */
+  input_connectors: {
+    [key: string]: InputEndpointConfig
+  }
+  /**
+   * Output connectors derived from the schema.
+   */
+  output_connectors: {
+    [key: string]: OutputEndpointConfig
+  }
+  schema: ProgramSchema
+  /**
+   * Generated user defined function (UDF) stubs Rust code: stubs.rs
+   */
+  udf_stubs: string
+}
+
+/**
  * Partially update the pipeline (PATCH).
  *
  * Note that the patching only applies to the main fields, not subfields.
@@ -1318,7 +1341,7 @@ export type PipelineInfo = {
   platform_version: string
   program_code: string
   program_config: ProgramConfig
-  program_info?: ProgramInfo | null
+  program_info?: PartialProgramInfo | null
   program_status: ProgramStatus
   program_status_since: string
   program_version: Version
@@ -1345,7 +1368,7 @@ export type PipelineSelectedInfo = {
   platform_version: string
   program_code?: string | null
   program_config?: ProgramConfig | null
-  program_info?: ProgramInfo | null
+  program_info?: PartialProgramInfo | null
   program_status: ProgramStatus
   program_status_since: string
   program_version: Version
@@ -1458,36 +1481,6 @@ export type ProgramConfig = {
    */
   cache?: boolean
   profile?: CompilationProfile | null
-}
-
-/**
- * Program information is the output of the SQL compiler.
- *
- * It includes information needed for Rust compilation (e.g., generated Rust code)
- * as well as only for runtime (e.g., schema, input/output connectors).
- */
-export type ProgramInfo = {
-  /**
-   * Input connectors derived from the schema.
-   */
-  input_connectors: {
-    [key: string]: InputEndpointConfig
-  }
-  /**
-   * Generated main program Rust code: main.rs
-   */
-  main_rust?: string
-  /**
-   * Output connectors derived from the schema.
-   */
-  output_connectors: {
-    [key: string]: OutputEndpointConfig
-  }
-  schema: ProgramSchema
-  /**
-   * Generated user defined function (UDF) stubs Rust code: stubs.rs
-   */
-  udf_stubs?: string
 }
 
 /**
@@ -1893,6 +1886,11 @@ export type S3InputConfig = {
    * S3 bucket name to access.
    */
   bucket_name: string
+  /**
+   * The endpoint URL used to communicate with this service. Can be used to make this connector
+   * talk to non-AWS services with an S3 API.
+   */
+  endpoint_url?: string | null
   /**
    * Read a single object specified by a key.
    */


### PR DESCRIPTION
The SQL compilation of large programs results in large Rust programs being generated, which are currently not used elsewhere by the API clients. As such, this commit removes the `main_rust` subfield of the `program_info` field at API level in order to speed up retrieval. Internally, the subfield is still present.

In addition, removes unnecessary cloning of fields when generating pipeline responses.