### PR TITLE
pipeline-manager: fix two error log prints

### DIFF
--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -993,7 +993,14 @@ async fn cleanup_rust_compilation(
                 BTreeMap::new()
             }),
             Err(e) => {
-                error!("Unable to read cleanup state file due to: {e}");
+                if !cleanup_state_file_path.exists() {
+                    debug!(
+                        "Cleanup state file does not yet exist -- \
+                        it will be created at the end of the first cleanup cycle"
+                    );
+                } else {
+                    error!("Unable to read cleanup state file due to: {e}");
+                }
                 BTreeMap::new()
             }
         };

--- a/crates/pipeline-manager/src/demo.rs
+++ b/crates/pipeline-manager/src/demo.rs
@@ -1,4 +1,4 @@
-use log::{debug, error};
+use log::{debug, error, warn};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -163,7 +163,7 @@ pub fn read_demos_from_directories(demos_dir: &Vec<String>) -> Vec<Demo> {
         let entries = match fs::read_dir(Path::new(dir)) {
             Ok(entries) => entries.collect::<Vec<_>>(),
             Err(e) => {
-                error!(
+                warn!(
                     "{}",
                     DemoError::UnableToReadDirectory {
                         path: dir.clone(),


### PR DESCRIPTION
It should be a warning when unable to read a demos directory, as it will still start. This is necessary as by default a path is provided for the argument to have demos show up even when running from source.

Initially at the start of the first Rust compilation cleanup cycle, it will be unable to read the cleanup state file as there is none. It is however still useful information to have, as it shouldn't be deleted afterwards. Therefore it should be at debug level.

**Notes:**
- Thanks @mihaibudiu for mentioning the issue
- Fixes: https://github.com/feldera/feldera/issues/3409