### PR TITLE
[dbsp] Missing track_caller annotations.

### DIFF
--- a/crates/dbsp/src/operator/asof_join.rs
+++ b/crates/dbsp/src/operator/asof_join.rs
@@ -33,6 +33,7 @@ where
     ///   value from `other` to an output value.
     /// * `ts_func1` - extracts the value of the timestamp column from a record in `self`.
     /// * `ts_func2` - extracts the value of the timestamp column from a record in `other`.
+    #[track_caller]
     pub fn asof_join<TS, F, TSF1, TSF2, V2, V>(
         &self,
         other: &Stream<RootCircuit, OrdIndexedZSet<K1, V2>>,

--- a/crates/dbsp/src/operator/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/chain_aggregate.rs
@@ -24,6 +24,7 @@ where
     /// * `finit` - returns the initial value of the aggregate.
     /// * `fupdate` - updates the aggregate given its previous value and a
     ///   new element of the group.
+    #[track_caller]
     pub fn chain_aggregate<A, FInit, FUpdate>(
         &self,
         finit: FInit,

--- a/crates/dbsp/src/operator/consolidate.rs
+++ b/crates/dbsp/src/operator/consolidate.rs
@@ -22,6 +22,7 @@ where
     /// computed as the sum of deltas across all iterations of the circuit.
     /// Once the iteration has converged (e.g., reaching a fixed point) is a
     /// good time to consolidate the output.
+    #[track_caller]
     pub fn consolidate(
         &self,
     ) -> Stream<C, TypedBatch<T::Key, T::Val, T::R, <T::InnerTrace as DynTrace>::Batch>> {

--- a/crates/dbsp/src/operator/controlled_filter.rs
+++ b/crates/dbsp/src/operator/controlled_filter.rs
@@ -24,6 +24,7 @@ where
     /// to the second output stream. More precisely `report_func` is invoked for each (key, value, weight)
     /// tuple whose key does not pass the filter and returns a value of type `E`, which is sent
     /// with weight 1 to the error stream.
+    #[track_caller]
     pub fn controlled_key_filter<T, E, F, RF>(
         &self,
         threshold: &Stream<C, TypedBox<T, DynData>>,
@@ -55,6 +56,7 @@ where
 
     /// Like [`Self::controlled_key_filter`], but values in the `threshold` stream are strongly typed
     /// instead of having type `TypedBox`.
+    #[track_caller]
     pub fn controlled_key_filter_typed<T, E, F, RF>(
         &self,
         threshold: &Stream<C, T>,
@@ -85,6 +87,7 @@ where
     /// to the second output stream. More precisely `report_func` is invoked for each (key, value, weight)
     /// tuple whose key and value do not pass the filter and returns a value of type `E`, which is sent
     /// with weight 1 to the error stream.
+    #[track_caller]
     pub fn controlled_value_filter<T, E, F, RF>(
         &self,
         threshold: &Stream<C, TypedBox<T, DynData>>,
@@ -116,6 +119,7 @@ where
 
     /// Like [`Self::controlled_value_filter`], but values in the `threshold` stream are strongly typed
     /// instead of having type `TypedBox`.
+    #[track_caller]
     pub fn controlled_value_filter_typed<T, E, F, RF>(
         &self,
         threshold: &Stream<C, T>,

--- a/crates/dbsp/src/operator/count.rs
+++ b/crates/dbsp/src/operator/count.rs
@@ -20,6 +20,7 @@ where
     /// that maps from the original keys to the weights.  Both the input and
     /// output are streams of updates.
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn weighted_count(&self) -> Stream<C, OrdIndexedZSet<Z::Key, ZWeight>> {
         let factories: IncAggregateLinearFactories<
             Z::Inner,
@@ -37,6 +38,7 @@ where
     }
 
     /// Like [`Self::dyn_weighted_count`], but can return any batch type.
+    #[track_caller]
     pub fn weighted_count_generic<O>(&self) -> Stream<C, O>
     where
         O: IndexedZSet<Key = Z::Key, DynK = Z::DynK, DynV = DynData>,
@@ -57,6 +59,7 @@ where
     /// that maps from the original keys to the unique value counts.  Both
     /// the input and output are streams of updates.
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn distinct_count(&self) -> Stream<C, OrdIndexedZSet<Z::Key, ZWeight>> {
         let factories: DistinctCountFactories<
             Z::Inner,
@@ -73,6 +76,7 @@ where
     }
 
     /// Like [`Self::dyn_distinct_count`], but can return any batch type.
+    #[track_caller]
     pub fn distinct_count_generic<O>(&self) -> Stream<C, O>
     where
         O: IndexedZSet<Key = Z::Key, DynK = DynData>,
@@ -92,6 +96,7 @@ where
     /// Z-set that maps from the original keys to the weights.  Both the
     /// input and output are streams of data (not updates).
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn stream_weighted_count(&self) -> Stream<C, OrdIndexedZSet<Z::Key, ZWeight>> {
         let factories: StreamLinearAggregateFactories<
             Z::Inner,
@@ -108,6 +113,7 @@ where
     }
 
     /// Like [`Self::dyn_stream_weighted_count`], but can return any batch type.
+    #[track_caller]
     pub fn stream_weighted_count_generic<O>(&self) -> Stream<C, O>
     where
         O: IndexedZSet<Key = Z::Key, DynK = Z::DynK, Val = ZWeight, DynV = DynData>,
@@ -128,6 +134,7 @@ where
     /// that maps from the original keys to the unique value counts.  Both
     /// the input and output are streams of data (not updates).
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn stream_distinct_count(&self) -> Stream<C, OrdIndexedZSet<Z::Key, ZWeight>> {
         let factories: StreamDistinctCountFactories<Z::Inner, DynOrdIndexedZSet<DynData, DynData>> =
             StreamDistinctCountFactories::new::<Z::Key, Z::Val, ZWeight>();
@@ -141,6 +148,7 @@ where
     }
 
     /// Like [`Self::dyn_distinct_count`], but can return any batch type.
+    #[track_caller]
     pub fn stream_distinct_count_generic<O>(&self) -> Stream<C, O>
     where
         O: IndexedZSet<Key = Z::Key, DynK = Z::DynK, Val = ZWeight, DynV = DynData>,

--- a/crates/dbsp/src/operator/delta0.rs
+++ b/crates/dbsp/src/operator/delta0.rs
@@ -18,6 +18,7 @@ where
     /// operator.
     ///
     /// See [`Delta0`] operator documentation.
+    #[track_caller]
     pub fn delta0<CC>(&self, subcircuit: &CC) -> Stream<CC, D>
     where
         CC: Circuit<Parent = C>,
@@ -30,6 +31,7 @@ where
 
     /// Like [`Self::delta0`], but overrides the ownership
     /// preference on the input stream with `input_preference`.
+    #[track_caller]
     pub fn delta0_with_preference<CC>(
         &self,
         subcircuit: &CC,

--- a/crates/dbsp/src/operator/differentiate.rs
+++ b/crates/dbsp/src/operator/differentiate.rs
@@ -30,11 +30,13 @@ where
     ///
     /// You shouldn't ordinarily need this operator, at least not for streams of
     /// Z-sets, because most DBSP operators are fully incremental.
+    #[track_caller]
     pub fn differentiate(&self) -> Stream<C, D> {
         self.differentiate_with_initial_value(D::zero())
     }
 
     /// Nested stream differentiation.
+    #[track_caller]
     pub fn differentiate_nested(&self) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(NestedDifferentiateId::new(self.stream_id()), || {
@@ -64,6 +66,7 @@ where
         + Eq
         + 'static,
 {
+    #[track_caller]
     pub fn differentiate_with_initial_value(&self, initial: D) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(DifferentiateId::new(self.stream_id()), || {

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -19,6 +19,7 @@ where
     ///
     /// Intuitively, the operator converts the input multiset into a set
     /// by eliminating duplicates.
+    #[track_caller]
     pub fn stream_distinct(&self) -> Stream<C, Z> {
         let factories = BatchReaderFactories::new::<Z::Key, Z::Val, ZWeight>();
 
@@ -42,6 +43,7 @@ where
     ///
     /// Intuitively, the operator converts the input multiset into a set
     /// by eliminating duplicates.
+    #[track_caller]
     pub fn distinct(&self) -> Stream<C, Z> {
         let factories = DistinctFactories::new::<Z::Key, Z::Val>();
 

--- a/crates/dbsp/src/operator/inspect.rs
+++ b/crates/dbsp/src/operator/inspect.rs
@@ -34,6 +34,7 @@ where
     /// })
     /// .unwrap();
     /// ```
+    #[track_caller]
     pub fn inspect<F>(&self, callback: F) -> Self
     where
         F: FnMut(&D) + 'static,

--- a/crates/dbsp/src/operator/integrate.rs
+++ b/crates/dbsp/src/operator/integrate.rs
@@ -78,6 +78,7 @@ where
     /// input:  1, 1, 1, 1, 1, ...
     /// output: 1, 2, 3, 4, 5, ...
     /// ```
+    #[track_caller]
     pub fn integrate(&self) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(IntegralId::new(self.stream_id()), || {
@@ -150,6 +151,7 @@ where
     /// 2 3 4 5 1
     /// 4 5 6 5 1
     /// ```
+    #[track_caller]
     pub fn integrate_nested(&self) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(NestedIntegralId::new(self.stream_id()), || {

--- a/crates/dbsp/src/operator/join.rs
+++ b/crates/dbsp/src/operator/join.rs
@@ -118,6 +118,7 @@ where
     /// * `F` - join function type: maps key and a pair of values from input
     ///   batches to an output value.
     /// * `V` - output value type.
+    #[track_caller]
     pub fn join<F, V2, V>(
         &self,
         other: &Stream<C, OrdIndexedZSet<K1, V2>>,
@@ -144,6 +145,7 @@ where
     ///
     /// Behaves like `join` followed by `flat_map`, but does not materialize
     /// intermediate values.
+    #[track_caller]
     pub fn join_flatmap<F, V2, V, It>(
         &self,
         other: &Stream<C, OrdIndexedZSet<K1, V2>>,
@@ -176,6 +178,7 @@ where
     /// This method generalizes [`Self::join`].  It takes a join function that
     /// returns an iterable collection of `(key, value)` pairs, used to
     /// construct an indexed output Z-set.
+    #[track_caller]
     pub fn join_index<F, V2, K, V, It>(
         &self,
         other: &Stream<C, OrdIndexedZSet<K1, V2>>,
@@ -205,6 +208,7 @@ where
 
     /// Like [`Stream::outer_join`], but uses default value for the missing side of the
     /// join.
+    #[track_caller]
     pub fn outer_join_default<F, V2, O>(
         &self,
         other: &Stream<C, OrdIndexedZSet<K1, V2>>,
@@ -250,6 +254,7 @@ where
     /// * `I1` - batch type in the first input stream.
     /// * `I2` - batch type in the second input stream.
     /// * `V` - output value type.
+    #[track_caller]
     pub fn stream_join<F, I2, V>(&self, other: &Stream<C, I2>, join: F) -> Stream<C, OrdZSet<V>>
     where
         I2: IndexedZSet<Key = I1::Key, DynK = I1::DynK>,
@@ -271,6 +276,7 @@ where
     }
 
     /// Like [`Self::stream_join`], but can return any batch type.
+    #[track_caller]
     pub fn stream_join_generic<F, I2, Z>(&self, other: &Stream<C, I2>, join: F) -> Stream<C, Z>
     where
         I2: IndexedZSet<Key = I1::Key, DynK = I1::DynK>,
@@ -297,6 +303,7 @@ where
     ///
     /// One such monotonic function is a join function that returns `(k, v1,
     /// v2)` itself.
+    #[track_caller]
     pub fn monotonic_stream_join<F, I2, Z>(&self, other: &Stream<C, I2>, join: F) -> Stream<C, Z>
     where
         I1: IndexedZSet,
@@ -318,6 +325,7 @@ where
             .typed()
     }
 
+    #[track_caller]
     pub fn join_generic<I2, F, Z, It>(&self, other: &Stream<C, I2>, join: F) -> Stream<C, Z>
     where
         I2: IndexedZSet<Key = I1::Key, DynK = I1::DynK>,
@@ -340,6 +348,7 @@ where
     ///
     /// Returns indexed Z-set consisting of the contents of `self`,
     /// excluding keys that are present in `other`.
+    #[track_caller]
     pub fn antijoin<I2>(&self, other: &Stream<C, I2>) -> Stream<C, I1>
     where
         I2: IndexedZSet<Key = I1::Key, DynK = I1::DynK>,
@@ -360,6 +369,7 @@ where
     ///   not `other`.
     /// - returns the output of `right_func` for keys only found in `other`, but
     ///   not `self`.
+    #[track_caller]
     pub fn outer_join<I2, F, FL, FR, O>(
         &self,
         other: &Stream<C, I2>,

--- a/crates/dbsp/src/operator/join_range.rs
+++ b/crates/dbsp/src/operator/join_range.rs
@@ -17,6 +17,7 @@ where
     ///
     /// This operator is non-incremental, i.e., it joins the pair of batches it
     /// receives at each timestamp ignoring previous inputs.
+    #[track_caller]
     pub fn stream_join_range<I2, RF, JF, It>(
         &self,
         other: &Stream<C, I2>,
@@ -71,6 +72,7 @@ where
     ///
     /// This operator is non-incremental, i.e., it joins the pair of batches it
     /// receives at each timestamp ignoring previous inputs.
+    #[track_caller]
     pub fn stream_join_range_index<I2, K, V, RF, JF, It>(
         &self,
         other: &Stream<C, I2>,
@@ -118,6 +120,7 @@ where
 
     /// Like [`Self::dyn_stream_join_range`], but can return any indexed Z-set
     /// type.
+    #[track_caller]
     pub fn stream_join_range_generic<I2, K, V, RF, JF, It, O>(
         &self,
         other: &Stream<C, I2>,

--- a/crates/dbsp/src/operator/neg.rs
+++ b/crates/dbsp/src/operator/neg.rs
@@ -16,6 +16,7 @@ where
 {
     /// Returns a stream with the same type as `self` in which each value is
     /// negated. Negating an indexed Z-set negates all the weights.
+    #[track_caller]
     pub fn neg(&self) -> Stream<C, D> {
         let negated = self
             .circuit()

--- a/crates/dbsp/src/operator/neighborhood.rs
+++ b/crates/dbsp/src/operator/neighborhood.rs
@@ -93,6 +93,7 @@ where
     /// preceding the specified anchor.  The last index may be smaller than
     /// `descr.after - 1` if the input stream doesn't contain `descr.after`
     /// rows following the anchor point.
+    #[track_caller]
     pub fn neighborhood(
         &self,
         neighborhood_descr: &NeighborhoodDescrStream<B::Key, B::Val>,

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -28,6 +28,7 @@ where
     /// available to the outside world.  At each clock cycle, the contents
     /// of the stream is buffered inside the handle and can be read using
     /// the [`OutputHandle`] API.
+    #[track_caller]
     pub fn output(&self) -> OutputHandle<T> {
         let (output, output_handle) = Output::new();
         self.circuit().add_sink(output, self);
@@ -43,6 +44,7 @@ where
     /// the end of the clock cycle, and [`OutputHandle::take_from_worker`] will
     /// return `None`.  This operator can be used to output a large collection,
     /// such as an integral of a stream, on demand.
+    #[track_caller]
     pub fn output_guarded(&self, guard: &Stream<RootCircuit, bool>) -> OutputHandle<T> {
         let (output, output_handle) = OutputGuarded::new();
         self.circuit().add_binary_sink(output, self, guard);

--- a/crates/dbsp/src/operator/plus.rs
+++ b/crates/dbsp/src/operator/plus.rs
@@ -52,6 +52,7 @@ where
     /// #     circuit.step().unwrap();
     /// # }
     /// ```
+    #[track_caller]
     pub fn plus(&self, other: &Stream<C, D>) -> Stream<C, D> {
         // If both inputs are properly sharded then the sum of those inputs will be
         // sharded
@@ -77,6 +78,7 @@ where
     /// Apply the [`Minus`] operator to `self` and `other`.
     /// Subtracting two indexed Z-sets subtracts the weights of matching
     /// key-value pairs.
+    #[track_caller]
     pub fn minus(&self, other: &Stream<C, D>) -> Stream<C, D> {
         // If both inputs are properly sharded then the difference of those inputs will
         // be sharded

--- a/crates/dbsp/src/operator/recursive.rs
+++ b/crates/dbsp/src/operator/recursive.rs
@@ -220,6 +220,7 @@ where
     ///     root.step().unwrap();
     /// }
     /// ```
+    #[track_caller]
     pub fn recursive<F, S>(&self, f: F) -> Result<S::Output, SchedulerError>
     where
         S: RecursiveStreams<ChildCircuit<Self>>,

--- a/crates/dbsp/src/operator/sample.rs
+++ b/crates/dbsp/src/operator/sample.rs
@@ -39,6 +39,7 @@ where
     /// WARNING: This operator (by definition) returns non-deterministic
     /// outputs.  As such it may not play well with most other DBSP operators
     /// and must be used with care.
+    #[track_caller]
     pub fn stream_sample_keys(
         &self,
         sample_size: &Stream<RootCircuit, usize>,
@@ -56,6 +57,7 @@ where
     /// Equivalent to `self.map(|(k, v)| (k, v)).stream_sample_keys()`,
     /// but is more efficient.
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn stream_sample_unique_key_vals(
         &self,
         sample_size: &Stream<RootCircuit, usize>,
@@ -95,6 +97,7 @@ where
     /// feeding the same input twice can produce different outputs.  As such it
     /// may not play well with most other DBSP operators and must be used with
     /// care.
+    #[track_caller]
     pub fn stream_key_quantiles(
         &self,
         num_quantiles: &Stream<RootCircuit, usize>,
@@ -113,6 +116,7 @@ where
     /// Equivalent to `self.map(|(k, v)| (k,
     /// v)).stream_unique_key_val_quantiles()`, but is more efficient.
     #[allow(clippy::type_complexity)]
+    #[track_caller]
     pub fn stream_unique_key_val_quantiles(
         &self,
         num_quantiles: &Stream<RootCircuit, usize>,

--- a/crates/dbsp/src/operator/semijoin.rs
+++ b/crates/dbsp/src/operator/semijoin.rs
@@ -24,6 +24,7 @@ where
     /// * `Pairs` - batch type in the first input stream.
     /// * `Keys` - batch type in the second input stream.
     /// * `Out` - output Z-set type.
+    #[track_caller]
     pub fn semijoin_stream<Keys, Out>(&self, keys: &Stream<C, Keys>) -> Stream<C, Out>
     where
         Keys: ZSet<Key = Pairs::Key, DynK = Pairs::DynK>,

--- a/crates/dbsp/src/operator/stream_fold.rs
+++ b/crates/dbsp/src/operator/stream_fold.rs
@@ -19,6 +19,7 @@ where
     /// * `fold_func` - closure that computes the new value of the accumulator
     ///   as a function of the previous value and the new input at each clock
     ///   cycle.
+    #[track_caller]
     pub fn stream_fold<A, F>(&self, init: A, fold_func: F) -> Stream<RootCircuit, A>
     where
         F: Fn(A, &T) -> A + 'static,

--- a/crates/dbsp/src/operator/sum.rs
+++ b/crates/dbsp/src/operator/sum.rs
@@ -24,6 +24,7 @@ where
     /// The first output is the sum of the first input from each input stream,
     /// the second output is the sum of the second input from each input stream,
     /// and so on.
+    #[track_caller]
     pub fn sum<'a, I>(&'a self, streams: I) -> Stream<C, D>
     where
         I: IntoIterator<Item = &'a Self>,

--- a/crates/dbsp/src/operator/trace.rs
+++ b/crates/dbsp/src/operator/trace.rs
@@ -25,6 +25,7 @@ where
     ///
     /// This operator labels each untimed batch in the stream with the current
     /// timestamp and adds it to a trace.
+    #[track_caller]
     pub fn trace(&self) -> Stream<C, TypedBatch<K, V, R, FileValSpine<B, C>>> {
         let factories = BatchReaderFactories::new::<K, V, R>();
         self.inner().dyn_trace(&factories).typed()
@@ -43,6 +44,7 @@ where
     ///            └─────────┤Z1Trace│◄──┘
     ///                      └───────┘
     /// ```
+    #[track_caller]
     pub fn trace_with_bound<T>(
         &self,
         lower_key_bound: TraceBound<B::Key>,

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -142,6 +142,7 @@ where
     C: Circuit,
 {
     /// Applies [`Z1`] operator to `self`.
+    #[track_caller]
     pub fn delay(&self) -> Stream<C, D>
     where
         D: Checkpoint + Eq + SizeOf + NumEntries + Clone + HasZero + 'static,
@@ -153,6 +154,7 @@ where
             .clone()
     }
 
+    #[track_caller]
     pub fn delay_with_initial_value(&self, initial: D) -> Stream<C, D>
     where
         D: Checkpoint + Eq + SizeOf + NumEntries + Clone + 'static,
@@ -166,6 +168,7 @@ where
     }
 
     /// Applies [`Z1Nested`] operator to `self`.
+    #[track_caller]
     pub fn delay_nested(&self) -> Stream<C, D>
     where
         D: Eq + Clone + HasZero + SizeOf + NumEntries + 'static,

--- a/crates/dbsp/src/storage/backend/mod.rs
+++ b/crates/dbsp/src/storage/backend/mod.rs
@@ -207,11 +207,11 @@ impl dyn StorageBackend {
         }
     }
 
-    fn is_tmpfs(path: &Path) -> bool {
+    fn is_tmpfs(_path: &Path) -> bool {
         #[cfg(target_os = "linux")]
         {
             use nix::sys::statfs;
-            statfs::statfs(path).is_ok_and(|s| s.filesystem_type() == statfs::TMPFS_MAGIC)
+            statfs::statfs(_path).is_ok_and(|s| s.filesystem_type() == statfs::TMPFS_MAGIC)
         }
 
         #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
We use `track_caller` annotations to output the location in `main.rs` that instantiates each operator in the generated profile.  This commit adds a bunch of missing annotations. Unfortunately, we are still not able to track every operator's location because this is still unstable:
https://doc.rust-lang.org/beta/unstable-book/language-features/closure-track-caller.html

But this still improves profile readability.