### PR TITLE
Add Arrow IPC format for ad-hoc queries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4664,6 +4664,7 @@ dependencies = [
 name = "fda"
 version = "0.42.0"
 dependencies = [
+ "arrow",
  "chrono",
  "clap 4.5.31",
  "clap_complete",

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3"
 tokio-util = "0.7"
 tempfile = "3.15"
 rmpv = { version = "1.3", features = ["with-serde"] }
+arrow = { version = "54", features = ["ipc", "prettyprint"] }
 
 [build-dependencies]
 prettyplease = "0.2.22"

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
+use std::fmt::Display;
 use std::path::PathBuf;
 
 use crate::cd::types::{CompilationProfile, ProgramConfig};
@@ -103,6 +104,26 @@ pub enum OutputFormat {
     ///
     /// This usually corresponds to the exact response returned from the server.
     Json,
+    /// Request the output in Arrow IPC format.
+    ///
+    /// This format can only be specified for SQL queries.
+    ArrowIpc,
+    /// Return the output in Parquet format.
+    ///
+    /// This format can only be specified for SQL queries.
+    Parquet,
+}
+
+impl Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            OutputFormat::Text => "text",
+            OutputFormat::Json => "json",
+            OutputFormat::ArrowIpc => "arrow_ipc",
+            OutputFormat::Parquet => "parquet",
+        };
+        write!(f, "{}", output)
+    }
 }
 
 #[derive(Subcommand)]

--- a/crates/fda/src/shell.rs
+++ b/crates/fda/src/shell.rs
@@ -150,6 +150,8 @@ pub async fn shell(format: OutputFormat, name: String, client: Client) {
                             let format = match format {
                                 OutputFormat::Text => "text",
                                 OutputFormat::Json => "json",
+                                OutputFormat::ArrowIpc => "arrow",
+                                OutputFormat::Parquet => "parquet",
                             };
                             match client
                                 .pipeline_adhoc_sql()

--- a/crates/feldera-types/src/query.rs
+++ b/crates/feldera-types/src/query.rs
@@ -12,6 +12,8 @@ pub enum AdHocResultFormat {
     Json,
     /// Download results in a parquet file.
     Parquet,
+    /// Stream data in the arrow IPC format.
+    ArrowIpc,
 }
 
 impl Display for AdHocResultFormat {
@@ -20,6 +22,7 @@ impl Display for AdHocResultFormat {
             AdHocResultFormat::Text => write!(f, "text"),
             AdHocResultFormat::Json => write!(f, "json"),
             AdHocResultFormat::Parquet => write!(f, "parquet"),
+            AdHocResultFormat::ArrowIpc => write!(f, "arrow_ipc"),
         }
     }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -2963,7 +2963,8 @@
         "enum": [
           "text",
           "json",
-          "parquet"
+          "parquet",
+          "arrow_ipc"
         ]
       },
       "AdhocQueryArgs": {


### PR DESCRIPTION
JSON is unable to represent some datatypes we support like MAP with non-string keys so the serialization to JSON fails (https://github.com/feldera/feldera/issues/3546).

This adds a new query format for arrow ipc to the backend and fda. Using this formats the queries also work for map types with non-string keys.

Also adds support for parquet format to fda which was previously missing.