### PR TITLE
[adapters] Parse Parquet data using arrow.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -108,7 +108,7 @@ pub trait DeCollectionStream: Send + Sync + InputBuffer {
 
 /// Like `DeCollectionStream`, but deserializes Arrow-encoded records before pushing them to a
 /// stream.
-pub trait ArrowStream: InputBuffer + Send {
+pub trait ArrowStream: InputBuffer + Send + Sync {
     fn insert(&mut self, data: &RecordBatch) -> AnyResult<()>;
 
     fn delete(&mut self, data: &RecordBatch) -> AnyResult<()>;

--- a/crates/adapters/src/format/avro/test.rs
+++ b/crates/adapters/src/format/avro/test.rs
@@ -320,6 +320,8 @@ where
         + Hash
         + Send
         + Sync
+        + Debug
+        + Clone
         + 'static,
 {
     for test in test_cases {

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -494,7 +494,7 @@ mod test {
 
     use super::JsonSplitter;
 
-    #[derive(PartialEq, Debug, Eq, Hash)]
+    #[derive(PartialEq, Debug, Eq, Hash, Clone)]
     struct TestStruct {
         b: bool,
         i: i32,
@@ -525,7 +525,7 @@ mod test {
         }
     }
 
-    #[derive(PartialEq, Debug, Eq, Hash)]
+    #[derive(PartialEq, Debug, Eq, Hash, Clone)]
     struct TestStructUpd {
         b: Option<bool>,
         i: i32,
@@ -570,6 +570,8 @@ mod test {
             + Hash
             + Send
             + Sync
+            + Debug
+            + Clone
             + 'static,
         U: Debug
             + Eq
@@ -577,6 +579,8 @@ mod test {
             + Hash
             + Send
             + Sync
+            + Debug
+            + Clone
             + 'static,
     {
         for test in test_cases {

--- a/crates/adapters/src/format/raw.rs
+++ b/crates/adapters/src/format/raw.rs
@@ -300,7 +300,7 @@ mod test {
     };
     use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, hash::Hash};
 
-    #[derive(Eq, PartialEq, Debug, Hash)]
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
     struct Binary {
         data: ByteArray,
     }
@@ -321,7 +321,7 @@ mod test {
         (data, "data", false, ByteArray, None)
     });
 
-    #[derive(Eq, PartialEq, Debug, Hash)]
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
     struct OptBinary {
         data: Option<ByteArray>,
     }
@@ -342,7 +342,7 @@ mod test {
         (data, "data", false, Option<ByteArray>, Some(None))
     });
 
-    #[derive(Eq, PartialEq, Debug, Hash)]
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
     struct Varchar {
         data: SqlString,
     }
@@ -363,7 +363,7 @@ mod test {
         )
     }
 
-    #[derive(Eq, PartialEq, Debug, Hash)]
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
     struct OptVarchar {
         data: Option<SqlString>,
     }
@@ -419,6 +419,8 @@ mod test {
             + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
             + Send
             + Sync
+            + Debug
+            + Clone
             + 'static,
     {
         for test in test_cases {

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -552,8 +552,8 @@ impl<K, D, C> ArrowZSetStream<K, D, C> {
 impl<K, D, C> ArrowStream for ArrowZSetStream<K, D, C>
 where
     K: DBData + From<D>,
-    D: for<'de> DeserializeWithContext<'de, C> + Send + 'static,
-    C: Clone + Send + 'static,
+    D: for<'de> DeserializeWithContext<'de, C> + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     fn insert(&mut self, data: &RecordBatch) -> AnyResult<()> {
         let deserializer = ArrowDeserializer::from_record_batch(data)?;
@@ -951,8 +951,8 @@ impl<K, D, C> ArrowSetStream<K, D, C> {
 impl<K, D, C> ArrowStream for ArrowSetStream<K, D, C>
 where
     K: DBData + From<D>,
-    D: for<'de> DeserializeWithContext<'de, C> + Send + 'static,
-    C: Clone + Send + 'static,
+    D: for<'de> DeserializeWithContext<'de, C> + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
 {
     fn insert(&mut self, data: &RecordBatch) -> AnyResult<()> {
         let deserializer = ArrowDeserializer::from_record_batch(data)?;

--- a/crates/adapters/src/test/datagen.rs
+++ b/crates/adapters/src/test/datagen.rs
@@ -14,7 +14,7 @@ use size_of::SizeOf;
 use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::time::Duration;
-use std::{env, thread};
+use std::{env, fmt::Debug, thread};
 
 #[derive(
     Debug,
@@ -90,8 +90,20 @@ fn mk_pipeline<T, U>(
     fields: Vec<Field>,
 ) -> AnyResult<(Box<dyn InputReader>, MockInputConsumer, MockDeZSet<T, U>)>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
 {
     let relation = Relation::new("test_input".into(), fields, true, BTreeMap::new());
     let (endpoint, consumer, _parser, zset) =

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -19,6 +19,7 @@ use std::hash::Hash;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::{
+    fmt::Debug,
     thread::sleep,
     time::{Duration, Instant},
 };
@@ -99,8 +100,20 @@ pub fn mock_parser_pipeline<T, U>(
     config: &FormatConfig,
 ) -> AnyResult<(MockInputConsumer, MockInputParser, MockDeZSet<T, U>)>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
 {
     let input_handle = <MockDeZSet<T, U>>::new();
     let consumer = MockInputConsumer::new();
@@ -134,8 +147,20 @@ pub fn mock_input_pipeline<T, U>(
     MockDeZSet<T, U>,
 )>
 where
-    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
-    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
+    T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
+    U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Hash
+        + Send
+        + Sync
+        + Debug
+        + Clone
+        + 'static,
 {
     let default_format = FormatConfig {
         name: Cow::from("json"),


### PR DESCRIPTION
Previously we parsed Parquet data by first converting it to JSON, which was highly inefficient. Since this code was written we added support for Arrow-based deserialization to `adapters`. This commit takes advantage of the ArrowStream API to parse Parquet data directly into a stream of RecordBatch's, which is several times more efficient.