### PR TITLE
Support deletes in the Delta sink connector.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -282,6 +282,14 @@ pub trait SerCursor: Send {
     /// Serialize current key into arrow format. Panics if invalid.
     fn serialize_key_to_arrow(&mut self, dst: &mut ArrayBuilder) -> AnyResult<()>;
 
+    /// Serialize current key into arrow format, adding additional metadata columns.
+    /// `metadata` must be a struct or a map.
+    fn serialize_key_to_arrow_with_metadata(
+        &mut self,
+        metadata: &dyn erased_serde::Serialize,
+        dst: &mut ArrayBuilder,
+    ) -> AnyResult<()>;
+
     #[cfg(feature = "with-avro")]
     /// Convert current key to an Avro value.
     fn key_to_avro(&mut self, schema: &AvroSchema, refs: &NamesRef<'_>) -> AnyResult<AvroValue>;
@@ -442,6 +450,15 @@ impl SerCursor for CursorWithPolarity<'_> {
 
     fn serialize_key_to_arrow(&mut self, dst: &mut ArrayBuilder) -> AnyResult<()> {
         self.cursor.serialize_key_to_arrow(dst)
+    }
+
+    fn serialize_key_to_arrow_with_metadata(
+        &mut self,
+        metadata: &dyn erased_serde::Serialize,
+        dst: &mut ArrayBuilder,
+    ) -> AnyResult<()> {
+        self.cursor
+            .serialize_key_to_arrow_with_metadata(metadata, dst)
     }
 
     fn serialize_val(&mut self, dst: &mut Vec<u8>) -> AnyResult<()> {

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -213,7 +213,7 @@ impl FileInputReader {
                     queue.push_back((start..end, buffer));
                 }
             }
-            if n == 0 {
+            if n == 0 && !follow {
                 consumer.eoi();
             }
         }

--- a/crates/feldera-types/src/serde_with_context/serialize.rs
+++ b/crates/feldera-types/src/serde_with_context/serialize.rs
@@ -388,6 +388,7 @@ macro_rules! serialize_struct {
             $($arg: $crate::serde_with_context::SerializeWithContext<C>),*
             $($($arg : $bound,)?),*
         {
+            #[inline(never)]
             fn serialize_with_context<S>(&self, serializer: S, context: &C) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
@@ -399,6 +400,7 @@ macro_rules! serialize_struct {
                 serde::ser::SerializeStruct::end(struct_serializer)
             }
 
+            #[inline(never)]
             fn serialize_fields_with_context<S>(
                 &self,
                 serializer: S,
@@ -427,6 +429,7 @@ macro_rules! serialize_table_record {
         #[allow(unused_variables)]
         #[allow(unused_mut)]
         impl $crate::serde_with_context::SerializeWithContext<$crate::serde_with_context::SqlSerdeConfig> for $struct {
+            #[inline(never)]
             fn serialize_with_context<S>(&self, serializer: S, context: & $crate::serde_with_context::SqlSerdeConfig) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
@@ -438,7 +441,7 @@ macro_rules! serialize_table_record {
                 serde::ser::SerializeStruct::end(struct_serializer)
             }
 
-
+            #[inline(never)]
             fn serialize_fields_with_context<S>(&self, serializer: S, context: & $crate::serde_with_context::SqlSerdeConfig, fields: &std::collections::HashSet<String>) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,

--- a/docs/connectors/sources/delta.md
+++ b/docs/connectors/sources/delta.md
@@ -6,15 +6,12 @@ See [top-level connector documentation](/connectors/) for general information
 about configuring input and output connectors.
 :::
 
-[Delta Lake](https://delta.io/) is an open-source storage framework for the
-[Lakehouse architecture](https://www.cidrdb.org/cidr2021/papers/cidr2021_paper17.pdf).
+[Delta Lake](https://delta.io/) is a popular open table format based on Parquet files.
 It is typically used with the [Apache Spark](https://spark.apache.org/) runtime.
-Data in a Delta Lake is organized in tables (called Delta Tables), stored in
+Data in a Delta Lake is organized in tables, stored in
 a file system or an object stores like [AWS S3](https://aws.amazon.com/s3/),
 [Google GCS](https://cloud.google.com/storage), or
 [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs).
-Like other Lakehouse-native storage formats, Delta Lake is optimized for both
-batch and stream processing, offering a bridge between the two worlds.
 
 The Delta Lake input connector does not yet support [fault
 tolerance](..#fault-tolerance).


### PR DESCRIPTION
Fixes #3286.

The Delta Lake format does not support efficient real-time deletes and updates.
To delete a record from a Delta table, one must first locate the record, which
often requires an expensive table scan. This limitation makes it inefficient to
directly write the output of a Feldera pipeline, which consists of both inserts
and deletes, to a Delta table.

To address this issue, we transform both inserts and deletes
into table records with additional metadata columns that describe the type and order
of operations. Specifically, this commit adds the following columns to the output
Delta table:

* `__feldera_op` -  Operation that this record represents: `i` for "insert" or `d`
  for "delete".
* `__feldera_ts` -  Timestamp of the update, used to establish the order of
  updates. Updates with smaller timestamps are applied before those with larger
  timestamps.

Effectively, we treat the table as a change log, where every record corresponds to
either an insert or delete operation. The user can run a periodic Spark job to
incorporate these change log into another Delta table, using the SQL `MERGE INTO`
operation.