### PR TITLE
Implement overlapped I/O for joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3723,7 +3723,7 @@ dependencies = [
  "metrics",
  "mimalloc-rust-sys",
  "minitrace",
- "nix 0.27.1",
+ "nix 0.29.0",
  "num",
  "num-derive",
  "num-traits",
@@ -6858,17 +6858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.8.0",
  "cfg-if",
  "libc",
 ]

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -80,7 +80,7 @@ version = "0.3.20"
 features = ["formatting", "macros", "serde", "serde-human-readable"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.27.1", features = ["uio", "feature", "fs"] }
+nix = { version = "0.29.0", features = ["uio", "event", "feature", "fs", "poll"] }
 io-uring = "0.6.3"
 
 [dev-dependencies]

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -1209,7 +1209,13 @@ where
         let mut output_tuples = self.timed_items_factory.default_box();
 
         let mut index_cursor = index.cursor();
-        let mut trace_cursor = trace.cursor();
+
+        let fetched = trace.fetch(index).await;
+        let mut trace_cursor = if let Some(fetched) = fetched.as_ref() {
+            fetched.get_cursor()
+        } else {
+            Box::new(trace.cursor())
+        };
 
         let time = self.clock.time();
 

--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         GlobalNodeId,
     },
     monitor::{visual_graph::Graph, TraceMonitor},
-    RootCircuit,
+    RootCircuit, Runtime,
 };
 use size_of::HumanBytes;
 use std::{
@@ -491,6 +491,21 @@ impl Profiler {
 
                 for item in default_meta {
                     meta.insert(0, item);
+                }
+
+                if let Some(cache) = Runtime::buffer_cache() {
+                    let (cur, max) = cache.occupancy();
+                    meta.insert(
+                        0,
+                        (
+                            Cow::Borrowed("cache occupancy"),
+                            MetaItem::String(format!(
+                                "{} used (max {})",
+                                HumanBytes::new(cur as u64),
+                                HumanBytes::new(max as u64)
+                            )),
+                        ),
+                    );
                 }
             }
         }

--- a/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/mod.rs
@@ -1,412 +1,57 @@
 //! [StorageBackend] implementation with [io_uring].
+//!
+//! This backend's [FileReader] and [FileWriter] both use `io_uring`, but in
+//! different ways:
+//!
+//! - The [FileWriter] implementation instantiates a per-backend (and thus
+//!   effectively per-thread) io_uring. This io_uring has a very small
+//!   submission and completion queue. This should generally be enough because
+//!   writes are sequential and issued only when about 4 MiB of data accumulates
+//!   on a file.
+//!
+//! - The [FileReader] implementation is a per-process singleton with larger
+//!   submission and completion queues and a thread dedicated to servicing it.
+//!   Because [FileReader] is `Send + Sync`, it's difficult to maintain the
+//!   per-thread `io_uring` model. Because `io_uring` completions arrive
+//!   asynchronously, it's also difficult to avoid dedicating a thread to it and
+//!   still achieve low latency.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
-use std::io::{Error as IoError, ErrorKind};
-use std::mem::ManuallyDrop;
-use std::os::fd::AsRawFd;
-use std::path::{Path, PathBuf};
-use std::rc::Weak;
-use std::{rc::Rc, sync::Arc};
+use std::{
+    cell::RefCell,
+    fs::OpenOptions,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
 
 use feldera_types::config::StorageCacheConfig;
-use io_uring::squeue::Entry;
-use io_uring::{opcode, types::Fd, IoUring};
-use libc::{c_void, iovec};
 use metrics::counter;
+use read::IoUringReader;
+use write::{IoUringWriter, WriterInner};
 
-use crate::storage::buffer_cache::FBuf;
 use crate::storage::init;
 use crate::{circuit::metrics::FILES_CREATED, storage::backend::StorageBackend};
 
-use super::posixio_impl::PosixReader;
-use super::{FileId, FileReader, FileWriter, HasFileId, StorageCacheFlags, StorageError, IOV_MAX};
+use super::{FileReader, FileWriter, StorageCacheFlags, StorageError};
+
+mod read;
+mod write;
 
 #[cfg(test)]
 mod tests;
 
-/// Meta-data we keep per file we created.
-struct IoUringWriter {
-    backend: Rc<RefCell<Inner>>,
-
-    file_id: FileId,
-    path: PathBuf,
-
-    status: Rc<RefCell<WorkStatus>>,
-
-    /// The file we're writing.
-    file: Arc<File>,
-
-    /// Write operation we're currently accumulating.
-    write: VectoredWrite,
-}
-
-#[derive(Default)]
-struct WorkStatus {
-    /// Total of the `work` elements in the [`Request`]s that reference this
-    /// file within [`Inner::requests`].
-    queued_work: u64,
-
-    /// If non-[`None`], the error that occurred while writing the file.  Errors
-    /// are reported by request completions, which might be processed while work
-    /// is happening for a file other than the one we're currently working on,
-    /// so we have to save the error and report it for the correct file.
-    error: Option<ErrorKind>,
-}
-
-impl IoUringWriter {
-    fn new(backend: Rc<RefCell<Inner>>, file: Arc<File>, path: PathBuf) -> Self {
-        Self {
-            backend,
-            file,
-            file_id: FileId::new(),
-            path,
-            status: Rc::new(RefCell::new(WorkStatus::default())),
-            write: VectoredWrite::default(),
-        }
-    }
-    fn error(&self) -> Result<(), IoError> {
-        self.status
-            .borrow()
-            .error
-            .map_or(Ok(()), |kind| Err(kind.into()))
-    }
-
-    /// If this file has any pending writes, submits them for processing.
-    fn flush(&mut self) -> Result<(), IoError> {
-        let write = self.write.take();
-        if write.len == 0 {
-            return Ok(());
-        }
-
-        let iovec = write
-            .buffers
-            .iter()
-            .map(|buf| iovec {
-                iov_base: buf.as_ptr() as *mut c_void,
-                iov_len: buf.len(),
-            })
-            .collect::<Vec<_>>();
-        let entry = opcode::Writev::new(
-            Fd(self.file.as_raw_fd()),
-            iovec.as_ptr(),
-            iovec.len() as u32,
-        )
-        .offset(write.offset)
-        .build();
-
-        self.backend.borrow_mut().submit_request(
-            &self.status,
-            entry,
-            write.len,
-            write.len as i32,
-            RequestResources {
-                iovec,
-                buffers: write.buffers,
-                file: self.file.clone(),
-            },
-        )?;
-        Ok(())
-    }
-
-    /// Blocks until `fd` has no more than `max_queued_work` units of work in
-    /// flight.
-    fn limit_queued_work(&mut self, max_queued_work: u64) -> Result<(), IoError> {
-        loop {
-            self.error()?;
-            if self.status.borrow().queued_work <= max_queued_work {
-                return Ok(());
-            }
-
-            if self.backend.borrow_mut().run_completions() == 0 {
-                self.backend.borrow().io_uring.submit_and_wait(1)?;
-            }
-        }
-    }
-}
-
-impl HasFileId for IoUringWriter {
-    fn file_id(&self) -> FileId {
-        self.file_id
-    }
-}
-
-impl FileWriter for IoUringWriter {
-    fn write_block(&mut self, offset: u64, data: FBuf) -> Result<Arc<FBuf>, StorageError> {
-        let block = Arc::new(data);
-        self.error()?;
-
-        if self.write.append(&block, offset).is_err() {
-            self.flush()?;
-            self.limit_queued_work(4 * 1024 * 1024)?;
-            self.write.append(&block, offset).unwrap();
-        }
-
-        Ok(block)
-    }
-
-    fn complete(mut self: Box<Self>) -> Result<(Arc<dyn FileReader>, PathBuf), StorageError> {
-        // Submit any pending writes and then wait for the writes to complete.
-        //
-        // This has two purposes.  First, it means that, on the read side, we
-        // don't have to be prepared to service uncompleted reads ourselves
-        // through an internal cache lookup (although we could put the
-        // `IO_DRAIN` flag on the first "read" operation as a barrier).
-        //
-        // Second, it ensures that we don't allow reads of data that might
-        // encounter an error before they make it to disk.  This property might
-        // not be important.
-        self.flush()?;
-        self.limit_queued_work(0)?;
-
-        // Submit an `fsync` request for the file.  This ensures that the
-        // metadata (and data, but we probably used `O_DIRECT`) for the file
-        // will be committed "soon".  It also ensures that we can make sure that
-        // everything we've written is on stable storage for the purpose of a
-        // checkpoint (which we don't do yet) simply by waiting for the entire
-        // io_uring to drain.
-        self.backend.borrow_mut().submit_request(
-            &self.status,
-            opcode::Fsync::new(Fd(self.file.as_raw_fd())).build(),
-            0,
-            0,
-            RequestResources {
-                iovec: Vec::new(),
-                buffers: Vec::new(),
-                file: self.file.clone(),
-            },
-        )?;
-        self.limit_queued_work(0)?;
-
-        Ok((
-            Arc::new(PosixReader::new(
-                self.file.clone(),
-                self.file_id,
-                self.path.clone(),
-                false,
-            )),
-            self.path.clone(),
-        ))
-    }
-}
-
-/// An accumulator for a multi-buffer sequential write operation.
-///
-/// It's significantly faster to write multiple buffers in a single operation
-/// than in multiple operations, even over `io_uring`, so this gathers them up.
-#[derive(Default)]
-struct VectoredWrite {
-    /// Buffers accumulated to write so far.
-    buffers: Vec<Arc<FBuf>>,
-
-    /// Starting offset for the write. If there are no buffers yet, this is not
-    /// meaningful (and should be 0).
-    offset: u64,
-
-    /// Sum of the lengths of the buffers in `buffers`.
-    len: u64,
-}
-
-impl VectoredWrite {
-    /// Tries to add a write of `block` at `offset` to this vectored write.
-    /// This will fail if adding `block` would make the vectored write too big
-    /// or non-sequential.
-    fn append(&mut self, block: &Arc<FBuf>, offset: u64) -> Result<(), ()> {
-        if self.len >= 1024 * 1024
-            || (self.len > 0 && self.offset + self.len != offset)
-            || self.buffers.len() >= *IOV_MAX
-        {
-            Err(())
-        } else {
-            if self.buffers.is_empty() {
-                self.offset = offset;
-                self.len = 0;
-            }
-            self.len += block.len() as u64;
-            self.buffers.push(block.clone());
-            Ok(())
-        }
-    }
-    fn take(&mut self) -> Self {
-        std::mem::take(self)
-    }
-}
-
-/// Resources associated with a request that must be kept around until the
-/// request is completed.
-#[allow(dead_code)]
-struct RequestResources {
-    /// Needs to be kept until request completion.
-    buffers: Vec<Arc<FBuf>>,
-
-    /// Needs to be kept until request completion.  (The kernel does not copy
-    /// out the iovec at submission time, it accesses it throughout request
-    /// execution.)
-    ///
-    /// ([`std::io::IoSlice`] would be better if its `advance_slices` method
-    /// were ever to be stabilized.)
-    iovec: Vec<iovec>,
-
-    /// Needs to be kept until request submission (but it's easier to just keep
-    /// it until completion).
-    file: Arc<File>,
-}
-
-/// A "write" or "fsync" request passed to the kernel via `io_uring`.
-struct Request {
-    /// Handle from `FileHandle`.
-    status: Weak<RefCell<WorkStatus>>,
-
-    /// A measure of the amount of work done by this request.  We limit the
-    /// total amount of queued work per-file because of the resource cost,
-    /// mainly memory (since we can't free write buffers until the write
-    /// completes).
-    ///
-    /// We currently measure work for a write request as the number of bytes
-    /// written.  We give fsync requests an arbitrary work of 0 because we don't
-    /// need to track the amount of work they do.
-    work: u64,
-
-    /// Expected result from the request (otherwise the request is considered to
-    /// have failed).
-    expected_result: i32,
-
-    /// Tracks resources that must not be dropped until the request is
-    /// completed, to prevent the kernel from scribbling on memory as a
-    /// use-after-free error.
-    resources: ManuallyDrop<RequestResources>,
-}
-
-impl Request {
-    /// Drops our resources.  Must only be called after this request has
-    /// completed (otherwise the kernel might scribble on freed memory).
-    unsafe fn complete(self) {
-        ManuallyDrop::into_inner(self.resources);
-    }
-}
-
-struct Inner {
-    /// Kernel `io_uring` structure.
-    io_uring: IoUring,
-
-    /// All requests that have been submitted to `io_uring` and not yet
-    /// completed.
-    requests: HashMap<u64, Request>,
-
-    /// Next request ID to use.
-    ///
-    /// The request IDs are passed to the kernel in the submission queue.  The
-    /// kernel passes them back in completion queue entries to identify the
-    /// request that completed.
-    next_request_id: u64,
-}
-
-impl Inner {
-    fn new() -> Result<Self, IoError> {
-        // Create our io_uring.
-        //
-        // We specify a submission queue size of 1 because the kernel sizes the
-        // maximum number of I/O threads as `min(n_sqes, 4 * n_cpus)` and,
-        // generally speaking, creating a lot of I/O threads for our file access
-        // is counterproductive.  One thread is enough and more than that slows
-        // us down.
-        //
-        // We specify a larger completion queue size so that we can leave
-        // completions around to be processed in a batch.
-        let io_uring = IoUring::builder()
-            .setup_coop_taskrun()
-            .setup_single_issuer()
-            .setup_cqsize(512)
-            .build(1)?;
-
-        Ok(Self {
-            io_uring,
-            requests: HashMap::new(),
-            next_request_id: 0,
-        })
-    }
-
-    /// Processes all of the entries in the completion queue.
-    fn run_completions(&mut self) -> usize {
-        let mut cq = self.io_uring.completion();
-        cq.sync();
-        assert_eq!(cq.overflow(), 0);
-        let n = cq.len();
-        for entry in cq {
-            let request = self.requests.remove(&entry.user_data()).unwrap();
-            if let Some(status) = request.status.upgrade() {
-                status.borrow_mut().queued_work -= request.work;
-                if request.expected_result != entry.result()
-                    && matches!(&status.borrow().error, None | Some(ErrorKind::WriteZero))
-                {
-                    status.borrow_mut().error = if entry.result() < 0 {
-                        Some(IoError::from_raw_os_error(-entry.result()).kind())
-                    } else {
-                        // Short write.
-                        //
-                        // The likely issues are a full disk or an
-                        // underlying device error.  The best response would
-                        // be to re-issue the remainder of the write so that
-                        // we can get the real error (or recover and
-                        // finish).  It would be hard to test this behavior
-                        // properly.  For now, just provide a placeholder
-                        // error.
-                        //
-                        // If we get a more specific error later, we'll
-                        // update it.
-                        Some(ErrorKind::WriteZero)
-                    }
-                }
-            } else {
-                // The file was dropped.
-            }
-            unsafe { request.complete() };
-        }
-        n
-    }
-
-    /// Adds `entry` to the submission queue and prepares for its completion.
-    /// `entry` should be an operation on `fd` that accounts for `work` work
-    /// units (see [`Request::work`]), whose expected return value is
-    /// `expected_result` and that requires `resources` not to be released
-    /// before completion.
-    fn submit_request(
-        &mut self,
-        status: &Rc<RefCell<WorkStatus>>,
-        entry: Entry,
-        work: u64,
-        expected_result: i32,
-        resources: RequestResources,
-    ) -> Result<(), IoError> {
-        let request_id = self.next_request_id;
-        self.next_request_id += 1;
-        let entry = entry.user_data(request_id);
-
-        // Submit the entry.  The only reason submission can fail is that the
-        // submission queue is full of unsubmitted requests, and we submit for
-        // every operation, so this should never fail.
-        unsafe { self.io_uring.submission().push(&entry) }.unwrap();
-        self.io_uring.submit()?;
-
-        status.borrow_mut().queued_work += work;
-        self.requests.insert(
-            request_id,
-            Request {
-                status: Rc::downgrade(status),
-                work,
-                expected_result,
-                resources: ManuallyDrop::new(resources),
-            },
-        );
-        Ok(())
-    }
-}
-
-/// State of the backend needed to satisfy the storage APIs.
+/// [io_uring] storage backend.
 pub struct IoUringBackend {
-    inner: Rc<RefCell<Inner>>,
+    /// Internals for the writer, which is per-backend.
+    ///
+    /// The reader is a singleton per-process, so we don't have a reference to
+    /// it here.
+    writer_inner: Rc<RefCell<WriterInner>>,
+
+    /// How we're caching data.
     cache: StorageCacheConfig,
+
     /// Directory in which we keep the files.
     base: PathBuf,
 }
@@ -416,10 +61,11 @@ impl IoUringBackend {
     /// `cache`.
     pub fn new<P: AsRef<Path>>(base: P, cache: StorageCacheConfig) -> Result<Self, IoError> {
         init();
+        IoUringReader::init()?;
         Ok(Self {
             base: base.as_ref().to_path_buf(),
             cache,
-            inner: Rc::new(RefCell::new(Inner::new()?)),
+            writer_inner: Rc::new(RefCell::new(WriterInner::new()?)),
         })
     }
 
@@ -449,13 +95,13 @@ impl StorageBackend for IoUringBackend {
 
         counter!(FILES_CREATED).increment(1);
         Ok(Box::new(IoUringWriter::new(
-            self.inner.clone(),
+            self.writer_inner.clone(),
             Arc::new(file),
             path,
         )))
     }
 
     fn open(&self, name: &Path) -> Result<Arc<dyn FileReader>, StorageError> {
-        PosixReader::open(self.base.join(name), self.cache)
+        IoUringReader::open(self.base.join(name), self.cache)
     }
 }

--- a/crates/dbsp/src/storage/backend/io_uring_impl/read.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/read.rs
@@ -1,0 +1,463 @@
+use std::{
+    cmp::min,
+    collections::{BTreeMap, VecDeque},
+    fs::{File, OpenOptions},
+    io::{Error as IoError, ErrorKind},
+    mem::{self, ManuallyDrop},
+    ops::Range,
+    os::{
+        fd::{AsFd, AsRawFd, BorrowedFd},
+        unix::fs::MetadataExt,
+    },
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicI64, AtomicU64, Ordering},
+        mpsc::{channel, Receiver, Sender},
+        Arc, LazyLock,
+    },
+    thread,
+};
+
+use feldera_types::config::StorageCacheConfig;
+use io_uring::{opcode, squeue::Entry, types::Fd, IoUring};
+use nix::{
+    poll::{PollFd, PollFlags, PollTimeout},
+    sys::eventfd::{EfdFlags, EventFd},
+};
+use tokio::sync::oneshot;
+use tracing::error;
+
+use crate::storage::{
+    backend::{
+        posixio_impl::DeleteOnDrop, BlockLocation, FileId, FileReader, HasFileId,
+        StorageCacheFlags, StorageError,
+    },
+    buffer_cache::FBuf,
+};
+
+/// Sends a request to the [ReadThread].
+///
+/// Like [ReadThread], this is a singleton.
+struct Submitter {
+    /// Sends a read request to the read thread.
+    sender: Sender<ReadRequest>,
+
+    /// For waking up the read thread after we send a request.
+    waker: Arc<EventFd>,
+}
+
+impl Submitter {
+    fn new() -> Result<Self, IoError> {
+        let waker = match EventFd::from_flags(EfdFlags::EFD_NONBLOCK) {
+            Ok(eventfd) => Arc::new(eventfd),
+            Err(errno) => {
+                tracing::warn!("could not create eventfd ({errno}), falling back to POSIX I/O");
+                return Err(errno.into());
+            }
+        };
+
+        let (sender, receiver) = channel();
+        let (init_sender, init_receiver) = oneshot::channel();
+        thread::Builder::new()
+            .name("io_uring".into())
+            .spawn({
+                let waker = waker.clone();
+                move || match ReadThread::new(receiver, waker) {
+                    Ok(mut thread) => {
+                        init_sender.send(Ok(())).unwrap();
+                        thread.run();
+                    }
+                    Err(error) => {
+                        init_sender.send(Err(error)).unwrap();
+                    }
+                }
+            })
+            .unwrap();
+        init_receiver
+            .blocking_recv()
+            .unwrap()
+            .inspect_err(|error| {
+                tracing::warn!(
+                "could not create io_uring for read thread ({error}), falling back to POSIX I/O"
+            );
+            })?;
+
+        Ok(Self { waker, sender })
+    }
+
+    fn singleton() -> Result<&'static Self, IoError> {
+        static SUBMITTER: LazyLock<Result<Submitter, IoError>> = LazyLock::new(Submitter::new);
+        match &*SUBMITTER {
+            Ok(submitter) => Ok(submitter),
+            Err(error) => Err(IoError::from(error.kind())),
+        }
+    }
+
+    /// Submits `request` to the [ReadThread].
+    fn submit(&self, request: ReadRequest) {
+        self.sender.send(request).unwrap();
+        self.waker.arm().unwrap();
+    }
+}
+
+/// The I/O uring background read thread.
+///
+/// This is a per-process singleton.
+struct ReadThread {
+    /// The kernel io_uring structure.
+    io_uring: IoUring,
+
+    /// Receives new read requests from the rest of the process.
+    receiver: Receiver<ReadRequest>,
+
+    /// A kernel eventfd for waking us up to receive a new read request.
+    ///
+    /// In an ideal world, this would not exist. This does exist because our
+    /// thread needs to be able to wait for the first of two different kinds of
+    /// events:
+    ///
+    /// - A completion arriving on [Self::io_uring].
+    ///
+    /// - A new read request arriving on [Self::receiver].
+    ///
+    /// Either one of these by itself is easy, but `receiver` is not exposed to
+    /// the kernel, so there's no way to ask the kernel to wait for one or the
+    /// other. So, we have to add a kernel-visible notification that there's a
+    /// new read request, via `waker`.
+    waker: Arc<EventFd>,
+
+    /// All requests that have been submitted to `io_uring` and not yet
+    /// completed.
+    ///
+    /// These are indexed by the smallest ID in their ID range (by
+    /// `r.ids.start`, for [ReadRequest] `r`).
+    requests: BTreeMap<u64, ReadRequest>,
+}
+
+fn retry_submit(io_uring: &IoUring, want: usize) -> Result<usize, IoError> {
+    loop {
+        match io_uring.submit_and_wait(want) {
+            Err(error)
+                if error.kind() == ErrorKind::WouldBlock
+                    || error.kind() == ErrorKind::Interrupted =>
+            {
+                // Retry following transient error.
+            }
+            result => return result,
+        }
+    }
+}
+
+impl ReadThread {
+    /// Finds the request that holds the given `id`, if any.
+    fn get_request(requests: &mut BTreeMap<u64, ReadRequest>, id: u64) -> Option<&mut ReadRequest> {
+        match requests.range_mut(..=id).next_back() {
+            Some((_, request)) if request.ids.contains(&id) => Some(request),
+            _ => None,
+        }
+    }
+
+    /// Process all completion queue entries in the completion queue.
+    fn process_cqes(&mut self) -> usize {
+        let mut n_completions = 0;
+        for cqe in self.io_uring.completion() {
+            n_completions += 1;
+
+            // Find the corresponding `ReadRequest`.
+            let id = cqe.user_data();
+            let Some(request) = Self::get_request(&mut self.requests, id) else {
+                error!("received io_uring completion for unknown request {id}");
+                continue;
+            };
+
+            // Take the corresponding `PendingRead`, complete it, and store the result.
+            //
+            // If this `unwrap` fails, then the kernel sent two completions for
+            // the same read operation, which it should not.
+            let index = (id - request.ids.start) as usize;
+            let pending = mem::take(&mut request.pending[index]).unwrap();
+            request.results[index] = Some(pending.complete(cqe.result()));
+
+            // If that was the last unfinished read operation in this
+            // `ReadRequest`, complete the request as a whole.
+            request.n_incomplete -= 1;
+            if request.n_incomplete == 0 {
+                // The first `unwrap` below cannot fail unless a single pending
+                // read has completed more than once, which cannot happen.
+                //
+                // The second `unwrap` cannot fail because every `ReadRequest`
+                // is in `self.request` under its starting ID.
+                let results = request.results.drain(..).map(|r| r.unwrap()).collect();
+                let start = request.ids.start;
+                let request = self.requests.remove(&start).unwrap();
+                (request.callback)(results);
+            }
+        }
+        n_completions
+    }
+
+    /// Initiates I/O for `request` and adds it to our tracking for requests.
+    fn add_request(&mut self, mut request: ReadRequest) {
+        // Assemble all of the submission queue entries in advance so that we
+        // can insert the request in the I/O queue. (There's a small chance we
+        // might need to process some CQEs for the request before we finish
+        // submitting all the SQEs, so this makes sure that that wouldn't fail.)
+        let mut entries = request
+            .pending
+            .iter_mut()
+            .enumerate()
+            .map(|(i, pending)| {
+                // This `unwrap` cannot panic because all of the read operations
+                // are pending before we initiate I/O.
+                pending
+                    .as_mut()
+                    .unwrap()
+                    .sqe(&request.file)
+                    .user_data(i as u64 + request.ids.start)
+            })
+            .collect::<VecDeque<_>>();
+        assert!(self.requests.insert(request.ids.start, request).is_none());
+
+        // Initiate I/O for each of the read operations in `request`.
+        //
+        // Ordinarily this loop will iterate once. It only iterates multiple
+        // times if the submission queue is full, so that we need to wait for
+        // some operations to complete before we submit more.
+        while !entries.is_empty() {
+            let mut submission = self.io_uring.submission();
+            let needed = entries.len();
+            let available = submission.capacity() - submission.len();
+            let chunk = min(needed, available);
+            if chunk > 0 {
+                // We can submit `chunk` of the operations (most commonly,
+                // `index == 0` and `chunk == n`).
+                //
+                // The `unwrap`s cannot fail because we already verified that
+                // there is enough room for these SQEs.
+                for entry in entries.drain(..chunk) {
+                    unsafe { submission.push(&entry) }.unwrap();
+                }
+                drop(submission);
+                retry_submit(&self.io_uring, 0).unwrap();
+            } else {
+                // We can't submit any operations because the submission queue
+                // is full.  This must be because there are many operations
+                // pending.  Wait for at least one operation to complete, then
+                // process the completion queue, which ought to free up
+                // submission queue space.
+                drop(submission);
+                retry_submit(&self.io_uring, 1).unwrap();
+                self.process_cqes();
+            }
+        }
+    }
+
+    fn run(&mut self) {
+        loop {
+            let n_cqes = self.process_cqes();
+
+            let mut n_new_requests = 0;
+            while let Ok(new_request) = self.receiver.try_recv() {
+                n_new_requests += 1;
+                println!("adding {}-block request", new_request.pending.len());
+                self.add_request(new_request);
+            }
+            if n_new_requests > 0 {
+                // Ignore the return value because we don't want to treat
+                // `EAGAIN` as an error.
+                let _ = self.waker.read();
+            }
+
+            if n_cqes == 0 && n_new_requests == 0 {
+                let _ = nix::poll::poll(
+                    &mut [
+                        PollFd::new(
+                            unsafe { BorrowedFd::borrow_raw(self.io_uring.as_raw_fd()) },
+                            PollFlags::POLLIN,
+                        ),
+                        PollFd::new(self.waker.as_fd(), PollFlags::POLLIN),
+                    ],
+                    PollTimeout::NONE,
+                );
+            }
+        }
+    }
+
+    fn new(receiver: Receiver<ReadRequest>, waker: Arc<EventFd>) -> Result<Self, IoError> {
+        Ok(Self {
+            io_uring: IoUring::builder()
+                .setup_coop_taskrun()
+                .setup_single_issuer()
+                .build(4096)?,
+            requests: BTreeMap::new(),
+            receiver,
+            waker,
+        })
+    }
+}
+
+/// A "read" request passed to the kernel via `io_uring`.
+struct ReadRequest {
+    ids: Range<u64>,
+
+    callback: Box<dyn FnOnce(Vec<Result<Arc<FBuf>, StorageError>>) + Send>,
+
+    pending: Vec<Option<PendingRead>>,
+    results: Vec<Option<Result<Arc<FBuf>, StorageError>>>,
+
+    n_incomplete: usize,
+
+    file: Arc<File>,
+}
+
+impl ReadRequest {
+    fn new(
+        file: Arc<File>,
+        blocks: Vec<BlockLocation>,
+        callback: Box<dyn FnOnce(Vec<Result<Arc<FBuf>, StorageError>>) + Send>,
+    ) -> Self {
+        let n = blocks.len();
+        Self {
+            ids: Self::allocate_ids(blocks.len()),
+            pending: blocks
+                .into_iter()
+                .map(|location| Some(PendingRead::new(location)))
+                .collect(),
+            results: vec![None; n],
+            n_incomplete: n,
+            callback,
+            file,
+        }
+    }
+
+    fn allocate_ids(n: usize) -> Range<u64> {
+        static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(0);
+        let id_base = NEXT_REQUEST_ID.fetch_add(n as u64, Ordering::Relaxed);
+        id_base..id_base + n as u64
+    }
+}
+
+struct PendingRead {
+    buffer: ManuallyDrop<FBuf>,
+    location: BlockLocation,
+}
+
+impl PendingRead {
+    fn new(location: BlockLocation) -> Self {
+        Self {
+            buffer: ManuallyDrop::new(FBuf::with_capacity(location.size)),
+            location,
+        }
+    }
+
+    fn complete(self, retval: i32) -> Result<Arc<FBuf>, StorageError> {
+        let mut buffer = ManuallyDrop::into_inner(self.buffer);
+        if retval < 0 {
+            Err(StorageError::from(IoError::from_raw_os_error(-retval)))
+        } else if retval != self.location.size as i32 {
+            Err(StorageError::from(IoError::from(ErrorKind::UnexpectedEof)))
+        } else {
+            unsafe { buffer.set_len(self.location.size) };
+            Ok(Arc::new(buffer))
+        }
+    }
+
+    /// Returns a submission queue entry for this read, in `file`.
+    fn sqe(&mut self, file: &File) -> Entry {
+        opcode::Read::new(
+            Fd(file.as_raw_fd()),
+            self.buffer.as_mut_ptr(),
+            self.location.size as u32,
+        )
+        .offset(self.location.offset)
+        .build()
+    }
+}
+
+pub(super) struct IoUringReader {
+    file: Arc<File>,
+    file_id: FileId,
+    drop: DeleteOnDrop,
+    /// File size.
+    ///
+    /// -1 if the file size is unknown.
+    size: AtomicI64,
+}
+
+impl IoUringReader {
+    pub(super) fn init() -> Result<(), IoError> {
+        Submitter::singleton().map(|_| ())
+    }
+
+    pub(super) fn new(file: Arc<File>, file_id: FileId, path: PathBuf, keep: bool) -> Self {
+        Self {
+            file,
+            file_id,
+            drop: DeleteOnDrop::new(path, keep),
+            size: AtomicI64::new(-1),
+        }
+    }
+    pub(super) fn open(
+        path: PathBuf,
+        cache: StorageCacheConfig,
+    ) -> Result<Arc<dyn FileReader>, StorageError> {
+        let file = OpenOptions::new()
+            .read(true)
+            .cache_flags(&cache)
+            .open(&path)?;
+
+        Ok(Arc::new(Self::new(
+            Arc::new(file),
+            FileId::new(),
+            path,
+            true,
+        )))
+    }
+}
+
+impl HasFileId for IoUringReader {
+    fn file_id(&self) -> FileId {
+        self.file_id
+    }
+}
+
+impl FileReader for IoUringReader {
+    fn mark_for_checkpoint(&self) {
+        self.drop.keep();
+    }
+
+    fn read_block(&self, location: BlockLocation) -> Result<Arc<FBuf>, StorageError> {
+        let mut buffer = FBuf::with_capacity(location.size);
+
+        match buffer.read_exact_at(&self.file, location.offset, location.size) {
+            Ok(()) => Ok(Arc::new(buffer)),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn get_size(&self) -> Result<u64, StorageError> {
+        let sz = self.size.load(Ordering::Relaxed);
+        if sz >= 0 {
+            Ok(sz as u64)
+        } else {
+            let sz = self.file.metadata()?.size();
+            self.size.store(sz.try_into().unwrap(), Ordering::Relaxed);
+            Ok(sz)
+        }
+    }
+
+    fn read_async(
+        &self,
+        blocks: Vec<BlockLocation>,
+        callback: Box<dyn FnOnce(Vec<Result<Arc<FBuf>, StorageError>>) + Send>,
+    ) {
+        if !blocks.is_empty() {
+            let request = ReadRequest::new(self.file.clone(), blocks, callback);
+            Submitter::singleton().unwrap().submit(request);
+        } else {
+            // The read thread doesn't tolerate empty requests. Might as well
+            // complete them early.
+            callback(Vec::new())
+        }
+    }
+}

--- a/crates/dbsp/src/storage/backend/io_uring_impl/write.rs
+++ b/crates/dbsp/src/storage/backend/io_uring_impl/write.rs
@@ -1,0 +1,393 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Error as IoError, ErrorKind};
+use std::mem::ManuallyDrop;
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::rc::Weak;
+use std::{rc::Rc, sync::Arc};
+
+use io_uring::squeue::Entry;
+use io_uring::{opcode, types::Fd, IoUring};
+use libc::{c_void, iovec};
+
+use crate::storage::backend::IOV_MAX;
+use crate::storage::buffer_cache::FBuf;
+
+use super::super::{FileId, FileReader, FileWriter, HasFileId, StorageError};
+use super::read::IoUringReader;
+
+/// Meta-data we keep per file we created.
+pub struct IoUringWriter {
+    backend: Rc<RefCell<WriterInner>>,
+
+    file_id: FileId,
+    path: PathBuf,
+
+    status: Rc<RefCell<WorkStatus>>,
+
+    /// The file we're writing.
+    file: Arc<File>,
+
+    /// Write operation we're currently accumulating.
+    write: VectoredWrite,
+}
+
+#[derive(Default)]
+struct WorkStatus {
+    /// Total of the `work` elements in the [`Request`]s that reference this
+    /// file within [`Inner::requests`].
+    queued_work: u64,
+
+    /// If non-[`None`], the error that occurred while writing the file.  Errors
+    /// are reported by request completions, which might be processed while work
+    /// is happening for a file other than the one we're currently working on,
+    /// so we have to save the error and report it for the correct file.
+    error: Option<ErrorKind>,
+}
+
+impl IoUringWriter {
+    pub fn new(backend: Rc<RefCell<WriterInner>>, file: Arc<File>, path: PathBuf) -> Self {
+        Self {
+            backend,
+            file,
+            file_id: FileId::new(),
+            path,
+            status: Rc::new(RefCell::new(WorkStatus::default())),
+            write: VectoredWrite::default(),
+        }
+    }
+    fn error(&self) -> Result<(), IoError> {
+        self.status
+            .borrow()
+            .error
+            .map_or(Ok(()), |kind| Err(kind.into()))
+    }
+
+    /// If this file has any pending writes, submits them for processing.
+    fn flush(&mut self) -> Result<(), IoError> {
+        let write = self.write.take();
+        if write.len == 0 {
+            return Ok(());
+        }
+
+        let iovec = write
+            .buffers
+            .iter()
+            .map(|buf| iovec {
+                iov_base: buf.as_ptr() as *mut c_void,
+                iov_len: buf.len(),
+            })
+            .collect::<Vec<_>>();
+        let entry = opcode::Writev::new(
+            Fd(self.file.as_raw_fd()),
+            iovec.as_ptr(),
+            iovec.len() as u32,
+        )
+        .offset(write.offset)
+        .build();
+
+        self.backend.borrow_mut().submit_request(
+            &self.status,
+            entry,
+            write.len,
+            write.len as i32,
+            RequestResources {
+                iovec,
+                buffers: write.buffers,
+                file: self.file.clone(),
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Blocks until `fd` has no more than `max_queued_work` units of work in
+    /// flight.
+    fn limit_queued_work(&mut self, max_queued_work: u64) -> Result<(), IoError> {
+        loop {
+            self.error()?;
+            if self.status.borrow().queued_work <= max_queued_work {
+                return Ok(());
+            }
+
+            if self.backend.borrow_mut().run_completions() == 0 {
+                self.backend.borrow().io_uring.submit_and_wait(1)?;
+            }
+        }
+    }
+}
+
+impl HasFileId for IoUringWriter {
+    fn file_id(&self) -> FileId {
+        self.file_id
+    }
+}
+
+impl FileWriter for IoUringWriter {
+    fn write_block(&mut self, offset: u64, data: FBuf) -> Result<Arc<FBuf>, StorageError> {
+        let block = Arc::new(data);
+        self.error()?;
+
+        if self.write.append(&block, offset).is_err() {
+            self.flush()?;
+            self.limit_queued_work(4 * 1024 * 1024)?;
+            self.write.append(&block, offset).unwrap();
+        }
+
+        Ok(block)
+    }
+
+    fn complete(mut self: Box<Self>) -> Result<(Arc<dyn FileReader>, PathBuf), StorageError> {
+        // Submit any pending writes and then wait for the writes to complete.
+        //
+        // This has two purposes.  First, it means that, on the read side, we
+        // don't have to be prepared to service uncompleted reads ourselves
+        // through an internal cache lookup (although we could put the
+        // `IO_DRAIN` flag on the first "read" operation as a barrier).
+        //
+        // Second, it ensures that we don't allow reads of data that might
+        // encounter an error before they make it to disk.  This property might
+        // not be important.
+        self.flush()?;
+        self.limit_queued_work(0)?;
+
+        // Submit an `fsync` request for the file.  This ensures that the
+        // metadata (and data, but we probably used `O_DIRECT`) for the file
+        // will be committed "soon".  It also ensures that we can make sure that
+        // everything we've written is on stable storage for the purpose of a
+        // checkpoint (which we don't do yet) simply by waiting for the entire
+        // io_uring to drain.
+        self.backend.borrow_mut().submit_request(
+            &self.status,
+            opcode::Fsync::new(Fd(self.file.as_raw_fd())).build(),
+            0,
+            0,
+            RequestResources {
+                iovec: Vec::new(),
+                buffers: Vec::new(),
+                file: self.file.clone(),
+            },
+        )?;
+        self.limit_queued_work(0)?;
+
+        Ok((
+            Arc::new(IoUringReader::new(
+                self.file.clone(),
+                self.file_id,
+                self.path.clone(),
+                false,
+            )),
+            self.path.clone(),
+        ))
+    }
+}
+
+/// An accumulator for a multi-buffer sequential write operation.
+///
+/// It's significantly faster to write multiple buffers in a single operation
+/// than in multiple operations, even over `io_uring`, so this gathers them up.
+#[derive(Default)]
+struct VectoredWrite {
+    /// Buffers accumulated to write so far.
+    buffers: Vec<Arc<FBuf>>,
+
+    /// Starting offset for the write. If there are no buffers yet, this is not
+    /// meaningful (and should be 0).
+    offset: u64,
+
+    /// Sum of the lengths of the buffers in `buffers`.
+    len: u64,
+}
+
+impl VectoredWrite {
+    /// Tries to add a write of `block` at `offset` to this vectored write.
+    /// This will fail if adding `block` would make the vectored write too big
+    /// or non-sequential.
+    fn append(&mut self, block: &Arc<FBuf>, offset: u64) -> Result<(), ()> {
+        if self.len >= 1024 * 1024
+            || (self.len > 0 && self.offset + self.len != offset)
+            || self.buffers.len() >= *IOV_MAX
+        {
+            Err(())
+        } else {
+            if self.buffers.is_empty() {
+                self.offset = offset;
+                self.len = 0;
+            }
+            self.len += block.len() as u64;
+            self.buffers.push(block.clone());
+            Ok(())
+        }
+    }
+    fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}
+
+/// Resources associated with a request that must be kept around until the
+/// request is completed.
+#[allow(dead_code)]
+struct RequestResources {
+    /// Needs to be kept until request completion.
+    buffers: Vec<Arc<FBuf>>,
+
+    /// Needs to be kept until request completion.  (The kernel does not copy
+    /// out the iovec at submission time, it accesses it throughout request
+    /// execution.)
+    iovec: Vec<iovec>,
+
+    /// Needs to be kept until request submission (but it's easier to just keep
+    /// it until completion).
+    file: Arc<File>,
+}
+
+/// A "write" or "fsync" request passed to the kernel via `io_uring`.
+struct Request {
+    /// Handle from `FileHandle`.
+    status: Weak<RefCell<WorkStatus>>,
+
+    /// A measure of the amount of work done by this request.  We limit the
+    /// total amount of queued work per-file because of the resource cost,
+    /// mainly memory (since we can't free write buffers until the write
+    /// completes).
+    ///
+    /// We currently measure work for a write request as the number of bytes
+    /// written.  We give fsync requests an arbitrary work of 0 because we don't
+    /// need to track the amount of work they do.
+    work: u64,
+
+    /// Expected result from the request (otherwise the request is considered to
+    /// have failed).
+    expected_result: i32,
+
+    /// Tracks resources that must not be dropped until the request is
+    /// completed, to prevent the kernel from scribbling on memory as a
+    /// use-after-free error.
+    resources: ManuallyDrop<RequestResources>,
+}
+
+impl Request {
+    /// Drops our resources.  Must only be called after this request has
+    /// completed (otherwise the kernel might scribble on freed memory).
+    unsafe fn complete(self) {
+        ManuallyDrop::into_inner(self.resources);
+    }
+}
+
+pub(super) struct WriterInner {
+    /// Kernel `io_uring` structure.
+    io_uring: IoUring,
+
+    /// All requests that have been submitted to `io_uring` and not yet
+    /// completed.
+    requests: HashMap<u64, Request>,
+
+    /// Next request ID to use.
+    ///
+    /// The request IDs are passed to the kernel in the submission queue.  The
+    /// kernel passes them back in completion queue entries to identify the
+    /// request that completed.
+    next_request_id: u64,
+}
+
+impl WriterInner {
+    pub(super) fn new() -> Result<Self, IoError> {
+        // Create our io_uring.
+        //
+        // We specify a submission queue size of 1 because the kernel sizes the
+        // maximum number of I/O threads as `min(n_sqes, 4 * n_cpus)` and,
+        // generally speaking, creating a lot of I/O threads for our file access
+        // is counterproductive.  One thread is enough and more than that slows
+        // us down.
+        //
+        // We specify a larger completion queue size so that we can leave
+        // completions around to be processed in a batch.
+        let io_uring = IoUring::builder()
+            .setup_coop_taskrun()
+            .setup_single_issuer()
+            .setup_cqsize(512)
+            .build(1)?;
+
+        Ok(Self {
+            io_uring,
+            requests: HashMap::new(),
+            next_request_id: 0,
+        })
+    }
+
+    /// Processes all of the entries in the completion queue.
+    fn run_completions(&mut self) -> usize {
+        let mut cq = self.io_uring.completion();
+        cq.sync();
+        assert_eq!(cq.overflow(), 0);
+        let n = cq.len();
+        for entry in cq {
+            let request = self.requests.remove(&entry.user_data()).unwrap();
+            if let Some(status) = request.status.upgrade() {
+                status.borrow_mut().queued_work -= request.work;
+                if request.expected_result != entry.result()
+                    && matches!(&status.borrow().error, None | Some(ErrorKind::WriteZero))
+                {
+                    status.borrow_mut().error = if entry.result() < 0 {
+                        Some(IoError::from_raw_os_error(-entry.result()).kind())
+                    } else {
+                        // Short write.
+                        //
+                        // The likely issues are a full disk or an
+                        // underlying device error.  The best response would
+                        // be to re-issue the remainder of the write so that
+                        // we can get the real error (or recover and
+                        // finish).  It would be hard to test this behavior
+                        // properly.  For now, just provide a placeholder
+                        // error.
+                        //
+                        // If we get a more specific error later, we'll
+                        // update it.
+                        Some(ErrorKind::WriteZero)
+                    }
+                }
+            } else {
+                // The file was dropped.
+            }
+            unsafe { request.complete() };
+        }
+        n
+    }
+
+    /// Adds `entry` to the submission queue and prepares for its completion.
+    /// `entry` should be an operation on `fd` that accounts for `work` work
+    /// units (see [`Request::work`]), whose expected return value is
+    /// `expected_result` and that requires `resources` not to be released
+    /// before completion.
+    fn submit_request(
+        &mut self,
+        status: &Rc<RefCell<WorkStatus>>,
+        entry: Entry,
+        work: u64,
+        expected_result: i32,
+        resources: RequestResources,
+    ) -> Result<(), IoError> {
+        let request_id = self.next_request_id;
+        self.next_request_id += 1;
+        let entry = entry.user_data(request_id);
+
+        // Submit the entry.  The only reason submission can fail is that the
+        // submission queue is full of unsubmitted requests, and we submit for
+        // every operation, so this should never fail.
+        unsafe { self.io_uring.submission().push(&entry) }.unwrap();
+        self.io_uring.submit()?;
+
+        status.borrow_mut().queued_work += work;
+        self.requests.insert(
+            request_id,
+            Request {
+                status: Rc::downgrade(status),
+                work,
+                expected_result,
+                resources: ManuallyDrop::new(resources),
+            },
+        );
+        Ok(())
+    }
+}

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs)]
 
 use feldera_types::config::{
-    StorageBackendConfig, StorageCacheConfig, StorageConfig, StorageOptions,
+    FileBackendConfig, StorageBackendConfig, StorageCacheConfig, StorageConfig, StorageOptions,
 };
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::{
@@ -158,8 +158,38 @@ pub trait FileReader: Send + Sync + HasFileId {
     /// as an error.
     fn read_block(&self, location: BlockLocation) -> Result<Arc<FBuf>, StorageError>;
 
+    /// Initiates an asynchronous read.  When the read completes, `callback`
+    /// will be called.
+    ///
+    /// The default implementation is not actually asynchronous.
+    fn read_async(
+        &self,
+        blocks: Vec<BlockLocation>,
+        callback: Box<dyn FnOnce(Vec<Result<Arc<FBuf>, StorageError>>) + Send>,
+    ) {
+        default_read_async(self, blocks, callback);
+    }
+
     /// Returns the file's size in bytes.
     fn get_size(&self) -> Result<u64, StorageError>;
+}
+
+/// Default implementation for [FileReader::read_async].
+///
+/// This implementation is not actually asynchronous.
+pub fn default_read_async<R>(
+    reader: &R,
+    blocks: Vec<BlockLocation>,
+    callback: Box<dyn FnOnce(Vec<Result<Arc<FBuf>, StorageError>>) + Send>,
+) where
+    R: FileReader + ?Sized,
+{
+    callback(
+        blocks
+            .into_iter()
+            .map(|location| reader.read_block(location))
+            .collect(),
+    )
 }
 
 /// A storage backend.
@@ -203,6 +233,7 @@ impl dyn StorageBackend {
 
         match &options.backend {
             StorageBackendConfig::Default => Ok(Self::new_default(config)),
+            StorageBackendConfig::File(options) => Ok(Self::new_file(config, options)),
             StorageBackendConfig::IoUring => Ok(Self::new_iouring(config)),
         }
     }
@@ -227,8 +258,16 @@ impl dyn StorageBackend {
         }
     }
 
+    fn new_file(config: &StorageConfig, options: &FileBackendConfig) -> Rc<Self> {
+        Rc::new(posixio_impl::PosixBackend::new(
+            config.path(),
+            config.cache,
+            options,
+        ))
+    }
+
     fn new_default(config: &StorageConfig) -> Rc<Self> {
-        Rc::new(posixio_impl::PosixBackend::new(config.path(), config.cache))
+        Self::new_file(config, &FileBackendConfig::default())
     }
 
     fn new_iouring(config: &StorageConfig) -> Rc<Self> {
@@ -298,7 +337,7 @@ pub struct InvalidBlockLocation {
 }
 
 /// A block that can be read or written in a [FileReader] or [FileWriter].
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BlockLocation {
     /// Byte offset, a multiple of 512.
     pub offset: u64,

--- a/crates/dbsp/src/storage/backend/tests.rs
+++ b/crates/dbsp/src/storage/backend/tests.rs
@@ -7,18 +7,38 @@
 use std::{path::Path, rc::Rc};
 
 use rand::{thread_rng, Fill, Rng};
+use tokio::sync::oneshot;
 
 use crate::storage::{backend::BlockLocation, buffer_cache::FBuf, test::init_test_logger};
 
 use super::{FileReader, StorageBackend};
 
-fn test_read_block(reader: &dyn FileReader, data: &[u8], offset: usize) -> usize {
-    let remaining = data.len() - offset;
+/// Returns a random length for reading a file of `size` bytes starting at
+/// `offset`.
+fn random_block_length(size: usize, offset: usize) -> usize {
+    let remaining = size - offset;
     let mut length = 1 << thread_rng().gen_range(9..=20);
     while length > remaining {
         length /= 2;
     }
-    assert!(offset == data.len() || length > 0);
+    assert!(offset == size || length > 0);
+    length
+}
+
+/// Returns a random offset for reading in a file of `size` bytes.
+fn random_block_offset(size: usize) -> usize {
+    thread_rng().gen_range(0..=size / 512) * 512
+}
+
+fn random_block(size: usize) -> BlockLocation {
+    assert!(size > 0);
+    let offset = random_block_offset(size - 512);
+    let size = random_block_length(size, offset);
+    BlockLocation::new(offset as u64, size).unwrap()
+}
+
+fn test_read_block(reader: &dyn FileReader, data: &[u8], offset: usize) -> usize {
+    let length = random_block_length(data.len(), offset);
     if length > 0 {
         let location = BlockLocation::new(offset as u64, length).unwrap();
         let block = reader.read_block(location).unwrap();
@@ -27,15 +47,42 @@ fn test_read_block(reader: &dyn FileReader, data: &[u8], offset: usize) -> usize
     length
 }
 
+fn test_read_async(reader: &dyn FileReader, data: &[u8]) {
+    if data.is_empty() {
+        // `read_async` disallows 0-length reads.
+        return;
+    }
+
+    let n_blocks = thread_rng().gen_range(0..100);
+    let blocks = (0..n_blocks)
+        .map(|_| random_block(data.len()))
+        .collect::<Vec<_>>();
+    let (sender, receiver) = oneshot::channel();
+    reader.read_async(
+        blocks.clone(),
+        Box::new(|results| sender.send(results).unwrap()),
+    );
+    let results = receiver.blocking_recv().unwrap();
+
+    assert_eq!(results.len(), blocks.len());
+    for (result, block) in results.into_iter().zip(blocks.into_iter()) {
+        let result = result.unwrap();
+        let range = block.offset as usize..block.offset as usize + block.size;
+        assert_eq!(result.as_slice(), &data[range]);
+    }
+}
+
 fn test_read(reader: &dyn FileReader, data: &[u8]) {
-    let mut rng = thread_rng();
     assert_eq!(reader.get_size().unwrap(), data.len() as u64);
     let mut offset = 0;
     while offset < data.len() {
         offset += test_read_block(reader, data, offset);
     }
     for _ in 0..100 {
-        test_read_block(reader, data, rng.gen_range(0..=data.len() / 512) * 512);
+        test_read_block(reader, data, random_block_offset(data.len()));
+    }
+    for _ in 0..100 {
+        test_read_async(reader, data);
     }
     reader
         .read_block(BlockLocation::new(data.len() as u64, 512).unwrap())

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -4,15 +4,25 @@
 //! client-provided function of the blocks.
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::future::Future;
 use std::ops::{Add, AddAssign};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::{collections::BTreeMap, ops::Range};
 
 use enum_map::{Enum, EnumMap};
+use futures::{
+    future::{self, Either},
+    pin_mut,
+    stream::FuturesUnordered,
+    StreamExt,
+};
+use tokio::sync::{oneshot, watch};
 
 use crate::circuit::metadata::{MetaItem, OperatorMeta};
-use crate::storage::backend::{BlockLocation, FileId, FileReader};
+use crate::storage::backend::{BlockLocation, FileId, FileReader, StorageError};
+
+use super::FBuf;
 
 /// A key for the block cache.
 ///
@@ -381,5 +391,152 @@ impl AddAssign for CacheCounts {
     fn add_assign(&mut self, rhs: Self) {
         self.count += rhs.count;
         self.bytes += rhs.bytes;
+    }
+}
+
+/// Context for asynchronous cached I/O.
+///
+/// This context allows for batching cached I/O to a [FileReader] in async Rust.
+/// Each async task uses [Self::read] to do I/O, which blocks if the read cannot
+/// be satisfied from cache. [Self::execute_tasks] runs all of the tasks in
+/// parallel, launching a round of I/O whenever all of the unfinished tasks
+/// block.
+pub struct AsyncCacheContext<E>
+where
+    E: CacheEntry,
+{
+    /// The underlying cache.
+    cache: Arc<BufferCache<E>>,
+
+    /// Identifies the file we're reading.
+    file_id: FileId,
+
+    /// [BTreeMap] is a better choice than `HashMap` for this because issuing
+    /// I/O in sorted order is usually a good idea.
+    requests: Mutex<BTreeMap<BlockLocation, Vec<oneshot::Sender<Result<Arc<FBuf>, StorageError>>>>>,
+
+    n_requests: watch::Sender<usize>,
+}
+
+impl<E> AsyncCacheContext<E>
+where
+    E: CacheEntry,
+{
+    pub fn new(cache: Arc<BufferCache<E>>, file: &dyn FileReader) -> Self {
+        Self {
+            cache,
+            file_id: file.file_id(),
+            requests: Mutex::new(BTreeMap::new()),
+            n_requests: watch::channel(0).0,
+        }
+    }
+
+    /// Reads the bytes at `location` from the file.  If the read can be
+    /// satisfied from cache, this completes quickly. Otherwise, it blocks until
+    /// [Self::execute_tasks] runs I/O for all of the blocking tasks in a batch.
+    pub async fn read<F, R>(&self, location: BlockLocation, parse: F) -> Result<E, R>
+    where
+        F: FnOnce(Arc<FBuf>, BlockLocation) -> Result<E, R>,
+        R: From<StorageError>,
+    {
+        let key = CacheKey::new(self.file_id, location.offset);
+        if let Some(aux) = self.cache.inner.lock().unwrap().get(key) {
+            return Ok(aux.clone());
+        }
+
+        let (sender, receiver) = oneshot::channel();
+
+        self.requests
+            .lock()
+            .unwrap()
+            .entry(location)
+            .or_default()
+            .push(sender);
+
+        self.n_requests.send_modify(|n| *n += 1);
+        let block = receiver.await.unwrap().map_err(|error| error.into())?; // XXX unwrap
+        let aux = parse(block, location)?;
+        self.cache.inner.lock().unwrap().insert(key, aux.clone());
+        Ok(aux)
+    }
+
+    /// Waits until `goal` threads have blocked on I/O in [Self::read].
+    pub async fn wait(&self, goal: usize) {
+        self.n_requests
+            .subscribe()
+            .wait_for(|n| *n >= goal)
+            .await
+            .unwrap();
+    }
+
+    /// Runs all of the pending I/O and wakes up threads blocked in [Self::read].
+    pub async fn run_io_batch<R>(&self, file: &R)
+    where
+        R: FileReader + ?Sized,
+    {
+        let requests = std::mem::take(&mut *self.requests.lock().unwrap());
+        let n_requests = requests.values().map(Vec::len).sum::<usize>();
+        self.n_requests.send_modify(|n| *n -= n_requests);
+        let blocks = requests.keys().cloned().collect::<Vec<_>>();
+        let (sender, receiver) = oneshot::channel();
+        file.read_async(
+            blocks,
+            Box::new(
+                move |result| sender.send(result).unwrap(), // XXX unwrap
+            ),
+        );
+        let result = receiver.await.unwrap(); // XXX unwrap
+        for (result, result_senders) in result.into_iter().zip(requests.into_values()) {
+            for result_sender in result_senders {
+                result_sender.send(result.clone()).unwrap(); // XXX unwrap
+            }
+        }
+    }
+
+    /// Execute all of the `tasks` on `file` until all of them run to
+    /// completion, returning a vector of their return values in the same order.
+    ///
+    /// Internally, this runs in a series of rounds, where in each round we run
+    /// each task until it either completes or blocks on I/O on `file`. At the
+    /// end of the round, if any tasks are still left, we do all of the I/O on
+    /// all of the tasks in a single batch of reads.
+    pub async fn execute_tasks<F, T, R>(
+        &self,
+        file: &R,
+        tasks: impl IntoIterator<Item = F>,
+    ) -> Vec<T>
+    where
+        F: Future<Output = T>,
+        R: FileReader + ?Sized,
+    {
+        let mut tasks = tasks
+            .into_iter()
+            .enumerate()
+            .map(|(index, future)| async move { (index, future.await) })
+            .collect::<FuturesUnordered<_>>();
+        let mut outputs = Vec::with_capacity(tasks.len());
+        for _ in 0..tasks.len() {
+            outputs.push(None);
+        }
+        while !tasks.is_empty() {
+            let wait = self.wait(tasks.len());
+            pin_mut!(wait);
+            match future::select(tasks.next(), wait).await {
+                Either::Left((Some((index, output)), _)) => {
+                    // A task has completed.
+                    outputs[index] = Some(output);
+                }
+                Either::Left((None, _)) => {
+                    // Unreachable because we know that `tasks` is not empty.
+                    unreachable!()
+                }
+                Either::Right((_, _)) => {
+                    // All of the tasks we launched have blocked on I/O. Launch a batch
+                    // of I/O and wait for it to complete.
+                    self.run_io_batch(file).await;
+                }
+            }
+        }
+        outputs.into_iter().map(|output| output.unwrap()).collect()
     }
 }

--- a/crates/dbsp/src/storage/buffer_cache/mod.rs
+++ b/crates/dbsp/src/storage/buffer_cache/mod.rs
@@ -6,7 +6,7 @@ mod cache;
 mod fbuf;
 
 pub use cache::{
-    AtomicCacheCounts, AtomicCacheStats, BufferCache, CacheAccess, CacheCounts, CacheEntry,
-    CacheStats,
+    AsyncCacheContext, AtomicCacheCounts, AtomicCacheStats, BufferCache, CacheAccess, CacheCounts,
+    CacheEntry, CacheStats,
 };
 pub use fbuf::{FBuf, FBufSerializer};

--- a/crates/dbsp/src/storage/file/cache.rs
+++ b/crates/dbsp/src/storage/file/cache.rs
@@ -2,8 +2,8 @@
 //!
 //! This implements an approximately LRU cache for layer files.  The
 //! [`Reader`](super::reader::Reader) and [writer](super::writer) use it.
+use std::mem::size_of;
 use std::sync::Arc;
-use std::{mem::size_of, sync::LazyLock};
 
 use crc32c::crc32c;
 
@@ -45,6 +45,7 @@ pub enum FileCacheEntry {
 }
 
 impl CacheEntry for FileCacheEntry {
+    /// Returns the data size in bytes.
     fn cost(&self) -> usize {
         match self {
             Self::FileTrailer(_) => size_of::<FileTrailer>(),
@@ -126,13 +127,6 @@ impl FileCacheEntry {
             _ => Err(Error::Corruption(CorruptionError::BadBlockType(location))),
         }
     }
-}
-
-/// Returns a global `FileCache` suitable for examples, tests, and other
-/// programs that don't need a specific backend configuration.
-pub fn default_cache() -> Arc<FileCache> {
-    static DEFAULT_CACHE: LazyLock<Arc<FileCache>> = LazyLock::new(|| Arc::new(FileCache::new()));
-    DEFAULT_CACHE.clone()
 }
 
 impl BufferCache<FileCacheEntry> {

--- a/crates/dbsp/src/storage/file/mod.rs
+++ b/crates/dbsp/src/storage/file/mod.rs
@@ -376,6 +376,13 @@ mod test {
             unsafe { cursor.item((tmp_key, tmp_aux)) },
             Some((key.erase_mut(), aux.erase_mut()))
         );
+
+        let mut cursor = row_group.before();
+        assert!(unsafe { cursor.seek_exact(&key) }.unwrap());
+        assert_eq!(
+            unsafe { cursor.item((tmp_key, tmp_aux)) },
+            Some((key.erase_mut(), aux.erase_mut()))
+        );
     }
 
     fn test_out_of_range<K, A, N, T>(
@@ -387,26 +394,38 @@ mod test {
         A: DBData,
         T: ColumnSpec,
     {
-        let mut tmp_key = K::default();
-        let mut tmp_aux = A::default();
-        let (tmp_key, tmp_aux): (&mut DynData, &mut DynData) =
-            (tmp_key.erase_mut(), tmp_aux.erase_mut());
+        let mut key1 = K::default();
+        let mut aux1 = A::default();
+        let (key1, aux1): (&mut DynData, &mut DynData) = (key1.erase_mut(), aux1.erase_mut());
+
+        let mut key2 = K::default();
+        let mut aux2 = A::default();
+        let (key2, aux2): (&mut DynData, &mut DynData) = (key2.erase_mut(), aux2.erase_mut());
 
         let mut cursor = row_group.first().unwrap();
         unsafe { cursor.advance_to_value_or_larger(after.erase()) }.unwrap();
-        assert_eq!(unsafe { cursor.item((tmp_key, tmp_aux)) }, None);
+        assert_eq!(unsafe { cursor.item((key1, aux1)) }, None);
 
         cursor.move_first().unwrap();
         unsafe { cursor.seek_forward_until(|k| k >= after.erase()) }.unwrap();
-        assert_eq!(unsafe { cursor.item((tmp_key, tmp_aux)) }, None);
+        assert_eq!(unsafe { cursor.item((key1, aux1)) }, None);
 
         let mut cursor = row_group.last().unwrap();
         unsafe { cursor.rewind_to_value_or_smaller(before.erase()) }.unwrap();
-        assert_eq!(unsafe { cursor.item((tmp_key, tmp_aux)) }, None);
+        assert_eq!(unsafe { cursor.item((key1, aux1)) }, None);
 
         cursor.move_last().unwrap();
         unsafe { cursor.seek_backward_until(|k| k <= before.erase()) }.unwrap();
-        assert_eq!(unsafe { cursor.item((tmp_key, tmp_aux)) }, None);
+        assert_eq!(unsafe { cursor.item((key1, aux1)) }, None);
+
+        cursor.move_first().unwrap();
+        let first1 = unsafe { cursor.item((key1, aux1)) };
+        assert!(!unsafe { cursor.seek_exact(after) }.unwrap());
+        let first2 = unsafe { cursor.item((key2, aux2)) };
+        assert_eq!(first1, first2);
+        assert!(!unsafe { cursor.seek_exact(before) }.unwrap());
+        let first2 = unsafe { cursor.item((key2, aux2)) };
+        assert_eq!(first1, first2);
     }
 
     #[allow(clippy::len_zero)]

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -1222,13 +1222,13 @@ where
     /// This internally creates an empty temporary file, which means that it can
     /// fail with an I/O error.
     pub fn empty(
-        cache: &Arc<BufferCache<FileCacheEntry>>,
+        cache: Arc<BufferCache<FileCacheEntry>>,
         storage_backend: &dyn StorageBackend,
     ) -> Result<Self, Error> {
         let (file_handle, path) = storage_backend.create()?.complete()?;
         Ok(Self(Arc::new(ReaderInner {
             file: ImmutableFileRef::new(
-                cache.clone(),
+                cache,
                 file_handle,
                 path,
                 None,

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -603,6 +603,13 @@ where
         best
     }
 
+    unsafe fn find_exact<C>(&self, target_rows: &Range<u64>, compare: &C) -> Option<usize>
+    where
+        C: Fn(&K) -> Ordering,
+    {
+        self.find_best_match(target_rows, compare, Equal)
+    }
+
     /// Returns the comparison of the key in `row` using `compare`.
     unsafe fn compare_row<C>(&self, row: u64, compare: &C) -> Ordering
     where
@@ -913,6 +920,130 @@ where
     unsafe fn get_bound(&self, index: usize, bound: &mut K) {
         let offset = self.inner.bounds.get(&self.inner.raw, index) as usize;
         bound.deserialize_from_bytes(&self.inner.raw, offset)
+    }
+
+    fn get_row_range(&self, child_idx: usize) -> Range<u64> {
+        let start = if child_idx > 0 {
+            self.inner.row_totals.get(&self.inner.raw, child_idx - 1)
+        } else {
+            0
+        } + self.first_row;
+        let end = self.inner.row_totals.get(&self.inner.raw, child_idx) + self.first_row;
+        start..end
+    }
+
+    unsafe fn find_exact<C>(&self, target_rows: &Range<u64>, compare: &C) -> Option<usize>
+    where
+        C: Fn(&K) -> Ordering,
+    {
+        let mut result = None;
+        self.key_factory.with(&mut |bound| {
+            let mut start = 0;
+            let mut end = self.n_children();
+            result = loop {
+                if start >= end {
+                    break None;
+                }
+                let mid = (start + end) / 2;
+                let rows = self.get_row_range(mid);
+
+                /// Compares `a` to `b` and reports their relationship.
+                fn compare_ranges(a: &Range<u64>, b: &Range<u64>) -> Case {
+                    if a.end <= b.start {
+                        Case::Before
+                    } else if b.end <= a.start {
+                        Case::After
+                    } else if b.end <= a.end {
+                        if a.start <= b.start {
+                            Case::Contains
+                        } else {
+                            Case::OverlapEnd
+                        }
+                    } else if b.start <= a.start {
+                        Case::Inside
+                    } else {
+                        Case::OverlapStart
+                    }
+                }
+
+                /// The relationship between two ranges `a` and `b`.
+                ///
+                /// A visual representation of the possibilities:
+                ///
+                /// ```text
+                ///                    [-------b-------]
+                ///   [--before--]        [--inside--]      [--after--]
+                ///              [---------contains---------]
+                ///              [overlap-start]
+                ///                           [-overlap-end-]
+                /// ```
+                enum Case {
+                    /// `a` is before `b`, with no overlap.
+                    Before,
+
+                    /// `a` is after `b`, with no overlap.
+                    After,
+
+                    /// `a` contains all of `b` (and might stick out on either
+                    /// side).  This includes the case where `a` and `b` are
+                    /// equal.
+                    Contains,
+
+                    /// `a` is inside `b`.  (If `a` and `b` are equal, that is
+                    /// [Self::Contains] instead.)
+                    Inside,
+
+                    /// `a` starts before `b` and overlaps its beginning (but
+                    /// not all of it: that would be [Self::Contains]).
+                    OverlapStart,
+
+                    /// `a` starts within `b` and overlaps its end (but doesn't
+                    /// contain all of `b`: that would be [Self::Contains]).
+                    OverlapEnd,
+                }
+
+                let cmp = match compare_ranges(target_rows, &rows) {
+                    Case::Before => Less,
+                    Case::After => Greater,
+                    Case::Inside => Equal,
+                    Case::Contains => {
+                        self.get_bound(mid * 2, bound);
+                        match compare(bound) {
+                            Greater => {
+                                self.get_bound(mid * 2 + 1, bound);
+                                match compare(bound) {
+                                    Less => Equal,
+                                    other => other,
+                                }
+                            }
+                            other => other,
+                        }
+                    }
+                    Case::OverlapStart => {
+                        self.get_bound(mid * 2, bound);
+                        match compare(bound) {
+                            Greater => Equal,
+                            other => other,
+                        }
+                    }
+                    Case::OverlapEnd => {
+                        self.get_bound(mid * 2 + 1, bound);
+                        match compare(bound) {
+                            Less => Equal,
+                            other => other,
+                        }
+                    }
+                };
+
+                match cmp {
+                    Less => end = mid,
+                    Greater => start = mid + 1,
+                    Equal => break Some(mid),
+                }
+            };
+        });
+
+        result
     }
 
     unsafe fn find_best_match<C>(
@@ -1596,6 +1727,16 @@ where
             .move_to_row(&self.row_group, self.row_group.rows.start)
     }
 
+    /// Moves just before the row group.
+    pub fn move_before(&mut self) {
+        self.position = Position::Before;
+    }
+
+    /// Moves just after the row group.
+    pub fn move_after(&mut self) {
+        self.position = Position::After;
+    }
+
     /// Moves to the last row in the row group.  If the row group is empty,
     /// this has no effect.
     pub fn move_last(&mut self) -> Result<(), Error> {
@@ -1722,6 +1863,22 @@ where
     /// Unsafe because `rkyv` deserialization is unsafe.
     pub unsafe fn advance_to_value_or_larger(&mut self, target: &K) -> Result<(), Error> {
         self.advance_to_first_ge(&|key| target.cmp(key))
+    }
+
+    /// Moves the cursor to the row whose key is exactly `target`.  This
+    /// function does not move the cursor if no key is exactly `target`.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe because `rkyv` deserialization is unsafe.
+    pub unsafe fn seek_exact(&mut self, target: &K) -> Result<bool, Error> {
+        match Position::find_exact::<N, T, _>(&self.row_group, &|key| target.cmp(key))? {
+            Some(position) => {
+                self.position = position;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     /// Moves the cursor forward past rows for which `compare` returns [`Less`],
@@ -1979,6 +2136,42 @@ where
                     let factories = data_block.factories.clone();
                     return Ok(data_block
                         .find_best_match(&row_group.rows, compare, bias)
+                        .map(|child_idx| Self {
+                            row: data_block.first_row + child_idx as u64,
+                            indexes,
+                            data: data_block,
+                            factories,
+                        }));
+                }
+            }
+        }
+    }
+
+    unsafe fn find_exact<N, T, C>(
+        row_group: &RowGroup<'_, K, A, N, T>,
+        compare: &C,
+    ) -> Result<Option<Self>, Error>
+    where
+        T: ColumnSpec,
+        C: Fn(&K) -> Ordering,
+    {
+        let mut indexes = Vec::new();
+        let Some(mut node) = row_group.reader.0.columns[row_group.column].root.clone() else {
+            return Ok(None);
+        };
+        loop {
+            match node.read(&row_group.reader.0.file, row_group.reader.0.compression)? {
+                TreeBlock::Index(index_block) => {
+                    let Some(child_idx) = index_block.find_exact(&row_group.rows, compare) else {
+                        return Ok(None);
+                    };
+                    node = index_block.get_child(child_idx)?;
+                    indexes.push(index_block);
+                }
+                TreeBlock::Data(data_block) => {
+                    let factories = data_block.factories.clone();
+                    return Ok(data_block
+                        .find_exact(&row_group.rows, compare)
                         .map(|child_idx| Self {
                             row: data_block.first_row + child_idx as u64,
                             indexes,
@@ -2280,6 +2473,16 @@ where
                 Position::Before
             }),
         }
+    }
+    unsafe fn find_exact<N, T, C>(
+        row_group: &RowGroup<'_, K, A, N, T>,
+        compare: &C,
+    ) -> Result<Option<Self>, Error>
+    where
+        T: ColumnSpec,
+        C: Fn(&K) -> Ordering,
+    {
+        Ok(Path::find_exact(row_group, compare)?.map(|path| Position::Row(path)))
     }
     fn absolute_position<N, T>(&self, row_group: &RowGroup<K, A, N, T>) -> u64
     where

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -904,9 +904,9 @@ struct BlockWriter {
 }
 
 impl BlockWriter {
-    fn new(cache: &Arc<FileCache>, file_handle: Box<dyn FileWriter>) -> Self {
+    fn new(cache: Arc<FileCache>, file_handle: Box<dyn FileWriter>) -> Self {
         Self {
-            cache: cache.clone(),
+            cache,
             file_handle: Some(file_handle),
             encoder: Encoder::new(),
             bounce: Vec::new(),
@@ -1007,7 +1007,7 @@ struct Writer {
 impl Writer {
     pub fn new(
         factories: &[&AnyFactories],
-        buffer_cache: &Arc<FileCache>,
+        buffer_cache: Arc<FileCache>,
         storage_backend: &dyn StorageBackend,
         parameters: Parameters,
         n_columns: usize,
@@ -1105,9 +1105,10 @@ impl Writer {
 /// # use dbsp::dynamic::{DynData, Erase, DynUnit};
 /// # use dbsp::storage::file::{writer::{Parameters, Writer1}};
 /// use feldera_types::config::{StorageConfig, StorageOptions};
+/// # use std::sync::Arc;
 /// use dbsp::storage::{
 ///     backend::StorageBackend,
-///     file::{cache::default_cache, Factories},
+///     file::{cache::FileCache, Factories},
 /// };
 /// let factories = Factories::<DynData, DynUnit>::new::<u32, ()>();
 /// let tempdir = tempfile::tempdir().unwrap();
@@ -1115,9 +1116,10 @@ impl Writer {
 ///     path: tempdir.path().to_string_lossy().to_string(),
 ///    cache: Default::default(),
 /// }, &StorageOptions::default()).unwrap();
+/// let cache = Arc::new(FileCache::new(1024 * 1024));
 /// let parameters = Parameters::default();
 /// let mut file =
-///     Writer1::new(&factories, &default_cache(), &*storage_backend, parameters).unwrap();
+///     Writer1::new(&factories, cache, &*storage_backend, parameters).unwrap();
 /// for i in 0..1000_u32 {
 ///     file.write0((i.erase(), ().erase())).unwrap();
 /// }
@@ -1143,7 +1145,7 @@ where
     /// Creates a new writer with the given parameters.
     pub fn new(
         factories: &Factories<K0, A0>,
-        buffer_cache: &Arc<FileCache>,
+        buffer_cache: Arc<FileCache>,
         storage_backend: &dyn StorageBackend,
         parameters: Parameters,
     ) -> Result<Self, StorageError> {
@@ -1228,10 +1230,11 @@ where
 /// ```
 /// # use dbsp::dynamic::{DynData, DynUnit};
 /// # use dbsp::storage::file::{writer::{Parameters, Writer2}};
+/// # use std::sync::Arc;
 /// use feldera_types::config::{StorageConfig, StorageOptions};
 /// use dbsp::storage::{
 ///     backend::StorageBackend,
-///     file::{cache::default_cache, Factories},
+///     file::{cache::FileCache, Factories},
 /// };
 /// let factories = Factories::<DynData, DynUnit>::new::<u32, ()>();
 /// let tempdir = tempfile::tempdir().unwrap();
@@ -1239,9 +1242,10 @@ where
 ///     path: tempdir.path().to_string_lossy().to_string(),
 ///    cache: Default::default(),
 /// }, &StorageOptions::default()).unwrap();
+/// let cache = Arc::new(FileCache::new(1024 * 1024));
 /// let parameters = Parameters::default();
 /// let mut file =
-///     Writer2::new(&factories, &factories, &default_cache(), &*storage_backend, parameters).unwrap();
+///     Writer2::new(&factories, &factories, cache, &*storage_backend, parameters).unwrap();
 /// for i in 0..1000_u32 {
 ///     for j in 0..10_u32 {
 ///         file.write1((&j, &())).unwrap();
@@ -1278,7 +1282,7 @@ where
     pub fn new(
         factories0: &Factories<K0, A0>,
         factories1: &Factories<K1, A1>,
-        buffer_cache: &Arc<FileCache>,
+        buffer_cache: Arc<FileCache>,
         storage_backend: &dyn StorageBackend,
         parameters: Parameters,
     ) -> Result<Self, StorageError> {

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -38,7 +38,7 @@ use crate::storage::buffer_cache::CacheStats;
 pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};
 use crate::time::Antichain;
 use crate::{dynamic::ArchivedDBData, storage::buffer_cache::FBuf};
-use cursor::CursorList;
+use cursor::{CursorFactory, CursorList};
 use dyn_clone::DynClone;
 use rand::Rng;
 use rkyv::ser::Serializer as _;
@@ -463,6 +463,43 @@ where
     where
         Self::Time: PartialEq<()>,
         RG: Rng;
+
+    /// Creates and returns a new batch that is a subset of this one, containing
+    /// only the key-value pairs whose keys are in `keys`. May also return
+    /// `None`, the default implementation, if the batch doesn't want to
+    /// implement this method.  In particular, a batch for which access through
+    /// a cursor is fast should return `None` to avoid the expense of copying
+    /// data.
+    ///
+    /// # Rationale
+    ///
+    /// This method enables performance optimizations for the case where these
+    /// assumptions hold:
+    ///
+    /// 1. Individual [Batch]es flowing through a circuit are small enough to
+    ///    fit comfortably in memory.
+    ///
+    /// 2. [Trace]s accumulated over time as a circuit executes may become large
+    ///    enough that they must be maintained in external storage.
+    ///
+    /// If an operator needs to fetch all of the data from a `trace` that
+    /// corresponds to some set of `keys`, then, given these assumptions, doing
+    /// so one key at a time with a cursor will be slow because every key fetch
+    /// potentially incurs a round trip to the storage, with total latency O(n)
+    /// in the number of keys. This method gives the batch implementation the
+    /// opportunity to implement parallel fetch for `trace.fetch(key)`, with
+    /// total latency O(1) in the number of keys.
+    #[allow(async_fn_in_trait)]
+    async fn fetch<B>(
+        &self,
+        keys: &B,
+    ) -> Option<Box<dyn CursorFactory<Self::Key, Self::Val, Self::Time, Self::R>>>
+    where
+        B: Batch<Key = Self::Key, Time = ()>,
+    {
+        let _ = keys;
+        None
+    }
 }
 
 /// A [`BatchReader`] plus features for constructing new batches.

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -243,7 +243,7 @@ where
         let mut writer = Writer2::new(
             &self.factories.factories0,
             &self.factories.factories1,
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             Runtime::file_writer_parameters(),
         )
@@ -415,7 +415,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;
@@ -565,7 +565,7 @@ where
             writer: Writer2::new(
                 &batch1.factories.factories0,
                 &batch1.factories.factories1,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )
@@ -889,7 +889,7 @@ where
             writer: Writer2::new(
                 &factories.factories0,
                 &factories.factories1,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -334,7 +334,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;
@@ -551,7 +551,7 @@ where
             writer: Writer2::new(
                 &batch1.factories.factories0,
                 &batch1.factories.factories1,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )
@@ -992,7 +992,7 @@ where
             writer: Writer2::new(
                 &factories.factories0,
                 &factories.factories1,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -359,7 +359,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;
@@ -631,7 +631,7 @@ where
         let mut output = Writer2::new(
             &source1.factories.factories0,
             &source1.factories().factories1,
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             Runtime::file_writer_parameters(),
         )
@@ -733,7 +733,7 @@ where
             factories: self.factories,
             file: self.result.take().unwrap_or(
                 Reader::empty(
-                    &Runtime::buffer_cache(),
+                    Runtime::buffer_cache().unwrap(),
                     &*Runtime::storage_backend().unwrap(),
                 )
                 .unwrap(),
@@ -1191,7 +1191,7 @@ where
             writer: Writer2::new(
                 &factories.factories0,
                 &factories.factories1,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -246,7 +246,7 @@ where
     fn neg_by_ref(&self) -> Self {
         let mut writer = Writer1::new(
             &self.factories.file_factories,
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             Runtime::file_writer_parameters(),
         )
@@ -430,7 +430,7 @@ where
         let any_factory0 = factories.file_factories.any_factories();
         let file = Reader::open(
             &[&any_factory0],
-            Runtime::buffer_cache(),
+            Runtime::buffer_cache().unwrap(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;
@@ -479,7 +479,7 @@ where
             lower2: 0,
             writer: Writer1::new(
                 &batch1.factories.file_factories,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )
@@ -790,7 +790,7 @@ where
             factories: factories.clone(),
             writer: Writer1::new(
                 &factories.file_factories,
-                &Runtime::buffer_cache(),
+                Runtime::buffer_cache().unwrap(),
                 &*Runtime::storage_backend().unwrap(),
                 Runtime::file_writer_parameters(),
             )

--- a/crates/dbsp/src/trace/spine_async/mod.rs
+++ b/crates/dbsp/src/trace/spine_async/mod.rs
@@ -22,6 +22,7 @@ use crate::storage::file::to_bytes;
 use crate::storage::write_commit_metadata;
 pub use crate::trace::spine_async::snapshot::SpineSnapshot;
 use crate::trace::CommittedSpine;
+use futures::{stream::FuturesUnordered, StreamExt};
 use ouroboros::self_referencing;
 use rand::Rng;
 use rkyv::{
@@ -45,10 +46,12 @@ use textwrap::indent;
 
 mod list_merger;
 mod snapshot;
+use self::thread::{BackgroundThread, WorkerStatus};
+
+use super::{cursor::CursorFactory, BatchLocation};
+
 mod thread;
 
-use self::thread::{BackgroundThread, WorkerStatus};
-use super::BatchLocation;
 use list_merger::{ListMerger, ListMergerBuilder};
 
 /// Maximum amount of levels in the spine.
@@ -830,6 +833,59 @@ where
                 }
             }
         }
+    }
+
+    async fn fetch<KR>(
+        &self,
+        keys: &KR,
+    ) -> Option<Box<dyn CursorFactory<Self::Key, Self::Val, Self::Time, Self::R>>>
+    where
+        KR: Batch<Key = Self::Key, Time = ()>,
+    {
+        let mut batches = Vec::new();
+        let mut fetched = Vec::new();
+        let mut futures = self
+            .merger
+            .get_batches()
+            .into_iter()
+            .map(|b| async move { (b.clone(), b.fetch(keys).await) })
+            .collect::<FuturesUnordered<_>>();
+        while let Some((batch, fetch)) = futures.next().await {
+            if let Some(fetch) = fetch {
+                fetched.push(fetch);
+            } else {
+                batches.push(batch);
+            }
+        }
+
+        Some(Box::new(Fetch {
+            weight_factory: self.factories.weight_factory(),
+            batches,
+            fetched,
+        }))
+    }
+}
+
+pub struct Fetch<B: Batch> {
+    weight_factory: &'static dyn Factory<B::R>,
+    batches: Vec<Arc<B>>,
+    fetched: Vec<Box<dyn CursorFactory<B::Key, B::Val, B::Time, B::R>>>,
+}
+
+impl<B> CursorFactory<B::Key, B::Val, B::Time, B::R> for Fetch<B>
+where
+    B: Batch,
+{
+    fn get_cursor<'a>(&'a self) -> Box<dyn Cursor<B::Key, B::Val, B::Time, B::R> + 'a> {
+        let cursors =
+            self.fetched
+                .iter()
+                .map(|hc| hc.get_cursor())
+                .chain(self.batches.iter().map(|b| {
+                    Box::new(b.cursor()) as Box<dyn Cursor<B::Key, B::Val, B::Time, B::R>>
+                }))
+                .collect::<Vec<_>>();
+        Box::new(CursorList::new(self.weight_factory, cursors))
     }
 }
 

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -165,11 +165,15 @@ pub enum StorageBackendConfig {
     #[default]
     Default,
 
+    /// Use the local file system.
+    ///
+    /// This uses ordinary system file operations.
+    File(FileBackendConfig),
+
     /// Use `io_uring` to access the local file system.
     ///
-    /// This falls back to ordinary access to the local file system if
-    /// `io_uring` is unavailable, as is often the case with cloud container
-    /// systems.
+    /// This falls back to [StorageBackendConfig::File] if `io_uring` is
+    /// unavailable, as is often the case with cloud container systems.
     IoUring,
 }
 
@@ -189,6 +193,18 @@ pub enum StorageCompression {
 
     /// Use [Snappy](https://en.wikipedia.org/wiki/Snappy_(compression)) compression.
     Snappy,
+}
+
+/// Configuration for local file system access.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(default)]
+pub struct FileBackendConfig {
+    /// Whether to use background threads for file I/O.
+    ///
+    /// Background threads should improve performance, but they can reduce
+    /// performance if too few cores are available. This is provided for
+    /// debugging and fine-tuning and should ordinarily be left unset.
+    pub async_threads: Option<bool>,
 }
 
 /// Global pipeline configuration settings. This is the publicly

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -138,6 +138,8 @@ pub struct StorageOptions {
     /// A value of 0 will write even empty batches to storage, and nonzero
     /// values provide a threshold.  `usize::MAX` would effectively disable
     /// storage.
+    ///
+    /// The default is 1,048,576 (1 MiB).
     pub min_storage_bytes: Option<usize>,
 
     /// The form of compression to use in data batches.
@@ -146,6 +148,11 @@ pub struct StorageOptions {
     /// NVMe and network bandwidth, which means that it can increase overall
     /// performance.
     pub compression: StorageCompression,
+
+    /// The maximum size of the in-memory storage cache, in mebibytes.
+    ///
+    /// The default is 256 MiB, times the number of workers.
+    pub cache_mib: Option<usize>,
 }
 
 /// Backend storage configuration.

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -141,6 +141,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::config::StorageCacheConfig,
         feldera_types::config::StorageOptions,
         feldera_types::config::StorageBackendConfig,
+        feldera_types::config::FileBackendConfig,
         feldera_types::config::StorageCompression,
         feldera_types::config::RuntimeConfig,
         feldera_types::config::FtConfig,

--- a/openapi.json
+++ b/openapi.json
@@ -414,7 +414,8 @@
                           "name": "default"
                         },
                         "min_storage_bytes": null,
-                        "compression": "default"
+                        "compression": "default",
+                        "cache_mib": null
                       },
                       "fault_tolerance": null,
                       "cpu_profiler": false,
@@ -4564,6 +4565,13 @@
               "name": "default"
             }
           },
+          "cache_mib": {
+            "type": "integer",
+            "description": "The maximum size of the in-memory storage cache, in mebibytes.\n\nThe default is 256 MiB, times the number of workers.",
+            "default": null,
+            "nullable": true,
+            "minimum": 0
+          },
           "compression": {
             "allOf": [
               {
@@ -4574,7 +4582,7 @@
           },
           "min_storage_bytes": {
             "type": "integer",
-            "description": "The minimum estimated number of bytes in a batch of data to write it to\nstorage.  This is provided for debugging and fine-tuning and should\nordinarily be left unset.\n\nA value of 0 will write even empty batches to storage, and nonzero\nvalues provide a threshold.  `usize::MAX` would effectively disable\nstorage.",
+            "description": "The minimum estimated number of bytes in a batch of data to write it to\nstorage.  This is provided for debugging and fine-tuning and should\nordinarily be left unset.\n\nA value of 0 will write even empty batches to storage, and nonzero\nvalues provide a threshold.  `usize::MAX` would effectively disable\nstorage.\n\nThe default is 1,048,576 (1 MiB).",
             "default": null,
             "nullable": true,
             "minimum": 0

--- a/openapi.json
+++ b/openapi.json
@@ -2534,6 +2534,18 @@
         ],
         "description": "A SQL field.\n\nMatches the SQL compiler JSON format."
       },
+      "FileBackendConfig": {
+        "type": "object",
+        "description": "Configuration for local file system access.",
+        "properties": {
+          "async_threads": {
+            "type": "boolean",
+            "description": "Whether to use background threads for file I/O.\n\nBackground threads should improve performance, but they can reduce\nperformance if too few cores are available. This is provided for\ndebugging and fine-tuning and should ordinarily be left unset.",
+            "default": null,
+            "nullable": true
+          }
+        }
+      },
       "FileInputConfig": {
         "type": "object",
         "description": "Configuration for reading data from a file with `FileInputTransport`",
@@ -4476,20 +4488,13 @@
           {
             "type": "object",
             "required": [
-              "name",
-              "config"
+              "name"
             ],
             "properties": {
-              "config": {
-                "type": "string",
-                "enum": [
-                  "default"
-                ]
-              },
               "name": {
                 "type": "string",
                 "enum": [
-                  "config"
+                  "default"
                 ]
               }
             }
@@ -4502,21 +4507,35 @@
             ],
             "properties": {
               "config": {
-                "type": "string",
-                "enum": [
-                  "io_uring"
-                ]
+                "$ref": "#/components/schemas/FileBackendConfig"
               },
               "name": {
                 "type": "string",
                 "enum": [
-                  "config"
+                  "file"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "io_uring"
                 ]
               }
             }
           }
         ],
-        "description": "Backend storage configuration."
+        "description": "Backend storage configuration.",
+        "discriminator": {
+          "propertyName": "name"
+        }
       },
       "StorageCacheConfig": {
         "type": "string",

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -3087,6 +3087,15 @@ export const $StorageOptions = {
         name: 'default'
       }
     },
+    cache_mib: {
+      type: 'integer',
+      description: `The maximum size of the in-memory storage cache, in mebibytes.
+
+The default is 256 MiB, times the number of workers.`,
+      default: null,
+      nullable: true,
+      minimum: 0
+    },
     compression: {
       allOf: [
         {
@@ -3103,7 +3112,9 @@ ordinarily be left unset.
 
 A value of 0 will write even empty batches to storage, and nonzero
 values provide a threshold.  \`usize::MAX\` would effectively disable
-storage.`,
+storage.
+
+The default is 1,048,576 (1 MiB).`,
       default: null,
       nullable: true,
       minimum: 0

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -677,6 +677,23 @@ export const $Field = {
 Matches the SQL compiler JSON format.`
 } as const
 
+export const $FileBackendConfig = {
+  type: 'object',
+  description: 'Configuration for local file system access.',
+  properties: {
+    async_threads: {
+      type: 'boolean',
+      description: `Whether to use background threads for file I/O.
+
+Background threads should improve performance, but they can reduce
+performance if too few cores are available. This is provided for
+debugging and fine-tuning and should ordinarily be left unset.`,
+      default: null,
+      nullable: true
+    }
+  }
+} as const
+
 export const $FileInputConfig = {
   type: 'object',
   description: 'Configuration for reading data from a file with `FileInputTransport`',
@@ -3009,15 +3026,11 @@ export const $StorageBackendConfig = {
   oneOf: [
     {
       type: 'object',
-      required: ['name', 'config'],
+      required: ['name'],
       properties: {
-        config: {
-          type: 'string',
-          enum: ['default']
-        },
         name: {
           type: 'string',
-          enum: ['config']
+          enum: ['default']
         }
       }
     },
@@ -3026,17 +3039,29 @@ export const $StorageBackendConfig = {
       required: ['name', 'config'],
       properties: {
         config: {
-          type: 'string',
-          enum: ['io_uring']
+          $ref: '#/components/schemas/FileBackendConfig'
         },
         name: {
           type: 'string',
-          enum: ['config']
+          enum: ['file']
+        }
+      }
+    },
+    {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: {
+          type: 'string',
+          enum: ['io_uring']
         }
       }
     }
   ],
-  description: 'Backend storage configuration.'
+  description: 'Backend storage configuration.',
+  discriminator: {
+    propertyName: 'name'
+  }
 } as const
 
 export const $StorageCacheConfig = {

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -509,6 +509,20 @@ export type Field = SqlIdentifier & {
 }
 
 /**
+ * Configuration for local file system access.
+ */
+export type FileBackendConfig = {
+  /**
+   * Whether to use background threads for file I/O.
+   *
+   * Background threads should improve performance, but they can reduce
+   * performance if too few cores are available. This is provided for
+   * debugging and fine-tuning and should ordinarily be left unset.
+   */
+  async_threads?: boolean | null
+}
+
+/**
  * Configuration for reading data from a file with `FileInputTransport`
  */
 export type FileInputConfig = {
@@ -1943,17 +1957,17 @@ export type SqlType =
  */
 export type StorageBackendConfig =
   | {
-      config: 'default'
-      name: 'config'
+      name: 'default'
     }
   | {
-      config: 'io_uring'
-      name: 'config'
+      config: FileBackendConfig
+      name: 'file'
+    }
+  | {
+      name: 'io_uring'
     }
 
-export type config = 'default'
-
-export type name = 'config'
+export type name = 'default'
 
 /**
  * How to cache access to storage within a Feldera pipeline.

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1988,6 +1988,12 @@ export type StorageConfig = {
  */
 export type StorageOptions = {
   backend?: StorageBackendConfig
+  /**
+   * The maximum size of the in-memory storage cache, in mebibytes.
+   *
+   * The default is 256 MiB, times the number of workers.
+   */
+  cache_mib?: number | null
   compression?: StorageCompression
   /**
    * The minimum estimated number of bytes in a batch of data to write it to
@@ -1997,6 +2003,8 @@ export type StorageOptions = {
    * A value of 0 will write even empty batches to storage, and nonzero
    * values provide a threshold.  `usize::MAX` would effectively disable
    * storage.
+   *
+   * The default is 1,048,576 (1 MiB).
    */
   min_storage_bytes?: number | null
 }


### PR DESCRIPTION
This should speed up joins, when enabled. This is just the beginning--many operations other than joins can be optimized in the same way.

This is disabled by default because it slowed things down on @ryzhyk's laptop. 