### PR TITLE
[adapters] ssl.ca.location defaults to probe.

### DIFF
--- a/crates/adapters/src/transport/kafka/ft/mod.rs
+++ b/crates/adapters/src/transport/kafka/ft/mod.rs
@@ -106,6 +106,12 @@ fn kafka_config(
     let default_redpanda_server = default_redpanda_server();
     set_option_if_missing(&mut settings, "bootstrap.servers", &default_redpanda_server);
 
+    // We link with openssl statically, which means that the default OPENSSLDIR location
+    // baked into openssl is not correct (see https://github.com/fede1024/rust-rdkafka/issues/594).
+    // We set the ssl.ca.location to "probe" so that librdkafka can find the CA certificates in a
+    // standard location (e.g., /etc/ssl/).
+    set_option_if_missing(&mut settings, "ssl.ca.location", "probe");
+
     let mut config = ClientConfig::new();
     for (key, value) in settings {
         config.set(String::from(key), resolve_secret(value)?);

--- a/crates/feldera-types/src/transport/kafka.rs
+++ b/crates/feldera-types/src/transport/kafka.rs
@@ -173,6 +173,12 @@ impl KafkaInputConfig {
         self.set_option_if_missing("group.id", &group_id);
         self.set_option_if_missing("enable.partition.eof", "false");
 
+        // We link with openssl statically, which means that the default OPENSSLDIR location
+        // baked into openssl is not correct (see https://github.com/fede1024/rust-rdkafka/issues/594).
+        // We set the ssl.ca.location to "probe" so that librdkafka can find the CA certificates in a
+        // standard location (e.g., /etc/ssl/).
+        self.set_option_if_missing("ssl.ca.location", "probe");
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fix a regression introduced in #3811.

We now link with openssl statically, which means that the default OPENSSLDIR location baked into openssl is not correct (see https://github.com/fede1024/rust-rdkafka/issues/594). We set `ssl.ca.location` to "probe" so that librdkafka can find the CA certificates in a standard location by default (e.g., /etc/ssl/).