### PR TITLE
[dbsp] Don't use `FilterMap` in the tutorial or reference it in docs.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -375,9 +375,8 @@ impl<D> RefStreamValue<D> {
 /// batch.  These functions apply to both streams of deltas and streams of data.
 ///
 /// The following methods are available for streams of indexed and non-indexed
-/// Z-sets that implement trait [`FilterMap`](`crate::FilterMap`).  Each of
-/// these takes a function that accepts a key (for non-indexed Z-sets) or a
-/// key-value pair (for indexed Z-sets):
+/// Z-sets.  Each of these takes a function that accepts a key (for non-indexed
+/// Z-sets) or a key-value pair (for indexed Z-sets):
 ///
 ///   * Use [`Stream::map`] to output a non-indexed Z-set using an
 ///     arbitrary mapping function, or [`Stream::map_index`] to map to

--- a/crates/dbsp/src/operator/dynamic/filter_map.rs
+++ b/crates/dbsp/src/operator/dynamic/filter_map.rs
@@ -23,7 +23,6 @@ use std::{borrow::Cow, marker::PhantomData};
 
 use super::{MonoIndexedZSet, MonoIndexedZSetFactories, MonoZSet, MonoZSetFactories};
 
-/// See [`crate::operator::FilterMap`].
 pub trait DynFilterMap: BatchReader {
     /// A borrowed version of the record type, e.g., `(&K, &V)` for a stream of
     /// `(key, value, weight)` tuples or `&K` if the value type is `()`.

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -399,9 +399,9 @@
 //! skeleton.
 //!
 //! Let's do just enough computation to demonstrate the concept.  Suppose we
-//! want to pick out a subset of the records.  We can use the [`FilterMap`]
-//! trait implemented for [`Stream`] to do that.  For example, we can take just
-//! the records for locations in the United Kingdom:
+//! want to pick out a subset of the records.  We can use [`Stream::filter`] to
+//! do that.  For example, we can take just the records for locations in the
+//! United Kingdom:
 //!
 //! ```
 //! # use anyhow::Result;
@@ -1972,7 +1972,7 @@
 //! let (mut circuit, (/*handles*/)) = Runtime::init_circuit(4, build_circuit)?;
 //! ```
 use crate::{
-    operator::{Aggregator, FilterMap, Max},
+    operator::{Aggregator, Max},
     CircuitHandle, IndexedZSet, OrdPartitionedIndexedZSet, OutputHandle, RootCircuit, Runtime,
     Stream, ZSet, ZSetHandle,
 };


### PR DESCRIPTION
It isn't needed and it is not available if `backend-mode` is enabled.

This fixes a broken build on main.