### PR TITLE
[SQL] Implement ARRAY as Arc<Vec>

### DIFF
--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -888,7 +888,8 @@ impl Arbitrary for DeltaTestStruct {
                                 (Variant::String("foo".to_string())),
                                 Variant::String(variant.to_string()),
                             ))
-                            .collect(),
+                            .collect::<BTreeMap<Variant, Variant>>()
+                            .into(),
                         ),
                         uuid: Uuid::from_bytes(uuid),
                     }

--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -3,6 +3,7 @@
 #![allow(non_snake_case)]
 
 use crate::{
+    array::Array,
     binary::ByteArray,
     error::{r2o, SqlResult, SqlRuntimeError},
     geopoint::*,
@@ -2908,25 +2909,28 @@ cast_variant!(LongInterval_YEARS, LongInterval, LongInterval);
 cast_variant!(GeoPoint, GeoPoint, Geometry);
 
 #[doc(hidden)]
-pub fn cast_to_V_vec<T>(vec: Vec<T>) -> SqlResult<Variant>
+pub fn cast_to_V_vec<T>(vec: Array<T>) -> SqlResult<Variant>
 where
     Variant: From<T>,
+    T: Clone,
 {
     Ok(vec.into())
 }
 
 #[doc(hidden)]
-pub fn cast_to_VN_vec<T>(vec: Vec<T>) -> SqlResult<Option<Variant>>
+pub fn cast_to_VN_vec<T>(vec: Array<T>) -> SqlResult<Option<Variant>>
 where
     Variant: From<T>,
+    T: Clone,
 {
     Ok(Some(vec.into()))
 }
 
 #[doc(hidden)]
-pub fn cast_to_V_vecN<T>(vec: Option<Vec<T>>) -> SqlResult<Variant>
+pub fn cast_to_V_vecN<T>(vec: Option<Array<T>>) -> SqlResult<Variant>
 where
     Variant: From<T>,
+    T: Clone,
 {
     match vec {
         None => Ok(Variant::SqlNull),
@@ -2935,17 +2939,18 @@ where
 }
 
 #[doc(hidden)]
-pub fn cast_to_VN_vecN<T>(vec: Option<Vec<T>>) -> SqlResult<Option<Variant>>
+pub fn cast_to_VN_vecN<T>(vec: Option<Array<T>>) -> SqlResult<Option<Variant>>
 where
     Variant: From<T>,
+    T: Clone,
 {
     r2o(cast_to_V_vecN(vec))
 }
 
 #[doc(hidden)]
-pub fn cast_to_vec_V<T>(value: Variant) -> SqlResult<Vec<T>>
+pub fn cast_to_vec_V<T>(value: Variant) -> SqlResult<Array<T>>
 where
-    Vec<T>: TryFrom<Variant, Error = Box<dyn Error>>,
+    Array<T>: TryFrom<Variant, Error = Box<dyn Error>>,
 {
     match value.try_into() {
         Ok(value) => Ok(value),
@@ -2954,9 +2959,9 @@ where
 }
 
 #[doc(hidden)]
-pub fn cast_to_vec_VN<T>(value: Option<Variant>) -> SqlResult<Option<Vec<T>>>
+pub fn cast_to_vec_VN<T>(value: Option<Variant>) -> SqlResult<Option<Array<T>>>
 where
-    Vec<T>: TryFrom<Variant, Error = Box<dyn Error>>,
+    Array<T>: TryFrom<Variant, Error = Box<dyn Error>>,
 {
     match value {
         None => Ok(None),
@@ -2965,9 +2970,9 @@ where
 }
 
 #[doc(hidden)]
-pub fn cast_to_vecN_V<T>(value: Variant) -> SqlResult<Option<Vec<T>>>
+pub fn cast_to_vecN_V<T>(value: Variant) -> SqlResult<Option<Array<T>>>
 where
-    Vec<T>: TryFrom<Variant, Error = Box<dyn Error>>,
+    Array<T>: TryFrom<Variant, Error = Box<dyn Error>>,
 {
     match value.try_into() {
         Ok(value) => Ok(Some(value)),
@@ -2976,9 +2981,9 @@ where
 }
 
 #[doc(hidden)]
-pub fn cast_to_vecN_VN<T>(value: Option<Variant>) -> SqlResult<Option<Vec<T>>>
+pub fn cast_to_vecN_VN<T>(value: Option<Variant>) -> SqlResult<Option<Array<T>>>
 where
-    Vec<T>: TryFrom<Variant, Error = Box<dyn Error>>,
+    Array<T>: TryFrom<Variant, Error = Box<dyn Error>>,
 {
     match value {
         None => Ok(None),

--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -60,7 +60,6 @@ use dbsp::{
     utils::*,
     DBData, OrdIndexedZSet, OrdZSet, OutputHandle, SetHandle, ZSetHandle, ZWeight,
 };
-use itertools::Itertools;
 use metrics::{counter, Counter};
 use num::{PrimInt, ToPrimitive};
 use num_traits::{Pow, Zero};
@@ -228,12 +227,12 @@ pub(crate) use some_function2;
 // The generic type may be a part of the type of both parameters, just one of
 // them or even the return type
 macro_rules! some_generic_function2 {
-    ($func_name:ident, $generic_type: ty, $arg_type0: ty, $arg_type1: ty, $trait_bound:ident, $ret_type: ty) => {
+    ($func_name:ident, $generic_type: ty, $arg_type0: ty, $arg_type1: ty, $bound: tt $(+ $bounds: tt)*, $ret_type: ty) => {
         ::paste::paste! {
             #[doc(hidden)]
             pub fn [<$func_name NN>]<$generic_type>( arg0: Option<$arg_type0>, arg1: Option<$arg_type1> ) -> Option<$ret_type>
             where
-                $generic_type: $trait_bound,
+                $generic_type: $bound $(+ $bounds)*,
             {
                 let arg0 = arg0?;
                 let arg1 = arg1?;
@@ -243,7 +242,7 @@ macro_rules! some_generic_function2 {
             #[doc(hidden)]
             pub fn [<$func_name _N>]<$generic_type>( arg0: $arg_type0, arg1: Option<$arg_type1> ) -> Option<$ret_type>
             where
-                $generic_type: $trait_bound,
+                $generic_type: $bound $(+ $bounds)*,
             {
                 let arg1 = arg1?;
                 Some([<$func_name __>](arg0, arg1))
@@ -252,7 +251,7 @@ macro_rules! some_generic_function2 {
             #[doc(hidden)]
             pub fn [<$func_name N_>]<$generic_type>( arg0: Option<$arg_type0>, arg1: $arg_type1 ) -> Option<$ret_type>
             where
-                $generic_type: $trait_bound,
+                $generic_type: $bound $(+ $bounds)*,
             {
                 let arg0 = arg0?;
                 Some([<$func_name __>](arg0, arg1))
@@ -758,32 +757,6 @@ where
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct ConcatSemigroup<V>(PhantomData<V>);
-
-#[doc(hidden)]
-impl<V> Semigroup<Vec<V>> for ConcatSemigroup<Vec<V>>
-where
-    V: Clone + Ord,
-{
-    #[doc(hidden)]
-    fn combine(left: &Vec<V>, right: &Vec<V>) -> Vec<V> {
-        left.iter().merge(right).cloned().collect()
-    }
-}
-
-#[doc(hidden)]
-impl<V> Semigroup<Option<Vec<V>>> for ConcatSemigroup<Option<Vec<V>>>
-where
-    V: Clone + Ord,
-{
-    #[doc(hidden)]
-    fn combine(left: &Option<Vec<V>>, right: &Option<Vec<V>>) -> Option<Vec<V>> {
-        match (left, right) {
-            (None, _) => right.clone(),
-            (_, None) => left.clone(),
-            (Some(left), Some(right)) => Some(left.iter().merge(right).cloned().collect()),
-        }
-    }
-}
 
 #[doc(hidden)]
 #[inline(always)]

--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -2,12 +2,13 @@
 
 #![allow(non_snake_case)]
 use crate::{
-    some_function1, some_function2, some_function3, some_function4, some_polymorphic_function1,
-    some_polymorphic_function2, Variant,
+    array::Array, some_function1, some_function2, some_function3, some_function4,
+    some_polymorphic_function1, some_polymorphic_function2, Variant,
 };
 
 use like::{Escape, Like};
 use regex::Regex;
+use std::sync::Arc;
 
 #[doc(hidden)]
 pub fn concat_s_s(mut left: String, right: String) -> String {
@@ -268,28 +269,32 @@ pub fn left__(source: String, size: i32) -> String {
 some_function2!(left, String, i32, String);
 
 #[doc(hidden)]
-pub fn split2__(source: String, separators: String) -> Vec<String> {
+pub fn split2__(source: String, separators: String) -> Array<String> {
     if separators.is_empty() {
-        return vec![source];
+        return Arc::new(vec![source]);
     }
     if source.is_empty() {
-        return vec![];
+        return Arc::new(vec![]);
     }
-    source.split(&separators).map(String::from).collect()
+    source
+        .split(&separators)
+        .map(String::from)
+        .collect::<Vec<String>>()
+        .into()
 }
 
-some_function2!(split2, String, String, Vec<String>);
+some_function2!(split2, String, String, Array<String>);
 
 #[doc(hidden)]
-pub fn split1_(source: String) -> Vec<String> {
+pub fn split1_(source: String) -> Array<String> {
     split2__(source, ",".to_string())
 }
 
-some_function1!(split1, String, Vec<String>);
+some_function1!(split1, String, Array<String>);
 
 #[doc(hidden)]
 pub fn split_part___(s: String, delimiter: String, n: i32) -> String {
-    let parts: Vec<String> = split2__(s, delimiter);
+    let parts: Array<String> = split2__(s, delimiter);
     let part_count = parts.len() as i32;
 
     // Handle negative indices
@@ -305,21 +310,21 @@ pub fn split_part___(s: String, delimiter: String, n: i32) -> String {
 some_function3!(split_part, String, String, i32, String);
 
 #[doc(hidden)]
-pub fn array_to_string2_vec__(value: Vec<String>, separator: String) -> String {
-    value.join(&separator)
+pub fn array_to_string2_vec__(value: Array<String>, separator: String) -> String {
+    (*value).join(&separator)
 }
 
-some_function2!(array_to_string2_vec, Vec<String>, String, String);
+some_function2!(array_to_string2_vec, Array<String>, String, String);
 
 #[doc(hidden)]
-pub fn array_to_string2Nvec__(value: Vec<Option<String>>, separator: String) -> String {
-    let capacity = value
+pub fn array_to_string2Nvec__(value: Array<Option<String>>, separator: String) -> String {
+    let capacity = (*value)
         .iter()
         .map(|s| s.as_ref().map_or(0, |s| s.len()))
         .sum();
     let mut result = String::with_capacity(capacity);
     let mut first = true;
-    for word in value {
+    for word in &*value {
         let append = match word.as_ref() {
             None => {
                 continue;
@@ -335,22 +340,22 @@ pub fn array_to_string2Nvec__(value: Vec<Option<String>>, separator: String) -> 
     result
 }
 
-some_function2!(array_to_string2Nvec, Vec<Option<String>>, String, String);
+some_function2!(array_to_string2Nvec, Array<Option<String>>, String, String);
 
 #[doc(hidden)]
 pub fn array_to_string3_vec___(
-    value: Vec<String>,
+    value: Array<String>,
     separator: String,
     _null_value: String,
 ) -> String {
     array_to_string2_vec__(value, separator)
 }
 
-some_function3!(array_to_string3_vec, Vec<String>, String, String, String);
+some_function3!(array_to_string3_vec, Array<String>, String, String, String);
 
 #[doc(hidden)]
 pub fn array_to_string3Nvec___(
-    value: Vec<Option<String>>,
+    value: Array<Option<String>>,
     separator: String,
     null_value: String,
 ) -> String {
@@ -361,7 +366,7 @@ pub fn array_to_string3Nvec___(
         .sum();
     let mut result = String::with_capacity(capacity);
     let mut first = true;
-    for word in value {
+    for word in &*value {
         let append = match word.as_ref() {
             None => null_value.as_str(),
             Some(r) => r,
@@ -377,7 +382,7 @@ pub fn array_to_string3Nvec___(
 
 some_function3!(
     array_to_string3Nvec,
-    Vec<Option<String>>,
+    Array<Option<String>>,
     String,
     String,
     String

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -1,6 +1,7 @@
 //! Support for SQL Timestamp and Date data types.
 
 use crate::{
+    array::Array,
     casts::*,
     interval::{LongInterval, ShortInterval},
     FromInteger, ToInteger,
@@ -805,7 +806,7 @@ pub fn hop_Timestamp_ShortInterval_ShortInterval_ShortInterval(
     period: ShortInterval,
     size: ShortInterval,
     start: ShortInterval,
-) -> Vec<Timestamp> {
+) -> Array<Timestamp> {
     let mut result = Vec::<Timestamp>::new();
     let round = hop_start(ts, period, size, start);
     let mut add = 0;
@@ -813,7 +814,7 @@ pub fn hop_Timestamp_ShortInterval_ShortInterval_ShortInterval(
         result.push(Timestamp::new(round + add));
         add += period.milliseconds();
     }
-    result
+    result.into()
 }
 
 #[doc(hidden)]
@@ -822,9 +823,9 @@ pub fn hop_TimestampN_ShortInterval_ShortInterval_ShortInterval(
     period: ShortInterval,
     size: ShortInterval,
     start: ShortInterval,
-) -> Vec<Timestamp> {
+) -> Array<Timestamp> {
     match ts {
-        None => Vec::new(),
+        None => Vec::new().into(),
         Some(ts) => {
             hop_Timestamp_ShortInterval_ShortInterval_ShortInterval(ts, period, size, start)
         }

--- a/demo/packaged/sql/08-dynamic-fga.udf.rs
+++ b/demo/packaged/sql/08-dynamic-fga.udf.rs
@@ -1,5 +1,6 @@
 use feldera_sqllib::Variant;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 pub fn check_condition(
     condition: Option<String>,
@@ -28,10 +29,10 @@ pub fn do_check_condition(
     let expr = jmespath::compile(&condition)
         .map_err(|e| println!("invalid jmes expression: {e}"))
         .ok()?;
-    let all_properties = Variant::Map(BTreeMap::from([
+    let all_properties = Variant::Map(Arc::new(BTreeMap::from([
         (Variant::String("subject".to_string()), subject_properties),
         (Variant::String("resource".to_string()), resource_properties),
-    ]));
+    ])));
 
     let result = expr
         .search(all_properties)

--- a/docs/sql/udf.md
+++ b/docs/sql/udf.md
@@ -271,13 +271,13 @@ crate, which is part of the Feldera SQL runtime.
 | `DOUBLE`                 | `feldera_sqllib::F64`                   |
 | `CHAR`, `CHAR(n)`        | `String`                                |
 | `VARCHAR`, `VARCHAR(n)`  | `String`                                |
-| `BINARY`, `BINARY(n)`, `VARBINARY`, `VARBINARY(n)` | `feldera_sqllib::ByteArray`             |
+| `BINARY`, `BINARY(n)`, `VARBINARY`, `VARBINARY(n)` | `feldera_sqllib::ByteArray`           |
 | `NULL`                   | `()`                                    |
 | `INTERVAL`               | `feldera_sqllib::ShortInterval`, `feldera_sqllib::LongInterval` |
 | `TIME`                   | `feldera_sqllib::Time`                  |
 | `TIMESTAMP`              | `feldera_sqllib::Timestamp`             |
 | `DATE`                   | `feldera_sqllib::Date`                  |
-| `T ARRAY`                | `Vec<T>`                                |
+| `T ARRAY`                | `feldera_sqllib::Array<T>`              |
 | `MAP<K, V>`              | `feldera_sqllib::Map<K, V>`             |
 | `UUID`                   | `feldera_sqllib::Uuid`                  |
 | `VARIANT`                | `feldera_sqllib::Variant`               |
@@ -293,7 +293,8 @@ and `LongInterval` (representing intervals from years to months).
 in a single expression.)
 
 Currently `feldera_sqlllib::Map` is defined as `type Map =
-Arc<BTreeMap>;`
+Arc<BTreeMap>`, and `feldera_sqlllib::Array` is defined as `type Array
+= Arc<Vec>`.
 
 ### Return types
 

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -15,7 +15,7 @@ fi
 #    exit 1
 # fi
 
-cd "${SQL_COMPILER_DIR}" && ./build.sh
+#cd "${SQL_COMPILER_DIR}" && ./build.sh
 
 DEFAULT_BIND_ADDRESS="127.0.0.1"
 BIND_ADDRESS="${2:-$DEFAULT_BIND_ADDRESS}"

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -84,7 +84,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUuidLiteral;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
@@ -100,7 +100,7 @@ import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeUser;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.IsTimeRelatedType;
 import org.dbsp.sqlCompiler.ir.type.IsNumericType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBinary;
@@ -543,7 +543,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
     }
 
     static String typeString(DBSPType type) {
-        DBSPTypeVec vec = type.as(DBSPTypeVec.class);
+        DBSPTypeArray vec = type.as(DBSPTypeArray.class);
         String result = "";
         if (vec != null)
             // This is the reverse of what you may expect
@@ -652,7 +652,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
     @SuppressWarnings("SameParameterValue")
     void nullLiteralToNullArray(List<DBSPExpression> ops, int arg) {
         if (ops.get(arg).is(DBSPNullLiteral.class)) {
-            ops.set(arg, new DBSPTypeVec(new DBSPTypeNull(CalciteObject.EMPTY), true).nullValue());
+            ops.set(arg, new DBSPTypeArray(new DBSPTypeNull(CalciteObject.EMPTY), true).nullValue());
         }
     }
 
@@ -678,26 +678,26 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
      */
     String getArrayCallNameWithElemNullability(RexCall call, DBSPExpression... ops) {
         String s = getArrayOrMapCallName(call, ops);
-        DBSPTypeVec vec = ops[0].type.to(DBSPTypeVec.class);
+        DBSPTypeArray vec = ops[0].type.to(DBSPTypeArray.class);
         DBSPType elemType = vec.getElementType();
         s = s + elemType.nullableUnderlineSuffix();
         return s;
     }
 
-    DBSPVecExpression arrayConstructor(CalciteObject node, DBSPType type, List<DBSPExpression> ops) {
-        DBSPTypeVec vec = type.to(DBSPTypeVec.class);
+    DBSPArrayExpression arrayConstructor(CalciteObject node, DBSPType type, List<DBSPExpression> ops) {
+        DBSPTypeArray vec = type.to(DBSPTypeArray.class);
         DBSPType elemType = vec.getElementType();
         List<DBSPExpression> args = Linq.map(ops, o -> o.cast(elemType, false));
-        return new DBSPVecExpression(node, type, args);
+        return new DBSPArrayExpression(node, type, args);
     }
 
     /** Ensures that all the elements of array 'vec' are of the expectedType
      * @param vec the Array of elements
      * @param expectedElementType the expected type of the elements */
     DBSPExpression ensureArrayElementsOfType(DBSPExpression vec, DBSPType expectedElementType) {
-        DBSPTypeVec argType = vec.getType().to(DBSPTypeVec.class);
+        DBSPTypeArray argType = vec.getType().to(DBSPTypeArray.class);
         DBSPType argElemType = argType.getElementType();
-        DBSPType expectedVecType = new DBSPTypeVec(expectedElementType, vec.type.mayBeNull);
+        DBSPType expectedVecType = new DBSPTypeArray(expectedElementType, vec.type.mayBeNull);
         if (!argElemType.sameType(expectedElementType))
             vec = vec.cast(expectedVecType, false);
         return vec;
@@ -1096,7 +1096,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         nullLiteralToNullArray(ops, 0);
                         DBSPExpression op0 = ops.get(0);
                         DBSPType arg0Type = op0.getType();
-                        if (arg0Type.is(DBSPTypeVec.class))
+                        if (arg0Type.is(DBSPTypeArray.class))
                             name += "Vec";
                         else if (arg0Type.is(DBSPTypeMap.class))
                             name += "Map";
@@ -1106,8 +1106,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                                     arg0Type.asSqlString() + " not yet implemented", 1265, node);
                         if (arg0Type.mayBeNull)
                             name += "N";
-                        op0 = this.makeStaticConstantIfPossible(op0);
-                        return new DBSPApplyExpression(node, name, type, op0.borrow());
+                        // op0 = this.makeStaticConstantIfPossible(op0);
+                        return new DBSPApplyExpression(node, name, type, op0);
                     }
                     case "writelog":
                         return new DBSPApplyExpression(node, opName, type, ops.get(0), ops.get(1));
@@ -1126,7 +1126,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         return makeBinaryExpression(node, type, DBSPOpcode.DIV, ops);
                     case "element": {
                         DBSPExpression arg = ops.get(0);
-                        DBSPTypeVec arrayType = arg.getType().to(DBSPTypeVec.class);
+                        DBSPTypeArray arrayType = arg.getType().to(DBSPTypeArray.class);
                         String method = "element";
                         method += arrayType.nullableUnderlineSuffix();
                         method += arrayType.getElementType().nullableUnderlineSuffix();
@@ -1210,12 +1210,12 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         return compileKeywordFunction(call, node, null, type, ops, 1, 2);
                     case "array_insert": {
                         validateArgCount(node, operationName, ops.size(), 3);
-                        assert type.is(DBSPTypeVec.class);
+                        assert type.is(DBSPTypeArray.class);
                         // Element type must be always nullable in result
-                        assert type.to(DBSPTypeVec.class).getElementType().mayBeNull;
+                        assert type.to(DBSPTypeArray.class).getElementType().mayBeNull;
                         this.ensureInteger(ops, 1, 32);
                         DBSPExpression inserted = ops.get(2);
-                        inserted = inserted.cast(type.to(DBSPTypeVec.class).getElementType(), false);
+                        inserted = inserted.cast(type.to(DBSPTypeArray.class).getElementType(), false);
                         String method = getArrayCallNameWithElemNullability(call, ops.get(0), ops.get(1), inserted);
                         return new DBSPApplyExpression(node, method, type, ops.get(0), ops.get(1), inserted)
                                 .cast(type, false);
@@ -1228,10 +1228,10 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         if (arg0.getType().is(DBSPTypeNull.class) || arg1.getType().is(DBSPTypeNull.class))
                             return type.none();
 
-                        DBSPTypeVec arg0Vec = arg0.getType().to(DBSPTypeVec.class);
+                        DBSPTypeArray arg0Vec = arg0.getType().to(DBSPTypeArray.class);
                         DBSPType arg0ElemType = arg0Vec.getElementType();
 
-                        DBSPTypeVec arg1Vec = arg1.getType().to(DBSPTypeVec.class);
+                        DBSPTypeArray arg1Vec = arg1.getType().to(DBSPTypeArray.class);
                         DBSPType arg1ElemType = arg1Vec.getElementType();
 
                         // if the two arrays are of different types of elements
@@ -1321,10 +1321,10 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 validateArgCount(node, operationName, ops.size(), 2, 3);
                 DBSPExpression op0 = ops.get(0);
                 DBSPType arg0Type = op0.getType();
-                if (!arg0Type.is(DBSPTypeVec.class))
+                if (!arg0Type.is(DBSPTypeArray.class))
                     throw new UnsupportedException("First argument must be an array" +
                             Utilities.singleQuote(operationName), node);
-                DBSPTypeVec vecType = arg0Type.to(DBSPTypeVec.class);
+                DBSPTypeArray vecType = arg0Type.to(DBSPTypeArray.class);
                 if (!vecType.getElementType().is(DBSPTypeString.class)) {
                     op0 = this.ensureArrayElementsOfType(op0, DBSPTypeString.varchar(vecType.getElementType().mayBeNull));
                     ops.set(0, op0);
@@ -1384,7 +1384,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     DBSPTypeMap map = collectionType.to(DBSPTypeMap.class);
                     index = index.applyCloneIfNeeded().cast(map.getKeyType(), false);
                     opcode = DBSPOpcode.MAP_INDEX;
-                    op0 = this.makeStaticConstantIfPossible(op0);
+                    // op0 = this.makeStaticConstantIfPossible(op0);
                 } else if (collectionType.is(DBSPTypeVariant.class)) {
                     opcode = DBSPOpcode.VARIANT_INDEX;
                 } else if (collectionType.is(DBSPTypeTuple.class)) {
@@ -1400,7 +1400,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     int fieldIndex = field.index;
                     return op0.field(fieldIndex).applyCloneIfNeeded();
                 } else {
-                    assert collectionType.is(DBSPTypeVec.class);
+                    assert collectionType.is(DBSPTypeArray.class);
                 }
                 return new DBSPBinaryExpression(node, type, opcode, op0, index);
             }
@@ -1439,8 +1439,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 DBSPExpression op0 = ops.get(0);
                 if (op0.getType().mayBeNull)
                     name += "N";
-                op0 = this.makeStaticConstantIfPossible(op0);
-                return new DBSPApplyExpression(node, name, type, op0.borrow());
+                // op0 = this.makeStaticConstantIfPossible(op0);
+                return new DBSPApplyExpression(node, name, type, op0);
             }
             case ARRAY_EXCEPT:
             case ARRAY_UNION:
@@ -1462,7 +1462,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 if (call.operands.size() != 2)
                     throw operandCountError(node, operationName, call.operandCount());
 
-                DBSPTypeVec vec = type.to(DBSPTypeVec.class);
+                DBSPTypeArray vec = type.to(DBSPTypeArray.class);
                 DBSPType elemType = vec.getElementType();
 
                 DBSPExpression arg0 = ops.get(0);
@@ -1506,7 +1506,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 validateArgCount(node, operationName, call.operandCount(), 2);
                 DBSPExpression arg0 = ops.get(0);
                 DBSPExpression arg1 = ops.get(1);
-                DBSPTypeVec vec = arg0.getType().to(DBSPTypeVec.class);
+                DBSPTypeArray vec = arg0.getType().to(DBSPTypeArray.class);
                 DBSPType elemType = vec.getElementType();
 
                 // If argument is null for certain, return null
@@ -1560,8 +1560,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 if (keyType.mayBeNull) {
                     arg1 = new DBSPApplyExpression(arg1.getNode(), "Some", arg1.type.withMayBeNull(true), arg1);
                 }
-                arg0 = this.makeStaticConstantIfPossible(arg0);
-                return new DBSPApplyExpression(node, method, type, arg0.borrow(), arg1);
+                // arg0 = this.makeStaticConstantIfPossible(arg0);
+                return new DBSPApplyExpression(node, method, type, arg0, arg1);
             }
             case ARRAY_DISTINCT: {
                 DBSPExpression arg0 = ops.get(0);
@@ -1584,7 +1584,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     throw operandCountError(node, operationName, call.operandCount());
 
                 DBSPExpression arg0 = ops.get(0);
-                DBSPTypeVec vecType = arg0.getType().to(DBSPTypeVec.class);
+                DBSPTypeArray vecType = arg0.getType().to(DBSPTypeArray.class);
                 DBSPType elemType = vecType.getElementType();
                 if (!elemType.mayBeNull) {
                     // The element type is not nullable.
@@ -1597,7 +1597,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     String warningMessage =
                             node + ": all elements are null; result is always an empty array";
                     this.compiler.reportWarning(node.getPositionRange(), "unnecessary function call", warningMessage);
-                    return new DBSPVecExpression(arg0.getNode(), arg0.getType(), Linq.list());
+                    return new DBSPArrayExpression(arg0.getNode(), arg0.getType(), Linq.list());
                 }
 
                 String method = getArrayOrMapCallName(call, arg0);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -47,7 +47,7 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBinary;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
@@ -320,7 +320,7 @@ public class TypeCompiler implements ICompilerComponent {
                 case ARRAY: {
                     RelDataType ct = Objects.requireNonNull(dt.getComponentType());
                     DBSPType elementType = this.convertType(ct, asStruct);
-                    return new DBSPTypeVec(elementType, dt.isNullable());
+                    return new DBSPTypeArray(elementType, dt.isNullable());
                 }
                 case UNKNOWN:
                 case ANY:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -112,7 +112,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUuidLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.path.DBSPPathSegment;
@@ -160,6 +160,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUSize;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUuid;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeBTreeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeOption;
@@ -168,6 +169,7 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeSemigroup;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeStream;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeTypedBox;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeUser;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWithCustomOrd;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
@@ -466,6 +468,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPTypeUser) node);
     }
 
+    public VisitDecision preorder(DBSPTypeArray node) {
+        return this.preorder((DBSPTypeUser) node);
+    }
+
     public VisitDecision preorder(DBSPTypeVec node) {
         return this.preorder((DBSPTypeUser) node);
     }
@@ -475,6 +481,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public VisitDecision preorder(DBSPTypeMap node) {
+        return this.preorder((DBSPTypeUser) node);
+    }
+
+    public VisitDecision preorder(DBSPTypeBTreeMap node) {
         return this.preorder((DBSPTypeUser) node);
     }
 
@@ -697,7 +707,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPLiteral) node);
     }
 
-    public VisitDecision preorder(DBSPVecExpression node) {
+    public VisitDecision preorder(DBSPArrayExpression node) {
         return this.preorder((DBSPExpression) node);
     }
 
@@ -1044,11 +1054,19 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder((DBSPTypeUser) node);
     }
 
+    public void postorder(DBSPTypeArray node) {
+        this.postorder((DBSPTypeUser) node);
+    }
+
     public void postorder(DBSPTypeVec node) {
         this.postorder((DBSPTypeUser) node);
     }
 
     public void postorder(DBSPTypeMap node) {
+        this.postorder((DBSPTypeUser) node);
+    }
+
+    public void postorder(DBSPTypeBTreeMap node) {
         this.postorder((DBSPTypeUser) node);
     }
 
@@ -1293,7 +1311,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder((DBSPLiteral) node);
     }
 
-    public void postorder(DBSPVecExpression node) {
+    public void postorder(DBSPArrayExpression node) {
         this.postorder((DBSPExpression) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/NonMonotoneType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/NonMonotoneType.java
@@ -10,7 +10,7 @@ import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRef;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWithCustomOrd;
 import org.dbsp.util.Linq;
 
@@ -29,7 +29,7 @@ public class NonMonotoneType extends ScalarMonotoneType {
 
     /** Create a non-monotone version of the specified type */
     public static IMaybeMonotoneType nonMonotone(DBSPType type) {
-        if (type.is(DBSPTypeBaseType.class) || type.is(DBSPTypeVec.class) ||
+        if (type.is(DBSPTypeBaseType.class) || type.is(DBSPTypeArray.class) ||
                 type.is(DBSPTypeMap.class) || type.is(DBSPTypeAny.class) ||
                 type.is(DBSPTypeWithCustomOrd.class)) {
             return new NonMonotoneType(type);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandHop.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandHop.java
@@ -24,7 +24,7 @@ import org.dbsp.sqlCompiler.ir.type.IsIntervalType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ public class ExpandHop extends CircuitCloneVisitor {
         hopArguments.add(size);
         hopArguments.add(start);
         DBSPType hopType = type.tupFields[nextIndex];
-        DBSPType resultType = new DBSPTypeVec(hopType, false);
+        DBSPType resultType = new DBSPTypeArray(hopType, false);
         StringBuilder functionName = new StringBuilder("hop");
         DBSPExpression[] operands = hopArguments.toArray(new DBSPExpression[0]);
         for (DBSPExpression op: hopArguments) {
@@ -96,10 +96,10 @@ public class ExpandHop extends CircuitCloneVisitor {
         DBSPLetStatement array = new DBSPLetStatement("array", collectionExpression);
         statements.add(array);
         DBSPLetStatement clone = new DBSPLetStatement(
-                "array_clone", array.getVarReference().deref().applyClone());
+                "array_clone", array.getVarReference().deref().deref().applyClone());
         statements.add(clone);
         DBSPExpression iter = new DBSPApplyMethodExpression("into_iter",
-                DBSPTypeAny.getDefault(), clone.getVarReference().applyClone());
+                DBSPTypeAny.getDefault(), clone.getVarReference());
         DBSPExpression[] resultFields = new DBSPExpression[type.size()];
         for (int i = 0; i < inputRowType.size(); i++)
             resultFields[i] = statements.get(i).to(DBSPLetStatement.class).getVarReference().applyClone();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -75,7 +75,7 @@ import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
@@ -767,7 +767,7 @@ public class Monotonicity extends CircuitVisitor {
      * expressions that we do not want to look at.
      * *DOES NOT WORK PROPERLY FOR EMPTY TUPLES. */
     static DBSPExpression makeNoExpression(DBSPType type) {
-        if (type.is(DBSPTypeBaseType.class) || type.is(DBSPTypeVec.class) || type.is(DBSPTypeMap.class)) {
+        if (type.is(DBSPTypeBaseType.class) || type.is(DBSPTypeArray.class) || type.is(DBSPTypeMap.class)) {
             return new NoExpression(type);
         } else if (type.is(DBSPTypeTupleBase.class)) {
             // Tricky if the tuple is empty, this *will* be monotone!

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
@@ -40,7 +40,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedWrapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnwrapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPWindowBoundExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
@@ -297,7 +297,7 @@ public class FindUnusedFields extends SymbolicInterpreter<FieldUseMap> {
     }
 
     @Override
-    public void postorder(DBSPVecExpression expression) {
+    public void postorder(DBSPArrayExpression expression) {
         if (expression.data != null) {
             for (DBSPExpression e: expression.data)
                 this.used(e);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.unusedFields;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.annotation.IsProjection;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
@@ -112,6 +113,13 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPJoinOperator join) {
+        boolean done = this.processJoin(join);
+        if (!done)
+            super.postorder(join);
+    }
+
+    @Override
+    public void postorder(DBSPJoinFilterMapOperator join) {
         boolean done = this.processJoin(join);
         if (!done)
             super.postorder(join);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
@@ -34,7 +34,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
 
@@ -43,26 +43,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Represents a vector described by its elements. */
-public final class DBSPVecExpression extends DBSPExpression
+/** Represents an ARRAY described by its elements. */
+public final class DBSPArrayExpression extends DBSPExpression
         implements IDBSPContainer, ISameValue, IConstructor {
     @Nullable
     public final List<DBSPExpression> data;
-    public final DBSPTypeVec vecType;
+    public final DBSPTypeArray vecType;
 
-    public static DBSPVecExpression emptyWithElementType(DBSPType elementType, boolean mayBeNull) {
-        return new DBSPVecExpression(CalciteObject.EMPTY, new DBSPTypeVec(elementType, mayBeNull), Linq.list());
+    public static DBSPArrayExpression emptyWithElementType(DBSPType elementType, boolean mayBeNull) {
+        return new DBSPArrayExpression(CalciteObject.EMPTY, new DBSPTypeArray(elementType, mayBeNull), Linq.list());
     }
 
-    public DBSPVecExpression(DBSPType vectorType, boolean isNull) {
+    public DBSPArrayExpression(DBSPType vectorType, boolean isNull) {
         super(CalciteObject.EMPTY, vectorType);
         this.data = isNull ? null : new ArrayList<>();
-        this.vecType = this.getType().to(DBSPTypeVec.class);
+        this.vecType = this.getType().to(DBSPTypeArray.class);
     }
 
-    public DBSPVecExpression(CalciteObject node, DBSPType type, @Nullable List<DBSPExpression> data) {
+    public DBSPArrayExpression(CalciteObject node, DBSPType type, @Nullable List<DBSPExpression> data) {
         super(node, type);
-        this.vecType = this.getType().to(DBSPTypeVec.class);
+        this.vecType = this.getType().to(DBSPTypeArray.class);
         if (data != null) {
             this.data = new ArrayList<>();
             for (DBSPExpression e : data) {
@@ -76,9 +76,9 @@ public final class DBSPVecExpression extends DBSPExpression
         }
     }
 
-    public DBSPVecExpression(boolean mayBeNull, DBSPExpression... data) {
-        super(CalciteObject.EMPTY, new DBSPTypeVec(data[0].getType(), mayBeNull));
-        this.vecType = this.getType().to(DBSPTypeVec.class);
+    public DBSPArrayExpression(boolean mayBeNull, DBSPExpression... data) {
+        super(CalciteObject.EMPTY, new DBSPTypeArray(data[0].getType(), mayBeNull));
+        this.vecType = this.getType().to(DBSPTypeArray.class);
         this.data = new ArrayList<>();
         for (DBSPExpression e: data) {
             if (!e.getType().sameType(data[0].getType()))
@@ -88,7 +88,7 @@ public final class DBSPVecExpression extends DBSPExpression
         }
     }
 
-    public DBSPVecExpression(DBSPExpression... data) {
+    public DBSPArrayExpression(DBSPExpression... data) {
        this(false, data);
     }
 
@@ -105,7 +105,7 @@ public final class DBSPVecExpression extends DBSPExpression
         return this;
     }
 
-    public void add(DBSPVecExpression other) {
+    public void add(DBSPArrayExpression other) {
         if (!this.getType().sameType(other.getType()))
             throw new InternalCompilerError("Added vectors do not have the same type " +
                     this.getElementType() + " vs " + other.getElementType(), this);
@@ -131,7 +131,7 @@ public final class DBSPVecExpression extends DBSPExpression
 
     @Override
     public boolean sameFields(IDBSPInnerNode other) {
-        DBSPVecExpression otherVec = other.as(DBSPVecExpression.class);
+        DBSPArrayExpression otherVec = other.as(DBSPArrayExpression.class);
         if (otherVec == null)
             return false;
         if (this.data == null)
@@ -150,7 +150,7 @@ public final class DBSPVecExpression extends DBSPExpression
     public boolean sameValue(@Nullable ISameValue o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DBSPVecExpression that = (DBSPVecExpression) o;
+        DBSPArrayExpression that = (DBSPArrayExpression) o;
         if (!Objects.equals(data, that.data)) return false;
         return vecType.equals(that.vecType);
     }
@@ -162,12 +162,12 @@ public final class DBSPVecExpression extends DBSPExpression
                     .append(this.type)
                     .append(")")
                     .append("null");
-        builder.append("vec!(");
+        builder.append("Arc::new(vec!(");
         if (this.data.size() > 1)
             builder
                 .increase();
         builder.intercalateI(System.lineSeparator(), this.data)
-                .append(")");
+                .append("))");
         if (this.data.size() > 1)
                 builder.decrease();
         return builder;
@@ -175,7 +175,7 @@ public final class DBSPVecExpression extends DBSPExpression
 
     @Override
     public DBSPExpression deepCopy() {
-        return new DBSPVecExpression(this.getNode(), this.getType(),
+        return new DBSPArrayExpression(this.getNode(), this.getType(),
                 this.data != null ? Linq.map(this.data, DBSPExpression::deepCopy) : null);
     }
 
@@ -185,7 +185,7 @@ public final class DBSPVecExpression extends DBSPExpression
 
     @Override
     public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
-        DBSPVecExpression otherExpression = other.as(DBSPVecExpression.class);
+        DBSPArrayExpression otherExpression = other.as(DBSPArrayExpression.class);
         if (otherExpression == null)
             return false;
         return context.equivalent(this.data, otherExpression.data);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldExpression.java
@@ -53,7 +53,13 @@ public final class DBSPFieldExpression extends DBSPExpression {
         if (type.is(DBSPTypeAny.class))
             return type;
         DBSPTypeTupleBase tuple = type.to(DBSPTypeTupleBase.class);
-        return tuple.getFieldType(fieldNo);
+        DBSPType fieldType = tuple.getFieldType(fieldNo);
+        /*
+        TODO: https://github.com/feldera/feldera/issues/3418
+        if (type.mayBeNull)
+            fieldType = fieldType.withMayBeNull(true);
+         */
+        return fieldType;
     }
 
     public DBSPFieldExpression(CalciteObject node, DBSPExpression expression, int fieldNo) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
@@ -31,7 +31,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeFunction;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.IIndentStream;
 
 import javax.annotation.Nullable;
@@ -55,11 +55,11 @@ public final class DBSPSortExpression extends DBSPExpression {
             DBSPComparatorExpression comparator, @Nullable DBSPExpression limit) {
         super(node, new DBSPTypeFunction(
                 // Return type
-                new DBSPTypeVec(elementType, false),
+                new DBSPTypeArray(elementType, false),
                 // Argument type
                 new DBSPTypeRawTuple(
                         new DBSPTypeRawTuple().ref(),
-                        new DBSPTypeVec(elementType, false).ref())));
+                        new DBSPTypeArray(elementType, false).ref())));
         this.comparator = comparator;
         this.elementType = elementType;
         this.limit = limit;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
@@ -13,7 +13,7 @@ import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
@@ -139,14 +139,14 @@ public final class DBSPZSetExpression extends DBSPExpression
     public DBSPExpression castRecursive(DBSPExpression expression, DBSPType type) {
         if (type.is(DBSPTypeBaseType.class)) {
             return expression.cast(type, false);
-        } else if (type.is(DBSPTypeVec.class)) {
-            DBSPTypeVec vec = type.to(DBSPTypeVec.class);
-            DBSPVecExpression vecLit = expression.to(DBSPVecExpression.class);
+        } else if (type.is(DBSPTypeArray.class)) {
+            DBSPTypeArray vec = type.to(DBSPTypeArray.class);
+            DBSPArrayExpression vecLit = expression.to(DBSPArrayExpression.class);
             if (vecLit.data == null) {
-                return new DBSPVecExpression(type, type.mayBeNull);
+                return new DBSPArrayExpression(type, type.mayBeNull);
             }
             List<DBSPExpression> fields = Linq.map(vecLit.data, e -> castRecursive(e, vec.getElementType()));
-            return new DBSPVecExpression(expression.getNode(), type, fields);
+            return new DBSPArrayExpression(expression.getNode(), type, fields);
         } else if (type.is(DBSPTypeTupleBase.class)) {
             DBSPTypeTupleBase tuple = type.to(DBSPTypeTupleBase.class);
             DBSPExpression[] fields = new DBSPExpression[tuple.size()];

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -37,7 +37,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPGeoPointConstructor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -85,7 +85,7 @@ public abstract class DBSPLiteral extends DBSPExpression
             case INTERVAL_LONG -> new DBSPIntervalMonthsLiteral(type.getNode(), type, null);
             case STRING -> new DBSPStringLiteral(CalciteObject.EMPTY, type, null, StandardCharsets.UTF_8);
             case TIME -> new DBSPTimeLiteral();
-            case VEC -> new DBSPVecExpression(type, true);
+            case ARRAY -> new DBSPArrayExpression(type, true);
             case MAP -> new DBSPMapExpression(type.to(DBSPTypeMap.class), null, null);
             case TUPLE -> DBSPTupleExpression.none(type.to(DBSPTypeTuple.class));
             case NULL -> new DBSPNullLiteral();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.ir.type;
 
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
@@ -128,9 +129,7 @@ public abstract class DBSPType extends DBSPNode implements IDBSPInnerNode {
     /** Given a type that is expected to be a reference type,
      * compute the type that is the dereferenced type. */
     public DBSPType deref() {
-        if (this.is(DBSPTypeAny.class))
-            return this;
-        return this.to(DBSPTypeRef.class).type;
+        throw new InternalCompilerError("Deref of " + this);
     }
 
     /** The null value with this type. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
@@ -48,7 +48,7 @@ public enum DBSPTypeCode {
     SEMIGROUP(null, "", ""),
     STREAM(null, "", ""),
     USER(null, "", ""),
-    VEC("ARRAY", "", ""),
+    ARRAY("ARRAY", "", "Array"),
     MAP("MAP", "", "Map"),
     VARIANT("VARIANT", "V", "Variant"),
     ZSET("MULTISET", "", ""),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
@@ -51,6 +51,11 @@ public class DBSPTypeRef extends DBSPType {
     }
 
     @Override
+    public DBSPType deref() {
+        return this.type;
+    }
+
+    @Override
     public DBSPType withMayBeNull(boolean mayBeNull) {
         if (this.mayBeNull == mayBeNull)
             return this;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeArray.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeArray.java
@@ -1,0 +1,57 @@
+package org.dbsp.sqlCompiler.ir.type.user;
+
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.ICollectionType;
+
+import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.ARRAY;
+
+/** Representation for a SQL ARRAY type. */
+public class DBSPTypeArray extends DBSPTypeUser implements ICollectionType {
+    public DBSPTypeArray(DBSPType vectorElementType, boolean mayBeNull) {
+        super(vectorElementType.getNode(), ARRAY, "Array", mayBeNull, vectorElementType);
+    }
+
+    public DBSPType getElementType() {
+        return this.getTypeArg(0);
+    }
+
+    public DBSPTypeVec innerType() {
+        return new DBSPTypeVec(this.getElementType(), this.mayBeNull);
+    }
+
+    @Override
+    public DBSPType deref() {
+        return this.innerType();
+    }
+
+    @Override
+    public DBSPExpression defaultValue() {
+        if (this.mayBeNull)
+            return this.none();
+        return new DBSPArrayExpression(this, false);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        for (DBSPType type: this.typeArgs)
+            type.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public DBSPType withMayBeNull(boolean mayBeNull) {
+        if (mayBeNull == this.mayBeNull)
+            return this;
+        return new DBSPTypeArray(this.getElementType(), mayBeNull);
+    }
+
+    // sameType and hashCode inherited from TypeUser.
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeMap.java
@@ -24,6 +24,11 @@ public class DBSPTypeMap extends DBSPTypeUser {
     }
 
     @Override
+    public DBSPType deref() {
+        return this.innerType();
+    }
+
+    @Override
     public void accept(InnerVisitor visitor) {
         VisitDecision decision = visitor.preorder(this);
         if (decision.stop()) return;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeVec.java
@@ -25,17 +25,18 @@ package org.dbsp.sqlCompiler.ir.type.user;
 
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.ICollectionType;
 
-import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.VEC;
+import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.USER;
 
 /** Represents the type of a Rust Vec as a TypeUser. */
 public class DBSPTypeVec extends DBSPTypeUser implements ICollectionType {
     public DBSPTypeVec(DBSPType vectorElementType, boolean mayBeNull) {
-        super(vectorElementType.getNode(), VEC, "Vec", mayBeNull, vectorElementType);
+        super(vectorElementType.getNode(), USER, "Vec", mayBeNull, vectorElementType);
     }
 
     public DBSPType getElementType() {
@@ -46,7 +47,15 @@ public class DBSPTypeVec extends DBSPTypeUser implements ICollectionType {
     public DBSPExpression defaultValue() {
         if (this.mayBeNull)
             return this.none();
-        return new DBSPVecExpression(this, false);
+        return new DBSPArrayExpression(this, false);
+    }
+
+    /** vec!() or Some(vec!()), depending on nullability */
+    public DBSPExpression emptyVector() {
+        DBSPExpression vec = new DBSPApplyExpression("vec!", this.withMayBeNull(false));
+        if (!this.mayBeNull)
+            return vec;
+        return vec.some();
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
@@ -18,7 +18,7 @@ import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.Maybe;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,22 +28,22 @@ import java.util.Objects;
 public class UnusedFieldsTest {
     @Test
     public void testZSetString() {
-        DBSPExpression none = new DBSPTypeVec(DBSPTypeString.varchar(false), true).none();
-        Assert.assertEquals("(Vec<s>?)null", none.toString());
+        DBSPExpression none = new DBSPTypeArray(DBSPTypeString.varchar(false), true).none();
+        Assert.assertEquals("(Array<s>?)null", none.toString());
         DBSPCompiler compiler = new DBSPCompiler(new CompilerOptions());
-        Assert.assertEquals("None::<Vec<String>>",
+        Assert.assertEquals("None::<Array<String>>",
                 ToRustInnerVisitor.toRustString(compiler, none, false));
         DBSPZSetExpression zset = new DBSPZSetExpression(none);
-        Assert.assertEquals("zset!((Vec<s>?)null => 1,)", zset.toString());
-        Assert.assertEquals("zset!(None::<Vec<String>> => 1)",
+        Assert.assertEquals("zset!((Array<s>?)null => 1,)", zset.toString());
+        Assert.assertEquals("zset!(None::<Array<String>> => 1)",
                 ToRustInnerVisitor.toRustString(compiler, zset, false));
         DBSPTupleExpression tup = new DBSPTupleExpression(none);
-        Assert.assertEquals("Tup1::new((Vec<s>?)null, )", tup.toString());
-        Assert.assertEquals("Tup1::new(None::<Vec<String>>)",
+        Assert.assertEquals("Tup1::new((Array<s>?)null, )", tup.toString());
+        Assert.assertEquals("Tup1::new(None::<Array<String>>)",
                 ToRustInnerVisitor.toRustString(compiler, tup, false));
         DBSPZSetExpression zset1 = new DBSPZSetExpression(tup);
-        Assert.assertEquals("zset!(Tup1::new((Vec<s>?)null, ) => 1,)", zset1.toString());
-        Assert.assertEquals("zset!(Tup1::new(None::<Vec<String>>) => 1)",
+        Assert.assertEquals("zset!(Tup1::new((Array<s>?)null, ) => 1,)", zset1.toString());
+        Assert.assertEquals("zset!(Tup1::new(None::<Array<String>>) => 1)",
                 ToRustInnerVisitor.toRustString(compiler, zset1, false));
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -9,7 +9,7 @@ import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class CatalogTests extends BaseSQLTests {
         var ccs = this.getCCS("""
                   CREATE TYPE X AS (x INT);
                   CREATE TABLE T(p int array, m MAP<INT, X ARRAY>);
-                  CREATE VIEW V AS SELECT p[0], m[2][3] FROM T;""");
+                  CREATE VIEW V AS SELECT p[1], m[2][3] FROM T;""");
         this.addRustTestCase(ccs);
     }
 
@@ -225,14 +225,14 @@ public class CatalogTests extends BaseSQLTests {
         Assert.assertTrue(sN.mayBeNull);
         Assert.assertTrue(sN.getFieldType(0).sameType(i32N));
         Assert.assertTrue(sN.getFieldType(1).sameType(i32));
-        Assert.assertTrue(sN.getFieldType(2).sameType(new DBSPTypeVec(i32N, true)));
-        Assert.assertTrue(sN.getFieldType(3).sameType(new DBSPTypeVec(i32N, false)));
+        Assert.assertTrue(sN.getFieldType(2).sameType(new DBSPTypeArray(i32N, true)));
+        Assert.assertTrue(sN.getFieldType(3).sameType(new DBSPTypeArray(i32N, false)));
 
         DBSPType t1 = t.getFieldType(1);
         Assert.assertTrue(t1.is(DBSPTypeTuple.class));
         DBSPTypeTuple nN = t1.to(DBSPTypeTuple.class);
         Assert.assertEquals(3, nN.size());
-        DBSPType vecS = new DBSPTypeVec(sN.withMayBeNull(true), true);
+        DBSPType vecS = new DBSPTypeArray(sN.withMayBeNull(true), true);
         Assert.assertTrue(nN.mayBeNull);
         Assert.assertTrue(nN.getFieldType(0).sameType(sN));
         Assert.assertTrue(nN.getFieldType(1).sameType(sN.withMayBeNull(false)));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
@@ -36,11 +36,11 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.Linq;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -77,14 +77,14 @@ public class ArrayTests extends BaseSQLTests {
                     vals foo_struct ARRAY
                 );""";
         String query = "SELECT * FROM bar, UNNEST(bar.vals)";
-        DBSPTypeVec vecType = new DBSPTypeVec(
+        DBSPTypeArray vecType = new DBSPTypeArray(
                 new DBSPTypeTuple(
                         CalciteObject.EMPTY, true,
                         Linq.list(new DBSPTypeInteger(CalciteObject.EMPTY, 64, true, false))
                 ), true);
         // null vector
         Change input = new Change(new DBSPZSetExpression(new DBSPTupleExpression(
-                Linq.list(new DBSPVecExpression(vecType, true)), false)));
+                Linq.list(new DBSPArrayExpression(vecType, true)), false)));
         Change output = new Change();
         InputOutputChangeStream stream = new InputOutputChangeStream().addPair(input, output);
         this.testQuery(statements, query, stream);
@@ -216,13 +216,13 @@ public class ArrayTests extends BaseSQLTests {
                 "ARR_TABLE, UNNEST(VALS) AS VAL";
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
                         new DBSPI32Literal(6)),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
@@ -250,21 +250,21 @@ public class ArrayTests extends BaseSQLTests {
                 "ARR_TABLE, UNNEST(VALS0) AS VAL0, UNNEST(VALS1) AS VAL1";
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true)),
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(4, true),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true)),
                         new DBSPI32Literal(7)),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(8, true),
                                 new DBSPI32Literal(9, true),
                                 new DBSPI32Literal(10, true)),
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(11, true),
                                 new DBSPI32Literal(12, true),
                                 new DBSPI32Literal(13, true)),
@@ -341,13 +341,13 @@ public class ArrayTests extends BaseSQLTests {
 
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
@@ -355,14 +355,14 @@ public class ArrayTests extends BaseSQLTests {
         );
         DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true),
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true),
@@ -379,13 +379,13 @@ public class ArrayTests extends BaseSQLTests {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
@@ -393,14 +393,14 @@ public class ArrayTests extends BaseSQLTests {
         );
         DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true),
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true),
@@ -417,14 +417,14 @@ public class ArrayTests extends BaseSQLTests {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY NULL)";
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
@@ -433,7 +433,7 @@ public class ArrayTests extends BaseSQLTests {
         );
         DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
@@ -441,7 +441,7 @@ public class ArrayTests extends BaseSQLTests {
                                 new DBSPI32Literal(4, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
@@ -459,13 +459,13 @@ public class ArrayTests extends BaseSQLTests {
         String ddl = "CREATE TABLE ARR_TBL(val INTEGER ARRAY)";
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
@@ -494,7 +494,7 @@ public class ArrayTests extends BaseSQLTests {
                         new DBSPI32Literal(5), new DBSPStringLiteral("there")));
         DBSPZSetExpression result = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                    new DBSPVecExpression(
+                    new DBSPArrayExpression(
                         new DBSPTupleExpression(
                             new DBSPI32Literal(5), new DBSPStringLiteral("there")),
                         new DBSPTupleExpression(
@@ -510,14 +510,14 @@ public class ArrayTests extends BaseSQLTests {
 
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 DBSPNullLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true)),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
@@ -542,13 +542,13 @@ public class ArrayTests extends BaseSQLTests {
 
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))
@@ -573,14 +573,14 @@ public class ArrayTests extends BaseSQLTests {
 
         DBSPZSetExpression input = new DBSPZSetExpression(
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 DBSPNullLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true)),
                                 new DBSPI32Literal(3, true))
                 ),
                 new DBSPTupleExpression(
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(5, true),
                                 new DBSPI32Literal(6, true),
                                 new DBSPI32Literal(7, true))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -44,7 +44,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
@@ -1006,7 +1006,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void orderbyTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2";
         this.testQuery(query, new DBSPZSetExpression(
-                new DBSPVecExpression(E1, E0)
+                new DBSPArrayExpression(E1, E0)
         ));
     }
 
@@ -1014,7 +1014,15 @@ public class EndToEndTests extends BaseSQLTests {
     public void limitTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2 LIMIT 1";
         this.testQuery(query, new DBSPZSetExpression(
-                new DBSPVecExpression(E1)
+                new DBSPArrayExpression(E1)
+        ));
+    }
+
+    @Test
+    public void limitTest2() {
+        String query = "SELECT * FROM T ORDER BY T.COL2 LIMIT 3";
+        this.testQuery(query, new DBSPZSetExpression(
+                new DBSPArrayExpression(E1, E0)
         ));
     }
 
@@ -1032,7 +1040,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void orderbyDescendingTest() {
         String query = "SELECT * FROM T ORDER BY T.COL2 DESC";
         this.testQuery(query, new DBSPZSetExpression(
-                new DBSPVecExpression(E0, E1)
+                new DBSPArrayExpression(E0, E1)
         ));
     }
 
@@ -1040,7 +1048,7 @@ public class EndToEndTests extends BaseSQLTests {
     public void orderby2Test() {
         String query = "SELECT * FROM T ORDER BY T.COL2, T.COL1";
         this.testQuery(query, new DBSPZSetExpression(
-                new DBSPVecExpression(E1, E0)
+                new DBSPArrayExpression(E1, E0)
         ));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -642,7 +642,6 @@ public class IncrementalRegressionTests extends SqlIoTest {
             if (toCompile == null)
                 return;
             for (File c: toCompile) {
-                if (!c.getName().contains("variant")) continue;
                 if (c.getName().contains("sql")) {
                     System.out.println("Compiling " + c);
                     String sql = Utilities.readFile(c.getPath());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -18,6 +18,13 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class RegressionTests extends SqlIoTest {
+    @Test @Ignore
+    public void issue3418() {
+        this.compileRustTestCase("""
+                create table t (r ROW(j VARCHAR));
+                create materialized view v as select parse_json(t.r.j) from t;""");
+    }
+
     @Test
     public void internalIssue174() {
         this.compileRustTestCase("""

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/StructTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/StructTests.java
@@ -11,7 +11,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
@@ -152,7 +152,7 @@ public class StructTests extends SqlIoTest {
         compiler.submitStatementsForCompilation(ddl);
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPExpression pers = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                     new DBSPStringLiteral("Broadway", true),
                     new DBSPStringLiteral("5th Avenue", true),
                     new DBSPStringLiteral("1st Street", true)));
@@ -172,7 +172,7 @@ public class StructTests extends SqlIoTest {
             CREATE VIEW V AS SELECT st FROM PERS, UNNEST(PERS.p0.street) AS st;""";
         CompilerCircuitStream ccs = this.getCCS(ddl);
         DBSPExpression pers = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPStringLiteral("Broadway", true),
                         new DBSPStringLiteral("5th Avenue", true),
                         new DBSPStringLiteral("1st Street", true)));
@@ -198,7 +198,7 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = this.getCCS(ddl);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(0, true), t),
                         new DBSPTupleExpression(
@@ -206,7 +206,7 @@ public class StructTests extends SqlIoTest {
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(2, true), t)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(
                                 true, new DBSPI32Literal(3, true), t),
                         new DBSPTupleExpression(
@@ -239,12 +239,12 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(0, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(1, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(2, true), t), true)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(3, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(4, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(5, true), t), true)));
@@ -274,12 +274,12 @@ public class StructTests extends SqlIoTest {
         CompilerCircuitStream ccs = new CompilerCircuitStream(compiler);
         DBSPBoolLiteral t = new DBSPBoolLiteral(true, true);
         DBSPExpression t0 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(0, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(1, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(2, true), t), true)));
         DBSPExpression t1 = new DBSPTupleExpression(true,
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(3, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(4, true), t), true),
                         new DBSPTupleExpression(Linq.list(new DBSPI32Literal(5, true), t), true)));
@@ -324,7 +324,7 @@ public class StructTests extends SqlIoTest {
         DBSPExpression person0 = new DBSPTupleExpression(true,
                 new DBSPStringLiteral("Mike", true),
                 new DBSPStringLiteral("John", true),
-                new DBSPVecExpression(true, address0, address0)
+                new DBSPArrayExpression(true, address0, address0)
         );
         DBSPExpression data = new DBSPTupleExpression(person0);
         DBSPZSetExpression input = new DBSPZSetExpression(data);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
@@ -26,7 +26,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
@@ -38,7 +38,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.util.Linq;
 import org.junit.Test;
 
@@ -129,7 +129,7 @@ public class VariantTests extends BaseSQLTests {
                 new DBSPBoolLiteral(false));
         // An array of variant values can have values with any underlying type
         this.testQuery("SELECT ARRAY[CAST(1 AS VARIANT), CAST('abc' AS VARIANT)]",
-                new DBSPVecExpression(
+                new DBSPArrayExpression(
                         new DBSPVariantExpression(new DBSPI32Literal(1)),
                         new DBSPVariantExpression(new DBSPStringLiteral("abc"))));
         // A map with VARCHAR keys and VARIANT values
@@ -145,7 +145,7 @@ public class VariantTests extends BaseSQLTests {
                                 new DBSPStringLiteral("c")),
                         Linq.list(new DBSPVariantExpression(new DBSPI32Literal(1)),
                                 new DBSPVariantExpression(new DBSPStringLiteral("abc")),
-                                new DBSPVariantExpression(new DBSPVecExpression(
+                                new DBSPVariantExpression(new DBSPArrayExpression(
                                         new DBSPI32Literal(1),
                                         new DBSPI32Literal(2),
                                         new DBSPI32Literal(3)
@@ -245,7 +245,7 @@ public class VariantTests extends BaseSQLTests {
                 new DBSPVariantExpression(null, new DBSPTypeVariant(CalciteObject.EMPTY, true)));
         this.testQuery("SELECT PARSE_JSON('[1,2,3]')",
                 new DBSPVariantExpression(
-                        new DBSPVecExpression(
+                        new DBSPArrayExpression(
                                 new DBSPVariantExpression(new DBSPDecimalLiteral(1)),
                                 new DBSPVariantExpression(new DBSPDecimalLiteral(2)),
                                 new DBSPVariantExpression(new DBSPDecimalLiteral(3)))));
@@ -278,18 +278,18 @@ public class VariantTests extends BaseSQLTests {
         // This is a bug in Calcite, the array should be nullable, and the elements should be nullable too
         this.testQuery("""
                 SELECT CAST(ARRAY[NULL, 1] AS INT ARRAY)""",
-                new DBSPVecExpression(false,
+                new DBSPArrayExpression(false,
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true).none(),
                         new DBSPI32Literal(1, true)));
         // result is null, since 1 cannot be converted to a string
         this.testQuery("""
                 SELECT CAST(PARSE_JSON('["a", 1]') AS STRING ARRAY)""",
-                new DBSPVecExpression(
-                        new DBSPTypeVec(DBSPTypeString.varchar(false), true),
+                new DBSPArrayExpression(
+                        new DBSPTypeArray(DBSPTypeString.varchar(false), true),
                         true));
         this.testQuery("""
                 SELECT CAST(PARSE_JSON('["a", 1]') AS VARIANT ARRAY)""",
-                new DBSPVecExpression(true,
+                new DBSPArrayExpression(true,
                         new DBSPVariantExpression(new DBSPStringLiteral("a", true)),
                         new DBSPVariantExpression(new DBSPDecimalLiteral(CalciteObject.EMPTY,
                                 DBSPTypeDecimal.getDefault(), new BigDecimal(1)))));
@@ -297,7 +297,7 @@ public class VariantTests extends BaseSQLTests {
         this.testQuery("""
                 SELECT CAST(ARRAY[NULL, 1] AS VARIANT)""",
                 new DBSPVariantExpression(
-                        new DBSPVecExpression(false,
+                        new DBSPArrayExpression(false,
                                 new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true).none(),
                                 new DBSPI32Literal(1, true))));
     }
@@ -411,7 +411,7 @@ public class VariantTests extends BaseSQLTests {
                                 Linq.list(
                                         new DBSPVariantExpression(new DBSPI32Literal(2)),
                                         new DBSPVariantExpression(new DBSPStringLiteral("a")),
-                                        new DBSPVariantExpression(new DBSPVecExpression(
+                                        new DBSPVariantExpression(new DBSPArrayExpression(
                                                 new DBSPI32Literal(1),
                                                 new DBSPI32Literal(2),
                                                 new DBSPI32Literal(3)))))));
@@ -421,17 +421,17 @@ public class VariantTests extends BaseSQLTests {
                 new DBSPTupleExpression(true,
                         new DBSPI32Literal(2, true),
                         new DBSPStringLiteral("a", true),
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPI32Literal(1, true),
                                 new DBSPI32Literal(2, true),
                                 new DBSPI32Literal(3, true))));
         this.testQuery("SELECT CAST(PARSE_JSON('{\"sa\": [{\"i\": 2, \"s\": \"a\", \"a\": [1, 2, 3]}]}') AS T)",
                 new DBSPTupleExpression(true,
-                        new DBSPVecExpression(true,
+                        new DBSPArrayExpression(true,
                                 new DBSPTupleExpression(true,
                                         new DBSPI32Literal(2, true),
                                         new DBSPStringLiteral("a", true),
-                                        new DBSPVecExpression(true,
+                                        new DBSPArrayExpression(true,
                                                 new DBSPI32Literal(1, true),
                                                 new DBSPI32Literal(2, true),
                                                 new DBSPI32Literal(3, true))))));
@@ -444,21 +444,21 @@ public class VariantTests extends BaseSQLTests {
                 new DBSPTupleExpression(true,
                         new DBSPI32Literal(0, true),
                         DBSPTypeString.varchar(true).none(),
-                        new DBSPTypeVec(i32, true).none()));
+                        new DBSPTypeArray(i32, true).none()));
         this.testQuery("SELECT CAST(CAST(MAP['i', 's'] AS VARIANT) AS S)",
                 new DBSPTupleExpression(true,
                         i32.none(),
                         DBSPTypeString.varchar(true).none(),
-                        new DBSPTypeVec(i32, true).none()));
+                        new DBSPTypeArray(i32, true).none()));
         this.testQuery("SELECT CAST(CAST(MAP['I', 0] AS VARIANT) AS S)",
                 new DBSPTupleExpression(true,
                         i32.none(),
                         DBSPTypeString.varchar(true).none(),
-                        new DBSPTypeVec(i32, true).none()));
+                        new DBSPTypeArray(i32, true).none()));
         this.testQuery("SELECT CAST(CAST(MAP['i', 0, 'X', 2] AS VARIANT) AS S)",
                 new DBSPTupleExpression(true,
                         new DBSPI32Literal(0, true),
                         DBSPTypeString.varchar(true).none(),
-                        new DBSPTypeVec(i32, true).none()));
+                        new DBSPTypeArray(i32, true).none()));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -22,13 +22,13 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUuidLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
@@ -288,11 +288,11 @@ public class TableParser {
                         throw new RuntimeException("Cannot parse boolean value " + Utilities.singleQuote(trimmed));
                     yield new DBSPBoolLiteral(CalciteObject.EMPTY, fieldType, isTrue);
                 }
-                case VEC -> {
-                    DBSPTypeVec vec = fieldType.to(DBSPTypeVec.class);
+                case ARRAY -> {
+                    DBSPTypeArray vec = fieldType.to(DBSPTypeArray.class);
                     // TODO: this does not handle nested arrays
                     if (trimmed.equals("NULL")) {
-                        yield new DBSPVecExpression(fieldType, true);
+                        yield new DBSPArrayExpression(fieldType, true);
                     } else {
                         if (!trimmed.startsWith("{") || !trimmed.endsWith("}"))
                             throw new UnimplementedException("Expected array constant to be bracketed: " + trimmed);
@@ -303,10 +303,10 @@ public class TableParser {
                             DBSPExpression[] fields;
                             fields = Linq.map(
                                     parts, p -> parseValue(vec.getElementType(), p), DBSPExpression.class);
-                            yield new DBSPVecExpression(fieldType.mayBeNull, fields);
+                            yield new DBSPArrayExpression(fieldType.mayBeNull, fields);
                         } else {
                             // empty vector
-                            yield new DBSPVecExpression(vec, false);
+                            yield new DBSPArrayExpression(vec, false);
                         }
                     }
                 }

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -58,14 +58,14 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVecExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeVec;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
@@ -221,9 +221,9 @@ public class DBSPExecutor extends SqlSltTestExecutor {
         DBSPZSetExpression result;
         IDBSPContainer container;
         DBSPType elementType = outputType.elementType;
-        if (elementType.is(DBSPTypeVec.class)) {
-            elementType = elementType.to(DBSPTypeVec.class).getElementType();
-            DBSPVecExpression vec = DBSPVecExpression.emptyWithElementType(elementType, false);
+        if (elementType.is(DBSPTypeArray.class)) {
+            elementType = elementType.to(DBSPTypeArray.class).getElementType();
+            DBSPArrayExpression vec = DBSPArrayExpression.emptyWithElementType(elementType, false);
             container = vec;
             result = new DBSPZSetExpression(vec);
         } else {
@@ -445,7 +445,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
         DBSPSinkOperator sink = sinks.get(outputNumber);
         DBSPType circuitOutputType = sink.outputType;
         // True if the output is a zset of vectors (generated for order by queries)
-        boolean isVector = circuitOutputType.to(DBSPTypeZSet.class).elementType.is(DBSPTypeVec.class);
+        boolean isVector = circuitOutputType.to(DBSPTypeZSet.class).elementType.is(DBSPTypeArray.class);
 
         DBSPLetStatement inputStream = new DBSPLetStatement("_in",
                 inputGeneratingFunction.call());
@@ -500,7 +500,7 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                 DBSPType elementType;
                 if (isVector) {
                     functionProducingStrings = "zset_of_vectors_to_strings";
-                    elementType = oType.elementType.to(DBSPTypeVec.class).getElementType();
+                    elementType = oType.elementType.to(DBSPTypeArray.class).getElementType();
                 } else {
                     functionProducingStrings = "zset_to_strings";
                     elementType = oType.elementType;

--- a/sql-to-dbsp-compiler/temp/src/stubs.rs
+++ b/sql-to-dbsp-compiler/temp/src/stubs.rs
@@ -1,11 +1,1 @@
-// Compiler-generated file.
-// This file contains stubs for user-defined functions declared in the SQL program.
-// Each stub defines a function prototype that must be implemented in `udf.rs`.
-// Copy these stubs to `udf.rs`, replacing their bodies with the actual UDF implementation.
-// See detailed documentation in https://docs.feldera.com/sql/udf.
-
-#![allow(non_snake_case)]
-
-use feldera_sqllib::*;
-use crate::*;
 


### PR DESCRIPTION
The changes are mostly in Rust libraries.
The compiler changes are mostly syntactic and should be easy to review.
I have renamed the old Vec type in the compiler to Array.
The compiler now distinguishes between Vec and Array, and between BTreeMap and Map.
The latter are the Arc of the former.
The former are still used in aggregation functions, which want mutable containers.

There was a lot of rust code refactoring, so I hope I didn't introduce any glaring inefficiencies.
