### PR TITLE
[SQL] Remove incorrect warning

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
@@ -191,7 +191,7 @@ public class CompilerMessages {
         return (int)this.messages.stream().filter(m -> m.warning).count();
     }
 
-    public Message getError(int ct) {
+    public Message getMessage(int ct) {
         return this.messages.get(ct);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -160,7 +160,7 @@ public class NegativeParserTests extends BaseSQLTests {
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         Assert.assertEquals(1, messages.exitCode);
         Assert.assertEquals(1, messages.errorCount());
-        CompilerMessages.Message msg = messages.getError(0);
+        CompilerMessages.Message msg = messages.getMessage(0);
         Assert.assertFalse(msg.warning);
         Assert.assertEquals("Non-query expression encountered in illegal context", msg.message);
 
@@ -168,7 +168,7 @@ public class NegativeParserTests extends BaseSQLTests {
         messages = CompilerMain.execute("-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         Assert.assertEquals(1, messages.exitCode);
         Assert.assertEquals(1, messages.errorCount());
-        msg = messages.getError(0);
+        msg = messages.getMessage(0);
         Assert.assertFalse(msg.warning);
         Assert.assertEquals("Object 't' not found", msg.message);
 
@@ -176,7 +176,7 @@ public class NegativeParserTests extends BaseSQLTests {
         messages = CompilerMain.execute("-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         Assert.assertEquals(1, messages.exitCode);
         Assert.assertEquals(1, messages.errorCount());
-        msg = messages.getError(0);
+        msg = messages.getMessage(0);
         Assert.assertFalse(msg.warning);
         TestUtil.assertMessagesContain(messages,
                 "cannot convert GEOMETRY literal to class org.locationtech.jts.geom.Point\n" +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -326,6 +326,17 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     }
 
     @Test
+    public void testUnionWarning() throws SQLException {
+        final String script = "../../demo/packaged/sql/02-sec-ops.sql";
+        CompilerMessages messages = CompilerMain.execute(
+                "-i", "--alltables", "-q", "--ignoreOrder", "-o", BaseSQLTests.TEST_FILE_PATH, script);
+        for (int i = 0; i < messages.warningCount(); i++) {
+            CompilerMessages.Message msg = messages.getMessage(i);
+            Assert.assertNotEquals("Fields reordered", msg.errorType);
+        }
+    }
+
+    @Test
     public void testPackagedDemos() throws SQLException, IOException, InterruptedException {
         final String projectsDirectory = "../../demo/packaged/sql";
         final File dir = new File(projectsDirectory);


### PR DESCRIPTION
We produced a warning for UNION when the field names are permuted.
Turns out that we can produce the warning when the permutation is the identity permutation, and the types are not identical (because they differ in nullability). This case no longer produces a warning.
This used to appear in the sec-ops demo.
