### PR TITLE
[adapters] Avro raw format with keys.

### DIFF
--- a/crates/adapters/src/format/avro/test.rs
+++ b/crates/adapters/src/format/avro/test.rs
@@ -762,8 +762,8 @@ fn test_raw_avro_output_indexed<K, T>(
 
             if let Some(key_schema) = &key_schema {
                 let key =
-                    from_avro_datum(&key_schema, &mut &k.as_ref().unwrap()[5..], None).unwrap();
-                let key = from_avro_value::<K>(&key, &key_schema).unwrap();
+                    from_avro_datum(key_schema, &mut &k.as_ref().unwrap()[5..], None).unwrap();
+                let key = from_avro_value::<K>(&key, key_schema).unwrap();
                 assert_eq!(key, key_func(&value));
             }
 


### PR DESCRIPTION
This PR refers to the `CREATE INDEX` mechanism, which hasn't been documented yet. I am writing those docs and will create another PR shortly. Wanted to get this in in the meantime.

---

Previously the Avro raw output format generated messages without the key component. This is problematic when sending to a Kafka topic with multiple partitions, since there is no way to ensure that messages with the same key are assigned to the same partition, while different keys are load balanced across all partitions. Depending on the Kafka config, we either end up with messages without a key assigned to random partitions, or to the same partition.

This commit adds the `key_mode` configuration option to the Avro output connector, which allows generating Kafka keys for output connectors with unique keys configured (via the `index` property).  This seems like a good default, so this setting is enabled by default for connectors with the `index` property set.