### PR TITLE
[adapters] kafka_input: start reading from offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ lcov.info
 .idea
 *.iml
 .DS_Store
+sql-to-dbsp-compiler/SQL-compiler/pom.xml-E
 
 **/benches/galen_data/
 **/benches/gdelt-data/

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -161,6 +161,7 @@ impl KafkaFtInputReaderInner {
                 for (topic, partitions) in topics.iter().zip(offsets.into_iter()) {
                     let mut buffered_partition = Vec::with_capacity(partitions.len());
                     for (partition, offsets) in partitions.into_iter().enumerate() {
+                        // TODO: support `start_from` for FtKafkaInput
                         assignment
                             .add_partition_offset(
                                 topic.as_str(),
@@ -424,6 +425,10 @@ impl KafkaFtInputReader {
         debug!("Starting Kafka input endpoint: {:?}", config);
 
         let mut client_config = ClientConfig::new();
+
+        if !config.start_from.is_empty() {
+            anyhow::bail!("unimplemented: `start_from` is not yet supported for fault tolerant kafka connector");
+        }
 
         for (key, value) in config.kafka_options.iter() {
             client_config.set(key, resolve_secret(value)?);

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -427,7 +427,11 @@ impl KafkaFtInputReader {
         let mut client_config = ClientConfig::new();
 
         if !config.start_from.is_empty() {
-            anyhow::bail!("unimplemented: `start_from` is not yet supported for fault tolerant kafka connector");
+            anyhow::bail!(
+                r#"unimplemented: `start_from` is not yet supported for fault tolerant kafka connector
+tracking issue: https://github.com/feldera/feldera/issues/3756
+"#
+            );
         }
 
         for (key, value) in config.kafka_options.iter() {

--- a/crates/adapters/src/transport/kafka/nonft/test.rs
+++ b/crates/adapters/src/transport/kafka/nonft/test.rs
@@ -215,13 +215,16 @@ format:
 }
 
 #[test]
-fn test_kafka_input_offset_trivial_earliest() {
-    let topic1 = "test_kafka_input_offset_trivial_earliest_topic1";
+#[should_panic(
+    expected = "provided offset '3' not currently in topic 'test_kafka_input_offset_doesnt_exist_1' partition '0'"
+)]
+fn test_kafka_input_offset_doesnt_exist() {
+    let topic1 = "test_kafka_input_offset_doesnt_exist_1";
     test_offset(
         Vec::new(),
         Vec::new(),
         topic1,
-        "test_kafka_input_offset_trivial_earliest_topic2",
+        "test_kafka_input_offset_doesnt_exist_2",
         KafkaStartFromConfig {
             topic: topic1.to_owned(),
             partition: 0,
@@ -232,13 +235,16 @@ fn test_kafka_input_offset_trivial_earliest() {
 }
 
 #[test]
-fn test_kafka_input_offset_trivial_latest() {
-    let topic1 = "test_kafka_input_offset_trivial_latest_topic1";
+#[should_panic(
+    expected = "provided offset '3' not currently in topic 'test_kafka_input_offset_doesnt_exist2_1' partition '0'"
+)]
+fn test_kafka_input_offset_doesnt_exist2() {
+    let topic1 = "test_kafka_input_offset_doesnt_exist2_1";
     test_offset(
         Vec::new(),
         Vec::new(),
         topic1,
-        "test_kafka_input_offset_trivial_latest_topic2",
+        "test_kafka_input_offset_doesnt_exist2_2",
         KafkaStartFromConfig {
             topic: topic1.to_owned(),
             partition: 0,
@@ -991,7 +997,7 @@ proptest! {
             data,
             data2,
             topic1,
-            "test_kafka_input_offset_earliest_topic2",
+            "proptest_kafka_input_offset_earliest_topic2",
             KafkaStartFromConfig {
                 topic: topic1.to_owned(),
                 partition: 0,

--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -51,6 +51,24 @@ pub struct KafkaInputConfig {
     /// helps with small messages but will not harm performance with large
     /// messagee
     pub poller_threads: Option<usize>,
+
+    /// A list of offset and partitions specifying where to begin reading
+    /// the topic from.
+    #[serde(default)]
+    pub start_from: Vec<KafkaStartFromConfig>,
+}
+
+/// Configuration for starting from a specific offset in a Kafka topic partition.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct KafkaStartFromConfig {
+    /// The Kafka topic.
+    pub topic: String,
+
+    /// The parition within the topic.
+    pub partition: u32,
+
+    /// The offset in the specified partition to start reading from.
+    pub offset: u64,
 }
 
 /// Kafka logging levels.

--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -52,8 +52,12 @@ pub struct KafkaInputConfig {
     /// messagee
     pub poller_threads: Option<usize>,
 
-    /// A list of offset and partitions specifying where to begin reading
-    /// the topic from.
+    /// A list of offsets and partitions specifying where to begin reading individual input topics.
+    ///
+    /// When specified, this property must contain a list of JSON objects with the following fields:
+    /// - `topic`: The name of the Kafka topic.
+    /// - `partition`: The partition number within the topic.
+    /// - `offset`: The specific offset from which to start consuming messages.
     #[serde(default)]
     pub start_from: Vec<KafkaStartFromConfig>,
 }

--- a/docs/connectors/sources/kafka.md
+++ b/docs/connectors/sources/kafka.md
@@ -11,6 +11,19 @@ tolerance](..#fault-tolerance).
   [Relevant options supported by it](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md)
   can be defined in the connector configuration.
 
+## Kafka Input Connector Configuration
+
+| Property                | Type             | Default | Description                                                                                                                                                                                                                                                                                                                                                       |
+|-------------------------|------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bootstrap.servers`*      | string           |         | A comma separated list of Kafka brokers to connect to.                                                                                                                                                                                                                                                                                                            |
+| `topics`*                 | list             |         | A list of Kafka topics to subscribe to.                                                                                                                                                                                                                                                                                                                           |
+| `log_level`               | string           |         | The log level for the Kafka client.                                                                                                                                                                                                                                                                                                                               |
+| `group_join_timeout_secs` | seconds          | 10      | Maximum timeout (in seconds) for the endpoint to join the Kafka consumer group during initialization.                                                                                                                                                                                                                                                             |
+| `poller_threads`          | positive integer | 3       | Number of threads used to poll Kafka messages. Setting it to multiple threads can improve performance with small messages. Default is 3.                                                                                                                                                                                                                          |
+| `start_from`              | list             |         | Specifies offsets and partitions to begin reading Kafka topics from. When specified, this property must contain a list of JSON objects with the following fields:  <ul><li>`topic`: The name of the Kafka topic.</li> <li>`partition`: The partition number within the topic.</li> <li>`offset`: The specific offset from which to start consuming messages.</li> |
+
+Any other configurations from [**librdkafka**](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) are directly passed to `librdkafka`.
+
 ## Example usage
 
 We will create a Kafka connector named `book-fair-sales`.

--- a/docs/connectors/sources/kafka.md
+++ b/docs/connectors/sources/kafka.md
@@ -55,6 +55,58 @@ CREATE TABLE INPUT (
 )
 ```
 
+### Starting from a specific offset
+
+:::caution Experimental feature
+Reading Kafka messages from a specific offset is an experimental feature.
+
+**Fault tolerant** kafka connectors **do not** yet support this.
+:::
+
+Feldera supports starting a Kafka connector from a specific offset in a specifc
+partition.
+
+```sql
+CREATE TABLE INPUT (
+   ... -- columns omitted
+) WITH (
+  'connectors' = '[
+    {
+      "transport": {
+          "name": "kafka_input",
+          "config": {
+              "bootstrap.servers": "example.com:9092",
+              "topics": ["book-fair-sales"],
+              "start_from": [{
+                "topic": "book-fair-sales",
+                "partition": 0,
+                "offset": 42
+              }]
+          }
+      },
+      "format": {
+          "name": "json",
+          "config": {
+              "update_format": "insert_delete",
+              "array": false
+          }
+      }
+  }]'
+)
+```
+
+The `start_from` field takes a list of JSON objects that must include the
+following fields:
+- `topic`: The name of the Kafka topic.
+- `partition`: The partition number within the topic.
+- `offset`: The specific offset from which to start consuming messages.
+
+:::important
+- The topic specified in `start_from` must also be included in `topics` field.
+- If a topic has multiple partitions but only one partition is defined in
+  `start_from`, only that partition will be read.
+:::
+
 ### How to write connector config
 
 Below are a couple of examples on how to connect to a Kafka broker

--- a/openapi.json
+++ b/openapi.json
@@ -3973,6 +3973,13 @@
             "nullable": true,
             "minimum": 0
           },
+          "start_from": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KafkaStartFromConfig"
+            },
+            "description": "A list of offset and partitions specifying where to begin reading\nthe topic from."
+          },
           "topics": {
             "type": "array",
             "items": {

--- a/openapi.json
+++ b/openapi.json
@@ -3978,7 +3978,7 @@
             "items": {
               "$ref": "#/components/schemas/KafkaStartFromConfig"
             },
-            "description": "A list of offset and partitions specifying where to begin reading\nthe topic from."
+            "description": "A list of offsets and partitions specifying where to begin reading individual input topics.\n\nWhen specified, this property must contain a list of JSON objects with the following fields:\n- `topic`: The name of the Kafka topic.\n- `partition`: The partition number within the topic.\n- `offset`: The specific offset from which to start consuming messages."
           },
           "topics": {
             "type": "array",


### PR DESCRIPTION
Implementation to support reading from a specific offset.

**Important Considerations:**
- The topic specified in `start_from` must also be included in `topics` field.
- If a topic has multiple partitions but only one partition is defined in
  `start_from`, only that partition will be read.

**Example:**
```sql
CREATE TABLE INPUT (
   ... -- columns omitted
) WITH (
  'connectors' = '[
    {
      "transport": {
          "name": "kafka_input",
          "config": {
              "bootstrap.servers": "example.com:9092",
              "topics": ["book-fair-sales"],
              "start_from": [{
                "topic": "book-fair-sales",
                "partition": 0,
                "offset": 42
              }]
          }
      },
      "format": {
          "name": "json",
          "config": {
              "update_format": "insert_delete",
              "array": false
          }
      }
  }]'
)
```

The `start_from` field takes a list of JSON objects that must include the
following fields:
- `topic`: The name of the Kafka topic.
- `partition`: The partition number within the topic.
- `offset`: The specific offset from which to start consuming messages.

Todo:
- [x] Docs
- [x] Read topics that aren't mentioned in the seek configuration
- [ ] Support `start_from` in Fault Tolerant connector