### PR TITLE
pipeline-manager: `refresh_version` field

### DIFF
--- a/crates/pipeline-manager/migrations/V21__refresh_version.sql
+++ b/crates/pipeline-manager/migrations/V21__refresh_version.sql
@@ -1,0 +1,5 @@
+-- Adds the `refresh_version` field to the `pipeline` table.
+
+ALTER TABLE pipeline
+ADD COLUMN refresh_version BIGINT NOT NULL DEFAULT 1;
+UPDATE pipeline SET refresh_version = version;

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -79,6 +79,7 @@ pub struct PipelineInfo {
     pub deployment_status_since: DateTime<Utc>,
     pub deployment_desired_status: PipelineDesiredStatus,
     pub deployment_error: Option<ErrorResponse>,
+    pub refresh_version: Version,
 }
 
 /// Pipeline information (internal).
@@ -111,6 +112,7 @@ pub struct PipelineInfoInternal {
     pub deployment_status_since: DateTime<Utc>,
     pub deployment_desired_status: PipelineDesiredStatus,
     pub deployment_error: Option<ErrorResponse>,
+    pub refresh_version: Version,
 }
 
 impl PipelineInfoInternal {
@@ -135,6 +137,7 @@ impl PipelineInfoInternal {
             deployment_status_since: extended_pipeline.deployment_status_since,
             deployment_desired_status: extended_pipeline.deployment_desired_status,
             deployment_error: extended_pipeline.deployment_error,
+            refresh_version: extended_pipeline.refresh_version,
         }
     }
 }
@@ -169,6 +172,7 @@ pub struct PipelineSelectedInfo {
     pub deployment_status_since: DateTime<Utc>,
     pub deployment_desired_status: PipelineDesiredStatus,
     pub deployment_error: Option<ErrorResponse>,
+    pub refresh_version: Version,
 }
 
 /// Pipeline information which has a selected subset of optional fields (internal).
@@ -205,6 +209,7 @@ pub struct PipelineSelectedInfoInternal {
     pub deployment_status_since: DateTime<Utc>,
     pub deployment_desired_status: PipelineDesiredStatus,
     pub deployment_error: Option<ErrorResponse>,
+    pub refresh_version: Version,
 }
 
 impl PipelineSelectedInfoInternal {
@@ -231,6 +236,7 @@ impl PipelineSelectedInfoInternal {
             deployment_status_since: extended_pipeline.deployment_status_since,
             deployment_desired_status: extended_pipeline.deployment_desired_status,
             deployment_error: extended_pipeline.deployment_error,
+            refresh_version: extended_pipeline.refresh_version,
         }
     }
 
@@ -255,6 +261,7 @@ impl PipelineSelectedInfoInternal {
             deployment_status_since: extended_pipeline.deployment_status_since,
             deployment_desired_status: extended_pipeline.deployment_desired_status,
             deployment_error: extended_pipeline.deployment_error,
+            refresh_version: extended_pipeline.refresh_version,
         }
     }
 }
@@ -284,6 +291,7 @@ pub enum PipelineFieldSelector {
     /// - `deployment_status_since`
     /// - `deployment_desired_status`
     /// - `deployment_error`
+    /// - `refresh_version`
     All,
     /// Select only the fields required to know the status of a pipeline.
     ///
@@ -301,6 +309,7 @@ pub enum PipelineFieldSelector {
     /// - `deployment_status_since`
     /// - `deployment_desired_status`
     /// - `deployment_error`
+    /// - `refresh_version`
     Status,
 }
 

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -88,6 +88,7 @@ fn extended_pipeline_1() -> ExtendedPipelineDescr {
         deployment_status_since: Default::default(),
         deployment_desired_status: PipelineDesiredStatus::Shutdown,
         deployment_error: None,
+        refresh_version: Version(4),
     }
 }
 
@@ -142,6 +143,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
         deployment_status_since: Default::default(),
         deployment_desired_status: PipelineDesiredStatus::Shutdown,
         deployment_error: None,
+        refresh_version: Version(1),
     }
 }
 
@@ -180,6 +182,7 @@ fn pipeline_info_internal_to_external(pipeline: PipelineInfoInternal) -> Pipelin
         deployment_status_since: pipeline.deployment_status_since,
         deployment_desired_status: pipeline.deployment_desired_status,
         deployment_error: pipeline.deployment_error,
+        refresh_version: pipeline.refresh_version,
     }
 }
 
@@ -228,6 +231,7 @@ fn pipeline_selected_info_internal_to_external(
         deployment_status_since: pipeline.deployment_status_since,
         deployment_desired_status: pipeline.deployment_desired_status,
         deployment_error: pipeline.deployment_error,
+        refresh_version: pipeline.refresh_version,
     }
 }
 

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -38,6 +38,7 @@ impl ExtendedPipelineDescrRunner {
                 deployment_desired_status: pipeline.deployment_desired_status,
                 deployment_error: pipeline.deployment_error.clone(),
                 deployment_location: pipeline.deployment_location.clone(),
+                refresh_version: pipeline.refresh_version,
             },
         }
     }

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2340,10 +2340,12 @@ impl ModelHelpers for Mutex<DbModel> {
         // Version changed: increment it
         if version_increment {
             pipeline.version = Version(pipeline.version.0 + 1);
+            pipeline.refresh_version = Version(pipeline.refresh_version.0 + 1);
         }
 
         // Program changed
         if program_version_increment {
+            assert!(version_increment); // Whenever program_version is incremented, version should also have been
             pipeline.program_version = Version(pipeline.program_version.0 + 1);
             pipeline.program_status = ProgramStatus::Pending;
             pipeline.program_status_since = Utc::now();
@@ -2470,6 +2472,7 @@ fn convert_descriptor_to_monitoring(
         deployment_desired_status: pipeline.deployment_desired_status,
         deployment_error: pipeline.deployment_error.clone(),
         deployment_location: pipeline.deployment_location.clone(),
+        refresh_version: pipeline.refresh_version,
     }
 }
 
@@ -2755,6 +2758,7 @@ impl Storage for Mutex<DbModel> {
             deployment_error: None,
             deployment_config: None,
             deployment_location: None,
+            refresh_version: Version(1),
         };
 
         // Insert into state
@@ -2873,6 +2877,7 @@ impl Storage for Mutex<DbModel> {
         pipeline.program_status_since = Utc::now();
         pipeline.program_info = None;
         pipeline.program_binary_url = None;
+        pipeline.refresh_version = Version(pipeline.refresh_version.0 + 1);
         self.lock()
             .await
             .pipelines
@@ -2917,6 +2922,7 @@ impl Storage for Mutex<DbModel> {
         pipeline.program_status = new_status;
         pipeline.program_status_since = Utc::now();
         pipeline.program_info = Some(program_info.clone());
+        pipeline.refresh_version = Version(pipeline.refresh_version.0 + 1);
         self.lock()
             .await
             .pipelines

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -404,7 +404,7 @@ pub struct ExtendedPipelineDescr {
     pub created_at: DateTime<Utc>,
 
     /// Pipeline version, incremented every time name, description, runtime_config, program_code,
-    /// program_config or platform_version is/are modified.
+    /// udf_rust, udf_toml, program_config or platform_version is/are modified.
     pub version: Version,
 
     /// Pipeline platform version.
@@ -426,7 +426,7 @@ pub struct ExtendedPipelineDescr {
     pub program_config: serde_json::Value,
 
     /// Program version, incremented every time program_code, udf_rust,
-    /// udf_toml, program_config or platform_version is modified.
+    /// udf_toml, program_config or platform_version is/are modified.
     pub program_version: Version,
 
     /// Program compilation status.
@@ -473,6 +473,12 @@ pub struct ExtendedPipelineDescr {
     /// Location where the pipeline can be reached at runtime
     /// (e.g., a TCP port number or a URI).
     pub deployment_location: Option<String>,
+
+    /// Refresh version, incremented for the same fields as `version` but also including
+    /// `program_info` as it contains information of interest to the user regarding the pipeline.
+    /// It is a notification mechanism for users. If a user detects it changed while monitoring
+    /// only the status fields, it should refresh fully (retrieve all fields).
+    pub refresh_version: Version,
 }
 
 /// Pipeline descriptor which includes the fields relevant to system monitoring.
@@ -497,4 +503,5 @@ pub struct ExtendedPipelineDescrMonitoring {
     pub deployment_desired_status: PipelineDesiredStatus,
     pub deployment_error: Option<ErrorResponse>,
     pub deployment_location: Option<String>,
+    pub refresh_version: Version,
 }

--- a/crates/pipeline-manager/src/integration_test.rs
+++ b/crates/pipeline-manager/src/integration_test.rs
@@ -957,7 +957,7 @@ async fn pipeline_get() {
 }
 
 /// Fields included in the `all` selector.
-const PIPELINE_FIELD_SELECTOR_ALL_FIELDS: [&str; 19] = [
+const PIPELINE_FIELD_SELECTOR_ALL_FIELDS: [&str; 20] = [
     "id",
     "name",
     "description",
@@ -977,10 +977,11 @@ const PIPELINE_FIELD_SELECTOR_ALL_FIELDS: [&str; 19] = [
     "deployment_status_since",
     "deployment_desired_status",
     "deployment_error",
+    "refresh_version",
 ];
 
 /// Fields included in the `status` selector.
-const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 13] = [
+const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 14] = [
     "id",
     "name",
     "description",
@@ -994,6 +995,7 @@ const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 13] = [
     "deployment_status_since",
     "deployment_desired_status",
     "deployment_error",
+    "refresh_version",
 ];
 
 /// Tests the retrieval of a pipeline and list of pipelines with a field selector.
@@ -3254,4 +3256,66 @@ async fn checkpoint() {
     {
         assert_ne!(response.status(), StatusCode::NOT_IMPLEMENTED);
     }
+}
+
+/// Incrementing of `refresh_version`.
+#[actix_web::test]
+#[serial]
+async fn refresh_version() {
+    let config = setup().await;
+
+    // Initial refresh version should be 1
+    let request_body = json!({
+        "name": "test",
+        "program_code": "",
+    });
+    let mut response = config.post("/v0/pipelines", &request_body).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let value: Value = response.json().await.unwrap();
+    assert_eq!(value["refresh_version"], json!(1));
+
+    // After compilation, refresh version should be 2
+    config
+        .wait_for_compilation("test", 1, config.compilation_timeout)
+        .await;
+    let mut response = config.get("/v0/pipelines/test").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = response.json().await.unwrap();
+    assert_eq!(value["refresh_version"], json!(2));
+
+    // Starting and shutting down should have no effect on the refresh version
+    let response = config.post_no_body("/v0/pipelines/test/pause").await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    config
+        .wait_for_deployment_status("test", PipelineStatus::Paused, config.start_timeout)
+        .await;
+    let response = config.post_no_body("/v0/pipelines/test/shutdown").await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    config
+        .wait_for_deployment_status("test", PipelineStatus::Shutdown, config.start_timeout)
+        .await;
+    let mut response = config.get("/v0/pipelines/test").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = response.json().await.unwrap();
+    assert_eq!(value["refresh_version"], json!(2));
+
+    // Edits should have an impact, incrementing refresh version to 3
+    let mut response = config
+        .patch(
+            "/v0/pipelines/test",
+            &json!({ "program_code": "CREATE TABLE t1 ( v1 INT );" }),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = response.json().await.unwrap();
+    assert_eq!(value["refresh_version"], json!(3));
+
+    // After compilation, refresh version should be 4
+    config
+        .wait_for_compilation("test", 2, config.compilation_timeout)
+        .await;
+    let mut response = config.get("/v0/pipelines/test").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = response.json().await.unwrap();
+    assert_eq!(value["refresh_version"], json!(4));
 }

--- a/openapi.json
+++ b/openapi.json
@@ -398,7 +398,8 @@
                     "deployment_status": "Shutdown",
                     "deployment_status_since": "1970-01-01T00:00:00Z",
                     "deployment_desired_status": "Shutdown",
-                    "deployment_error": null
+                    "deployment_error": null,
+                    "refresh_version": 4
                   },
                   {
                     "id": "67e55044-10b1-426f-9247-bb680e5fe0c9",
@@ -441,7 +442,8 @@
                     "deployment_status": "Shutdown",
                     "deployment_status_since": "1970-01-01T00:00:00Z",
                     "deployment_desired_status": "Shutdown",
-                    "deployment_error": null
+                    "deployment_error": null,
+                    "refresh_version": 1
                   }
                 ]
               }
@@ -560,7 +562,8 @@
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "deployment_desired_status": "Shutdown",
-                  "deployment_error": null
+                  "deployment_error": null,
+                  "refresh_version": 4
                 }
               }
             }
@@ -682,7 +685,8 @@
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "deployment_desired_status": "Shutdown",
-                  "deployment_error": null
+                  "deployment_error": null,
+                  "refresh_version": 4
                 }
               }
             }
@@ -818,7 +822,8 @@
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "deployment_desired_status": "Shutdown",
-                  "deployment_error": null
+                  "deployment_error": null,
+                  "refresh_version": 4
                 }
               }
             }
@@ -871,7 +876,8 @@
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "deployment_desired_status": "Shutdown",
-                  "deployment_error": null
+                  "deployment_error": null,
+                  "refresh_version": 4
                 }
               }
             }
@@ -1058,7 +1064,8 @@
                   "deployment_status": "Shutdown",
                   "deployment_status_since": "1970-01-01T00:00:00Z",
                   "deployment_desired_status": "Shutdown",
-                  "deployment_error": null
+                  "deployment_error": null,
+                  "refresh_version": 4
                 }
               }
             }
@@ -3383,7 +3390,8 @@
           "program_status_since",
           "deployment_status",
           "deployment_status_since",
-          "deployment_desired_status"
+          "deployment_desired_status",
+          "refresh_version"
         ],
         "properties": {
           "created_at": {
@@ -3444,6 +3452,9 @@
           "program_version": {
             "$ref": "#/components/schemas/Version"
           },
+          "refresh_version": {
+            "$ref": "#/components/schemas/Version"
+          },
           "runtime_config": {
             "$ref": "#/components/schemas/RuntimeConfig"
           },
@@ -3473,7 +3484,8 @@
           "program_status_since",
           "deployment_status",
           "deployment_status_since",
-          "deployment_desired_status"
+          "deployment_desired_status",
+          "refresh_version"
         ],
         "properties": {
           "created_at": {
@@ -3538,6 +3550,9 @@
             "format": "date-time"
           },
           "program_version": {
+            "$ref": "#/components/schemas/Version"
+          },
+          "refresh_version": {
             "$ref": "#/components/schemas/Version"
           },
           "runtime_config": {

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -1808,7 +1808,8 @@ It both includes fields which are user-provided and system-generated.`,
     'program_status_since',
     'deployment_status',
     'deployment_status_since',
-    'deployment_desired_status'
+    'deployment_desired_status',
+    'refresh_version'
   ],
   properties: {
     created_at: {
@@ -1869,6 +1870,9 @@ It both includes fields which are user-provided and system-generated.`,
     program_version: {
       $ref: '#/components/schemas/Version'
     },
+    refresh_version: {
+      $ref: '#/components/schemas/Version'
+    },
     runtime_config: {
       $ref: '#/components/schemas/RuntimeConfig'
     },
@@ -1901,7 +1905,8 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
     'program_status_since',
     'deployment_status',
     'deployment_status_since',
-    'deployment_desired_status'
+    'deployment_desired_status',
+    'refresh_version'
   ],
   properties: {
     created_at: {
@@ -1966,6 +1971,9 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
       format: 'date-time'
     },
     program_version: {
+      $ref: '#/components/schemas/Version'
+    },
+    refresh_version: {
       $ref: '#/components/schemas/Version'
     },
     runtime_config: {

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1345,6 +1345,7 @@ export type PipelineInfo = {
   program_status: ProgramStatus
   program_status_since: string
   program_version: Version
+  refresh_version: Version
   runtime_config: RuntimeConfig
   udf_rust: string
   udf_toml: string
@@ -1372,6 +1373,7 @@ export type PipelineSelectedInfo = {
   program_status: ProgramStatus
   program_status_since: string
   program_version: Version
+  refresh_version: Version
   runtime_config?: RuntimeConfig | null
   udf_rust?: string | null
   udf_toml?: string | null


### PR DESCRIPTION
Adds the `refresh_version` field to the pipeline. The `refresh_version` is incremented for the same fields as `version` but also including `program_info` as it contains information of interest to the user regarding the pipeline. It is a notification mechanism for users. If a user detects it changed while monitoring only the status fields, it should refresh fully (retrieve all fields). This will reduce the frequency at which the full pipeline with all fields needs to be retrieved.