### PR TITLE
py: support disabling SSL verification

### DIFF
--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -10,6 +10,7 @@ from feldera.rest.errors import (
 
 import json
 import requests
+from requests.packages import urllib3
 from typing import Callable, Optional, Any, Union, Mapping, Sequence, List
 
 
@@ -22,6 +23,11 @@ class HttpRequests:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.headers = {"User-Agent": "feldera-python-sdk/v1"}
+        self.requests_verify = config.requests_verify
+
+        if not self.requests_verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         if self.config.api_key:
             self.headers["Authorization"] = f"Bearer {self.config.api_key}"
 
@@ -69,6 +75,7 @@ class HttpRequests:
                     headers=headers,
                     params=params,
                     stream=stream,
+                    verify=self.requests_verify,
                 )
             elif isinstance(body, bytes):
                 request = http_method(
@@ -78,6 +85,7 @@ class HttpRequests:
                     data=body,
                     params=params,
                     stream=stream,
+                    verify=self.requests_verify,
                 )
             else:
                 request = http_method(
@@ -87,6 +95,7 @@ class HttpRequests:
                     data=json_serialize(body) if serialize else body,
                     params=params,
                     stream=stream,
+                    verify=self.requests_verify,
                 )
 
             resp = self.__validate(request, stream=stream)

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -12,15 +12,19 @@ class Config:
         api_key: Optional[str] = None,
         version: Optional[str] = None,
         timeout: Optional[float] = None,
+        requests_verify: bool = True,
     ) -> None:
         """
         :param url: The url to the Feldera API (ex: https://try.feldera.com)
         :param api_key: The optional API key to access Feldera
         :param version: The version of the API to use
         :param timeout: The timeout for the HTTP requests
+        :param requests_verify: The `verify` parameter passed to the requests
+            library. `True` by default.
         """
 
         self.url: str = url
         self.api_key: Optional[str] = api_key
         self.version: Optional[str] = version or "v0"
         self.timeout: Optional[float] = timeout
+        self.requests_verify: bool = requests_verify

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -40,7 +40,9 @@ class FelderaClient:
             library. `True` by default.
         """
 
-        self.config = Config(url, api_key, timeout=timeout, requests_verify=requests_verify)
+        self.config = Config(
+            url, api_key, timeout=timeout, requests_verify=requests_verify
+        )
         self.http = HttpRequests(self.config)
 
         try:

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -29,15 +29,18 @@ class FelderaClient:
         url: str,
         api_key: Optional[str] = None,
         timeout: Optional[float] = None,
+        requests_verify: bool = True,
     ) -> None:
         """
         :param url: The url to Feldera API (ex: https://try.feldera.com)
         :param api_key: The optional API key for Feldera
         :param timeout: (optional) The amount of time in seconds that the client will wait for a response before timing
             out.
+        :param requests_verify: The `verify` parameter passed to the requests
+            library. `True` by default.
         """
 
-        self.config = Config(url, api_key, timeout=timeout)
+        self.config = Config(url, api_key, timeout=timeout, requests_verify=requests_verify)
         self.http = HttpRequests(self.config)
 
         try:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -80,7 +80,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Adds parameter `requests_verify` to `FelderaClient`, this parameter is passed to the requests package while making HTTP requests.

If `requests_verify` is set to `False` then, SSL warnings are suppressed. `requests_verify` is set to `True` by default.