### PR TITLE
[adapters] Add operation type to raw Avro messages.

### DIFF
--- a/crates/adapterlib/src/format.rs
+++ b/crates/adapterlib/src/format.rs
@@ -208,8 +208,18 @@ pub trait OutputConsumer: Send {
     fn max_buffer_size_bytes(&self) -> usize;
 
     fn batch_start(&mut self, step: Step);
+
+    /// See OutputEndpoint::push_buffer.
     fn push_buffer(&mut self, buffer: &[u8], num_records: usize);
-    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>, num_records: usize);
+
+    /// See OutputEndpoint::push_key.
+    fn push_key(
+        &mut self,
+        key: Option<&[u8]>,
+        val: Option<&[u8]>,
+        headers: &[(&str, Option<&[u8]>)],
+        num_records: usize,
+    );
     fn batch_end(&mut self);
 }
 

--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -502,14 +502,22 @@ pub trait OutputEndpoint: Send {
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()>;
 
-    /// Output a message consisting of a key/value pair, with optional value.
+    /// Output a message consisting of a key/value pair, with optional headers.
     ///
     /// This API is implemented by Kafka and other transports that transmit
-    /// messages consisting of key and value fields and in invoked by
+    /// messages consisting of key and value fields and is invoked by
     /// Kafka-specific data formats that rely on this message structure,
     /// e.g., Debezium. If a given transport does not implement this API, it
     /// should return an error.
-    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>) -> AnyResult<()>;
+    ///
+    /// `headers` contains a list of key/optional_value pairs to be appended
+    /// to Kafka message headers.
+    fn push_key(
+        &mut self,
+        key: Option<&[u8]>,
+        val: Option<&[u8]>,
+        headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()>;
 
     /// Notifies the output endpoint that output for the current step is
     /// complete.

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -2511,10 +2511,17 @@ impl OutputConsumer for OutputProbe {
         }
     }
 
-    fn push_key(&mut self, key: &[u8], val: Option<&[u8]>, num_records: usize) {
-        let num_bytes = key.len() + val.map(|v| v.len()).unwrap_or_default();
+    fn push_key(
+        &mut self,
+        key: Option<&[u8]>,
+        val: Option<&[u8]>,
+        headers: &[(&str, Option<&[u8]>)],
+        num_records: usize,
+    ) {
+        let num_bytes =
+            key.map(|k| k.len()).unwrap_or_default() + val.map(|v| v.len()).unwrap_or_default();
 
-        match self.endpoint.push_key(key, val) {
+        match self.endpoint.push_key(key, val, headers) {
             Ok(()) => {
                 self.controller
                     .status

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -385,8 +385,12 @@ impl Encoder for JsonEncoder {
                     //     buffer.len() /*std::str::from_utf8(&buffer).unwrap()*/
                     // );
                     if !key_buffer.is_empty() {
-                        self.output_consumer
-                            .push_key(&key_buffer, Some(&buffer), num_records);
+                        self.output_consumer.push_key(
+                            Some(&key_buffer),
+                            Some(&buffer),
+                            &[],
+                            num_records,
+                        );
                     } else {
                         self.output_consumer.push_buffer(&buffer, num_records);
                     }
@@ -405,7 +409,7 @@ impl Encoder for JsonEncoder {
             }
             if !key_buffer.is_empty() {
                 self.output_consumer
-                    .push_key(&key_buffer, Some(&buffer), num_records);
+                    .push_key(Some(&key_buffer), Some(&buffer), &[], num_records);
             } else {
                 self.output_consumer.push_buffer(&buffer, num_records);
             }
@@ -634,7 +638,7 @@ mod test {
                     .lock()
                     .unwrap()
                     .iter()
-                    .filter_map(|(_k, v)| v.clone())
+                    .filter_map(|(_k, v, _headers)| v.clone())
                     .flatten()
                     .collect::<Vec<_>>()
             )
@@ -645,7 +649,7 @@ mod test {
             .lock()
             .unwrap()
             .iter()
-            .filter_map(|(_k, v)| v.clone())
+            .filter_map(|(_k, v, _headers)| v.clone())
             .flatten()
             .collect::<Vec<_>>();
         let deserializer = serde_json::Deserializer::from_slice(&consumer_data);
@@ -793,7 +797,7 @@ mod test {
             .lock()
             .unwrap()
             .iter()
-            .map(|(k, v)| {
+            .map(|(k, v, _headers)| {
                 (
                     k.clone()
                         .map(|k| (serde_json::from_slice::<serde_json::Value>(&k).unwrap())),

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -177,7 +177,7 @@ fn parquet_output() {
             .lock()
             .unwrap()
             .iter()
-            .filter_map(|(_k, v)| v.clone())
+            .filter_map(|(_k, v, _headers)| v.clone())
             .flatten()
             .collect(),
     );
@@ -186,7 +186,7 @@ fn parquet_output() {
         .lock()
         .unwrap()
         .iter()
-        .filter_map(|(_k, v)| v.clone())
+        .filter_map(|(_k, v, _headers)| v.clone())
         .flatten()
         .collect::<Vec<_>>();
 

--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -410,7 +410,13 @@ impl OutputConsumer for DeltaTableWriter {
         unreachable!()
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>, _num_records: usize) {
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+        _num_records: usize,
+    ) {
         unreachable!()
     }
 
@@ -508,7 +514,12 @@ impl OutputEndpoint for DeltaTableWriter {
         unreachable!()
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
         unreachable!()
     }
 

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -271,7 +271,12 @@ impl OutputEndpoint for FileOutputEndpoint {
         Ok(())
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
         bail!(
             "File output transport does not support key-value pairs. \
 This output endpoint was configured with a data format that produces outputs as key-value pairs; \

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -278,7 +278,12 @@ impl OutputEndpoint for HttpOutputEndpoint {
             .push_buffer(Some(buffer), self.inner.backpressure)
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
         bail!(
             "HTTP output transport does not support key-value pairs. \
 This output endpoint was configured with a data format that produces outputs as key-value pairs; \

--- a/crates/adapters/src/transport/kafka/ft/output.rs
+++ b/crates/adapters/src/transport/kafka/ft/output.rs
@@ -249,7 +249,12 @@ impl OutputEndpoint for KafkaOutputEndpoint {
         Ok(())
     }
 
-    fn push_key(&mut self, _key: &[u8], _val: Option<&[u8]>) -> AnyResult<()> {
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
         todo!()
     }
 

--- a/docs/formats/avro.md
+++ b/docs/formats/avro.md
@@ -6,8 +6,9 @@ See [top-level connector documentation](/connectors/) for general information
 about configuring input and output connectors.
 :::
 
-Feldera supports sending and receiving data in the Avro format. While Avro-encoded messages are commonly
-transmitted over Kafka, any other supported [transport](/connectors/) can be used.
+Feldera supports sending and receiving data in the Avro format. We currently only support
+the Avro format in conjunction with Kafka [source](/connectors/sources/kafka) and
+[sink](/connectors/sinks/kafka) transport connectors.
 Avro is a strongly-typed format that requires a shared **schema** between the sender and receiver for successful
 data encoding and decoding.
 
@@ -23,9 +24,12 @@ include only schema identifiers:
 We support several Avro-based formats:
 
 * **Raw** - every message contains a single Avro-encoded record that represents a row in a SQL
-  table or view. This format does not carry any additional metadata that can be used to distinguish
-  inserts and deletes.  It is therefore only suitable for representing inserts and upserts, but not
-  deletions.
+  table or view.
+  * **Raw input**: An input connector configured with the raw Avro format treats all
+    incoming messages as inserts.
+  * **Raw output**: An output connector configured with the Raw Avro format includes an operation type
+   (`"op"`) as a header in each output Kafka message: `"op": "insert"` represents an insertion and
+   `"op": "delete"` representa a deletion.
 
 * **Debezium** (input only) - used to synchronize a Feldera table with an external database using
   [Debezium](https://debezium.io/).  See [Debezium source connector documentation](/connectors/sources/debezium)


### PR DESCRIPTION
Previously, the Avro encoder simply dropped deletions in raw mode. This commit changes the behavior to output both insertions and deletions, and use a Kafka header to encode operation type. I can imagine making this behavior more configurable, but I think this is strictly an improvement compared to silently dropping deletes.