### PR TITLE
[SQL] Merkle-tree based operator naming

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/MerkleHash.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/MerkleHash.java
@@ -1,0 +1,32 @@
+package org.dbsp.sqlCompiler.circuit.annotation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.util.JsonStream;
+import org.dbsp.util.Utilities;
+
+/** Stores a hash value for each operator */
+public class MerkleHash extends Annotation {
+    public final String hash;
+
+    public MerkleHash(String hash) {
+        this.hash = hash;
+    }
+
+    @Override
+    public boolean invisible() {
+        return true;
+    }
+
+    public static MerkleHash fromJson(JsonNode node) {
+        String hash = Utilities.getStringProperty(node, "hash");
+        return new MerkleHash(hash);
+    }
+
+    @Override
+    public void asJson(JsonStream stream) {
+        stream.beginObject().appendClass(this);
+        stream.label("hash");
+        stream.append(this.hash);
+        stream.endObject();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -50,24 +50,24 @@ public final class DBSPIntegrateTraceRetainKeysOperator
         DBSPExpression compare0 = controlArg.deref().field(0).not();
         if (data.outputType().is(DBSPTypeIndexedZSet.class)) {
             DBSPType keyType = data.getOutputIndexedZSetType().keyType;
-            DBSPVariablePath dataArg = keyType.var();
-            param = new DBSPParameter(dataArg.variable, dataArg.getType().ref());
+            DBSPVariablePath dataArg = keyType.ref().var();
+            param = new DBSPParameter(dataArg.variable, dataArg.getType());
             IMaybeMonotoneType dataField0 = dataProjection
                     .to(PartiallyMonotoneTuple.class)
                     .getField(0);
             if (!dataField0.mayBeMonotone())
                 return null;
             DBSPExpression project = dataField0
-                    .projectExpression(dataArg);
+                    .projectExpression(dataArg.deref());
             compare = DBSPControlledKeyFilterOperator.generateTupleCompare(
                     project, controlArg.deref().field(1).field(0), DBSPOpcode.CONTROLLED_FILTER_GTE);
         } else {
             DBSPType keyType = data.getOutputZSetElementType();
-            DBSPVariablePath dataArg = keyType.var();
-            param = new DBSPParameter(dataArg.variable, dataArg.getType().ref());
+            DBSPVariablePath dataArg = keyType.ref().var();
+            param = new DBSPParameter(dataArg.variable, dataArg.getType());
             if (!dataProjection.mayBeMonotone())
                 return null;
-            DBSPExpression project = dataProjection.projectExpression(dataArg);
+            DBSPExpression project = dataProjection.projectExpression(dataArg.deref());
             compare = DBSPControlledKeyFilterOperator.generateTupleCompare(
                     project, controlArg.deref().field(1), DBSPOpcode.CONTROLLED_FILTER_GTE);
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
@@ -41,12 +41,12 @@ public final class DBSPIntegrateTraceRetainValuesOperator
         DBSPVariablePath controlArg = controlType.ref().var();
         assert data.outputType().is(DBSPTypeIndexedZSet.class);
         DBSPType valueType = data.getOutputIndexedZSetType().elementType;
-        DBSPVariablePath dataArg = valueType.var();
-        DBSPParameter param = new DBSPParameter(dataArg.variable, dataArg.getType().ref());
+        DBSPVariablePath dataArg = valueType.ref().var();
+        DBSPParameter param = new DBSPParameter(dataArg.variable, dataArg.getType());
         DBSPExpression project = dataProjection
                 .to(PartiallyMonotoneTuple.class)
                 .getField(1)
-                .projectExpression(dataArg);
+                .projectExpression(dataArg.deref());
         DBSPExpression compare0 = controlArg.deref().field(0).not();
         DBSPExpression compare = DBSPControlledKeyFilterOperator.generateTupleCompare(
                 project, controlArg.deref().field(1), DBSPOpcode.CONTROLLED_FILTER_GTE);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/MerkleInner.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/MerkleInner.java
@@ -1,0 +1,29 @@
+package org.dbsp.sqlCompiler.compiler.backend;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.util.JsonStream;
+
+/* Converts each inner node into a hash of its Rust code. */
+public class MerkleInner extends ToJsonInnerVisitor {
+    // This has nothing to do with JSON, but it is invoked from
+    // MerkleOuter, which extends ToJsonOuterVisitor, so this
+    // has to also extend ToJsonInnerVisitor.
+    public MerkleInner(DBSPCompiler compiler, JsonStream stream) {
+        super(compiler, stream, 0);
+    }
+
+    public static String hash(String data) {
+        return DigestUtils.sha256Hex(data);
+    }
+
+    @Override
+    public VisitDecision preorder(IDBSPInnerNode node) {
+        String rust = node.toString();
+        this.stream.append(this.hash(rust));
+        // no traversal needed at all
+        return VisitDecision.STOP;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/MerkleOuter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/MerkleOuter.java
@@ -1,0 +1,88 @@
+package org.dbsp.sqlCompiler.compiler.backend;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.annotation.MerkleHash;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.util.IndentStreamBuilder;
+import org.dbsp.util.JsonStream;
+import org.dbsp.util.Logger;
+import org.dbsp.util.Utilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Computes a Merkle hash for each operator.
+ * The hash combines the hashes of the inputs, and the hashes of all
+ * the code that the operator invokes (e.g., function).  For operators
+ * involved in input/output, it also includes metadata (e.g., column names).
+ *
+ * <p>This visitor is declared read-only, but it actually modifies the annotations on operators. */
+public class MerkleOuter extends ToJsonOuterVisitor {
+    public final Map<Long, String> operatorHash;
+
+    MerkleOuter(DBSPCompiler compiler, ToJsonInnerVisitor inner, Map<Long, String> operatorHash) {
+        super(compiler, 0, inner);
+        this.operatorHash = operatorHash;
+    }
+
+    public MerkleOuter(DBSPCompiler compiler) {
+        this(compiler, new MerkleInner(compiler, new JsonStream(new IndentStreamBuilder().setIndentAmount(1))), new HashMap<>());
+    }
+
+    MerkleOuter(MerkleOuter other) {
+        this(other.compiler, new MerkleInner(
+                other.compiler, new JsonStream(new IndentStreamBuilder())), other.operatorHash);
+    }
+
+    void setHash(DBSPOperator operator, String hash) {
+        Logger.INSTANCE.belowLevel(this, 1)
+                .append("Merkle hash ")
+                .append(operator.getId())
+                .append(" is ")
+                .append(hash)
+                .newline();
+        Utilities.putNew(this.operatorHash, operator.id, hash);
+        operator.annotations.add(new MerkleHash(hash));
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPOperator operator) {
+        this.stream.beginObject();
+        if (this.operatorHash.containsKey(operator.getId())) {
+            this.stream.label("node");
+            String hash = Utilities.getExists(this.operatorHash, operator.getId());
+            this.stream.append(hash);
+            this.stream.endObject();
+            return VisitDecision.STOP;
+        }
+
+        // Use a new visitor, to generate a JSON object per Operator.
+        // Then we hash that JSON object.
+        MerkleOuter perOp = new MerkleOuter(this);
+        if (operator.is(DBSPNestedOperator.class)) {
+            return VisitDecision.CONTINUE;
+        }
+
+        operator.accept(this.innerVisitor);
+        this.stream.appendClass(operator);
+        this.label("inputs");
+        this.stream.beginArray();
+        for (OutputPort port: operator.inputs) {
+            port.asJson(perOp);
+        }
+        this.stream.endArray();
+        String string = perOp.getJsonString();
+        String hash = MerkleInner.hash(string);
+        this.setHash(operator, hash);
+        this.stream.endObject();
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public void postorder(DBSPNestedOperator nested) {
+        this.stream.endObject();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -585,7 +585,6 @@ public class ToJsonInnerVisitor extends InnerVisitor {
 
     @Override
     public void postorder(DBSPUSizeLiteral node) {
-        
         if (node.value != null) {
             this.property("value");
             this.stream.append(node.value.toString());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -28,8 +28,10 @@ import org.dbsp.sqlCompiler.circuit.annotation.Waterline;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.ICompilerComponent;
+import org.dbsp.sqlCompiler.compiler.backend.MerkleOuter;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.BetaReduction;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.CanonicalForm;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EliminateDump;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpandCasts;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpandWriteLog;
@@ -138,7 +140,10 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         passes.add(new CSE(compiler));
         passes.add(new RemoveViewOperators(compiler, true));
         // passes.add(new TestSerialize(compiler));
+        // The canonical form is needed if we want the Merkle hashes to be "stable".
+        passes.add(new CanonicalForm(compiler).getCircuitVisitor(false));
         passes.add(new CompactNames(compiler));
+        passes.add(new MerkleOuter(compiler));
         return new Passes("CircuitOptimizer", compiler, passes);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TestSerialize.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TestSerialize.java
@@ -9,6 +9,7 @@ import org.dbsp.sqlCompiler.compiler.backend.ToJsonOuterVisitor;
 import org.dbsp.util.Utilities;
 
 /** Tests serialization to Json and back */
+@SuppressWarnings("unused")
 public class TestSerialize implements CircuitTransform {
     DBSPCompiler compiler;
 
@@ -23,7 +24,7 @@ public class TestSerialize implements CircuitTransform {
 
     @Override
     public DBSPCircuit apply(DBSPCircuit circuit) {
-        ToJsonOuterVisitor visitor = new ToJsonOuterVisitor(compiler, 1);
+        ToJsonOuterVisitor visitor = ToJsonOuterVisitor.create(compiler, 1);
         visitor.apply(circuit);
         String str = visitor.getJsonString();
         // System.out.println(str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPParameter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPParameter.java
@@ -28,7 +28,6 @@ import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IHasType;
 import org.dbsp.util.IIndentStream;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ICastable.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ICastable.java
@@ -48,6 +48,13 @@ public interface ICastable {
         return result;
     }
 
+    default <T> T to(Class<T> clazz, String error) {
+        T result = this.as(clazz);
+        if (result == null)
+            throw new RuntimeException(error);
+        return result;
+    }
+
     default <T> boolean is(Class<T> clazz) {
         return clazz.isInstance(this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IIndentStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IIndentStream.java
@@ -31,31 +31,177 @@ import java.util.stream.Stream;
 @SuppressWarnings("UnusedReturnValue")
 public interface IIndentStream {
     IIndentStream appendChar(char c);
-    IIndentStream append(String string);
-    IIndentStream append(boolean b);
-    <T extends ToIndentableString> IIndentStream append(T value);
-    IIndentStream append(int value);
-    IIndentStream append(long value);
+
+    default IIndentStream append(String string) {
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            this.appendChar(c);
+        }
+        return this;
+    }
+
+    default IIndentStream append(boolean b) {
+        return this.append(Boolean.toString(b));
+    }
+
+    default <T extends ToIndentableString> IIndentStream append(T value) {
+        value.toString(this);
+        return this;
+    }
+
+    default IIndentStream append(int value) {
+        this.append(Integer.toString(value));
+        return this;
+    }
+
+    default IIndentStream append(long value) {
+        this.append(Long.toString(value));
+        return this;
+    }
+
     /** For lazy evaluation of the argument. */
-    IIndentStream appendSupplier(Supplier<String> supplier);
-    IIndentStream joinS(String separator, Collection<String> data);
-    <T extends ToIndentableString> IIndentStream joinI(String separator, Collection<T> data);
-    IIndentStream join(String separator, String[] data);
-    IIndentStream join(String separator, Stream<String> data);
-    <T> IIndentStream join(String separator, T[] data, Function<T, String> generator);
-    <T> IIndentStream intercalate(String separator, T[] data, Function<T, String> generator);
-    <T extends ToIndentableString> IIndentStream join(String separator, T[] data);
-    IIndentStream join(String separator, Collection<String> data);
-    IIndentStream joinSupplier(String separator, Supplier<Collection<String>> data);
-    IIndentStream intercalate(String separator, Collection<String> data);
-    IIndentStream intercalate(String separator, String[] data);
-    IIndentStream intercalateS(String separator, Collection<String> data);
-    <T extends ToIndentableString> IIndentStream intercalateI(String separator, Collection<T> data);
-    <T extends ToIndentableString> IIndentStream intercalateI(String separator, T[] data);
-    IIndentStream newline();
+    default IIndentStream appendSupplier(Supplier<String> supplier) {
+        return this.append(supplier.get());
+    }
+
+    default IIndentStream joinS(String separator, Collection<String> data) {
+        boolean first = true;
+        for (String d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(d);
+        }
+        return this;
+    }
+
+    default <T extends ToIndentableString> IIndentStream joinI(String separator, Collection<T> data) {
+        boolean first = true;
+        for (ToIndentableString d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(d);
+        }
+        return this;
+    }
+
+    default IIndentStream join(String separator, String[] data) {
+        boolean first = true;
+        for (String d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(d);
+        }
+        return this;
+    }
+
+    default IIndentStream join(String separator, Stream<String> data) {
+        final boolean[] first = {true};
+        data.forEach(d -> {
+            if (!first[0])
+                this.append(separator);
+            first[0] = false;
+            this.append(d);
+        });
+        return this;
+    }
+
+    default <T> IIndentStream join(String separator, T[] data, Function<T, String> generator) {
+        boolean first = true;
+        for (T d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(generator.apply(d));
+        }
+        return this;
+    }
+    
+    default <T> IIndentStream intercalate(String separator, T[] data, Function<T, String> generator) {
+        for (T d: data) {
+            this.append(generator.apply(d));
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default <T extends ToIndentableString> IIndentStream join(String separator, T[] data) {
+        boolean first = true;
+        for (ToIndentableString d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(d);
+        }
+        return this;
+    }
+
+    default IIndentStream join(String separator, Collection<String> data) {
+        boolean first = true;
+        for (String d: data) {
+            if (!first)
+                this.append(separator);
+            first = false;
+            this.append(d);
+        }
+        return this;
+    }
+
+    default IIndentStream joinSupplier(String separator, Supplier<Collection<String>> data) {
+        return this.join(separator, data.get());
+    }
+
+    default IIndentStream intercalate(String separator, Collection<String> data) {
+        for (String d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default IIndentStream intercalate(String separator, String[] data) {
+        for (String d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default IIndentStream intercalateS(String separator, Collection<String> data) {
+        for (String d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default <T extends ToIndentableString>
+    IIndentStream intercalateI(String separator, Collection<T> data) {
+        for (T d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default <T extends ToIndentableString> IIndentStream intercalateI(String separator, T[] data) {
+        for (T d: data) {
+            this.append(d);
+            this.append(separator);
+        }
+        return this;
+    }
+
+    default IIndentStream newline()  {
+        return this.append("\n");
+    }
+
     /** Increase indentation and emit a newline. */
     IIndentStream increase();
     IIndentStream decrease();
+
     default IIndentStream appendJsonLabelAndColon(String label) {
         return this.append("\"").append(Utilities.escapeDoubleQuotes(label)).append("\": ");
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IndentStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IndentStream.java
@@ -26,10 +26,6 @@
 package org.dbsp.util;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 public class IndentStream implements IIndentStream {
     private Appendable stream;
@@ -50,8 +46,9 @@ public class IndentStream implements IIndentStream {
     }
 
     /** Set the indent amount.  If less or equal to 0, newline will have no effect. */
-    public void setIndentAmount(int amount) {
+    public IndentStream setIndentAmount(int amount) {
         this.amount = amount;
+        return this;
     }
 
     @Override
@@ -74,193 +71,6 @@ public class IndentStream implements IIndentStream {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-    }
-
-    @Override
-    public IIndentStream append(String string) {
-        for (int i = 0; i < string.length(); i++) {
-            char c = string.charAt(i);
-            this.appendChar(c);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream append(boolean b) {
-        return this.append(Boolean.toString(b));
-    }
-
-    @Override
-    public <T extends ToIndentableString> IIndentStream append(T value) {
-        value.toString(this);
-        return this;
-    }
-
-    @Override
-    public IIndentStream append(int value) {
-        this.append(Integer.toString(value));
-        return this;
-    }
-
-    @Override
-    public IIndentStream append(long value) {
-        this.append(Long.toString(value));
-        return this;
-    }
-
-    @Override
-    public IIndentStream appendSupplier(Supplier<String> supplier) {
-        return this.append(supplier.get());
-    }
-
-    @Override
-    public IIndentStream joinS(String separator, Collection<String> data) {
-        boolean first = true;
-        for (String d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(d);
-        }
-        return this;
-    }
-
-    @Override
-    public <T extends ToIndentableString>
-    IIndentStream joinI(String separator, Collection<T> data) {
-        boolean first = true;
-        for (ToIndentableString d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(d);
-        }
-        return this;
-    }
-
-    @Override
-    public <T> IIndentStream join(String separator, T[] data, Function<T, String> generator) {
-        boolean first = true;
-        for (T d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(generator.apply(d));
-        }
-        return this;
-    }
-
-    @Override
-    public <T> IIndentStream intercalate(String separator, T[] data, Function<T, String> generator) {
-        for (T d: data) {
-            this.append(generator.apply(d));
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream join(String separator, String[] data) {
-        boolean first = true;
-        for (String d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(d);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream join(String separator, Stream<String> data) {
-        final boolean[] first = {true};
-        data.forEach(d -> {
-            if (!first[0])
-                this.append(separator);
-            first[0] = false;
-            this.append(d);
-        });
-        return this;
-    }
-
-    @Override
-    public <T extends ToIndentableString> IIndentStream join(String separator, T[] data) {
-        boolean first = true;
-        for (ToIndentableString d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(d);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream join(String separator, Collection<String> data) {
-        boolean first = true;
-        for (String d: data) {
-            if (!first)
-                this.append(separator);
-            first = false;
-            this.append(d);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream joinSupplier(String separator, Supplier<Collection<String>> data) {
-        return this.join(separator, data.get());
-    }
-
-    @Override
-    public IIndentStream intercalate(String separator, Collection<String> data) {
-        for (String d: data) {
-            this.append(d);
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream intercalate(String separator, String[] data) {
-        for (String d: data) {
-            this.append(d);
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream intercalateS(String separator, Collection<String> data) {
-        for (String d: data) {
-            this.append(d);
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public <T extends ToIndentableString>
-    IIndentStream intercalateI(String separator, Collection<T> data) {
-        for (T d: data) {
-            this.append(d);
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public <T extends ToIndentableString> IIndentStream intercalateI(String separator, T[] data) {
-        for (T d: data) {
-            this.append(d);
-            this.append(separator);
-        }
-        return this;
-    }
-
-    @Override
-    public IIndentStream newline() {
-        return this.append("\n");
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/JsonStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/JsonStream.java
@@ -9,15 +9,14 @@ public class JsonStream {
         public int index;
     }
 
-    static class InArray extends Context {
-    }
+    static class InArray extends Context {}
 
     static class InObject extends Context {
         public boolean expectLabel = true;
     }
 
-    List<Context> context = new ArrayList<>();
-    IIndentStream stream;
+    final List<Context> context = new ArrayList<>();
+    private final IIndentStream stream;
 
     public JsonStream(IIndentStream stream) {
         this.stream = stream;
@@ -85,8 +84,10 @@ public class JsonStream {
     }
 
     public JsonStream label(String label) {
+        assert !label.isEmpty();
         Context last = Utilities.last(this.context);
-        InObject io = last.to(InObject.class);
+        InObject io = last.to(InObject.class,
+                "Adding label but not within JsonObject");
         if (!io.expectLabel)
             throw new RuntimeException("Consecutive labels");
         io.expectLabel = false;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullIndentStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/NullIndentStream.java
@@ -30,9 +30,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-/**
- * Drops all data written.
- */
+/** Drops all data written. */
 public class NullIndentStream implements IIndentStream {
     public NullIndentStream() {}
 

--- a/sql-to-dbsp-compiler/slt/skip.txt
+++ b/sql-to-dbsp-compiler/slt/skip.txt
@@ -9,3 +9,6 @@ SELECT ALL CASE - 6 WHEN + 70 + ( 81 ) THEN NULL WHEN COALESCE ( - 22, - + COALE
 SELECT ALL - 23 / 19 / - 0 / ( - 13 ) * ( - MIN ( + CAST ( NULL AS INTEGER ) ) ) + - ( - + 1 )
 // test/random/expr/slt_good_118.test: test 7834, division by zero
 SELECT ALL 12 / + + 0 * - MAX ( + CASE - 75 WHEN ( 44 ) * - 15 - - ( - + 55 ) * 89 THEN 45 WHEN 67 THEN NULL ELSE NULL END ) + 39 * - 69 AS col2
+// test/random/expr/slt_good_115.test: test 9895, multiplication overflow
+SELECT DISTINCT - 27 + 0 + 47 - - 3, - 72 * + + 23 * - - NULLIF ( ( 36 ), 23 * + MIN ( - 66 ) * - 84 * 58 * 48 * - - 61 / - ( 58 ) ) * COUNT ( * ) + + 95 + + COUNT ( DISTINCT + 42 ) col1
+


### PR DESCRIPTION
This is a step towards having circuits reuse storage after being restarted.
What this PR does is to add a method of fingerprinting operators based on Merkle trees (really DAGs in our case).
There is a visitor called `MerkleOuter` which computes a cryptographic hash value for each operator in a circuit.
This hash value will be used in the future to derive the name of the storage files that are keeping the data for this operator.
The hash has the property that if two nodes have the same hash, then very (very!) likely they are computing the same function.
The hash of an operator is computed by applying a hash function to the following strings:
- the hash of its inputs (recursively computed)
- the hash of the functions it is invoking
- other metadata the operator may have (e.g., column names for inputs, boolean properties, etc.)
The visitor reuses the Json visitor by generating a Json string with all this information and hashing that.

The hash of the functions is currently produced by generating Rust code as a string, and hashing that. A new visitor called `CanonicalForm` has been created which does alpha-renaming of all closures so that they have parameters named in some deterministic way.

There is a test that shows how this scheme can reuse all operators in a circuit when a new view is added.

We also disable a faulty SLT test.