### PR TITLE
[adapters] Initialize connectors concurrently.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,6 +3876,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "test_bin",
+ "threadpool",
  "tokio",
  "tokio-postgres",
  "tokio-util",
@@ -10508,6 +10509,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -122,6 +122,7 @@ num-bigint = "0.4.6"
 redis = { version = "0.28.2", features = ["r2d2"], optional = true }
 r2d2 = { version = "0.8.10", optional = true }
 async-channel = "2.3.1"
+threadpool = "1.8.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1948,6 +1948,14 @@ impl ControllerInner {
     ) -> Result<EndpointId, ControllerError> {
         debug!("Adding input endpoint '{endpoint_name}'; config: {endpoint_config:?}");
 
+        // NOTE: We release the lock after the check below and then re-acquire it in the end of the function
+        // to actually insert the new inpoint in the map. This means that this function is racey (a concurrent
+        // invocation can insert an endpoint with the same name). I think it's ok the way we use it: when
+        // initializing the pipeline, we have an endpoint map with names that are guaranteed to be unique;
+        // hence it's safe to call `add_input_endpoint` concurrently. In the future we may need to maintain
+        // a separate set of reserved connector names to avoid the race. The alternative solution that keeps
+        // the lock across the entire body of the function isn't good, because it will force serial connector
+        // initialization.
         if self
             .status
             .inputs
@@ -2106,9 +2114,21 @@ impl ControllerInner {
         endpoint_config: &OutputEndpointConfig,
         endpoint: Option<Box<dyn OutputEndpoint>>,
     ) -> Result<EndpointId, ControllerError> {
-        let mut outputs = self.outputs.write().unwrap();
-
-        if outputs.lookup_by_name(endpoint_name).is_some() {
+        // NOTE: We release the lock after the check below and then re-acquire it in the end of the function
+        // to actually insert the new inpoint in the map. This means that this function is racey (a concurrent
+        // invocation can insert an endpoint with the same name). I think it's ok the way we use it: when
+        // initializing the pipeline, we have an endpoint map with names that are guaranteed to be unique;
+        // hence it's safe to call `add_output_endpoint` concurrently. In the future we may need to maintain
+        // a separate set of reserved endpoint names to avoid the race. The alternative solution that keeps
+        // the lock across the entire body of the function isn't good, because it will force serial connector
+        // initialization.
+        if self
+            .outputs
+            .read()
+            .unwrap()
+            .lookup_by_name(endpoint_name)
+            .is_some()
+        {
             Err(ControllerError::duplicate_output_endpoint(endpoint_name))?;
         }
 
@@ -2229,7 +2249,10 @@ impl ControllerInner {
         let disconnect_flag = endpoint_descr.disconnect_flag.clone();
         let controller = self.clone();
 
-        outputs.insert(endpoint_id, handles.clone(), endpoint_descr);
+        self.outputs
+            .write()
+            .unwrap()
+            .insert(endpoint_id, handles.clone(), endpoint_descr);
 
         let endpoint_name_string = endpoint_name.to_string();
         let output_buffer_config = endpoint_config
@@ -2250,8 +2273,6 @@ impl ControllerInner {
                 controller,
             )
         });
-
-        drop(outputs);
 
         // Initialize endpoint stats.
         self.status

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -63,6 +63,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, sync_channel, Receiver, Sender};
@@ -1821,8 +1822,12 @@ impl ControllerInner {
                     let controller = controller.clone();
                     let input_name = input_name.clone();
                     let input_config = input_config.clone();
-                    Box::new(move || controller.connect_input(&input_name, &input_config))
-                        as Box<dyn FnOnce() -> Result<_, ControllerError> + Send>
+                    Box::new(move || {
+                        catch_unwind(AssertUnwindSafe(|| {
+                            controller.connect_input(&input_name, &input_config)
+                        }))
+                        .unwrap_or_else(|_| Err(ControllerError::ControllerPanic))
+                    }) as Box<dyn FnOnce() -> Result<_, ControllerError> + Send>
                 });
 
         let sink_tasks =
@@ -1835,8 +1840,12 @@ impl ControllerInner {
                     let controller = controller.clone();
                     let output_name = output_name.clone();
                     let output_config = output_config.clone();
-                    Box::new(move || controller.connect_output(&output_name, &output_config))
-                        as Box<dyn FnOnce() -> Result<_, ControllerError> + Send>
+                    Box::new(move || {
+                        catch_unwind(AssertUnwindSafe(|| {
+                            controller.connect_output(&output_name, &output_config)
+                        }))
+                        .unwrap_or_else(|_| Err(ControllerError::ControllerPanic))
+                    }) as Box<dyn FnOnce() -> Result<_, ControllerError> + Send>
                 });
 
         let pool_size = config.max_parallel_connector_init();
@@ -3253,8 +3262,7 @@ outputs:
 
         let connectors = connectors.join("\n");
 
-        // Controller configuration with two input connectors;
-        // the second starts after the first one finishes.
+        // Controller configuration with 100 input connectors.
         let config_str = format!(
             r#"
 name: test
@@ -3303,6 +3311,76 @@ inputs:
         _test_concurrent_init(1);
         _test_concurrent_init(10);
         _test_concurrent_init(100);
+    }
+
+    #[test]
+    fn test_connector_init_error() {
+        init_test_logger();
+
+        // Two JSON files with a few records each.
+        let (_temp_input_files, connectors): (Vec<_>, Vec<_>) = (0..20)
+            .map(|i| {
+                let file = NamedTempFile::new().unwrap();
+                file.as_file()
+                    .write_all(&format!(r#"[{{"id": {i}, "b": true, "s": "foo"}}]"#).into_bytes())
+                    .unwrap();
+                let path = file.path().to_str().unwrap();
+                let config = format!(
+                    r#"
+    test_input1.endpoint{i}:
+        stream: test_input1
+        transport:
+            name: file_input
+            config:
+                path: {path:?}
+        format:
+            name: json
+            config:
+                array: true
+                update_format: raw"#
+                );
+                (file, config)
+            })
+            .unzip();
+
+        let connectors = connectors.join("\n");
+
+        // Controller configuration with two input connectors;
+        // the second starts after the first one finishes.
+        let config_str = format!(
+            r#"
+name: test
+workers: 4
+inputs:
+{connectors}
+    test_input1.error_endpoint:
+        stream: test_input1
+        transport:
+            name: file_input
+            config:
+                path: path_does_not_exist
+        format:
+            name: json
+            config:
+                array: true
+                update_format: raw"#
+        );
+
+        println!("config: {config_str}");
+
+        let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+        let result = Controller::with_config(
+            |circuit_config| {
+                Ok(test_circuit::<TestStruct>(
+                    circuit_config,
+                    &TestStruct::schema(),
+                ))
+            },
+            &config,
+            Box::new(|e| panic!("error: {e}")),
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -256,6 +256,11 @@ impl<I, O> Drop for JobQueue<I, O> {
 // TODO:
 // * add a flag to wait for all tasks to finish on error.
 // * if we go async, it may be possible to cancel tasks.
+//
+// # Panics
+//
+// This function doesn't implement any form of panic handling. If a task can panic,
+// you can wrap it in `catch_unwind` and convert a panic into an error.
 pub(crate) fn run_on_thread_pool<I, T, E>(name: &str, num_threads: usize, tasks: I) -> Result<(), E>
 where
     I: IntoIterator<Item = Box<dyn FnOnce() -> Result<T, E> + Send>>,

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -98,6 +98,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
             clock_resolution_usecs: Some(100_000),
             pin_cpus: Vec::new(),
             provisioning_timeout_secs: Some(1200),
+            max_parallel_connector_init: Some(10),
         })
         .unwrap(),
         program_code: "CREATE TABLE table2 ( col2 VARCHAR );".to_string(),

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -254,6 +254,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> serde_json::V
             clock_resolution_usecs: val.val13,
             pin_cpus: Vec::new(),
             provisioning_timeout_secs: val.val14,
+            max_parallel_connector_init: None,
         })
         .unwrap()
     }
@@ -985,6 +986,7 @@ async fn pipeline_versioning() {
         clock_resolution_usecs: None,
         pin_cpus: Vec::new(),
         provisioning_timeout_secs: None,
+        max_parallel_connector_init: None,
     })
     .unwrap();
     handle
@@ -1447,6 +1449,7 @@ async fn pipeline_provision_version_guard() {
                     clock_resolution_usecs: None,
                     pin_cpus: Vec::new(),
                     provisioning_timeout_secs: None,
+                    max_parallel_connector_init: None,
                 })
                 .unwrap(),
             ),

--- a/openapi.json
+++ b/openapi.json
@@ -388,7 +388,8 @@
                       },
                       "clock_resolution_usecs": 100000,
                       "pin_cpus": [],
-                      "provisioning_timeout_secs": null
+                      "provisioning_timeout_secs": null,
+                      "max_parallel_connector_init": null
                     },
                     "program_code": "CREATE TABLE table1 ( col1 INT );",
                     "udf_rust": "",
@@ -445,7 +446,8 @@
                       },
                       "clock_resolution_usecs": 100000,
                       "pin_cpus": [],
-                      "provisioning_timeout_secs": 1200
+                      "provisioning_timeout_secs": 1200,
+                      "max_parallel_connector_init": 10
                     },
                     "program_code": "CREATE TABLE table2 ( col2 VARCHAR );",
                     "udf_rust": "",
@@ -524,7 +526,8 @@
                   },
                   "clock_resolution_usecs": 100000,
                   "pin_cpus": [],
-                  "provisioning_timeout_secs": null
+                  "provisioning_timeout_secs": null,
+                  "max_parallel_connector_init": null
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -572,7 +575,8 @@
                     },
                     "clock_resolution_usecs": 100000,
                     "pin_cpus": [],
-                    "provisioning_timeout_secs": null
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -715,7 +719,8 @@
                     },
                     "clock_resolution_usecs": 100000,
                     "pin_cpus": [],
-                    "provisioning_timeout_secs": null
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -821,7 +826,8 @@
                   },
                   "clock_resolution_usecs": 100000,
                   "pin_cpus": [],
-                  "provisioning_timeout_secs": null
+                  "provisioning_timeout_secs": null,
+                  "max_parallel_connector_init": null
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -869,7 +875,8 @@
                     },
                     "clock_resolution_usecs": 100000,
                     "pin_cpus": [],
-                    "provisioning_timeout_secs": null
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -929,7 +936,8 @@
                     },
                     "clock_resolution_usecs": 100000,
                     "pin_cpus": [],
-                    "provisioning_timeout_secs": null
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -1156,7 +1164,8 @@
                     },
                     "clock_resolution_usecs": 100000,
                     "pin_cpus": [],
-                    "provisioning_timeout_secs": null
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -4415,6 +4424,14 @@
                 "default": 0,
                 "minimum": 0
               },
+              "max_parallel_connector_init": {
+                "type": "integer",
+                "format": "int64",
+                "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be intitialized\nin parallel.\n\nThe default is 10.",
+                "default": null,
+                "nullable": true,
+                "minimum": 0
+              },
               "min_batch_size_records": {
                 "type": "integer",
                 "format": "int64",
@@ -5302,6 +5319,14 @@
             "format": "int64",
             "description": "Maximal delay in microseconds to wait for `min_batch_size_records` to\nget buffered by the controller, defaults to 0.",
             "default": 0,
+            "minimum": 0
+          },
+          "max_parallel_connector_init": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be intitialized\nin parallel.\n\nThe default is 10.",
+            "default": null,
+            "nullable": true,
             "minimum": 0
           },
           "min_batch_size_records": {


### PR DESCRIPTION
Fixes #3663.

Use a thread pool to initialize multiple input/output connectors in parallel in order to reduce the startup time for circuits with many connectors that requires slow initialization (e.g., Delta).