### PR TITLE
[adapters] Automatic connector orchestration.

### DIFF
--- a/crates/adapters/src/adhoc/table.rs
+++ b/crates/adapters/src/adhoc/table.rs
@@ -284,6 +284,8 @@ impl DataSink for AdHocTableSink {
                 max_batch_size: default_max_batch_size(),
                 max_queued_records: default_max_queued_records(),
                 paused: false,
+                labels: vec![],
+                start_after: None,
             },
         };
 

--- a/crates/adapters/src/controller/validate.rs
+++ b/crates/adapters/src/controller/validate.rs
@@ -1,0 +1,162 @@
+use std::collections::{BTreeMap, HashSet};
+
+use feldera_adapterlib::errors::controller::ConfigError;
+use feldera_types::config::PipelineConfig;
+
+pub fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
+    let mut dependencies = Vec::new();
+
+    for (endpoint_name, input) in config.inputs.iter() {
+        if let Some(start_after) = input.connector_config.start_after.as_ref() {
+            if start_after.is_empty() {
+                return Err(ConfigError::empty_start_after(endpoint_name));
+            }
+            for start_after in start_after.iter() {
+                for label in input.connector_config.labels.iter() {
+                    dependencies.push((
+                        endpoint_name.to_string(),
+                        label.clone(),
+                        start_after.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // check for cycles
+    if let Some(cycle) = find_cycle(&dependencies) {
+        return Err(ConfigError::cyclic_dependency(cycle));
+    }
+
+    Ok(())
+}
+
+/// Detect the first cycle in a directed graph
+fn find_cycle(edges: &[(String, String, String)]) -> Option<Vec<(String, String)>> {
+    let mut graph: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+
+    // Build adjacency list from edge list
+    for (endpoint, u, v) in edges {
+        graph
+            .entry(u.clone())
+            .or_default()
+            .push((endpoint.clone(), v.clone()));
+    }
+
+    let mut visited = HashSet::new();
+    let mut recursion_stack = Vec::new();
+    let mut stack_set = HashSet::new(); // For quick lookup in the stack
+
+    fn dfs(
+        node: &str,
+        graph: &BTreeMap<String, Vec<(String, String)>>,
+        visited: &mut HashSet<String>,
+        recursion_stack: &mut Vec<(String, String)>,
+        stack_set: &mut HashSet<String>,
+    ) -> Option<Vec<(String, String)>> {
+        if stack_set.contains(node) {
+            // Cycle detected → extract the cycle from the stack
+            let pos = recursion_stack.iter().position(|x| x.1 == node).unwrap();
+            return Some(recursion_stack[pos..].to_vec());
+        }
+
+        if visited.contains(node) {
+            return None; // Already processed
+        }
+
+        visited.insert(node.to_string());
+        stack_set.insert(node.to_string());
+
+        if let Some(neighbors) = graph.get(node) {
+            for (endpoint, neighbor) in neighbors {
+                recursion_stack.push((endpoint.clone(), node.to_string()));
+
+                if let Some(cycle) = dfs(neighbor, graph, visited, recursion_stack, stack_set) {
+                    return Some(cycle);
+                }
+
+                // Backtrack
+                recursion_stack.pop();
+            }
+        }
+
+        stack_set.remove(node);
+
+        None
+    }
+
+    // Perform DFS from each node
+    for node in graph.keys() {
+        if !visited.contains(node) {
+            if let Some(cycle) = dfs(
+                node,
+                &graph,
+                &mut visited,
+                &mut recursion_stack,
+                &mut stack_set,
+            ) {
+                return Some(cycle);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+#[test]
+fn test_find_cycle() {
+    let edges1 = vec![
+        ("ep1".to_string(), "A".to_string(), "B".to_string()),
+        ("ep2".to_string(), "B".to_string(), "C".to_string()),
+        ("ep3".to_string(), "C".to_string(), "A".to_string()), // Cycle: A → B → C → A
+    ];
+
+    let edges2 = vec![
+        ("ep1".to_string(), "X".to_string(), "Y".to_string()),
+        ("ep2".to_string(), "Y".to_string(), "Z".to_string()),
+    ]; // No cycle
+
+    let edges3 = vec![
+        ("ep1".to_string(), "A".to_string(), "B".to_string()),
+        ("ep2".to_string(), "B".to_string(), "C".to_string()),
+        ("ep3".to_string(), "C".to_string(), "D".to_string()),
+        ("ep4".to_string(), "D".to_string(), "E".to_string()),
+        ("ep5".to_string(), "E".to_string(), "C".to_string()), // Cycle: C → D → E → C
+    ];
+
+    let edges4 = vec![
+        ("ep1".to_string(), "A".to_string(), "B".to_string()),
+        ("ep1".to_string(), "A".to_string(), "C".to_string()),
+        ("ep2".to_string(), "C".to_string(), "D".to_string()),
+        ("ep3".to_string(), "C".to_string(), "E".to_string()),
+        ("ep4".to_string(), "D".to_string(), "A".to_string()),
+        // Cycle: A → C → D → A
+    ];
+
+    assert_eq!(
+        find_cycle(&edges1),
+        Some(vec![
+            ("ep1".to_string(), "A".to_string()),
+            ("ep2".to_string(), "B".to_string()),
+            ("ep3".to_string(), "C".to_string())
+        ])
+    );
+    assert_eq!(find_cycle(&edges2), None);
+    assert_eq!(
+        find_cycle(&edges3),
+        Some(vec![
+            ("ep3".to_string(), "C".to_string()),
+            ("ep4".to_string(), "D".to_string()),
+            ("ep5".to_string(), "E".to_string())
+        ])
+    );
+    assert_eq!(
+        find_cycle(&edges4),
+        Some(vec![
+            ("ep1".to_string(), "A".to_string()),
+            ("ep2".to_string(), "C".to_string()),
+            ("ep4".to_string(), "D".to_string())
+        ])
+    );
+}

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -732,6 +732,8 @@ async fn create_http_input_endpoint(
             max_batch_size: default_max_batch_size(),
             max_queued_records: HttpInputTransport::default_max_buffered_records(),
             paused: false,
+            labels: vec![],
+            start_after: None,
         },
     };
 
@@ -930,6 +932,8 @@ async fn output_endpoint(
             max_batch_size: default_max_batch_size(),
             max_queued_records: HttpOutputTransport::default_max_buffered_records(),
             paused: false,
+            labels: vec![],
+            start_after: None,
         },
     };
 

--- a/docs/connectors/index.mdx
+++ b/docs/connectors/index.mdx
@@ -1,4 +1,3 @@
-
 # Connectors: connect to data sources and sinks
 
 A Feldera pipeline can process data from multiple heterogeneous sources and
@@ -90,12 +89,21 @@ The following attributes are common to all connectors:
 * `name` - The name that is given to the connector, which must be
   unique among the connectors of the table or view. This is particularly
   useful to define when wanting to refer to it, for example to
-  [start or pause it at runtime](#input-connector-orchestration).
+  [start or pause it at runtime](/connectors/orchestration).
   By default, this is randomly generated.
 
 * `paused` - If set to to true the connector will not fetch or push data to the pipeline when started
    unless [explicitly enabled through the API](/api/start-resume-or-pause-the-input-connector).
    By default this is set to false.
+
+* `labels` - An optional list of text labels associated with the connector.
+  This property is used in conjunction with the `start_after` property
+  to implement [automatic connector orchestration](/connectors/orchestration#automatic-connector-orchestration).
+
+* `start_after` - Specifies one or more labels. When this property is set, the connector is created
+  in the Paused state and is automatically activated once all connectors tagged with at least one
+  of the specified labels have finished ingesting data.  This property is used in conjunction with the `labels` property
+  to implement [automatic connector orchestration](/connectors/orchestration#automatic-connector-orchestration).
 
 * `max_queued_records` - The approximate maximum number of records to
   keep in memory.  For an input connector, this is the maximum number
@@ -167,94 +175,13 @@ specified.
 See [Delta Lake output connector documentation](/connectors/sinks/delta)
 for an example of configuring the output buffer.
 
-## Input connector orchestration
-
-Connector Orchestration enables users to activate or deactivate input connectors
-on demand, giving them control over the timing and order of data ingestion from
-multiple sources. It can, for example, be used to backfill a pipeline with
-historical data from a database or data lake before switching over to real-time
-ingestion from a streaming source like Kafka.
-
-Input connectors can be in either the `Running` or `Paused` state. By default,
-connectors are initialized in the `Running` state when a pipeline is deployed.
-In this state, the connector actively fetches data from its configured data
-source and forwards it to the pipeline. If needed, a connector can be created
-in the `Paused` state by setting its
-[`paused`](/connectors/#generic-attributes) property
-to `true`.
-The current connector state can be retrieved via the
-[pipeline statistics endpoint](/api/retrieve-pipeline-statistics-e-g-metrics-performance-counters).
-
-When paused, the connector remains idle until it is reactivated.
-Conversely, a connector in the `Running` state can be paused at any time.
-This can be done by calling its
-[start/pause endpoint](/api/start-resume-or-pause-the-input-connector),
-in which to specify table and connector name.
-
-Note that only if both the pipeline *and* the connector state is `Running`,
-is the input connector active. The following table illustrates this:
-```text
-Pipeline state    Connector state    Connector is active?
---------------    ---------------    --------------------
-Paused            Paused             No
-Paused            Running            No
-Running           Paused             No
-Running           Running            Yes
-```
-
-### Orchestration example
-
-1. Create and start a pipeline named `example` with the following SQL:
-   ```sql
-   CREATE TABLE numbers (
-     num INT
-   ) WITH (
-       'connectors' = '[
-           {
-               "name": "c1",
-               "paused": true,
-               "transport": {
-                   "name": "datagen",
-                   "config": {"plan": [{ "rate": 1, "fields": { "num": { "range": [0, 10], "strategy": "uniform" } } }]}
-               }
-           },
-           {
-               "name": "c2",
-               "paused": false,
-               "transport": {
-                   "name": "datagen",
-                   "config": {"plan": [{ "rate": 1, "fields": { "num": { "range": [10, 20], "strategy": "uniform" } } }]}
-               }
-           }
-       ]'
-   );
-   ```
-
-   Note that the `numbers` table has two input connectors, one of which has `paused` property set to `true`.
-   This connector will be created in the `Paused` state.
-
-2. Check the `numbers` table checkbox in the Change Stream tab. Observe that although the pipeline is `Running`,
-   the change stream only shows input records from connector `c2` (i.e., `[10, 20)`) but not of connector
-   `c1` (i.e., `[0, 10)`).
-
-3. Start connector `c1`:
-   ```
-   fda table-connector example numbers c1 start
-   ```
-   Now the Changes Stream tab will show new input records from both connectors.
-
-4. Pause connector `c2`:
-   ```
-   fda table-connector example numbers c2 pause
-   ```
-   Now the Changes Stream tab no longer will show new input records from connector `c2`.
-
 ## Additional resources
 
 For more information, see:
 
 * [Tutorial on using input and output connectors](/tutorials/basics/part3)
 * [Tutorial on using HTTP-based Input and Output](/tutorials/basics/part2)
+* [Input connector orchestration](/connectors/orchestration)
 * [Supported source transports](/connectors/sources)
 * [Supported sinks transports](/connectors/sinks)
 * [End to End Example with Kafka using Feldera Python SDK](pathname:///python/examples.html#end-to-end-example-with-kafka-sink)

--- a/docs/connectors/orchestration.md
+++ b/docs/connectors/orchestration.md
@@ -1,0 +1,155 @@
+# Input connector orchestration
+
+Connector Orchestration enables users to activate or deactivate input connectors
+on demand, giving them control over the timing and order of data ingestion from
+multiple sources. It can, for example, be used to backfill a pipeline with
+historical data from a database or data lake before switching over to real-time
+ingestion from a streaming source like Kafka.
+
+Input connectors can be in either the `Running` or `Paused` state. By default,
+connectors are initialized in the `Running` state when a pipeline is deployed.
+In this state, the connector actively fetches data from its configured data
+source and forwards it to the pipeline. If needed, a connector can be created
+in the `Paused` state by setting its
+[`paused`](/connectors/#generic-attributes) property
+to `true`.
+The current connector state can be retrieved via the
+[pipeline statistics endpoint](/api/retrieve-pipeline-statistics-e-g-metrics-performance-counters).
+
+When paused, the connector remains idle until it is reactivated.
+Conversely, a connector in the `Running` state can be paused at any time.
+This can be done by calling its
+[start/pause endpoint](/api/start-resume-or-pause-the-input-connector).
+
+Note that only if both the pipeline *and* the connector state is `Running`,
+is the input connector active. The following table illustrates this:
+```text
+Pipeline state    Connector state    Connector is active?
+--------------    ---------------    --------------------
+Paused            Paused             No
+Paused            Running            No
+Running           Paused             No
+Running           Running            Yes
+```
+
+## Orchestration example
+
+1. Create and start a pipeline named `example` with the following SQL:
+   ```sql
+   CREATE TABLE numbers (
+     num INT
+   ) WITH (
+       'connectors' = '[
+           {
+               "name": "c1",
+               "paused": true,
+               "transport": {
+                   "name": "datagen",
+                   "config": {"plan": [{ "rate": 1, "fields": { "num": { "range": [0, 10], "strategy": "uniform" } } }]}
+               }
+           },
+           {
+               "name": "c2",
+               "paused": false,
+               "transport": {
+                   "name": "datagen",
+                   "config": {"plan": [{ "rate": 1, "fields": { "num": { "range": [10, 20], "strategy": "uniform" } } }]}
+               }
+           }
+       ]'
+   );
+   ```
+
+   Note that the `numbers` table has two input connectors, one of which has `paused` property set to `true`.
+   This connector will be created in the `Paused` state.
+
+2. Check the `numbers` table checkbox in the Change Stream tab. Observe that although the pipeline is `Running`,
+   the change stream only shows input records from connector `c2` (i.e., `[10, 20)`) but not of connector
+   `c1` (i.e., `[0, 10)`).
+
+3. Start connector `c1`:
+   ```
+   fda table-connector example numbers c1 start
+   ```
+   Now the Changes Stream tab will show new input records from both connectors.
+
+4. Pause connector `c2`:
+   ```
+   fda table-connector example numbers c2 pause
+   ```
+   Now the Changes Stream tab no longer will show new input records from connector `c2`.
+
+## Automatic connector orchestration
+
+Feldera allows encoding the order of connector activation directly in the SQL program.
+This mechanism can express ordering constraints of the form "start connector
+C1 after connectors C1, C2, ... have finished ingesting all inputs".
+While less general than the mechanism described above, it covers most
+practical situations, while eliminating the need to write
+scripts to monitor and manage connector status via the API.
+
+To configure automatic connector orchestration, you need to:
+
+1. Assign labels to connectors based on their role.
+2. Set the `start_after` attribute to configure the order of connector activation.
+
+### Labels
+
+A connector can be assigned one or more text labels that reflect its role in the pipeline.
+For example, the following label indicates that the connector is used
+to backfill the pipeline with historical data.
+
+```
+"label": ["backfill"]
+```
+
+### Configuring the order of connector activation using `start_after`
+
+A connector can be configured with a `start_after` attribute, which specifies
+one or more labels, e.g.:
+
+```
+"start_after": "backfill"
+```
+
+or
+
+```
+"start_after": ["label1",  "label2"]
+```
+
+Such a connector is created in the Paused state and is automatically activated once
+all connectors tagged with at least one of the specified labels have reached the end of input.
+
+### Example
+
+The Feldera Basics tutorial gives an example of a
+[table with two input connectors](/tutorials/basics/part3#configure-connectors).
+The following snippet shows a modified version of this example where the
+second connector is configured to start after the first connector completes:
+
+```sql
+create table PRICE (
+    part bigint not null,
+    vendor bigint not null,
+    price integer
+) WITH ('connectors' = '[{
+    "labels": "price.backfill",
+    "transport": {
+        "name": "url_input", "config": {"path": "https://feldera-basics-tutorial.s3.amazonaws.com/price.json"  }
+    },
+    "format": { "name": "json" }
+},
+{
+    "start_after": ["price.backfill"],
+    "format": {"name": "json"},
+    "transport": {
+        "name": "kafka_input",
+        "config": {
+            "topics": ["price"],
+            "bootstrap.servers": "redpanda:9092",
+            "auto.offset.reset": "earliest"
+        }
+    }
+}]');
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -206,6 +206,7 @@ const sidebars = {
                         id: 'connectors/index'
                     },
                     items: [
+                        'connectors/orchestration',
                         {
                             type: 'category',
                             label: 'Input',
@@ -249,11 +250,11 @@ const sidebars = {
                                     id: 'connectors/sources/debezium',
                                     label: 'Debezium'
                                 },
-				{
-				    type: 'doc',
-				    id: 'connectors/sources/postgresql',
-				    label: 'PostgreSQL'
-				},
+                                {
+                                    type: 'doc',
+                                    id: 'connectors/sources/postgresql',
+                                    label: 'PostgreSQL'
+                                },
                                 {
                                     type: 'doc',
                                     id: 'connectors/sources/s3',

--- a/openapi.json
+++ b/openapi.json
@@ -2218,6 +2218,13 @@
                 "description": "Name of the index that the connector is attached to.\n\nThis property is valid for output connectors only.  It is used with data\ntransports and formats that expect output updates in the form of key/value\npairs, where the key typically represents a unique id associated with the\ntable or view.\n\nTo support such output formats, an output connector can be attached to an\nindex created using the SQL CREATE INDEX statement.  An index of a table\nor view contains the same updates as the table or view itself, indexed by\none or more key columns.\n\nSee individual connector documentation for details on how they work\nwith indexes.",
                 "nullable": true
               },
+              "labels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Arbitrary user-defined text labels associated with the connector.\n\nThese labels can be used in conjunction with the `start_after` property\nto control the start order of connectors."
+              },
               "max_batch_size": {
                 "type": "integer",
                 "format": "int64",
@@ -2233,6 +2240,14 @@
               "paused": {
                 "type": "boolean",
                 "description": "Create connector in paused state.\n\nThe default is `false`."
+              },
+              "start_after": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Start the connector after all connectors with specified labels.\n\nThis property is used to control the start order of connectors.\nThe connector will not start until all connectors with the specified\nlabels have finished processing all inputs.",
+                "nullable": true
               },
               "transport": {
                 "$ref": "#/components/schemas/TransportConfig"


### PR DESCRIPTION
Fixes https://github.com/feldera/feldera/issues/3535

Introduce two new connector attributes that support automatic connector orchestration:

* `labels` - attach arbitrary text labels to connectors
* `start_after` - start the connector once all connectors with specified labels have finished.

See https://github.com/feldera/feldera/issues/3535 for a detailed design discussion.

I added docs for the new feature and moved the connector orchestration section to a separate doc page, since it was getting too big.

TODO: The connector orchestration doc needs an explanation of the end-of-input flag (including the fact that only some of the connectors can reach the end of input and only with certain configuration options), and the API to check it. I plan to work on this in a separate PR, which will also introduce a better API for querying connector status.