### PR TITLE
[dbsp] Profiling improvements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "csv",
  "derive_more 1.0.0",
  "dyn-clone",
+ "enum-map",
  "env_logger 0.11.6",
  "fdlimit",
  "feldera-ijson",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -72,6 +72,7 @@ minitrace = "0.6"
 ouroboros = "0.18.4"
 tracing = "0.1.40"
 snap = "1.1.1"
+enum-map = "2.7.3"
 
 
 [dependencies.time]

--- a/crates/dbsp/src/circuit/metadata.rs
+++ b/crates/dbsp/src/circuit/metadata.rs
@@ -27,6 +27,12 @@ pub const SHARED_BYTES_LABEL: &str = "shared bytes";
 /// operator, e.g., the number of entries in a trace.
 pub const NUM_ENTRIES_LABEL: &str = "total size";
 
+/// The number of input tuples ingested by the operator.
+pub const NUM_INPUTS: &str = "inputs";
+
+/// The number of output tuples ingested by the operator.
+pub const NUM_OUTPUTS: &str = "outputs";
+
 /// An operator's location within the source program
 pub type OperatorLocation = Option<&'static Location<'static>>;
 

--- a/crates/dbsp/src/operator/communication/exchange.rs
+++ b/crates/dbsp/src/operator/communication/exchange.rs
@@ -7,14 +7,16 @@
 
 use crate::{
     circuit::{
-        metadata::OperatorLocation,
+        metadata::{MetaItem, OperatorLocation, OperatorMeta, NUM_INPUTS, NUM_OUTPUTS},
+        metrics::Gauge,
         operator_traits::{Operator, SinkOperator, SourceOperator},
         tokio::TOKIO,
-        Host, LocalStoreMarker, OwnershipPreference, Runtime, Scope,
+        GlobalNodeId, Host, LocalStoreMarker, OwnershipPreference, Runtime, Scope,
     },
     circuit_cache_key,
     storage::file::to_bytes,
     trace::{unaligned_deserialize, Rkyv},
+    NumEntries,
 };
 use crossbeam_utils::CachePadded;
 use futures::{future, prelude::*};
@@ -774,6 +776,11 @@ where
     partition: L,
     outputs: Vec<T>,
     exchange: Arc<Exchange<T>>,
+
+    // Total number of input tuples processed by the operator.
+    num_inputs: usize,
+    num_inputs_metric: Option<Gauge>,
+
     phantom: PhantomData<D>,
 }
 
@@ -795,6 +802,8 @@ where
             partition,
             outputs: Vec::with_capacity(runtime.num_workers()),
             exchange: Exchange::with_runtime(runtime, exchange_id),
+            num_inputs: 0,
+            num_inputs_metric: None,
             phantom: PhantomData,
         }
     }
@@ -808,6 +817,29 @@ where
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::from("ExchangeSender")
+    }
+
+    fn init(&mut self, global_id: &GlobalNodeId) {
+        self.num_inputs_metric = Some(Gauge::new(
+            NUM_INPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+    }
+
+    fn metrics(&self) {
+        self.num_inputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+    }
+
+    fn metadata(&self, meta: &mut OperatorMeta) {
+        meta.extend(metadata! {
+            NUM_INPUTS => MetaItem::Count(self.num_inputs),
+        });
     }
 
     fn location(&self) -> OperatorLocation {
@@ -840,7 +872,7 @@ where
 
 impl<D, T, L> SinkOperator<D> for ExchangeSender<D, T, L>
 where
-    D: Clone + 'static,
+    D: Clone + NumEntries + 'static,
     T: Clone + Send + Rkyv + 'static,
     L: FnMut(D, &mut Vec<T>) + 'static,
 {
@@ -849,6 +881,8 @@ where
     }
 
     async fn eval_owned(&mut self, input: D) {
+        self.num_inputs += input.num_entries_deep();
+
         debug_assert!(self.ready());
         self.outputs.clear();
         (self.partition)(input, &mut self.outputs);
@@ -887,6 +921,10 @@ where
     init: IF,
     combine: L,
     exchange: Arc<Exchange<T>>,
+
+    // Total number of input tuples processed by the operator.
+    num_outputs: usize,
+    num_outputs_metric: Option<Gauge>,
 }
 
 impl<IF, T, L> ExchangeReceiver<IF, T, L>
@@ -909,6 +947,8 @@ where
             init,
             combine,
             exchange: Exchange::with_runtime(runtime, exchange_id),
+            num_outputs: 0,
+            num_outputs_metric: None,
         }
     }
 }
@@ -925,6 +965,29 @@ where
 
     fn location(&self) -> OperatorLocation {
         self.location
+    }
+
+    fn init(&mut self, global_id: &GlobalNodeId) {
+        self.num_outputs_metric = Some(Gauge::new(
+            NUM_OUTPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+    }
+
+    fn metrics(&self) {
+        self.num_outputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_outputs as f64);
+    }
+
+    fn metadata(&self, meta: &mut OperatorMeta) {
+        meta.extend(metadata! {
+            NUM_OUTPUTS => MetaItem::Count(self.num_outputs),
+        });
     }
 
     fn is_async(&self) -> bool {
@@ -950,7 +1013,7 @@ where
 
 impl<D, IF, T, L> SourceOperator<D> for ExchangeReceiver<IF, T, L>
 where
-    D: 'static,
+    D: NumEntries + 'static,
     T: Clone + Send + Rkyv + 'static,
     IF: Fn() -> D + 'static,
     L: Fn(&mut D, T) + 'static,
@@ -963,6 +1026,8 @@ where
             .try_receive_all(self.worker_index, |x| (self.combine)(&mut combined, x));
 
         debug_assert!(res);
+
+        self.num_outputs += combined.num_entries_deep();
         combined
     }
 }

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -8,7 +8,10 @@ use crate::{
         OrdIndexedZSetFactories, PartialOrder, ZRingValue, ZTrace,
     },
     circuit::{
-        metadata::{MetaItem, OperatorMeta, SHARED_BYTES_LABEL, USED_BYTES_LABEL},
+        metadata::{
+            MetaItem, OperatorLocation, OperatorMeta, NUM_ENTRIES_LABEL, NUM_INPUTS, NUM_OUTPUTS,
+            SHARED_BYTES_LABEL, USED_BYTES_LABEL,
+        },
         operator_traits::{BinaryOperator, Operator, UnaryOperator},
         Circuit, GlobalNodeId, Scope, Stream, WithClock,
     },
@@ -19,6 +22,7 @@ use crate::{
 };
 use minitrace::trace;
 use size_of::SizeOf;
+use std::panic::Location;
 use std::{
     borrow::Cow,
     cmp::{min, Ordering},
@@ -149,7 +153,10 @@ where
                     if circuit.root_scope() == 0 {
                         // Use an implementation optimized to work in the root scope.
                         circuit.add_binary_operator(
-                            DistinctIncrementalTotal::new(&factories.input_factories),
+                            DistinctIncrementalTotal::new(
+                                Location::caller(),
+                                &factories.input_factories,
+                            ),
                             &stream,
                             &stream
                                 .dyn_integrate_trace(&factories.input_factories)
@@ -166,6 +173,7 @@ where
                         // ```
                         circuit.add_binary_operator(
                             DistinctIncremental::new(
+                                Location::caller(),
                                 &factories.input_factories,
                                 &factories.aux_factories,
                                 circuit.clone(),
@@ -237,13 +245,28 @@ where
 /// values in the support of `a`.
 struct DistinctIncrementalTotal<Z: IndexedZSet, I> {
     input_factories: Z::Factories,
+    location: &'static Location<'static>,
+
+    // Total number of input tuples processed by the operator.
+    num_inputs: usize,
+    num_inputs_metric: Option<Gauge>,
+
+    // Total number of output tuples processed by the operator.
+    num_outputs: usize,
+    num_outputs_metric: Option<Gauge>,
+
     _type: PhantomData<(Z, I)>,
 }
 
 impl<Z: IndexedZSet, I> DistinctIncrementalTotal<Z, I> {
-    pub fn new(input_factories: &Z::Factories) -> Self {
+    pub fn new(location: &'static Location<'static>, input_factories: &Z::Factories) -> Self {
         Self {
             input_factories: input_factories.clone(),
+            location,
+            num_inputs: 0,
+            num_inputs_metric: None,
+            num_outputs: 0,
+            num_outputs_metric: None,
             _type: PhantomData,
         }
     }
@@ -258,6 +281,47 @@ where
         Cow::from("DistinctIncrementalTotal")
     }
 
+    fn location(&self) -> OperatorLocation {
+        Some(self.location)
+    }
+
+    fn init(&mut self, global_id: &GlobalNodeId) {
+        self.num_inputs_metric = Some(Gauge::new(
+            NUM_INPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+
+        self.num_outputs_metric = Some(Gauge::new(
+            NUM_OUTPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+    }
+
+    fn metrics(&self) {
+        self.num_inputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+
+        self.num_outputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+    }
+
+    fn metadata(&self, meta: &mut OperatorMeta) {
+        meta.extend(metadata! {
+            NUM_INPUTS => MetaItem::Count(self.num_inputs),
+            NUM_OUTPUTS => MetaItem::Count(self.num_outputs),
+        });
+    }
+
     fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
@@ -270,6 +334,8 @@ where
 {
     #[trace]
     async fn eval(&mut self, delta: &Z, delayed_integral: &I) -> Z {
+        self.num_inputs += delta.len();
+
         let mut builder = Z::Builder::with_capacity(&self.input_factories, (), delta.len());
         let mut delta_cursor = delta.cursor();
         let mut integral_cursor = delayed_integral.cursor();
@@ -321,7 +387,9 @@ where
             delta_cursor.step_key();
         }
 
-        builder.done()
+        let result = builder.done();
+        self.num_outputs += result.len();
+        result
     }
 
     // TODO: owned implementation.
@@ -348,6 +416,9 @@ where
 {
     #[size_of(skip)]
     input_factories: Z::Factories,
+
+    location: &'static Location<'static>,
+
     #[size_of(skip)]
     aux_factories: OrdIndexedZSetFactories<Z::Key, Z::Val>,
     #[size_of(skip)]
@@ -362,8 +433,16 @@ where
     // Used in computing partial derivatives
     // (we keep it here to reuse allocations across `eval_keyval` calls).
     distinct_vals: Vec<(Option<T::Time>, ZWeight)>,
-    // Handle to update the metric `total_updates`
-    total_updates_metric: Option<Gauge>,
+    // Handle to update the metric `total size`
+    total_size_metric: Option<Gauge>,
+    // Total number of input tuples processed by the operator.
+    num_inputs: usize,
+    num_inputs_metric: Option<Gauge>,
+
+    // Total number of output tuples processed by the operator.
+    num_outputs: usize,
+    num_outputs_metric: Option<Gauge>,
+
     _type: PhantomData<(Z, T)>,
 }
 
@@ -374,6 +453,7 @@ where
     Clk: WithClock<Time = T::Time>,
 {
     fn new(
+        location: &'static Location<'static>,
         input_factories: &Z::Factories,
         aux_factories: &OrdIndexedZSetFactories<Z::Key, Z::Val>,
         clock: Clk,
@@ -381,6 +461,7 @@ where
         let depth = clock.nesting_depth();
 
         Self {
+            location,
             input_factories: input_factories.clone(),
             aux_factories: aux_factories.clone(),
             clock,
@@ -389,7 +470,11 @@ where
             empty_output: false,
             distinct_vals: vec![(None, HasZero::zero()); 2 << depth],
             _type: PhantomData,
-            total_updates_metric: None,
+            total_size_metric: None,
+            num_inputs: 0,
+            num_inputs_metric: None,
+            num_outputs: 0,
+            num_outputs_metric: None,
         }
     }
 
@@ -596,9 +681,29 @@ where
         Cow::Borrowed("DistinctIncremental")
     }
 
+    fn location(&self) -> OperatorLocation {
+        Some(self.location)
+    }
+
     fn init(&mut self, global_id: &GlobalNodeId) {
-        self.total_updates_metric = Some(Gauge::new(
-            "total_updates",
+        self.total_size_metric = Some(Gauge::new(
+            NUM_ENTRIES_LABEL,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+
+        self.num_inputs_metric = Some(Gauge::new(
+            NUM_INPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+
+        self.num_outputs_metric = Some(Gauge::new(
+            NUM_OUTPUTS,
             None,
             Some("count"),
             global_id,
@@ -608,8 +713,17 @@ where
 
     fn metrics(&self) {
         let size: usize = self.keys_of_interest.values().map(|v| v.len()).sum();
+        self.total_size_metric.as_ref().unwrap().set(size as f64);
 
-        self.total_updates_metric.as_ref().unwrap().set(size as f64);
+        self.num_inputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+
+        self.num_outputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_outputs as f64);
     }
 
     fn metadata(&self, meta: &mut OperatorMeta) {
@@ -617,7 +731,9 @@ where
         let bytes = self.size_of();
 
         meta.extend(metadata! {
-            "total updates" => MetaItem::bytes(size),
+            NUM_ENTRIES_LABEL => MetaItem::Count(size),
+            NUM_INPUTS => MetaItem::Count(self.num_inputs),
+            NUM_OUTPUTS => MetaItem::Count(self.num_outputs),
             USED_BYTES_LABEL => MetaItem::bytes(bytes.used_bytes()),
             "allocations" => MetaItem::Count(bytes.distinct_allocations()),
             SHARED_BYTES_LABEL => MetaItem::bytes(bytes.shared_bytes()),
@@ -666,6 +782,7 @@ where
     #[trace]
     async fn eval(&mut self, delta: &Z, trace: &T) -> Z {
         let time = self.clock.time();
+        self.num_inputs += delta.len();
 
         Self::init_distinct_vals(&mut self.distinct_vals, Some(time.clone()));
         self.empty_input = delta.is_empty();
@@ -844,6 +961,7 @@ where
         let result = result_builder.done();
         self.empty_output = result.is_empty();
 
+        self.num_outputs += result.len();
         result
     }
 }

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -1,4 +1,5 @@
 use crate::circuit::circuit_builder::StreamId;
+use crate::circuit::metadata::NUM_INPUTS;
 use crate::circuit::metrics::Gauge;
 use crate::{
     circuit::{
@@ -646,6 +647,10 @@ pub struct UntimedTraceAppend<T>
 where
     T: Trace,
 {
+    // Total number of input tuples processed by the operator.
+    num_inputs: usize,
+    num_inputs_metric: Option<Gauge>,
+
     _phantom: PhantomData<T>,
 }
 
@@ -655,6 +660,8 @@ where
 {
     pub fn new() -> Self {
         Self {
+            num_inputs: 0,
+            num_inputs_metric: None,
             _phantom: PhantomData,
         }
     }
@@ -676,6 +683,30 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("UntimedTraceAppend")
     }
+
+    fn init(&mut self, global_id: &GlobalNodeId) {
+        self.num_inputs_metric = Some(Gauge::new(
+            NUM_INPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+    }
+
+    fn metrics(&self) {
+        self.num_inputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+    }
+
+    fn metadata(&self, meta: &mut OperatorMeta) {
+        meta.extend(metadata! {
+            NUM_INPUTS => MetaItem::Count(self.num_inputs),
+        });
+    }
+
     fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
@@ -693,6 +724,7 @@ where
 
     #[trace]
     async fn eval_owned_and_ref(&mut self, mut trace: T, batch: &T::Batch) -> T {
+        self.num_inputs += batch.len();
         trace.insert(batch.clone());
         trace
     }
@@ -705,6 +737,8 @@ where
 
     #[trace]
     async fn eval_owned(&mut self, mut trace: T, batch: T::Batch) -> T {
+        self.num_inputs += batch.len();
+
         trace.insert(batch);
         trace
     }
@@ -720,6 +754,11 @@ where
 pub struct TraceAppend<T: Trace, B: BatchReader, C> {
     clock: C,
     output_factories: T::Factories,
+
+    // Total number of input tuples processed by the operator.
+    num_inputs: usize,
+    num_inputs_metric: Option<Gauge>,
+
     _phantom: PhantomData<(T, B)>,
 }
 
@@ -728,6 +767,8 @@ impl<T: Trace, B: BatchReader, C> TraceAppend<T, B, C> {
         Self {
             clock,
             output_factories: output_factories.clone(),
+            num_inputs: 0,
+            num_inputs_metric: None,
             _phantom: PhantomData,
         }
     }
@@ -744,6 +785,29 @@ where
     }
     fn fixedpoint(&self, _scope: Scope) -> bool {
         true
+    }
+
+    fn init(&mut self, global_id: &GlobalNodeId) {
+        self.num_inputs_metric = Some(Gauge::new(
+            NUM_INPUTS,
+            None,
+            Some("count"),
+            global_id,
+            vec![],
+        ));
+    }
+
+    fn metrics(&self) {
+        self.num_inputs_metric
+            .as_ref()
+            .unwrap()
+            .set(self.num_inputs as f64);
+    }
+
+    fn metadata(&self, meta: &mut OperatorMeta) {
+        meta.extend(metadata! {
+            NUM_INPUTS => MetaItem::Count(self.num_inputs),
+        });
     }
 }
 
@@ -764,6 +828,7 @@ where
     async fn eval_owned_and_ref(&mut self, mut trace: T, batch: &B) -> T {
         // TODO: extend `trace` type to feed untimed batches directly
         // (adding fixed timestamp on the fly).
+        self.num_inputs += batch.len();
         trace.insert(T::Batch::from_batch(
             batch,
             &self.clock.time(),
@@ -780,6 +845,8 @@ where
 
     #[trace]
     async fn eval_owned(&mut self, mut trace: T, batch: B) -> T {
+        self.num_inputs += batch.len();
+
         trace.insert(T::Batch::from_batch(
             &batch,
             &self.clock.time(),

--- a/crates/dbsp/src/storage/buffer_cache/mod.rs
+++ b/crates/dbsp/src/storage/buffer_cache/mod.rs
@@ -5,5 +5,8 @@ mod cache;
 /// A file-backed buffer.
 mod fbuf;
 
-pub use cache::{BufferCache, CacheEntry};
+pub use cache::{
+    AtomicCacheCounts, AtomicCacheStats, BufferCache, CacheAccess, CacheCounts, CacheEntry,
+    CacheStats,
+};
 pub use fbuf::{FBuf, FBufSerializer};

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -38,10 +38,7 @@ use crate::{
 
 use super::cache::{FileCache, FileCacheEntry};
 use super::format::Compression;
-use super::{
-    reader::{ImmutableFileRef, Reader},
-    AnyFactories, Factories, Serializer,
-};
+use super::{reader::Reader, AnyFactories, Factories, Serializer};
 
 struct VarintWriter {
     varint: Varint,
@@ -1203,14 +1200,11 @@ where
     pub fn into_reader(
         self,
     ) -> Result<Reader<(&'static K0, &'static A0, ())>, super::reader::Error> {
-        let storage = self.storage().clone();
+        let cache = self.storage().clone();
         let any_factories = self.factories.any_factories();
 
         let (file_handle, path) = self.close()?;
-        Reader::new(
-            &[&any_factories],
-            ImmutableFileRef::new(&storage, file_handle, path),
-        )
+        Reader::new(&[&any_factories], path, cache, file_handle)
     }
 }
 
@@ -1376,13 +1370,15 @@ where
         Reader<(&'static K0, &'static A0, (&'static K1, &'static A1, ()))>,
         super::reader::Error,
     > {
-        let storage = self.storage().clone();
+        let cache = self.storage().clone();
         let any_factories0 = self.factories0.any_factories();
         let any_factories1 = self.factories1.any_factories();
         let (file_handle, path) = self.close()?;
         Reader::new(
             &[&any_factories0, &any_factories1],
-            ImmutableFileRef::new(&storage, file_handle, path),
+            path,
+            cache,
+            file_handle,
         )
     }
 }

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -1209,7 +1209,7 @@ where
         let (file_handle, path) = self.close()?;
         Reader::new(
             &[&any_factories],
-            Arc::new(ImmutableFileRef::new(&storage, file_handle, path)),
+            ImmutableFileRef::new(&storage, file_handle, path),
         )
     }
 }
@@ -1382,7 +1382,7 @@ where
         let (file_handle, path) = self.close()?;
         Reader::new(
             &[&any_factories0, &any_factories1],
-            Arc::new(ImmutableFileRef::new(&storage, file_handle, path)),
+            ImmutableFileRef::new(&storage, file_handle, path),
         )
     }
 }

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -34,6 +34,7 @@
 
 use crate::circuit::metadata::{MetaItem, OperatorMeta};
 use crate::dynamic::{ClonableTrait, DynDataTyped, DynUnit, Weight};
+use crate::storage::buffer_cache::CacheStats;
 pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};
 use crate::time::Antichain;
 use crate::{dynamic::ArchivedDBData, storage::buffer_cache::FBuf};
@@ -406,6 +407,13 @@ where
     /// Where the batch's data is stored.
     fn location(&self) -> BatchLocation {
         BatchLocation::Memory
+    }
+
+    /// Storage cache access statistics for this batch only.
+    ///
+    /// Most batches are in-memory, so they don't have any statistics.
+    fn cache_stats(&self) -> CacheStats {
+        CacheStats::default()
     }
 
     /// True if the batch is empty.

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -1,7 +1,7 @@
 use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef, ZRingValue},
     dynamic::{DataTrait, DynPair, DynVec, Erase, WeightTrait, WeightTraitTyped},
-    storage::file::reader::Error as ReaderError,
+    storage::{buffer_cache::CacheStats, file::reader::Error as ReaderError},
     time::{Antichain, AntichainRef},
     trace::{
         cursor::DelegatingCursor,
@@ -264,6 +264,13 @@ where
         match &self.inner {
             Inner::Vec(vec) => vec.location(),
             Inner::File(file) => file.location(),
+        }
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        match &self.inner {
+            Inner::Vec(vec) => vec.cache_stats(),
+            Inner::File(file) => file.cache_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -3,7 +3,7 @@ use crate::{
         DataTrait, DynDataTyped, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory,
         WeightTrait,
     },
-    storage::file::reader::Error as ReaderError,
+    storage::{buffer_cache::CacheStats, file::reader::Error as ReaderError},
     time::{Antichain, AntichainRef},
     trace::{
         cursor::DelegatingCursor,
@@ -270,6 +270,13 @@ where
         match &self.inner {
             Inner::Vec(vec) => vec.location(),
             Inner::File(file) => file.location(),
+        }
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        match &self.inner {
+            Inner::Vec(vec) => vec.cache_stats(),
+            Inner::File(file) => file.cache_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -3,6 +3,7 @@ use std::mem::replace;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
+use crate::storage::buffer_cache::CacheStats;
 use crate::trace::cursor::DelegatingCursor;
 use crate::trace::ord::file::val_batch::FileValBuilder;
 use crate::trace::ord::vec::val_batch::VecValBuilder;
@@ -280,6 +281,13 @@ where
         match &self.inner {
             Inner::Vec(vec) => vec.location(),
             Inner::File(file) => file.location(),
+        }
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        match &self.inner {
+            Inner::Vec(vec) => vec.cache_stats(),
+            Inner::File(file) => file.cache_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -5,7 +5,7 @@ use crate::{
         DataTrait, DynDataTyped, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory,
         WeightTrait, WeightTraitTyped,
     },
-    storage::file::reader::Error as ReaderError,
+    storage::{buffer_cache::CacheStats, file::reader::Error as ReaderError},
     time::{Antichain, AntichainRef},
     trace::{
         cursor::DelegatingCursor,
@@ -349,6 +349,13 @@ where
         match &self.inner {
             Inner::Vec(vec) => vec.location(),
             Inner::File(file) => file.location(),
+        }
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        match &self.inner {
+            Inner::Vec(vec) => vec.cache_stats(),
+            Inner::File(file) => file.cache_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -408,7 +408,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -4,10 +4,13 @@ use crate::{
         DataTrait, DynDataTyped, DynOpt, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase,
         Factory, WeightTrait, WeightTraitTyped, WithFactory,
     },
-    storage::file::{
-        reader::{Cursor as FileCursor, Error as ReaderError, Reader},
-        writer::Writer2,
-        Factories as FileFactories,
+    storage::{
+        buffer_cache::CacheStats,
+        file::{
+            reader::{Cursor as FileCursor, Error as ReaderError, Reader},
+            writer::Writer2,
+            Factories as FileFactories,
+        },
     },
     time::{Antichain, AntichainRef},
     trace::{
@@ -346,6 +349,10 @@ where
     #[inline]
     fn location(&self) -> BatchLocation {
         BatchLocation::Storage
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.file.cache_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -327,7 +327,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -3,10 +3,13 @@ use crate::{
         DataTrait, DynDataTyped, DynOpt, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase,
         Factory, LeanVec, WeightTrait, WithFactory,
     },
-    storage::file::{
-        reader::{Cursor as FileCursor, Error as ReaderError, Reader},
-        writer::Writer2,
-        Factories as FileFactories,
+    storage::{
+        buffer_cache::CacheStats,
+        file::{
+            reader::{Cursor as FileCursor, Error as ReaderError, Reader},
+            writer::Writer2,
+            Factories as FileFactories,
+        },
     },
     time::{Antichain, AntichainRef},
     trace::{
@@ -267,6 +270,10 @@ where
     #[inline]
     fn location(&self) -> BatchLocation {
         BatchLocation::Storage
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.file.cache_stats()
     }
 
     fn lower(&self) -> AntichainRef<'_, T> {

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -354,7 +354,7 @@ where
         let any_factory1 = factories.factories1.any_factories();
         let file = Reader::open(
             &[&any_factory0, &any_factory1],
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::buffer_cache::CacheStats;
 use crate::trace::cursor::{HasTimeDiffCursor, TimeDiffCursor};
 use crate::trace::{BatchLocation, TimedBuilder};
 use crate::{
@@ -292,6 +293,10 @@ where
     #[inline]
     fn location(&self) -> BatchLocation {
         BatchLocation::Storage
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.file.cache_stats()
     }
 
     fn lower(&self) -> AntichainRef<'_, T> {

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -4,10 +4,13 @@ use crate::{
         DataTrait, DynDataTyped, DynPair, DynUnit, DynVec, DynWeightedPairs, Erase, Factory,
         LeanVec, WeightTrait, WeightTraitTyped, WithFactory,
     },
-    storage::file::{
-        reader::{Cursor as FileCursor, Error as ReaderError, Reader},
-        writer::Writer1,
-        Factories as FileFactories,
+    storage::{
+        buffer_cache::CacheStats,
+        file::{
+            reader::{Cursor as FileCursor, Error as ReaderError, Reader},
+            writer::Writer1,
+            Factories as FileFactories,
+        },
     },
     time::{Antichain, AntichainRef},
     trace::{
@@ -363,6 +366,10 @@ where
     #[inline]
     fn location(&self) -> BatchLocation {
         BatchLocation::Storage
+    }
+
+    fn cache_stats(&self) -> CacheStats {
+        self.file.cache_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -423,7 +423,7 @@ where
         let any_factory0 = factories.file_factories.any_factories();
         let file = Reader::open(
             &[&any_factory0],
-            &Runtime::buffer_cache(),
+            Runtime::buffer_cache(),
             &*Runtime::storage_backend().unwrap(),
             path,
         )?;


### PR DESCRIPTION
- Include input/output tuple counts in the profile for distinct, map, exchange, and trace-append operators.
- Some more missing #[track_caller] annotations (for input operators)