### PR TITLE
pipeline-manager: increase HTTP ingress timeout to 300s

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -113,7 +113,7 @@ async fn http_input(
             &endpoint,
             req,
             body,
-            None,
+            Some(Duration::from_secs(300)),
         )
         .await
 }


### PR DESCRIPTION
This will allow larger (Parquet) file upload using the ingress endpoint.