### PR TITLE
[SQL] Common-subexpression elimination in inner IR

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -16,6 +16,9 @@ jobs:
       options: --user=ubuntu
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download Test Binaries
         uses: actions/download-artifact@v4
         with:

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -58,8 +58,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
                 <configuration>
+                    <argLine>-ea</argLine>
                     <properties>
                         <property>
                             <name>listener</name>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -222,6 +222,11 @@ public final class DBSPCircuit extends DBSPNode
     public void accept(InnerVisitor visitor) {}
 
     @Override
+    public long getDerivedFrom() {
+        return this.id;
+    }
+
+    @Override
     public void accept(CircuitVisitor visitor) {
         visitor.push(this);
         VisitDecision decision = visitor.preorder(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPDeclaration.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPDeclaration.java
@@ -26,6 +26,11 @@ public final class DBSPDeclaration extends DBSPNode implements IDBSPOuterNode {
     }
 
     @Override
+    public long getDerivedFrom() {
+        return this.id;
+    }
+
+    @Override
     public void accept(CircuitVisitor visitor) {
         visitor.push(this);
         VisitDecision decision = visitor.preorder(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
@@ -49,7 +49,7 @@ public abstract class DBSPOperator extends DBSPNode implements IDBSPOuterNode {
         super(node);
         this.inputs = new ArrayList<>();
         this.annotations = new Annotations();
-        this.derivedFrom = -1;
+        this.derivedFrom = this.id;
     }
 
     public DBSPOperator copyAnnotations(DBSPOperator source) {
@@ -58,14 +58,12 @@ public abstract class DBSPOperator extends DBSPNode implements IDBSPOuterNode {
         return this;
     }
 
-    public String getDerivedFrom() {
-        if (this.derivedFrom >= 0)
-            return Long.toString(this.derivedFrom);
-        return Long.toString(this.id);
+    public long getDerivedFrom() {
+        return this.derivedFrom;
     }
 
     public void setDerivedFrom(long id) {
-        if (id != this.id && this.derivedFrom < 0) {
+        if (id != this.id) {
             this.derivedFrom = id;
             assert id < this.id;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUnaryOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPUnaryOperator.java
@@ -35,8 +35,7 @@ public abstract class DBSPUnaryOperator extends DBSPSimpleOperator {
     protected DBSPUnaryOperator(CalciteRelNode node, String operation,
                                 @Nullable DBSPExpression function, DBSPType outputType,
                                 boolean isMultiset, OutputPort source) {
-        super(node, operation, function, outputType, isMultiset);
-        this.addInput(source);
+        this(node, operation, function, outputType, isMultiset, source, null);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -128,6 +128,7 @@ public class RustFileWriter {
                 use ::serde::{Deserialize,Serialize};
                 use compare::{Compare, Extract};
                 use std::{
+                    cell::LazyCell,
                     collections::BTreeMap,
                     convert::identity,
                     ops::Neg,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -400,14 +400,7 @@ public class ToRustVisitor extends CircuitVisitor {
     }
 
     void generateOperator(DBSPOperator operator) {
-        List<Annotation> hash = operator.annotations.get(a -> a.is(MerkleHash.class));
-        assert operator.is(DBSPNestedOperator.class) || !hash.isEmpty();
         if (this.compiler.options.ioOptions.verbosity > 0) {
-            if (!hash.isEmpty()) {
-                this.builder.append("// Hash: ")
-                        .append(hash.get(0).to(MerkleHash.class).hash)
-                        .newline();
-            }
             String str = operator.getNode().toInternalString();
             this.writeComments(str);
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -37,6 +37,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RelColumnMetadata;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RelStruct;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.IsNumericType;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
@@ -271,13 +272,13 @@ public class TypeCompiler implements ICompilerComponent {
                 case BOOLEAN:
                     return new DBSPTypeBool(node, nullable);
                 case TINYINT:
-                    return new DBSPTypeInteger(node, 8, true, nullable);
+                    return DBSPTypeInteger.getType(node, DBSPTypeCode.INT8, nullable);
                 case SMALLINT:
-                    return new DBSPTypeInteger(node, 16, true, nullable);
+                    return DBSPTypeInteger.getType(node, DBSPTypeCode.INT16, nullable);
                 case INTEGER:
-                    return new DBSPTypeInteger(node, 32, true, nullable);
+                    return DBSPTypeInteger.getType(node, DBSPTypeCode.INT32, nullable);
                 case BIGINT:
-                    return new DBSPTypeInteger(node, 64, true, nullable);
+                    return DBSPTypeInteger.getType(node, DBSPTypeCode.INT64, nullable);
                 case DECIMAL: {
                     int precision = dt.getPrecision();
                     int scale = dt.getScale();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -1,0 +1,485 @@
+package org.dbsp.sqlCompiler.compiler.visitors.inner;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.aggregate.LinearAggregate;
+import org.dbsp.sqlCompiler.ir.aggregate.NonLinearAggregate;
+import org.dbsp.sqlCompiler.ir.expression.*;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
+import org.dbsp.sqlCompiler.ir.statement.DBSPConstItem;
+import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPStructItem;
+import org.dbsp.sqlCompiler.ir.statement.DBSPStructWithHelperItem;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeFunction;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.util.Linq;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A visitor which translates expressions and statements, mostly in postorder */
+public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
+    public ExpressionTranslator(DBSPCompiler compiler) {
+        super(compiler);
+    }
+
+    public DBSPExpression getE(DBSPExpression expression) {
+        return this.get(expression).to(DBSPExpression.class);
+    }
+
+    @Nullable
+    public DBSPExpression getEN(@Nullable DBSPExpression expression) {
+        if (expression == null)
+            return null;
+        IDBSPInnerNode result = this.getN(expression);
+        if (result == null)
+            return null;
+        return result.to(DBSPExpression.class);
+    }
+
+    public DBSPExpression[] get(DBSPExpression[] expressions) {
+        return Linq.map(expressions, this::getE, DBSPExpression.class);
+    }
+
+    void map(DBSPExpression expression, DBSPExpression result) {
+        if (expression.sameFields(result)) {
+            this.set(expression, expression);
+        } else {
+            this.set(expression, result);
+        }
+    }
+
+    void map(DBSPStatement statement, DBSPStatement result) {
+        if (statement.sameFields(result))
+            this.set(statement, statement);
+        else
+            this.set(statement, result);
+    }
+
+    @Override
+    public void postorder(DBSPApplyExpression node) {
+        DBSPExpression function = this.getE(node.function);
+        DBSPExpression[] args = this.get(node.arguments);
+        DBSPExpression result = new DBSPApplyExpression(function, node.getType(), args);
+        this.map(node, result);
+    }
+
+    @Override
+    public void postorder(DBSPApplyMethodExpression node) {
+        DBSPExpression function = this.getE(node.function);
+        DBSPExpression[] args = this.get(node.arguments);
+        DBSPExpression self = this.getE(node.self);
+        DBSPExpression result = new DBSPApplyMethodExpression(function, node.getType(), self, args);
+        this.map(node, result);
+    }
+
+    @Override
+    public void postorder(DBSPArrayExpression node) {
+        if (node.data == null) {
+            this.map(node, node);
+        } else {
+            List<DBSPExpression> data = Linq.map(node.data, this::getE);
+            this.map(node, new DBSPArrayExpression(node.getNode(), node.getType(), data));
+        }
+    }
+
+    @Override
+    public void postorder(DBSPAssignmentExpression node) {
+        DBSPExpression left = this.getE(node.left);
+        DBSPExpression right = this.getE(node.right);
+        this.map(node, new DBSPAssignmentExpression(left, right));
+    }
+
+    @Override
+    public void postorder(DBSPBinaryExpression node) {
+        DBSPExpression left = this.getE(node.left);
+        DBSPExpression right = this.getE(node.right);
+        this.map(node, new DBSPBinaryExpression(node.getNode(),
+                node.getType(),
+                node.opcode,
+                left,
+                right));
+    }
+
+    @Override
+    public void postorder(DBSPBlockExpression node) {
+        List<DBSPStatement> statements =
+                Linq.map(node.contents, c -> this.get(c).to(DBSPStatement.class));
+        DBSPExpression lastExpression = this.getEN(node.lastExpression);
+        this.map(node, new DBSPBlockExpression(statements, lastExpression));
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPType type) {
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public void postorder(DBSPBorrowExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, expression.borrow(node.mut));
+    }
+
+    @Override
+    public void postorder(DBSPCastExpression node) {
+        DBSPExpression expression = this.getE(node.source);
+        this.map(node, new DBSPCastExpression(node.getNode(), expression, node.getType(), node.safe));
+    }
+
+    @Override
+    public void postorder(DBSPCloneExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, expression.applyClone());
+    }
+
+    @Override
+    public void postorder(DBSPClosureExpression node) {
+        DBSPExpression body = this.getE(node.body);
+        this.map(node, new DBSPClosureExpression(node.getNode(), body, node.parameters));
+    }
+
+    @Override
+    public void postorder(DBSPConditionalAggregateExpression node) {
+        DBSPExpression left = this.getE(node.left);
+        DBSPExpression right = this.getE(node.right);
+        DBSPExpression condition = this.getEN(node.condition);
+        this.map(node, new DBSPConditionalAggregateExpression(
+                node.getNode(), node.opcode, node.getType(), left, right, condition));
+    }
+
+    @Override
+    public void postorder(DBSPConstructorExpression node) {
+        DBSPExpression function = this.getE(node.function);
+        DBSPExpression[] arguments = this.get(node.arguments);
+        this.map(node, new DBSPConstructorExpression(function, node.getType(), arguments));
+    }
+
+    @Override
+    public void postorder(DBSPCustomOrdExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        DBSPExpression comparator = this.getE(node.comparator);
+        this.map(node, new DBSPCustomOrdExpression(node.getNode(), source, comparator.to(DBSPComparatorExpression.class)));
+    }
+
+    @Override
+    public void postorder(DBSPCustomOrdField node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPCustomOrdField(expression, node.fieldNo));
+    }
+
+    @Override
+    public void postorder(DBSPDerefExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPDerefExpression(expression));
+    }
+
+    @Override
+    public void postorder(DBSPDirectComparatorExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, new DBSPDirectComparatorExpression(
+                node.getNode(), source.to(DBSPComparatorExpression.class), node.ascending));
+    }
+
+    @Override
+    public void postorder(DBSPExpression node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPExpressionStatement node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPExpressionStatement(expression));
+    }
+
+    @Override
+    public void postorder(DBSPComment node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPFieldComparatorExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, new DBSPFieldComparatorExpression(
+                node.getNode(), source.to(DBSPComparatorExpression.class), node.fieldNo, node.ascending));
+    }
+
+    @Override
+    public void postorder(DBSPFieldExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPFieldExpression(node.getNode(), expression, node.fieldNo));
+    }
+
+    @Override
+    public void postorder(DBSPFlatmap node) {
+        DBSPExpression collectionExpression = this.getE(node.collectionExpression);
+        List<DBSPClosureExpression> rightProjections = null;
+        if (node.rightProjections != null)
+            rightProjections = Linq.map(node.rightProjections,
+                    e -> this.getE(e).to(DBSPClosureExpression.class));
+        this.map(node, new DBSPFlatmap(node.getNode(), node.getType().to(DBSPTypeFunction.class),
+                node.inputElementType, collectionExpression.to(DBSPClosureExpression.class), node.leftInputIndexes,
+                rightProjections, node.ordinalityIndexType, node.shuffle));
+    }
+
+    @Override
+    public void postorder(DBSPForExpression node) {
+        throw new UnimplementedException();
+    }
+
+    @Override
+    public void postorder(DBSPGeoPointConstructor node) {
+        DBSPExpression left = this.getEN(node.left);
+        DBSPExpression right = this.getEN(node.right);
+        this.map(node, new DBSPGeoPointConstructor(node.getNode(), left, right, node.type));
+    }
+
+    @Override
+    public void postorder(DBSPStructItem node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPStructWithHelperItem node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPConstItem node) {
+        DBSPExpression expression = this.getEN(node.expression);
+        this.map(node, new DBSPConstItem(node.name, node.type, expression));
+    }
+
+    @Override
+    public void postorder(DBSPIfExpression node) {
+        DBSPExpression condition = this.getE(node.condition);
+        DBSPExpression positive = this.getE(node.positive);
+        DBSPExpression negative = this.getEN(node.negative);
+        this.map(node, new DBSPIfExpression(node.getNode(), condition, positive, negative));
+    }
+
+    @Override
+    public void postorder(DBSPIndexedZSetExpression node) {
+        this.map(node, node);
+    }
+
+    public void postorder(DBSPIsNullExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPIsNullExpression(node.getNode(), expression));
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPLetExpression node) {
+        // This one is done in preorder
+        node.initializer.accept(this);
+        DBSPExpression initializer = this.getE(node.initializer);
+        // Effects of initializer should be visible while processing consumer
+        node.consumer.accept(this);
+        DBSPExpression consumer = this.getE(node.consumer);
+        DBSPExpression result = new DBSPLetExpression(node.variable, initializer, consumer);
+        this.map(node, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public void postorder(DBSPLetStatement node) {
+        DBSPExpression initializer = this.getEN(node.initializer);
+        DBSPStatement result;
+        if (initializer != null)
+            result = new DBSPLetStatement(node.variable, initializer, node.mutable);
+        else
+            result = new DBSPLetStatement(node.variable, node.type, node.mutable);
+        this.map(node, result);
+    }
+
+    @Override
+    public void postorder(DBSPLiteral node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPMapExpression node) {
+        List<DBSPExpression> keys = null;
+        if (node.keys != null)
+            keys = Linq.map(node.keys, this::getE);
+        List<DBSPExpression> values = null;
+        if (node.values != null)
+            values = Linq.map(node.values, this::getE);
+        this.map(node, new DBSPMapExpression(node.mapType, keys, values));
+    }
+
+    @Override
+    public void postorder(DBSPNoComparatorExpression node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPPathExpression node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPQualifyTypeExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPQualifyTypeExpression(expression, node.types));
+    }
+
+    @Override
+    public void postorder(DBSPQuestionExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, source.question());
+    }
+
+    @Override
+    public void postorder(DBSPRawTupleExpression node) {
+        if (node.fields != null) {
+            DBSPExpression[] fields = this.get(node.fields);
+            DBSPExpression result = new DBSPRawTupleExpression(
+                    node.getNode(), node.getType().to(DBSPTypeRawTuple.class), fields);
+            this.map(node, result);
+        } else {
+            this.map(node, node.getType().none());
+        }
+    }
+
+    @Override
+    public void postorder(DBSPReturnExpression node) {
+        DBSPExpression argument = this.getE(node.argument);
+        this.map(node, new DBSPReturnExpression(node.getNode(), argument));
+    }
+
+    @Override
+    public void postorder(DBSPSomeExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPSomeExpression(node.getNode(), expression));
+    }
+
+    @Override
+    public void postorder(DBSPSortExpression node) {
+        DBSPExpression comparator = this.getE(node.comparator);
+        DBSPExpression limit = this.getEN(node.limit);
+        this.map(node, new DBSPSortExpression(node.getNode(), node.elementType,
+                comparator.to(DBSPComparatorExpression.class), limit));
+    }
+
+    @Override
+    public void postorder(DBSPStaticExpression node) {
+        DBSPExpression initializer = this.getE(node.initializer);
+        this.map(node, new DBSPStaticExpression(node.getNode(), initializer));
+    }
+
+    @Override
+    public void postorder(DBSPTupleExpression node) {
+        if (node.fields != null) {
+            DBSPExpression[] fields = this.get(node.fields);
+            DBSPExpression result = new DBSPTupleExpression(node.getNode(), node.getType().to(DBSPTypeTuple.class), fields);
+            this.map(node, result);
+        } else {
+            this.map(node, node.getType().none());
+        }
+    }
+
+    @Override
+    public void postorder(DBSPUnaryExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, new DBSPUnaryExpression(node.getNode(), node.type, node.opcode, source));
+    }
+
+    @Override
+    public void postorder(DBSPUnsignedUnwrapExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, new DBSPUnsignedUnwrapExpression(
+                node.getNode(), source, node.type, node.ascending, node.nullsLast));
+    }
+
+    @Override
+    public void postorder(DBSPUnsignedWrapExpression node) {
+        DBSPExpression source = this.getE(node.source);
+        this.map(node, new DBSPUnsignedWrapExpression(
+                node.getNode(), source, node.ascending, node.nullsLast));
+    }
+
+    @Override
+    public void postorder(DBSPUnwrapCustomOrdExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPUnwrapCustomOrdExpression(expression));
+    }
+
+    @Override
+    public void postorder(DBSPUnwrapExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPUnwrapExpression(expression));
+    }
+
+    @Override
+    public void postorder(DBSPVariablePath node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(DBSPVariantExpression node) {
+        DBSPExpression value = this.getEN(node.value);
+        this.map(node, new DBSPVariantExpression(value, node.getType().mayBeNull));
+    }
+
+    @Override
+    public void postorder(DBSPLazyCellExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        this.map(node, new DBSPLazyCellExpression(expression));
+    }
+
+    @Override
+    public void postorder(DBSPWindowBoundExpression node) {
+        DBSPExpression representation = this.getE(node.representation);
+        this.map(node, new DBSPWindowBoundExpression(node.getNode(), node.isPreceding, representation));
+    }
+
+    @Override
+    public void postorder(DBSPZSetExpression node) {
+        Map<DBSPExpression, Long> data = new HashMap<>();
+        for (Map.Entry<DBSPExpression, Long> e : node.data.entrySet())
+            data.put(this.getE(e.getKey()), e.getValue());
+        this.map(node, new DBSPZSetExpression(data, node.elementType));
+    }
+
+    @Override
+    public void postorder(LinearAggregate node) {
+        DBSPExpression map = this.getE(node.map);
+        DBSPExpression postProcess = this.getE(node.postProcess);
+        DBSPExpression emptySetResult = this.getE(node.emptySetResult);
+        this.map(node, new LinearAggregate(node.getNode(), map.to(DBSPClosureExpression.class),
+                postProcess.to(DBSPClosureExpression.class), emptySetResult));
+    }
+
+    @Override
+    public void postorder(NoExpression node) {
+        this.map(node, node);
+    }
+
+    @Override
+    public void postorder(NonLinearAggregate node) {
+        DBSPExpression zero = this.getE(node.zero);
+        DBSPExpression increment = this.getE(node.increment);
+        DBSPExpression postProcess = this.getEN(node.postProcess);
+        DBSPExpression emptySetResult = this.getE(node.emptySetResult);
+        this.map(node, new NonLinearAggregate(node.getNode(), zero, increment.to(DBSPClosureExpression.class),
+                postProcess != null ? postProcess.to(DBSPClosureExpression.class) : null, emptySetResult, node.semigroup));
+    }
+
+    @Override
+    public IDBSPInnerNode apply(IDBSPInnerNode node) {
+        this.startVisit(node);
+        node.accept(this);
+        IDBSPInnerNode result = this.get(node);
+        this.endVisit();
+        return result;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionsCSE.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionsCSE.java
@@ -1,0 +1,249 @@
+package org.dbsp.sqlCompiler.compiler.visitors.inner;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.IDBSPDeclaration;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPAssignmentExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBorrowExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPCloneExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPDerefExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPLazyCellExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPLetExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeLazy;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Logger;
+import org.dbsp.util.Utilities;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Given information computed by {@link ValueNumbering}, replace common subexpressions with variables
+ * in {@link DBSPLetExpression}s */
+public class ExpressionsCSE extends ExpressionTranslator {
+    final Map<DBSPExpression, ValueNumbering.CanonicalExpression> numbering;
+    final Map<DBSPExpression, DBSPVariablePath> cseVariables;
+    final List<Assignment> assignments;
+
+    record Assignment(DBSPVariablePath var, DBSPExpression expression, Set<IDBSPDeclaration> dependsOn) {
+        Assignment {
+            assert var.getType().deref().sameType(expression.getType());
+        }
+
+        @Override
+        public String toString() {
+            return "Assignment{" +
+                    "var=" + this.var +
+                    ", dependsOn=" + Linq.list(Linq.map(this.dependsOn, IDBSPDeclaration::getName)) +
+                    ", expression=" + this.expression +
+                    '}';
+        }
+    }
+
+    public ExpressionsCSE(DBSPCompiler compiler, Map<DBSPExpression, ValueNumbering.CanonicalExpression> numbering) {
+        super(compiler);
+        this.numbering = numbering;
+        this.cseVariables = new HashMap<>();
+        this.assignments = new ArrayList<>();
+    }
+
+    @Override
+    void map(DBSPExpression expression, DBSPExpression result) {
+        ValueNumbering.CanonicalExpression canon = this.numbering.get(expression);
+        assert this.operatorContext != null;
+        if (canon != null) {
+            DBSPVariablePath var = null;
+            if (this.cseVariables.containsKey(canon.expression)) {
+                // Variable already exists
+                var = Utilities.getExists(this.cseVariables, canon.expression);
+            } else if (canon.expression != result &&
+                    canon.expensive &&
+                    canon.manyUsers(this.numbering)) {
+                // Variable is worth creating
+                var = new DBSPTypeLazy(expression.getType()).var();
+                Utilities.putNew(this.cseVariables, canon.expression, var);
+                this.assignments.add(new Assignment(var, result, canon.dependsOn));
+            }
+            if (var != null)
+                result = var.deref().applyCloneIfNeeded();
+            // If variable hasn't been created now, use the suggested result
+        }
+        if (!this.translationMap.containsKey(expression)) {
+            super.map(expression, result);
+        }
+    }
+
+    @Override
+    public void postorder(DBSPCloneExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        // super.map does NOT CSE
+        super.map(node, expression.applyClone());
+    }
+
+    @Override
+    public void postorder(DBSPBorrowExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        // super.map does NOT CSE
+        super.map(node, expression.borrow(node.mut));
+    }
+
+    @Override
+    public void postorder(DBSPRawTupleExpression node) {
+        if (node.fields != null) {
+            DBSPExpression[] fields = this.get(node.fields);
+            // super.map does NOT CSE
+            super.map(node, new DBSPRawTupleExpression(node.getNode(), node.getType().to(DBSPTypeRawTuple.class), fields));
+        } else {
+            // super.map does NOT CSE
+            super.map(node, node.getType().none());
+        }
+    }
+
+    @Override
+    public void postorder(DBSPTupleExpression node) {
+        if (node.fields != null) {
+            DBSPExpression[] fields = this.get(node.fields);
+            // super.map does NOT CSE
+            super.map(node, new DBSPTupleExpression(node.getNode(), node.getType().to(DBSPTypeTuple.class), fields));
+        } else {
+            // super.map does NOT CSE
+            super.map(node, node.getType().none());
+        }
+    }
+
+    @Override
+    public void postorder(DBSPDerefExpression node) {
+        DBSPExpression expression = this.getE(node.expression);
+        // super.map does NOT CSE
+        super.map(node, expression.deref());
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPAssignmentExpression node) {
+        throw new InternalCompilerError("CSE does not work on expressions that use assignment");
+    }
+
+    @Override
+    public void postorder(DBSPLetExpression node) {
+        DBSPExpression consumer = this.getE(node.consumer);
+        List<Assignment> assignments = new ArrayList<>(this.assignments);
+        // LetExpressions are created inside-out, so we need to reverse the assignments
+        Collections.reverse(assignments);
+        this.assignments.clear();
+        for (Assignment assign : assignments) {
+            if (assign.dependsOn.contains(node)) {
+                consumer = new DBSPLetExpression(
+                        assign.var, new DBSPLazyCellExpression(assign.expression), consumer);
+            } else {
+                // Put it back, we'll insert it later
+                this.assignments.add(assign);
+            }
+        }
+        Collections.reverse(this.assignments);
+        this.map(node, new DBSPLetExpression(node.variable, node.initializer, consumer));
+    }
+
+    @Override
+    public void postorder(DBSPBlockExpression expression) {
+        DBSPExpression last = this.getEN(expression.lastExpression);
+        if (this.assignments.isEmpty()) {
+            List<DBSPStatement> stats = Linq.map(
+                    expression.contents, e -> this.get(e).to(DBSPStatement.class));
+            this.map(expression, new DBSPBlockExpression(stats, last));
+            return;
+        }
+
+        List<DBSPStatement> result = new ArrayList<>();
+        // Iterate over original statements
+        for (DBSPStatement stat: expression.contents) {
+            DBSPStatement repl = this.get(stat).to(DBSPStatement.class);
+            // But insert the transformed statements
+            result.add(repl);
+            if (stat.is(DBSPLetStatement.class)) {
+                // Add all statements that depend on stat
+                DBSPLetStatement let = stat.to(DBSPLetStatement.class);
+                List<Assignment> assignments = new ArrayList<>(this.assignments);
+                this.assignments.clear();
+                for (Assignment assign : assignments) {
+                    if (assign.dependsOn.contains(let)) {
+                        var add = new DBSPLetStatement(
+                                assign.var.variable, new DBSPLazyCellExpression(assign.expression));
+                        result.add(add);
+                    } else {
+                        this.assignments.add(assign);
+                    }
+                }
+            }
+        }
+        // Put back in the list of available assignments
+        this.map(expression, new DBSPBlockExpression(result, last));
+    }
+
+    @Override
+    public void postorder(DBSPClosureExpression node) {
+        boolean outer = this.context.isEmpty();
+        DBSPExpression translation = this.getE(node.body);
+        List<Assignment> assignments = new ArrayList<>(this.assignments);
+        this.assignments.clear();
+        Collections.reverse(assignments);
+        for (Assignment assign : assignments) {
+            boolean insert = outer;
+            if (!insert) {
+                for (DBSPParameter param : node.parameters) {
+                    if (assign.dependsOn.contains(param)) {
+                        insert = true;
+                        break;
+                    }
+                }
+            }
+            if (insert) {
+                translation = new DBSPLetExpression(
+                        assign.var, new DBSPLazyCellExpression(assign.expression), translation);
+            } else {
+                // Put it back, we'll insert it later
+                this.assignments.add(assign);
+            }
+        }
+
+        Collections.reverse(this.assignments);
+        DBSPExpression result = new DBSPClosureExpression(node.getNode(), translation, node.parameters);
+        this.map(node, result);
+        if (!node.sameFields(result)) {
+            Logger.INSTANCE.belowLevel(this, 2)
+                    .append("CSE rewrote").newline()
+                    .appendSupplier(node::toString).newline()
+                    .append("to").newline()
+                    .appendSupplier(result::toString).newline();
+        }
+    }
+
+    @Override
+    public void startVisit(IDBSPInnerNode node) {
+        this.assignments.clear();
+        this.cseVariables.clear();
+        super.startVisit(node);
+    }
+
+    @Override
+    public void endVisit() {
+        assert this.assignments.isEmpty()
+                : "Unused CSE expressions";
+        super.endVisit();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/IRTransform.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/IRTransform.java
@@ -1,8 +1,12 @@
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.util.ICastable;
 
 import java.util.function.Function;
 
-public interface IRTransform extends Function<IDBSPInnerNode, IDBSPInnerNode>, ICastable {}
+public interface IRTransform extends Function<IDBSPInnerNode, IDBSPInnerNode>, ICastable {
+    /** The operator containing the inner node that is being transformed */
+    void setOperatorContext(DBSPOperator operator);
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerPasses.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerPasses.java
@@ -1,15 +1,19 @@
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /** Applies multiple other inner visitors in sequence. */
 public class InnerPasses implements IWritesLogs, IRTransform {
     public final List<IRTransform> passes;
+    @Nullable
+    protected DBSPOperator operatorContext = null;
 
     public InnerPasses(IRTransform... passes) {
         this(Linq.list(passes));
@@ -44,5 +48,10 @@ public class InnerPasses implements IWritesLogs, IRTransform {
     @Override
     public String toString() {
         return super.toString() + this.passes;
+    }
+
+    @Override
+    public void setOperatorContext(DBSPOperator operator) {
+        this.operatorContext = operator;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -35,6 +35,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
 import org.dbsp.sqlCompiler.ir.expression.DBSPForExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIsNullExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPLazyCellExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPLetExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPNoComparatorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
@@ -104,6 +105,7 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeBTreeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRef;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeLazy;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeOption;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeStream;
@@ -395,6 +397,16 @@ public abstract class InnerRewriteVisitor
         DBSPType elementType = this.transform(type.getElementType());
         this.pop(type);
         DBSPType result = new DBSPTypeArray(elementType, type.mayBeNull);
+        this.map(type, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPTypeLazy type) {
+        this.push(type);
+        DBSPType elementType = this.transform(type.typeArgs[0]);
+        DBSPType result = new DBSPTypeLazy(elementType);
+        this.pop(type);
         this.map(type, result);
         return VisitDecision.STOP;
     }
@@ -870,6 +882,16 @@ public abstract class InnerRewriteVisitor
         DBSPExpression source = this.transform(expression.expression);
         this.pop(expression);
         DBSPExpression result = source.borrow(expression.mut);
+        this.map(expression, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPLazyCellExpression expression) {
+        this.push(expression);
+        DBSPExpression source = this.transform(expression.expression);
+        this.pop(expression);
+        DBSPExpression result = new DBSPLazyCellExpression(source);
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.ICompilerComponent;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
@@ -114,6 +115,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeBTreeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeLazy;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeOption;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeResult;
@@ -141,11 +143,18 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     static long crtId = 0;
     public final DBSPCompiler compiler;
     protected final List<IDBSPInnerNode> context;
+    @Nullable protected DBSPOperator operatorContext;
+
+    @Override
+    public void setOperatorContext(@Nullable DBSPOperator operatorContext) {
+        this.operatorContext = operatorContext;
+    }
 
     public InnerVisitor(DBSPCompiler compiler) {
         this.id = crtId++;
         this.compiler = compiler;
         this.context = new ArrayList<>();
+        this.operatorContext = null;
     }
 
     @Override
@@ -440,6 +449,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPTypeUser) node);
     }
 
+    public VisitDecision preorder(DBSPTypeLazy node) {
+        return this.preorder((DBSPTypeUser) node);
+    }
+
     public VisitDecision preorder(DBSPTypeVec node) {
         return this.preorder((DBSPTypeUser) node);
     }
@@ -661,6 +674,8 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     public VisitDecision preorder(DBSPUnsignedUnwrapExpression node) { return this.preorder((DBSPExpression) node); }
 
     public VisitDecision preorder(DBSPWindowBoundExpression node) { return this.preorder((DBSPExpression) node); }
+
+    public VisitDecision preorder(DBSPLazyCellExpression node) { return this.preorder((DBSPExpression) node); }
 
     // Literals
     public VisitDecision preorder(DBSPLiteral node) {
@@ -1042,6 +1057,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder((DBSPTypeUser) node);
     }
 
+    public void postorder(DBSPTypeLazy node) {
+        this.postorder((DBSPTypeUser) node);
+    }
+
     public void postorder(DBSPTypeVec node) {
         this.postorder((DBSPTypeUser) node);
     }
@@ -1263,6 +1282,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public void postorder(DBSPWindowBoundExpression node) {
+        this.postorder((DBSPExpression) node);
+    }
+
+    public void postorder(DBSPLazyCellExpression node) {
         this.postorder((DBSPExpression) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ValueNumbering.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ValueNumbering.java
@@ -1,0 +1,377 @@
+package org.dbsp.sqlCompiler.compiler.visitors.inner;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.ir.IDBSPDeclaration;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.expression.*;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
+import org.dbsp.util.IIndentStream;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Logger;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.CheckReturnValue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Find common subexpressions, write them into the 'canonical' map. */
+public class ValueNumbering extends InnerVisitor {
+    record ExpressionUser(DBSPExpression expression, int operand) {
+        @Override
+        public String toString() {
+            return "ExpressionUser(" + this.expression.getId() + " " +
+                    this.expression + ", operand=" + this.operand + ")";
+        }
+    }
+
+    public static class CanonicalExpression {
+        final DBSPExpression expression;
+        /** Expressions which use this CanonicalExpression as a subexpression */
+        Set<ExpressionUser> users;
+        boolean expensive;
+        /** List of declarations whose values are used by this expression */
+        final Set<IDBSPDeclaration> dependsOn;
+
+        CanonicalExpression(DBSPExpression expression, Set<IDBSPDeclaration> dependsOn, boolean expensive) {
+            this.expression = expression;
+            this.users = new HashSet<>();
+            this.expensive = expensive;
+            this.dependsOn = dependsOn;
+        }
+
+        void use(DBSPExpression user, int operand) {
+            this.users.add(new ExpressionUser(user, operand));
+        }
+
+        @Override
+        public String toString() {
+            return this.expression.getId() + " " +
+                    this.expression + " (" + this.users.size() + ") " +
+                    Linq.list(Linq.map(this.dependsOn, IDBSPDeclaration::getName)) +
+                    (this.expensive ? "*" : "");
+        }
+
+        /** Check if an expression has multiple users.
+         *
+         * @param translation A map from expression to canonical expression.
+         * @return True if there are at least 2 users. */
+        boolean manyUsers(Map<DBSPExpression, CanonicalExpression> translation) {
+            if (this.users.size() < 2)
+                return false;
+            Set<ExpressionUser> canon = new HashSet<>();
+            for (var l: this.users) {
+                if (translation.containsKey(l.expression)) {
+                    DBSPExpression canonical = translation.get(l.expression).expression;
+                    canon.add(new ExpressionUser(canonical, l.operand));
+                } else {
+                    canon.add(new ExpressionUser(this.expression, l.operand));
+                }
+                if (canon.size() > 1)
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    /** Maps each operator to its canonical representative */
+    public final Map<DBSPExpression, CanonicalExpression> canonical;
+    final Map<String, CanonicalExpression> representation;
+    final ResolveReferences resolver;
+    /** If true we cannot CSE safely */
+    public boolean foundAssignment;
+    public List<Boolean> inClosure;
+
+    public ValueNumbering(DBSPCompiler compiler) {
+        super(compiler);
+        this.canonical = new HashMap<>();
+        this.representation = new HashMap<>();
+        this.resolver = new ResolveReferences(compiler, false);
+        this.foundAssignment = false;
+        this.inClosure = new ArrayList<>();
+    }
+
+    @SuppressWarnings("unused")
+    public void dump(IIndentStream stream) {
+        for (var e: this.canonical.entrySet()) {
+            stream.append(e.getKey().getId())
+                    .append(" ")
+                    .append(e.getKey().toString())
+                    .append("->")
+                    .append(e.getValue().toString())
+                    .newline();
+        }
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPType type) {
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPClosureExpression expression) {
+        this.inClosure.add(true);
+        return super.preorder(expression);
+    }
+
+    @Override
+    public void postorder(DBSPClosureExpression expression) {
+        Utilities.removeLast(this.inClosure);
+        super.postorder(expression);
+    }
+
+    @Override
+    public void postorder(DBSPLiteral literal) {
+        Representation repr;
+        boolean expensive = literal.getType().is(DBSPTypeDecimal.class);
+        if (literal.isNull()) {
+            repr = new Representation("None::" + literal.getType(), false);
+        } else {
+            repr = new Representation(literal + ":" + literal.getType(), expensive);
+        }
+        this.checkRepresentation(literal, repr, false);
+    }
+
+    Representation getId(DBSPExpression expression, DBSPExpression user, int operand) {
+        if (!this.canonical.containsKey(expression))
+            // Invalid representation
+            return new Representation("", new HashSet<>(), false, true);
+        CanonicalExpression canon = Utilities.getExists(this.canonical, expression);
+        canon.use(user, operand);
+        return new Representation(Long.toString(canon.expression.getId()), canon.dependsOn, canon.expensive, false);
+    }
+
+    record Representation(String repr, Set<IDBSPDeclaration> dependsOn, boolean expensive, boolean invalid) {
+        Representation() {
+            this("", new HashSet<>(), false, false);
+        }
+
+        Representation(String repr, boolean expensive) {
+            this(repr, new HashSet<>(), expensive, false);
+        }
+
+        @CheckReturnValue
+        public Representation add(Representation repr) {
+            return new Representation(
+                    this.repr + repr.repr,
+                    Utilities.concatSet(this.dependsOn, repr.dependsOn),
+                    this.expensive || repr.expensive,
+                    repr.invalid || this.invalid);
+        }
+
+        @CheckReturnValue
+        public Representation add(String repr) {
+            return new Representation(this.repr + repr, this.dependsOn, this.expensive, this.invalid);
+        }
+    }
+    
+    @Override
+    public void postorder(DBSPBinaryExpression expression) {
+        Representation repr = this.getId(expression.left, expression, 0)
+                .add(expression.opcode.toString())
+                .add(this.getId(expression.right, expression, 1));
+        boolean expensive = switch (expression.opcode) {
+            case MUL, MAP_CONVERT, INTERVAL_MUL, ADD, SUB, DIV, DIV_NULL, MOD, MUL_WEIGHT, CONCAT, IS_DISTINCT, SQL_INDEX,
+                 MAP_INDEX, VARIANT_INDEX, RUST_INDEX, INTERVAL_DIV -> true;
+            default -> false;
+        };
+        this.checkRepresentation(expression, repr, expensive);
+    }
+
+    @Override
+    public void postorder(DBSPApplyExpression expression) {
+        Representation repr = new Representation("", false)
+                .add(this.getId(expression.function, expression, 0)).add("(");
+        int operand = 1;
+        for (DBSPExpression arg : expression.arguments)
+            repr = repr.add(this.getId(arg, expression, operand++)).add(",");
+        // For some polymorphic functions, such as vec!() we need the return type as well.
+        repr = repr.add(")").add(expression.type.toString());
+        this.checkRepresentation(expression, repr, true);
+    } 
+    
+    @Override
+    public void postorder(DBSPApplyMethodExpression expression) {
+        Representation repr = new Representation()
+                .add(this.getId(expression.self, expression, 0)).add(".")
+                .add(this.getId(expression.function, expression, 1)).add("(");
+        int operand = 2;
+        for (DBSPExpression arg : expression.arguments)
+            repr = repr.add(this.getId(arg, expression, operand++)).add(",");
+        // For some polymorphic functions, such as vec!() we need the return type as well.
+        repr = repr.add(")").add(expression.type.toString());
+        this.checkRepresentation(expression, repr, true);
+    }
+        
+    @Override public void postorder(DBSPAssignmentExpression expression) {
+        this.foundAssignment = true;
+    }
+
+    @Override public void postorder(DBSPBorrowExpression expression) {
+        Representation repr = new Representation("&", false)
+                .add(this.getId(expression.expression, expression, 0));
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPCastExpression expression) {
+        Representation repr = new Representation("(" + expression.type + "," + expression.safe + ")", false)
+                .add(this.getId(expression.source, expression, 0));
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPCloneExpression expression) {
+        Representation repr = this.getId(expression.expression, expression, 0)
+                .add(".clone()");
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPDerefExpression expression) {
+        Representation repr = new Representation("*", false)
+                .add(this.getId(expression.expression, expression, 0));
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPFieldExpression expression) {
+        Representation repr = this.getId(expression.expression, expression, 0)
+                .add("." + expression.fieldNo);
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPIfExpression expression) {
+        Representation repr = new Representation("if", false)
+                .add(this.getId(expression.condition, expression, 0))
+                .add("?")
+                .add(this.getId(expression.positive, expression, 1));
+        if (expression.negative != null)
+            repr = repr.add(":").add(this.getId(expression.negative, expression, 2));
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPIsNullExpression expression) {
+        Representation repr = this.getId(expression.expression, expression, 0)
+                .add(".is_null()");
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPLetExpression expression) {
+        Representation repr = new Representation("", Linq.set(expression), false, false)
+                .add("let " + expression.variable + " = ")
+                .add(this.getId(expression.initializer, expression, 0))
+                .add(" in ").add(this.getId(expression.consumer, expression, 1));
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPPathExpression expression) {
+        this.checkRepresentation(expression,
+                new Representation(expression.path.asString(), false), false);
+    }
+
+    @Override public void postorder(DBSPRawTupleExpression expression) {
+        Representation repr = new Representation();
+        if (expression.fields == null) {
+            repr = repr.add(expression + ":" + expression.type);
+        } else {
+            repr = repr.add("(");
+            int operand = 0;
+            for (DBSPExpression elem : expression.fields)
+                repr = repr.add(this.getId(elem, expression, operand++)).add(",");
+            repr = repr.add(")");
+        }
+        this.checkRepresentation(expression, repr, expression.fields != null && expression.size() > 0);
+    }
+
+    @Override public void postorder(DBSPSomeExpression expression) {
+        Representation repr = new Representation("Some(", false)
+                .add(this.getId(expression.expression, expression, 0))
+                .add(")");
+        this.checkRepresentation(expression, repr, false);
+    }
+
+    @Override public void postorder(DBSPTupleExpression expression) {
+        Representation repr = new Representation();
+        if (expression.fields == null) {
+            repr = repr.add(expression + ":" + expression.type);
+        } else {
+            repr = repr.add("Tup(");
+            int operand = 0;
+            for (DBSPExpression elem : expression.fields)
+                repr = repr.add(this.getId(elem, expression, operand++)).add(",");
+            repr = repr.add(")");
+        }
+        this.checkRepresentation(expression, repr, expression.fields != null && expression.size() > 0);
+    }
+
+    @Override public void postorder(DBSPUnaryExpression expression) {
+        Representation repr = new Representation(expression.opcode.toString(), false)
+                .add(this.getId(expression.source, expression, 0));
+        boolean expensive = expression.opcode != DBSPOpcode.NOT;
+        this.checkRepresentation(expression, repr, expensive);
+    }
+
+    @Override public void postorder(DBSPVariablePath var) {
+        IDBSPDeclaration decl = this.resolver.reference.get(var);
+        assert decl != null;
+        Representation repr = new Representation(
+                Long.toString(decl.getId()), Linq.set(decl), false, false);
+        this.checkRepresentation(var, repr, false);
+    }
+
+    void checkRepresentation(DBSPExpression expression, Representation repr, boolean expensive) {
+        if (repr.invalid || this.inClosure.isEmpty())
+            return;
+        if (this.representation.containsKey(repr.repr())) {
+            CanonicalExpression expr = Utilities.getExists(this.representation, repr.repr());
+            this.setCanonical(expression, expr);
+        } else {
+            this.newCanonical(expression, repr.repr(), repr.dependsOn, repr.expensive() || expensive);
+        }
+    }
+
+    @Override
+    public void startVisit(IDBSPInnerNode node) {
+        // This node may not be a DBSPClosureExpression.
+        // It can be a e.g., Fold constructor.
+        Logger.INSTANCE.belowLevel(this, 1)
+                .append("CSE analyzing ")
+                .appendSupplier(node::toString)
+                .newline();
+        super.startVisit(node);
+        this.canonical.clear();
+        this.representation.clear();
+        this.resolver.apply(node);
+        this.foundAssignment = false;
+    }
+
+    @Override
+    public void endVisit() {
+        if (this.getDebugLevel() >= 1) {
+            IIndentStream stream = Logger.INSTANCE.belowLevel(this, 1);
+            this.dump(stream);
+        }
+    }
+    
+    void newCanonical(DBSPExpression expression, String repr,
+                      Set<IDBSPDeclaration> dependsOn, boolean expensive) {
+        CanonicalExpression canonical = new CanonicalExpression(expression, dependsOn, expensive);
+        Utilities.putNew(this.representation, repr, canonical);
+        this.setCanonical(expression, canonical);
+    } 
+
+    void setCanonical(DBSPExpression expression, CanonicalExpression canonical) {
+        Logger.INSTANCE.belowLevel(this, 2)
+                .append("CSE ")
+                .append(expression.id)
+                .append(" ")
+                .appendSupplier(expression::toString)
+                .append(" -> ")
+                .appendSupplier(canonical::toString)
+                .newline();
+        this.canonical.put(expression, canonical);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -27,7 +27,6 @@ import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.annotation.Waterline;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.ICompilerComponent;
 import org.dbsp.sqlCompiler.compiler.backend.MerkleOuter;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.BetaReduction;
@@ -42,12 +41,14 @@ import org.dbsp.sqlCompiler.compiler.visitors.unusedFields.UnusedFields;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.monotonicity.MonotoneAnalyzer;
 import org.dbsp.sqlCompiler.ir.IDBSPOuterNode;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /** Very high level circuit-level optimizations.
  * Does not really look at the functions inside the circuit. */
-public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerComponent {
+public class CircuitOptimizer extends Passes {
+    public CircuitOptimizer(DBSPCompiler compiler) {
+        super("Optimizer", compiler);
+        this.createOptimizer();
+    }
+    
     static class StopOnError extends CircuitVisitor {
         public StopOnError(DBSPCompiler compiler) {
             super(compiler);
@@ -61,92 +62,89 @@ public record CircuitOptimizer(DBSPCompiler compiler) implements ICompilerCompon
         }
     }
 
-    CircuitTransform getOptimizer() {
-        List<CircuitTransform> passes = new ArrayList<>();
-        DBSPCompiler compiler = this.compiler();
+    void createOptimizer() {
         CompilerOptions options = this.compiler().options;
         // Example dumping circuit to a png file
-        // passes.add(ToDot.dumper(compiler, "x.png", 2));
+        // this.add(ToDot.dumper(compiler, "x.png", 2));
         // First part of optimizations may still synthesize some circuit components
-        passes.add(new ImplementNow(compiler));
-        passes.add(new DeterministicDefault(compiler));
-        passes.add(new StopOnError(compiler));
-        passes.add(new RecursiveComponents(compiler));
-        passes.add(new DeadCode(compiler, options.languageOptions.generateInputForEveryTable, true));
+        this.add(new ImplementNow(compiler));
+        this.add(new DeterministicDefault(compiler));
+        this.add(new StopOnError(compiler));
+        this.add(new RecursiveComponents(compiler));
+        this.add(new DeadCode(compiler, options.languageOptions.generateInputForEveryTable, true));
         if (options.languageOptions.outputsAreSets)
-            passes.add(new EnsureDistinctOutputs(compiler));
-        passes.add(new UnusedFields(compiler));
-        passes.add(new CSE(compiler));
-        passes.add(new MinMaxOptimize(compiler, compiler.weightVar));
-        passes.add(new ExpandAggregateZero(compiler));
-        passes.add(new MergeSums(compiler));
-        passes.add(new OptimizeWithGraph(compiler, g -> new RemoveNoops(compiler, g)));
-        passes.add(new PropagateEmptySources(compiler));
-        passes.add(new DeadCode(compiler, true, false));
-        passes.add(new OptimizeDistinctVisitor(compiler));
+            this.add(new EnsureDistinctOutputs(compiler));
+        this.add(new UnusedFields(compiler));
+        this.add(new CSE(compiler));
+        this.add(new MinMaxOptimize(compiler, compiler.weightVar));
+        this.add(new ExpandAggregateZero(compiler));
+        this.add(new MergeSums(compiler));
+        this.add(new OptimizeWithGraph(compiler, g -> new RemoveNoops(compiler, g)));
+        this.add(new PropagateEmptySources(compiler));
+        this.add(new DeadCode(compiler, true, false));
+        this.add(new OptimizeDistinctVisitor(compiler));
         // This is useful even without incrementalization if we have recursion
-        passes.add(new OptimizeIncrementalVisitor(compiler));
-        passes.add(new DeadCode(compiler, true, false));
+        this.add(new OptimizeIncrementalVisitor(compiler));
+        this.add(new DeadCode(compiler, true, false));
         if (options.languageOptions.incrementalize) {
-            passes.add(new IncrementalizeVisitor(compiler));
+            this.add(new IncrementalizeVisitor(compiler));
         }
-        passes.add(new OptimizeIncrementalVisitor(compiler));
-        passes.add(new RemoveIAfterD(compiler));
-        passes.add(new DeadCode(compiler, true, false));
-        passes.add(new Simplify(compiler).circuitRewriter(true));
-        passes.add(new OptimizeWithGraph(compiler, g -> new OptimizeProjectionVisitor(compiler, g)));
-        passes.add(new OptimizeWithGraph(compiler, g -> new OptimizeMaps(compiler, true, g)));
-        passes.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
-        passes.add(new MonotoneAnalyzer(compiler));
-        passes.add(new RemoveTable(compiler, DBSPCompiler.ERROR_TABLE_NAME));
+        this.add(new OptimizeIncrementalVisitor(compiler));
+        this.add(new RemoveIAfterD(compiler));
+        this.add(new DeadCode(compiler, true, false));
+        this.add(new Simplify(compiler).circuitRewriter(true));
+        this.add(new OptimizeWithGraph(compiler, g -> new OptimizeProjectionVisitor(compiler, g)));
+        this.add(new OptimizeWithGraph(compiler, g -> new OptimizeMaps(compiler, true, g)));
+        this.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
+        this.add(new MonotoneAnalyzer(compiler));
+        this.add(new RemoveTable(compiler, DBSPCompiler.ERROR_TABLE_NAME));
         // The circuit is complete here, start optimizing for real.
         // Doing this after the monotone analysis only
 
-        passes.add(new LinearPostprocessRetainKeys(compiler));
+        this.add(new LinearPostprocessRetainKeys(compiler));
         if (!options.ioOptions.emitHandles)
-            passes.add(new IndexedInputs(compiler));
-        passes.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
-        passes.add(new DeadCode(compiler, true, false));
-        passes.add(new Simplify(compiler).circuitRewriter(true));
+            this.add(new IndexedInputs(compiler));
+        this.add(new OptimizeWithGraph(compiler, g -> new FilterJoinVisitor(compiler, g)));
+        this.add(new DeadCode(compiler, true, false));
+        this.add(new Simplify(compiler).circuitRewriter(true));
         // The predicate below controls which nodes have their output dumped at runtime
-        passes.add(new InstrumentDump(compiler, t -> false));
+        this.add(new InstrumentDump(compiler, t -> false));
         if (options.languageOptions.incrementalize)
-            passes.add(new NoIntegralVisitor(compiler));
-        passes.add(new ExpandHop(compiler));
-        passes.add(new RemoveDeindexOperators(compiler));
-        passes.add(new OptimizeWithGraph(compiler, g -> new RemoveNoops(compiler, g)));
-        passes.add(new RemoveViewOperators(compiler, false));
-        passes.add(new RemoveIdentityOperators(compiler));
-        passes.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
-        passes.add(new OptimizeWithGraph(compiler, g -> new ChainVisitor(compiler, g)));
-        passes.add(new OptimizeWithGraph(compiler, g -> new OptimizeMaps(compiler, false, g)));
-        passes.add(new SimplifyWaterline(compiler)
+            this.add(new NoIntegralVisitor(compiler));
+        this.add(new ExpandHop(compiler));
+        this.add(new RemoveDeindexOperators(compiler));
+        this.add(new OptimizeWithGraph(compiler, g -> new RemoveNoops(compiler, g)));
+        this.add(new RemoveViewOperators(compiler, false));
+        this.add(new RemoveIdentityOperators(compiler));
+        this.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
+        this.add(new OptimizeWithGraph(compiler, g -> new ChainVisitor(compiler, g)));
+        this.add(new OptimizeWithGraph(compiler, g -> new OptimizeMaps(compiler, false, g)));
+        this.add(new SimplifyWaterline(compiler)
                 .circuitRewriter(node -> node.hasAnnotation(a -> a.is(Waterline.class))));
-        passes.add(new EliminateDump(compiler).circuitRewriter(false));
-        passes.add(new ExpandWriteLog(compiler).circuitRewriter(false));
-        passes.add(new Simplify(compiler).circuitRewriter(true));
-        passes.add(new CSE(compiler));
-        passes.add(new RecursiveComponents.ValidateRecursiveOperators(compiler));
+        this.add(new EliminateDump(compiler).circuitRewriter(false));
+        this.add(new ExpandWriteLog(compiler).circuitRewriter(false));
+        this.add(new Simplify(compiler).circuitRewriter(true));
+        this.add(new CSE(compiler));
+        this.add(new RecursiveComponents.ValidateRecursiveOperators(compiler));
         // Lowering implements aggregates and inlines some calls.
-        passes.add(new LowerCircuitVisitor(compiler));
+        this.add(new LowerCircuitVisitor(compiler));
         // Lowering may surface additional casts that need to be expanded
-        passes.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
+        this.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
         // Beta reduction after implementing aggregates.
-        passes.add(new BetaReduction(compiler).getCircuitVisitor(false));
-        passes.add(new LazyStatics(compiler).circuitRewriter(false));
-        passes.add(new ExpandJoins(compiler));
-        passes.add(new CSE(compiler));
-        passes.add(new RemoveViewOperators(compiler, true));
-        // passes.add(new TestSerialize(compiler));
+        this.add(new BetaReduction(compiler).getCircuitVisitor(false));
+        this.add(new ExpandJoins(compiler));
+        this.add(new CSE(compiler));
+        this.add(new RemoveViewOperators(compiler, true));
+        this.add(new CircuitRewriter(compiler, new InnerCSE(compiler), false, InnerCSE::process));
+        this.add(new LazyStatics(compiler).circuitRewriter(false));
+        // this.add(new TestSerialize(compiler));
         // The canonical form is needed if we want the Merkle hashes to be "stable".
-        passes.add(new CanonicalForm(compiler).getCircuitVisitor(false));
-        passes.add(new CompactNames(compiler));
-        passes.add(new MerkleOuter(compiler));
-        return new Passes("CircuitOptimizer", compiler, passes);
+        this.add(new CanonicalForm(compiler).getCircuitVisitor(false));
+        this.add(new CompactNames(compiler));
+        this.add(new MerkleOuter(compiler));
     }
 
     public DBSPCircuit optimize(DBSPCircuit input) {
-        CircuitTransform optimizer = this.getOptimizer();
-        return optimizer.apply(input);
+        return this.apply(input);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -106,6 +106,9 @@ public class CircuitRewriter extends CircuitCloneVisitor {
         if (!this.toOptimize.test(this.getCurrent().to(DBSPOperator.class))) {
             return expression;
         }
+        DBSPOperator operator = this.getCurrent().as(DBSPOperator.class);
+        if (operator != null)
+            this.transform.setOperatorContext(operator);
         IDBSPInnerNode result = this.transform.apply(expression);
         return result.to(DBSPExpression.class);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementNow.java
@@ -746,7 +746,7 @@ public class ImplementNow extends Passes {
                             operator, current.simpleNode(), expression.to(TemporalFilterList.class)).outputPort();
                 } else {
                     // NowComparison expressions have been eliminated by combineExpressions
-                    DBSPExpression body = ExpressionCompiler.wrapBoolIfNeeded(expression.to(NoNow.class).noNow);
+                    DBSPExpression body = expression.to(NoNow.class).noNow.wrapBoolIfNeeded();
                     DBSPClosureExpression closure = body.closure(param);
                     DBSPFilterOperator filter = new DBSPFilterOperator(operator.getRelNode(), closure, current);
                     this.addOperator(filter);
@@ -783,8 +783,7 @@ public class ImplementNow extends Passes {
                 // Implement leftover as a join
                 DBSPSimpleOperator join = this.createJoin(result, operator);
                 RewriteNowClosure rn = new RewriteNowClosure(this.compiler());
-                DBSPExpression filterBody = ExpressionCompiler.wrapBoolIfNeeded(
-                        leftOver.to(NonTemporalFilter.class).expression);
+                DBSPExpression filterBody = leftOver.to(NonTemporalFilter.class).expression.wrapBoolIfNeeded();
                 function = filterBody.closure(closure.parameters);
                 function = rn.apply(function).to(DBSPExpression.class);
                 DBSPSimpleOperator filter = new DBSPFilterOperator(operator.getRelNode(), function, join.outputPort());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/InnerCSE.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/InnerCSE.java
@@ -1,0 +1,53 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpressionsCSE;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.IRTransform;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.ValueNumbering;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.util.Logger;
+
+/** Perform common-subexpression elimination on the inner IR */
+public class InnerCSE implements IRTransform {
+    final ValueNumbering numbering;
+    final ExpressionsCSE cse;
+
+    /** Return 'true' for operators where we want to apply CSE */
+    public static boolean process(DBSPOperator operator) {
+        return !operator.is(DBSPConstantOperator.class);
+    }
+
+    InnerCSE(DBSPCompiler compiler) {
+        this.numbering = new ValueNumbering(compiler);
+        this.cse = new ExpressionsCSE(compiler, this.numbering.canonical);
+    }
+
+    @Override
+    public IDBSPInnerNode apply(IDBSPInnerNode node) {
+        if (!node.is(DBSPExpression.class))
+            return node;
+        this.numbering.apply(node);
+        if (!this.numbering.foundAssignment) {
+            return this.cse.apply(node);
+        } else {
+            Logger.INSTANCE.belowLevel("ExpressionsCSE", 1)
+                    .append("Skipping ")
+                    .appendSupplier(node::toString);
+            return node;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "InnerCSE";
+    }
+
+    @Override
+    public void setOperatorContext(DBSPOperator operator) {
+        this.numbering.setOperatorContext(operator);
+        this.cse.setOperatorContext(operator);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
@@ -371,7 +371,7 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPChainOperator node) {
-        DBSPClosureExpression function = node.chain.collapse();
+        DBSPClosureExpression function = node.chain.collapse(this.compiler);
         DBSPSimpleOperator result;
         if (node.outputType.is(DBSPTypeZSet.class)) {
             result = new DBSPFlatMapOperator(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeIncrementalVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeIncrementalVisitor.java
@@ -263,7 +263,7 @@ public class OptimizeIncrementalVisitor extends CircuitCloneVisitor {
 
         // The rest is a copy of super.postorder, with the added integrators
         DBSPNestedOperator result = Utilities.removeLast(this.underConstruction).to(DBSPNestedOperator.class);
-        result.setDerivedFrom(operator.id);
+        result.setDerivedFrom(operator.derivedFrom);
         result.copyAnnotations(operator);
 
         if (result.sameCircuit(operator))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Passes.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Passes.java
@@ -101,7 +101,7 @@ public class Passes implements IWritesLogs, CircuitTransform, ICompilerComponent
                 .append(this.toString())
                 .append(" took ")
                 .append(finish - begin)
-                .append("ms")
+                .append("ms.")
                 .newline();
         return circuit;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RecursiveComponents.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/RecursiveComponents.java
@@ -239,7 +239,7 @@ public class RecursiveComponents extends Passes {
                         DBSPViewDeclarationOperator view = result.to(DBSPViewDeclarationOperator.class);
                         Utilities.putNew(declByName, view.originalViewName(), view);
                     }
-                    result.setDerivedFrom(operator.id);
+                    result.setDerivedFrom(operator.derivedFrom);
                     this.map(simple, result, true);
                 }
             }
@@ -351,7 +351,7 @@ public class RecursiveComponents extends Passes {
             }
 
             DBSPSimpleOperator result = operator.withInputs(sources, this.force);
-            result.setDerivedFrom(operator.id);
+            result.setDerivedFrom(operator.derivedFrom);
             block.addOperator(result);
             DBSPViewOperator view = result.as(DBSPViewOperator.class);
             OutputPort port = result.outputPort();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -1286,7 +1286,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
             boolean mayBeNull = type.mayBeNull || right.getType().mayBeNull;
             DBSPExpression compare = ExpressionCompiler.makeBinaryExpression(left.getNode(),
                     DBSPTypeBool.create(mayBeNull), DBSPOpcode.EQ, left, right);
-            return ExpressionCompiler.wrapBoolIfNeeded(compare);
+            return compare.wrapBoolIfNeeded();
         } else if (type.is(DBSPTypeTupleBase.class)) {
             DBSPTypeTupleBase tuple = type.to(DBSPTypeTupleBase.class);
             DBSPExpression result = new DBSPBoolLiteral(true);
@@ -1332,7 +1332,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         List<OutputPort> sources = Linq.map(operator.inputs, this::mapped);
         DBSPSimpleOperator replacement = operator.withInputs(sources, this.force);
-        replacement.setDerivedFrom(operator.id);
+        replacement.setDerivedFrom(operator.derivedFrom);
         this.addOperator(replacement);
 
         // The waterline operator will compute the *minimum legal value* of all the
@@ -1394,6 +1394,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         DBSPClosureExpression closure = compare.closure(controlArg, dataVar);
 
         // The last parameter is not used
+        DBSPVariablePath dataVar0 = dataVar.getType().var();
         DBSPVariablePath valArg = new DBSPTypeRawTuple().ref().var();
         DBSPVariablePath weightArg = DBSPTypeWeight.INSTANCE.var();
         DBSPClosureExpression error = new DBSPTupleExpression(
@@ -1402,8 +1403,8 @@ public class InsertLimiters extends CircuitCloneVisitor {
                 new DBSPApplyExpression("format!",
                         DBSPTypeAny.INSTANCE,
                         new DBSPStrLiteral("{:?}"),
-                        dataVar).applyMethod("into", DBSPTypeString.varchar(false)))
-                .closure(controlArg, dataVar, valArg, weightArg);
+                        dataVar0).applyMethod("into", DBSPTypeString.varchar(false)))
+                .closure(controlArg, dataVar0, valArg, weightArg);
         DBSPControlledKeyFilterOperator result = new DBSPControlledKeyFilterOperator(
                 node, closure, error, data, control);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MonotoneAnalyzer.java
@@ -16,6 +16,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitTransform;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.Graph;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.OptimizeWithGraph;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.expansion.ExpandOperators;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.util.IWritesLogs;
 import org.dbsp.util.IndentStream;
@@ -90,10 +91,16 @@ public class MonotoneAnalyzer implements CircuitTransform, IWritesLogs {
         final boolean debug = this.getDebugLevel() >= 1;
         final int details = this.getDebugLevel();
 
-        IRTransform transform = e -> {
-            if (e.is(DBSPExpression.class))
-                return e.to(DBSPExpression.class).ensureTree(compiler);
-            return e;
+        IRTransform transform = new IRTransform() {
+            @Override
+            public void setOperatorContext(DBSPOperator operator) {}
+
+            @Override
+            public IDBSPInnerNode apply(IDBSPInnerNode e) {
+                if (e.is(DBSPExpression.class))
+                    return e.to(DBSPExpression.class).ensureTree(compiler);
+                return e;
+            }
         };
         CircuitRewriter toTree = new CircuitRewriter(this.compiler, transform, false);
         circuit = toTree.apply(circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
@@ -109,7 +109,7 @@ public class SeparateIntegrators extends CircuitCloneWithGraphsVisitor {
         }
 
         DBSPSimpleOperator result = operator.withInputs(sources, this.force);
-        result.setDerivedFrom(operator.id);
+        result.setDerivedFrom(operator.derivedFrom);
         this.map(operator, result);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/IDBSPOuterNode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/IDBSPOuterNode.java
@@ -28,6 +28,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 
 /** IR nodes for the outer language: circuits, operators, declarations. */
 public interface IDBSPOuterNode extends IDBSPNode {
+    long getDerivedFrom();
     void accept(CircuitVisitor visitor);
     /** Run the inner visitor on all fields that are relevant */
     void accept(InnerVisitor visitor);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPBinaryExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPBinaryExpression.java
@@ -80,13 +80,16 @@ public final class DBSPBinaryExpression extends DBSPExpression {
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append(this.left)
+        return builder
+                .append("(")
+                .append(this.left)
                 .append(" ")
                 .append(this.left.getType().mayBeNull ? "?" : "")
                 .append(this.opcode.toString())
                 .append(this.right.getType().mayBeNull ? "?" : "")
                 .append(" ")
-                .append(this.right);
+                .append(this.right)
+                .append(")");
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPClosureExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPClosureExpression.java
@@ -149,7 +149,7 @@ public final class DBSPClosureExpression extends DBSPExpression {
     public IIndentStream toString(IIndentStream builder) {
         return builder.append("(|")
                 .join(",", this.parameters)
-                .append("| ")
+                .append("|").newline()
                 .append(this.body)
                 .append(")");
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -48,6 +48,7 @@ import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeResult;
 import org.dbsp.sqlCompiler.ir.type.IHasType;
 import org.dbsp.util.Linq;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
@@ -87,6 +88,17 @@ public abstract class DBSPExpression
 
     public DBSPBorrowExpression borrow() {
         return new DBSPBorrowExpression(this);
+    }
+
+    @CheckReturnValue
+    public DBSPExpression wrapBoolIfNeeded() {
+        DBSPType type = this.getType();
+        if (type.mayBeNull) {
+            return new DBSPUnaryExpression(
+                    this.getNode(), type.withMayBeNull(false),
+                    DBSPOpcode.WRAP_BOOL, this);
+        }
+        return this;
     }
 
     /** Unwrap a Rust 'Result' type */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLazyCellExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLazyCellExpression.java
@@ -1,0 +1,66 @@
+package org.dbsp.sqlCompiler.ir.expression;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeLazy;
+import org.dbsp.util.IIndentStream;
+
+/** Represents an expression that is lazily evaluated.  Implemented using
+ * Rust LazyCell. */
+public class DBSPLazyCellExpression extends DBSPExpression {
+    public final DBSPExpression expression;
+
+    public DBSPLazyCellExpression(DBSPExpression expression) {
+        super(expression.getNode(), new DBSPTypeLazy(expression.getType()));
+        this.expression = expression;
+    }
+
+    @Override
+    public DBSPExpression deepCopy() {
+        return new DBSPLazyCellExpression(this.expression.deepCopy());
+    }
+
+    @Override
+    public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
+        DBSPLazyCellExpression otherExpression = other.as(DBSPLazyCellExpression.class);
+        if (otherExpression == null)
+            return false;
+        return context.equivalent(this.expression, otherExpression.expression);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        visitor.property("expression");
+        this.expression.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean sameFields(IDBSPInnerNode other) {
+        DBSPLazyCellExpression otherExpression = other.as(DBSPLazyCellExpression.class);
+        if (otherExpression == null)
+            return false;
+        return this.expression == otherExpression.expression;
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        return builder.append("LazyCell::new(|| ")
+                .append(this.expression)
+                .append(")");
+    }
+
+    @SuppressWarnings("unused")
+    public static DBSPLazyCellExpression fromJson(JsonNode node, JsonDecoder decoder) {
+        DBSPExpression expression = fromJsonInner(node, "expression", decoder, DBSPExpression.class);
+        return new DBSPLazyCellExpression(expression);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLetExpression.java
@@ -77,16 +77,14 @@ public class DBSPLetExpression extends DBSPExpression implements IDBSPDeclaratio
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.increase()
-                .append("{")
-                .append("let ")
+        return builder
+                .append("{let ")
                 .append(this.variable)
                 .append(" = ")
                 .append(this.initializer)
                 .append(";")
                 .newline()
                 .append(this.consumer)
-                .decrease()
                 .append("}");
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
@@ -9,6 +9,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -47,8 +48,8 @@ public final class DBSPUnsignedWrapExpression extends DBSPExpression {
         static DBSPTypeInteger getInitialIntegerType(DBSPType sourceType) {
             return switch (sourceType.code) {
                 case INT8, INT16, INT32, INT64, INT128 -> sourceType.withMayBeNull(false).to(DBSPTypeInteger.class);
-                case DATE -> new DBSPTypeInteger(sourceType.getNode(), 32, true, false);
-                case TIMESTAMP, TIME -> new DBSPTypeInteger(sourceType.getNode(), 64, true, false);
+                case DATE -> DBSPTypeInteger.getType(sourceType.getNode(), DBSPTypeCode.INT32, false);
+                case TIMESTAMP, TIME -> DBSPTypeInteger.getType(sourceType.getNode(), DBSPTypeCode.INT64, false);
                 default -> throw new InternalCompilerError("Not yet supported wrappers for " + sourceType, sourceType.getNode());
             };
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI128Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI128Literal.java
@@ -10,6 +10,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -43,7 +44,7 @@ public final class DBSPI128Literal extends DBSPIntLiteral implements IsNumericLi
     }
 
     public DBSPI128Literal(CalciteObject node, @Nullable BigInteger value, boolean nullable) {
-        this(node, new DBSPTypeInteger(CalciteObject.EMPTY, 128, true, nullable), value);
+        this(node, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT128, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI16Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI16Literal.java
@@ -10,6 +10,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -36,7 +37,7 @@ public final class DBSPI16Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPI16Literal(@Nullable Short value, boolean nullable) {
-        this(CalciteObject.EMPTY, new DBSPTypeInteger(CalciteObject.EMPTY, 16, true, nullable), value);
+        this(CalciteObject.EMPTY, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT16, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI32Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI32Literal.java
@@ -33,6 +33,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -60,7 +61,7 @@ public final class DBSPI32Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPI32Literal(@Nullable Integer value, boolean nullable) {
-        this(CalciteObject.EMPTY, new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, nullable), value);
+        this(CalciteObject.EMPTY, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI64Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI64Literal.java
@@ -34,6 +34,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -64,7 +65,7 @@ public final class DBSPI64Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPI64Literal(CalciteObject node, @Nullable Long value, boolean nullable) {
-        this(node, new DBSPTypeInteger(CalciteObject.EMPTY, 64, true, nullable), value);
+        this(node, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT64, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI8Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI8Literal.java
@@ -10,6 +10,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -36,7 +37,7 @@ public final class DBSPI8Literal extends DBSPIntLiteral implements IsNumericLite
     }
 
     public DBSPI8Literal(@Nullable Byte value, boolean nullable) {
-        this(CalciteObject.EMPTY, new DBSPTypeInteger(CalciteObject.EMPTY, 8, true, nullable), value);
+        this(CalciteObject.EMPTY, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT8, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU128Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU128Literal.java
@@ -12,6 +12,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -32,7 +33,7 @@ public final class DBSPU128Literal extends DBSPIntLiteral implements IsNumericLi
     }
 
     public DBSPU128Literal(CalciteObject node, @Nullable BigInteger value, boolean nullable) {
-        this(node, new DBSPTypeInteger(CalciteObject.EMPTY, 128, false, nullable), value);
+        this(node, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.UINT128, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU16Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU16Literal.java
@@ -35,6 +35,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -78,7 +79,7 @@ public final class DBSPU16Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPU16Literal(@Nullable Integer value, boolean nullable) {
-        this(CalciteObject.EMPTY, new DBSPTypeInteger(CalciteObject.EMPTY, 16, false, nullable), value);
+        this(CalciteObject.EMPTY, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.UINT16, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
         if (value != null && value < 0)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU32Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU32Literal.java
@@ -35,6 +35,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -73,7 +74,7 @@ public final class DBSPU32Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPU32Literal(@Nullable Long value, boolean nullable) {
-        this(CalciteObject.EMPTY, new DBSPTypeInteger(CalciteObject.EMPTY, 32, false, nullable), value);
+        this(CalciteObject.EMPTY, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.UINT32, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
         if (value != null && value < 0)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU64Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU64Literal.java
@@ -35,6 +35,7 @@ import org.dbsp.sqlCompiler.ir.ISameValue;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -55,7 +56,7 @@ public final class DBSPU64Literal extends DBSPIntLiteral implements IsNumericLit
     }
 
     public DBSPU64Literal(CalciteObject node, @Nullable BigInteger value, boolean nullable) {
-        this(node, new DBSPTypeInteger(CalciteObject.EMPTY, 64, false, nullable), value);
+        this(node, DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.UINT64, nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/statement/DBSPComment.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/statement/DBSPComment.java
@@ -34,6 +34,11 @@ public final class DBSPComment extends DBSPStatement implements IDBSPOuterNode {
     }
 
     @Override
+    public long getDerivedFrom() {
+        return this.id;
+    }
+
+    @Override
     public void accept(CircuitVisitor visitor) {
         visitor.push(this);
         VisitDecision decision = visitor.preorder(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
@@ -44,7 +44,8 @@ public class DBSPTypeRef extends DBSPType {
 
     public DBSPTypeRef(DBSPType type, boolean mutable, boolean mayBeNull) {
         super(type.getNode(), REF, mayBeNull);
-        assert !type.is(DBSPTypeRef.class);
+        assert !type.is(DBSPTypeRef.class)
+                : "Reference of reference not supported";
         this.type = type;
         this.mutable = mutable;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeLazy.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeLazy.java
@@ -1,0 +1,51 @@
+package org.dbsp.sqlCompiler.ir.type.user;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
+
+import java.util.List;
+
+import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.USER;
+
+/** A LazyCell type */
+public class DBSPTypeLazy extends DBSPTypeUser {
+    public DBSPTypeLazy(DBSPType resultType) {
+        super(resultType.getNode(), USER, "LazyCell",
+                false, resultType, DBSPTypeAny.getDefault());
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        visitor.startArrayProperty("typeArgs");
+        int index = 0;
+        for (DBSPType type: this.typeArgs) {
+            visitor.propertyIndex(index);
+            type.accept(visitor);
+            index++;
+        }
+        visitor.endArrayProperty("typeArgs");
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    // sameType, visit, and hashCode inherited from TypeUser.
+
+    @SuppressWarnings("unused")
+    public static DBSPTypeLazy fromJson(JsonNode node, JsonDecoder decoder) {
+        List<DBSPType> typeArgs = fromJsonInnerList(node, "typeArgs", decoder, DBSPType.class);
+        assert typeArgs.size() == 1;
+        return new DBSPTypeLazy(typeArgs.get(0));
+    }
+
+    @Override
+    public DBSPType deref() {
+        return this.typeArgs[0];
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Linq.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Linq.java
@@ -32,11 +32,14 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-/**
- * Some utility classes inspired by C# Linq.
- */
+/** Some utility classes inspired by C# Linq. */
 @SuppressWarnings("unused")
 public class Linq {
+    @SafeVarargs
+    public static <T> Set<T> set(T... value) {
+        return new HashSet<>(Linq.list(value));
+    }
+
     static class MapIterator<T, S> implements Iterator<S> {
         final Iterator<T> data;
         final Function<T, S> map;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -49,10 +49,12 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class Utilities {
     private Utilities() {}
@@ -347,6 +349,12 @@ public class Utilities {
         return true;
     }
 
+    public static <T> List<T> concat(List<T> left, List<T> right) {
+        List<T> result = new ArrayList<>(left);
+        result.addAll(right);
+        return result;
+    }
+
     public static long timeStringToNanoseconds(TimeString ts) {
         // TimeString has a pretty strict format
         String v = ts.toString();
@@ -433,5 +441,11 @@ public class Utilities {
             return null;
         JsonNode prop = Utilities.getProperty(node, property);
         return prop.asLong();
+    }
+
+    public static <T> Set<T> concatSet(Set<T> left, Set<T> right) {
+        Set<T> result = new HashSet<>(left);
+        result.addAll(right);
+        return result;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/UnusedFieldsTest.java
@@ -111,24 +111,25 @@ public class UnusedFieldsTest {
         RewriteFields rw = fu.getFieldRewriter(1);
         DBSPClosureExpression rewritten = rw.rewriteClosure(closure);
         DBSPClosureExpression result = cf.apply(rewritten).to(DBSPClosureExpression.class);
-        Assert.assertEquals("(|p0: &Tup3<i32?, b?, Tup2<s?, s>>| " +
-                        "Tup3::new(((*p0).0), ((*p0).1), ((((*p0).2).0).clone()), ))",
+        Assert.assertEquals("""
+                        (|p0: &Tup3<i32?, b?, Tup2<s?, s>>|
+                        Tup3::new(((*p0).0), ((*p0).1), ((((*p0).2).0).clone()), ))""",
                 result.toString());
 
         FieldUseMap fm = rw.getUseMap(closure.parameters[0]);
         DBSPClosureExpression projection = Objects.requireNonNull(fm.getProjection(1));
 
         projection = cf.apply(projection).to(DBSPClosureExpression.class);
-        Assert.assertEquals(
-                "(|p0: &Tup4<i32?, b, b?, Tup2<s?, s>>| " +
-                        "Tup3::new(((*p0).0), ((*p0).2), (((*p0).3).clone()), ))",
+        Assert.assertEquals("""
+                        (|p0: &Tup4<i32?, b, b?, Tup2<s?, s>>|
+                        Tup3::new(((*p0).0), ((*p0).2), (((*p0).3).clone()), ))""",
                 projection.toString());
 
         DBSPClosureExpression compose = result.applyAfter(compiler, projection, Maybe.YES);
         compose = cf.apply(compose).to(DBSPClosureExpression.class);
-        Assert.assertEquals(
-                "(|p0: &Tup4<i32?, b, b?, Tup2<s?, s>>| " +
-                        "Tup3::new(((*p0).0), ((*p0).2), ((((*p0).3).0).clone()), ))",
+        Assert.assertEquals("""
+                        (|p0: &Tup4<i32?, b, b?, Tup2<s?, s>>|
+                        Tup3::new(((*p0).0), ((*p0).2), ((((*p0).3).0).clone()), ))""",
                 compose.toString());
         Assert.assertTrue(compose.equivalent(closure));
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -125,7 +125,8 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                     // CREATE TABLE `t` (`col1` INTEGER NOT NULL, `col2` DOUBLE NOT NULL, `col3` BOOLEAN NOT NULL, `col4` VARCHAR NOT NULL, `col5` INTEGER, `col6` DOUBLE)
                     let s1 = t();
                     // DBSPMapOperator s2
-                    let s2: stream<WSet<Tup1<b>>> = s1.map((|p0: &Tup6<i32, d, b, s, i32?, d?>| Tup1::new(((*p0).2), )));
+                    let s2: stream<WSet<Tup1<b>>> = s1.map((|p0: &Tup6<i32, d, b, s, i32?, d?>|
+                    Tup1::new(((*p0).2), )));
                     // CREATE VIEW `v` AS
                     // SELECT `t`.`col3`
                     // FROM `schema`.`t` AS `t`

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -2047,8 +2047,32 @@ public class RegressionTests extends SqlIoTest {
     @Test
     public void testUuid() {
         this.statementsFailingInCompilation("""
-            DECLARE RECURSIVE VIEW V(u UUID);
-            CREATE VIEW V AS SELECT 1 AS u;""",
+                        DECLARE RECURSIVE VIEW V(u UUID);
+                        CREATE VIEW V AS SELECT 1 AS u;""",
                 "does not match the declared type v(u UUID)");
+    }
+
+    @Test
+    public void issue3744() {
+        this.getCCS("""
+                CREATE TABLE row_of_map_tbl(
+                  c1 ROW(m1_int MAP<VARCHAR, INT> NOT NULL));
+                
+                CREATE MATERIALIZED VIEW v AS SELECT
+                c1[1]['1'] AS c1_one
+                FROM row_of_map_tbl;""");
+    }
+
+    @Test
+    public void cseTest() {
+        this.getCCS("""
+                CREATE TABLE binary_tbl(
+                id INT,
+                c1 BINARY(4),
+                c2 BINARY(4) NULL);
+                
+                CREATE VIEW binary_array_where AS SELECT
+                ARRAY_AGG(c1) FILTER(WHERE c1 < c2) AS f_c1, ARRAY_AGG(c2) FILTER(WHERE c1 < c2) AS f_c2
+                FROM binary_tbl;""");
     }
 }

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -54,15 +54,15 @@ if [ ${NEXT} = 'y' ]; then
     update_pom ${CALCITE_NEXT}
     pushd /tmp >/dev/null
     if [[ ! -z "${CALCITE_NEXT_COMMIT}" ]]; then
-	GIT_ARGS="--no-checkout"
+        GIT_ARGS="--no-checkout"
     else
-	GIT_ARGS="--depth 1"
+        GIT_ARGS="--depth 1"
     fi
     git clone --quiet --single-branch --branch ${CALCITE_BRANCH} ${GIT_ARGS} ${CALCITE_REPO}
     cd calcite
     if [[ ! -z "${CALCITE_NEXT_COMMIT}" ]]; then
         git fetch origin ${CALCITE_NEXT_COMMIT}
-	git checkout ${CALCITE_NEXT_COMMIT}
+        git checkout ${CALCITE_NEXT_COMMIT}
     fi
 
     GROUP=org.apache.calcite
@@ -80,4 +80,4 @@ else
     update_pom ${CALCITE_CURRENT}
 fi
 
-mvn package -DskipTests --no-transfer-progress -q -B
+mvn package -DskipTests --no-transfer-progress -DargLine="-ea" -q -B

--- a/sql-to-dbsp-compiler/slt/pom.xml
+++ b/sql-to-dbsp-compiler/slt/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes #3727 
Fixes #3744 

This PR implements ValueNumbering (for detecting common-subexpressions) and Common-subexpression elimination. This is applied to essentially all functions (closures) in our programs. It works across the entire function, not just in a basic block. 

This is trickier than it looks because it has to handle correctly the following features
- it works across basic blocks
- it CSEs expressions which may be only conditionally evaluated, so these are lazily evaluated using the rust `LazyCell`, in order not to trigger exceptions that wouldn't otherwise happen
- it handles correctly nested closures, let expressions, and let statements
- (the only thing we currently do not handle is reassignments to mutable variables, but these only appear in some aggregate computations)
- CSE expressions must be lifted to the earliest possible place in a dataflow graph, but this does not mean always at the beginning of the function. For example, an expression that depends on a variable must be evaluated only after the point at which the variable is defined. An expression can depend on any number of variables
- this also handles subexpressions of common subexpressions which are themselves common subexpressions. Something is a useful common subexpression only if there is no single larger common subexpression that uses it. So we have to keep track for each subexpression of the number of distinct users.