### PR TITLE
Remove ci.yml build from merge_queue trigger.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
       - 'CODE_OF_CONDUCT.md'
       - 'CONTRIBUTING.md'
       - './vscode/**'
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I think this will prevent ci.yml from running twice
(in merge queue and for PRs). We have a branch
rule that it needs to pass all steps called `build` before being merged which according to

https://github.com/orgs/community/discussions/103114

is sufficient for checking that ci.yml passed.