### PR TITLE
[dbsp] Use seek_key_exact more widely.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
@@ -135,10 +135,8 @@ where
             let mut key = clone_box(delta_cursor.key());
             let mut retract = false;
 
-            output_trace_cursor.seek_key(&key);
-
             // Read the current value of the aggregate, be careful to skip entries with weight 0.
-            if output_trace_cursor.key_valid() && output_trace_cursor.key() == key.as_ref() {
+            if output_trace_cursor.seek_key_exact(&key) {
                 while output_trace_cursor.val_valid() {
                     if **output_trace_cursor.weight() == 0 {
                         output_trace_cursor.step_val();

--- a/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
@@ -847,15 +847,12 @@ where
         //     time
         // );
 
-        // Lookup key in input.
-        input_cursor.seek_key(key);
-
         let (output_key, aggregate) = key_aggregate.split_mut();
         key.clone_to(output_key);
 
         // If found, compute `agg` using formula (1) above; otherwise the aggregate is
         // `0`.
-        if input_cursor.key_valid() && input_cursor.key() == key {
+        if input_cursor.seek_key_exact(key) {
             // Apply aggregator to a `CursorGroup` that iterates over the nested
             // Z-set associated with `input_cursor.key()` at time `time`.
             self.aggregator.aggregate_and_finalize(

--- a/crates/dbsp/src/operator/dynamic/asof_join.rs
+++ b/crates/dbsp/src/operator/dynamic/asof_join.rs
@@ -257,8 +257,7 @@ where
         R: WeightTrait + ?Sized,
         C: Cursor<K, V, T, R>,
     {
-        cursor.seek_key(key);
-        if cursor.get_key() == Some(key) {
+        if cursor.seek_key_exact(key) {
             Some(cursor)
         } else {
             None

--- a/crates/dbsp/src/operator/dynamic/group/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/group/mod.rs
@@ -435,8 +435,6 @@ where
                 &mut cb_desc as &mut dyn FnMut(&mut OB::Val, &mut B::R)
             };
 
-            input_trace_cursor.seek_key(&key);
-
             let mut delta_group_cursor = CursorGroup::new(&mut delta_cursor, ());
 
             // I was not able to avoid 4-way code duplication below.  Depending on
@@ -445,12 +443,10 @@ where
             // empty/non-empty cursors.  Since the cursors have different types
             // (`CursorEmpty` and `CursorGroup`), we can't bind them to the same
             // variable.
-            if input_trace_cursor.key_valid() && input_trace_cursor.key() == key.as_ref() {
+            if input_trace_cursor.seek_key_exact(&key) {
                 let mut input_group_cursor = CursorGroup::new(&mut input_trace_cursor, ());
 
-                output_trace_cursor.seek_key(&key);
-
-                if output_trace_cursor.key_valid() && output_trace_cursor.key() == key.as_ref() {
+                if output_trace_cursor.seek_key_exact(&key) {
                     let mut output_group_cursor = CursorGroup::new(&mut output_trace_cursor, ());
 
                     self.transformer.transform(
@@ -474,9 +470,7 @@ where
                 let mut input_group_cursor =
                     CursorEmpty::new(self.output_factories.weight_factory());
 
-                output_trace_cursor.seek_key(&key);
-
-                if output_trace_cursor.key_valid() && output_trace_cursor.key() == key.as_ref() {
+                if output_trace_cursor.seek_key_exact(&key) {
                     let mut output_group_cursor = CursorGroup::new(&mut output_trace_cursor, ());
 
                     self.transformer.transform(

--- a/crates/dbsp/src/operator/dynamic/input_upsert.rs
+++ b/crates/dbsp/src/operator/dynamic/input_upsert.rs
@@ -399,9 +399,7 @@ where
                 cur_val.set_none();
 
                 // Generate retraction if `key` is present in the trace.
-                trace_cursor.seek_key(key);
-
-                if trace_cursor.key_valid() && trace_cursor.key() == key {
+                if trace_cursor.seek_key_exact(key) {
                     // println!("{}: found key in trace_cursor", Runtime::worker_index());
                     while trace_cursor.val_valid() {
                         let mut weight = ZWeight::zero();

--- a/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -392,12 +392,12 @@ where
 
             let delta_partition_cursor = PartitionCursor::new(&mut delta_cursor);
 
-            input_cursor.seek_key(&key);
-            output_cursor.seek_key(&key);
+            let found_input = input_cursor.seek_key_exact(&key);
+            let found_output = output_cursor.seek_key_exact(&key);
 
             updates.clear();
 
-            if input_cursor.key_valid() && input_cursor.key() == &*key {
+            if found_input {
                 // println!("input partition exists");
                 /*while input_cursor.val_valid() {
                     // println!("input val: {:x?}", input_cursor.val());
@@ -405,7 +405,7 @@ where
                 }*/
                 //input_cursor.rewind_vals();
 
-                if output_cursor.key_valid() && output_cursor.key() == &*key {
+                if found_output {
                     // println!("tree partition exists");
 
                     radix_tree_update::<TS, V, Acc, _, _, _, _>(
@@ -428,7 +428,7 @@ where
                         &mut *updates,
                     );
                 }
-            } else if output_cursor.key_valid() && output_cursor.key() == &*key {
+            } else if found_output {
                 radix_tree_update::<TS, V, Acc, _, _, _, _>(
                     &self.factories.radix_tree_factories,
                     delta_partition_cursor,

--- a/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/rolling_aggregate.rs
@@ -795,8 +795,7 @@ where
             // println!("affected_ranges: {ranges:?}");
 
             // Clear old outputs.
-            output_trace_cursor.seek_key(delta_cursor.key());
-            if output_trace_cursor.key_valid() && output_trace_cursor.key() == delta_cursor.key() {
+            if output_trace_cursor.seek_key_exact(delta_cursor.key()) {
                 let mut range_cursor = RangeCursor::new(
                     PartitionCursor::new(&mut output_trace_cursor),
                     ranges.clone(),
@@ -820,15 +819,10 @@ where
             };
 
             // Compute new outputs.
-            input_trace_cursor.seek_key(delta_cursor.key());
-            tree_cursor.seek_key(delta_cursor.key());
-
-            if input_trace_cursor.key_valid()
-                && input_trace_cursor.key() == delta_cursor.key()
+            if input_trace_cursor.seek_key_exact(delta_cursor.key())
                 // It's possible that the key is in the input trace with weight 0, but it's no longer in the tree, which
                 // caused `test_empty_tree()` to fail without this check.
-                && tree_cursor.key_valid()
-                && tree_cursor.key() == delta_cursor.key()
+                && tree_cursor.seek_key_exact(delta_cursor.key())
             {
                 let mut tree_partition_cursor = PartitionCursor::new(&mut tree_cursor);
                 let mut input_range_cursor =

--- a/crates/dbsp/src/operator/dynamic/upsert.rs
+++ b/crates/dbsp/src/operator/dynamic/upsert.rs
@@ -353,9 +353,7 @@ where
                 key_updates.push_val(&mut *item);
             }
 
-            trace_cursor.seek_key(key);
-
-            if trace_cursor.key_valid() && trace_cursor.key() == key {
+            if trace_cursor.seek_key_exact(key) {
                 // println!("{}: found key in trace_cursor", Runtime::worker_index());
                 while trace_cursor.val_valid() {
                     let mut weight = ZWeight::zero();


### PR DESCRIPTION
Fixes #3486

`seek_key_exact` is more efficient than `seek_key` as it takes advantage of the Bloom filter and possibly other future optimizations. Most of DBSP operators that use `seek_key` can use `seek_key_exact` instead, so we apply it wherever possible. In particular, using it in `input_upsert` makes ingesting data in tables with primary keys much more efficient.