### PR TITLE
[python] test_delete_all_pipelines: shutdown before deletion

### DIFF
--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -15,6 +15,7 @@ class TestPipeline(unittest.TestCase):
     def test_delete_all_pipelines(self):
         pipelines = TEST_CLIENT.pipelines()
         for pipeline in pipelines:
+            TEST_CLIENT.shutdown_pipeline(pipeline.name)
             TEST_CLIENT.delete_pipeline(pipeline.name)
 
     def test_create_pipeline(


### PR DESCRIPTION
All tests that used `test_create_pipeline` and therefore transitively `test_delete_all_pipelines` were sometimes failing during deletion because they weren't shutdown. 
This explicitly calls shutdown before deleting these pipelines.