### PR TITLE
[dbsp] Associate spine metrics with operators.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -875,6 +875,9 @@ pub struct Z1Trace<T: Trace> {
     bounds: TraceBounds<T::Key, T::Val>,
     // Handle to update the metric `total_size`.
     total_size_metric: Option<Gauge>,
+
+    // Metrics maintained by the trace.
+    trace_metrics: Option<T::Metrics>,
 }
 
 impl<T> Z1Trace<T>
@@ -896,6 +899,7 @@ where
             reset_on_clock_start,
             bounds,
             total_size_metric: None,
+            trace_metrics: None,
         }
     }
 }
@@ -933,6 +937,8 @@ where
             global_id,
             vec![],
         ));
+
+        self.trace_metrics = Some(T::init_operator_metrics(global_id));
     }
 
     fn metrics(&self) {
@@ -946,6 +952,9 @@ where
             .as_ref()
             .unwrap()
             .set(total_size as f64);
+        if let Some(trace) = self.trace.as_ref() {
+            trace.metrics(self.trace_metrics.as_ref().unwrap());
+        }
     }
 
     fn metadata(&self, meta: &mut OperatorMeta) {

--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -27,6 +27,7 @@
 //! the `(time, diff)` pairs associated with a key and value.
 
 use crate::circuit::metadata::{MetaItem, OperatorMeta};
+use crate::circuit::GlobalNodeId;
 use crate::dynamic::{ClonableTrait, DynDataTyped, DynUnit, Weight};
 use crate::storage::buffer_cache::CacheStats;
 pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};
@@ -235,6 +236,13 @@ pub trait Trace: BatchReader {
         Factories = Self::Factories,
     >;
 
+    /// Metrics output by the trace.
+    ///
+    /// We want to attribute trace metrics to the operator that created the trace.
+    /// Therefore metrics (gauges, counters, etc.) are stored in the operator and
+    /// updated by the trace on-demand.
+    type Metrics;
+
     /// Allocates a new empty trace.
     fn new(factories: &Self::Factories) -> Self;
 
@@ -307,6 +315,12 @@ pub trait Trace: BatchReader {
 
     /// Allows the trace to report additional metadata.
     fn metadata(&self, _meta: &mut OperatorMeta) {}
+
+    /// Create a set of metrics for this trace type.
+    fn init_operator_metrics(global_node_id: &GlobalNodeId) -> Self::Metrics;
+
+    /// Update trace metrics.
+    fn metrics(&self, metrics: &Self::Metrics);
 }
 
 /// Where a batch is stored.

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -1262,13 +1262,9 @@ where
         &self.value_filter
     }
 
-    fn init_operator_metrics(_global_node_id: &crate::circuit::GlobalNodeId) -> Self::Metrics {
-        ()
-    }
+    fn init_operator_metrics(_global_node_id: &crate::circuit::GlobalNodeId) -> Self::Metrics {}
 
-    fn metrics(&self, _metrics: &Self::Metrics) {
-        ()
-    }
+    fn metrics(&self, _metrics: &Self::Metrics) {}
 }
 
 /// Test random sampling methods.

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -1207,6 +1207,7 @@ where
     T: Timestamp,
 {
     type Batch = Self;
+    type Metrics = ();
 
     fn new(_factories: &Self::Factories) -> Self {
         Self {
@@ -1259,6 +1260,14 @@ where
 
     fn value_filter(&self) -> &Option<Filter<Self::Val>> {
         &self.value_filter
+    }
+
+    fn init_operator_metrics(_global_node_id: &crate::circuit::GlobalNodeId) -> Self::Metrics {
+        ()
+    }
+
+    fn metrics(&self, _metrics: &Self::Metrics) {
+        ()
     }
 }
 


### PR DESCRIPTION
We used to assign each spine a unique ID and use this ID to generate metrics for the spine. This caused two issues. First, spine metrics weren't attributed to an operator. Second, there is at least one situation where a new spine is generated dynamically on every step (in a recursive fragment), which causes un unbounded number of gauges to be created over time.

The fix decouples metrics from a spine instance that generates them: metrics are stored in the operator, which invokes the spine to update them on-demand.