### PR TITLE
pipeline-manager: pipeline interaction metrics endpoint

### DIFF
--- a/benchmark/feldera-sql/run.py
+++ b/benchmark/feldera-sql/run.py
@@ -443,8 +443,18 @@ def main():
                 print("Failed to get stats: ", req)
             if req.status_code == 400:
                 break
-
             stats = req.json()
+
+            req = requests.get(
+                f"{api_url}/v0/pipelines/{full_name}/metrics?format=json",
+                headers=headers,
+            )
+            if req.status_code != 200:
+                print("Failed to get metrics: ", req)
+            if req.status_code == 400:
+                break
+            metrics_json = req.json()
+
             # for input in stats["inputs"]:
             #    print(input["endpoint_name"], input["metrics"]["end_of_input"])
             elapsed = time.time() - start
@@ -458,7 +468,7 @@ def main():
                 for key, value in global_metrics.items():
                     metrics_seen.add(key)
                     metrics_dict[key] = value
-                for s in stats["metrics"]:
+                for s in metrics_json:
                     key = s["key"].replace(".", "_")
                     value = s["value"]
                     if "Counter" in value and value["Counter"] is not None:

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -224,6 +224,7 @@ pub struct ControllerStatus {
     outputs: OutputsStatus,
 
     /// Metrics.
+    #[serde(skip)]
     pub metrics: Mutex<Vec<ControllerMetric>>,
 }
 

--- a/crates/feldera-types/src/lib.rs
+++ b/crates/feldera-types/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod format;
 pub mod program_schema;
 pub mod query;
+pub mod query_params;
 pub mod secret_ref;
 pub mod serde_with_context;
 pub mod transport;

--- a/crates/feldera-types/src/query_params.rs
+++ b/crates/feldera-types/src/query_params.rs
@@ -1,0 +1,27 @@
+//! Types for the query parameters of the pipeline endpoints.
+
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
+/// Circuit metrics output format.
+/// - `prometheus`: format expected by Prometheus, as documented at:
+///   <https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md>
+/// - `json`: JSON format
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricsFormat {
+    Prometheus,
+    Json,
+}
+
+/// Returns default metrics format.
+fn default_metrics_format() -> MetricsFormat {
+    MetricsFormat::Prometheus
+}
+
+/// Query parameters to retrieve pipeline circuit metrics.
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+pub struct MetricsParameters {
+    #[serde(default = "default_metrics_format")]
+    pub format: MetricsFormat,
+}

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -80,6 +80,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         endpoints::pipeline_interaction::get_pipeline_output_connector_status,
         endpoints::pipeline_interaction::get_pipeline_logs,
         endpoints::pipeline_interaction::get_pipeline_stats,
+        endpoints::pipeline_interaction::get_pipeline_metrics,
         endpoints::pipeline_interaction::get_pipeline_circuit_profile,
         endpoints::pipeline_interaction::get_pipeline_heap_profile,
         endpoints::pipeline_interaction::pipeline_adhoc_sql,
@@ -205,6 +206,8 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::program_schema::SourcePosition,
         feldera_types::program_schema::PropertyValue,
         feldera_types::program_schema::SqlIdentifier,
+        feldera_types::query_params::MetricsFormat,
+        feldera_types::query_params::MetricsParameters,
         feldera_types::error::ErrorResponse,
     ),),
     tags(
@@ -254,6 +257,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_interaction::get_pipeline_output_connector_status)
         .service(endpoints::pipeline_interaction::get_pipeline_logs)
         .service(endpoints::pipeline_interaction::get_pipeline_stats)
+        .service(endpoints::pipeline_interaction::get_pipeline_metrics)
         .service(endpoints::pipeline_interaction::get_pipeline_circuit_profile)
         .service(endpoints::pipeline_interaction::get_pipeline_heap_profile)
         .service(endpoints::pipeline_interaction::pipeline_adhoc_sql)

--- a/openapi.json
+++ b/openapi.json
@@ -2047,6 +2047,127 @@
         ]
       }
     },
+    "/v0/pipelines/{pipeline_name}/metrics": {
+      "get": {
+        "tags": [
+          "Pipeline interaction"
+        ],
+        "summary": "Retrieve circuit metrics of a running or paused pipeline.",
+        "operationId": "get_pipeline_metrics",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/MetricsFormat"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline circuit metrics retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Disconnected during response": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was shutdown, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was shutdown, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
+                      }
+                    }
+                  },
+                  "Pipeline is currently unavailable": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
+                      }
+                    }
+                  },
+                  "Pipeline is not deployed": {
+                    "value": {
+                      "message": "Unable to interact with pipeline because the deployment status ('shutdown') is not one of the deployed statuses ('running', 'paused' or 'unavailable') -- to resolve this: wait for the pipeline to become running or paused",
+                      "error_code": "PipelineInteractionNotDeployed",
+                      "details": {
+                        "status": "Shutdown",
+                        "desired_status": "Running"
+                      }
+                    }
+                  },
+                  "Response timeout": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
     "/v0/pipelines/{pipeline_name}/query": {
       "get": {
         "tags": [
@@ -2195,7 +2316,7 @@
         "tags": [
           "Pipeline interaction"
         ],
-        "summary": "Retrieve statistics (e.g., metrics, performance counters) of a running or paused pipeline.",
+        "summary": "Retrieve statistics (e.g., performance counters) of a running or paused pipeline.",
         "operationId": "get_pipeline_stats",
         "parameters": [
           {
@@ -2210,7 +2331,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Pipeline metrics retrieved successfully",
+            "description": "Pipeline statistics retrieved successfully",
             "content": {
               "application/json": {
                 "schema": {
@@ -3994,6 +4115,23 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp from which the user should be reminded of the license expiring soon"
+          }
+        }
+      },
+      "MetricsFormat": {
+        "type": "string",
+        "description": "Circuit metrics output format.\n- `prometheus`: format expected by Prometheus, as documented at:\n<https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md>\n- `json`: JSON format",
+        "enum": [
+          "prometheus",
+          "json"
+        ]
+      },
+      "MetricsParameters": {
+        "type": "object",
+        "description": "Query parameters to retrieve pipeline circuit metrics.",
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/MetricsFormat"
           }
         }
       },

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -1525,6 +1525,25 @@ export const $LicenseInformation = {
   }
 } as const
 
+export const $MetricsFormat = {
+  type: 'string',
+  description: `Circuit metrics output format.
+- \`prometheus\`: format expected by Prometheus, as documented at:
+<https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md>
+- \`json\`: JSON format`,
+  enum: ['prometheus', 'json']
+} as const
+
+export const $MetricsParameters = {
+  type: 'object',
+  description: 'Query parameters to retrieve pipeline circuit metrics.',
+  properties: {
+    format: {
+      $ref: '#/components/schemas/MetricsFormat'
+    }
+  }
+} as const
+
 export const $NewApiKeyRequest = {
   type: 'object',
   description: 'Request to create a new API key.',

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -57,6 +57,9 @@ import type {
   GetPipelineLogsData,
   GetPipelineLogsError,
   GetPipelineLogsResponse,
+  GetPipelineMetricsData,
+  GetPipelineMetricsError,
+  GetPipelineMetricsResponse,
   PipelineAdhocSqlData,
   PipelineAdhocSqlError,
   PipelineAdhocSqlResponse,
@@ -314,6 +317,16 @@ export const getPipelineLogs = (options: Options<GetPipelineLogsData>) => {
 }
 
 /**
+ * Retrieve circuit metrics of a running or paused pipeline.
+ */
+export const getPipelineMetrics = (options: Options<GetPipelineMetricsData>) => {
+  return (options?.client ?? client).get<GetPipelineMetricsResponse, GetPipelineMetricsError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/metrics'
+  })
+}
+
+/**
  * Execute an ad-hoc SQL query in a running or paused pipeline.
  * The evaluation is not incremental.
  */
@@ -325,7 +338,7 @@ export const pipelineAdhocSql = (options: Options<PipelineAdhocSqlData>) => {
 }
 
 /**
- * Retrieve statistics (e.g., metrics, performance counters) of a running or paused pipeline.
+ * Retrieve statistics (e.g., performance counters) of a running or paused pipeline.
  */
 export const getPipelineStats = (options: Options<GetPipelineStatsData>) => {
   return (options?.client ?? client).get<GetPipelineStatsResponse, GetPipelineStatsError>({

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1161,6 +1161,21 @@ export type LicenseInformation = {
 }
 
 /**
+ * Circuit metrics output format.
+ * - `prometheus`: format expected by Prometheus, as documented at:
+ * <https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md>
+ * - `json`: JSON format
+ */
+export type MetricsFormat = 'prometheus' | 'json'
+
+/**
+ * Query parameters to retrieve pipeline circuit metrics.
+ */
+export type MetricsParameters = {
+  format?: MetricsFormat
+}
+
+/**
  * Request to create a new API key.
  */
 export type NewApiKeyRequest = {
@@ -2694,6 +2709,24 @@ export type GetPipelineLogsResponse = Blob | File
 
 export type GetPipelineLogsError = ErrorResponse
 
+export type GetPipelineMetricsData = {
+  path: {
+    /**
+     * Unique pipeline name
+     */
+    pipeline_name: string
+  }
+  query?: {
+    format?: MetricsFormat
+  }
+}
+
+export type GetPipelineMetricsResponse = {
+  [key: string]: unknown
+}
+
+export type GetPipelineMetricsError = ErrorResponse
+
 export type PipelineAdhocSqlData = {
   path: {
     /**
@@ -3130,6 +3163,25 @@ export type $OpenApiTs = {
       }
     }
   }
+  '/v0/pipelines/{pipeline_name}/metrics': {
+    get: {
+      req: GetPipelineMetricsData
+      res: {
+        /**
+         * Pipeline circuit metrics retrieved successfully
+         */
+        '200': {
+          [key: string]: unknown
+        }
+        /**
+         * Pipeline with that name does not exist
+         */
+        '404': ErrorResponse
+        '500': ErrorResponse
+        '503': ErrorResponse
+      }
+    }
+  }
   '/v0/pipelines/{pipeline_name}/query': {
     get: {
       req: PipelineAdhocSqlData
@@ -3156,7 +3208,7 @@ export type $OpenApiTs = {
       req: GetPipelineStatsData
       res: {
         /**
-         * Pipeline metrics retrieved successfully
+         * Pipeline statistics retrieved successfully
          */
         '200': {
           [key: string]: unknown


### PR DESCRIPTION
No longer serializes `metrics` as part of `/stats`.

Exposes the retrieval of circuit metrics to the user via `GET /v0/pipelines/{pipeline_name}/metrics`. The output format can be specified via the `format` query parameter, with two formats currently being supported: `prometheus` (default) and `json`.

This separate retrieval functionality is needed because metrics are no longer included in the `/stats` endpoint response.

This commit does not change the underlying snapshot mechanism which supplies the metrics, and as such does not improve or affect the existing performance overhead it incurs.

**Related issues**
- Fixes: https://github.com/feldera/feldera/issues/3725