### PR TITLE
[dbsp] Init operators with correct ids.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -102,7 +102,7 @@ pub use feldera_types::config::{
 };
 use feldera_types::format::json::{JsonFlavor, JsonParserConfig, JsonUpdateFormat};
 use feldera_types::program_schema::{canonical_identifier, SqlIdentifier};
-pub use stats::{ControllerStatus, InputEndpointStatus, OutputEndpointStatus};
+pub use stats::{ControllerMetric, ControllerStatus, InputEndpointStatus, OutputEndpointStatus};
 
 /// Maximal number of concurrent API connections per circuit
 /// (including both input and output connections).
@@ -391,11 +391,13 @@ impl Controller {
 
     /// Returns controller status.
     pub fn status(&self) -> &ControllerStatus {
-        // Update pipeline metrics computed on-demand.
-        self.inner
-            .status
-            .update(self.inner.metrics_snapshotter.snapshot());
+        // Update pipeline stats computed on-demand.
+        self.inner.status.update();
         &self.inner.status
+    }
+
+    pub fn metrics_snapshotter(&self) -> Arc<Snapshotter> {
+        self.inner.metrics_snapshotter.clone()
     }
 
     pub fn catalog(&self) -> &Arc<Box<dyn CircuitCatalog>> {

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -1,3 +1,4 @@
+use crate::controller::ControllerMetric;
 use crate::dyn_event;
 use crate::format::{get_input_format, get_output_format};
 use crate::{
@@ -612,7 +613,17 @@ async fn metrics(
                     }),
                 }
             }
-            MetricsFormat::Json => Ok(HttpResponse::Ok().json(&controller.status().metrics)),
+            MetricsFormat::Json => {
+                let snapshotter = controller.metrics_snapshotter();
+                let metrics: Vec<ControllerMetric> = snapshotter
+                    .snapshot()
+                    .into_vec()
+                    .into_iter()
+                    .map(|element| element.into())
+                    .collect();
+
+                Ok(HttpResponse::Ok().json(&metrics))
+            }
         },
         None => Err(missing_controller_error(&state)),
     }

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -891,7 +891,7 @@ pub trait Node {
     /// * `scope` - the scope whose clock is ending.
     fn clock_end(&mut self, scope: Scope);
 
-    fn init(&mut self, _gid: &GlobalNodeId) {}
+    fn init(&mut self) {}
 
     fn metrics(&self) {}
 
@@ -1956,7 +1956,7 @@ where
     where
         N: Node + 'static,
     {
-        node.init(&self.global_node_id);
+        node.init();
         self.nodes
             .borrow_mut()
             .push(RefCell::new(Box::new(node) as Box<dyn Node>));
@@ -3400,8 +3400,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -3496,8 +3496,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -3606,8 +3606,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -3708,8 +3708,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -3868,8 +3868,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4028,8 +4028,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4162,8 +4162,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4317,8 +4317,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4457,8 +4457,8 @@ where
         self.operator.clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.init(gid);
+    fn init(&mut self) {
+        self.operator.init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4583,8 +4583,8 @@ where
         self.operator.borrow_mut().clock_end(scope);
     }
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.borrow_mut().init(gid);
+    fn init(&mut self) {
+        self.operator.borrow_mut().init(&self.id);
     }
 
     fn metrics(&self) {
@@ -4690,8 +4690,8 @@ where
 
     fn clock_end(&mut self, _scope: Scope) {}
 
-    fn init(&mut self, gid: &GlobalNodeId) {
-        self.operator.borrow_mut().init(gid);
+    fn init(&mut self) {
+        self.operator.borrow_mut().init(&self.id);
     }
 
     fn metrics(&self) {


### PR DESCRIPTION
We used to init operators with circuit id instead of operator's own id. So far this has only affected metrics, but going forward it will be used in more ways.