### PR TITLE
[dbsp] Monomorphic version of DBSP API.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -198,6 +198,7 @@ test-dbsp:
     FROM +build-dbsp
     ENV RUST_BACKTRACE 1
     DO rust+CARGO --args="test --package dbsp"
+    DO rust+CARGO --args="test --package dbsp --features backend-mode"
 
 test-nexmark:
     FROM +build-nexmark

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -22,6 +22,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 # main.yml and coverage.yml:
 default = []
 
+# Enable when using with compiler-generated code.
+# See comments in `mono/mod.rs`
+backend-mode = []
+
 [dependencies]
 num = "0.4.0"
 anyhow = "1.0.57"

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -2054,6 +2054,8 @@ where
 /// bounds of a circuit using [`Stream::output`].
 pub type RootCircuit = ChildCircuit<()>;
 
+pub type NestedCircuit = ChildCircuit<RootCircuit>;
+
 impl<P> Clone for ChildCircuit<P>
 where
     P: WithClock,

--- a/crates/dbsp/src/circuit/mod.rs
+++ b/crates/dbsp/src/circuit/mod.rs
@@ -32,7 +32,7 @@ pub mod trace;
 
 pub use circuit_builder::{
     ChildCircuit, Circuit, CircuitHandle, ExportId, ExportStream, FeedbackConnector, GlobalNodeId,
-    NodeId, OwnershipPreference, RootCircuit, Scope, Stream, WithClock,
+    NestedCircuit, NodeId, OwnershipPreference, RootCircuit, Scope, Stream, WithClock,
 };
 pub use dbsp_handle::{
     CircuitConfig, CircuitStorageConfig, DBSPHandle, Host, Layout, StorageCacheConfig,

--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -81,6 +81,9 @@ pub mod time;
 pub mod trace;
 pub mod utils;
 
+#[cfg(feature = "backend-mode")]
+pub mod mono;
+
 pub use crate::{
     error::{DetailedError, Error},
     hash::default_hash,
@@ -92,12 +95,14 @@ pub use crate::time::Timestamp;
 pub use algebra::{DynZWeight, ZWeight};
 
 pub use circuit::{
-    ChildCircuit, Circuit, CircuitHandle, DBSPHandle, RootCircuit, Runtime, RuntimeError,
-    SchedulerError, Stream,
+    ChildCircuit, Circuit, CircuitHandle, DBSPHandle, NestedCircuit, RootCircuit, Runtime,
+    RuntimeError, SchedulerError, Stream,
 };
+#[cfg(not(feature = "backend-mode"))]
+pub use operator::FilterMap;
 pub use operator::{
     input::{IndexedZSetHandle, InputHandle, MapHandle, SetHandle, ZSetHandle},
-    CmpFunc, FilterMap, OrdPartitionedIndexedZSet, OutputHandle,
+    CmpFunc, OrdPartitionedIndexedZSet, OutputHandle,
 };
 pub use trace::{DBData, DBWeight};
 pub use typed_batch::{
@@ -106,7 +111,7 @@ pub use typed_batch::{
     OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, Trace, TypedBox, ZSet,
 };
 
-#[cfg(doc)]
+#[cfg(all(doc, not(feature = "backend-mode")))]
 pub mod tutorial;
 
 // TODO: import from `circuit`.

--- a/crates/dbsp/src/mono/mod.rs
+++ b/crates/dbsp/src/mono/mod.rs
@@ -1,0 +1,879 @@
+//! Monomorphic versions of DBSP operators for use by the SQL compiler.
+//!
+//! This module contains versions of several DBSP operators that force the implementation
+//! of these operators to get compiled as part of the DBSP crate instead of the client crate
+//! that uses DBSP. Using these operators instead of the equivalents in `crate::operators`
+//! can significantly speed up Rust compilation when the client code is decomposed into many
+//! crates.
+//!
+//! To understand how this works, consider for example the `Stream::join` operator. This operator
+//! is a wrapper on top of `Stream::dyn_join`, which is generic over circuit type, key and
+//! value types. In practice it is always instantiated with key=`DynData`, value=`DynData` and
+//! circuit being either `RootCircuit` or `NestedCircuit`.  As such, it needs to be instantiated
+//! at most twice in any program. However, since this instantiation happens when compiling the
+//! client crate, it ends up being instantiated once in each client crate of a multi-crate project.
+//!
+//! The API in this module solves the problem by forcing the instantiation of `dyn_join` in the
+//! `dbsp` crate. It provides a less generic API: all methods take and return `OrdIndexedZSet`/`OrdZSet`
+//! streams and are specialized for a specific type of circuit, `RootCircuit` or `NestedCircuit` (which
+//! means that they don't work for arbitrary levels of nesting).  Internally they call monomorphized
+//! versions of `dyn_` operators (e.g., `dyn_join_mono`).
+//!
+//! This API is enabled by the `backend-mode` feature, which also disables the matching polymorphic
+//! API in `crate::operators`. Enabling this feature should be transparent for most client code.
+
+use std::mem::take;
+
+use crate::{
+    algebra::MulByRef,
+    circuit::WithClock,
+    dynamic::{DowncastTrait, DynData, DynUnit, DynWeight, Erase},
+    operator::{
+        dynamic::{
+            aggregate::{DynAggregatorImpl, IncAggregateFactories, IncAggregateLinearFactories},
+            controlled_filter::ControlledFilterFactories,
+            distinct::DistinctFactories,
+            join::{AntijoinFactories, JoinFactories},
+            MonoIndexedZSet,
+        },
+        join::{mk_trace_join_flatmap_funcs, mk_trace_join_funcs, mk_trace_join_generic_funcs},
+        time_series::OrdPartitionedOverStream,
+        Aggregator,
+    },
+    trace::BatchReaderFactories,
+    utils::Tup2,
+    DBData, DBWeight, DynZWeight, NestedCircuit, OrdIndexedZSet, OrdZSet, RootCircuit, Stream,
+    TypedBox, ZWeight,
+};
+
+impl<K, V> Stream<RootCircuit, OrdIndexedZSet<K, V>>
+where
+    K: DBData,
+    V: DBData,
+{
+    #[allow(clippy::type_complexity)]
+    #[track_caller]
+    pub fn aggregate<A>(&self, aggregator: A) -> Stream<RootCircuit, OrdIndexedZSet<K, A::Output>>
+    where
+        A: Aggregator<V, (), ZWeight>,
+    {
+        let aggregate_factories = IncAggregateFactories::new::<K, V, ZWeight, A::Output>();
+
+        let dyn_aggregator =
+            DynAggregatorImpl::<DynData, V, (), DynZWeight, ZWeight, A, DynData, DynData>::new(
+                aggregator,
+            );
+
+        self.inner()
+            .dyn_aggregate_mono(&aggregate_factories, &dyn_aggregator)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn aggregate_linear_postprocess<F, A, OF, OV>(
+        &self,
+        f: F,
+        of: OF,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<K, OV>>
+    where
+        A: DBWeight + MulByRef<ZWeight, Output = A>,
+        OV: DBData,
+        F: Fn(&V) -> A + Clone + 'static,
+        OF: Fn(A) -> OV + Clone + 'static,
+    {
+        let factories: IncAggregateLinearFactories<
+            MonoIndexedZSet,
+            DynWeight,
+            MonoIndexedZSet,
+            (),
+        > = IncAggregateLinearFactories::new::<K, A, OV>();
+
+        self.inner()
+            .dyn_aggregate_linear_mono(
+                &factories,
+                Box::new(move |_k, v, r, acc| unsafe {
+                    *acc.downcast_mut::<A>() = f(v.downcast::<V>()).mul_by_ref(&**r)
+                }),
+                Box::new(move |w, out| unsafe {
+                    *out.downcast_mut::<OV>() = of(take(w.downcast_mut::<A>()))
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join<F, V2, OV>(
+        &self,
+        other: &Stream<RootCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<RootCircuit, OrdZSet<OV>>
+    where
+        V2: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> OV + Clone + 'static,
+    {
+        let join_funcs =
+            mk_trace_join_funcs::<OrdIndexedZSet<K, V>, OrdIndexedZSet<K, V2>, OrdZSet<OV>, _>(
+                join,
+            );
+
+        let join_factories = JoinFactories::new::<K, V, V2, OV, ()>();
+
+        self.inner()
+            .dyn_join_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join_flatmap<F, V2, OV, It>(
+        &self,
+        other: &Stream<RootCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<RootCircuit, OrdZSet<OV>>
+    where
+        V2: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> It + Clone + 'static,
+        It: IntoIterator<Item = OV> + 'static,
+    {
+        let join_funcs = mk_trace_join_flatmap_funcs::<
+            OrdIndexedZSet<K, V>,
+            OrdIndexedZSet<K, V2>,
+            OrdZSet<OV>,
+            _,
+            It,
+        >(join);
+
+        let join_factories = JoinFactories::new::<K, V, V2, OV, ()>();
+
+        self.inner()
+            .dyn_join_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join_index<F, V2, OK, OV, It>(
+        &self,
+        other: &Stream<RootCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        V2: DBData,
+        OK: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> It + Clone + 'static,
+        It: IntoIterator<Item = (OK, OV)> + 'static,
+    {
+        let join_funcs = mk_trace_join_generic_funcs::<
+            OrdIndexedZSet<K, V>,
+            OrdIndexedZSet<K, V2>,
+            OrdIndexedZSet<OK, OV>,
+            _,
+            _,
+        >(join);
+
+        let join_factories = JoinFactories::new::<K, V, V2, OK, OV>();
+
+        self.inner()
+            .dyn_join_index_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn antijoin<K2, V2>(&self, other: &Stream<RootCircuit, OrdIndexedZSet<K2, V2>>) -> Self
+    where
+        K2: DBData,
+        V2: DBData,
+    {
+        let factories = AntijoinFactories::new::<K, V>();
+
+        self.inner()
+            .dyn_antijoin_mono(&factories, &other.inner())
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn distinct(&self) -> Self {
+        let factories = DistinctFactories::new::<K, V>();
+
+        self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn waterline<TS, WF, IF, LB>(
+        &self,
+        init: IF,
+        extract_ts: WF,
+        least_upper_bound: LB,
+    ) -> Stream<RootCircuit, TypedBox<TS, DynData>>
+    where
+        TS: DBData,
+        IF: Fn() -> TS + 'static,
+        WF: Fn(&K, &V) -> TS + 'static,
+        LB: Fn(&TS, &TS) -> TS + Clone + 'static,
+    {
+        let result = self.inner().dyn_waterline_mono(
+            Box::new(move || Box::new(init()).erase_box()),
+            Box::new(move |k, v, ts: &mut DynData| unsafe {
+                *ts.downcast_mut::<TS>() = extract_ts(k.downcast(), v.downcast())
+            }),
+            Box::new(move |l, r, ts| unsafe {
+                *ts.downcast_mut() = least_upper_bound(l.downcast(), r.downcast())
+            }),
+        );
+
+        unsafe { result.typed_data() }
+    }
+
+    #[track_caller]
+    pub fn filter<F>(&self, filter_func: F) -> Self
+    where
+        F: Fn((&K, &V)) -> bool + 'static,
+    {
+        self.inner()
+            .dyn_filter_mono(Box::new(move |(k, v)| unsafe {
+                filter_func((k.downcast(), v.downcast()))
+            }))
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map<F, OK>(&self, map_func: F) -> Stream<RootCircuit, OrdZSet<OK>>
+    where
+        OK: DBData,
+        F: Fn((&K, &V)) -> OK + Clone + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, (), ZWeight>();
+
+        self.inner()
+            .dyn_map_mono(
+                &factories,
+                Box::new(move |(k, v), pair| {
+                    let mut key = map_func(unsafe { (k.downcast(), v.downcast()) });
+                    pair.from_vals(key.erase_mut(), ().erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map_index<F, OK, OV>(&self, map_func: F) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        OK: DBData,
+        OV: DBData,
+        F: Fn((&K, &V)) -> (OK, OV) + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_map_index_mono(
+                &factories,
+                Box::new(move |(k, v), pair| {
+                    let (mut key, mut val) = map_func(unsafe { (k.downcast(), v.downcast()) });
+                    pair.from_vals(key.erase_mut(), val.erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map<F, I>(&self, mut func: F) -> Stream<RootCircuit, OrdZSet<I::Item>>
+    where
+        F: FnMut((&K, &V)) -> I + 'static,
+        I: IntoIterator + 'static,
+        I::Item: DBData,
+    {
+        let factories = BatchReaderFactories::new::<I::Item, (), ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_mono(
+                &factories,
+                Box::new(move |(k, v), cb| {
+                    for mut key in func(unsafe { (k.downcast(), v.downcast()) }) {
+                        cb(key.erase_mut(), ().erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map_index<F, OK, OV, I>(
+        &self,
+        mut func: F,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        F: FnMut((&K, &V)) -> I + 'static,
+        I: IntoIterator<Item = (OK, OV)> + 'static,
+        OK: DBData,
+        OV: DBData,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_index_mono(
+                &factories,
+                Box::new(move |(k, v), cb| {
+                    for (mut key, mut val) in func(unsafe { (k.downcast(), v.downcast()) }) {
+                        cb(key.erase_mut(), val.erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+}
+
+impl<K> Stream<RootCircuit, OrdZSet<K>>
+where
+    K: DBData,
+{
+    #[track_caller]
+    pub fn distinct(&self) -> Self {
+        let factories = DistinctFactories::new::<K, ()>();
+
+        self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn waterline<TS, WF, IF, LB>(
+        &self,
+        init: IF,
+        extract_ts: WF,
+        least_upper_bound: LB,
+    ) -> Stream<RootCircuit, TypedBox<TS, DynData>>
+    where
+        TS: DBData,
+        IF: Fn() -> TS + 'static,
+        WF: Fn(&K, &()) -> TS + 'static,
+        LB: Fn(&TS, &TS) -> TS + Clone + 'static,
+    {
+        let result = self.inner().dyn_waterline_mono(
+            Box::new(move || Box::new(init()).erase_box()),
+            Box::new(move |k, v, ts: &mut DynData| unsafe {
+                *ts.downcast_mut::<TS>() = extract_ts(k.downcast(), v.downcast())
+            }),
+            Box::new(move |l, r, ts| unsafe {
+                *ts.downcast_mut() = least_upper_bound(l.downcast(), r.downcast())
+            }),
+        );
+
+        unsafe { result.typed_data() }
+    }
+
+    #[track_caller]
+    pub fn filter<F>(&self, filter_func: F) -> Self
+    where
+        F: Fn(&K) -> bool + 'static,
+    {
+        self.inner()
+            .dyn_filter_mono(Box::new(move |k| unsafe { filter_func(k.downcast()) }))
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map<F, OK>(&self, map_func: F) -> Stream<RootCircuit, OrdZSet<OK>>
+    where
+        OK: DBData,
+        F: Fn(&K) -> OK + Clone + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, (), ZWeight>();
+
+        self.inner()
+            .dyn_map_mono(
+                &factories,
+                Box::new(move |k, pair| {
+                    let mut key = map_func(unsafe { k.downcast() });
+                    pair.from_vals(key.erase_mut(), ().erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map_index<F, OK, OV>(&self, map_func: F) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        OK: DBData,
+        OV: DBData,
+        F: Fn(&K) -> (OK, OV) + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_map_index_mono(
+                &factories,
+                Box::new(move |k, pair| {
+                    let (mut key, mut val) = map_func(unsafe { k.downcast() });
+                    pair.from_vals(key.erase_mut(), val.erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map<F, I>(&self, mut func: F) -> Stream<RootCircuit, OrdZSet<I::Item>>
+    where
+        F: FnMut(&K) -> I + 'static,
+        I: IntoIterator + 'static,
+        I::Item: DBData,
+    {
+        let factories = BatchReaderFactories::new::<I::Item, (), ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_mono(
+                &factories,
+                Box::new(move |k, cb| {
+                    for mut key in func(unsafe { k.downcast() }) {
+                        cb(key.erase_mut(), ().erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map_index<F, OK, OV, I>(
+        &self,
+        mut func: F,
+    ) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        F: FnMut(&K) -> I + 'static,
+        I: IntoIterator<Item = (OK, OV)> + 'static,
+        OK: DBData,
+        OV: DBData,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_index_mono(
+                &factories,
+                Box::new(move |k, cb| {
+                    for (mut key, mut val) in func(unsafe { k.downcast() }) {
+                        cb(key.erase_mut(), val.erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+
+    pub fn controlled_key_filter_typed<T, E, F, RF>(
+        &self,
+        threshold: &Stream<RootCircuit, T>,
+        filter_func: F,
+        report_func: RF,
+    ) -> (Self, Stream<RootCircuit, OrdZSet<E>>)
+    where
+        E: DBData,
+        T: DBData,
+        F: Fn(&T, &K) -> bool + 'static,
+        RF: Fn(&T, &K, &(), ZWeight) -> E + 'static,
+    {
+        let factories = ControlledFilterFactories::new::<K, (), E>();
+
+        let (output, error_stream) = self.inner().dyn_controlled_key_filter_mono(
+            factories,
+            &threshold.typed_box::<DynData>().inner_data(),
+            Box::new(move |t: &DynData, k: &DynData| unsafe {
+                filter_func(t.downcast(), k.downcast())
+            }),
+            Box::new(
+                move |t: &DynData, k: &DynData, v: &DynUnit, w: ZWeight, e: &mut DynData| unsafe {
+                    *e.downcast_mut() = report_func(t.downcast(), k.downcast(), v.downcast(), w)
+                },
+            ),
+        );
+
+        (output.typed(), error_stream.typed())
+    }
+}
+
+impl<K, V> Stream<NestedCircuit, OrdIndexedZSet<K, V>>
+where
+    K: DBData,
+    V: DBData,
+{
+    #[allow(clippy::type_complexity)]
+    #[track_caller]
+    pub fn aggregate<A>(&self, aggregator: A) -> Stream<NestedCircuit, OrdIndexedZSet<K, A::Output>>
+    where
+        A: Aggregator<V, <NestedCircuit as WithClock>::Time, ZWeight>,
+    {
+        let aggregate_factories = IncAggregateFactories::new::<K, V, ZWeight, A::Output>();
+
+        let dyn_aggregator = DynAggregatorImpl::<
+            DynData,
+            V,
+            <NestedCircuit as WithClock>::Time,
+            DynZWeight,
+            ZWeight,
+            A,
+            DynData,
+            DynData,
+        >::new(aggregator);
+
+        self.inner()
+            .dyn_aggregate_mono(&aggregate_factories, &dyn_aggregator)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn aggregate_linear_postprocess<F, A, OF, OV>(
+        &self,
+        f: F,
+        of: OF,
+    ) -> Stream<NestedCircuit, OrdIndexedZSet<K, OV>>
+    where
+        A: DBWeight + MulByRef<ZWeight, Output = A>,
+        OV: DBData,
+        F: Fn(&V) -> A + Clone + 'static,
+        OF: Fn(A) -> OV + Clone + 'static,
+    {
+        let factories: IncAggregateLinearFactories<
+            MonoIndexedZSet,
+            DynWeight,
+            MonoIndexedZSet,
+            <NestedCircuit as WithClock>::Time,
+        > = IncAggregateLinearFactories::new::<K, A, OV>();
+
+        self.inner()
+            .dyn_aggregate_linear_mono(
+                &factories,
+                Box::new(move |_k, v, r, acc| unsafe {
+                    *acc.downcast_mut::<A>() = f(v.downcast::<V>()).mul_by_ref(&**r)
+                }),
+                Box::new(move |w, out| unsafe {
+                    *out.downcast_mut::<OV>() = of(take(w.downcast_mut::<A>()))
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join<F, V2, OV>(
+        &self,
+        other: &Stream<NestedCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<NestedCircuit, OrdZSet<OV>>
+    where
+        V2: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> OV + Clone + 'static,
+    {
+        let join_funcs =
+            mk_trace_join_funcs::<OrdIndexedZSet<K, V>, OrdIndexedZSet<K, V2>, OrdZSet<OV>, _>(
+                join,
+            );
+
+        let join_factories = JoinFactories::new::<K, V, V2, OV, ()>();
+
+        self.inner()
+            .dyn_join_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join_flatmap<F, V2, OV, It>(
+        &self,
+        other: &Stream<NestedCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<NestedCircuit, OrdZSet<OV>>
+    where
+        V2: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> It + Clone + 'static,
+        It: IntoIterator<Item = OV> + 'static,
+    {
+        let join_funcs = mk_trace_join_flatmap_funcs::<
+            OrdIndexedZSet<K, V>,
+            OrdIndexedZSet<K, V2>,
+            OrdZSet<OV>,
+            _,
+            It,
+        >(join);
+
+        let join_factories = JoinFactories::new::<K, V, V2, OV, ()>();
+
+        self.inner()
+            .dyn_join_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn join_index<F, V2, OK, OV, It>(
+        &self,
+        other: &Stream<NestedCircuit, OrdIndexedZSet<K, V2>>,
+        join: F,
+    ) -> Stream<NestedCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        V2: DBData,
+        OK: DBData,
+        OV: DBData,
+        F: Fn(&K, &V, &V2) -> It + Clone + 'static,
+        It: IntoIterator<Item = (OK, OV)> + 'static,
+    {
+        let join_funcs = mk_trace_join_generic_funcs::<
+            OrdIndexedZSet<K, V>,
+            OrdIndexedZSet<K, V2>,
+            OrdIndexedZSet<OK, OV>,
+            _,
+            _,
+        >(join);
+
+        let join_factories = JoinFactories::new::<K, V, V2, OK, OV>();
+
+        self.inner()
+            .dyn_join_index_mono(&join_factories, &other.inner(), join_funcs)
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn antijoin<K2, V2>(&self, other: &Stream<NestedCircuit, OrdIndexedZSet<K2, V2>>) -> Self
+    where
+        K2: DBData,
+        V2: DBData,
+    {
+        let factories = AntijoinFactories::new::<K, V>();
+
+        self.inner()
+            .dyn_antijoin_mono(&factories, &other.inner())
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn distinct(&self) -> Self {
+        let factories = DistinctFactories::new::<K, V>();
+
+        self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn filter<F>(&self, filter_func: F) -> Self
+    where
+        F: Fn((&K, &V)) -> bool + 'static,
+    {
+        self.inner()
+            .dyn_filter_mono(Box::new(move |(k, v)| unsafe {
+                filter_func((k.downcast(), v.downcast()))
+            }))
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map<F, OK>(&self, map_func: F) -> Stream<NestedCircuit, OrdZSet<OK>>
+    where
+        OK: DBData,
+        F: Fn((&K, &V)) -> OK + Clone + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, (), ZWeight>();
+
+        self.inner()
+            .dyn_map_mono(
+                &factories,
+                Box::new(move |(k, v), pair| {
+                    let mut key = map_func(unsafe { (k.downcast(), v.downcast()) });
+                    pair.from_vals(key.erase_mut(), ().erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map_index<F, OK, OV>(&self, map_func: F) -> Stream<NestedCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        OK: DBData,
+        OV: DBData,
+        F: Fn((&K, &V)) -> (OK, OV) + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_map_index_mono(
+                &factories,
+                Box::new(move |(k, v), pair| {
+                    let (mut key, mut val) = map_func(unsafe { (k.downcast(), v.downcast()) });
+                    pair.from_vals(key.erase_mut(), val.erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map<F, I>(&self, mut func: F) -> Stream<NestedCircuit, OrdZSet<I::Item>>
+    where
+        F: FnMut((&K, &V)) -> I + 'static,
+        I: IntoIterator + 'static,
+        I::Item: DBData,
+    {
+        let factories = BatchReaderFactories::new::<I::Item, (), ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_mono(
+                &factories,
+                Box::new(move |(k, v), cb| {
+                    for mut key in func(unsafe { (k.downcast(), v.downcast()) }) {
+                        cb(key.erase_mut(), ().erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map_index<F, OK, OV, I>(
+        &self,
+        mut func: F,
+    ) -> Stream<NestedCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        F: FnMut((&K, &V)) -> I + 'static,
+        I: IntoIterator<Item = (OK, OV)> + 'static,
+        OK: DBData,
+        OV: DBData,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_index_mono(
+                &factories,
+                Box::new(move |(k, v), cb| {
+                    for (mut key, mut val) in func(unsafe { (k.downcast(), v.downcast()) }) {
+                        cb(key.erase_mut(), val.erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+}
+
+impl<K> Stream<NestedCircuit, OrdZSet<K>>
+where
+    K: DBData,
+{
+    #[track_caller]
+    pub fn distinct(&self) -> Self {
+        let factories = DistinctFactories::new::<K, ()>();
+
+        self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn filter<F>(&self, filter_func: F) -> Self
+    where
+        F: Fn(&K) -> bool + 'static,
+    {
+        self.inner()
+            .dyn_filter_mono(Box::new(move |k| unsafe { filter_func(k.downcast()) }))
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map<F, OK>(&self, map_func: F) -> Stream<NestedCircuit, OrdZSet<OK>>
+    where
+        OK: DBData,
+        F: Fn(&K) -> OK + Clone + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, (), ZWeight>();
+
+        self.inner()
+            .dyn_map_mono(
+                &factories,
+                Box::new(move |k, pair| {
+                    let mut key = map_func(unsafe { k.downcast() });
+                    pair.from_vals(key.erase_mut(), ().erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn map_index<F, OK, OV>(&self, map_func: F) -> Stream<NestedCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        OK: DBData,
+        OV: DBData,
+        F: Fn(&K) -> (OK, OV) + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_map_index_mono(
+                &factories,
+                Box::new(move |k, pair| {
+                    let (mut key, mut val) = map_func(unsafe { k.downcast() });
+                    pair.from_vals(key.erase_mut(), val.erase_mut());
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map<F, I>(&self, mut func: F) -> Stream<NestedCircuit, OrdZSet<I::Item>>
+    where
+        F: FnMut(&K) -> I + 'static,
+        I: IntoIterator + 'static,
+        I::Item: DBData,
+    {
+        let factories = BatchReaderFactories::new::<I::Item, (), ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_mono(
+                &factories,
+                Box::new(move |k, cb| {
+                    for mut key in func(unsafe { k.downcast() }) {
+                        cb(key.erase_mut(), ().erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+
+    #[track_caller]
+    pub fn flat_map_index<F, OK, OV, I>(
+        &self,
+        mut func: F,
+    ) -> Stream<NestedCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        F: FnMut(&K) -> I + 'static,
+        I: IntoIterator<Item = (OK, OV)> + 'static,
+        OK: DBData,
+        OV: DBData,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_flat_map_index_mono(
+                &factories,
+                Box::new(move |k, cb| {
+                    for (mut key, mut val) in func(unsafe { k.downcast() }) {
+                        cb(key.erase_mut(), val.erase_mut());
+                    }
+                }),
+            )
+            .typed()
+    }
+}
+
+// For use with rolling aggregates only.
+impl<PK, TS, V> OrdPartitionedOverStream<PK, TS, V>
+where
+    PK: DBData,
+    V: DBData,
+    TS: DBData,
+{
+    #[track_caller]
+    pub fn map_index<F, OK, OV>(&self, map_func: F) -> Stream<RootCircuit, OrdIndexedZSet<OK, OV>>
+    where
+        OK: DBData,
+        OV: DBData,
+        F: Fn((&PK, &Tup2<TS, Option<V>>)) -> (OK, OV) + 'static,
+    {
+        let factories = BatchReaderFactories::new::<OK, OV, ZWeight>();
+
+        self.inner()
+            .dyn_map_index(
+                &factories,
+                Box::new(move |(k, v), pair| {
+                    let (mut key, mut val) = map_func(unsafe { (k.downcast(), v.downcast()) });
+                    pair.from_vals(key.erase_mut(), val.erase_mut());
+                }),
+            )
+            .typed()
+    }
+}

--- a/crates/dbsp/src/operator/asof_join.rs
+++ b/crates/dbsp/src/operator/asof_join.rs
@@ -77,7 +77,7 @@ where
         );
 
         self.inner()
-            .dyn_asof_join(
+            .dyn_asof_join_mono(
                 &join_factories,
                 &other.inner(),
                 dyn_ts_func1,

--- a/crates/dbsp/src/operator/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/chain_aggregate.rs
@@ -39,7 +39,7 @@ where
         let output_factories = BatchReaderFactories::new::<K, A, ZWeight>();
 
         self.inner()
-            .dyn_chain_aggregate(
+            .dyn_chain_aggregate_mono(
                 &input_factories,
                 &output_factories,
                 Box::new(move |acc: &mut DynData, v: &DynData, w: ZWeight| unsafe {

--- a/crates/dbsp/src/operator/controlled_filter.rs
+++ b/crates/dbsp/src/operator/controlled_filter.rs
@@ -56,6 +56,7 @@ where
 
     /// Like [`Self::controlled_key_filter`], but values in the `threshold` stream are strongly typed
     /// instead of having type `TypedBox`.
+    #[cfg(not(feature = "backend-mode"))]
     #[track_caller]
     pub fn controlled_key_filter_typed<T, E, F, RF>(
         &self,

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -1,7 +1,4 @@
-use crate::{
-    operator::dynamic::distinct::DistinctFactories, trace::BatchReaderFactories,
-    typed_batch::IndexedZSet, Circuit, Stream, ZWeight,
-};
+use crate::{trace::BatchReaderFactories, typed_batch::IndexedZSet, Circuit, Stream, ZWeight};
 
 impl<C, Z> Stream<C, Z>
 where
@@ -43,9 +40,11 @@ where
     ///
     /// Intuitively, the operator converts the input multiset into a set
     /// by eliminating duplicates.
+    #[cfg(not(feature = "backend-mode"))]
     #[track_caller]
     pub fn distinct(&self) -> Stream<C, Z> {
-        let factories = DistinctFactories::new::<Z::Key, Z::Val>();
+        let factories =
+            crate::operator::dynamic::distinct::DistinctFactories::new::<Z::Key, Z::Val>();
 
         self.inner().dyn_distinct(&factories).typed()
     }

--- a/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
@@ -6,11 +6,26 @@ use minitrace::trace;
 use crate::{
     algebra::IndexedZSet,
     circuit::operator_traits::{BinaryOperator, Operator},
-    dynamic::{ClonableTrait, Erase},
-    operator::dynamic::trace::{TraceBounds, TraceFeedback},
+    dynamic::{ClonableTrait, DynData, Erase},
+    operator::dynamic::{
+        trace::{TraceBounds, TraceFeedback},
+        MonoIndexedZSet,
+    },
     trace::{BatchReader, BatchReaderFactories, Builder, Cursor, Spine},
     Circuit, RootCircuit, Scope, Stream, ZWeight,
 };
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    pub fn dyn_chain_aggregate_mono(
+        &self,
+        input_factories: &<MonoIndexedZSet as BatchReader>::Factories,
+        output_factories: &<MonoIndexedZSet as BatchReader>::Factories,
+        finit: Box<dyn Fn(&mut DynData, &DynData, ZWeight)>,
+        fupdate: Box<dyn Fn(&mut DynData, &DynData, ZWeight)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_chain_aggregate(input_factories, output_factories, finit, fupdate)
+    }
+}
 
 impl<Z> Stream<RootCircuit, Z>
 where

--- a/crates/dbsp/src/operator/dynamic/asof_join.rs
+++ b/crates/dbsp/src/operator/dynamic/asof_join.rs
@@ -7,8 +7,8 @@ use crate::{
         operator_traits::{Operator, QuaternaryOperator},
     },
     dynamic::{
-        ClonableTrait, DataTrait, DowncastTrait, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase,
-        Factory, LeanVec, WeightTrait, WithFactory,
+        ClonableTrait, DataTrait, DowncastTrait, DynData, DynPair, DynUnit, DynVec,
+        DynWeightedPairs, Erase, Factory, LeanVec, WeightTrait, WithFactory,
     },
     trace::{
         cursor::{CursorEmpty, CursorPair},
@@ -16,6 +16,8 @@ use crate::{
     },
     Circuit, DBData, DynZWeight, RootCircuit, Scope, Stream, ZWeight,
 };
+
+use super::{MonoIndexedZSet, MonoZSet};
 
 pub struct AsofJoinFactories<TS, I1, I2, O>
 where
@@ -72,6 +74,28 @@ where
             right_factories: self.right_factories.clone(),
             output_factories: self.output_factories.clone(),
         }
+    }
+}
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    #[track_caller]
+    pub fn dyn_asof_join_mono(
+        &self,
+        factories: &AsofJoinFactories<DynData, MonoIndexedZSet, MonoIndexedZSet, MonoZSet>,
+        other: &Stream<RootCircuit, MonoIndexedZSet>,
+        ts_func1: Box<dyn Fn(&DynData, &mut DynData)>,
+        tscmp_func: Box<dyn Fn(&DynData, &DynData) -> Ordering>,
+        valts_cmp_func: Box<dyn Fn(&DynData, &DynData) -> Ordering>,
+        join_func: Box<AsofJoinFunc<DynData, DynData, DynData, DynData, DynUnit>>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_asof_join(
+            factories,
+            other,
+            ts_func1,
+            tscmp_func,
+            valts_cmp_func,
+            join_func,
+        )
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -20,6 +20,7 @@ use crate::{
     trace::{Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor},
     DBData, Timestamp, ZWeight,
 };
+use crate::{NestedCircuit, RootCircuit};
 use minitrace::trace;
 use size_of::SizeOf;
 use std::panic::Location;
@@ -30,6 +31,8 @@ use std::{
     marker::PhantomData,
     ops::Neg,
 };
+
+use super::{MonoIndexedZSet, MonoZSet};
 
 circuit_cache_key!(DistinctId<C, D>(StreamId => Stream<C, D>));
 circuit_cache_key!(DistinctIncrementalId<C, D>(StreamId => Stream<C, D>));
@@ -115,6 +118,42 @@ where
         if input.has_distinct_version() {
             self.mark_distinct();
         }
+    }
+}
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    pub fn dyn_distinct_mono(
+        &self,
+        factories: &DistinctFactories<MonoIndexedZSet, ()>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_distinct(factories)
+    }
+}
+
+impl Stream<RootCircuit, MonoZSet> {
+    pub fn dyn_distinct_mono(
+        &self,
+        factories: &DistinctFactories<MonoZSet, ()>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_distinct(factories)
+    }
+}
+
+impl Stream<NestedCircuit, MonoIndexedZSet> {
+    pub fn dyn_distinct_mono(
+        &self,
+        factories: &DistinctFactories<MonoIndexedZSet, <NestedCircuit as WithClock>::Time>,
+    ) -> Stream<NestedCircuit, MonoIndexedZSet> {
+        self.dyn_distinct(factories)
+    }
+}
+
+impl Stream<NestedCircuit, MonoZSet> {
+    pub fn dyn_distinct_mono(
+        &self,
+        factories: &DistinctFactories<MonoZSet, <NestedCircuit as WithClock>::Time>,
+    ) -> Stream<NestedCircuit, MonoZSet> {
+        self.dyn_distinct(factories)
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/filter_map.rs
+++ b/crates/dbsp/src/operator/dynamic/filter_map.rs
@@ -3,6 +3,7 @@
 use crate::circuit::metadata::{MetaItem, OperatorLocation, OperatorMeta, NUM_INPUTS, NUM_OUTPUTS};
 use crate::circuit::metrics::Gauge;
 use crate::circuit::GlobalNodeId;
+use crate::dynamic::DynData;
 use crate::trace::VecWSet;
 use crate::{
     circuit::{
@@ -15,9 +16,12 @@ use crate::{
         Builder, Cursor, OrdIndexedWSet, OrdIndexedWSetFactories, OrdWSet, OrdWSetFactories,
     },
 };
+use crate::{NestedCircuit, RootCircuit};
 use minitrace::trace;
 use std::panic::Location;
 use std::{borrow::Cow, marker::PhantomData};
+
+use super::{MonoIndexedZSet, MonoIndexedZSetFactories, MonoZSet, MonoZSetFactories};
 
 /// See [`crate::operator::FilterMap`].
 pub trait DynFilterMap: BatchReader {
@@ -51,6 +55,178 @@ pub trait DynFilterMap: BatchReader {
     ) -> Stream<C, O>
     where
         O: Batch<Time = (), R = Self::R> + Clone + 'static;
+}
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    #[track_caller]
+    pub fn dyn_filter_mono(&self, filter_func: Box<dyn Fn((&DynData, &DynData)) -> bool>) -> Self {
+        self.dyn_filter(filter_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        map_func: Box<dyn Fn((&DynData, &DynData), &mut DynPair<DynData, DynUnit>)>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_map(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        map_func: Box<dyn Fn((&DynData, &DynData), &mut DynPair<DynData, DynData>)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_map_index(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        func: Box<dyn FnMut((&DynData, &DynData), &mut dyn FnMut(&mut DynData, &mut DynUnit))>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_flat_map(output_factories, func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        func: Box<dyn FnMut((&DynData, &DynData), &mut dyn FnMut(&mut DynData, &mut DynData))>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_flat_map_index(output_factories, func)
+    }
+}
+
+impl Stream<RootCircuit, MonoZSet> {
+    #[track_caller]
+    pub fn dyn_filter_mono(&self, filter_func: Box<dyn Fn(&DynData) -> bool>) -> Self {
+        self.dyn_filter(filter_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        map_func: Box<dyn Fn(&DynData, &mut DynPair<DynData, DynUnit>)>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_map(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        map_func: Box<dyn Fn(&DynData, &mut DynPair<DynData, DynData>)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_map_index(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        func: Box<dyn FnMut(&DynData, &mut dyn FnMut(&mut DynData, &mut DynUnit))>,
+    ) -> Stream<RootCircuit, MonoZSet> {
+        self.dyn_flat_map(output_factories, func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        func: Box<dyn FnMut(&DynData, &mut dyn FnMut(&mut DynData, &mut DynData))>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_flat_map_index(output_factories, func)
+    }
+}
+
+impl Stream<NestedCircuit, MonoIndexedZSet> {
+    #[track_caller]
+    pub fn dyn_filter_mono(&self, filter_func: Box<dyn Fn((&DynData, &DynData)) -> bool>) -> Self {
+        self.dyn_filter(filter_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        map_func: Box<dyn Fn((&DynData, &DynData), &mut DynPair<DynData, DynUnit>)>,
+    ) -> Stream<NestedCircuit, MonoZSet> {
+        self.dyn_map(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        map_func: Box<dyn Fn((&DynData, &DynData), &mut DynPair<DynData, DynData>)>,
+    ) -> Stream<NestedCircuit, MonoIndexedZSet> {
+        self.dyn_map_index(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        func: Box<dyn FnMut((&DynData, &DynData), &mut dyn FnMut(&mut DynData, &mut DynUnit))>,
+    ) -> Stream<NestedCircuit, MonoZSet> {
+        self.dyn_flat_map(output_factories, func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        func: Box<dyn FnMut((&DynData, &DynData), &mut dyn FnMut(&mut DynData, &mut DynData))>,
+    ) -> Stream<NestedCircuit, MonoIndexedZSet> {
+        self.dyn_flat_map_index(output_factories, func)
+    }
+}
+
+impl Stream<NestedCircuit, MonoZSet> {
+    #[track_caller]
+    pub fn dyn_filter_mono(&self, filter_func: Box<dyn Fn(&DynData) -> bool>) -> Self {
+        self.dyn_filter(filter_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        map_func: Box<dyn Fn(&DynData, &mut DynPair<DynData, DynUnit>)>,
+    ) -> Stream<NestedCircuit, MonoZSet> {
+        self.dyn_map(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        map_func: Box<dyn Fn(&DynData, &mut DynPair<DynData, DynData>)>,
+    ) -> Stream<NestedCircuit, MonoIndexedZSet> {
+        self.dyn_map_index(output_factories, map_func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_mono(
+        &self,
+        output_factories: &MonoZSetFactories,
+        func: Box<dyn FnMut(&DynData, &mut dyn FnMut(&mut DynData, &mut DynUnit))>,
+    ) -> Stream<NestedCircuit, MonoZSet> {
+        self.dyn_flat_map(output_factories, func)
+    }
+
+    #[track_caller]
+    pub fn dyn_flat_map_index_mono(
+        &self,
+        output_factories: &MonoIndexedZSetFactories,
+        func: Box<dyn FnMut(&DynData, &mut dyn FnMut(&mut DynData, &mut DynData))>,
+    ) -> Stream<NestedCircuit, MonoIndexedZSet> {
+        self.dyn_flat_map_index(output_factories, func)
+    }
 }
 
 impl<C: Circuit, B: DynFilterMap> Stream<C, B> {

--- a/crates/dbsp/src/operator/dynamic/group/lag.rs
+++ b/crates/dbsp/src/operator/dynamic/group/lag.rs
@@ -4,8 +4,10 @@ use crate::operator::dynamic::filter_map::DynFilterMap;
 use crate::{
     algebra::{HasZero, IndexedZSet, OrdIndexedZSet, ZCursor},
     dynamic::{
-        ClonableTrait, DataTrait, DynPair, DynUnit, DynVec, Erase, Factory, LeanVec, WithFactory,
+        ClonableTrait, DataTrait, DynData, DynPair, DynUnit, DynVec, Erase, Factory, LeanVec,
+        WithFactory,
     },
+    operator::dynamic::MonoIndexedZSet,
     trace::{
         cursor::{CursorPair, ReverseKeyCursor},
         BatchReaderFactories,
@@ -108,6 +110,19 @@ where
                 },
             )),
         )
+    }
+}
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    pub fn dyn_lag_custom_order_mono(
+        &self,
+        factories: &LagCustomOrdFactories<MonoIndexedZSet, DynData, DynData, DynData>,
+        offset: isize,
+        encode: Box<dyn Fn(&DynData, &mut DynData)>,
+        project: Box<dyn Fn(Option<&DynData>, &mut DynData)>,
+        decode: Box<dyn Fn(&DynData, &DynData, &mut DynData)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_lag_custom_order(factories, offset, encode, project, decode)
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/group/topk.rs
+++ b/crates/dbsp/src/operator/dynamic/group/topk.rs
@@ -6,7 +6,8 @@ use crate::{
         AddAssignByRef, HasOne, HasZero, IndexedZSet, OrdIndexedZSet, OrdIndexedZSetFactories,
         ZCursor, ZRingValue,
     },
-    dynamic::{DataTrait, DynUnit, Erase, Factory, WeightTrait},
+    dynamic::{DataTrait, DynData, DynUnit, Erase, Factory, WeightTrait},
+    operator::dynamic::MonoIndexedZSet,
     trace::{BatchReaderFactories, OrdIndexedWSetFactories},
     DBData, DBWeight, DynZWeight, RootCircuit, Stream, ZWeight,
 };
@@ -130,6 +131,50 @@ where
                 TopK::desc(factories.input_factories.val_factory(), k),
             )),
         )
+    }
+}
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    pub fn dyn_topk_custom_order_mono(
+        &self,
+        factories: &TopKCustomOrdFactories<DynData, DynData, DynData, DynZWeight>,
+        k: usize,
+        encode: Box<dyn Fn(&DynData, &mut DynData)>,
+        decode: Box<dyn Fn(&DynData) -> &DynData>,
+    ) -> Self {
+        self.dyn_topk_custom_order(factories, k, encode, decode)
+    }
+
+    pub fn dyn_topk_rank_custom_order_mono(
+        &self,
+        factories: &TopKRankCustomOrdFactories<DynData, DynData, DynData>,
+        k: usize,
+        encode: Box<dyn Fn(&DynData, &mut DynData)>,
+        rank_eq_func: Box<dyn Fn(&DynData, &DynData) -> bool>,
+        output_func: Box<dyn Fn(i64, &DynData, &mut DynData)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_topk_rank_custom_order(factories, k, encode, rank_eq_func, output_func)
+    }
+
+    pub fn dyn_topk_dense_rank_custom_order_mono(
+        &self,
+        factories: &TopKRankCustomOrdFactories<DynData, DynData, DynData>,
+        k: usize,
+        encode: Box<dyn Fn(&DynData, &mut DynData)>,
+        rank_eq_func: Box<dyn Fn(&DynData, &DynData) -> bool>,
+        output_func: Box<dyn Fn(i64, &DynData, &mut DynData)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_topk_dense_rank_custom_order(factories, k, encode, rank_eq_func, output_func)
+    }
+
+    pub fn dyn_topk_row_number_custom_order_mono(
+        &self,
+        factories: &TopKRankCustomOrdFactories<DynData, DynData, DynData>,
+        k: usize,
+        encode: Box<dyn Fn(&DynData, &mut DynData)>,
+        output_func: Box<dyn Fn(i64, &DynData, &mut DynData)>,
+    ) -> Stream<RootCircuit, MonoIndexedZSet> {
+        self.dyn_topk_row_number_custom_order(factories, k, encode, output_func)
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/input.rs
+++ b/crates/dbsp/src/operator/dynamic/input.rs
@@ -4,8 +4,8 @@ use crate::{
     },
     circuit::RootCircuit,
     dynamic::{
-        ClonableTrait, DataTrait, DynBool, DynOpt, DynPair, DynPairs, DynUnit, DynWeightedPairs,
-        Erase, Factory, LeanVec, WithFactory,
+        ClonableTrait, DataTrait, DynBool, DynData, DynOpt, DynPair, DynPairs, DynUnit,
+        DynWeightedPairs, Erase, Factory, LeanVec, WithFactory,
     },
     operator::{
         dynamic::{
@@ -197,6 +197,47 @@ where
             input_pairs_factory: self.input_pairs_factory,
             upsert_pair_factory: self.upsert_pair_factory,
         }
+    }
+}
+
+impl RootCircuit {
+    pub fn dyn_add_input_zset_mono(
+        &self,
+        factories: &AddInputZSetFactories<DynData>,
+    ) -> (
+        ZSetStream<DynData>,
+        CollectionHandle<DynPair<DynData, DynUnit>, DynZWeight>,
+    ) {
+        self.dyn_add_input_zset(factories)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn dyn_add_input_indexed_zset_mono(
+        &self,
+        factories: &AddInputIndexedZSetFactories<DynData, DynData>,
+    ) -> (
+        IndexedZSetStream<DynData, DynData>,
+        CollectionHandle<DynData, DynPair<DynData, DynZWeight>>,
+    ) {
+        self.dyn_add_input_indexed_zset(factories)
+    }
+
+    pub fn dyn_add_input_set_mono(
+        &self,
+        factories: &AddInputSetFactories<OrdZSet<DynData>>,
+    ) -> (ZSetStream<DynData>, UpsertHandle<DynData, DynBool>) {
+        self.dyn_add_input_set(factories)
+    }
+
+    pub fn dyn_add_input_map_mono(
+        &self,
+        factories: &AddInputMapFactories<OrdIndexedZSet<DynData, DynData>, DynData>,
+        patch_func: PatchFunc<DynData, DynData>,
+    ) -> (
+        IndexedZSetStream<DynData, DynData>,
+        UpsertHandle<DynData, DynUpdate<DynData, DynData>>,
+    ) {
+        self.dyn_add_input_map(factories, patch_func)
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/mod.rs
@@ -1,3 +1,8 @@
+use crate::{
+    algebra::{OrdIndexedZSet, OrdIndexedZSetFactories, OrdZSet, OrdZSetFactories},
+    dynamic::DynData,
+};
+
 pub mod aggregate;
 pub mod asof_join;
 mod communication;
@@ -20,3 +25,14 @@ pub mod semijoin;
 pub mod time_series;
 pub mod trace;
 pub(crate) mod upsert;
+
+/// The "standard" indexed Z-set type used by monomorphic
+/// versions of operators.
+pub type MonoIndexedZSet = OrdIndexedZSet<DynData, DynData>;
+
+/// The "standard" Z-set type used by monomorphic
+/// versions of operators.
+pub type MonoZSet = OrdZSet<DynData>;
+
+pub type MonoIndexedZSetFactories = OrdIndexedZSetFactories<DynData, DynData>;
+pub type MonoZSetFactories = OrdZSetFactories<DynData>;

--- a/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
@@ -2,6 +2,8 @@ use dyn_clone::clone_box;
 use size_of::SizeOf;
 
 use crate::circuit::checkpointer::Checkpoint;
+use crate::dynamic::{DynData, DynUnit};
+use crate::operator::dynamic::{MonoIndexedZSet, MonoZSet};
 use crate::{
     dynamic::DataTrait,
     operator::communication::new_exchange_operators,
@@ -24,6 +26,30 @@ where
 }
 
 pub type LeastUpperBoundFunc<TS> = Box<dyn LeastUpperBoundFn<TS>>;
+
+impl Stream<RootCircuit, MonoIndexedZSet> {
+    #[track_caller]
+    pub fn dyn_waterline_mono(
+        &self,
+        init: Box<dyn Fn() -> Box<DynData>>,
+        extract_ts: Box<dyn Fn(&DynData, &DynData, &mut DynData)>,
+        least_upper_bound: LeastUpperBoundFunc<DynData>,
+    ) -> Stream<RootCircuit, Box<DynData>> {
+        self.dyn_waterline(init, extract_ts, least_upper_bound)
+    }
+}
+
+impl Stream<RootCircuit, MonoZSet> {
+    #[track_caller]
+    pub fn dyn_waterline_mono(
+        &self,
+        init: Box<dyn Fn() -> Box<DynData>>,
+        extract_ts: Box<dyn Fn(&DynData, &DynUnit, &mut DynData)>,
+        least_upper_bound: LeastUpperBoundFunc<DynData>,
+    ) -> Stream<RootCircuit, Box<DynData>> {
+        self.dyn_waterline(init, extract_ts, least_upper_bound)
+    }
+}
 
 impl<B> Stream<RootCircuit, B>
 where

--- a/crates/dbsp/src/operator/group/topk.rs
+++ b/crates/dbsp/src/operator/group/topk.rs
@@ -61,7 +61,7 @@ where
         >();
 
         self.inner()
-            .dyn_topk_custom_order(
+            .dyn_topk_custom_order_mono(
                 &factories,
                 k,
                 Box::new(
@@ -122,7 +122,7 @@ where
         >();
 
         self.inner()
-            .dyn_topk_rank_custom_order(
+            .dyn_topk_rank_custom_order_mono(
                 &factories,
                 k,
                 Box::new(
@@ -169,7 +169,7 @@ where
         >();
 
         self.inner()
-            .dyn_topk_dense_rank_custom_order(
+            .dyn_topk_dense_rank_custom_order_mono(
                 &factories,
                 k,
                 Box::new(
@@ -226,7 +226,7 @@ where
         >();
 
         self.inner()
-            .dyn_topk_row_number_custom_order(
+            .dyn_topk_row_number_custom_order_mono(
                 &factories,
                 k,
                 Box::new(

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -242,7 +242,7 @@ impl RootCircuit {
         K: DBData,
     {
         let factories = AddInputZSetFactories::new::<K>();
-        let (stream, handle) = self.dyn_add_input_zset(&factories);
+        let (stream, handle) = self.dyn_add_input_zset_mono(&factories);
 
         (stream.typed(), ZSetHandle::new(handle))
     }
@@ -277,7 +277,7 @@ impl RootCircuit {
         V: DBData,
     {
         let factories = AddInputIndexedZSetFactories::new::<K, V>();
-        let (stream, handle) = self.dyn_add_input_indexed_zset(&factories);
+        let (stream, handle) = self.dyn_add_input_indexed_zset_mono(&factories);
 
         (stream.typed(), IndexedZSetHandle::new(handle))
     }
@@ -359,7 +359,7 @@ impl RootCircuit {
         K: DBData,
     {
         let factories = AddInputSetFactories::new::<K>();
-        let (stream, handle) = self.dyn_add_input_set(&factories);
+        let (stream, handle) = self.dyn_add_input_set_mono(&factories);
 
         (stream.typed(), SetHandle::new(handle))
     }
@@ -463,7 +463,7 @@ impl RootCircuit {
         PF: Fn(&mut V, &U) + 'static,
     {
         let factories = AddInputMapFactories::new::<K, V, U>();
-        let (stream, handle) = self.dyn_add_input_map(
+        let (stream, handle) = self.dyn_add_input_map_mono(
             &factories,
             Box::new(move |v: &mut DynData, u: &DynData| unsafe {
                 patch_func(v.downcast_mut::<V>(), u.downcast::<U>())

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -36,10 +36,11 @@ mod consolidate;
 pub mod controlled_filter;
 mod distinct;
 pub mod dynamic;
+#[cfg(not(feature = "backend-mode"))]
 pub mod filter_map;
 pub mod group;
 pub mod input;
-mod join;
+pub mod join;
 mod join_range;
 pub mod neighborhood;
 mod recursive;
@@ -64,6 +65,7 @@ pub use inspect::Inspect;
 pub use dynamic::join_range::StreamJoinRange;
 // // //pub use neg::UnaryMinus;
 pub use dynamic::{neighborhood::NeighborhoodDescr, trace::TraceBound};
+#[cfg(not(feature = "backend-mode"))]
 pub use filter_map::FilterMap;
 pub use neighborhood::{NeighborhoodDescrBox, NeighborhoodDescrStream};
 pub use output::OutputHandle;

--- a/crates/dbsp/src/operator/time_series/waterline.rs
+++ b/crates/dbsp/src/operator/time_series/waterline.rs
@@ -91,6 +91,7 @@ where
     /// * `extract_ts` - extracts a timestamp from a key-value pair.
     /// * `least_upper_bound` - computes the least upper bound of two
     ///   timestamps.
+    #[cfg(not(feature = "backend-mode"))]
     #[track_caller]
     pub fn waterline<TS, DynTS, WF, IF, LB>(
         &self,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -98,7 +98,6 @@ public class RustFileWriter {
                     circuit::{checkpointer::Checkpoint, Circuit, CircuitConfig, Stream},
                     operator::{
                         Generator,
-                        FilterMap,
                         Fold,
                         group::WithCustomOrd,
                         time_series::{RelRange, RelOffset, OrdPartitionedIndexedZSet},

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -933,7 +933,7 @@ public class ToRustVisitor extends CircuitVisitor {
                 .append(operator.input().getOutputName())
                 .append(".")
                 .append(operator.operation)
-                .append("::<_, DynData, _, _, _>(");
+                .append("(");
         // This part is different from a standard operator.
         operator.init.accept(this.innerVisitor);
         this.builder.append(", ");

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 [dependencies]
 paste = { version = "1.0.12" }
 derive_more = { version = "0.99.17", features = ["add", "not", "from"] }
-dbsp = { path = "../../crates/dbsp" }
+dbsp = { path = "../../crates/dbsp", features = ["backend-mode"] }
 dbsp_adapters = { path = "../../crates/adapters", default-features = false }
 feldera-types = { path = "../../crates/feldera-types" }
 feldera-sqllib = { path = "../../crates/sqllib" }


### PR DESCRIPTION
This commit should significantly speedup multicrate builds, while possibly also improving single-crate compilation times.

As we started experimenting with multi-crate compilation of DBSP pipelines, we discovered that the compiler ends up instantiating identical copies of dyn_XXX operators in multiple client crates, which significantly slows down compilation and increases generated code size. The problem is described in detail in `srs/mono/mod.rs`.

The solution (also described in `mono/mod.rs`) is a less polymorphic version of the DBSP API. On the outside the API can still be parameterized with arbitrary static key and value types, but internally it instantiates a monomorphic version of the dynamically typed API, forcing that code to be generated in the `dbsp` crate.

The new API is enabled by the `backend-mode` feature and shadows the regular API, so that most clients won't require any change to use it.

We change the template `Cargo.toml` file to enable this feature, so the compiler takes advantage of it.

While this is useful for multi-crate projects, I expect some improvement for small single-crate projects as well, since the operators will get compiled once in the dbsp crate and won't get re-compiled with each sql update.

TODO:
- the rolling aggregate operator cannot be monomorphised yet, because it takes one concrete type parameter (timestamp type).


Fixes #3374 