### PR TITLE
[adapters] Improve deserialize_table_record.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4866,6 +4866,7 @@ dependencies = [
  "anyhow",
  "csv",
  "enum-map",
+ "erased-serde",
  "feldera_rust_decimal",
  "libc",
  "log",

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -12,7 +12,7 @@ dbsp = { path = "../dbsp" }
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 serde_yaml = "0.9.34+deprecated"
 actix-web = { version = "4.4.0", default-features = false, features = ["cookies", "macros", "compress-gzip", "compress-brotli"] }
-erased-serde = "0.3.23"
+erased-serde = "0.3.31"
 dyn-clone = "1.0.17"
 arrow = { version = "54.2.0", features = ["chrono-tz"] }
 apache-avro = { version = "0.17.0", optional = true }

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -45,7 +45,7 @@ circular-queue = { version = "0.2.6", features = ["serde_support"] }
 crossbeam = "0.8.2"
 dbsp = { path = "../dbsp" }
 serde = { version = "1.0", features = ["derive", "rc"] }
-erased-serde = "0.3.23"
+erased-serde = "0.3.31"
 once_cell = "1.9.0"
 serde_yaml = "0.9.14"
 serde_json = { version = "1.0.127", features = ["raw_value"] }

--- a/crates/adapters/src/adhoc/mod.rs
+++ b/crates/adapters/src/adhoc/mod.rs
@@ -279,7 +279,7 @@ pub async fn stream_adhoc_result(
                 let mut writer = StreamWriter::try_new(&mut channel_writer, &schema).unwrap();
 
                 while let Some(batch) = stream.next().await {
-                    let batch = batch.map_err(DataFusionError::from)?;
+                    let batch = batch?;
                     writer.write(&batch).map_err(DataFusionError::from)?;
                 }
                 writer.flush().map_err(DataFusionError::from)?;

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -362,7 +362,7 @@ impl Parser for JsonParser {
                     self.apply_update::<WeightedUpdate<_>>(update, &mut errors)
                 }
                 JsonUpdateFormat::Raw => self.apply_update::<&RawValue>(update, &mut errors),
-                JsonUpdateFormat::Redis | JsonUpdateFormat::Snowflake { .. } => {
+                JsonUpdateFormat::Redis | JsonUpdateFormat::Snowflake => {
                     panic!("Unexpected update format: {:?}", &self.config.update_format)
                 }
             }

--- a/crates/adapters/src/format/json/output.rs
+++ b/crates/adapters/src/format/json/output.rs
@@ -113,7 +113,7 @@ fn validate(
         JsonUpdateFormat::InsertDelete
             | JsonUpdateFormat::Snowflake
             | JsonUpdateFormat::Redis
-            | JsonUpdateFormat::Debezium { .. }
+            | JsonUpdateFormat::Debezium
     ) {
         return Err(ControllerError::output_format_not_supported(
             endpoint_name,
@@ -186,7 +186,7 @@ impl JsonEncoder {
         if config.json_flavor.is_none() {
             config.json_flavor = Some(match config.update_format {
                 JsonUpdateFormat::Snowflake => JsonFlavor::Snowflake,
-                JsonUpdateFormat::Debezium { .. } => JsonFlavor::KafkaConnectJsonConverter,
+                JsonUpdateFormat::Debezium => JsonFlavor::KafkaConnectJsonConverter,
                 _ => JsonFlavor::Default,
             });
         }

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -683,7 +683,7 @@ async fn test_follow(
     for chunk in data[split_at..].chunks(std::cmp::max(data[split_at..].len() / 10, 1)) {
         total_count += chunk.len();
         input_table = write_data_to_table(input_table, &arrow_schema, chunk).await;
-        wait_for_count_records(&mut output_table, (total_count + 1) / 2, &datafusion).await;
+        wait_for_count_records(&mut output_table, total_count.div_ceil(2), &datafusion).await;
     }
 
     // TODO: this does not currently work because our output delta connector doesn't support
@@ -826,7 +826,7 @@ async fn test_cdc(
         wait_for_count_records_materialized(
             &read_pipeline,
             &SqlIdentifier::from("test_output1"),
-            (total_count + 1) / 2,
+            total_count.div_ceil(2),
         )
         .await;
     }
@@ -841,7 +841,7 @@ async fn test_cdc(
         wait_for_count_records_materialized(
             &read_pipeline,
             &SqlIdentifier::from("test_output1"),
-            (total_count + 1) / 2 - (deleted_count + 1) / 2,
+            total_count.div_ceil(2) - deleted_count.div_ceil(2),
         )
         .await;
     }

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -840,7 +840,7 @@ impl IcebergTestStruct {
     }
 }
 
-serialize_table_record!(IcebergTestStruct[13]{
+serialize_table_record!(IcebergTestStruct[12]{
     b["b"]: bool,
     i["i"]: i32,
     l["l"]: i64,
@@ -856,7 +856,7 @@ serialize_table_record!(IcebergTestStruct[13]{
     varbin["varbin"]: ByteArray
 });
 
-deserialize_table_record!(IcebergTestStruct["IcebergTestStruct", 13] {
+deserialize_table_record!(IcebergTestStruct["IcebergTestStruct", 12] {
     (b, "b", false, bool, None),
     (i, "i", false, i32, None),
     (l, "l", false, i64, None),

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -277,7 +277,7 @@ impl KafkaFtInputReaderInner {
                         let mut hasher = KafkaFtHasher::new(&partition_counts);
                         let mut ranges = partition_counts
                             .iter()
-                            .map(|n_partitions| iter::repeat(None).take(*n_partitions).collect())
+                            .map(|n_partitions| std::iter::repeat_n(None, *n_partitions).collect())
                             .collect::<Vec<Vec<Option<Range<i64>>>>>();
                         while total < consumer.max_batch_size() {
                             let mut empty = true;

--- a/crates/dbsp/benches/gdelt/main.rs
+++ b/crates/dbsp/benches/gdelt/main.rs
@@ -139,14 +139,14 @@ fn main() {
             // We now have a url in this form: `http://data.gdeltproject.org/gdeltv2/20150218230000.gkg.csv.zip`
             let url = line
                 .ends_with(GKG_SUFFIX)
-                .then(|| line.split(' ').last().unwrap());
+                .then(|| line.split(' ').next_back().unwrap());
 
             fn filter_date(url: Option<&str>, cmp: impl Fn(u64) -> bool) -> Option<&str> {
                 url.filter(|url| {
                     url.strip_prefix(GDELT_URL)
                         .and_then(|url| url.strip_suffix(GKG_SUFFIX))
                         .and_then(|date| date.parse::<u64>().ok())
-                        .map_or(false, cmp)
+                        .is_some_and(cmp)
                 })
             }
 

--- a/crates/dbsp/src/dynamic/lean_vec.rs
+++ b/crates/dbsp/src/dynamic/lean_vec.rs
@@ -692,7 +692,7 @@ impl RawVec {
 
             // For medium vectors, grow by 1.5x
         } else {
-            (capacity * 3 + 1) / 2
+            (capacity * 3).div_ceil(2)
         }
     }
 

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -11,8 +11,8 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     hash::{Hash, Hasher},
-    intrinsics::transmute,
     marker::PhantomData,
+    mem::transmute,
     sync::Arc,
 };
 use typedmap::TypedMapKey;

--- a/crates/dbsp/src/utils/consolidation/quicksort.rs
+++ b/crates/dbsp/src/utils/consolidation/quicksort.rs
@@ -512,7 +512,7 @@ where
             debug_assert!(width(l, r) == block_l + block_r);
         }
 
-        if start_l == end_l {
+        if std::ptr::eq(start_l, end_l) {
             // Trace `block_l` elements from the left side.
             start_l = offsets_l.as_mut_ptr().cast();
             end_l = start_l;
@@ -541,7 +541,7 @@ where
             }
         }
 
-        if start_r == end_r {
+        if std::ptr::eq(start_r, end_r) {
             // Trace `block_r` elements from the right side.
             start_r = offsets_r.as_mut_ptr().cast();
             end_r = start_r;
@@ -651,7 +651,7 @@ where
             }
         }
 
-        if start_l == end_l {
+        if std::ptr::eq(start_l, end_l) {
             // All out-of-order elements in the left block were moved. Move to the next
             // block.
 
@@ -666,7 +666,7 @@ where
             l = unsafe { l.add(block_l) };
         }
 
-        if start_r == end_r {
+        if std::ptr::eq(start_r, end_r) {
             // All out-of-order elements in the right block were moved. Move to the previous
             // block.
 

--- a/crates/feldera-types/Cargo.toml
+++ b/crates/feldera-types/Cargo.toml
@@ -25,6 +25,7 @@ proptest-derive = { version = "0.5.0", optional = true }
 rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1" }
 actix-web = "4.3"
 enum-map = "2.7.3"
+erased-serde = "0.3.31"
 
 [dev-dependencies]
 rust_decimal_macros = "1.32"

--- a/crates/feldera-types/src/serde_with_context/mod.rs
+++ b/crates/feldera-types/src/serde_with_context/mod.rs
@@ -2,6 +2,10 @@ pub mod deserialize;
 pub mod serde_config;
 pub mod serialize;
 
-pub use deserialize::{DeserializationContext, DeserializeWithContext, FieldParseError};
+pub use deserialize::{
+    field_parse_error, invalid_length_error, missing_field_error, DeserializationContext,
+    DeserializeWithContext, ErasedDeserializationContext, ErasedDeserializeWithContext,
+    FieldParseError,
+};
 pub use serde_config::{DateFormat, SqlSerdeConfig, TimeFormat, TimestampFormat};
 pub use serialize::{SerializationContext, SerializeWithContext};

--- a/crates/feldera-types/src/serde_with_context/serde_config.rs
+++ b/crates/feldera-types/src/serde_with_context/serde_config.rs
@@ -201,7 +201,7 @@ impl From<JsonFlavor> for SqlSerdeConfig {
             JsonFlavor::Datagen => SqlSerdeConfig::default()
                 .with_variant_format(VariantFormat::Json)
                 .with_timestamp_format(TimestampFormat::Rfc3339),
-            JsonFlavor::KafkaConnectJsonConverter { .. } => Self {
+            JsonFlavor::KafkaConnectJsonConverter => Self {
                 time_format: TimeFormat::Millis,
                 date_format: DateFormat::DaysSinceEpoch,
                 timestamp_format: TimestampFormat::MillisSinceEpoch,

--- a/crates/sqllib/src/array.rs
+++ b/crates/sqllib/src/array.rs
@@ -276,8 +276,7 @@ pub fn array_repeat__<T>(element: T, count: i32) -> Array<T>
 where
     T: Clone,
 {
-    std::iter::repeat(element)
-        .take(usize::try_from(count).unwrap_or(0))
+    std::iter::repeat_n(element, usize::try_from(count).unwrap_or(0))
         .collect::<Vec<T>>()
         .into()
 }

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -21,6 +21,7 @@ rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1" 
 rust_decimal_macros = { version = "1.36" }
 serde_json = { version = "1.0.127", features = ["arbitrary_precision"] }
 rkyv = { version = "0.7.45", default-features = false, features = ["std", "size_64"] }
+erased-serde = "0.3.31"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5.4", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }


### PR DESCRIPTION
The `deserialize_table_record` macro generated Rust code that compiled very slowly. This commit improves compilation times significantly by breaking the code up into smaller functions and shoving dynamic dispatch down compiler's throat.

* Invoke `deserialize` for individual fields via dynamic dispatch, thus preventing these functions from getting inlined.

* Convert generared `visit_map` and `visit_seq` into loops.

* Use a static HashMap for field name lookups. This can potentially speed up the parsing of records with many fields, but I haven't run any benchmarks.

I've been testing this on a program that consists of ~10 tables with ~90 columns each. It reduces the number of generated LLVM code by ~30% and compilation time by approximately 2.5x (which shows that the compiler doesn't like large functions, so in the future we may want to focus our optimizations on those).

TODOs:
* We can do the same for serialization functions, which are less terrible that deserialization, but can still benefit from the same optimizations.