### PR TITLE
[adapters] Don't read kafka message 0 if we're not queuing or replaying.

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -399,7 +399,7 @@ impl KafkaFtInputReaderInner {
                     self.pause_partitions()
                         .map_err(|error| self.refine_error(error).1)?;
                     for receiver in receivers.iter() {
-                        receiver.set_max_offset(0);
+                        receiver.set_max_offset(i64::MIN);
                     }
                     kafka_paused = true;
                 }
@@ -632,12 +632,15 @@ struct PartitionReceiver {
     partition: i32,
     queue: PartitionQueue<KafkaFtInputContext>,
 
-    /// The maximum message offset that we want to receive.
+    /// The maximum message offset that we want to receive, used as follows:
     ///
-    /// If we are replaying, then this is the offset of the final message to be
-    /// replayed.
+    /// - `i64::MIN`, the initial value, disables receiving messages entirely.
     ///
-    /// If we are not replaying, then this is `i64::MAX`.
+    /// - The offset of a specific message ensures that we will not read
+    ///   messages beyond that one.  This is used during replay, set to the
+    ///   offset of the final message to be replayed.
+    ///
+    /// - `i64::MAX`, used when replaying is complete, will read all messages.
     max_offset: AtomicI64,
 
     /// The minimum message offset that we could receive next in this partition
@@ -663,7 +666,7 @@ impl PartitionReceiver {
         Self {
             partition,
             queue,
-            max_offset: AtomicI64::new(0),
+            max_offset: AtomicI64::new(i64::MIN),
             next_offset: AtomicI64::new(next_offset),
             messages: Mutex::new(BTreeSet::new()),
             eof: AtomicBool::new(false),

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -23,7 +23,8 @@ use feldera_types::config::{
 };
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::kafka::{
-    default_group_join_timeout_secs, KafkaInputConfig, KafkaLogLevel, KafkaStartFromConfig,
+    default_group_join_timeout_secs, default_redpanda_server, KafkaInputConfig, KafkaLogLevel,
+    KafkaStartFromConfig,
 };
 use parquet::data_type::AsBytes;
 use proptest::prelude::*;
@@ -1111,7 +1112,7 @@ fn test_offset(
                     if let Some(auto_offset_reset) = auto_offset_reset {
                         kafka_options.insert("auto.offset.reset".into(), auto_offset_reset.into());
                     }
-                    kafka_options.insert("bootstrap.servers".into(), "localhost:9092".into());
+                    kafka_options.insert("bootstrap.servers".into(), default_redpanda_server());
                     kafka_options.insert("group.id".into(), "test-client".into());
                     kafka_options
                 },


### PR DESCRIPTION
For replay in Kafka, we need to make sure that we only read exactly the
messages in the range to be replayed.  In general, we're pretty good about
this, with one exception: initially, the maximum offset is set to 0
(inclusive).  If the first range of records to be replayed is empty (0..0),
then an initial maximum of 0 will allow in a record anyway.

This commit sets the initial maximum to i64::MIN instead, to fix the
problem.  (-1, or any other negative value, would also work.)

This bug manifested in a failure of the `empty_initial_input` test, e.g.:

```
2025-04-11T16:21:27.9716520Z thread 'transport::kafka::ft::test::empty_initial_input' panicked at crates/adapters/src/transport/kafka/ft/test.rs:240:26:
2025-04-11T16:21:27.9716629Z assertion `left == right` failed
2025-04-11T16:21:27.9716737Z   left: [Replayed { num_records: 0 }]
2025-04-11T16:21:27.9716830Z  right: [Replayed { num_records: 1 }]
```

Signed-off-by: Ben Pfaff <blp@feldera.com>