### PR TITLE
pipeline-manager: configurable provisioning timeout

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -358,6 +358,10 @@ pub struct RuntimeConfig {
     /// as long as different pipelines running on the same machine are pinned to
     /// different CPUs.
     pub pin_cpus: Vec<usize>,
+
+    /// Timeout in seconds for the `Provisioning` phase of the pipeline.
+    /// Setting this value will override the default of the runner.
+    pub provisioning_timeout_secs: Option<u64>,
 }
 
 /// Accepts "true" and "false" and converts them to the new format.
@@ -480,6 +484,7 @@ impl Default for RuntimeConfig {
                 Some(100_000)
             },
             pin_cpus: Vec::new(),
+            provisioning_timeout_secs: None,
         }
     }
 }

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -97,6 +97,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
             },
             clock_resolution_usecs: Some(100_000),
             pin_cpus: Vec::new(),
+            provisioning_timeout_secs: Some(1200),
         })
         .unwrap(),
         program_code: "CREATE TABLE table2 ( col2 VARCHAR );".to_string(),

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -214,6 +214,7 @@ struct RuntimeConfigPropVal {
     val11: Option<u64>,
     val12: Option<String>,
     val13: Option<u64>,
+    val14: Option<u64>,
 }
 type ProgramConfigPropVal = (u8, bool, bool, bool);
 type ProgramInfoPropVal = (u8, u8, u8);
@@ -252,6 +253,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> serde_json::V
             },
             clock_resolution_usecs: val.val13,
             pin_cpus: Vec::new(),
+            provisioning_timeout_secs: val.val14,
         })
         .unwrap()
     }
@@ -982,6 +984,7 @@ async fn pipeline_versioning() {
         },
         clock_resolution_usecs: None,
         pin_cpus: Vec::new(),
+        provisioning_timeout_secs: None,
     })
     .unwrap();
     handle
@@ -1443,6 +1446,7 @@ async fn pipeline_provision_version_guard() {
                     resources: Default::default(),
                     clock_resolution_usecs: None,
                     pin_cpus: Vec::new(),
+                    provisioning_timeout_secs: None,
                 })
                 .unwrap(),
             ),

--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -4,6 +4,7 @@ use actix_web::{
     body::BoxBody, http::StatusCode, HttpResponse, HttpResponseBuilder, ResponseError,
 };
 use feldera_types::error::{DetailedError, ErrorResponse};
+use indoc::writedoc;
 use serde::Serialize;
 use std::{borrow::Cow, error::Error as StdError, fmt, fmt::Display, time::Duration};
 
@@ -214,21 +215,33 @@ impl Display for RunnerError {
                 )
             }
             Self::AutomatonProvisioningTimeout { timeout } => {
-                write!(
+                writedoc! {
                     f,
-                    "Waiting for provisioning timed out after {}s \
-                    -- this occurs when the required resources requested by the runner \
-                    for deployment took too long to be provisioned",
+                    "
+                    Pipeline could not be provisioned within the timeout of {}s. Possible reasons:
+
+                    1) It takes too long to bring up the pipeline (e.g., cloud resources) compared to the timeout.
+                       If so, try increasing `provisioning_timeout_secs` in the Pipeline settings.
+
+                    2) Your cloud environment could not provision some required resources like volumes or containers.
+                       The pipeline logs might provide more insight if this is the case.
+                    ",
                     timeout.as_secs()
-                )
+                }
             }
             Self::AutomatonInitializingTimeout { timeout } => {
-                write!(
+                writedoc! {
                     f,
-                    "Waiting for initialization timed out after {}s \
-                    -- additional information about the cause can likely be found in the pipeline logs",
+                    "
+                    Pipeline could not be initialized within the timeout of {}s. Possible reasons:
+
+                    (1) It takes too long to initialize the internal state and connectors compared to the timeout.
+
+                    (2) Initialization encountered an unexpected issue.
+                        The pipeline logs might provide more insight if this is the case.
+                    ",
                     timeout.as_secs()
-                )
+                }
             }
             Self::AutomatonAfterInitializationBecameRunning => {
                 write!(

--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -383,12 +383,8 @@ impl LocalRunner {
 impl PipelineExecutor for LocalRunner {
     type Config = LocalRunnerConfig;
 
-    // Provisioning is over once the pipeline port file has been detected.
-    const PROVISIONING_TIMEOUT: Duration = Duration::from_millis(20_000);
-    const PROVISIONING_POLL_PERIOD: Duration = Duration::from_millis(250);
-
-    // Shutdown is over once the process has exited.
-    const SHUTDOWN_POLL_PERIOD: Duration = Duration::from_millis(500);
+    // Provisioning is over once the process is spawned and the port file created by it is detected.
+    const DEFAULT_PROVISIONING_TIMEOUT: Duration = Duration::from_millis(20_000);
 
     /// Creation steps:
     /// - Spawn a log rejection thread

--- a/crates/pipeline-manager/src/runner/main.rs
+++ b/crates/pipeline-manager/src/runner/main.rs
@@ -265,9 +265,7 @@ async fn reconcile<E: PipelineExecutor + 'static>(
                                     notifier.clone(),
                                     client.clone(),
                                     pipeline_handle,
-                                    E::PROVISIONING_TIMEOUT,
-                                    E::PROVISIONING_POLL_PERIOD,
-                                    E::SHUTDOWN_POLL_PERIOD,
+                                    E::DEFAULT_PROVISIONING_TIMEOUT,
                                 )
                                 .run(),
                             );

--- a/crates/pipeline-manager/src/runner/pipeline_executor.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_executor.rs
@@ -30,10 +30,8 @@ pub trait PipelineExecutor: Sync + Send {
     /// Configuration unique to the runner type.
     type Config: Clone;
 
-    // Timing constants, which should be set based on the runner type.
-    const PROVISIONING_TIMEOUT: Duration;
-    const PROVISIONING_POLL_PERIOD: Duration;
-    const SHUTDOWN_POLL_PERIOD: Duration;
+    /// Timeout for the `Provisioning` stage in which resources are provisioned.
+    const DEFAULT_PROVISIONING_TIMEOUT: Duration;
 
     // Logs buffer size limit constants.
     const LOGS_BUFFER_LIMIT_BYTE: usize = 1_000_000; // 1 MB

--- a/openapi.json
+++ b/openapi.json
@@ -387,7 +387,8 @@
                         "storage_class": null
                       },
                       "clock_resolution_usecs": 100000,
-                      "pin_cpus": []
+                      "pin_cpus": [],
+                      "provisioning_timeout_secs": null
                     },
                     "program_code": "CREATE TABLE table1 ( col1 INT );",
                     "udf_rust": "",
@@ -443,7 +444,8 @@
                         "storage_class": null
                       },
                       "clock_resolution_usecs": 100000,
-                      "pin_cpus": []
+                      "pin_cpus": [],
+                      "provisioning_timeout_secs": 1200
                     },
                     "program_code": "CREATE TABLE table2 ( col2 VARCHAR );",
                     "udf_rust": "",
@@ -521,7 +523,8 @@
                     "storage_class": null
                   },
                   "clock_resolution_usecs": 100000,
-                  "pin_cpus": []
+                  "pin_cpus": [],
+                  "provisioning_timeout_secs": null
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -568,7 +571,8 @@
                       "storage_class": null
                     },
                     "clock_resolution_usecs": 100000,
-                    "pin_cpus": []
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -710,7 +714,8 @@
                       "storage_class": null
                     },
                     "clock_resolution_usecs": 100000,
-                    "pin_cpus": []
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -815,7 +820,8 @@
                     "storage_class": null
                   },
                   "clock_resolution_usecs": 100000,
-                  "pin_cpus": []
+                  "pin_cpus": [],
+                  "provisioning_timeout_secs": null
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -862,7 +868,8 @@
                       "storage_class": null
                     },
                     "clock_resolution_usecs": 100000,
-                    "pin_cpus": []
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -921,7 +928,8 @@
                       "storage_class": null
                     },
                     "clock_resolution_usecs": 100000,
-                    "pin_cpus": []
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -1147,7 +1155,8 @@
                       "storage_class": null
                     },
                     "clock_resolution_usecs": 100000,
-                    "pin_cpus": []
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -4271,6 +4280,14 @@
                 "description": "Optionally, a list of CPU numbers for CPUs to which the pipeline may pin\nits worker threads.  Specify at least twice as many CPU numbers as\nworkers.  CPUs are generally numbered starting from 0.  The pipeline\nmight not be able to honor CPU pinning requests.\n\nCPU pinning can make pipelines run faster and perform more consistently,\nas long as different pipelines running on the same machine are pinned to\ndifferent CPUs.",
                 "default": []
               },
+              "provisioning_timeout_secs": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Timeout in seconds for the `Provisioning` phase of the pipeline.\nSetting this value will override the default of the runner.",
+                "default": null,
+                "nullable": true,
+                "minimum": 0
+              },
               "resources": {
                 "allOf": [
                   {
@@ -5151,6 +5168,14 @@
             },
             "description": "Optionally, a list of CPU numbers for CPUs to which the pipeline may pin\nits worker threads.  Specify at least twice as many CPU numbers as\nworkers.  CPUs are generally numbered starting from 0.  The pipeline\nmight not be able to honor CPU pinning requests.\n\nCPU pinning can make pipelines run faster and perform more consistently,\nas long as different pipelines running on the same machine are pinned to\ndifferent CPUs.",
             "default": []
+          },
+          "provisioning_timeout_secs": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Timeout in seconds for the `Provisioning` phase of the pipeline.\nSetting this value will override the default of the runner.",
+            "default": null,
+            "nullable": true,
+            "minimum": 0
           },
           "resources": {
             "allOf": [

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -1945,6 +1945,15 @@ as long as different pipelines running on the same machine are pinned to
 different CPUs.`,
           default: []
         },
+        provisioning_timeout_secs: {
+          type: 'integer',
+          format: 'int64',
+          description: `Timeout in seconds for the \`Provisioning\` phase of the pipeline.
+Setting this value will override the default of the runner.`,
+          default: null,
+          nullable: true,
+          minimum: 0
+        },
         resources: {
           allOf: [
             {
@@ -1982,7 +1991,11 @@ different CPUs.`,
         workers: {
           type: 'integer',
           format: 'int32',
-          description: 'Number of DBSP worker threads.',
+          description: `Number of DBSP worker threads.
+
+Each DBSP "foreground" worker thread is paired with a "background"
+thread for LSM merging, making the total number of threads twice the
+specified number.`,
           default: 8,
           minimum: 0
         }
@@ -3007,6 +3020,15 @@ as long as different pipelines running on the same machine are pinned to
 different CPUs.`,
       default: []
     },
+    provisioning_timeout_secs: {
+      type: 'integer',
+      format: 'int64',
+      description: `Timeout in seconds for the \`Provisioning\` phase of the pipeline.
+Setting this value will override the default of the runner.`,
+      default: null,
+      nullable: true,
+      minimum: 0
+    },
     resources: {
       allOf: [
         {
@@ -3044,7 +3066,11 @@ different CPUs.`,
     workers: {
       type: 'integer',
       format: 'int32',
-      description: 'Number of DBSP worker threads.',
+      description: `Number of DBSP worker threads.
+
+Each DBSP "foreground" worker thread is paired with a "background"
+thread for LSM merging, making the total number of threads twice the
+specified number.`,
       default: 8,
       minimum: 0
     }
@@ -3455,9 +3481,11 @@ export const $StorageOptions = {
     },
     cache_mib: {
       type: 'integer',
-      description: `The maximum size of the in-memory storage cache, in mebibytes.
+      description: `The maximum size of the in-memory storage cache, in MiB.
 
-The default is 256 MiB, times the number of workers.`,
+If set, the specified cache size is spread across all the foreground and
+background threads. If unset, each foreground or background thread cache
+is limited to 256 MiB.`,
       default: null,
       nullable: true,
       minimum: 0

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1466,6 +1466,11 @@ export type PipelineConfig = {
    * different CPUs.
    */
   pin_cpus?: Array<number>
+  /**
+   * Timeout in seconds for the `Provisioning` phase of the pipeline.
+   * Setting this value will override the default of the runner.
+   */
+  provisioning_timeout_secs?: number | null
   resources?: ResourceConfig
   storage?: StorageOptions | null
   /**
@@ -1478,6 +1483,10 @@ export type PipelineConfig = {
   tracing_endpoint_jaeger?: string
   /**
    * Number of DBSP worker threads.
+   *
+   * Each DBSP "foreground" worker thread is paired with a "background"
+   * thread for LSM merging, making the total number of threads twice the
+   * specified number.
    */
   workers?: number
 } & {
@@ -2057,6 +2066,11 @@ export type RuntimeConfig = {
    * different CPUs.
    */
   pin_cpus?: Array<number>
+  /**
+   * Timeout in seconds for the `Provisioning` phase of the pipeline.
+   * Setting this value will override the default of the runner.
+   */
+  provisioning_timeout_secs?: number | null
   resources?: ResourceConfig
   storage?: StorageOptions | null
   /**
@@ -2069,6 +2083,10 @@ export type RuntimeConfig = {
   tracing_endpoint_jaeger?: string
   /**
    * Number of DBSP worker threads.
+   *
+   * Each DBSP "foreground" worker thread is paired with a "background"
+   * thread for LSM merging, making the total number of threads twice the
+   * specified number.
    */
   workers?: number
 }
@@ -2272,9 +2290,11 @@ export type StorageConfig = {
 export type StorageOptions = {
   backend?: StorageBackendConfig
   /**
-   * The maximum size of the in-memory storage cache, in mebibytes.
+   * The maximum size of the in-memory storage cache, in MiB.
    *
-   * The default is 256 MiB, times the number of workers.
+   * If set, the specified cache size is spread across all the foreground and
+   * background threads. If unset, each foreground or background thread cache
+   * is limited to 256 MiB.
    */
   cache_mib?: number | null
   compression?: StorageCompression


### PR DESCRIPTION
The provisioning timeout can be set per pipeline using the `provisioning_timeout_secs` parameter in the runtime configuration. This is useful for pipelines with resources that take longer to provision than usual.

The poll periods in each deployment status are set by the automaton, and an explanation of each value is provided.

The setting of `initializing_timeout_secs` will be in a follow-up PR.

**Related issues**
- Partial fix for: https://github.com/feldera/feldera/issues/3662

**Notes**
- Default initializing timeout 300s -> 600s
- Default provisioning timeout remains at 20s for local runner