### PR TITLE
Allow shutting down Unavailable pipelines on home page

### DIFF
--- a/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
+++ b/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
@@ -45,7 +45,7 @@
       .with('Paused', () => ['shutdown', 'start'])
       .with('Resuming', () => ['shutdown', 'delete'])
       .with('ShuttingDown', () => ['shutdown'])
-      .with('Unavailable', () => ['delete'])
+      .with('Unavailable', () => ['shutdown', 'delete'])
       .with('SqlError', 'RustError', 'SystemError', () => ['delete'])
       .with({ PipelineError: P.any }, () => ['shutdown', 'delete'])
       .exhaustive()


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/3160: Shutdown button presence