### PR TITLE
pipeline-manager: platform version suffix

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -74,6 +74,8 @@ jobs:
           tags: ${{ steps.meta_pipeline_manager.outputs.tags }}
           labels: ${{ steps.meta_pipeline_manager.outputs.labels }}
           annotations: ${{ steps.meta_pipeline_manager.outputs.annotations }}
+          build-args: |
+            FELDERA_PLATFORM_VERSION_SUFFIX=${{ github.sha }}
 
       - name: Export multiarch image digest
         id: export_image_digest

--- a/crates/pipeline-manager/build.rs
+++ b/crates/pipeline-manager/build.rs
@@ -65,4 +65,10 @@ fn main() {
         let _ = resource_dir.with_generated_filename(out_dir.join("generated.rs"));
         resource_dir.build().expect("SvelteKit app failed to build")
     };
+
+    // Determine whether the platform version includes a suffix
+    let platform_version_suffix =
+        env::var("FELDERA_PLATFORM_VERSION_SUFFIX").unwrap_or("".to_string());
+    println!("cargo:rerun-if-env-changed=FELDERA_PLATFORM_VERSION_SUFFIX");
+    println!("cargo:rustc-env=FELDERA_PLATFORM_VERSION_SUFFIX={platform_version_suffix}");
 }

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -10,10 +10,18 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// The default `platform_version`, which is retrieved from the
-/// environment variable `CARGO_PKG_VERSION` set by Cargo.
+/// The default `platform_version` is formed using two compilation environment variables:
+/// - `CARGO_PKG_VERSION` set by Cargo
+/// - `FELDERA_PLATFORM_VERSION_SUFFIX` set by the custom `build.rs` script,
+///   which is determined using the similarly named environment variable
 fn default_platform_version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+    let package_version = env!("CARGO_PKG_VERSION").to_string();
+    let suffix = env!("FELDERA_PLATFORM_VERSION_SUFFIX").to_string();
+    if suffix.is_empty() {
+        package_version
+    } else {
+        format!("{package_version}+{suffix}")
+    }
 }
 
 /// Default working directory: ~/.feldera
@@ -132,7 +140,7 @@ fn help_canonicalize_dir(dir: &str) -> AnyResult<String> {
 #[command(author, version, about, long_about = None)]
 pub struct CommonConfig {
     /// Platform version which is used to determine if an upgrade occurred.
-    /// Default is the package version.
+    /// Default is determined at compile time.
     #[serde(default = "default_platform_version")]
     #[arg(long, default_value_t = default_platform_version())]
     pub platform_version: String,

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -89,6 +89,7 @@ RUN mkdir sql-to-dbsp-compiler || true
 COPY sql-to-dbsp-compiler/lib sql-to-dbsp-compiler/lib
 COPY --from=web-ui-builder /web-console/build web-console-build
 ENV WEBCONSOLE_BUILD_DIR=/app/web-console-build
+ARG FELDERA_PLATFORM_VERSION_SUFFIX=""
 RUN /root/.cargo/bin/cargo build --release --bin=pipeline-manager --features=pg-embed
 
 # Java build can be performed in parallel. Outputs should be architecture independent


### PR DESCRIPTION
Introduces the `FELDERA_PLATFORM_VERSION_SUFFIX` environment variable at compile-time, which can be used to add a suffix to the platform version. This suffix enables the upgrade of pipelines for the same release version by setting the suffix to the git commit hash.