### PR TITLE
[dbsp] Fix cache sizing.

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -11,7 +11,7 @@ use crate::{
     DetailedError,
 };
 use core_affinity::{get_core_ids, CoreId};
-use enum_map::{enum_map, EnumMap};
+use enum_map::{enum_map, Enum, EnumMap};
 use feldera_types::config::StorageCompression;
 use indexmap::IndexSet;
 use once_cell::sync::Lazy;
@@ -319,9 +319,9 @@ impl RuntimeInner {
             storage
                 .options
                 .cache_mib
-                .unwrap_or(nworkers * 256)
-                .saturating_mul(1024 * 1024)
-                / nworkers
+                .map_or(256 * 1024 * 1024, |cache_mib| {
+                    cache_mib.saturating_mul(1024 * 1024) / nworkers / ThreadType::LENGTH
+                })
         } else {
             // Dummy buffer cache.
             1

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -153,9 +153,11 @@ pub struct StorageOptions {
     /// performance.
     pub compression: StorageCompression,
 
-    /// The maximum size of the in-memory storage cache, in mebibytes.
+    /// The maximum size of the in-memory storage cache, in MiB.
     ///
-    /// The default is 256 MiB, times the number of workers.
+    /// If set, the specified cache size is spread across all the foreground and
+    /// background threads. If unset, each foreground or background thread cache
+    /// is limited to 256 MiB.
     pub cache_mib: Option<usize>,
 }
 
@@ -282,6 +284,10 @@ pub struct ObjectStorageConfig {
 #[serde(default)]
 pub struct RuntimeConfig {
     /// Number of DBSP worker threads.
+    ///
+    /// Each DBSP "foreground" worker thread is paired with a "background"
+    /// thread for LSM merging, making the total number of threads twice the
+    /// specified number.
     pub workers: u16,
 
     /// Storage configuration.

--- a/openapi.json
+++ b/openapi.json
@@ -4308,7 +4308,7 @@
               "workers": {
                 "type": "integer",
                 "format": "int32",
-                "description": "Number of DBSP worker threads.",
+                "description": "Number of DBSP worker threads.\n\nEach DBSP \"foreground\" worker thread is paired with a \"background\"\nthread for LSM merging, making the total number of threads twice the\nspecified number.",
                 "default": 8,
                 "minimum": 0
               }
@@ -5189,7 +5189,7 @@
           "workers": {
             "type": "integer",
             "format": "int32",
-            "description": "Number of DBSP worker threads.",
+            "description": "Number of DBSP worker threads.\n\nEach DBSP \"foreground\" worker thread is paired with a \"background\"\nthread for LSM merging, making the total number of threads twice the\nspecified number.",
             "default": 8,
             "minimum": 0
           }
@@ -5641,7 +5641,7 @@
           },
           "cache_mib": {
             "type": "integer",
-            "description": "The maximum size of the in-memory storage cache, in mebibytes.\n\nThe default is 256 MiB, times the number of workers.",
+            "description": "The maximum size of the in-memory storage cache, in MiB.\n\nIf set, the specified cache size is spread across all the foreground and\nbackground threads. If unset, each foreground or background thread cache\nis limited to 256 MiB.",
             "default": null,
             "nullable": true,
             "minimum": 0


### PR DESCRIPTION
Before this commit, each foreground and background worker had cache size:
- If `cache_mib` was unset, 256 MiB.
- If `cache_mib` was set, `cache_mib / nworkers` MiB.

After this commit, each foreground and background worker has cache size:
- If `cache_mib` is unset, 128 MiB.
- If `cache_mib` is set, `cache_mib / nworkers / 2` MiB.

This change is meant to better implement what the documentation says, which is that `cache_mib` is the total cache size (not half the total) and that in its absence each worker gets 256 MiB (not 256 MiB times 2).

Fixes https://github.com/feldera/feldera/issues/3664.