### PR TITLE
ci: python: set test execution timeout

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -295,8 +295,8 @@ test-python:
             (./pipeline-manager --bind-address=0.0.0.0 --compiler-working-directory=/working-dir/compiler --runner-working-directory=/working-dir/local-runner --sql-compiler-home=/dbsp/sql-to-dbsp-compiler --dbsp-override-path=/dbsp --db-connection-string=postgresql://postgres:postgres@localhost:5432 --compilation-profile=unoptimized &) && \
             sleep 5 && \
             PYTHONPATH=`pwd` python3 ./tests/aggregate_tests/main.py && \
-            if [ $ALL = "1" ]; then \
-                cd tests && python -m pytest . ; \
+            if [ $all = "1" ]; then \
+                cd tests && python -m pytest . --timeout=300; \
             else \
                 echo "Skipping pytest as --all argument is not set to 1"; \
             fi

--- a/Earthfile
+++ b/Earthfile
@@ -296,7 +296,7 @@ test-python:
             sleep 5 && \
             PYTHONPATH=`pwd` python3 ./tests/aggregate_tests/main.py && \
             if [ $all = "1" ]; then \
-                cd tests && python -m pytest . --timeout=300; \
+                cd tests && python3 -m pytest . --timeout=300; \
             else \
                 echo "Skipping pytest as --all argument is not set to 1"; \
             fi

--- a/python/tests/aggregate_tests/aggtst_base.py
+++ b/python/tests/aggregate_tests/aggtst_base.py
@@ -163,7 +163,7 @@ class TstAccumulator:
             data = table.get_data()
             pipeline.input_json(table.name, data, update_format="insert_delete")
 
-        pipeline.wait_for_completion(shutdown=False)
+        pipeline.wait_for_completion(shutdown=False, timeout_s=3600)
         for view in self.views:
             view.validate(pipeline)
 

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,2 +1,2 @@
 kafka-python-ng==2.2.2
-pytest
+pytest-timeout

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -193,16 +193,16 @@ pub fn t2t(i: Option<Time>) -> Result<Option<Time>, Box<dyn std::error::Error>> 
 pub fn nt2nt(i: Time) -> Result<Time, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn arr2arr(i: Option<Vec<Option<i32>>>) -> Result<Option<Vec<Option<i32>>>, Box<dyn std::error::Error>> {
+pub fn arr2arr(i: Option<Array<Option<i32>>>) -> Result<Option<Array<Option<i32>>>, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn narr2narr(i: Vec<Option<i32>>) -> Result<Vec<Option<i32>>, Box<dyn std::error::Error>> {
+pub fn narr2narr(i: Array<Option<i32>>) -> Result<Array<Option<i32>>, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn map2map(i: Option<BTreeMap<String, Option<String>>>) -> Result<Option<BTreeMap<String, Option<String>>>, Box<dyn std::error::Error>> {
+pub fn map2map(i: Option<Map<SqlString, Option<SqlString>>>) -> Result<Option<Map<SqlString, Option<SqlString>>>, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn nmap2nmap(i: BTreeMap<String, Option<String>>) -> Result<BTreeMap<String, Option<String>>, Box<dyn std::error::Error>> {
+pub fn nmap2nmap(i: Map<SqlString, Option<SqlString>>) -> Result<Map<SqlString, Option<SqlString>>, Box<dyn std::error::Error>> {
     Ok(i)
 }
 pub fn var2var(i: Option<Variant>) -> Result<Option<Variant>, Box<dyn std::error::Error>> {
@@ -217,10 +217,10 @@ pub fn dec2dec(i: Option<Decimal>) -> Result<Option<Decimal>, Box<dyn std::error
 pub fn ndec2ndec(i: Decimal) -> Result<Decimal, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn str2str(i: Option<String>) -> Result<Option<String>, Box<dyn std::error::Error>> {
+pub fn str2str(i: Option<SqlString>) -> Result<Option<SqlString>, Box<dyn std::error::Error>> {
     Ok(i)
 }
-pub fn nstr2nstr(i: String) -> Result<String, Box<dyn std::error::Error>> {
+pub fn nstr2nstr(i: SqlString) -> Result<SqlString, Box<dyn std::error::Error>> {
     Ok(i)
 }
 // pub fn struct2struct(i: Option<struct_1>) -> Result<Option<struct_2>, Box<dyn std::error::Error>> {

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.34.1"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+++ b/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Fixes: #3306

* 5 min for individual tests
* 1 hour for compiling aggregate tests

Also changes the shebang on the bash scripts to `/usr/bin/env bash` instead of `/bin/bash` as it doesn't exist in non Filesystem Hierarchy Standard compliant systems (like NixOS).