### PR TITLE
Change prefixes of number formatting to colloquial

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -9,7 +9,10 @@
   import { getDeploymentStatusLabel } from '$lib/functions/pipelines/status'
   import { useInterval } from '$lib/compositions/common/useInterval.svelte'
 
-  const formatQty = (v: number) => format(v >= 1000 ? '.3s' : '.0f')(v)
+  const formatQty = (v: number) =>
+    format(v >= 1000 ? '.3s' : '.0f')(v)
+      .replace(/G/, 'B')
+      .replace(/P/, 'Q')
 
   let {
     pipeline,


### PR DESCRIPTION
The current unit formatting uses SI prefixes for orders of magnitude. This PR changes: G (Giga) -> B (Billion), P (Peta) -> Q (Quintillion)

Fix https://github.com/feldera/feldera/issues/3624: Use appropriate units for large numbers in the UI