### PR TITLE
[dbsp] Don't include "backend-mode" in features for docs.rs.

### DIFF
--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -111,7 +111,7 @@ pub use typed_batch::{
     OrdIndexedWSet, OrdIndexedZSet, OrdWSet, OrdZSet, Trace, TypedBox, ZSet,
 };
 
-#[cfg(all(doc, not(feature = "backend-mode")))]
+#[cfg(doc)]
 pub mod tutorial;
 
 // TODO: import from `circuit`.


### PR DESCRIPTION
This feature disables the tutorial, which we want in the docs.