### PR TITLE
[dbsp] hash_distinct operator

### DIFF
--- a/crates/dbsp/src/mono/mod.rs
+++ b/crates/dbsp/src/mono/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         dynamic::{
             aggregate::{DynAggregatorImpl, IncAggregateFactories, IncAggregateLinearFactories},
             controlled_filter::ControlledFilterFactories,
-            distinct::DistinctFactories,
+            distinct::{DistinctFactories, HashDistinctFactories},
             join::{AntijoinFactories, JoinFactories},
             MonoIndexedZSet,
         },
@@ -200,6 +200,13 @@ where
     }
 
     #[track_caller]
+    pub fn hash_distinct(&self) -> Self {
+        let factories = HashDistinctFactories::new::<K, V>();
+
+        self.inner().dyn_hash_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
     pub fn waterline<TS, WF, IF, LB>(
         &self,
         init: IF,
@@ -332,6 +339,13 @@ where
         let factories = DistinctFactories::new::<K, ()>();
 
         self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn hash_distinct(&self) -> Self {
+        let factories = HashDistinctFactories::new::<K, ()>();
+
+        self.inner().dyn_hash_distinct_mono(&factories).typed()
     }
 
     #[track_caller]
@@ -646,6 +660,13 @@ where
     }
 
     #[track_caller]
+    pub fn hash_distinct(&self) -> Self {
+        let factories = HashDistinctFactories::new::<K, V>();
+
+        self.inner().dyn_hash_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
     pub fn filter<F>(&self, filter_func: F) -> Self
     where
         F: Fn((&K, &V)) -> bool + 'static,
@@ -752,6 +773,13 @@ where
         let factories = DistinctFactories::new::<K, ()>();
 
         self.inner().dyn_distinct_mono(&factories).typed()
+    }
+
+    #[track_caller]
+    pub fn hash_distinct(&self) -> Self {
+        let factories = HashDistinctFactories::new::<K, ()>();
+
+        self.inner().dyn_hash_distinct_mono(&factories).typed()
     }
 
     #[track_caller]

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -48,4 +48,18 @@ where
 
         self.inner().dyn_distinct(&factories).typed()
     }
+
+    /// A version of [`Self::distinct`] that uses a hash-based implementation.
+    ///
+    /// This method is functionally equivalent to [`Self::distinct`], but uses a slightly different
+    /// implementation, which indexes the input stream by the hash of the key before computing distinct
+    /// on it. It can potentially be more efficient for z-sets with large keys.
+    #[cfg(not(feature = "backend-mode"))]
+    #[track_caller]
+    pub fn hash_distinct(&self) -> Stream<C, Z> {
+        let factories =
+            crate::operator::dynamic::distinct::HashDistinctFactories::new::<Z::Key, Z::Val>();
+
+        self.inner().dyn_has_distinct(&factories).typed()
+    }
 }

--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -217,6 +217,11 @@ where
 
     /// Returns `true` if this stream is sharded.
     pub fn is_sharded(&self) -> bool {
+        let num_workers = Runtime::runtime().map(|r| r.num_workers()).unwrap_or(1);
+        if num_workers == 1 {
+            return true;
+        }
+
         self.circuit()
             .cache_get(&ShardId::<C, T>::new((
                 self.stream_id(),


### PR DESCRIPTION
We have noticed that the `distinct` operator can be very expensive for
collections with large keys. This commit introduces a new operator that
may solve this problem. It is a version of `distinct` that has the exact
same semantics, but internally it indexes the input collection by the
hash of the key before computing `distinct`.  This has the potential to
avoid the overheads related to reading, deserializing, and comparing
large keys.

I so far don't have any experimental validation that the new operator is
beneficial.

To take advantage of this, we will need to add logic to the compiler to
call `hash_distinct` instead of `distinct` when it expects the input
collection to have wide keys.

In addition, there are a couple of places where we use `distinct`
internally, most notably in `recursive`. We could hardwire
`hash_distinct` there, but a better solution might be to override this
in the compiler by either providing a version of `recursive` that doesn't
automatically `distinct` outputs internally or relying on the fact that
`distinct` is a no-op for collections that are already distinct.

TODO: The hash_distinct operator internally does
`map_index().distinct().map_index()`.  The second `map_index` can be
folded into `distinct`, but I think this can wait until we have
empirical proof that the new operator is useful.