### PR TITLE
[dbsp] Avoid warnings for `from_archived`.

### DIFF
--- a/crates/dbsp/src/dynamic/lean_vec.rs
+++ b/crates/dbsp/src/dynamic/lean_vec.rs
@@ -1,5 +1,5 @@
 use rkyv::{
-    from_archived, out_field,
+    out_field,
     ser::{ScratchSpace, Serializer},
     Archive, Archived, Deserialize, DeserializeUnsized, Fallible, RelPtr, Serialize,
     SerializeUnsized,
@@ -934,7 +934,7 @@ impl<T> ArchivedLeanVec<T> {
     /// Returns the number of elements in the archived vec.
     #[inline]
     pub fn len(&self) -> usize {
-        from_archived!(self.len) as usize
+        self.len as usize
     }
 
     /// Returns whether the archived vec is empty.


### PR DESCRIPTION
The code that this fixes produced warnings like this:

```
warning: unexpected `cfg` condition value: `archive_le`
   --> crates/dbsp/src/dynamic/lean_vec.rs:937:9
    |
937 |         from_archived!(self.len) as usize
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `backend-mode` and `default`
```

I think this is a bug in rkyv: it tests for the `archive_le` and `archive_be` features inside the macro implementation, which ends up testing dbsp's features instead of rkyv's.  The correct way to do it would be to test the feature outside the macro implementation, and use a different macro implementation depending on the feature set.  The bug wasn't visible before updating to Rust 1.85 (which starts warning about unknown features) but it was still there.

This commit avoids the warning but it won't be compatible with either `archive_le` or `archive_be` features.  We don't currently use those.

There probably is no point in reporting the bug in rkyv because we use an old version of `rkyv`.  Updating `rkyv` is a good idea but a big task (and we might want to move away from `rkyv` instead).

Fixes https://github.com/feldera/feldera/issues/3660.