### PR TITLE
Automate release in CI

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -2,10 +2,6 @@ name: "Docker CI Image"
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - ".github/workflows/build-docker-dev.yml"
-      - "deploy/build.Dockerfile"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -1,0 +1,65 @@
+name: Post Release Tasks
+
+on:
+  release:
+    types: [published]
+
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_DIR: /sccache
+
+jobs:
+  publish-python:
+    name: ""
+    uses: ./.github/workflows/publish-python.yml
+    secrets: inherit
+  publish-crates:
+    name: ""
+    uses: ./.github/workflows/publish-crates.yml
+    secrets: inherit
+  adjust-versions:
+    runs-on: [self-hosted, skylake40]
+    container:
+      image: ghcr.io/feldera/feldera-dev:39c1b55d0972ccd26375cf2f7cbc8554f4609da8
+      options: --user=ubuntu
+      volumes:
+        - /sccache:/sccache
+    needs: [publish-crates, publish-python]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This runs on main because we make the commit on main at the end of the workflow,
+          # we use the token so it can circument push to main protection rules
+          ref: main
+          token: ${{ secrets.CI_RELEASE }}
+      - name: Rustup set default toolchain
+        run: rustup default stable
+      - name: Determine current version based on pipeline-manager
+        run: |
+          echo "CURRENT_VERSION=$(cargo metadata --no-deps | jq -r '.packages[]|select(.name == "pipeline-manager")|.version')" >> $GITHUB_ENV
+      - name: Bump cargo versions
+        run: |
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p feldera-types
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p feldera-storage
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p dbsp
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p fda
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p pipeline-manager
+          cargo set-version --bump ${{ vars.RELEASE_NEXT_VERSION }} -p feldera-sqllib
+          cargo run --release  --locked --bin pipeline-manager -- --dump-openapi
+      - name: Determine next version based on pipeline-manager
+        run: |
+          echo "NEXT_VERSION=$(cargo metadata --no-deps | jq -r '.packages[]|select(.name == "pipeline-manager")|.version')" >> $GITHUB_ENV
+      - name: Adjust python version
+        working-directory: ./python
+        run: |
+          sed -i "s/version = \"${{ env.CURRENT_VERSION }}\"/version = \"${{ env.NEXT_VERSION }}\"/g" pyproject.toml
+          uv sync
+      - name: List changes
+        run: |
+          git diff
+      - uses: EndBug/add-and-commit@v9
+        with:
+          message: "ci: Prepare for v${{ env.NEXT_VERSION }}"
+          author_name: feldera-ci
+          author_email: feldera-ci-noreply@feldera.io
+          push: origin main

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,86 @@
+name: Create a new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "SHA to release (a recent commit from main that hasn't been released yet)"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      SHA_TO_RELEASE: ${{ github.event.inputs.sha || github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ env.SHA_TO_RELEASE }}
+
+      - name: Determine version to release based on pipeline-manager
+        run: |
+          echo "CURRENT_VERSION=$(cargo metadata --no-deps | jq -r '.packages[]|select(.name == "pipeline-manager")|.version')" >> $GITHUB_ENV
+
+      - name: Check if version is already released (do we have git tag for this version?)
+        run: |
+          if git tag -l | grep -q "^v${{ env.CURRENT_VERSION }}$"; then
+            echo "Version ${CURRENT_VERSION} is already released"
+            echo "version_exists=true" >> $GITHUB_ENV
+          else
+            echo "Version ${CURRENT_VERSION} is not released yet"
+            echo "version_exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Download artifact
+        if: env.version_exists == 'false'
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: ci.yml
+          workflow_conclusion: success
+          commit: ${{ env.SHA_TO_RELEASE }}
+          name: feldera-sql-compiler-*|feldera-binaries-*
+          name_is_regexp: true
+          skip_unpack: true
+          if_no_artifact_found: fail
+
+      - name: Attach version to binaries
+        if: env.version_exists == 'false'
+        run: |
+          mv feldera-binaries-aarch64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
+          mv feldera-binaries-x86_64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
+          mv feldera-sql-compiler.zip feldera-sql-compiler-v${{ env.CURRENT_VERSION }}.zip
+
+      - name: Release on GitHub
+        if: env.version_exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.CURRENT_VERSION }}
+          generate_release_notes: true
+          make_latest: true
+          files: |
+            feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
+            feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
+            feldera-sql-compiler-v${{ env.CURRENT_VERSION }}.zip
+          # A custom token is necessary so the ci-post-release.yml workflow is triggered
+          # see also https://github.com/softprops/action-gh-release/issues/59
+          token: ${{ secrets.CI_RELEASE }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Tag docker image with version and latest
+        run: |
+          docker buildx imagetools create -t ${{ vars.FELDERA_IMAGE_NAME }}:${{ env.CURRENT_VERSION }} ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ env.SHA_TO_RELEASE }}
+          docker buildx imagetools create -t ${{ vars.FELDERA_IMAGE_NAME }}:latest ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ env.SHA_TO_RELEASE }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,35 @@
+name: Upload crates.io packages
+
+on:
+  workflow_call:
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, skylake40]
+    container:
+      image: ghcr.io/feldera/feldera-dev:3012ef118aaaa2b7d49e1dfeda938288a70ba66c
+      options: --user=ubuntu
+      volumes:
+        - /sccache:/sccache
+    steps:
+      - uses: actions/checkout@v4
+
+      # The docker container when executed in the action runs with a different home directory
+      # than we set in the dev container (?), hence this step is necessary (sigh)
+      # https://github.com/actions/runner/issues/863
+      - name: Rustup set default toolchain
+        run: rustup default stable
+
+      - name: Run cargo publish
+        run: |
+          cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-types
+          cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-storage
+          cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package dbsp
+          cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package fda
+          cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-sqllib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           uv build
       - name: Publish package
+        if: github.repository == 'feldera/feldera'
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           packages_dir: ./python/dist

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -7,9 +7,8 @@ jobs:
   adapter-tests:
     name: Test Adapters
     runs-on: [ubuntu-latest]
-    # TODO: this neds ubuntu 24.04 due to glibc being outdated on runner XD
-    # can't run in container because see below
     #runs-on: [self-hosted, skylake40]
+    # can't run in container because see below
     # For some dumb reason we can't run these tests in the dev container
     # because while it finds redis on the docker network it doesn't find
     # redpanda or pubsub (wtf?)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "fda"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "chrono",
  "clap 4.5.31",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-sqllib"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "arcstr",
  "base64 0.22.1",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-storage"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "feldera-types",
  "inventory",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-types"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7733,7 +7733,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline-manager"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ First, make sure you have [Docker](https://docs.docker.com/) installed. Then run
 following command:
 
 ```text
-docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:0.39.0
+docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
 ```
 
 Once the container image downloads and you see the Feldera logo on your terminal, visit

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbsp"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Continuous streaming analytics engine"
@@ -66,7 +66,7 @@ fdlimit = { version = "0.3.0" }
 metrics = { version = "0.23.0" }
 serde = { version = "1.0", features = ["derive"] }
 ptr_meta = "0.2.0"
-feldera-types = { path = "../feldera-types", version = "0.39.0" }
+feldera-types = { path = "../feldera-types", version = "0.40.0" }
 libc = "0.2.153"
 static_assertions = "1.1.0"
 zip = "0.6.2"
@@ -78,7 +78,7 @@ enum-map = "2.7.3"
 fastbloom = "0.8.0"
 core_affinity = "0.8.1"
 indexmap = "2.7.1"
-feldera-storage = { path = "../storage", version = "0.39.0" }
+feldera-storage = { path = "../storage", version = "0.40.0" }
 inventory = "0.3"
 
 [dependencies.time]

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -4,7 +4,7 @@ description = "A CLI tool for interacting with Feldera"
 homepage = "https://github.com/feldera/feldera"
 repository = "https://github.com/feldera/feldera"
 license = "MIT OR Apache-2.0"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 include = ["openapi.json", "/src", "build.rs", "COPYRIGHT", "README.md"]
 
@@ -20,7 +20,7 @@ serde_json = { version = "1.0" }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.11.0", features = ["serde", "v7"] }
 tokio = { version = "1.0.0", features = ["rt-multi-thread", "macros", "io-std", "process"] }
-feldera-types = { path = "../feldera-types", version = "0.39.0" }
+feldera-types = { path = "../feldera-types", version = "0.40.0" }
 env_logger = "0.11"
 tabled = { version = "0.17", features = ["macros", "ansi"] }
 json_to_table = "0.9.0"

--- a/crates/feldera-types/Cargo.toml
+++ b/crates/feldera-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feldera-types"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 license = "MIT"
 description = "Public API types for Feldera"

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeline-manager"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Data pipeline manager for the Feldera continuous analytics platform."

--- a/crates/sqllib/Cargo.toml
+++ b/crates/sqllib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feldera-sqllib"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 license = "MIT"
 description = "SQL runtime library for Feldera"
@@ -12,8 +12,8 @@ publish = true
 
 [dependencies]
 thiserror = "1.0"
-dbsp = { path = "../dbsp", version = "0.39.0" }
-feldera-types = { path = "../feldera-types", version = "0.39.0" }
+dbsp = { path = "../dbsp", version = "0.40.0" }
+feldera-types = { path = "../feldera-types", version = "0.40.0" }
 itertools = { version = "0.13.0" }
 # `serde-with-arbitrary-precision` is needed because we enable `arbitrary_precision` in `serde_json`.
 rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1", features = ["maths", "rkyv", "serde-float", "serde-arbitrary-precision"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feldera-storage"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Storage crate for feldera"
 homepage = "https://github.com/feldera/feldera"
@@ -8,7 +8,7 @@ repository = "https://github.com/feldera/feldera"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-feldera-types = { path = "../feldera-types", version = "0.39.0" }
+feldera-types = { path = "../feldera-types", version = "0.40.0" }
 tokio = { version = "1.25.0", features = ["macros", "rt", "rt-multi-thread"] }
 libc = "0.2.153"
 rkyv = { version = "0.7.45", default-features = false, features = ["std", "size_64", "validation", "uuid"] }

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -1,9 +1,7 @@
 # This Dockerfile is used by CI to build things.
 #
 # The image is built by the `build-docker-dev.yml` action
-# whenever it changes. But you'll have to change the sha in
-# other actions that rely on this image if you want to use
-# a newer version in CI.
+# You can run it manually using the github actions UI.
 
 # We need a Java and Rust compiler to run alongside the pipeline manager
 FROM ubuntu:24.04 AS base
@@ -69,6 +67,7 @@ ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.bun/bin:/home/ubuntu/.cargo/bin:
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.83.0
+RUN cargo install cargo-machete@0.7.0 cargo-edit@0.13.1
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/0.6.5/install.sh | sh

--- a/deploy/docker-compose-extra.yml
+++ b/deploy/docker-compose-extra.yml
@@ -4,7 +4,7 @@ services:
     profiles: [ "kafka-connect",
                 "demo-debezium-mysql", "demo-snowflake-sink", "demo-debezium-jdbc",
                 "demo-debezium-postgres" ]
-    image: ghcr.io/feldera/kafka-connect:${FELDERA_VERSION:-0.39.0}
+    image: ghcr.io/feldera/kafka-connect:${FELDERA_VERSION:-latest}
     build:
       context: ../
       dockerfile: deploy/Dockerfile.kafka-connect

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,7 +2,7 @@ name: feldera
 services:
   pipeline-manager:
     tty: true
-    image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-0.39.0}
+    image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-latest}
     ports:
       # If you change the host side of the port mapping here, don't forget to
       # also add a corresponding --allowed-origins argument to the pipeline

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ use, check out [Feldera Enterprise](/enterprise).
 ## Docker Quickstart
 
 ```
-docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:0.39.0
+docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
 ```
 
 Once you see the Feldera logo on your terminal, go ahead and open the Web Console

--- a/openapi.json
+++ b/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.39.0"
+    "version": "0.40.0"
   },
   "paths": {
     "/config/authentication": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "feldera"
 readme = "README.md"
 description = "The feldera python client"
-version = "0.39.0"
+version = "0.40.0"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 authors = [

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.39.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
This provides a release action that does all the steps to release our software (currently still needs to be triggered manually, but if it works we can run this in nightly).

As opposed to updating the version with a commit before the release in the repo, we now set the versions to the next release after the release is done. This makes sure we can release a commit that passed the merge queue and has pre-built artifacts.