### PR TITLE
[dbsp] Add CPU affinity support for pipelines.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,6 +2843,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,6 +3714,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "clap 4.5.27",
+ "core_affinity",
  "crc32c",
  "criterion",
  "crossbeam",
@@ -3721,6 +3733,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "impl-trait-for-tuples",
+ "indexmap 2.7.1",
  "indicatif",
  "io-uring",
  "itertools 0.14.0",

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1386,6 +1386,7 @@ impl ControllerInit {
     ) -> Result<CircuitConfig, ControllerError> {
         Ok(CircuitConfig {
             layout: Layout::new_solo(pipeline_config.global.workers as usize),
+            pin_cpus: pipeline_config.global.pin_cpus.clone(),
             // Put the circuit's checkpoints in a `circuit` subdirectory of the
             // storage directory.
             storage: if let Some(options) = &pipeline_config.global.storage {

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -79,6 +79,8 @@ snap = "1.1.1"
 enum-map = "2.7.3"
 fastbloom = "0.8.0"
 bytemuck = "1.21.0"
+core_affinity = "0.8.1"
+indexmap = "2.7.1"
 
 [dependencies.time]
 version = "0.3.20"

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -219,6 +219,9 @@ pub struct CircuitConfig {
     /// How the circuit is laid out across one or multiple machines.
     pub layout: Layout,
 
+    /// Optionally, CPU numbers for pinning the worker threads.
+    pub pin_cpus: Vec<usize>,
+
     /// Storage configuration. If present, then storage is enabled..
     pub storage: Option<CircuitStorageConfig>,
 }
@@ -247,6 +250,7 @@ impl CircuitConfig {
     pub fn with_workers(n: usize) -> Self {
         Self {
             layout: Layout::new_solo(n),
+            pin_cpus: Vec::new(),
             storage: None,
         }
     }
@@ -1023,6 +1027,7 @@ pub(crate) mod tests {
         let temp = tempdir().expect("Can't create temp dir for storage");
         let cconf = CircuitConfig {
             layout: Layout::new_solo(1),
+            pin_cpus: Vec::new(),
             storage: Some(CircuitStorageConfig {
                 config: StorageConfig {
                     path: temp.path().to_string_lossy().into_owned(),

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -259,6 +259,16 @@ pub struct RuntimeConfig {
     ///
     /// Set to `null` to disable periodic clock updates.
     pub clock_resolution_usecs: Option<u64>,
+
+    /// Optionally, a list of CPU numbers for CPUs to which the pipeline may pin
+    /// its worker threads.  Specify at least twice as many CPU numbers as
+    /// workers.  CPUs are generally numbered starting from 0.  The pipeline
+    /// might not be able to honor CPU pinning requests.
+    ///
+    /// CPU pinning can make pipelines run faster and perform more consistently,
+    /// as long as different pipelines running on the same machine are pinned to
+    /// different CPUs.
+    pub pin_cpus: Vec<usize>,
 }
 
 /// Accepts "true" and "false" and converts them to the new format.
@@ -380,6 +390,7 @@ impl Default for RuntimeConfig {
                 // Every 100 ms.
                 Some(100_000)
             },
+            pin_cpus: Vec::new(),
         }
     }
 }

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -116,6 +116,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
                 storage_class: None,
             },
             clock_resolution_usecs: Some(100_000),
+            pin_cpus: Vec::new(),
         })
         .unwrap(),
         program_code: "CREATE TABLE table2 ( col2 VARCHAR );".to_string(),

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -180,6 +180,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::transport::iceberg::IcebergCatalogType,
         feldera_types::transport::iceberg::RestCatalogConfig,
         feldera_types::transport::iceberg::GlueCatalogConfig,
+        feldera_types::transport::postgres::PostgresReaderConfig,
         feldera_types::transport::http::Chunk,
         feldera_types::query::AdhocQueryArgs,
         feldera_types::query::AdHocResultFormat,

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -250,6 +250,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> serde_json::V
                 storage_class: val.val12,
             },
             clock_resolution_usecs: val.val13,
+            pin_cpus: Vec::new(),
         })
         .unwrap()
     }
@@ -962,6 +963,7 @@ async fn pipeline_versioning() {
             storage_class: None,
         },
         clock_resolution_usecs: None,
+        pin_cpus: Vec::new(),
     })
     .unwrap();
     handle
@@ -1388,6 +1390,7 @@ async fn pipeline_provision_version_guard() {
                     max_buffering_delay_usecs: 0,
                     resources: Default::default(),
                     clock_resolution_usecs: None,
+                    pin_cpus: Vec::new(),
                 })
                 .unwrap(),
             ),

--- a/openapi.json
+++ b/openapi.json
@@ -381,7 +381,8 @@
                         "storage_mb_max": null,
                         "storage_class": null
                       },
-                      "clock_resolution_usecs": 100000
+                      "clock_resolution_usecs": 100000,
+                      "pin_cpus": []
                     },
                     "program_code": "CREATE TABLE table1 ( col1 INT );",
                     "udf_rust": "",
@@ -431,7 +432,8 @@
                         "storage_mb_max": 10000,
                         "storage_class": null
                       },
-                      "clock_resolution_usecs": 100000
+                      "clock_resolution_usecs": 100000,
+                      "pin_cpus": []
                     },
                     "program_code": "CREATE TABLE table2 ( col2 VARCHAR );",
                     "udf_rust": "",
@@ -503,7 +505,8 @@
                     "storage_mb_max": null,
                     "storage_class": null
                   },
-                  "clock_resolution_usecs": 100000
+                  "clock_resolution_usecs": 100000,
+                  "pin_cpus": []
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -549,7 +552,8 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000
+                    "clock_resolution_usecs": 100000,
+                    "pin_cpus": []
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -671,7 +675,8 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000
+                    "clock_resolution_usecs": 100000,
+                    "pin_cpus": []
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -760,7 +765,8 @@
                     "storage_mb_max": null,
                     "storage_class": null
                   },
-                  "clock_resolution_usecs": 100000
+                  "clock_resolution_usecs": 100000,
+                  "pin_cpus": []
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -806,7 +812,8 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000
+                    "clock_resolution_usecs": 100000,
+                    "pin_cpus": []
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -859,7 +866,8 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000
+                    "clock_resolution_usecs": 100000,
+                    "pin_cpus": []
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -1046,7 +1054,8 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000
+                    "clock_resolution_usecs": 100000,
+                    "pin_cpus": []
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -3285,6 +3294,15 @@
                 "default": 0,
                 "minimum": 0
               },
+              "pin_cpus": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "description": "Optionally, a list of CPU numbers for CPUs to which the pipeline may pin\nits worker threads.  Specify at least twice as many CPU numbers as\nworkers.  CPUs are generally numbered starting from 0.  The pipeline\nmight not be able to honor CPU pinning requests.\n\nCPU pinning can make pipelines run faster and perform more consistently,\nas long as different pipelines running on the same machine are pinned to\ndifferent CPUs.",
+                "default": []
+              },
               "resources": {
                 "allOf": [
                   {
@@ -3647,6 +3665,24 @@
           "udf_toml": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "PostgresReaderConfig": {
+        "type": "object",
+        "description": "Postgres input connector configuration.",
+        "required": [
+          "uri",
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Query that specifies what data to fetch from postgres."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Postgres URI."
           }
         }
       },
@@ -4151,6 +4187,15 @@
             "description": "Minimal input batch size.\n\nThe controller delays pushing input records to the circuit until at\nleast `min_batch_size_records` records have been received (total\nacross all endpoints) or `max_buffering_delay_usecs` microseconds\nhave passed since at least one input records has been buffered.\nDefaults to 0.",
             "default": 0,
             "minimum": 0
+          },
+          "pin_cpus": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "Optionally, a list of CPU numbers for CPUs to which the pipeline may pin\nits worker threads.  Specify at least twice as many CPU numbers as\nworkers.  CPUs are generally numbered starting from 0.  The pipeline\nmight not be able to honor CPU pinning requests.\n\nCPU pinning can make pipelines run faster and perform more consistently,\nas long as different pipelines running on the same machine are pinned to\ndifferent CPUs.",
+            "default": []
           },
           "resources": {
             "allOf": [


### PR DESCRIPTION
In my testing, setting CPU affinity both speeds up the fastest that pipelines run, and reduces the variability between the fastest and slowest runs from over 2x to about 1.3x.