### PR TITLE
pipeline: `/status` endpoint

### DIFF
--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -135,6 +135,10 @@ impl GlobalControllerMetrics {
         }
     }
 
+    pub fn get_state(&self) -> PipelineState {
+        self.state.load(Ordering::Acquire)
+    }
+
     fn input_batch(&self, num_records: u64) -> u64 {
         self.total_input_records
             .fetch_add(num_records, Ordering::AcqRel);

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -508,6 +508,7 @@ where
         .service(start)
         .service(pause)
         .service(shutdown)
+        .service(status)
         .service(query)
         .service(stats)
         .service(metrics)
@@ -540,6 +541,20 @@ async fn pause(state: WebData<ServerState>) -> impl Responder {
         Some(controller) => {
             controller.pause();
             Ok(HttpResponse::Ok().json("Pipeline paused"))
+        }
+        None => Err(missing_controller_error(&state)),
+    }
+}
+
+/// Retrieve pipeline status.
+///
+/// The status is either `Paused`, `Running` or `Terminated`.
+#[get("/status")]
+async fn status(state: WebData<ServerState>) -> impl Responder {
+    match &*state.controller.lock().unwrap() {
+        Some(controller) => {
+            let status = controller.status().global_metrics.get_state();
+            Ok(HttpResponse::Ok().json(status))
         }
         None => Err(missing_controller_error(&state)),
     }


### PR DESCRIPTION
Introduces the `/status` endpoint to the pipeline which solely returns the status (i.e., `Paused`, `Running`, or `Terminated`). This is useful for the pipeline automaton to only retrieve the minimal information it needs, as the endpoint is called frequently for monitoring. The endpoint is not (yet) directly exposed to the user, as it is folded into the `deployment_status` by the automaton. This might change in the future.

This commit is part of series of changes to replace the `/stats` endpoint which is used for too many purposes currently.