### PR TITLE
[adapters] Delta source: wait for state=RUNNING.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -552,6 +552,9 @@ impl DeltaTableInputEndpointInner {
         // shutdown command from the controller.
         let _ = init_status_sender.send(Ok(())).await;
 
+        // Wait for the pipeline to start before reading.
+        wait_running(&mut receiver).await;
+
         if self.config.snapshot() && self.config.timestamp_column.is_none() {
             // Read snapshot chunk-by-chunk.
             self.read_unordered_snapshot(&table, input_stream.as_mut(), &mut receiver)


### PR DESCRIPTION
We used to start reading the initial snapshot of a Delta table without waiting for the rest of the pipeline to initialize. No data was actually parsed or pushed to the pipeline, but the connector could issue a read request to the storage layer prematurely, and after that start waiting for pipeline state=RUNNING. This could cause S3 timeouts for pipelines that take a long time to initialize.