### PR TITLE
[SQL] Global Merkle hashes in recursive components are computed twice

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNestedOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNestedOperator.java
@@ -89,6 +89,17 @@ public class DBSPNestedOperator extends DBSPOperator implements ICircuit {
         return new OutputPort(this, this.internalOutputs.size() - 1);
     }
 
+    /** The output of the operator that corresponds to this declaration */
+    @Nullable
+    public OutputPort outputForDeclaration(DBSPViewDeclarationOperator operator) {
+        DBSPSimpleOperator source = operator.getCorrespondingView(this);
+        if (source != null)
+            return source.outputPort();
+        // May happen after views have been deleted
+        int index = this.outputViews.indexOf(operator.originalViewName());
+        return this.internalOutputs.get(index);
+    }
+
     @Nullable
     @Override
     public DBSPViewOperator getView(ProgramIdentifier name) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -135,7 +135,7 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
                 .newline();
         ICircuit parent = this.getUnderConstruction();
         parent.addOperator(operator);
-        if (!this.current.isEmpty()) {
+        if (!this.context.isEmpty()) {
             // Current can be empty when operators are inserted in startVisit, for example.
             // Such operators are not derived from the "current" operator.
             IDBSPOuterNode node = this.getCurrent();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -59,12 +59,12 @@ public abstract class CircuitVisitor
     protected DBSPCircuit circuit = null;
     public final DBSPCompiler compiler;
     /** Circuit or operator currently being visited. */
-    protected final List<IDBSPOuterNode> current;
+    protected final List<IDBSPOuterNode> context;
 
     public CircuitVisitor(DBSPCompiler compiler) {
         this.id = crtId++;
         this.compiler = compiler;
-        this.current = new ArrayList<>();
+        this.context = new ArrayList<>();
     }
 
     @Override
@@ -77,8 +77,8 @@ public abstract class CircuitVisitor
     }
 
     public ICircuit getParent() {
-        assert this.current.size() > 1;
-        return this.current.get(this.current.size() - 2).to(ICircuit.class);
+        assert this.context.size() > 1;
+        return this.context.get(this.context.size() - 2).to(ICircuit.class);
     }
 
     /** Property of a node that is being visited */
@@ -108,7 +108,7 @@ public abstract class CircuitVisitor
     }
 
     public IDBSPOuterNode getCurrent() {
-        return Utilities.last(this.current);
+        return Utilities.last(this.context);
     }
 
     /** Returns by default the input circuit unmodified. */
@@ -121,11 +121,11 @@ public abstract class CircuitVisitor
     }
 
     public void push(IDBSPOuterNode node) {
-        this.current.add(node);
+        this.context.add(node);
     }
 
     public void pop(IDBSPOuterNode node) {
-        Utilities.removeLast(this.current, node);
+        Utilities.removeLast(this.context, node);
     }
 
     /************************* PREORDER *****************************/

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -2,9 +2,11 @@ package org.dbsp.sqlCompiler.compiler.sql.recursive;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
+import org.dbsp.sqlCompiler.compiler.backend.MerkleOuter;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.DeclareViewStatement;
 import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.util.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Fixes #3740 

This ensures that the back-edges are used at least once in the hash computation