### PR TITLE
Enable sccache for build-rust jobs.

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -6,6 +6,9 @@ on:
 env:
   CARGO_FLAGS: "--release --locked --all-targets --features pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue"
   FELDERA_PLATFORM_VERSION_SUFFIX: ${{ github.sha }}
+  RUSTC_WRAPPER: sccache
+  SCCACHE_DIR: /sccache
+  BLACKSMITH_SCCACHE_DISK: /mnt/sccache-disk
 
 jobs:
   build-rust:
@@ -18,19 +21,46 @@ jobs:
           - runner: [self-hosted, skylake40]
             arch: x86_64
             target: x86_64-unknown-linux-gnu
+            sccache_size: 1024G
           - runner: blacksmith-16vcpu-ubuntu-2204-arm
             arch: aarch64
             target: aarch64-unknown-linux-gnu
-
+            sccache_size: 50G
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:0a775f772b2ebde13708744d3e6a219ca4a492d2
-      options: --user=ubuntu
+      image: ghcr.io/feldera/feldera-dev:3012ef118aaaa2b7d49e1dfeda938288a70ba66c
+      options: --user=ubuntu --privileged
+      volumes:
+        - /sccache:/sccache
+      env:
+        VM_ID: ${{ env.VM_ID }}
+        GITHUB_REPO_NAME: ${{ env.GITHUB_REPO_NAME }}
+        BLACKSMITH_STICKYDISK_TOKEN: ${{ env.BLACKSMITH_STICKYDISK_TOKEN }}
+        BLACKSMITH_INSTALLATION_MODEL_ID: ${{ env.BLACKSMITH_INSTALLATION_MODEL_ID }}
+        BLACKSMITH_REGION: ${{ env.BLACKSMITH_REGION }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # We can't put it in /sccache because it's a volume mount already in the self-hosted runner
+      - name: Figure out sccache directory path on blacksmith runner
+        if: ${{ startsWith(matrix.runner, 'blacksmith') }}
+        run: |
+          sudo mkdir -p ${{ env.BLACKSMITH_SCCACHE_DISK }}
+          sudo chown ubuntu:ubuntu -R ${{ env.BLACKSMITH_SCCACHE_DISK }}
+          echo "SCCACHE_DIR=${{ env.BLACKSMITH_SCCACHE_DISK }}/sccache" >> $GITHUB_ENV
+      - name: Mount sccache directory on blacksmith runner
+        if: ${{ startsWith(matrix.runner, 'blacksmith') }}
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache
+          path: ${{ env.BLACKSMITH_SCCACHE_DISK }}
+
+      - name: Set sccache size environment variable
+        run: |
+          echo "SCCACHE_CACHE_SIZE=${{ matrix.sccache_size }}" >> $GITHUB_ENV
 
       # The docker container when executed in the action runs with a different home directory
       # than we set in the dev container (?), hence this step is necessary (sigh)
@@ -38,12 +68,13 @@ jobs:
       - name: Rustup set default toolchain
         run: rustup default stable
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
       - name: Build Rust binaries
         run: |
           cargo build ${{ env.CARGO_FLAGS }} --target=${{ matrix.target }}
+
+      - name: Print sccache stats
+        run: |
+          sccache --show-stats
 
       # Get list of executables
       - name: Collect executables
@@ -72,7 +103,7 @@ jobs:
           mv build-artifacts/pipeline-manager build-release-artifacts/
 
       # Upload test binaries as one artifact
-      - name: Upload build artifacts
+      - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
           name: feldera-test-binaries-${{ matrix.target }}
@@ -80,7 +111,7 @@ jobs:
           retention-days: 7
 
       # Upload binaries to run the product as another artifact
-      - name: Upload build artifacts
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
           name: feldera-binaries-${{ matrix.target }}

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -1,17 +1,11 @@
 # This Dockerfile is used by CI to build things.
 #
-# To build the image, run:
-#    docker build -f build.Dockerfile -t ghcr.io/gz/feldera-dev:latest .
-#
-# To inspect the image locally, run:
-#    docker run -it ghcr.io/gz/feldera-dev:latest
-#
-# To push the image to GitHub Container Registry, run:
-#    docker push ghcr.io/gz/feldera-dev:latest
+# The image is built by the `build-docker-dev.yml` action
+# whenever it changes. But you'll have to change the sha in
+# other actions that rely on this image if you want to use
+# a newer version in CI.
 
-# The build image contains tools to build the code given that
-# we need a Java and Rust compiler to run alongside the pipeline manager
-# as of now. This will change later.
+# We need a Java and Rust compiler to run alongside the pipeline manager
 FROM ubuntu:24.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -44,7 +38,13 @@ RUN apt-get update --fix-missing && apt-get install -y \
     # Required for bun installation
     unzip \
     # For debugging things
-    strace
+    strace \
+    # For blacksmith runners configuring disks
+    sudo
+
+# Give ubuntu user with sudo privileges for mounting dirs in blacksmith runner
+RUN usermod -aG sudo ubuntu
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Install redpanda's rpk cli
 RUN arch=`dpkg --print-architecture`; \
@@ -70,11 +70,11 @@ ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.bun/bin:/home/ubuntu/.cargo/bin:
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.83.0
 
-## Install uv
+# Install uv
 RUN curl -LsSf https://astral.sh/uv/0.6.5/install.sh | sh
 RUN uv python install 3.10
 
-## Install Bun.js
+# Install Bun.js
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.2"
 
 # The download URL for mold uses x86_64/aarch64 whereas dpkg --print-architecture says amd64/arm64
@@ -83,6 +83,13 @@ RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86
     && tar -xzvf mold-2.32.1-$arch-linux.tar.gz \
     && mv mold-2.32.1-$arch-linux /home/ubuntu/mold \
     && rm mold-2.32.1-$arch-linux.tar.gz
+
+# Install sccache
+RUN  arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
+    cd /home/ubuntu && curl -LO https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-$arch-unknown-linux-musl.tar.gz \
+    && tar zxvf sccache-v0.10.0-$arch-unknown-linux-musl.tar.gz \
+    && cp sccache-v0.10.0-$arch-unknown-linux-musl/sccache /home/ubuntu/.cargo/bin \
+    && chmod +x /home/ubuntu/.cargo/bin/sccache
 
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 RUN rustup default stable


### PR DESCRIPTION
This speeds up CI job by a few minutes. Rust build on x86 is down to 3 min and on arm down to 8 min with this.

I also figured out how to configure sccache to our docker build precompile step and the integration test but currently the cache hit rate is 0% because the build paths we form in the manager are not deterministic so I'm hoping the many-crates-pr will fix that and we should see some significant speedup once this in.