### PR TITLE
pipeline-manager: flag to preinstall pg-embed

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -347,6 +347,7 @@ build-pipeline-manager-container:
     ENV PATH="$PATH:/home/feldera/.cargo/bin"
 
     RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/database-stream-processor/sql-to-dbsp-compiler --compilation-cargo-lock-path=/home/feldera/Cargo.lock --compilation-profile=unoptimized --dbsp-override-path=/home/feldera/database-stream-processor --precompile
+    RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/database-stream-processor/sql-to-dbsp-compiler --compilation-cargo-lock-path=/home/feldera/Cargo.lock --compilation-profile=unoptimized --dbsp-override-path=/home/feldera/database-stream-processor --preinstall-pg-embed
     ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/database-stream-processor/sql-to-dbsp-compiler", "--compilation-cargo-lock-path=/home/feldera/Cargo.lock", "--dbsp-override-path=/home/feldera/database-stream-processor", "--compilation-profile=unoptimized", "--demos-dir", "/home/feldera/demos"]
 
 # Same as the above, but with a permissive CORS setting, else playwright doesn't work

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -159,6 +159,12 @@ pub struct PgEmbedConfig {
     #[serde(default = "default_pg_embed_working_directory")]
     #[arg(long, default_value_t = default_pg_embed_working_directory())]
     pub pg_embed_working_directory: String,
+
+    /// Whether to preinstall a Postgres embedded instance and immediately return.
+    /// The --precompile flag takes precedence over this flag and is checked before.
+    /// As such, if both are specified, pg-embed pre-installation will not occur.
+    #[arg(long)]
+    pub preinstall_pg_embed: bool,
 }
 
 impl PgEmbedConfig {

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -140,5 +140,7 @@ ENV PATH="$PATH:/home/feldera/.cargo/bin:/home/feldera/mold/bin"
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 # Run the precompile phase to speed up Rust compilations during deployment
 RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler --compilation-cargo-lock-path=/home/feldera/Cargo.lock --dbsp-override-path=/home/feldera/lib --precompile
+# Run the pg-embed preinstall such that it doesn't need to download the Postgres binaries afterward
+RUN ./pipeline-manager --bind-address=0.0.0.0 --sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler --compilation-cargo-lock-path=/home/feldera/Cargo.lock --dbsp-override-path=/home/feldera/lib --preinstall-pg-embed
 ENV BANNER_ADDR=localhost
 ENTRYPOINT ["./pipeline-manager", "--bind-address=0.0.0.0", "--sql-compiler-home=/home/feldera/lib/sql-to-dbsp-compiler", "--compilation-cargo-lock-path=/home/feldera/Cargo.lock", "--dbsp-override-path=/home/feldera/lib", "--demos-dir", "/home/feldera/demos"]


### PR DESCRIPTION
The `--preinstall-pg-embed` flag causes the pipeline-manager main to download the Postgres binaries, run the embedded instance, connect to it, and then immediately return. The benefit of this is that it doesn't need to download the Postgres binaries afterward.

**Related issues**
- Fixes: https://github.com/feldera/feldera/issues/3642