### PR TITLE
Fix streaming HTTP requests (e.g. logs) not cancelling

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -45,13 +45,13 @@
     }
   }
   const startReadingStream = (pipelineName: string, relationName: string) => {
-    const handle = relationEgressStream(pipelineName, relationName).then((stream) => {
-      if ('message' in stream) {
+    const request = relationEgressStream(pipelineName, relationName).then((result) => {
+      if (result instanceof Error) {
         pipelinesRelations[pipelineName][relationName].cancelStream = undefined
         return undefined
       }
       const { cancel } = parseCancellable(
-        stream,
+        result,
         {
           pushChanges: (rows: XgressEntry[]) => {
             const initialLen = changeStream[pipelineName].rows.length
@@ -114,7 +114,7 @@
       }
     })
     return () => {
-      handle.then((cancel) => {
+      request.then((cancel) => {
         cancel?.()
         pipelinesRelations[pipelineName][relationName].cancelStream = undefined
         ;({ rows: changeStream[pipelineName].rows, headers: changeStream[pipelineName].headers } =

--- a/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -102,7 +102,7 @@
       )
       streams[pipelineName] = {
         firstRowIndex: 0,
-        stream: { open: result, stop: cancel },
+        stream: { open: result.stream, stop: cancel },
         rows: [],
         rowBoundaries: [],
         totalSkippedBytes: 0


### PR DESCRIPTION
Fix streaming HTTP requests (e.g. logs) not cancelling when leaving context (page, tab etc.)

Steps to reproduce:
- Open WebConsole in Firefox
- Start a pipeline in local form factor and navigate between "Changes Stream" and "Logs" tabs 9 times
- Observe that the UI becomes unresponsive to certain actions (e.g. stop the pipeline)