### PR TITLE
adapters: `/checkpoint` return type is JSON

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -704,7 +704,7 @@ async fn checkpoint(state: WebData<ServerState>) -> impl Responder {
             }
         };
         receiver.await.unwrap()?;
-        Ok(HttpResponse::Ok())
+        Ok(HttpResponse::Ok().json("Checkpoint completed"))
     }
 
     #[cfg(not(feature = "feldera-enterprise"))]


### PR DESCRIPTION
Return type is now JSON for both success and failure.
This fixes the checkpoint test in the `pipeline-manager`.