### PR TITLE
[adapters] Better arrow error reporting.

### DIFF
--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -1,11 +1,19 @@
 use std::borrow::Cow;
 use std::path::Path;
 use std::{
+    error::Error,
     fs::File,
     io::{Error as IoError, Write},
 };
 
 use tempfile::NamedTempFile;
+
+pub(crate) fn root_cause(mut err: &dyn Error) -> &dyn Error {
+    while let Some(source) = err.source() {
+        err = source;
+    }
+    err
+}
 
 pub(crate) fn truncate_ellipse<'a>(s: &'a str, len: usize, ellipse: &str) -> Cow<'a, str> {
     if s.len() <= len {


### PR DESCRIPTION
This patch improves error reporting when reading from Delta Lake. The DataFusionError type can wrap multiple errors from different crates. In case when the error is returned from object_store via the arrow crate, printing it using the Display trait outputs partial information about the error, e.g.,:

"Generic S3 error: error decoding response body"

This fix additionally prints the root cause of the error, e.g.:

"Generic S3 error: error decoding response body (root cause: operation timed out)"