### PR TITLE
[SQL] Quote column names when generating SQL code internally

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -789,12 +789,12 @@ public class SqlToRelCompiler implements IWritesLogs {
               CREATE TABLE T(... column WATERMARK expression ...);
               SELECT column - value FROM tmp;
               and validate it. */
-            String sql = "CREATE TABLE TMP(" +
-                    columnName + " " +
+            String sql = "CREATE TABLE TMP(\"" +
+                    columnName + "\" " +
                     columnType + ");\n" +
-                    "CREATE VIEW V AS SELECT " +
+                    "CREATE VIEW V AS SELECT \"" +
                     columnName +
-                    " - " + value +
+                    "\" - " + value +
                     " FROM TMP;\n";
             Logger.INSTANCE.belowLevel(this, 4)
                     .newline()

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -36,6 +36,14 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void internalIssue143() {
+        this.compileRustTestCase("""
+                CREATE TABLE T(x INT);
+                CREATE VIEW V as SELECT x as "timestamp" FROM T;
+                LATENESS trades."timestamp" INTERVAL 1 HOUR;""");
+    }
+
+    @Test
     public void issue3164() {
         this.getCCS("""
              CREATE TABLE T(x INTEGER LATENESS 10);


### PR DESCRIPTION
Without this PR, adding lateness annotations on a view can cause a parse error, if the view's column is a reserved keyword which is quoted, e.g.:

```sql
CREATE VIEW V AS SELECT x as "timestamp" FROM t;
LATENESS V."timestamp" 0;
```