### PR TITLE
 [adapters] Only ingest Delta columns declared in SQL. 

### DIFF
--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -53,7 +53,10 @@ pub trait TransportInputEndpoint: InputEndpoint {
 }
 
 pub trait IntegratedInputEndpoint: InputEndpoint {
-    fn open(&self, input_handle: &InputCollectionHandle) -> AnyResult<Box<dyn InputReader>>;
+    fn open(
+        self: Box<Self>,
+        input_handle: &InputCollectionHandle,
+    ) -> AnyResult<Box<dyn InputReader>>;
 }
 
 /// Commands for an [InputReader] to execute.

--- a/crates/adapters/src/integrated/postgres/input.rs
+++ b/crates/adapters/src/integrated/postgres/input.rs
@@ -70,7 +70,10 @@ impl InputEndpoint for PostgresInputEndpoint {
     }
 }
 impl IntegratedInputEndpoint for PostgresInputEndpoint {
-    fn open(&self, input_handle: &InputCollectionHandle) -> AnyResult<Box<dyn InputReader>> {
+    fn open(
+        self: Box<Self>,
+        input_handle: &InputCollectionHandle,
+    ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(PostgresInputReader::new(
             &self.inner,
             input_handle,

--- a/crates/iceberg/src/input.rs
+++ b/crates/iceberg/src/input.rs
@@ -79,7 +79,10 @@ impl InputEndpoint for IcebergInputEndpoint {
 }
 
 impl IntegratedInputEndpoint for IcebergInputEndpoint {
-    fn open(&self, input_handle: &InputCollectionHandle) -> AnyResult<Box<dyn InputReader>> {
+    fn open(
+        self: Box<Self>,
+        input_handle: &InputCollectionHandle,
+    ) -> AnyResult<Box<dyn InputReader>> {
         Ok(Box::new(IcebergInputReader::new(
             &self.inner,
             input_handle,


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/3487

Previously the DeltaLake connector read all columns from the Delta
table, including columns that were not part of the Feldera table
declaration. These columns get discarded during deserialization. Reading
only relevant columns instead reduces network traffic and speeds up
ingestion and parsing, especially for wide tables.

For now, we only optimize the backfill logic. Table following requires
extra care as the schema