### PR TITLE
[dbsp] Write Bloom filters to layer files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,7 +3713,6 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "binrw",
- "bytemuck",
  "chrono",
  "clap 4.5.31",
  "core_affinity",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -77,7 +77,6 @@ tracing = "0.1.40"
 snap = "1.1.1"
 enum-map = "2.7.3"
 fastbloom = "0.8.0"
-bytemuck = "1.21.0"
 core_affinity = "0.8.1"
 indexmap = "2.7.1"
 feldera-storage = { path = "../storage", version = "0.38.0" }

--- a/crates/storage/src/block.rs
+++ b/crates/storage/src/block.rs
@@ -45,3 +45,9 @@ pub struct InvalidBlockLocation {
     /// Number of bytes.
     pub size: usize,
 }
+
+impl Display for InvalidBlockLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} bytes at offset {}", self.size, self.offset)
+    }
+}


### PR DESCRIPTION
This fixes the problem that filters disappeared when restarting from a checkpoint with FT enabled.