### PR TITLE
[adapters] Experimental CDC mode for DeltaLake.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -113,6 +113,11 @@ pub trait ArrowStream: InputBuffer + Send {
 
     fn delete(&mut self, data: &RecordBatch) -> AnyResult<()>;
 
+    /// Insert records in `data` with polarities from the `polarities` array.
+    ///
+    /// `polarities` must be the same length as `data`.
+    fn insert_with_polarities(&mut self, data: &RecordBatch, polarities: &[bool]) -> AnyResult<()>;
+
     /// Create a new deserializer with the same configuration connected to
     /// the same input stream.
     fn fork(&self) -> Box<dyn ArrowStream>;
@@ -308,6 +313,17 @@ pub trait SerCursor: Send {
 
     /// Rewinds the cursor to the first value for current key.
     fn rewind_vals(&mut self);
+
+    fn count_keys(&mut self) -> usize {
+        let mut count = 0;
+
+        while self.key_valid() {
+            count += 1;
+            self.step_key()
+        }
+
+        count
+    }
 }
 
 /// A handle to an output stream of a circuit that yields type-erased

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -10,11 +10,24 @@ use crate::{
     TransportInputEndpoint,
 };
 use anyhow::{anyhow, Error as AnyError, Result as AnyResult};
+use arrow::array::BooleanArray;
+use arrow::datatypes::Schema;
+use datafusion::catalog::TableProvider;
 use datafusion::common::arrow::array::{AsArray, RecordBatch};
+use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::{
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+};
+use datafusion::datasource::MemTable;
+use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_expr::sqlparser::parser::ParserError;
+use datafusion::logical_expr::{Filter, LogicalPlan, Projection};
+use datafusion::physical_plan::PhysicalExpr;
+use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::prelude::SessionConfig;
 use datafusion::scalar::ScalarValue;
 use dbsp::circuit::tokio::TOKIO;
+use dbsp::operator::input;
 use dbsp::InputHandle;
 use deltalake::datafusion::common::Column;
 use deltalake::datafusion::dataframe::DataFrame;
@@ -25,6 +38,7 @@ use deltalake::datafusion::sql::sqlparser::keywords::Keyword::SQL;
 use deltalake::datafusion::sql::sqlparser::parser::Parser;
 use deltalake::datafusion::sql::sqlparser::test_utils::table;
 use deltalake::delta_datafusion::cdf::FileAction;
+use deltalake::delta_datafusion::logical;
 use deltalake::kernel::Action;
 use deltalake::kernel::Error::Parse;
 use deltalake::operations::create::CreateBuilder;
@@ -65,6 +79,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 /// Polling delay before retrying an unsuccessful read from a delta log.
 const RETRY_INTERVAL: Duration = Duration::from_millis(2000);
+
+const REPORT_ERROR: &str =
+    "please report this error to developers (https://github.com/feldera/feldera/issues)";
 
 /// Integrated input connector that reads from a delta table.
 pub struct DeltaTableInputEndpoint {
@@ -197,6 +214,41 @@ impl DeltaTableInputEndpointInner {
             datafusion: SessionContext::new_with_config(session_config),
             queue,
         }
+    }
+
+    fn validate_cdc_config(&self) -> Result<(), ControllerError> {
+        if self.config.is_cdc() {
+            let Some(cdc_order_by) = &self.config.cdc_order_by else {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "the DeltaLake connector is configured in 'cdc' mode, but the 'cdc_order_by' property is not set",
+                ));
+            };
+
+            self.validate_cdc_order_by()?;
+
+            if self.config.cdc_delete_filter.is_none() {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "the DeltaLake connector is configured in 'cdc' mode, but the 'cdc_delete_filter' property is not set",
+                ));
+            }
+        } else {
+            if self.config.cdc_delete_filter.is_some() {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "the 'cdc_delete_filter' property can only be used when 'mode=cdc'",
+                ));
+            }
+            if self.config.cdc_order_by.is_some() {
+                return Err(ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    "the 'cdc_order_by' property can only be used with 'mode=cdc'",
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     async fn worker_task(
@@ -384,6 +436,14 @@ impl DeltaTableInputEndpointInner {
             return;
         };
 
+        let cdc_delete_filter = match self.prepare_cdc().await {
+            Err(e) => {
+                let _ = init_status_sender.send(Err(e)).await;
+                return;
+            }
+            Ok(cdc_delete_filter) => cdc_delete_filter,
+        };
+
         // Code before this point is part of endpoint initialization.
         // After this point, the thread should continue running until it receives a
         // shutdown command from the controller.
@@ -411,6 +471,7 @@ impl DeltaTableInputEndpointInner {
                         self.process_log_entry(
                             &actions,
                             &table,
+                            cdc_delete_filter.clone(),
                             input_stream.as_mut(),
                             &mut receiver,
                         )
@@ -556,6 +617,118 @@ impl DeltaTableInputEndpointInner {
         Ok(())
     }
 
+    /// Validate the cdc_order_by expression.
+    fn validate_cdc_order_by(&self) -> Result<(), ControllerError> {
+        if let Some(order_by) = &self.config.cdc_order_by {
+            validate_sql_expression(order_by).map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("error parsing 'cdc_order_by' expression '{order_by}': {e}"),
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Convert the delete filter SQL expression into a Datafusion PhysicalExpr.
+    ///
+    /// To do this, we generate a query plan for the `select * from snapshot where <delete_filter>`
+    /// query and extract the logical expression from the plan and then convert it to
+    /// a physical expression.
+    //
+    // FIXME: I wonder if there's a simpler way that doesn't require registering the `snapshot`
+    // table just so we can compile this query.
+    async fn extract_delete_filter_expr(
+        &self,
+    ) -> Result<Option<Arc<dyn PhysicalExpr>>, ControllerError> {
+        let Some(delete_filter) = &self.config.cdc_delete_filter else {
+            return Ok(None);
+        };
+
+        let query = format!("SELECT * FROM snapshot WHERE {}", delete_filter);
+
+        let logical_plan = self
+            .datafusion
+            .sql(&query)
+            .await
+            .map_err(|e| {
+                ControllerError::invalid_transport_configuration(
+                    &self.endpoint_name,
+                    &format!("invalid delete filter '{delete_filter}': the 'cdc_delete_filter' expression must be a valid SQL expression that can be used in a 'SELECT * FROM snapshot WHERE <cdc_delete_filter>' query, but the following error was encountered when compiling '{query}': {e}"),
+                )
+            })?
+            .logical_plan()
+            .clone();
+
+        let filter_expr = if let LogicalPlan::Projection(filter_plan) = &logical_plan {
+            if let LogicalPlan::Filter(filter) = filter_plan.input.as_ref() {
+                filter.predicate.clone()
+            } else {
+                return Err(ControllerError::invalid_encoder_configuration(
+                    &self.endpoint_name,
+                    &format!("internal error when compiling the 'cdc_delete_filter' expression '{delete_filter}'; {REPORT_ERROR}: unexpected logical plan {logical_plan}"),
+                ));
+            }
+        } else {
+            return Err(ControllerError::invalid_encoder_configuration(
+                &self.endpoint_name,
+                &format!("internal error when compiling the 'cdc_delete_filter' expression '{delete_filter}'; {REPORT_ERROR}: unexpected logical plan {logical_plan}"),
+            ));
+        };
+
+        let schema = self
+            .datafusion
+            .table("snapshot")
+            .await
+            .map_err(|e| {
+                ControllerError::invalid_transport_configuration(&self.endpoint_name, &format!("internal error when compiling the 'cdc_delete_filter' expession '{delete_filter}'; {REPORT_ERROR}: table 'snapshot' not found"))
+            })?
+            .schema()
+            .clone();
+
+        let physical_expr = DefaultPhysicalPlanner::default()
+            .create_physical_expr(&filter_expr, &schema, &self.datafusion.state())
+            .map_err(|e| ControllerError::invalid_transport_configuration(&self.endpoint_name, &format!("internal error when compiling the 'cdc_delete_filter' expession '{delete_filter}'; {REPORT_ERROR}: error generating physical plan: {e}")))?;
+
+        Ok(Some(physical_expr))
+    }
+
+    /// Evaluate delete filter expression against a batch of updates; returns a vector of polarities.
+    async fn eval_delete_filter(
+        &self,
+        delete_filter: &dyn PhysicalExpr,
+        batch: &RecordBatch,
+    ) -> AnyResult<Vec<bool>> {
+        let deletions = delete_filter.evaluate(batch).map_err(|e| {
+            anyhow!("internal error evaluating the delete filter expression; {REPORT_ERROR}: {e}")
+        })?;
+
+        let array = deletions
+            .into_array(batch.num_rows())
+            .map_err(|e| {
+                anyhow!(
+                    "internal error converting the result of the delete filter expressions to array; {REPORT_ERROR}: {e}"
+                )
+            })?;
+        let bitmask = array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| {
+                anyhow!(
+                    "internal error converting the result of the delete filter exptession to BooleanArray; {REPORT_ERROR}: expected Boolean, found {:?}", array.data_type()
+                )
+            })?;
+
+        let polarities = bitmask
+            .into_iter()
+            // treat NULLs as inserts.
+            .map(|b| !b.unwrap_or(false))
+            .collect::<Vec<bool>>();
+
+        Ok(polarities)
+    }
+
     /// Prepare to read initial snapshot, if required by endpoint configuration.
     ///
     /// * register snapshot as a datafusion table
@@ -565,7 +738,7 @@ impl DeltaTableInputEndpointInner {
         table: &Arc<DeltaTable>,
         schema: &Relation,
     ) -> Result<(), ControllerError> {
-        if !self.config.snapshot() {
+        if !self.config.snapshot() && !self.config.is_cdc() {
             return Ok(());
         }
 
@@ -584,6 +757,14 @@ impl DeltaTableInputEndpointInner {
         };
 
         Ok(())
+    }
+
+    /// Prepare to process CDC stream.
+    async fn prepare_cdc(&self) -> Result<Option<Arc<dyn PhysicalExpr>>, ControllerError> {
+        self.validate_cdc_config()?;
+
+        let delete_expr = self.extract_delete_filter_expr().await?;
+        Ok(delete_expr)
     }
 
     /// Execute a SQL query to load a complete or partial snapshot of the DeltaTable.
@@ -613,7 +794,7 @@ impl DeltaTableInputEndpointInner {
             }
         };
 
-        self.execute_df(df, true, &descr, input_stream, receiver)
+        self.execute_df(df, true, None, &descr, input_stream, receiver)
             .await;
     }
 
@@ -631,6 +812,7 @@ impl DeltaTableInputEndpointInner {
         &self,
         dataframe: DataFrame,
         polarity: bool,
+        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         descr: &str,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
@@ -663,7 +845,26 @@ impl DeltaTableInputEndpointInner {
             num_batches += 1;
             let bytes = batch.get_array_memory_size();
             let result = if polarity {
-                input_stream.insert(&batch)
+                if let Some(delete_filter_expr) = &cdc_delete_filter {
+                    let polarities = match self
+                        .eval_delete_filter(delete_filter_expr.as_ref(), &batch)
+                        .await
+                    {
+                        Ok(polarities) => polarities,
+                        Err(e) => {
+                            self.consumer.error(false, e);
+                            continue;
+                        }
+                    };
+                    // println!(
+                    //     "insert_with_polarities: {} updates, {} insertions",
+                    //     polarities.len(),
+                    //     polarities.iter().filter(|x| **x == true).count()
+                    // );
+                    input_stream.insert_with_polarities(&batch, &polarities)
+                } else {
+                    input_stream.insert(&batch)
+                }
             } else {
                 input_stream.delete(&batch)
             };
@@ -688,16 +889,142 @@ impl DeltaTableInputEndpointInner {
         &self,
         actions: &[Action],
         table: &DeltaTable,
+        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
     ) {
-        // TODO: consider processing all Add actions and all Remove actions in one
-        // go using `ListingTable`, which understands partitioning and can probably
-        // parallelize the load.
-        for action in actions {
-            self.process_action(action, table, input_stream, receiver)
+        if self.config.is_cdc() {
+            self.process_cdc_transaction(actions, table, cdc_delete_filter, input_stream, receiver)
                 .await;
+        } else {
+            // TODO: consider processing all Add actions and all Remove actions in one
+            // go using `ListingTable`, which understands partitioning and can probably
+            // parallelize the load.
+            for action in actions {
+                self.process_action(action, table, input_stream, receiver)
+                    .await;
+            }
         }
+    }
+
+    /// Process a DeltaLake transaction in CDC mode:
+    ///
+    /// * Ignore delete actions (the assumption is that CDC tables are append-only,
+    ///   where only old records are deleted as part of the table maintenance)
+    /// * Order all rows from all insert actions by `cdc_order_by`, compute the
+    ///   polarity of each row using `cdc_delete_filter` and insert the row with
+    ///   appropriate polarity.
+    async fn process_cdc_transaction(
+        &self,
+        actions: &[Action],
+        table: &DeltaTable,
+        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) {
+        let result = self
+            .do_process_cdc_transaction(actions, table, cdc_delete_filter, input_stream, receiver)
+            .await;
+
+        // Deregister the table registered by `do_process_cdc_transaction`.
+        // If the table does not exist, there's no harm.
+        let _ = self.datafusion.deregister_table("tmp_table");
+
+        if let Err(e) = result {
+            self.consumer.error(false, e);
+        }
+    }
+
+    async fn do_process_cdc_transaction(
+        &self,
+        actions: &[Action],
+        table: &DeltaTable,
+        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+    ) -> AnyResult<()> {
+        // List all files that occur in Add actions.
+        let files = actions
+            .iter()
+            .flat_map(|action| match action {
+                Action::Add(add) if add.data_change => Some(format!(
+                    "{}{}",
+                    table.log_store().object_store_url().as_str(),
+                    add.path
+                )),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        let description = format!(
+            "CDC transaction consisting of {} files {:?}",
+            files.len(),
+            &files
+        );
+
+        // Create a datafusion table backed by these files.
+        let table = Arc::new(
+            self.create_parquet_table(table, files, &description)
+                .await?,
+        );
+
+        self.datafusion.register_table("tmp_table", table).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error registering Parquet table: {e}")
+        })?;
+
+        // Order the table by the `cdc_order_by expressions`
+        let order_by = self.config.cdc_order_by.as_ref().unwrap();
+        let query = format!("SELECT * FROM tmp_table ORDER BY {order_by}");
+
+        let df = self.datafusion.sql(&query).await.map_err(|e| {
+            anyhow!("invalid 'cdc_order_by' expression '{order_by}': 'cdc_order_by' must be a valid SQL expression that can be used in a 'SELECT * FROM <table> ORDER BY <cdc_order_by>' query, but the following error was encountered when compiling '{query}': {e}")
+        })?;
+
+        self.execute_df(
+            df,
+            true,
+            cdc_delete_filter,
+            &description,
+            input_stream,
+            receiver,
+        )
+        .await;
+
+        Ok(())
+    }
+
+    /// Creates a table provider from a list of Parquet files
+    async fn create_parquet_table(
+        &self,
+        table: &DeltaTable,
+        files: Vec<String>,
+        description: &str,
+    ) -> AnyResult<ListingTable> {
+        let Some(schema) = table.schema() else {
+            // At this point the table should have a schema, as it's definitely not empty.
+            return Err(anyhow!("internal error processing {description}; {REPORT_ERROR}: Delta table has not schema"));
+        };
+
+        let schema: Schema = schema.try_into().map_err(|e| anyhow!("internal error processing {description}; {REPORT_ERROR}; error converting Delta schema {schema:?} to arrow schema: {e}"))?;
+
+        let listing_options =
+            ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
+
+        let mut urls = Vec::with_capacity(files.len());
+        for file in files.iter() {
+            urls.push(ListingTableUrl::parse(file).map_err(|e| anyhow!("internal error processing {description}; {REPORT_ERROR}; error converting file path '{file}' to table URL: {e}"))?);
+        }
+
+        let listing_options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+            .with_file_extension_opt(Some(".parquet"));
+
+        let table_config = ListingTableConfig::new_with_multi_paths(urls)
+            .with_schema(Arc::new(schema))
+            .with_listing_options(listing_options);
+
+        ListingTable::try_new(table_config).map_err(|e| {
+            anyhow!("internal error processing {description}; {REPORT_ERROR}; error creating Parquet table: {e}")
+        })
     }
 
     async fn process_action(
@@ -712,7 +1039,9 @@ impl DeltaTableInputEndpointInner {
                 self.add_with_polarity(&add.path, true, table, input_stream, receiver)
                     .await;
             }
-            Action::Remove(remove) if remove.data_change => {
+            Action::Remove(remove)
+                if remove.data_change && self.config.cdc_delete_filter.is_none() =>
+            {
                 self.add_with_polarity(&remove.path, false, table, input_stream, receiver)
                     .await;
             }
@@ -748,6 +1077,7 @@ impl DeltaTableInputEndpointInner {
         self.execute_df(
             df,
             polarity,
+            None,
             &format!("file '{path}'"),
             input_stream,
             receiver,

--- a/crates/sqllib/src/aggregates.rs
+++ b/crates/sqllib/src/aggregates.rs
@@ -407,8 +407,6 @@ some_aggregate!(agg_plus_dec, agg_plus, dec, Dec);
 
 for_all_int_aggregate!(agg_plus, agg_plus);
 
-///
-
 #[doc(hidden)]
 pub fn agg_plus_non_null<T>(left: T, right: T) -> T
 where

--- a/openapi.json
+++ b/openapi.json
@@ -2357,7 +2357,8 @@
         "enum": [
           "snapshot",
           "follow",
-          "snapshot_and_follow"
+          "snapshot_and_follow",
+          "cdc"
         ]
       },
       "DeltaTableReaderConfig": {
@@ -2368,6 +2369,16 @@
           "mode"
         ],
         "properties": {
+          "cdc_delete_filter": {
+            "type": "string",
+            "description": "A predicate that determines whether the record represents a deletion.\n\nThis setting is only valid in the 'cdc' mode. It specifies a predicate applied to\neach row in the Delta table to determine whether the row represents a deletion event.\nIts value must be a valid Boolean SQL expression that can be used in a query of the\nform `SELECT * from <table> WHERE <cdc_delete_filter>`.",
+            "nullable": true
+          },
+          "cdc_order_by": {
+            "type": "string",
+            "description": "An expression that determines the ordering of updates in the Delta table.\n\nThis setting is only valid in the 'cdc' mode. It specifies a predicate applied to\neach row in the Delta table to determine the order in which updates in the table should\nbe applied. Its value must be a valid SQL expression that can be used in a query of the\nform `SELECT * from <table> ORDER BY <cdc_order_by>`.",
+            "nullable": true
+          },
           "datetime": {
             "type": "string",
             "description": "Optional timestamp for the snapshot in the ISO-8601/RFC-3339 format, e.g.,\n\"2024-12-09T16:09:53+00:00\".\n\nWhen this option is set, the connector finds and opens the version of the table as of the\nspecified point in time (based on the server time recorded in the transaction log, not the\nevent time encoded in the data).  In `snapshot` and `snapshot_and_follow` modes, it\nretrieves the snapshot of this version of the table.  In `follow` and `snapshot_and_follow`\nmodes, it follows transaction log records **after** this version.\n\nNote: at most one of `version` and `datetime` options can be specified.\nWhen neither of the two options is specified, the latest committed version of the table\nis used.",

--- a/python/tests/aggregate_tests/test_decimal_stddev_pop.py
+++ b/python/tests/aggregate_tests/test_decimal_stddev_pop.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 class aggtst_decimal_stddev_pop(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('2154.11'), 'c2': Decimal('2318.75')}]
+        self.data = [{"c1": Decimal("2154.11"), "c2": Decimal("2318.75")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop AS SELECT
                       STDDEV_POP(c1) AS c1,
                       STDDEV_POP(c2) AS c2
@@ -16,8 +16,8 @@ class aggtst_decimal_stddev_pop_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': Decimal('0.00'), 'c2': Decimal('785.40')},
-            {'id': 1, 'c1': Decimal('0.00'), 'c2': Decimal('177.00')}
+            {"id": 0, "c1": Decimal("0.00"), "c2": Decimal("785.40")},
+            {"id": 1, "c1": Decimal("0.00"), "c2": Decimal("177.00")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop_gby AS SELECT
                       id,
@@ -30,7 +30,7 @@ class aggtst_decimal_stddev_pop_groupby(TstView):
 class aggtst_decimal_stddev_pop_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('2284.78'), 'c2': Decimal('2318.75')}]
+        self.data = [{"c1": Decimal("2284.78"), "c2": Decimal("2318.75")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop_distinct AS SELECT
                       STDDEV_POP(DISTINCT c1) AS c1,
                       STDDEV_POP(DISTINCT c2) AS c2
@@ -41,8 +41,8 @@ class aggtst_decimal_stddev_pop_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': Decimal('0.00'), 'c2': Decimal('785.40')},
-            {'id': 1, 'c1': Decimal('0.00'), 'c2': Decimal('177.00')}
+            {"id": 0, "c1": Decimal("0.00"), "c2": Decimal("785.40")},
+            {"id": 1, "c1": Decimal("0.00"), "c2": Decimal("177.00")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop_distinct_gby AS SELECT
                       id,
@@ -55,7 +55,7 @@ class aggtst_decimal_stddev_pop_distinct_groupby(TstView):
 class aggtst_decimal_stddev_pop_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('0.00'), 'c2': Decimal('1754.95')}]
+        self.data = [{"c1": Decimal("0.00"), "c2": Decimal("1754.95")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop_where AS SELECT
                       STDDEV_POP(c1) FILTER (WHERE c2 > 2231.90) AS c1,
                       STDDEV_POP(c2) FILTER (WHERE c2 > 2231.90) AS c2
@@ -66,8 +66,8 @@ class aggtst_decimal_stddev_pop_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': None, 'c2': Decimal('0.00')},
-            {'id': 1, 'c1': Decimal('0.00'), 'c2': Decimal('177.00')}
+            {"id": 0, "c1": None, "c2": Decimal("0.00")},
+            {"id": 1, "c1": Decimal("0.00"), "c2": Decimal("177.00")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_pop_where_gby AS SELECT
                       id,

--- a/python/tests/aggregate_tests/test_decimal_stddev_samp.py
+++ b/python/tests/aggregate_tests/test_decimal_stddev_samp.py
@@ -5,9 +5,9 @@ from decimal import Decimal
 class aggtst_decimal_stddev(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('2638.23'), 'c2': Decimal('2677.47')}]
+        self.data = [{"c1": Decimal("2638.23"), "c2": Decimal("2677.47")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_samp AS SELECT
-                      STDDEV_SAMP(c1) AS c1, 
+                      STDDEV_SAMP(c1) AS c1,
                       STDDEV_SAMP(c2) AS c2
                       FROM decimal_tbl"""
 
@@ -16,12 +16,12 @@ class aggtst_decimal_stddev_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': None, 'c2': Decimal('1110.73')},
-            {'id': 1, 'c1': Decimal('0.00'), 'c2': Decimal('250.31')}
+            {"id": 0, "c1": None, "c2": Decimal("1110.73")},
+            {"id": 1, "c1": Decimal("0.00"), "c2": Decimal("250.31")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_samp_gby AS SELECT
-                      id, 
-                      STDDEV_SAMP(c1) AS c1, 
+                      id,
+                      STDDEV_SAMP(c1) AS c1,
                       STDDEV_SAMP(c2) AS c2
                       FROM decimal_tbl
                       GROUP BY id"""
@@ -30,7 +30,7 @@ class aggtst_decimal_stddev_groupby(TstView):
 class aggtst_decimal_stddev_distinct(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('3231.16'), 'c2': Decimal('2677.47')}]
+        self.data = [{"c1": Decimal("3231.16"), "c2": Decimal("2677.47")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_samp_distinct AS SELECT
                       STDDEV_SAMP(DISTINCT c1) AS c1,
                       STDDEV_SAMP(DISTINCT c2) AS c2
@@ -41,8 +41,8 @@ class aggtst_decimal_stddev_distinct_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': None, 'c2': Decimal('1110.73')},
-            {'id': 1, 'c1': None, 'c2': Decimal('250.31')}
+            {"id": 0, "c1": None, "c2": Decimal("1110.73")},
+            {"id": 1, "c1": None, "c2": Decimal("250.31")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_samp_distinct_gby AS SELECT
                       id,
@@ -55,7 +55,7 @@ class aggtst_decimal_stddev_distinct_groupby(TstView):
 class aggtst_decimal_stddev_where(TstView):
     def __init__(self):
         # Validated on Postgres
-        self.data = [{'c1': Decimal('0.00'), 'c2': Decimal('2149.36')}]
+        self.data = [{"c1": Decimal("0.00"), "c2": Decimal("2149.36")}]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_where AS SELECT
                       STDDEV_SAMP(c1) FILTER (WHERE c2 > 2231.90) AS c1,
                       STDDEV_SAMP(c2) FILTER (WHERE c2 > 2231.90) AS c2
@@ -66,8 +66,8 @@ class aggtst_decimal_stddev_where_groupby(TstView):
     def __init__(self):
         # Validated on Postgres
         self.data = [
-            {'id': 0, 'c1': None, 'c2': None},
-            {'id': 1, 'c1': Decimal('0.00'), 'c2': Decimal('250.31')}
+            {"id": 0, "c1": None, "c2": None},
+            {"id": 1, "c1": Decimal("0.00"), "c2": Decimal("250.31")},
         ]
         self.sql = """CREATE MATERIALIZED VIEW decimal_stddev_where_gby AS SELECT
                       id,


### PR DESCRIPTION
In CDC mode the table behaves as an append-only log where every row represents an insert
or delete action.  The order of actions is determined by the `cdc_order_by`
property, and the type of each action is determined by the `cdc_delete_filter`
property.

In this mode, the connector does not read the initial snapshot of the table
and follows the transaction log starting from the version of the table
specified by the `version` or `datetime` property.