### PR TITLE
ci: validate and run packaged demos

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Login to GHCR Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -136,6 +138,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Tag docker image with version and latest
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Make binaries executable
         run: chmod +x ./build/*
 
+      - name: Validate and run packaged demos
+        run: |
+          (cd demo/packaged && uv run validate-preamble.py sql/*.sql)
+          uv run demo/all-packaged/run.py --api-url http://pipeline-manager:8080
+        env:
+          PYTHONPATH: ${{ github.workspace }}/python
+
       - name: Run manager tests
         run: ./build/integration_test-*
         env:

--- a/demo/all-packaged/run.py
+++ b/demo/all-packaged/run.py
@@ -1,7 +1,15 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "feldera @ file:///${PROJECT_ROOT}/python",
+#     "requests<3",
+# ]
+# ///
+
 #!/bin/python3
 
 # Run locally with:
-#   python3 demo/all-packaged/run.py --api-url http://localhost:8080
+#   uv run demo/all-packaged/run.py --api-url http://localhost:8080
 
 import time
 import requests


### PR DESCRIPTION
This seems to have gotten removed during the CI rework.

Additionally, fix `setup-buildx-action`.