### PR TITLE
Revert "[adapters] Serialize Kafka adapter initialization."

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -1,5 +1,4 @@
 use crate::transport::kafka::ft::count_partitions_in_topic;
-use crate::transport::kafka::serialize_kafka_initialization;
 use crate::transport::secret_resolver::resolve_secret;
 use crate::transport::InputCommandReceiver;
 use crate::{
@@ -506,7 +505,6 @@ impl TransportInputEndpoint for KafkaFtInputEndpoint {
         parser: Box<dyn Parser>,
         _schema: Relation,
     ) -> AnyResult<Box<dyn InputReader>> {
-        let _guard = serialize_kafka_initialization();
         Ok(Box::new(KafkaFtInputReader::new(
             &self.config,
             consumer,

--- a/crates/adapters/src/transport/kafka/mod.rs
+++ b/crates/adapters/src/transport/kafka/mod.rs
@@ -13,7 +13,8 @@ use sha2::Digest;
 use std::cmp::min;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::{Mutex, MutexGuard};
+#[cfg(test)]
+use std::sync::Mutex;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use tracing::warn;
@@ -284,14 +285,4 @@ where
 
 fn is_retriable_send_error(error: RDKafkaErrorCode) -> bool {
     error == RDKafkaErrorCode::QueueFull
-}
-
-/// Returns a mutex guard for serializing initialization of Kafka connectors.
-///
-/// [Issue 3794](https://github.com/feldera/feldera/issues/3794) reported that
-/// parallel initialization can cause timeouts.
-fn serialize_kafka_initialization() -> MutexGuard<'static, ()> {
-    static SERIALIZE: Mutex<()> = Mutex::new(());
-
-    SERIALIZE.lock().unwrap()
 }

--- a/crates/adapters/src/transport/kafka/nonft/input.rs
+++ b/crates/adapters/src/transport/kafka/nonft/input.rs
@@ -1,4 +1,4 @@
-use crate::transport::kafka::{serialize_kafka_initialization, PemToLocation};
+use crate::transport::kafka::PemToLocation;
 use crate::transport::secret_resolver::resolve_secret;
 use crate::transport::{InputEndpoint, InputQueue, InputReaderCommand, NonFtInputReaderCommand};
 use crate::Parser;
@@ -622,7 +622,6 @@ impl TransportInputEndpoint for KafkaInputEndpoint {
         parser: Box<dyn Parser>,
         _schema: Relation,
     ) -> AnyResult<Box<dyn InputReader>> {
-        let _guard = serialize_kafka_initialization();
         Ok(Box::new(KafkaInputReader::new(
             &self.config,
             consumer,


### PR DESCRIPTION
This reverts commit d047940fc161675b71a6e3d28a99dcda509b9e9f. Serialization of Kafka adapter initialization should no longer be necessary now that we fixed out the likely root cause for the problem with commit daade5140962 ("[adapters] Make sure Kafka input connectors have unique group IDs.")