### PR TITLE
[adapters] Raw input format.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -32,6 +32,7 @@ pub enum RecordFormat {
     Parquet(SqlSerdeConfig),
     #[cfg(feature = "with-avro")]
     Avro,
+    Raw,
 }
 
 /// An input handle that deserializes and buffers records.

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod avro;
 pub(crate) mod csv;
 mod json;
 pub mod parquet;
+pub(crate) mod raw;
 
 #[cfg(feature = "with-avro")]
 use crate::format::avro::output::AvroOutputFormat;
@@ -25,6 +26,7 @@ pub use self::csv::{byte_record_deserializer, string_record_deserializer};
 use self::{
     csv::{CsvInputFormat, CsvOutputFormat},
     json::{JsonInputFormat, JsonOutputFormat},
+    raw::RawInputFormat,
 };
 
 pub use feldera_adapterlib::format::*;
@@ -42,6 +44,7 @@ static INPUT_FORMATS: Lazy<BTreeMap<&'static str, Box<dyn InputFormat>>> = Lazy:
         ),
         #[cfg(feature = "with-avro")]
         ("avro", Box::new(AvroInputFormat) as Box<dyn InputFormat>),
+        ("raw", Box::new(RawInputFormat) as Box<dyn InputFormat>),
     ])
 });
 

--- a/crates/adapters/src/format/raw.rs
+++ b/crates/adapters/src/format/raw.rs
@@ -1,0 +1,530 @@
+use crate::{
+    catalog::{DeCollectionStream, RecordFormat},
+    format::{InputFormat, ParseError, Parser},
+    ControllerError,
+};
+use actix_web::HttpRequest;
+use core::str;
+use erased_serde::Serialize as ErasedSerialize;
+use feldera_types::{
+    format::raw::{RawParserConfig, RawParserMode},
+    serde_with_context::{serde_config::BinaryFormat, SqlSerdeConfig},
+};
+use serde::{de::Error as _, de::SeqAccess, forward_to_deserialize_any, Deserialize, Deserializer};
+use serde_urlencoded::Deserializer as UrlDeserializer;
+use std::{borrow::Cow, fmt::Display};
+
+use crate::catalog::InputCollectionHandle;
+use serde_yaml::Value as YamlValue;
+
+use super::{InputBuffer, LineSplitter, Sponge};
+
+/// Raw format parser.
+///
+/// Ingest raw byte stream into a table with a single column of type VARCHAR or VARBINARY.
+pub struct RawInputFormat;
+
+pub fn raw_serde_config() -> SqlSerdeConfig {
+    SqlSerdeConfig::default().with_binary_format(BinaryFormat::Bytes)
+}
+
+impl InputFormat for RawInputFormat {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("raw")
+    }
+
+    fn config_from_http_request(
+        &self,
+        endpoint_name: &str,
+        request: &HttpRequest,
+    ) -> Result<Box<dyn ErasedSerialize>, ControllerError> {
+        Ok(Box::new(
+            RawParserConfig::deserialize(UrlDeserializer::new(form_urlencoded::parse(
+                request.query_string().as_bytes(),
+            )))
+            .map_err(|e| {
+                ControllerError::parser_config_parse_error(
+                    endpoint_name,
+                    &e,
+                    request.query_string(),
+                )
+            })?,
+        ))
+    }
+
+    fn new_parser(
+        &self,
+        endpoint_name: &str,
+        input_stream: &InputCollectionHandle,
+        config: &YamlValue,
+    ) -> Result<Box<dyn Parser>, ControllerError> {
+        let config = RawParserConfig::deserialize(config).map_err(|e| {
+            ControllerError::parser_config_parse_error(
+                endpoint_name,
+                &e,
+                &serde_yaml::to_string(config).unwrap_or_default(),
+            )
+        })?;
+
+        let num_columns = input_stream.schema.fields.len();
+
+        if num_columns != 1 {
+            return Err(ControllerError::invalid_parser_configuration(
+                endpoint_name,
+                &format!("'raw' input format can only be used with tables that have a single column of type 'VARCHAR' or 'VARBINARY', but table '{}' has {num_columns} columns", input_stream.schema.name),
+            ));
+        }
+
+        let typ = input_stream.schema.fields[0].columntype.typ;
+
+        if !typ.is_varchar() && !typ.is_varbinary() {
+            return Err(ControllerError::invalid_parser_configuration(
+                endpoint_name,
+                &format!("'raw' input format can only be used with tables that have a single column of type 'VARCHAR' or 'VARBINARY', but table '{}' has a column of type {typ}", input_stream.schema.name),
+            ));
+        }
+
+        let input_stream = input_stream
+            .handle
+            .configure_deserializer(RecordFormat::Raw)?;
+        Ok(Box::new(RawParser::new(input_stream, config)) as Box<dyn Parser>)
+    }
+}
+
+struct RawParser {
+    /// Input handle to push parsed data to.
+    input_stream: Box<dyn DeCollectionStream>,
+
+    config: RawParserConfig,
+
+    last_event_number: u64,
+}
+
+impl RawParser {
+    fn new(input_stream: Box<dyn DeCollectionStream>, config: RawParserConfig) -> Self {
+        Self {
+            input_stream,
+            last_event_number: 0,
+            config,
+        }
+    }
+
+    fn parse_record(&mut self, record: &[u8], errors: &mut Vec<ParseError>) {
+        if let Err(e) = self.input_stream.insert(record) {
+            errors.push(ParseError::bin_event_error(
+                format!("failed to deserialize raw record: {e}"),
+                self.last_event_number + 1,
+                record,
+                None,
+            ));
+        }
+    }
+}
+
+impl Parser for RawParser {
+    fn fork(&self) -> Box<dyn Parser> {
+        Box::new(Self::new(self.input_stream.fork(), self.config.clone()))
+    }
+
+    fn splitter(&self) -> Box<dyn super::Splitter> {
+        match self.config.mode {
+            RawParserMode::Lines => Box::new(LineSplitter),
+            RawParserMode::Blob => Box::new(Sponge),
+        }
+    }
+
+    fn parse(&mut self, data: &[u8]) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
+        let mut errors = Vec::new();
+
+        match self.config.mode {
+            RawParserMode::Blob => {
+                self.parse_record(data, &mut errors);
+                self.last_event_number += 1;
+            }
+            RawParserMode::Lines => {
+                for line in data.split(|b| b == &b'\n') {
+                    if !line.is_empty() {
+                        self.parse_record(line, &mut errors);
+                        self.last_event_number += 1;
+                    }
+                }
+            }
+        }
+
+        (self.input_stream.take_all(), errors)
+    }
+}
+
+/// Deserializer implementation that deserializes a byte slice as a struct with one column that contains
+/// these bytes.
+pub(crate) struct RawDeserializer<'de> {
+    bytes: &'de [u8],
+}
+
+impl<'de> RawDeserializer<'de> {
+    pub(crate) fn new(bytes: &'de [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+#[derive(Clone)]
+struct RawSeqDeserializer<'de> {
+    bytes: &'de [u8],
+    done: bool,
+}
+
+impl<'de> RawSeqDeserializer<'de> {
+    fn new(bytes: &'de [u8]) -> Self {
+        Self { bytes, done: false }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RawDeserializeError {
+    message: String,
+}
+
+impl Display for RawDeserializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl std::error::Error for RawDeserializeError {}
+
+impl serde::de::Error for RawDeserializeError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self {
+            message: msg.to_string(),
+        }
+    }
+}
+
+impl<'de> SeqAccess<'de> for RawSeqDeserializer<'de> {
+    type Error = RawDeserializeError;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        if self.done {
+            Ok(None)
+        } else {
+            self.done = true;
+            Ok(Some(seed.deserialize(self.clone())?))
+        }
+    }
+}
+
+impl<'de> Deserializer<'de> for RawSeqDeserializer<'de> {
+    type Error = RawDeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_bytes(self.bytes)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        let s = str::from_utf8(self.bytes).map_err(|e| {
+            RawDeserializeError::custom(format!("unable to convert buffer to UTF-8 string (consider changing column type to 'VARBINARY'): {e}"))
+        })?;
+        visitor.visit_str(s)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_bytes(self.bytes)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char
+        byte_buf unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum struct identifier ignored_any
+    }
+}
+
+impl<'de> Deserializer<'de> for RawDeserializer<'de> {
+    type Error = RawDeserializeError;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_seq(RawSeqDeserializer::new(self.bytes))
+    }
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum struct identifier ignored_any
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test::{mock_parser_pipeline, MockUpdate};
+    use crate::FormatConfig;
+    use feldera_adapterlib::{
+        format::{InputBuffer, ParseError, Parser},
+        transport::InputConsumer,
+    };
+    use feldera_sqllib::{ByteArray, SqlString};
+    use feldera_types::{
+        deserialize_table_record,
+        format::raw::{RawParserConfig, RawParserMode},
+        program_schema::{ColumnType, Field, Relation, SqlIdentifier},
+        serde_with_context::{DeserializeWithContext, SqlSerdeConfig},
+    };
+    use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, hash::Hash};
+
+    #[derive(Eq, PartialEq, Debug, Hash)]
+    struct Binary {
+        data: ByteArray,
+    }
+
+    fn binary_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("binary", false),
+            vec![Field::new(
+                SqlIdentifier::new("data", false),
+                ColumnType::varbinary(false),
+            )],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    deserialize_table_record!(Binary["Binary", 1] {
+        (data, "data", false, ByteArray, None)
+    });
+
+    #[derive(Eq, PartialEq, Debug, Hash)]
+    struct OptBinary {
+        data: Option<ByteArray>,
+    }
+
+    fn opt_binary_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("opt_binary", false),
+            vec![Field::new(
+                SqlIdentifier::new("data", false),
+                ColumnType::varbinary(true),
+            )],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    deserialize_table_record!(OptBinary["OptBinary", 1] {
+        (data, "data", false, Option<ByteArray>, Some(None))
+    });
+
+    #[derive(Eq, PartialEq, Debug, Hash)]
+    struct Varchar {
+        data: SqlString,
+    }
+
+    deserialize_table_record!(Varchar["Varchar", 1] {
+        (data, "data", false, SqlString, None)
+    });
+
+    fn varchar_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("string_table", false),
+            vec![Field::new(
+                SqlIdentifier::new("data", false),
+                ColumnType::varchar(false),
+            )],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    #[derive(Eq, PartialEq, Debug, Hash)]
+    struct OptVarchar {
+        data: Option<SqlString>,
+    }
+
+    deserialize_table_record!(OptVarchar["OptVarchar", 1] {
+        (data, "data", false, Option<SqlString>, Some(None))
+    });
+
+    fn opt_varchar_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("opt_string_table", false),
+            vec![Field::new(
+                SqlIdentifier::new("data", false),
+                ColumnType::varchar(true),
+            )],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    #[derive(Debug)]
+    struct TestCase<T> {
+        config: RawParserConfig,
+        /// Input data, expected result.
+        input_batches: Vec<(Vec<u8>, Vec<ParseError>)>,
+        /// Expected contents at the end of the test.
+        expected_output: Vec<MockUpdate<T, ()>>,
+        schema: Relation,
+    }
+
+    impl<T> TestCase<T> {
+        #[track_caller]
+        fn new(
+            config: RawParserConfig,
+            input_batches: Vec<(Vec<u8>, Vec<ParseError>)>,
+            expected_output: Vec<MockUpdate<T, ()>>,
+            schema: Relation,
+        ) -> Self {
+            Self {
+                config,
+                input_batches,
+                expected_output,
+                schema,
+            }
+        }
+    }
+
+    fn run_test_cases<T>(test_cases: Vec<TestCase<T>>)
+    where
+        T: Debug
+            + Eq
+            + Hash
+            + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+            + Send
+            + Sync
+            + 'static,
+    {
+        for test in test_cases {
+            println!("test: {test:?}");
+            let format_config = FormatConfig {
+                name: Cow::from("raw"),
+                config: serde_yaml::to_value(test.config).unwrap(),
+            };
+
+            let (consumer, mut parser, outputs) =
+                mock_parser_pipeline(&test.schema, &format_config).unwrap();
+            consumer.on_error(Some(Box::new(|_, _| {})));
+            parser.on_error(Some(Box::new(|_, _| {})));
+            for (data, expected_errors) in test.input_batches {
+                let (mut buffer, errors) = parser.parse(&data);
+                assert_eq!(&errors, &expected_errors);
+                buffer.flush();
+            }
+            consumer.eoi();
+            assert_eq!(&test.expected_output, &outputs.state().flushed);
+        }
+    }
+
+    #[test]
+    fn test_raw_varchar() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Lines,
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![
+                MockUpdate::with_polarity(Varchar { data: "foo".into() }, true),
+                MockUpdate::with_polarity(Varchar { data: "bar".into() }, true),
+            ],
+            varchar_schema(),
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_opt_varchar() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Blob,
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![MockUpdate::with_polarity(
+                OptVarchar {
+                    data: Some("foo\nbar".into()),
+                },
+                true,
+            )],
+            opt_varchar_schema(),
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_varbinary() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Lines,
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![
+                MockUpdate::with_polarity(
+                    Binary {
+                        data: b"foo".as_slice().into(),
+                    },
+                    true,
+                ),
+                MockUpdate::with_polarity(
+                    Binary {
+                        data: b"bar".as_slice().into(),
+                    },
+                    true,
+                ),
+            ],
+            binary_schema(),
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_opt_varbinary() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Blob,
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![MockUpdate::with_polarity(
+                OptBinary {
+                    data: Some(b"foo\nbar".as_slice().into()),
+                },
+                true,
+            )],
+            opt_binary_schema(),
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+}

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -431,6 +431,7 @@ where
                     ),
                 )
             }
+            RecordFormat::Raw => todo!(),
         })
     }
 }

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -1,8 +1,9 @@
 use crate::{
     catalog::{ArrowStream, AvroStream, DeCollectionStream, RecordFormat},
-    format::{avro::from_avro_value, InputBuffer},
+    format::{avro::from_avro_value, raw::raw_serde_config, InputBuffer},
     static_compile::deinput::{
         CsvDeserializerFromBytes, DeserializerFromBytes, JsonDeserializerFromBytes,
+        RawDeserializerFromBytes,
     },
     ControllerError, DeCollectionHandle,
 };
@@ -150,6 +151,14 @@ where
             RecordFormat::Avro => {
                 todo!()
             }
+            RecordFormat::Raw => Ok(Box::new(MockDeZSetStream::<
+                RawDeserializerFromBytes,
+                T,
+                U,
+                _,
+            >::new(
+                self.clone(), raw_serde_config()
+            ))),
         }
     }
 

--- a/crates/feldera-types/src/format/mod.rs
+++ b/crates/feldera-types/src/format/mod.rs
@@ -2,3 +2,4 @@ pub mod avro;
 pub mod csv;
 pub mod json;
 pub mod parquet;
+pub mod raw;

--- a/crates/feldera-types/src/format/raw.rs
+++ b/crates/feldera-types/src/format/raw.rs
@@ -1,0 +1,20 @@
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+pub enum RawParserMode {
+    #[default]
+    #[serde(rename = "blob")]
+    Blob,
+
+    #[serde(rename = "lines")]
+    Lines,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
+#[serde(default)]
+pub struct RawParserConfig {
+    pub mode: RawParserMode,
+}

--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -542,6 +542,14 @@ impl SqlType {
     pub fn is_string(&self) -> bool {
         matches!(self, Self::Char | Self::Varchar)
     }
+
+    pub fn is_varchar(&self) -> bool {
+        matches!(self, Self::Varchar)
+    }
+
+    pub fn is_varbinary(&self) -> bool {
+        matches!(self, Self::Varbinary)
+    }
 }
 
 /// It so happens that when the type field is missing in the Calcite schema, it's a struct,

--- a/crates/feldera-types/src/serde_with_context/serde_config.rs
+++ b/crates/feldera-types/src/serde_with_context/serde_config.rs
@@ -104,10 +104,12 @@ impl Default for VariantFormat {
 /// Representation of the SQL `BINARY` and `VARBINARY` types.
 #[derive(Clone, Debug)]
 pub enum BinaryFormat {
-    /// Serialize as array of bytes.
+    /// Serialize as a sequence of bytes.
     Array,
     /// Serialize as base64-encoded string.
     Base64,
+    /// Serialize as a byte slice (`&[u8]``)
+    Bytes,
 }
 
 impl Default for BinaryFormat {

--- a/docs/formats/raw.md
+++ b/docs/formats/raw.md
@@ -1,0 +1,99 @@
+# Raw Format
+
+:::note
+This page describes configuration options specific to the raw data format.
+See [top-level connector documentation](/connectors/) for general information
+about configuring input and output connectors.
+:::
+
+The **raw** data format can be used to configure an input connector to pass
+raw, unparsed, data buffers from the [transport connector](/connectors/sources) to the SQL program.
+Normally the byte stream received from the transport connector is parsed using the specified data [format](/formats),
+e.g., [JSON](/formats/json) or [Avro](/formats/avro). The parser converts the raw byte stream into a stream
+of SQL table records.  In some cases it is preferable to pass the raw bytes to the SQL program unmodified and
+perform all parsing in SQL. In particular this is useful for:
+
+* **Custom data formats:** If the required data format is not supported by built-in parsers, raw data can be
+  ingested into a SQL table and decoded using a [UDF](/sql/udf).
+
+* **Parallelized parsing**: Parsing large volumes of incoming data can become a performance bottleneck.
+  Normally parsing is performed by the input connector outside of the SQL runtime.
+  Moving parsing into the SQL program enables it to leverage the parallelism in the Feldera
+  SQL runtime.
+
+The raw format is currently only supported for input connectors.
+
+Note that the raw format supports only inserting records into the table and does not support deletions.
+This limitation exists because the raw data stream lacks the metadata to differentiate between inserts and deletes.
+
+## Configuring raw input connector
+
+In order to ingest raw data:
+
+1. Declare a table with a single column of type `VARBINARY [NOT NUL]` or `VARCHAR [NOT NULL]`.  In the latter case, the connector
+   will parse input data as a UTF-8 string and will fail to parse chunks that are not valid UTF-8.
+
+2. Configure an input connector with the format name `raw`.  The connector currently supports a single configuration
+   option, `mode`, which can be set to:
+   * `blob` (default) - ingest the entire data chunk received from the transport connector as a single SQL row.
+     For message-oriented transports, such as Kafka or Pub/Sub, an input chunk corresponds to a message.
+     For file-based transports, e.g., the [URL](/connectors/sources/http-get) connector or
+     the [S3](/connectors/sources/s3) connector, a chunk represents an entire file or object.
+   * `lines` - split the input byte stream on the new line character (`\n`) and ingest each line as a separate SQL row.
+
+:::note
+
+When using the `blob` mode with a file-oriented transport connector such as S3, the entire file or object is ingested
+as a single record.  This can require a lot of memory when reading large files.
+
+:::
+
+### Example
+
+The following example shows a table with an input connector configured to ingest raw data from a URL line-by-line.
+
+```sql
+create table raw_table(
+    data varchar
+) with (
+    'connectors' = '[{
+        "format": {
+            "name": "raw",
+            "config": {
+                "mode": "lines"
+            }
+        },
+        "transport": {
+            "name": "url_input",
+            "config": {
+                "path": "https://feldera-basics-tutorial.s3.amazonaws.com/part.json"
+            }
+        }
+    }]'
+);
+```
+
+
+## Ingesting raw data via HTTP
+
+You can also push raw data to a pipeline via [HTTP](/connectors/sources/http) by specifying
+`format=json` and, optionally, `mode=lines` in the request URL:
+
+### Example
+
+Create a pipeline called `my_pipeline` with the following table declaration:
+
+```sql
+create table raw_table(
+    data varchar
+);
+```
+
+Insert two records with values `hello` and `world`:
+
+```bash
+curl -i -X 'POST' \
+  http://localhost:8080/v0/pipelines/my_pipeline/ingress/raw_table?format=raw&mode=lines \
+  -d 'hello
+  world'
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -301,6 +301,7 @@ const sidebars = {
                         'formats/avro',
                         'formats/parquet',
                         'formats/csv',
+                        'formats/raw'
                     ],
                 },
                 "fault-tolerance"


### PR DESCRIPTION
The raw data format can be used to configure an input connector to pass raw, unparsed, data buffers from the transport connector to the SQL program.  Normally the byte stream received from the transport connector is parsed using the specified data format, e.g., JSON or Avro.  The parser converts the raw byte stream into a stream of SQL table records. In some cases it is preferable to pass the raw bytes to the SQL program unmodified and perform all parsing in SQL.  In particular this is useful for:

* **Custom data formats:** If the required data format is not supported by built-in parsers, raw data can be ingested into a SQL table and processed using a UDF.

* **Parallelized parsing**: Parsing large volumes of incoming data can become a performance bottleneck.  Offloading parsing to the SQL program enables parallel execution, leveraging the multithreaded Feldera SQL runtime.

The raw format is currently only supported for input connectors.