### PR TITLE
py: add `Pipeline.program_error`

### DIFF
--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -807,3 +807,12 @@ resume a paused pipeline."""
 
         self.refresh()
         return self._inner.program_info
+
+    def program_error(self) -> Mapping[str, Any]:
+        """
+        Return the program error of the pipeline.
+        If there are no errors, the `exit_code` field inside both `sql_compilation` and `rust_compilation` will be 0.
+        """
+
+        self.refresh()
+        return self._inner.program_error

--- a/python/tests/test_pipeline_builder.py
+++ b/python/tests/test_pipeline_builder.py
@@ -1141,6 +1141,38 @@ CREATE MATERIALIZED VIEW v AS SELECT * FROM map_tbl;
         pipeline.shutdown()
         pipeline.delete()
 
+    def test_program_error0(self):
+        sql = "create taabl;"
+        name = "test_program_error0"
+
+        try:
+            _ = PipelineBuilder(TEST_CLIENT, name, sql).create_or_replace()
+        except Exception:
+            pass
+
+        pipeline = Pipeline.get(name, TEST_CLIENT)
+        err = pipeline.program_error()
+
+        assert err["sql_compilation"] != 0
+
+        pipeline.shutdown()
+        pipeline.delete()
+
+    def test_program_error1(self):
+        sql = ""
+        name = "test_program_error1"
+
+        _ = PipelineBuilder(TEST_CLIENT, name, sql).create_or_replace()
+
+        pipeline = Pipeline.get(name, TEST_CLIENT)
+        err = pipeline.program_error()
+
+        assert err["sql_compilation"]["exit_code"] == 0
+        assert err["rust_compilation"]["exit_code"] == 0
+
+        pipeline.shutdown()
+        pipeline.delete()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`Pipeline.program_error` returns compilation errors, if any. If there are no errors, field `exit_code` inside the fields `sql_compilation` and `rust_compilation` will have the value 0.

Todo:

- [ ] add a top level method for all types of errors
- [ ] add an example in the docs showing how to connect to an existing pipeline and analyze its status

Fixes: #3827 