### PR TITLE
Add a tooltip to warn when can't edit the pipeline's name

### DIFF
--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -262,6 +262,11 @@ example = "1.0"`
                 {pipeline.current.name}
               </span>
             </DoubleClickInput>
+            {#if editDisabled}
+              <Tooltip class="z-10 rounded bg-white text-surface-950-50 dark:bg-black">
+                Cannot edit the pipeline's name while it's running
+              </Tooltip>
+            {/if}
           {/snippet}
         </PipelineBreadcrumbs>
         <PipelineStatus class="h-6 sm:mt-0.5" status={pipeline.current.status}></PipelineStatus>

--- a/web-console/src/lib/components/pipelines/PipelineNameInput.svelte
+++ b/web-console/src/lib/components/pipelines/PipelineNameInput.svelte
@@ -10,7 +10,6 @@
     createButton,
     afterInput,
     inputClass,
-    assistCreatingPipeline,
     onHideInput,
     onSuccess
   }: {
@@ -18,7 +17,6 @@
     createButton: Snippet<[onclick: () => void]>
     afterInput?: Snippet<[error?: string]>
     inputClass?: string
-    assistCreatingPipeline?: boolean
     onHideInput?: () => void
     onSuccess?: () => void
   } = $props()


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/3694: Pipeline name edit (pencil) tooltip when you can't edit