### PR TITLE
[WebConsole] Fix long error content breaks adhoc results table

### DIFF
--- a/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
+++ b/web-console/src/lib/components/common/virtualList/HeadlessVirtualList.svelte
@@ -117,7 +117,7 @@
   {#each indices as index, i (index)}
     {@render item({
       index,
-      style: `transform: translateY(${(indexOffset - (stickyRow === undefined ? 0 : 1)) * itemSize}px);`
+      style: `transform: translateY(${(indexOffset - (stickyRow === undefined ? 0 : 1)) * itemSize}px); white-space: nowrap;`
     })}
   {/each}
   {@render footer?.()}

--- a/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
+++ b/web-console/src/lib/components/pipelines/editor/LogsStreamList.svelte
@@ -41,7 +41,7 @@
   role="textbox"
   class="bg-white-dark h-full w-full overflow-y-auto whitespace-pre-wrap rounded pl-2 scrollbar"
   style="font-family: {theme.config.monospaceFontFamily}; user-select: contain;"
-  tabindex={99}
+  tabindex={-1}
   use:reverseScroll.action
   use:selectScope
   use:virtualSelect={{

--- a/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
@@ -44,7 +44,7 @@
     class="flex min-h-full flex-1 flex-col gap-4 rounded"
     use:selectScope
     role="textbox"
-    tabindex={99}
+    tabindex={-1}
   >
     {#if verbatimErrors.value}
       {@const stderr = [


### PR DESCRIPTION
Now, when the results contain a single error it is displayed as a simple element, not in a virtual table
If the multiline error will appear after some ad-hoc results it will be displayed in a single line
The issue is this particular virtual table implementation does not support multiline rows

The proper fix is to display ad-hoc query results in a virtual list component that supports both multiline rows and native HTML tables, which requires an upstream contribution to a library we use

Fix https://github.com/feldera/feldera/issues/3630: Fix multiline ad-hoc error breaks the results table

Also: added ability to Ctrl+A only the content of a single ad-hoc query error