### PR TITLE
[dbsp] trace: Change `Builder` to reduce copying and comparing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3723,7 +3723,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "indicatif",
  "io-uring",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "libc",
  "metrics",
  "mimalloc-rust-sys",
@@ -6222,6 +6222,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.9.0"
 hashbrown = "0.14.2"
 csv = { version = "1.2.2" }
 impl-trait-for-tuples = "0.2"
-itertools = "0.10.5"
+itertools = "0.14.0"
 textwrap = "0.15.0"
 ordered-float = { version = "3.9.1", features = ["serde", "rkyv_64"] }
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }

--- a/crates/dbsp/src/algebra/zset/mod.rs
+++ b/crates/dbsp/src/algebra/zset/mod.rs
@@ -167,16 +167,21 @@ where
 {
     fn distinct(&self) -> Self {
         let factories = self.factories();
-        let mut builder = Self::Builder::with_capacity(&factories, (), self.key_count());
+        let mut builder = Self::Builder::with_capacity(&factories, self.key_count());
         let mut cursor = self.cursor();
 
         while cursor.key_valid() {
+            let mut n_updates = 0;
             while cursor.val_valid() {
                 let weight = cursor.weight();
                 if weight.ge0() {
-                    builder.push_refs(cursor.key(), cursor.val(), ZWeight::one().erase());
+                    builder.push_val_diff(cursor.val(), ZWeight::one().erase());
+                    n_updates += 1;
                 }
                 cursor.step_val();
+            }
+            if n_updates > 0 {
+                builder.push_key(cursor.key());
             }
             cursor.step_key();
         }

--- a/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
@@ -126,7 +126,7 @@ where
         let mut delta_cursor = delta.cursor();
         let mut output_trace_cursor = output_trace.cursor();
 
-        let mut builder = OZ::Builder::with_capacity(&self.output_factories, (), delta.len());
+        let mut builder = OZ::Builder::with_capacity(&self.output_factories, delta.len());
 
         let mut old = self.output_factories.val_factory().default_box();
         let mut new = self.output_factories.val_factory().default_box();
@@ -170,18 +170,21 @@ where
             if retract {
                 match new.cmp(&old) {
                     Ordering::Less => {
-                        builder.push_refs(&key, &new, (1 as ZWeight).erase());
-                        builder.push_vals(&mut key, &mut old, (-1 as ZWeight).erase_mut());
+                        builder.push_val_diff_mut(&mut new, (1 as ZWeight).erase_mut());
+                        builder.push_val_diff_mut(&mut old, (-1 as ZWeight).erase_mut());
+                        builder.push_key_mut(&mut key);
                     }
                     Ordering::Greater => {
-                        builder.push_refs(&key, &old, (-1 as ZWeight).erase());
-                        builder.push_vals(&mut key, &mut new, (1 as ZWeight).erase_mut());
+                        builder.push_val_diff_mut(&mut old, (-1 as ZWeight).erase_mut());
+                        builder.push_val_diff_mut(&mut new, (1 as ZWeight).erase_mut());
+                        builder.push_key_mut(&mut key);
                     }
                     _ => (),
                 }
                 // do nothing if new == old.
             } else {
-                builder.push_vals(&mut key, &mut new, 1.erase_mut());
+                builder.push_val_diff_mut(&mut new, 1.erase_mut());
+                builder.push_key_mut(&mut key);
             }
 
             delta_cursor.step_key();

--- a/crates/dbsp/src/operator/dynamic/group/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/group/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     trace::{
         cursor::{CursorEmpty, CursorGroup, CursorPair},
         BatchFactories, BatchReaderFactories, Builder, Cursor, OrdIndexedWSetFactories, Spine,
+        TupleBuilder,
     },
     Circuit, DynZWeight, RootCircuit, Stream,
 };
@@ -399,7 +400,10 @@ where
         let mut input_trace_cursor = input_trace.cursor();
         let mut output_trace_cursor = output_trace.cursor();
 
-        let mut builder = OB::Builder::with_capacity(&self.output_factories, (), delta.len());
+        let mut builder = TupleBuilder::new(
+            &self.output_factories,
+            OB::Builder::with_capacity(&self.output_factories, delta.len()),
+        );
 
         while delta_cursor.key_valid() {
             let key = clone_box(delta_cursor.key());
@@ -410,7 +414,7 @@ where
             let mut cb_asc = |val: &mut OB::Val, w: &mut B::R| {
                 key.clone_to(&mut key2);
                 // println!("val: {val:?}, w: {w:?}");
-                builder.push_vals(&mut key2, val, w);
+                builder.push_vals(&mut key2, val, &mut (), w);
             };
             // Output callback that pushes to an intermediate buffer.
             let mut cb_desc = |val: &mut OB::Val, w: &mut B::R| {

--- a/crates/dbsp/src/operator/dynamic/input.rs
+++ b/crates/dbsp/src/operator/dynamic/input.rs
@@ -1051,7 +1051,6 @@ mod test {
                 let mut cursor = batch.inner().cursor();
                 let mut result = <DynOrdZSet<DynData> as DynBatch>::Builder::with_capacity(
                     &BatchReaderFactories::new::<u64, (), ZWeight>(),
-                    (),
                     batch.len(),
                 );
 
@@ -1060,7 +1059,8 @@ mod test {
                         .weight()
                         .downcast_checked::<ZWeight>()
                         .mul(nworkers as i64);
-                    result.push_refs(cursor.key(), ().erase(), w.erase());
+                    result.push_val_diff(().erase(), w.erase());
+                    result.push_key(cursor.key());
                     cursor.step_key();
                 }
                 TypedBatch::new(result.done())

--- a/crates/dbsp/src/operator/dynamic/join.rs
+++ b/crates/dbsp/src/operator/dynamic/join.rs
@@ -959,7 +959,7 @@ where
 
         // Choose capacity heuristically.
         let mut builder =
-            Z::Builder::with_capacity(&self.output_factories, (), min(i1.len(), i2.len()));
+            Z::Builder::with_capacity(&self.output_factories, min(i1.len(), i2.len()));
 
         let mut output = output_key_factory.default_box();
 
@@ -977,12 +977,9 @@ where
 
                             (self.join_func)(cursor1.key(), v1, v2, output.as_mut());
 
-                            Builder::push_vals(
-                                &mut builder,
-                                output.as_mut(),
-                                ().erase_mut(),
-                                w1.mul_by_ref(&w2).erase_mut(),
-                            );
+                            builder
+                                .push_val_diff_mut(().erase_mut(), w1.mul_by_ref(&w2).erase_mut());
+                            builder.push_key_mut(output.as_mut());
                             cursor2.step_val();
                         }
 

--- a/crates/dbsp/src/operator/dynamic/neighborhood.rs
+++ b/crates/dbsp/src/operator/dynamic/neighborhood.rs
@@ -9,6 +9,7 @@ use crate::{
     trace::{
         ord::fallback::indexed_wset::{FallbackIndexedWSet, FallbackIndexedWSetFactories},
         Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, Spine,
+        TupleBuilder,
     },
     utils::Tup2,
     Circuit, DBData, DynZWeight, NumEntries, RootCircuit, Stream, ZWeight,
@@ -422,11 +423,11 @@ where
             }
 
             // Assemble final result.
-            let mut builder = <<OrdIndexedZSet<_, _> as Batch>::Builder>::with_capacity(
+            let builder = <<OrdIndexedZSet<_, _> as Batch>::Builder>::with_capacity(
                 &self.output_factories,
-                (),
                 before.len() + after.len(),
             );
+            let mut builder = TupleBuilder::new(&self.output_factories, builder);
             for update in before.dyn_iter_mut().rev() {
                 builder.push(update);
             }
@@ -559,11 +560,11 @@ where
                 }
             }
 
-            let mut builder = <<DynNeighborhood<T::Key, T::Val> as Batch>::Builder>::with_capacity(
+            let builder = <<DynNeighborhood<T::Key, T::Val> as Batch>::Builder>::with_capacity(
                 &self.output_factories,
-                (),
                 before.len() + after.len(),
             );
+            let mut builder = TupleBuilder::new(&self.output_factories, builder);
             for update in before.dyn_iter_mut().rev() {
                 builder.push(update);
             }

--- a/crates/dbsp/src/operator/dynamic/sample.rs
+++ b/crates/dbsp/src/operator/dynamic/sample.rs
@@ -138,12 +138,12 @@ where
                 } else {
                     let mut builder = <<VecZSet<_> as Batch>::Builder>::with_capacity(
                         &output_factories,
-                        (),
                         num_quantiles,
                     );
                     for i in 0..num_quantiles {
                         let key = &sample.layer.keys[(i * sample_size) / num_quantiles];
-                        builder.push_refs(key, ().erase(), ZWeight::one().erase());
+                        builder.push_val_diff(().erase(), ZWeight::one().erase());
+                        builder.push_key(key);
                     }
                     builder.done()
                 }
@@ -172,12 +172,12 @@ where
                 } else {
                     let mut builder = <<VecZSet<_> as Batch>::Builder>::with_capacity(
                         &factories.output_factories,
-                        (),
                         num_quantiles,
                     );
                     for i in 0..num_quantiles {
                         let key = &sample.layer.keys[(i * sample_size) / num_quantiles];
-                        builder.push_refs(key, ().erase(), ZWeight::one().erase());
+                        builder.push_val_diff(().erase(), ZWeight::one().erase());
+                        builder.push_key(key);
                     }
                     builder.done()
                 }
@@ -233,11 +233,11 @@ where
 
             let mut builder = <<VecZSet<_> as Batch>::Builder>::with_capacity(
                 &self.output_factories,
-                (),
                 sample.len(),
             );
             for key in sample.dyn_iter_mut() {
-                builder.push_vals(key, ().erase_mut(), ZWeight::one().erase_mut());
+                builder.push_val_diff(().erase(), ZWeight::one().erase());
+                builder.push_key_mut(key);
             }
             builder.done()
         } else {
@@ -308,7 +308,6 @@ where
 
             let mut builder = <<VecZSet<_> as Batch>::Builder>::with_capacity(
                 &self.output_factories,
-                (),
                 sample_size,
             );
 
@@ -320,11 +319,8 @@ where
                 while cursor.val_valid() {
                     if !cursor.weight().is_zero() {
                         item.from_refs(key, cursor.val());
-                        builder.push_refs(
-                            item.as_mut(),
-                            ().erase_mut(),
-                            ZWeight::one().erase_mut(),
-                        );
+                        builder.push_val_diff(().erase(), ZWeight::one().erase());
+                        builder.push_key_mut(item.as_mut());
                         break;
                     }
                     cursor.step_val();

--- a/crates/dbsp/src/operator/dynamic/semijoin.rs
+++ b/crates/dbsp/src/operator/dynamic/semijoin.rs
@@ -130,7 +130,7 @@ where
 
         // Choose capacity heuristically.
         let mut builder =
-            Out::Builder::with_capacity(&self.output_factories, (), min(pairs.len(), keys.len()));
+            Out::Builder::with_capacity(&self.output_factories, min(pairs.len(), keys.len()));
 
         // While both keys are valid
         while key_cursor.key_valid() && pair_cursor.key_valid() {
@@ -151,7 +151,8 @@ where
                         item.from_refs(pair_cursor.key(), pair_cursor.val());
 
                         // Add to our output batch
-                        builder.push_vals(item.as_mut(), ().erase_mut(), kv_weight.erase_mut());
+                        builder.push_val_diff_mut(().erase_mut(), kv_weight.erase_mut());
+                        builder.push_key_mut(item.as_mut());
                         pair_cursor.step_val();
                     }
 

--- a/crates/dbsp/src/operator/dynamic/upsert.rs
+++ b/crates/dbsp/src/operator/dynamic/upsert.rs
@@ -8,7 +8,9 @@ use crate::{
     operator::dynamic::trace::{
         DelayedTraceId, TraceAppend, TraceBounds, TraceId, ValSpine, Z1Trace,
     },
-    trace::{Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor},
+    trace::{
+        Batch, BatchFactories, BatchReader, BatchReaderFactories, Builder, Cursor, TupleBuilder,
+    },
     Circuit, DBData, Stream, Timestamp, ZWeight,
 };
 use minitrace::trace;
@@ -319,7 +321,8 @@ where
 
         let mut trace_cursor = trace.cursor();
 
-        let mut builder = B::Builder::with_capacity(&self.batch_factories, (), updates.len() * 2);
+        let builder = B::Builder::with_capacity(&self.batch_factories, updates.len() * 2);
+        let mut builder = TupleBuilder::new(&self.batch_factories, builder);
 
         let val_filter = self.bounds.effective_val_filter();
         let key_filter = self.bounds.effective_key_filter();

--- a/crates/dbsp/src/trace/layers/leaf.rs
+++ b/crates/dbsp/src/trace/layers/leaf.rs
@@ -123,6 +123,25 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> Leaf<K, R> {
         result
     }
 
+    pub fn from_parts(
+        factories: &LeafFactories<K, R>,
+        mut keys: Box<DynVec<K>>,
+        mut diffs: Box<DynVec<R>>,
+    ) -> Self {
+        debug_assert_eq!(keys.len(), diffs.len());
+        if keys.spare_capacity() >= keys.len() / 10 {
+            keys.shrink_to_fit();
+        }
+        if diffs.spare_capacity() >= diffs.len() / 10 {
+            diffs.shrink_to_fit();
+        }
+        Self {
+            factories: factories.clone(),
+            keys,
+            diffs,
+        }
+    }
+
     // FIXME: We need to do some extra stuff for zsts
     pub fn len(&self) -> usize {
         debug_assert_eq!(self.keys.len(), self.diffs.len());

--- a/crates/dbsp/src/trace/layers/mod.rs
+++ b/crates/dbsp/src/trace/layers/mod.rs
@@ -22,6 +22,7 @@ pub trait OrdOffset:
     Copy
     + Debug
     + PartialEq
+    + PartialOrd
     + Add<Output = Self>
     + Sub<Output = Self>
     + TryFrom<usize>
@@ -44,6 +45,7 @@ where
     O: Copy
         + Debug
         + PartialEq
+        + PartialOrd
         + Add<Output = Self>
         + Sub<Output = Self>
         + TryFrom<usize>

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -6,13 +6,12 @@ use crate::{
     },
     time::{Antichain, AntichainRef},
     trace::{
-        cursor::{HasTimeDiffCursor, TimeDiffCursor},
         layers::{
-            Builder as _, Cursor as _, Layer, LayerBuilder, LayerCursor, LayerFactories, Leaf,
-            LeafBuilder, LeafCursor, LeafFactories, MergeBuilder, OrdOffset, Trie, TupleBuilder,
+            Builder as _, Cursor as _, Layer, LayerCursor, LayerFactories, Leaf, LeafFactories,
+            MergeBuilder, OrdOffset, Trie,
         },
         Batch, BatchFactories, BatchLocation, BatchReader, BatchReaderFactories, Builder, Cursor,
-        Deserializer, Filter, Merger, Serializer, TimedBuilder,
+        Deserializer, Filter, Merger, Serializer,
     },
     utils::{ConsolidatePairedSlices, Tup2},
     DBData, DBWeight, NumEntries, Timestamp,
@@ -39,6 +38,7 @@ where
     consolidate_weights: &'static dyn ConsolidatePairedSlices<DynDataTyped<T>, R>,
     weighted_item_factory: &'static dyn Factory<DynPair<DynPair<K, V>, R>>,
     weighted_items_factory: &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>>,
+    weighted_vals_factory: &'static dyn Factory<DynWeightedPairs<V, R>>,
     time_diffs_factory: &'static dyn Factory<DynWeightedPairs<DynDataTyped<T>, R>>,
 }
 
@@ -56,6 +56,7 @@ where
             consolidate_weights: self.consolidate_weights,
             weighted_item_factory: self.weighted_item_factory,
             weighted_items_factory: self.weighted_items_factory,
+            weighted_vals_factory: self.weighted_vals_factory,
             time_diffs_factory: self.time_diffs_factory,
         }
     }
@@ -92,6 +93,7 @@ where
             weighted_item_factory: WithFactory::<Tup2<Tup2<KType, VType>, RType>>::FACTORY,
             weighted_items_factory:
                 WithFactory::<LeanVec<Tup2<Tup2<KType, VType>, RType>>>::FACTORY,
+            weighted_vals_factory: WithFactory::<LeanVec<Tup2<VType, RType>>>::FACTORY,
             time_diffs_factory: WithFactory::<LeanVec<Tup2<T, RType>>>::FACTORY,
         }
     }
@@ -132,6 +134,10 @@ where
 
     fn weighted_items_factory(&self) -> &'static dyn Factory<DynWeightedPairs<DynPair<K, V>, R>> {
         self.weighted_items_factory
+    }
+
+    fn weighted_vals_factory(&self) -> &'static dyn Factory<DynWeightedPairs<V, R>> {
+        self.weighted_vals_factory
     }
 
     fn time_diffs_factory(
@@ -720,49 +726,6 @@ where
     }
 }
 
-pub struct VecValTimeDiffCursor<'a, T, R>(LeafCursor<'a, DynDataTyped<T>, R>)
-where
-    T: Timestamp,
-    R: WeightTrait + ?Sized;
-
-impl<'a, T, R> TimeDiffCursor<'a, T, R> for VecValTimeDiffCursor<'a, T, R>
-where
-    T: Timestamp,
-    R: WeightTrait + ?Sized,
-{
-    fn current(&mut self, _tmp: &mut R) -> Option<(&T, &R)> {
-        if self.0.valid() {
-            Some((self.0.current_key(), self.0.current_diff()))
-        } else {
-            None
-        }
-    }
-    fn step(&mut self) {
-        self.0.step()
-    }
-}
-
-impl<K, V, T, R, O> HasTimeDiffCursor<K, V, T, R> for VecValCursor<'_, K, V, T, R, O>
-where
-    K: DataTrait + ?Sized,
-    V: DataTrait + ?Sized,
-    T: Timestamp,
-    R: WeightTrait + ?Sized,
-    O: OrdOffset,
-{
-    type TimeDiffCursor<'a>
-        = VecValTimeDiffCursor<'a, T, R>
-    where
-        Self: 'a;
-
-    fn time_diff_cursor(&self) -> Self::TimeDiffCursor<'_> {
-        VecValTimeDiffCursor(self.cursor.child.values())
-    }
-}
-
-type RawVecValBuilder<K, V, T, R, O> =
-    LayerBuilder<K, LayerBuilder<V, LeafBuilder<DynDataTyped<T>, R>, O>, O>;
-
 /// A builder for creating layers from unsorted update tuples.
 #[derive(SizeOf)]
 pub struct VecValBuilder<K, V, T, R, O = usize>
@@ -773,18 +736,17 @@ where
     T: Timestamp,
     O: OrdOffset,
 {
-    time: T,
-    builder: RawVecValBuilder<K, V, T, R, O>,
     #[size_of(skip)]
     factories: VecValBatchFactories<K, V, T, R>,
-    // #[size_of(skip)]
-    // item_factory: &'static PairVTable<K, V>,
-    // #[size_of(skip)]
-    // weighted_item_factory: &'static WeightedVTable<Pair<K, V>, R>,
-    // batch_item_factory: &'static BatchItemVTable<K, V, Pair<K, V>, R>,
+    keys: Box<DynVec<K>>,
+    offs: Vec<O>,
+    vals: Box<DynVec<V>>,
+    val_offs: Vec<O>,
+    times: Box<DynVec<DynDataTyped<T>>>,
+    diffs: Box<DynVec<R>>,
 }
 
-impl<K, V, T, R, O> TimedBuilder<VecValBatch<K, V, T, R, O>> for VecValBuilder<K, V, T, R, O>
+impl<K, V, T, R, O> VecValBuilder<K, V, T, R, O>
 where
     K: DataTrait + ?Sized,
     V: DataTrait + ?Sized,
@@ -792,21 +754,16 @@ where
     T: Timestamp,
     O: OrdOffset,
 {
-    fn push_time(&mut self, key: &K, val: &V, time: &T, weight: &R) {
-        self.builder.push_refs((key, (val, (time, weight))));
+    fn pushed_key(&mut self) {
+        let off = O::from_usize(self.vals.len());
+        debug_assert!(off > *self.offs.last().unwrap());
+        self.offs.push(off);
     }
 
-    fn done_with_bounds(
-        self,
-        lower: Antichain<T>,
-        upper: Antichain<T>,
-    ) -> VecValBatch<K, V, T, R, O> {
-        VecValBatch {
-            layer: self.builder.done(),
-            lower,
-            upper,
-            factories: self.factories,
-        }
+    fn pushed_val(&mut self) {
+        let val_off = O::from_usize(self.times.len());
+        debug_assert!(val_off > *self.val_offs.last().unwrap());
+        self.val_offs.push(val_off);
     }
 }
 
@@ -819,73 +776,96 @@ where
     T: Timestamp,
     O: OrdOffset,
 {
-    #[inline]
-    fn new_builder(factories: &VecValBatchFactories<K, V, T, R>, time: T) -> Self {
+    fn with_capacity(factories: &VecValBatchFactories<K, V, T, R>, capacity: usize) -> Self {
+        let mut keys = factories.layer_factories.keys.default_box();
+        keys.reserve_exact(capacity);
+
+        let mut offs = Vec::with_capacity(capacity + 1);
+        offs.push(O::zero());
+
+        let mut vals = factories.layer_factories.child.keys.default_box();
+        vals.reserve_exact(capacity);
+
+        let mut val_offs = Vec::with_capacity(capacity + 1);
+        val_offs.push(O::zero());
+
+        let mut times = factories.layer_factories.child.child.keys.default_box();
+        times.reserve_exact(capacity);
+
+        let mut diffs = factories.layer_factories.child.child.diffs.default_box();
+        diffs.reserve_exact(capacity);
         Self {
-            time,
-            builder: RawVecValBuilder::<K, V, T, R, O>::new(&factories.layer_factories),
             factories: factories.clone(),
-            // item_factory: factories.item_factory,
-            // weighted_item_factory: factories.weighted_item_factory,
-            // batch_item_factory: factories.batch_item_factory,
+            keys,
+            offs,
+            vals,
+            val_offs,
+            times,
+            diffs,
         }
     }
 
-    #[inline]
-    fn with_capacity(factories: &VecValBatchFactories<K, V, T, R>, time: T, cap: usize) -> Self {
-        Self {
-            time,
-            builder: <RawVecValBuilder<K, V, T, R, O> as TupleBuilder>::with_capacity(
-                &factories.layer_factories,
-                cap,
-            ),
-            factories: factories.clone(),
-            // item_factory: factories.item_factory,
-            // weighted_item_factory: factories.weighted_item_factory,
-            // batch_item_factory: factories.batch_item_factory,
-        }
-    }
-
-    #[inline]
     fn reserve(&mut self, additional: usize) {
-        self.builder.reserve(additional);
+        self.keys.reserve(additional);
+        self.offs.reserve(additional);
+        self.vals.reserve(additional);
+        self.times.reserve(additional);
+        self.diffs.reserve(additional);
     }
 
-    #[inline]
-    fn push(&mut self, kvr: &mut DynPair<DynPair<K, V>, R>) {
-        let (kv, r) = kvr.split_mut();
-        let (k, v) = kv.split_mut();
-        self.builder
-            .push_tuple((k, (v, (&mut self.time.clone(), r))));
+    fn push_key(&mut self, key: &K) {
+        self.keys.push_ref(key);
+        self.pushed_key();
     }
 
-    #[inline]
-    fn push_refs(&mut self, key: &K, val: &V, weight: &R) {
-        self.builder.push_refs((key, (val, (&self.time, weight))));
+    fn push_key_mut(&mut self, key: &mut K) {
+        self.keys.push_val(key);
+        self.pushed_key();
     }
 
-    #[inline]
-    fn push_vals(&mut self, key: &mut K, val: &mut V, weight: &mut R) {
-        self.builder
-            .push_tuple((key, (val, (&mut self.time.clone(), weight))));
+    fn push_val(&mut self, val: &V) {
+        self.vals.push_ref(val);
+        self.pushed_val();
     }
 
-    #[inline(never)]
-    fn done(self) -> VecValBatch<K, V, T, R, O> {
-        let time_next = self.time.advance(0);
-        let upper = if time_next <= self.time {
-            Antichain::new()
-        } else {
-            Antichain::from_elem(time_next)
-        };
+    fn push_val_mut(&mut self, val: &mut V) {
+        self.vals.push_val(val);
+        self.pushed_val();
+    }
+
+    fn push_time_diff(&mut self, time: &T, weight: &R) {
+        self.times.push(time.clone());
+        self.diffs.push_ref(weight);
+    }
+
+    fn push_time_diff_mut(&mut self, time: &mut T, weight: &mut R) {
+        self.times.push(time.clone());
+        self.diffs.push_val(weight);
+    }
+
+    fn done_with_bounds(
+        self,
+        (lower, upper): (Antichain<T>, Antichain<T>),
+    ) -> VecValBatch<K, V, T, R, O> {
         VecValBatch {
-            layer: self.builder.done(),
-            lower: Antichain::from_elem(self.time),
-            upper,
+            layer: Layer::from_parts(
+                &self.factories.layer_factories,
+                self.keys,
+                self.offs,
+                Layer::from_parts(
+                    &self.factories.layer_factories.child,
+                    self.vals,
+                    self.val_offs,
+                    Leaf::from_parts(
+                        &self.factories.layer_factories.child.child,
+                        self.times,
+                        self.diffs,
+                    ),
+                ),
+            ),
             factories: self.factories,
-            // item_factory: self.item_factory,
-            // weighted_item_factory: self.weighted_item_factory,
-            // batch_item_factory: self.batch_item_factory,
+            upper,
+            lower,
         }
     }
 }


### PR DESCRIPTION
The `Builder` trait requires the implementation to internally compare any key and value pushed in against the previous ones, and some implementations to keep a copy of the previous key and value as well.  This is unneeded overhead in most cases, since usually the client knows whether the key and value passed in are different from the previous one.  This commit changes the interface to require the client to group keys and values.

This yielded a modest performance improvement in my tests.