### PR TITLE
[adapters] Make sure Kafka input connectors have unique group IDs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,6 +4877,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -11335,9 +11336,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
  "rand 0.9.0",

--- a/crates/feldera-types/Cargo.toml
+++ b/crates/feldera-types/Cargo.toml
@@ -26,6 +26,7 @@ rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1" 
 actix-web = "4.3"
 enum-map = "2.7.3"
 erased-serde = "0.3.31"
+uuid = "1.16.0"
 
 [dev-dependencies]
 rust_decimal_macros = "1.32"

--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -3,12 +3,9 @@ use serde::de::{Error, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use std::fmt::Formatter;
-use std::{
-    collections::BTreeMap,
-    env,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::BTreeMap, env};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 /// Configuration for reading data from Kafka topics with `InputTransport`.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
@@ -151,13 +148,7 @@ impl KafkaInputConfig {
         self.set_option_if_missing("enable.auto.commit", "false");
         self.set_option_if_missing("enable.auto.offset.store", "false");
 
-        let group_id = format!(
-            "{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis()
-        );
+        let group_id = format!("{}", Uuid::now_v7());
         self.set_option_if_missing("group.id", &group_id);
         self.set_option_if_missing("enable.partition.eof", "false");
 


### PR DESCRIPTION
Every non-FT Kafka input connector needs a unique `group.id`.  Until now, uniqueness was ensured by using a timestamp in milliseconds.  Until commit d6d512e86ebf ("[adapters] Initialize connectors concurrently."), the connectors were initialized one-by-one.  Initialization took multiple milliseconds, at least, because it required a round trip to the broker. After that commit, though, the early phase of initialization that assigned `group.id` happened concurrently, so it was possible to get duplicate timestamps and therefore duplicate `group.id`s.

This commit fixes the problem by using a UUID instead.

With this commit, it might be possible to revert commit d047940fc161 ("[adapters] Serialize Kafka adapter initialization.").

Thanks to Simon Kassing for reporting the bug.