### PR TITLE
pipeline-manager: `/config` endpoint type and adjust `platform_version`

### DIFF
--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -156,6 +156,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::config::TransportConfig,
         feldera_types::config::FormatConfig,
         feldera_types::config::ResourceConfig,
+        feldera_types::config::ObjectStorageConfig,
         feldera_types::transport::adhoc::AdHocInputConfig,
         feldera_types::transport::file::FileInputConfig,
         feldera_types::transport::file::FileOutputConfig,

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -10,17 +10,30 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// The default `platform_version` is formed using two compilation environment variables:
+/// The default `platform_version` is formed using three compilation environment variables:
 /// - `CARGO_PKG_VERSION` set by Cargo
+/// - `FELDERA_ENTERPRISE_VERSION` set by the custom `build.rs` script,
+///   which is determined using the similarly named environment variable
 /// - `FELDERA_PLATFORM_VERSION_SUFFIX` set by the custom `build.rs` script,
 ///   which is determined using the similarly named environment variable
+///
+/// ... and whether the `feldera-enterprise` feature is enabled.
 fn default_platform_version() -> String {
-    let package_version = env!("CARGO_PKG_VERSION").to_string();
     let suffix = env!("FELDERA_PLATFORM_VERSION_SUFFIX").to_string();
-    if suffix.is_empty() {
-        package_version
+    if cfg!(feature = "feldera-enterprise") {
+        let enterprise_version = env!("FELDERA_ENTERPRISE_VERSION").to_string();
+        if suffix.is_empty() {
+            format!("{enterprise_version}+enterprise")
+        } else {
+            format!("{enterprise_version}+enterprise.{suffix}")
+        }
     } else {
-        format!("{package_version}+{suffix}")
+        let package_version = env!("CARGO_PKG_VERSION").to_string();
+        if suffix.is_empty() {
+            package_version
+        } else {
+            format!("{package_version}+{suffix}")
+        }
     }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -3002,14 +3002,26 @@
         "type": "object",
         "required": [
           "telemetry",
-          "version"
+          "edition",
+          "version",
+          "revision"
         ],
         "properties": {
+          "edition": {
+            "type": "string",
+            "description": "Feldera edition: \"Open source\" or \"Enterprise\""
+          },
+          "revision": {
+            "type": "string",
+            "description": "Specific revision corresponding to the edition `version` (e.g., git commit hash).\nThis is an empty string if it is unspecified."
+          },
           "telemetry": {
-            "type": "string"
+            "type": "string",
+            "description": "Telemetry key."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version corresponding to the type of `edition`.\nFormat is `x.y.z`."
           }
         }
       },
@@ -3951,6 +3963,22 @@
           "auction",
           "person"
         ]
+      },
+      "ObjectStorageConfig": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "URL.\n\nThe following URL schemes are supported:\n\n* S3:\n- `s3://<bucket>/<path>`\n- `s3a://<bucket>/<path>`\n- `https://s3.<region>.amazonaws.com/<bucket>`\n- `https://<bucket>.s3.<region>.amazonaws.com`\n- `https://ACCOUNT_ID.r2.cloudflarestorage.com/bucket`\n* Google Cloud Storage:\n- `gs://<bucket>/<path>`\n* Microsoft Azure Blob Storage:\n- `abfs[s]://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))\n- `abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>`\n- `abfs[s]://<file_system>@<account_name>.dfs.fabric.microsoft.com/<path>`\n- `az://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))\n- `adl://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))\n- `azure://<container>/<path>` (custom)\n- `https://<account>.dfs.core.windows.net`\n- `https://<account>.blob.core.windows.net`\n- `https://<account>.blob.core.windows.net/<container>`\n- `https://<account>.dfs.fabric.microsoft.com`\n- `https://<account>.dfs.fabric.microsoft.com/<container>`\n- `https://<account>.blob.fabric.microsoft.com`\n- `https://<account>.blob.fabric.microsoft.com/<container>`\n\nSettings derived from the URL will override other settings."
+          }
+        },
+        "additionalProperties": {
+          "type": "string",
+          "description": "Additional options as key-value pairs.\n\nThe following keys are supported:\n\n* S3:\n- `access_key_id`: AWS Access Key.\n- `secret_access_key`: AWS Secret Access Key.\n- `region`: Region.\n- `default_region`: Default region.\n- `endpoint`: Custom endpoint for communicating with S3,\ne.g. `https://localhost:4566` for testing against a localstack\ninstance.\n- `token`: Token to use for requests (passed to underlying provider).\n- [Other keys](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants).\n* Google Cloud Storage:\n- `service_account`: Path to the service account file.\n- `service_account_key`: The serialized service account key.\n- `google_application_credentials`: Application credentials path.\n- [Other keys](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html).\n* Microsoft Azure Blob Storage:\n- `access_key`: Azure Access Key.\n- `container_name`: Azure Container Name.\n- `account`: Azure Account.\n- `bearer_token_authorization`: Static bearer token for authorizing requests.\n- `client_id`: Client ID for use in client secret or Kubernetes federated credential flow.\n- `client_secret`: Client secret for use in client secret flow.\n- `tenant_id`: Tenant ID for use in client secret or Kubernetes federated credential flow.\n- `endpoint`: Override the endpoint for communicating with blob storage.\n- [Other keys](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants).\n\nOptions set through the URL take precedence over those set with these\noptions."
+        }
       },
       "OutputBufferConfig": {
         "type": "object",

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -150,7 +150,23 @@ export type ColumnType = {
 export type CompilationProfile = 'dev' | 'unoptimized' | 'optimized'
 
 export type Configuration = {
+  /**
+   * Feldera edition: "Open source" or "Enterprise"
+   */
+  edition: string
+  /**
+   * Specific revision corresponding to the edition `version` (e.g., git commit hash).
+   * This is an empty string if it is unspecified.
+   */
+  revision: string
+  /**
+   * Telemetry key.
+   */
   telemetry: string
+  /**
+   * The version corresponding to the type of `edition`.
+   * Format is `x.y.z`.
+   */
   version: string
 }
 
@@ -401,6 +417,12 @@ export type DeltaTableReaderConfig = {
    */
   datetime?: string | null
   mode: DeltaTableIngestMode
+  /**
+   * The number of parallel parsing tasks the connector uses to process data read from the
+   * table. Increasing this value can enhance performance by allowing more concurrent processing.
+   * Recommended range: 1–10. The default is 4.
+   */
+  num_parsers?: number
   /**
    * Optional row filter.
    *
@@ -1163,6 +1185,75 @@ export type NexmarkInputOptions = {
  * Table in Nexmark.
  */
 export type NexmarkTable = 'bid' | 'auction' | 'person'
+
+export type ObjectStorageConfig = {
+  /**
+   * URL.
+   *
+   * The following URL schemes are supported:
+   *
+   * * S3:
+   * - `s3://<bucket>/<path>`
+   * - `s3a://<bucket>/<path>`
+   * - `https://s3.<region>.amazonaws.com/<bucket>`
+   * - `https://<bucket>.s3.<region>.amazonaws.com`
+   * - `https://ACCOUNT_ID.r2.cloudflarestorage.com/bucket`
+   * * Google Cloud Storage:
+   * - `gs://<bucket>/<path>`
+   * * Microsoft Azure Blob Storage:
+   * - `abfs[s]://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+   * - `abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>`
+   * - `abfs[s]://<file_system>@<account_name>.dfs.fabric.microsoft.com/<path>`
+   * - `az://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+   * - `adl://<container>/<path>` (according to [fsspec](https://github.com/fsspec/adlfs))
+   * - `azure://<container>/<path>` (custom)
+   * - `https://<account>.dfs.core.windows.net`
+   * - `https://<account>.blob.core.windows.net`
+   * - `https://<account>.blob.core.windows.net/<container>`
+   * - `https://<account>.dfs.fabric.microsoft.com`
+   * - `https://<account>.dfs.fabric.microsoft.com/<container>`
+   * - `https://<account>.blob.fabric.microsoft.com`
+   * - `https://<account>.blob.fabric.microsoft.com/<container>`
+   *
+   * Settings derived from the URL will override other settings.
+   */
+  url: string
+  /**
+   * Additional options as key-value pairs.
+   *
+   * The following keys are supported:
+   *
+   * * S3:
+   * - `access_key_id`: AWS Access Key.
+   * - `secret_access_key`: AWS Secret Access Key.
+   * - `region`: Region.
+   * - `default_region`: Default region.
+   * - `endpoint`: Custom endpoint for communicating with S3,
+   * e.g. `https://localhost:4566` for testing against a localstack
+   * instance.
+   * - `token`: Token to use for requests (passed to underlying provider).
+   * - [Other keys](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants).
+   * * Google Cloud Storage:
+   * - `service_account`: Path to the service account file.
+   * - `service_account_key`: The serialized service account key.
+   * - `google_application_credentials`: Application credentials path.
+   * - [Other keys](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html).
+   * * Microsoft Azure Blob Storage:
+   * - `access_key`: Azure Access Key.
+   * - `container_name`: Azure Container Name.
+   * - `account`: Azure Account.
+   * - `bearer_token_authorization`: Static bearer token for authorizing requests.
+   * - `client_id`: Client ID for use in client secret or Kubernetes federated credential flow.
+   * - `client_secret`: Client secret for use in client secret flow.
+   * - `tenant_id`: Tenant ID for use in client secret or Kubernetes federated credential flow.
+   * - `endpoint`: Override the endpoint for communicating with blob storage.
+   * - [Other keys](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants).
+   *
+   * Options set through the URL take precedence over those set with these
+   * options.
+   */
+  '[key: string]': string | undefined
+}
 
 export type OutputBufferConfig = {
   /**
@@ -2084,17 +2175,17 @@ export type SqlType =
  */
 export type StorageBackendConfig =
   | {
-      config: 'default'
-      name: 'config'
+      name: 'default'
     }
   | {
-      config: 'io_uring'
-      name: 'config'
+      name: 'io_uring'
+    }
+  | {
+      config: ObjectStorageConfig
+      name: 'object'
     }
 
-export type config = 'default'
-
-export type name = 'config'
+export type name = 'default'
 
 /**
  * How to cache access to storage within a Feldera pipeline.


### PR DESCRIPTION
Aligns the type of the `/config` endpoint denoted by the OpenAPI to what is returned.

Adjusts the `platform_version` depending on if it is the enterprise edition and whether a suffix (e.g., git commit hash) is provided:
- `x.y.z`
- `x.y.z+[suffix]`
- `x.y.z+enterprise`
- `x.y.z+enterprise.[suffix]`

... with `x.y.z` either the package version (open source) or the enterprise version.