### PR TITLE
 [adapters] Upgrade serde_arrow to handle Utf8View

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.82.0
+          toolchain: 1.83.0
           components: rustfmt clippy
       - uses: actions/setup-python@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    rust: 1.82.0
+    rust: 1.83.0
 repos:
 -   repo: local
     hooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6612,6 +6612,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "marrow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5fc5916496c19f17c6b7b6ebc8210546f3fe42d59179efe78ac9562e09a2d6"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "bytemuck",
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9511,17 +9526,16 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.12.3"
+version = "0.13.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11687c1f0a104aa039fb29816dc67c2e7458f4a381a7cdcd85a260fd48d5a5a4"
+checksum = "3955420f8b683a83cd73d469fb6b55866edea1e401cd8ae696ef167de7e7c4d9"
 dependencies = [
  "arrow-array",
- "arrow-buffer",
- "arrow-data",
  "arrow-schema",
  "bytemuck",
  "chrono",
  "half",
+ "marrow",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9527,8 +9527,7 @@ dependencies = [
 [[package]]
 name = "serde_arrow"
 version = "0.13.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3955420f8b683a83cd73d469fb6b55866edea1e401cd8ae696ef167de7e7c4d9"
+source = "git+https://github.com/ryzhyk/serde_arrow.git?rev=dbab218#dbab218949c6c3e4495ef07d6c7e94a9e65f22cb"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ENV RUSTUP_HOME=$HOME/.rustup
 ENV CARGO_HOME=$HOME/.cargo
 # Adds python and rust binaries to the path
 ENV PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
-ENV RUST_VERSION=1.82.0
+ENV RUST_VERSION=1.83.0
 ENV RUST_BUILD_MODE='' # set to --release for release builds
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV DEBIAN_FRONTEND=noninteractive

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -16,7 +16,7 @@ erased-serde = "0.3.23"
 dyn-clone = "1.0.17"
 arrow = { version = "53.3.0", features = ["chrono-tz"] }
 apache-avro = { version = "0.17.0", optional = true }
-serde_arrow = { version = "0.12.2", features = ["arrow-53"] }
+serde_arrow = { version = "0.13.0-rc.1", features = ["arrow-53"] }
 serde = { version = "1.0.213", features = ["derive"] }
 serde_json = { version = "1.0.127", features = ["raw_value"] }
 rmp-serde = "1.3.0"

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -16,7 +16,7 @@ erased-serde = "0.3.23"
 dyn-clone = "1.0.17"
 arrow = { version = "53.3.0", features = ["chrono-tz"] }
 apache-avro = { version = "0.17.0", optional = true }
-serde_arrow = { version = "0.13.0-rc.1", features = ["arrow-53"] }
+serde_arrow = { git = "https://github.com/ryzhyk/serde_arrow.git", rev = "dbab218", features = ["arrow-53"] }
 serde = { version = "1.0.213", features = ["derive"] }
 serde_json = { version = "1.0.127", features = ["raw_value"] }
 rmp-serde = "1.3.0"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -80,7 +80,7 @@ tempfile = "3.10.0"
 async-trait = "0.1"
 arrow = { version = "53.3.0", features = ["chrono-tz"] }
 parquet = { version = "53.3.0", features = ["json"] }
-serde_arrow = { version = "0.13.0-rc.1", features = ["arrow-53"] }
+serde_arrow = { git = "https://github.com/ryzhyk/serde_arrow.git", rev = "dbab218", features = ["arrow-53"] }
 arrow-json = { version = "53.3.0" }
 bytes = "1.5.0"
 # `datafusion` must be enabled for the writer to implement the `Invariant` feature.

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -80,7 +80,7 @@ tempfile = "3.10.0"
 async-trait = "0.1"
 arrow = { version = "53.3.0", features = ["chrono-tz"] }
 parquet = { version = "53.3.0", features = ["json"] }
-serde_arrow = { version = "0.12.2", features = ["arrow-53"] }
+serde_arrow = { version = "0.13.0-rc.1", features = ["arrow-53"] }
 arrow-json = { version = "53.3.0" }
 bytes = "1.5.0"
 # `datafusion` must be enabled for the writer to implement the `Invariant` feature.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -35,7 +35,7 @@ ENV LANGUAGE=en_US:en
 # Use cargo-chef to produce a recipe.json file
 # to cache the requisite dependencies
 FROM base AS chef
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.82.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.83.0
 RUN /root/.cargo/bin/cargo install cargo-chef
 WORKDIR app
 
@@ -130,7 +130,7 @@ COPY sql-to-dbsp-compiler/temp lib/sql-to-dbsp-compiler/temp
 COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp lib/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
 
 # Install cargo and rust for this non-root user
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.82.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.83.0
 # The download URL for mold uses x86_64/aarch64 whereas dpkg --print-architecture says amd64/arm64
 RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
   curl -LO https://github.com/rui314/mold/releases/download/v2.32.1/mold-2.32.1-$arch-linux.tar.gz \


### PR DESCRIPTION
Some time ago we started seeing serde_arrow errors due to unsupported
Utf8View type. This was caused by the new version of deltalake,
datafusion, and arrow crates generating schemas with view types. Back
then configuring
`datafusion.execution.parquet.schema_force_view_types=false` solved the
issue.  Recently a user shared an example creating a delta table using
polars with a recent version of the Python Arrow package that triggered
the same error in the `follow` mode. I am not sure how this is possible
given that `Utf8View` is an internal arrow type, which should be stored
as a regular string in Parquet.

Fortunately, the creator of serde_arrow recently added support for
Utf8View (https://github.com/chmp/serde_arrow/issues/252) in 0.13-rc.1,
so I was able to fix the issue by simply upgrading to that.