### PR TITLE
pipeline-manager: pipeline identifier in pipeline action logging

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -787,15 +787,14 @@ pub(crate) async fn post_pipeline_action(
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ManagerError> {
     let (pipeline_name, action) = path.into_inner();
-    let verb = match action.as_str() {
+    let pipeline_id = match action.as_str() {
         "start" => {
             state
                 .db
                 .lock()
                 .await
                 .set_deployment_desired_status_running(*tenant_id, &pipeline_name)
-                .await?;
-            "starting"
+                .await?
         }
         "pause" => {
             state
@@ -803,8 +802,7 @@ pub(crate) async fn post_pipeline_action(
                 .lock()
                 .await
                 .set_deployment_desired_status_paused(*tenant_id, &pipeline_name)
-                .await?;
-            "pausing"
+                .await?
         }
         "shutdown" => {
             state
@@ -812,16 +810,15 @@ pub(crate) async fn post_pipeline_action(
                 .lock()
                 .await
                 .set_deployment_desired_status_shutdown(*tenant_id, &pipeline_name)
-                .await?;
-            "shutting down"
+                .await?
         }
         _ => Err(ManagerError::from(ApiError::InvalidPipelineAction {
-            action: action.to_string(),
+            action: action.clone(),
         }))?,
     };
 
     info!(
-        "Accepted action: {verb} pipeline '{pipeline_name}' (tenant: {})",
+        "Accepted action: going to {action} pipeline {pipeline_id} (tenant: {})",
         *tenant_id
     );
     Ok(HttpResponse::Accepted().finish())

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -743,7 +743,7 @@ pub(crate) async fn set_deployment_desired_status(
     tenant_id: TenantId,
     pipeline_name: &str,
     new_desired_status: PipelineDesiredStatus,
-) -> Result<(), DBError> {
+) -> Result<PipelineId, DBError> {
     let current = get_pipeline(txn, tenant_id, pipeline_name).await?;
 
     // Check that the desired status can be set
@@ -767,7 +767,7 @@ pub(crate) async fn set_deployment_desired_status(
         )
         .await?;
     if modified_rows > 0 {
-        Ok(())
+        Ok(current.id)
     } else {
         Err(DBError::UnknownPipeline {
             pipeline_id: current.id,

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -258,21 +258,21 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError>;
+    ) -> Result<PipelineId, DBError>;
 
     /// Sets deployment desired status to `Paused`.
     async fn set_deployment_desired_status_paused(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError>;
+    ) -> Result<PipelineId, DBError>;
 
     /// Sets deployment desired status to `Shutdown`.
     async fn set_deployment_desired_status_shutdown(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError>;
+    ) -> Result<PipelineId, DBError>;
 
     /// Transitions deployment status to `Provisioning`.
     async fn transit_deployment_status_to_provisioning(

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -584,10 +584,10 @@ impl Storage for StoragePostgres {
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        operations::pipeline::set_deployment_desired_status(
+        let pipeline_id = operations::pipeline::set_deployment_desired_status(
             &txn,
             tenant_id,
             pipeline_name,
@@ -595,17 +595,17 @@ impl Storage for StoragePostgres {
         )
         .await?;
         txn.commit().await?;
-        Ok(())
+        Ok(pipeline_id)
     }
 
     async fn set_deployment_desired_status_paused(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        operations::pipeline::set_deployment_desired_status(
+        let pipeline_id = operations::pipeline::set_deployment_desired_status(
             &txn,
             tenant_id,
             pipeline_name,
@@ -613,17 +613,17 @@ impl Storage for StoragePostgres {
         )
         .await?;
         txn.commit().await?;
-        Ok(())
+        Ok(pipeline_id)
     }
 
     async fn set_deployment_desired_status_shutdown(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
-        operations::pipeline::set_deployment_desired_status(
+        let pipeline_id = operations::pipeline::set_deployment_desired_status(
             &txn,
             tenant_id,
             pipeline_name,
@@ -631,7 +631,7 @@ impl Storage for StoragePostgres {
         )
         .await?;
         txn.commit().await?;
-        Ok(())
+        Ok(pipeline_id)
     }
 
     async fn transit_deployment_status_to_provisioning(

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -3038,7 +3038,7 @@ impl Storage for Mutex<DbModel> {
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let new_desired_status = PipelineDesiredStatus::Running;
         let mut pipeline = self
             .help_transit_deployment_desired_status(tenant_id, pipeline_name, &new_desired_status)
@@ -3048,14 +3048,14 @@ impl Storage for Mutex<DbModel> {
             .await
             .pipelines
             .insert((tenant_id, pipeline.id), pipeline.clone());
-        Ok(())
+        Ok(pipeline.id)
     }
 
     async fn set_deployment_desired_status_paused(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let new_desired_status = PipelineDesiredStatus::Paused;
         let mut pipeline = self
             .help_transit_deployment_desired_status(tenant_id, pipeline_name, &new_desired_status)
@@ -3065,14 +3065,14 @@ impl Storage for Mutex<DbModel> {
             .await
             .pipelines
             .insert((tenant_id, pipeline.id), pipeline.clone());
-        Ok(())
+        Ok(pipeline.id)
     }
 
     async fn set_deployment_desired_status_shutdown(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
-    ) -> Result<(), DBError> {
+    ) -> Result<PipelineId, DBError> {
         let new_desired_status = PipelineDesiredStatus::Shutdown;
         let mut pipeline = self
             .help_transit_deployment_desired_status(tenant_id, pipeline_name, &new_desired_status)
@@ -3082,7 +3082,7 @@ impl Storage for Mutex<DbModel> {
             .await
             .pipelines
             .insert((tenant_id, pipeline.id), pipeline.clone());
-        Ok(())
+        Ok(pipeline.id)
     }
 
     async fn transit_deployment_status_to_provisioning(


### PR DESCRIPTION
The start/pause/shutdown pipeline action info logging now displays the pipeline identifier instead of the name, which is in line with the other pipeline management endpoints. The consistency is important such that the log messages across the endpoints relate to each other. In addition, they must also relate to other internal logs (i.e., the compiler server and runner). The usage of pipeline identifiers might later be replaced with a 2-tuple (tenant id, name) or a different naming solution that is both not verbose and unique across tenants, however this change would be quite involved as it needs to be applied everywhere to have consistent logs. Currently with the pipeline identifier, an operator can `grep` the pipeline identifier to get all relevant lines in a log.