### PR TITLE
[sqllib] Implement SqlString using arcstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,6 @@ dependencies = [
  "flate2",
  "geo",
  "hex",
- "internment",
  "itertools 0.13.0",
  "like",
  "metrics",
@@ -6148,18 +6147,6 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "internment"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
-dependencies = [
- "ahash 0.8.11",
- "dashmap 5.5.3",
- "hashbrown 0.15.2",
- "once_cell",
-]
 
 [[package]]
 name = "io-uring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,9 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "array-init"
@@ -4791,6 +4794,7 @@ dependencies = [
 name = "feldera-sqllib"
 version = "0.36.0"
 dependencies = [
+ "arcstr",
  "base64 0.22.1",
  "chrono",
  "dbsp",

--- a/crates/sqllib/Cargo.toml
+++ b/crates/sqllib/Cargo.toml
@@ -10,10 +10,6 @@ keywords = ["DBSP", "streaming", "analytics", "database", "sql"]
 categories = ["database", "api-bindings", "network-programming"]
 publish = true
 
-[features]
-default = []
-interned_string = ["internment"]
-
 [dependencies]
 thiserror = "1.0"
 dbsp = { path = "../dbsp", version = "0.36.0" }
@@ -38,7 +34,6 @@ flate2 = "1.0.28"
 metrics = { version = "0.23.0" }
 base64 = "0.22.1"
 uuid = { version = "1.11.0", features = ["v4", "std"] }
-internment = { version = "0.8.5", features = ["arc"], optional = true }
 arcstr = { version = "1.2.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/crates/sqllib/Cargo.toml
+++ b/crates/sqllib/Cargo.toml
@@ -39,6 +39,7 @@ metrics = { version = "0.23.0" }
 base64 = "0.22.1"
 uuid = { version = "1.11.0", features = ["v4", "std"] }
 internment = { version = "0.8.5", features = ["arc"], optional = true }
+arcstr = { version = "1.2.0", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1.0.107"

--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -18,6 +18,7 @@ use feldera_types::{deserialize_without_context, serialize_without_context};
 use internment::ArcIntern;
 use like::{Escape, Like};
 use regex::Regex;
+use rkyv::Fallible;
 use serde::{Deserialize, Serialize};
 use size_of::{Context, SizeOf};
 use std::{
@@ -26,11 +27,14 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(not(feature = "interned_string"))]
+use arcstr::ArcStr;
+
 #[cfg(feature = "interned_string")]
 type StringRef = ArcIntern<String>;
 
 #[cfg(not(feature = "interned_string"))]
-type StringRef = Arc<String>;
+type StringRef = ArcStr;
 
 /// An immutable reference counted string.
 #[derive(
@@ -44,11 +48,11 @@ type StringRef = Arc<String>;
     PartialOrd,
     Serialize,
     Deserialize,
-    rkyv::Archive,
-    rkyv::Serialize,
-    rkyv::Deserialize,
+    // rkyv::Archive,
+    // rkyv::Serialize,
+    // rkyv::Deserialize,
 )]
-#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+//#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
 #[serde(transparent)]
 pub struct SqlString(StringRef);
 
@@ -117,6 +121,41 @@ impl From<&str> for SqlString {
 impl SizeOf for SqlString {
     fn size_of_children(&self, context: &mut Context) {
         self.str().size_of_children(context)
+    }
+}
+
+impl rkyv::Archive for SqlString {
+    type Archived = ();
+    type Resolver = ();
+    unsafe fn resolve(&self, _pos: usize, _resolver: Self::Resolver, _out: *mut Self::Archived) {
+        todo!()
+    }
+}
+
+impl<D> rkyv::Deserialize<SqlString, D> for ()
+where
+    D: Fallible + ?Sized,
+{
+    fn deserialize(&self, _deserializer: &mut D) -> Result<SqlString, D::Error> {
+        todo!()
+    }
+}
+
+impl<D> rkyv::Deserialize<SqlString, D> for SqlString
+where
+    D: Fallible + ?Sized,
+{
+    fn deserialize(&self, _deserializer: &mut D) -> Result<SqlString, D::Error> {
+        todo!()
+    }
+}
+
+impl<S> rkyv::Serialize<S> for SqlString
+where
+    S: Fallible + ?Sized,
+{
+    fn serialize(&self, _serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        todo!()
     }
 }
 

--- a/docs/sql/udf.md
+++ b/docs/sql/udf.md
@@ -294,7 +294,8 @@ in a single expression.)
 
 Currently `feldera_sqlllib::Map` is defined as `type Map =
 Arc<BTreeMap>`, and `feldera_sqlllib::Array` is defined as `type Array
-= Arc<Vec>`.
+= Arc<Vec>`.  Currently `feldera_sqlllib::SqlString` is a thin wrapper
+type around the `ArcStr` type from the `arcstr` crate.
 
 ### Return types
 

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [features]
 default = []
-interned_string = ["feldera-sqllib/interned_string"]
 
 [dependencies]
 paste = { version = "1.0.12" }


### PR DESCRIPTION
The previous SqlString implementation was backed by `Arc<String>`,
which creates two heap allocations per string. This made creating and
deserializing strings, including from rkyv relatively expensive.  This
commit instead uses the `ArcStr` type from the `arcstr` crate, which
is a reference-counted string backed by a single memory allocation.