### PR TITLE
Add reverse scroll behavior for ad-hoc query tab

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -110,13 +110,13 @@
           }}
         >
           {#if 'insert' in row}
-            <td class="block h-7 w-20 bg-opacity-30 pt-1 text-center font-mono bg-success-100-900"
-              >Insert</td
-            >
+            <td class="block h-7 w-20 bg-opacity-30 pt-1 text-center font-mono bg-success-100-900">
+              Insert
+            </td>
           {:else}
-            <td class="block h-7 w-20 bg-opacity-30 text-center font-mono bg-error-100-900"
-              >Delete</td
-            >
+            <td class="block h-7 w-20 bg-opacity-30 pt-1 text-center font-mono bg-error-100-900">
+              Delete
+            </td>
           {/if}
 
           {#each Object.values(data) as value}

--- a/web-console/src/lib/compositions/common/useReverseScrollContainer.svelte.ts
+++ b/web-console/src/lib/compositions/common/useReverseScrollContainer.svelte.ts
@@ -39,12 +39,13 @@ export const useReverseScrollContainer = () => {
     if (!ref || !(ref instanceof HTMLDivElement)) {
       return
     }
-    stickToBottom = Math.round(ref.scrollTop - ref.scrollHeight + ref.clientHeight) >= 0
+
+    stickToBottom = Math.round(ref.scrollTop - ref.scrollHeight + ref.clientHeight + 1) >= 0 // + 1 pixel is added to account for imprecision between calculated .scrollTop and .scrollHeight
   }
 
   return {
-    action: ((_node, props?: { observe?: (node: HTMLElement) => HTMLElement }) => {
-      const node = props?.observe?.(_node) ?? _node
+    action: ((_node, props?: { getContainerElement?: (node: HTMLElement) => HTMLElement }) => {
+      const node = props?.getContainerElement?.(_node) ?? _node
       lastHeight = node.offsetHeight
       if (!(node instanceof HTMLDivElement)) {
         return


### PR DESCRIPTION
For convenience, when executing a new ad-hoc query the tab automatically scrolls down to display its results' table