### PR TITLE
Add deployment_id to PipelineConfig.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1508,6 +1508,7 @@ impl ControllerInit {
 
             // Other settings from the pipeline manager.
             name: config.name,
+            deployment_id: config.deployment_id,
             storage_config: config.storage_config,
         };
 

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -27,6 +27,7 @@ use std::fmt::Display;
 use std::path::Path;
 use std::{borrow::Cow, cmp::max, collections::BTreeMap};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 const DEFAULT_MAX_PARALLEL_CONNECTOR_INIT: u64 = 10;
 
@@ -57,6 +58,11 @@ pub struct PipelineConfig {
 
     /// Pipeline name.
     pub name: Option<String>,
+
+    /// Pipeline deployment ID.
+    ///
+    /// This allows the pipeline manager to uniquely identify the pipeline.
+    pub deployment_id: Uuid,
 
     /// Configuration for persistent storage
     ///

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -409,6 +409,7 @@ fn limited_pipeline_config() -> impl Strategy<Value = serde_json::Value> {
             serde_json::to_value(PipelineConfig {
                 global: serde_json::from_value(runtime_config).unwrap(),
                 name: Some(format!("pipeline-{}", val.1)),
+                deployment_id: Uuid::now_v7(),
                 storage_config: None,
                 inputs: program_info.input_connectors,
                 outputs: program_info.output_connectors,

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 use std::string::ParseError;
 use thiserror::Error as ThisError;
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 /// Enumeration of possible compilation profiles that can be passed to the Rust compiler
 /// as an argument via `cargo build --profile <>`. A compilation profile affects among
@@ -634,6 +635,7 @@ pub fn generate_pipeline_config(
     outputs: &BTreeMap<Cow<'static, str>, OutputEndpointConfig>,
 ) -> PipelineConfig {
     PipelineConfig {
+        deployment_id: Uuid::now_v7(),
         name: Some(format!("pipeline-{pipeline_id}")),
         global: runtime_config.clone(),
         storage_config: None, // Set by the runner based on global field

--- a/crates/pipeline-manager/src/db/types/utils.rs
+++ b/crates/pipeline-manager/src/db/types/utils.rs
@@ -132,6 +132,7 @@ mod tests {
     use feldera_types::config::{PipelineConfig, RuntimeConfig};
     use feldera_types::program_schema::ProgramSchema;
     use serde_json::json;
+    use uuid::Uuid;
 
     #[test]
     fn test_valid_names() {
@@ -255,6 +256,7 @@ mod tests {
         let deployment_config = PipelineConfig {
             global: Default::default(),
             name: None,
+            deployment_id: Uuid::now_v7(),
             storage_config: None,
             inputs: Default::default(),
             outputs: Default::default(),

--- a/openapi.json
+++ b/openapi.json
@@ -4521,9 +4521,15 @@
           {
             "type": "object",
             "required": [
+              "deployment_id",
               "inputs"
             ],
             "properties": {
+              "deployment_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Pipeline deployment ID.\n\nThis allows the pipeline manager to uniquely identify the pipeline."
+              },
               "inputs": {
                 "type": "object",
                 "description": "Input endpoint configuration.",


### PR DESCRIPTION
This will allow the pipeline-manager to uniquely identify pipelines.