### PR TITLE
Add workflow_dispatch to ci-integration.yml

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -2,6 +2,7 @@ name: Integration Tests
 
 on:
   merge_group:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Add a `workflow_dispatch` clause to the integration test script, so we can run it on-demand.