### PR TITLE
[dbsp] Handle Path::advance_to_first_ge breaking invariant without error.

### DIFF
--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -471,13 +471,8 @@ where
     V: DataTrait + ?Sized,
     R: WeightTrait + ?Sized,
 {
-    pub fn new_from(wset: &'s FileIndexedWSet<K, V, R>, lower_bound: usize) -> Self {
-        let key_cursor = wset
-            .file
-            .rows()
-            .subset(lower_bound as u64..)
-            .first()
-            .unwrap();
+    pub fn new(wset: &'s FileIndexedWSet<K, V, R>) -> Self {
+        let key_cursor = wset.file.rows().first().unwrap();
         let mut key = wset.factories.key_factory().default_box();
         unsafe { key_cursor.key(&mut key) };
 
@@ -493,10 +488,6 @@ where
             val,
             diff,
         }
-    }
-
-    pub fn new(wset: &'s FileIndexedWSet<K, V, R>) -> Self {
-        Self::new_from(wset, 0)
     }
 
     fn move_key<F>(&mut self, op: F)


### PR DESCRIPTION
`Path::advance_to_first_get` was documented as breaking the `Path`
invariant if it returned `Err(_)`, and the caller properly handled that.
However, it could also break the invariant if it returned `Ok(false)`,
which the caller did not properly handle.  This fixes the problem.

Fixes: https://github.com/feldera/feldera/issues/3876