### PR TITLE
[adapters] Don't write empty transaction to Delta.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/output.rs
+++ b/crates/adapters/src/integrated/delta_table/output.rs
@@ -324,6 +324,11 @@ impl WriterTask {
                 .close()
                 .await
                 .map_err(|e| anyhow!("error flushing {} Parquet rows: {e}", self.num_rows))?;
+
+            if actions.is_empty() {
+                return Ok(());
+            }
+
             let num_bytes = actions.iter().map(|action| action.size as usize).sum();
 
             // The snapshot version for the next commit is computed as the current version + 1.


### PR DESCRIPTION
We used to create a Delta Lake transaction on every step even if the output was empty. This patch only creates a transaction when there is some new data to add to the Delta table.