### PR TITLE
[adapters] Remove cmake dependency for rdkafka.

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build Compiler
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:0a775f772b2ebde13708744d3e6a219ca4a492d2
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:3012ef118aaaa2b7d49e1dfeda938288a70ba66c
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu --privileged
       volumes:
         - /sccache:/sccache

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -20,7 +20,7 @@ jobs:
   adjust-versions:
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:39c1b55d0972ccd26375cf2f7cbc8554f4609da8
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu
       volumes:
         - /sccache:/sccache

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -9,6 +9,11 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      # Required by librdkafka.
+      - name: Install libsasl2-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsasl2-dev
       - uses: actions/checkout@v3
       - uses: oven-sh/setup-bun@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:3012ef118aaaa2b7d49e1dfeda938288a70ba66c
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu
       volumes:
         - /sccache:/sccache

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,7 +9,7 @@ jobs:
     name: Integration Tests
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:0a775f772b2ebde13708744d3e6a219ca4a492d2
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
 
     services:
       pipeline-manager:

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -8,7 +8,7 @@ jobs:
     name: Execute Java Tests
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:0a775f772b2ebde13708744d3e6a219ca4a492d2
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rust Unit Tests
     runs-on: [self-hosted, skylake40]
     container:
-      image: ghcr.io/feldera/feldera-dev:0a775f772b2ebde13708744d3e6a219ca4a492d2
+      image: ghcr.io/feldera/feldera-dev:f4797ad926773a38483275405728a9eb3b9005b5
       options: --user=ubuntu
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Our dependencies are:
         - this will need a C and C++ compiler installed (e.g., gcc, gcc++)
     - cmake
     - libssl-dev
+    - libsasl2-dev
 - SQL Compiler
     - a Java Virtual Machine (at least Java 19)
     - maven

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8658,7 +8658,6 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To run Feldera from sources, first install required dependencies:
 - [Rust tool chain](https://www.rust-lang.org/tools/install)
 - cmake
 - libssl-dev
+- libsasl2-dev
 - Java Development Kit (JDK), version 19 or newer
 - maven
 - [Bun](https://bun.sh/docs/installation)

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -52,8 +52,7 @@ serde_json = { version = "1.0.127", features = ["raw_value"] }
 serde_urlencoded = "0.7.1"
 form_urlencoded = "1.2.0"
 csv = "1.2.2"
-# cmake-build is required on Windows.
-rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "zstd", "libz"], optional = true }
+rdkafka = { version = "0.37.0", features = ["ssl-vendored", "gssapi-vendored", "zstd", "libz"], optional = true }
 aws-sdk-s3 = { version = "1.17.0", features = ["behavior-version-latest"] }
 aws-types = "1.1.7"
 actix = "0.13.1"

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -30,8 +30,7 @@ regex = { version = "1.6.0" }
 time = { version = "0.3.14", features = ["formatting"] }
 paste = { version = "1.0.9" }
 rand = { version = "0.8", features = ["small_rng"] }
-# cmake-build is required on Windows.
-rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"], optional = true }
+rdkafka = { version = "0.37.0", features = ["ssl-vendored", "gssapi-vendored"], optional = true }
 clap = { version = "3.2.8", features = ["derive", "env"] }
 cached = { version = "0.38.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -15,8 +15,9 @@ ENV OPENSSL_STATIC=1
 RUN apt update --fix-missing && apt install \
   # pkg-config is required for cargo to find libssl
   libssl-dev pkg-config \
-  # rdkafka dependency needs cmake and a CXX compiler
-  cmake build-essential \
+  cmake \
+  # rdkafka dependency needs libsasl2-dev and the CXX compiler
+  libsasl2-dev build-essential \
   # To install rust
   curl  \
   # For running the SQL compiler

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -15,8 +15,9 @@ ENV OPENSSL_STATIC=1
 RUN apt-get update --fix-missing && apt-get install -y \
     # pkg-config is required for cargo to find libssl
     libssl-dev pkg-config \
-    # rdkafka dependency needs cmake and a CXX compiler
-    cmake build-essential \
+    cmake \
+    # rdkafka dependency needs libsasl2-dev and a CXX compiler
+    libsasl2-dev build-essential \
     # To install rust
     curl  \
     # For running the SQL compiler


### PR DESCRIPTION
Building Kafka with cmake started causing issues recently (most likely due to pip installing cmake 4.0 and this issue: https://github.com/confluentinc/librdkafka/issues/4594#issuecomment-2765371512)

This feature should only be needed on Windows, which we don't support anyway, so this commit removes it.  Hopefully this will make rdkafka builds less fragile in the future.