### PR TITLE
[adapters] Parsing for avro decimals.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -127,9 +127,9 @@ pub trait ArrowStream: InputBuffer + Send + Sync {
 /// stream.
 #[cfg(feature = "with-avro")]
 pub trait AvroStream: InputBuffer + Send + Sync {
-    fn insert(&mut self, data: &AvroValue) -> AnyResult<()>;
+    fn insert(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()>;
 
-    fn delete(&mut self, data: &AvroValue) -> AnyResult<()>;
+    fn delete(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()>;
 
     /// Create a new deserializer with the same configuration connected to
     /// the same input stream.

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -116,6 +116,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 comfy-table = "7.1.3"
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1", "with-uuid-1", "with-chrono-0_4"]}
+num-bigint = "0.4.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"
@@ -143,5 +144,4 @@ rust_decimal_macros = "1.32"
 mockall = "0.12.1"
 pretty_assertions = "1.4.0"
 feldera-sqllib = { path = "../sqllib" }
-num-bigint = "0.4.4"
 google-cloud-googleapis = "0.15.0"

--- a/crates/adapters/src/format/avro/serializer.rs
+++ b/crates/adapters/src/format/avro/serializer.rs
@@ -935,6 +935,7 @@ mod test {
                 ("foo".to_string(), 1),
                 ("bar".to_string(), 2),
             ])),
+            field_7: rust_decimal::Decimal::new(10000, 3),
         };
 
         let avro2_1: AvroValue = AvroValue::Record(vec![
@@ -965,6 +966,10 @@ mod test {
                         ("bar".to_string(), AvroValue::Long(2)),
                     ]))),
                 ),
+            ),
+            (
+                "dec".to_string(),
+                AvroValue::Decimal(Decimal::from(&BigInt::from(10000).to_signed_bytes_be())),
             ),
         ]);
 

--- a/crates/adapters/src/static_compile/deinput.rs
+++ b/crates/adapters/src/static_compile/deinput.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result as AnyResult};
 #[cfg(feature = "with-avro")]
-use apache_avro::types::Value as AvroValue;
+use apache_avro::{types::Value as AvroValue, Schema as AvroSchema};
 use arrow::array::RecordBatch;
 use dbsp::dynamic::Data;
 use dbsp::{
@@ -661,18 +661,18 @@ where
     K: DBData + From<D>,
     D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
 {
-    fn insert(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: D =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn insert(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: D = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         self.buffer.updates.push(Tup2(K::from(v), 1));
 
         Ok(())
     }
 
-    fn delete(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: D =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn delete(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: D = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         self.buffer.updates.push(Tup2(K::from(v), -1));
 
@@ -1058,18 +1058,18 @@ where
     K: DBData + From<D>,
     D: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Send + Sync + 'static,
 {
-    fn insert(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: D =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn insert(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: D = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         self.buffer.updates.push(Tup2(K::from(v), true));
 
         Ok(())
     }
 
-    fn delete(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: D =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn delete(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: D = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         self.buffer.updates.push(Tup2(K::from(v), false));
 
@@ -1631,9 +1631,9 @@ where
     U: DBData,
     VF: Fn(&V) -> K + Clone + Send + Sync + 'static,
 {
-    fn insert(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: VD =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn insert(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: VD = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         let val = V::from(v);
         self.buffer
@@ -1643,9 +1643,9 @@ where
         Ok(())
     }
 
-    fn delete(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: VD =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn delete(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: VD = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         let val = V::from(v);
         self.buffer

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use anyhow::Result as AnyResult;
-use apache_avro::types::Value as AvroValue;
+use apache_avro::{types::Value as AvroValue, Schema as AvroSchema};
 use arrow::array::RecordBatch;
 use dbsp::DBData;
 use erased_serde::Deserializer as ErasedDeserializer;
@@ -454,16 +454,16 @@ where
     T: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
     U: for<'de> DeserializeWithContext<'de, SqlSerdeConfig> + Hash + Send + Sync + 'static,
 {
-    fn insert(&mut self, data: &AvroValue) -> AnyResult<()> {
-        let v: T =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn insert(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: T = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
         self.updates.push(MockUpdate::Insert(v));
         Ok(())
     }
 
-    fn delete(&mut self, data: &apache_avro::types::Value) -> AnyResult<()> {
-        let v: T =
-            from_avro_value(data).map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
+    fn delete(&mut self, data: &AvroValue, schema: &AvroSchema) -> AnyResult<()> {
+        let v: T = from_avro_value(data, schema)
+            .map_err(|e| anyhow!("error deserializing Avro record: {e}"))?;
 
         self.updates.push(MockUpdate::Delete(v));
         Ok(())


### PR DESCRIPTION
The Avro parser did not previously support parsing decimal values.  The issue was that serde_avro::Decimal stores only the mantissa; scale must be extracted from the schema, so I had to modify the deserializer to thread the schema throughout the deserialization process.

I also simplified the deserializer by removing support for enums, which we don't currently use.  Finally I removed tests that we inherited from `serde_avro`, since they were a pain to maintain, and it's easier to keep extending our own tests in `avro/test.rs`.