### PR TITLE
[py] Use 127.0.0.1 instead of localhost.

### DIFF
--- a/docs/connectors/sinks/http.md
+++ b/docs/connectors/sinks/http.md
@@ -24,7 +24,7 @@ We will subscribe to a stream of updates to the `average_price` view for pipelin
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?query=table\&mode=watch\&format=json
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/egress/average_price?query=table\&mode=watch\&format=json
 ```
 
 ### Python (direct API calls)
@@ -32,7 +32,7 @@ curl -i -X 'POST' \
 ```python
 import requests
 
-api_url = "http://localhost:8080"
+api_url = "http://127.0.0.1:8080"
 headers = {"authorization": f"Bearer <API-KEY>"}
 
 with requests.post(

--- a/docs/connectors/sinks/redis.md
+++ b/docs/connectors/sinks/redis.md
@@ -48,7 +48,7 @@ create materialized view v0 with (
     "transport": {
       "name": "redis_output",
       "config": {
-        "connection_string": "redis://localhost:6379/0",
+        "connection_string": "redis://127.0.0.1:6379/0",
         "key_separator": ":"
       }
     },

--- a/docs/connectors/sources/debezium.md
+++ b/docs/connectors/sources/debezium.md
@@ -152,7 +152,7 @@ CREATE TABLE my_table (
       "transport": {
           "name": "kafka_input",
           "config": {
-              "bootstrap.servers": "localhost:9092",
+              "bootstrap.servers": "127.0.0.1:9092",
               "auto.offset.reset": "earliest",
               "topics": ["my_topic"]
           }
@@ -178,7 +178,7 @@ CREATE TABLE my_table (
       "transport": {
           "name": "kafka_input",
           "config": {
-              "bootstrap.servers": "localhost:9092",
+              "bootstrap.servers": "127.0.0.1:9092",
               "auto.offset.reset": "earliest",
               "topics": ["my_topic"]
           }
@@ -209,7 +209,7 @@ CREATE TABLE my_table (
     "transport": {
       "name": "kafka_input",
       "config": {
-        "bootstrap.servers": "localhost:9092",
+        "bootstrap.servers": "127.0.0.1:9092",
         "auto.offset.reset": "earliest",
         "topics": ["my_topic"]
       }
@@ -217,7 +217,7 @@ CREATE TABLE my_table (
     "format": {
       "name": "avro",
       "config": {
-        "registry_urls": ["http://localhost:8081"],
+        "registry_urls": ["http://127.0.0.1:8081"],
         "update_format": "debezium"
       }
     }

--- a/docs/connectors/sources/http-get.md
+++ b/docs/connectors/sources/http-get.md
@@ -49,7 +49,7 @@ WITH ('connectors' = '[{
 ### curl
 
 ```bash
-curl -i -X PUT http://localhost:8080/v0/pipelines/workshop \
+curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/workshop \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile code program.sql \
@@ -69,7 +69,7 @@ curl -i -X PUT http://localhost:8080/v0/pipelines/workshop \
 ```python
 import requests
 
-api_url = "http://localhost:8080"
+api_url = "http://127.0.0.1:8080"
 headers = { "authorization": f"Bearer <API-KEY>" }
 requests.put(
     f"{api_url}/v0/pipelines/workshop",

--- a/docs/connectors/sources/http.md
+++ b/docs/connectors/sources/http.md
@@ -26,7 +26,7 @@ We will insert rows into table `product` for pipeline `supply-chain-pipeline`.
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5.0}}'
 ```
 
@@ -34,7 +34,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -H "Authorization: Bearer <API-KEY>" -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5.0}}'
 ```
 
@@ -42,7 +42,7 @@ curl -i -H "Authorization: Bearer <API-KEY>" -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
   -d '{"insert": {"pid": 0, "name": "hammer", "price": 5}}
 {"insert": {"pid": 1, "name": "nail", "price": 0.02}}'
 ```
@@ -51,7 +51,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json\&array=true \
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json\&array=true \
   -d '[{"insert": {"pid": 0, "name": "hammer", "price": 5}}, {"insert": {"pid": 1, "name": "nail", "price": 0.02}}]'
 ```
 
@@ -59,7 +59,7 @@ curl -i -X 'POST' \
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
+  http://127.0.0.1:8080/v0/pipelines/supply-chain-pipeline/ingress/product?format=json \
   -d '{"delete": {"pid": 1}}'
 ```
 
@@ -74,7 +74,7 @@ and a random price between 1 and 100. Batching can improve throughput.
 import random
 import requests
 
-api_url = "http://localhost:8080"
+api_url = "http://127.0.0.1:8080"
 headers = {"authorization": f"Bearer <API-KEY>"}
 
 batch = []
@@ -103,7 +103,7 @@ import requests
 from feldera import FelderaClient
 
 api_key = "<API-KEY>"
-CLIENT = FelderaClient("http://localhost:8080", api_key)
+CLIENT = FelderaClient("http://127.0.0.1:8080", api_key)
 
 batch = []
 for product_id in range(0, 1000):

--- a/docs/connectors/sources/iceberg.md
+++ b/docs/connectors/sources/iceberg.md
@@ -259,7 +259,7 @@ create table iceberg_table(
 ### Read an Iceberg table from S3 through a REST catalog
 
 Create an Iceberg input connector to read a snapshot of a table stored in an S3 bucket
-through a REST catalog runnin on `http://localhost:8181`.
+through a REST catalog runnin on `http://127.0.0.1:8181`.
 
 ```sql
 create table iceberg_table(
@@ -278,7 +278,7 @@ with (
                 "mode": "snapshot",
                 "catalog_type": "rest",
                 "table_name": "iceberg_test.test_table",
-                "rest.uri": "http://localhost:8181",
+                "rest.uri": "http://127.0.0.1:8181",
                 "rest.warehouse": "s3://feldera-iceberg-test/",
                 "s3.access-key-id": "<AWS_ACCESS_KEY_ID>",
                 "s3.secret-access-key": "<AWS_SECRET_ACCESS_KEY>",

--- a/docs/connectors/sources/postgresql.md
+++ b/docs/connectors/sources/postgresql.md
@@ -17,7 +17,7 @@ The PostgreSQL connector does not yet support fault tolerance.
 
 | Property | Type   | Default    | Description                                                                                                                                                                                                                                     |
 |----------|--------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `uri`*   | string |            | A PostgreSQL connection URL, e.g., "postgresql://postgres:1234@localhost:7373/postgres" (see the tokio-postgres [Config](https://docs.rs/tokio-postgres/0.7.12/tokio_postgres/config/struct.Config.html) struct for a detailed list of options) |
+| `uri`*   | string |            | A PostgreSQL connection URL, e.g., "postgresql://postgres:1234@127.0.0.1:7373/postgres" (see the tokio-postgres [Config](https://docs.rs/tokio-postgres/0.7.12/tokio_postgres/config/struct.Config.html) struct for a detailed list of options) |
 | `query`* | string |            | A PostgreSQL query which returns a list of rows to be ingested, e.g., "select a, b from table where a = 1 limit 100;" (check the [SELECT](https://www.postgresql.org/docs/current/sql-select.html) documentation in PostgreSQL for the syntax)  |
 
 
@@ -58,10 +58,10 @@ Please [let us know](https://github.com/feldera/feldera/issues) if you need supp
 
 ## A simple example
 
-We first connect to a PostgreSQL database running on `localhost:7373` with the username `postgres` and password `1234`.
+We first connect to a PostgreSQL database running on `127.0.0.1:7373` with the username `postgres` and password `1234`.
 
 ```bash
-psql postgresql://postgres:1234@localhost:7373/postgres
+psql postgresql://postgres:1234@127.0.0.1:7373/postgres
 ```
 
 Next we create a table `people` with columns `id`, `name`, and `age` by pasting the following SQL in `psql`:
@@ -94,7 +94,7 @@ create table people (
     "transport": {
       "name": "postgres_input",
       "config": {
-        "uri": "postgresql://postgres:1234@localhost:7373/postgres",
+        "uri": "postgresql://postgres:1234@127.0.0.1:7373/postgres",
         "query": "select id, name, age as the_age, 1 as extra from people;"
       }
     }
@@ -295,7 +295,7 @@ CREATE TABLE all_types_example (
     "transport": {
       "name": "postgres_input",
       "config": {
-        "uri": "postgresql://postgres:1234@localhost:7373/postgres",
+        "uri": "postgresql://postgres:1234@127.0.0.1:7373/postgres",
         "query": "select * from all_types_example;"
       }
     }

--- a/docs/contributors/dev-flow.md
+++ b/docs/contributors/dev-flow.md
@@ -27,7 +27,7 @@ RUST_LOG=info RUST_BACKTRACE=1 cargo run --bin pipeline-manager --features pg-em
 
 > `--dbsp-override-path .` should be the path of the Feldera repository root - so update the argument if you are running from a different directory.
 
-You should now be able to access the Web Console at http://localhost:8080/, connected to your local Pipeline Manager instance!
+You should now be able to access the Web Console at http://127.0.0.1:8080/, connected to your local Pipeline Manager instance!
 
 You can also open Web Console in dev mode to be able to see your changes to it live:
 
@@ -35,7 +35,7 @@ You can also open Web Console in dev mode to be able to see your changes to it l
 cd web-console && bun install && bun run dev
 ```
 
-The Web Console in dev mode is available at http://localhost:3000/
+The Web Console in dev mode is available at http://127.0.0.1:3000/
 
 Now you can proceed with the [demo](#manually-starting-the-demos).
 
@@ -55,8 +55,8 @@ First, setup an AWS Cognito user pool, configure an app client and enable the
 UI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-app-integration.html#cognito-user-pools-app-integration-amplify).
 When setting up the hosted UI, setup a redirect URI as
 `<feldera-api-url>/auth/aws/` (note the trailing slash). For example, when
-running Feldera on localhost:8080, the redirect URI should be
-`http://localhost:8080/auth/aws/`. In this process, you will also set up a
+running Feldera on 127.0.0.1:8080, the redirect URI should be
+`http://127.0.0.1:8080/auth/aws/`. In this process, you will also set up a
 `Cognito domain`, which will be something like
 `https://<domain-name>.auth.us-east-1.amazoncognito.com`. This domain forms the
 base of the [login and logout

--- a/docs/contributors/ui-testing.md
+++ b/docs/contributors/ui-testing.md
@@ -51,7 +51,7 @@ install Playwright on your host system: https://playwright.dev/docs/intro
 
 Execute Playwright Codegen with:
 ```bash
-yarn playwright codegen http://localhost:8080/
+yarn playwright codegen http://127.0.0.1:8080/
 ```
 
 Keep in mind that codegen is not designed to produce production-ready code,

--- a/docs/formats/avro.md
+++ b/docs/formats/avro.md
@@ -125,7 +125,7 @@ CREATE TABLE my_table (
     "transport": {
       "name": "kafka_input",
       "config": {
-        "bootstrap.servers": "localhost:19092",
+        "bootstrap.servers": "127.0.0.1:19092",
         "auto.offset.reset": "earliest",
         "topics": ["my_topic"]
       }
@@ -152,7 +152,7 @@ CREATE TABLE my_table (
     "transport": {
       "name": "kafka_input",
       "config": {
-        "bootstrap.servers": "localhost:19092,
+        "bootstrap.servers": "127.0.0.1:19092,
         "auto.offset.reset": "earliest",
         "topics": ["my_topic"]
       }
@@ -160,7 +160,7 @@ CREATE TABLE my_table (
     "format": {
       "name": "avro",
       "config": {
-        "registry_urls": ["http://localhost:18081"],
+        "registry_urls": ["http://127.0.0.1:18081"],
         "update_format": "debezium"
       }
     }
@@ -215,7 +215,7 @@ WITH (
     "transport": {
       "name": "kafka_output",
       "config": {
-        "bootstrap.servers": "localhost:19092",
+        "bootstrap.servers": "127.0.0.1:19092",
         "topic": "my_topic",
         "auto.offset.reset": "earliest"
       }
@@ -244,7 +244,7 @@ WITH (
     "transport": {
       "name": "kafka_output",
       "config": {
-        "bootstrap.servers": "localhost:19092",
+        "bootstrap.servers": "127.0.0.1:19092",
         "topic": "my_topic"
       }
     },
@@ -252,7 +252,7 @@ WITH (
       "name": "avro",
       "config": {
         "update_format": "confluent_jdbc",
-        "registry_urls": ["http://localhost:18081"],
+        "registry_urls": ["http://127.0.0.1:18081"],
         "key_fields": ["id"]
       }
     }

--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -283,7 +283,7 @@ API endpoint, the data format is specified as part of the URL, e.g.:
 # `&update_format=insert_delete` - Specifies data change event format. Supported values are `insert_delete` and `raw`.
 # `&array=false` - Don't use array encoding.
 # replace PIPELINE_NAME with the name of the pipeline and TABLE_NAME with the name of the table
-curl -X 'POST' 'http://localhost:8080/v0/pipelines/PIPELINE_NAME/ingress/TABLE_NAME?format=json&update_format=insert_delete&array=false' -d '
+curl -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/PIPELINE_NAME/ingress/TABLE_NAME?format=json&update_format=insert_delete&array=false' -d '
 {"insert": {"id": 1, "name": "Flux Capacitor"}}
 {"insert": {"id": 2, "name": "Warp Core"}}
 {"insert": {"id": 3, "name": "Kyber Crystal"}}'
@@ -297,7 +297,7 @@ to choose this encoding for output data.
 
 ```bash
 # replace PIPELINE_NAME with the name of the pipeline and VIEW_NAME with the name of the table
-curl -s -N -X 'POST' 'http://localhost:8080/v0/pipelines/PIPELINE_NAME/egress/VIEW_NAME?format=json'
+curl -s -N -X 'POST' 'http://127.0.0.1:8080/v0/pipelines/PIPELINE_NAME/egress/VIEW_NAME?format=json'
 ```
 
 See also the [HTTP input and output tutorial](/tutorials/basics/part3.md).

--- a/docs/formats/raw.md
+++ b/docs/formats/raw.md
@@ -93,7 +93,7 @@ Insert two records with values `hello` and `world`:
 
 ```bash
 curl -i -X 'POST' \
-  http://localhost:8080/v0/pipelines/my_pipeline/ingress/raw_table?format=raw&mode=lines \
+  http://127.0.0.1:8080/v0/pipelines/my_pipeline/ingress/raw_table?format=raw&mode=lines \
   -d 'hello
   world'
 ```

--- a/docs/get-started/docker.md
+++ b/docs/get-started/docker.md
@@ -11,7 +11,7 @@ docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
 ```
 
 Once you see the Feldera logo on your terminal, go ahead and open the Web Console
-at `http://localhost:8080` and try out one of our pre-packaged demo pipelines.
+at `http://127.0.0.1:8080` and try out one of our pre-packaged demo pipelines.
 
 ## Optional: Docker Compose Quickstart
 
@@ -32,7 +32,7 @@ docker compose -f - up pipeline-manager redpanda
 ```
 
 Similar to the previous section, once you see the Feldera logo on your
-terminal, go ahead and open the Web Console at `http://localhost:8080` and try
+terminal, go ahead and open the Web Console at `http://127.0.0.1:8080` and try
 out one of our pre-packaged demo pipelines.
 
 ## Installing Docker

--- a/docs/get-started/enterprise/helm-guide.md
+++ b/docs/get-started/enterprise/helm-guide.md
@@ -79,8 +79,8 @@ on a Kubernetes cluster. It requires a valid Feldera Enterprise license
    ```
 
    ... after which you can (leaving the forwarding running in a terminal):
-   * Visit Web Console in browser: http://localhost:8080
-   * Interact with the API: [**http://localhost:8080/v0/...**](http://localhost:8080/v0/...)
+   * Visit Web Console in browser: http://127.0.0.1:8080
+   * Interact with the API: [**http://127.0.0.1:8080/v0/...**](http://127.0.0.1:8080/v0/...)
 
    _Note:_ access through kubectl port-forwarding is mostly useful for test and development.
    In other cases, setting up an ingress (e.g., [in EKS](kubernetes-guides/eks/ingress.md)) is likely preferable.

--- a/docs/get-started/enterprise/kubernetes-guides/eks/ingress.md
+++ b/docs/get-started/enterprise/kubernetes-guides/eks/ingress.md
@@ -129,7 +129,7 @@ you can also reach the load balancer endpoint via kubectl port-forwarding:
 kubectl port-forward -n ingress-nginx-internal service/ingress-nginx-internal-controller-internal 8080:80
 ```
 
-While keeping it running in a terminal, visit http://localhost:8080
+While keeping it running in a terminal, visit http://127.0.0.1:8080
 in a browser to see the Feldera Web Console.
 
 ## Additional resources

--- a/docs/get-started/enterprise/quickstart.md
+++ b/docs/get-started/enterprise/quickstart.md
@@ -33,7 +33,7 @@ in a Kubernetes cluster.
    ```
    kubectl port-forward -n feldera svc/feldera-api-server 8080:8080
    ```
-   ... after which the Web Console and API are accessible at: http://localhost:8080
+   ... after which the Web Console and API are accessible at: http://127.0.0.1:8080
 
 ## Additional resources
 

--- a/docs/interface/index.mdx
+++ b/docs/interface/index.mdx
@@ -11,7 +11,7 @@ import Link from '@docusaurus/Link';
     <h3>
       <Link to="/concepts">Web Console</Link>
     </h3>
-    <p>The Web Console is the most convenient starting point to using Feldera. Simply aim your web browser at a running Feldera instance (and authenticate if required). This is typically `localhost:8080` if you are using our Docker instance or `try.feldera.com` if you are using our public cloud sandbox.</p>
+    <p>The Web Console is the most convenient starting point to using Feldera. Simply aim your web browser at a running Feldera instance (and authenticate if required). This is typically `127.0.0.1:8080` if you are using our Docker instance or `try.feldera.com` if you are using our public cloud sandbox.</p>
   </div>
 </div>
 <div className="card">

--- a/docs/interface/web-console.md
+++ b/docs/interface/web-console.md
@@ -2,5 +2,5 @@
 
 The Web Console is the most convenient starting point to using Feldera. Simply
 aim your web browser at a running Feldera instance (and authenticate if
-required). This is typically `localhost:8080` if you are using our Docker
+required). This is typically `127.0.0.1:8080` if you are using our Docker
 instance or [try.feldera.com](https://try.feldera.com) if you are using our public cloud sandbox.

--- a/docs/sql/grammar.md
+++ b/docs/sql/grammar.md
@@ -118,7 +118,7 @@ CREATE TABLE empsalary (
     enroll_date date
 ) WITH (
     'source' = 'kafka',
-    'url' = 'localhost:8080'
+    'url' = '127.0.0.1:8080'
 );
 ```
 

--- a/docs/sql/udf.md
+++ b/docs/sql/udf.md
@@ -175,7 +175,7 @@ base64 = "0.22.1"
 """
 
 # Create a pipeline using the above SQL, Rust, and TOML code.
-feldera = FelderaClient("http://localhost:8080")
+feldera = FelderaClient("http://127.0.0.1:8080")
 pipeline = PipelineBuilder(
     feldera, name="udf_test", sql=sql, udf_rust=udf_rust, udf_toml = udf_toml).create_or_replace()
 
@@ -227,7 +227,7 @@ base64 = \"0.22.1\"
 " > udf.toml
 
 
-curl -i -X PUT http://localhost:8080/v0/pipelines/udf_api_test \
+curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/udf_api_test \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile sql program.sql \

--- a/docs/tour/tour.md
+++ b/docs/tour/tour.md
@@ -1,7 +1,7 @@
 # Use Case: Security Operations
 
 Once you've started the Feldera demo, as described in [Get
-Started](/docker), navigate to http://localhost:8080
+Started](/docker), navigate to http://127.0.0.1:8080
 in your web browser to view the Feldera user interface.  A status
 dashboard fills most of the home screen, as shown below, and a
 sidebar on the left offers access to tabs for Feldera features:

--- a/docs/tutorials/basics/part1.md
+++ b/docs/tutorials/basics/part1.md
@@ -12,7 +12,7 @@ price for each part across all vendors.
 
 Make sure that you have Feldera up and running by following the [Getting
 Started](/get-started/docker.md) guide.  Open the Feldera Web Console on
-http://localhost:8080.
+http://127.0.0.1:8080.
 
 ## Step 1. Create a pipeline
 

--- a/docs/tutorials/basics/part2.md
+++ b/docs/tutorials/basics/part2.md
@@ -25,7 +25,7 @@ Start the pipeline you created in Part 1 of the tutorial from a clean state:
 Subscribe to changes to the `PREFERRED_VENDOR` view:
 
 ```bash
-curl -s -N -X 'POST' http://localhost:8080/v0/pipelines/supply_chain/egress/PREFERRED_VENDOR?format=json | jq
+curl -s -N -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/egress/PREFERRED_VENDOR?format=json | jq
 ```
 
 You should see periodic heartbeat messages:
@@ -52,7 +52,7 @@ In another terminal, use the following command to populate the `PART` table
 with the same data we entered manually in part 1 of the tutorial:
 
 ```bash
-curl -X 'POST' http://localhost:8080/v0/pipelines/supply_chain/ingress/PART?format=json -d '
+curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PART?format=json -d '
 {"insert": {"id": 1, "name": "Flux Capacitor"}}
 {"insert": {"id": 2, "name": "Warp Core"}}
 {"insert": {"id": 3, "name": "Kyber Crystal"}}'
@@ -66,12 +66,12 @@ Records are encoded as JSON objects with one key per table column.
 Next, we populate the other two tables:
 
 ```bash
-curl -X 'POST' http://localhost:8080/v0/pipelines/supply_chain/ingress/VENDOR?format=json -d '
+curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/VENDOR?format=json -d '
 {"insert": {"id": 1, "name": "Gravitech Dynamics", "address": "222 Graviton Lane"}}
 {"insert": {"id": 2, "name": "HyperDrive Innovations", "address": "456 Warp Way"}}
 {"insert": {"id": 3, "name": "DarkMatter Devices", "address": "333 Singularity Street"}}'
 
-curl -X 'POST' http://localhost:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
+curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
 {"insert": {"part": 1, "vendor": 2, "price": 10000}}
 {"insert": {"part": 2, "vendor": 1, "price": 15000}}
 {"insert": {"part": 3, "vendor": 3, "price": 9000}}'
@@ -137,7 +137,7 @@ that there is no `update` command.  Modifying a record amounts to deleting the
 old version and inserting the new one.
 
 ```bash
-curl -X 'POST' http://localhost:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
+curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply_chain/ingress/PRICE?format=json -d '
 {"delete": {"part": 1, "vendor": 2, "price": 10000}}
 {"insert": {"part": 1, "vendor": 2, "price": 30000}}
 {"delete": {"part": 2, "vendor": 1, "price": 15000}}

--- a/docs/tutorials/monitoring/index.md
+++ b/docs/tutorials/monitoring/index.md
@@ -19,15 +19,15 @@ is then used to visualize these metrics.
     - job_name: 'feldera'
       scrape_interval: 1s
       static_configs:
-        - targets: ['localhost:8081']
+        - targets: ['127.0.0.1:8081']
     ```
-    - Replace `localhost:8081` with the address of your Feldera instance. Note that `8081` is the default port for
+    - Replace `127.0.0.1:8081` with the address of your Feldera instance. Note that `8081` is the default port for
       metrics.
     - Restart Prometheus.
 3. **Grafana:** You must have [Grafana installed](https://grafana.com).
 4. **Add Prometheus To Grafana:**
     - If you are using a local prometheus instance, the URL for the Prometheus data source will
-      be http://localhost:9090.
+      be http://127.0.0.1:9090.
     - Follow the steps in the [Grafana
       documentation](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source)
       to add Prometheus as a data source.
@@ -82,7 +82,7 @@ step.
 3. **Tracing a Feldera pipeline**
     - Enable/disable tracing and specify the Jaeger endpoint in the pipeline `runtime_config`:
    ```bash
-   curl -i -X PATCH http://localhost:8080/v0/pipelines/tracing-pipeline \
+   curl -i -X PATCH http://127.0.0.1:8080/v0/pipelines/tracing-pipeline \
    -H 'Content-Type: application/json' \
    -d '{
      "runtime_config": {"tracing": true, "tracing_endpoint_jaeger": "host.docker.internal:6831", <other config settings> }

--- a/docs/tutorials/rest_api/index.md
+++ b/docs/tutorials/rest_api/index.md
@@ -31,7 +31,7 @@ language (e.g., in Python using the `requests` module).
    ```
    (leave it running in a separate terminal while going through this tutorial)
 
-   > For the remainder of this tutorial, we will use http://localhost:8080 as
+   > For the remainder of this tutorial, we will use http://127.0.0.1:8080 as
    > this is the default local hostname:port for the docker Feldera instance.
    > You will need to change it to match the Feldera instance you are using.
 
@@ -41,7 +41,7 @@ language (e.g., in Python using the `requests` module).
    You can add it to a `curl` call by replacing `<API-KEY>`
    with the generated string starting with `apikey:...`:
    ```
-   curl -s -H "Authorization: Bearer <API-KEY>" -X GET http://localhost:8080/v0/pipelines | jq
+   curl -s -H "Authorization: Bearer <API-KEY>" -X GET http://127.0.0.1:8080/v0/pipelines | jq
    ```
 
    > For the remainder of this tutorial, you will need to add
@@ -49,7 +49,7 @@ language (e.g., in Python using the `requests` module).
 
 5. **Check whether your setup works:** You can verify your setup by running:
    ```
-   curl -s -X GET http://localhost:8080/v0/programs | jq
+   curl -s -X GET http://127.0.0.1:8080/v0/programs | jq
    ```
 
    ... this will output a JSON array of program objects, which when there are
@@ -82,7 +82,7 @@ We'll be going through the following steps:
 ... all using just `curl`!
 
 > Note: at any point in the tutorial, don't forget you can check out the
-> Web Console by visiting http://localhost:8080 in your browser!
+> Web Console by visiting http://127.0.0.1:8080 in your browser!
 
 ### Step 1: SQL pipeline
 
@@ -162,7 +162,7 @@ specifies the pipeline's name, description, the different configuration paramter
 contents of `program.sql` into the `program_code` field.
 
 ```
-curl -i -X PUT http://localhost:8080/v0/pipelines/supply-chain \
+curl -i -X PUT http://127.0.0.1:8080/v0/pipelines/supply-chain \
 -H 'Content-Type: application/json' \
 -d "$(jq -Rsn \
   --rawfile code program.sql \
@@ -184,7 +184,7 @@ updated, its version is incremented and compilation is automatically triggered.
 Now let's check the program's compilation status a few times:
 
 ```
-curl -s http://localhost:8080/v0/pipelines/supply-chain | jq '.program_status'
+curl -s http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.program_status'
 ```
 ...which will show "CompilingRust" at first, but in about 30 seconds or so say "Success".
 
@@ -195,7 +195,7 @@ The pipeline is now ready to be started.
 We start the pipeline using:
 
 ```
-curl -i -X POST http://localhost:8080/v0/pipelines/supply-chain/start
+curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/start
 ```
 
 ... which will return `HTTP/1.1 202 Accepted` when successful.
@@ -203,7 +203,7 @@ curl -i -X POST http://localhost:8080/v0/pipelines/supply-chain/start
 Check that it has successfully started using:
 
 ```
-curl -s GET http://localhost:8080/v0/pipelines/supply-chain | jq '.deployment_status'
+curl -s GET http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_status'
 ```
 
 ... which will say 'Running` when the pipeline has started:
@@ -216,11 +216,11 @@ curl -s GET http://localhost:8080/v0/pipelines/supply-chain | jq '.deployment_st
 > take effect):
 > ```
 > # Shut it down:
-> curl -i -X POST http://localhost:8080/v0/pipelines/supply-chain/shutdown
+> curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown
 > # ... wait for the current_status to become Shutdown by checking:
-> curl -X GET http://localhost:8080/v0/pipelines/supply-chain
+> curl -X GET http://127.0.0.1:8080/v0/pipelines/supply-chain
 > # ... and then start:
-> curl -i -X POST http://localhost:8080/v0/pipelines/supply-chain/start
+> curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/start
 > ```
 
 ### Step 3: Pipeline progress
@@ -228,7 +228,7 @@ curl -s GET http://localhost:8080/v0/pipelines/supply-chain | jq '.deployment_st
 A running pipeline provides several useful stats:
 
 ```
-curl -sX GET http://localhost:8080/v0/pipelines/supply-chain/stats | jq
+curl -sX GET http://127.0.0.1:8080/v0/pipelines/supply-chain/stats | jq
 ```
 
 ... such as the number of input and processed records.
@@ -257,7 +257,7 @@ output of data can directly be performed using HTTP requests as well.
 We can retrieve a snapshot of the `preferred\_vendor` view using `curl`:
 
 ```
-curl -X POST 'http://localhost:8080/v0/pipelines/supply-chain/egress/PREFERRED_VENDOR?format=json&mode=snapshot&query=quantiles' | jq
+curl -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/egress/PREFERRED_VENDOR?format=json&mode=snapshot&query=quantiles' | jq
 ```
 
 ... which for each of the parts will show the preferred vendor:
@@ -304,7 +304,7 @@ It is also possible to actively monitor a view for changes rather than
 retrieving a snapshot:
 
 ```
-curl -s -N -X POST 'http://localhost:8080/v0/pipelines/supply-chain/egress/PREFERRED_VENDOR?format=json&mode=watch' | jq
+curl -s -N -X POST 'http://127.0.0.1:8080/v0/pipelines/supply-chain/egress/PREFERRED_VENDOR?format=json&mode=watch' | jq
 ```
 
 Keep this open in a separate terminal for the next step.
@@ -316,7 +316,7 @@ It is possible to INSERT, UPSERT or even DELETE a single row within a table. In 
 we have HyperDrive Innovations supply the Warp Core at a lower price of 12000:
 
 ```
-curl -X 'POST' http://localhost:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json \
+curl -X 'POST' http://127.0.0.1:8080/v0/pipelines/supply-chain/ingress/PRICE?format=json \
 -d '{"insert": {"part": 2, "vendor": 2, "price": 12000}}'
 ```
 
@@ -359,19 +359,19 @@ down the pipeline (which will automatically terminate monitoring the
 view if it is still running):
 
 ```
-curl -i -X POST http://localhost:8080/v0/pipelines/supply-chain/shutdown
+curl -i -X POST http://127.0.0.1:8080/v0/pipelines/supply-chain/shutdown
 ```
 
 Check that it has been shut down using:
 
 ```
-curl -s http://localhost:8080/v0/pipelines/supply-chain | jq '.deployment_status'
+curl -s http://127.0.0.1:8080/v0/pipelines/supply-chain | jq '.deployment_status'
 ```
 ... and you  should see `deployment_status` set to `Shutdown`.
 
 Next, let's DELETE the pipeline:
 ```
-curl -i -X DELETE http://localhost:8080/v0/pipelines/supply-chain
+curl -i -X DELETE http://127.0.0.1:8080/v0/pipelines/supply-chain
 ```
 
 You can also delete the `program.sql` file we used to create the program.

--- a/docs/use_cases/fine_grained_authorization/dynamic.md
+++ b/docs/use_cases/fine_grained_authorization/dynamic.md
@@ -244,7 +244,7 @@ select * from derived_binary_relationships;
 
 Let's see if it works. Open the complete code provided above in one of the following environments:
 * Feldera online sandbox: [https://try.feldera.com/create/?name=dynamic-fga](https://try.feldera.com/create/?name=dynamic-fga) OR
-* Your local Feldera instance: [localhost:8080/create/?name=dynamic-fga](http://localhost:8080/create/?name=dynamic-fga)
+* Your local Feldera instance: [127.0.0.1:8080/create/?name=dynamic-fga](http://127.0.0.1:8080/create/?name=dynamic-fga)
 
 Start the pipeline and create rules for the file manager example using ad hoc queries:
 

--- a/docs/use_cases/fraud_detection/fraud_detection.md
+++ b/docs/use_cases/fraud_detection/fraud_detection.md
@@ -301,7 +301,7 @@ eval_metrics(y_test, y_pred)
 
 Here we use the [Feldera online sandbox](https://try.feldera.com).
 You can also use a local instance of Feldera running in a Docker
-container on http://localhost:8080.
+container on http://127.0.0.1:8080.
 See [instructions](/docker) for running Feldera in Docker.
 
 :::

--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -29,7 +29,7 @@ Connecting to Feldera on localhost
 
     from feldera import FelderaClient, PipelineBuilder
 
-    client = FelderaClient('http://localhost:8080', api_key=api_key)
+    client = FelderaClient('http://127.0.0.1:8080', api_key=api_key)
 
     pipeline = PipelineBuilder(client, name, sql).create()
 
@@ -45,7 +45,7 @@ This example sets the timeout for each HTTP request to 10 seconds.
 
     from feldera import FelderaClient, PipelineBuilder
 
-    client = FelderaClient("http://localhost:8080", api_key=api_key, timeout=10)
+    client = FelderaClient("http://127.0.0.1:8080", api_key=api_key, timeout=10)
 
 .. note::
     This is for an individual HTTP request, and does not affect things like waiting for a pipeline to start,

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -57,7 +57,7 @@ class FelderaClient:
         Create a FelderaClient that connects to the local Feldera instance
         """
 
-        return FelderaClient(f"http://localhost:{port}")
+        return FelderaClient(f"http://127.0.0.1:{port}")
 
     def get_pipeline(self, pipeline_name) -> Pipeline:
         """


### PR DESCRIPTION
A user reported that DNS lookup significantly slowed down the entire Python SDK on Windows with Feldera running in WSL. So we skip the lookup by using 127.0.0.1 instead.