### PR TITLE
Documentation improvements around recursion

### DIFF
--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -188,6 +188,10 @@ name = "tutorial10"
 path = "examples/tutorial/tutorial10.rs"
 
 [[example]]
+name = "tutorial11"
+path = "examples/tutorial/tutorial11.rs"
+
+[[example]]
 name = "coord"
 path = "examples/dist/coord.rs"
 

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -44,7 +44,12 @@ mimalloc-rust-sys = { workspace = true }
 rand = { workspace = true }
 rust_decimal = { package = "feldera_rust_decimal", version = "1.33.1-feldera.1" }
 rkyv = { workspace = true, features = ["std", "size_64", "validation", "uuid"] }
-size-of = { workspace = true, features = ["hashbrown", "xxhash-xxh3", "arcstr", "chrono"] }
+size-of = { workspace = true, features = [
+    "hashbrown",
+    "xxhash-xxh3",
+    "arcstr",
+    "chrono",
+] }
 tarpc = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
@@ -79,7 +84,12 @@ core_affinity = { workspace = true }
 indexmap = { workspace = true }
 feldera-storage = { workspace = true }
 inventory = { workspace = true }
-time = { workspace = true, features = ["formatting", "macros", "serde", "serde-human-readable"] }
+time = { workspace = true, features = [
+    "formatting",
+    "macros",
+    "serde",
+    "serde-human-readable",
+] }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { version = "0.27.1", features = ["uio", "feature", "fs"] }
@@ -172,6 +182,10 @@ path = "examples/tutorial/tutorial8.rs"
 [[example]]
 name = "tutorial9"
 path = "examples/tutorial/tutorial9.rs"
+
+[[example]]
+name = "tutorial10"
+path = "examples/tutorial/tutorial10.rs"
 
 [[example]]
 name = "coord"

--- a/crates/dbsp/examples/tutorial/tutorial10.rs
+++ b/crates/dbsp/examples/tutorial/tutorial10.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use dbsp::{
     operator::Generator,
     utils::{Tup3, Tup4},
-    zset, zset_set, Circuit, OrdZSet, RootCircuit, Stream,
+    zset, zset_set, Circuit, OrdZSet, Runtime, Stream,
 };
 
 fn main() -> Result<()> {
@@ -10,104 +10,109 @@ fn main() -> Result<()> {
     // points out, to see a fixed-point computation which does _not_ terminate.
     const STEPS: usize = 2;
 
-    let (circuit_handle, output_handle) = RootCircuit::build(move |root_circuit| {
-        let mut edges_data = ([
-            // The first step adds a graph of four nodes:
-            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
-            zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
-            // The second step removes the edge |1| -1-> |2|.
-            zset! { Tup3(1, 2, 1) => -1 },
-            // The third step would introduce a cycle but that would
-            // cause the fixed-point computation to never terminate because we keep
-            // on finding new paths with a higher cumulative weight and hopcount.
-            // In total, we have the following graph:
-            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
-            //  ^                                   |
-            //  |                                   |
-            //  ------------------3------------------
-            // zset_set! { Tup3(1,2,1), Tup3(4, 0, 3)}
-        ] as [_; STEPS])
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+
+    let (mut circuit_handle, output_handle) = Runtime::init_circuit(
+        threads,
+        move |root_circuit| {
+            let mut edges_data = ([
+                // The first step adds a graph of four nodes:
+                // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+                zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
+                // The second step removes the edge |1| -1-> |2|.
+                zset! { Tup3(1, 2, 1) => -1 },
+                // The third step would introduce a cycle but that would
+                // cause the fixed-point computation to never terminate because we keep
+                // on finding new paths with a higher cumulative weight and hopcount.
+                // In total, we have the following graph:
+                // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+                //  ^                                   |
+                //  |                                   |
+                //  ------------------3------------------
+                // zset_set! { Tup3(1,2,1), Tup3(4, 0, 3)}
+            ] as [_; STEPS])
+                .into_iter();
+
+            let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
+
+            // Create a base stream with all paths of length 1.
+            let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
+
+            let closure = root_circuit.recursive(
+                |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Tup4<usize, usize, usize, usize>>>| {
+                    // Import the `edges` and `len_1` stream from the parent circuit.
+                    let edges = edges.delta0(child_circuit);
+                    let len_1 = len_1.delta0(child_circuit);
+
+                    // Perform an iterative step (n-1 to n) through joining the
+                    // paths of length n-1 with the edges.
+                    let len_n = len_n_minus_1
+                        .map_index(|Tup4(start, end, cum_weight, hopcnt)| {
+                            (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                        })
+                        .join(
+                            &edges
+                                .map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
+                            |_end_from,
+                            Tup4(start, _end, cum_weight, hopcnt),
+                            Tup3(_from, to, weight)| {
+                                Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
+                            },
+                        )
+                        .plus(&len_1);
+
+                    Ok(len_n)
+                },
+            )?;
+
+            Ok(closure.output())
+        },
+    )?;
+
+    let mut expected_outputs = ([
+        // We expect the full transitive closure in the first step.
+        zset! {
+            Tup4(0, 1, 1, 1) => 1,
+            Tup4(0, 2, 2, 2) => 1,
+            Tup4(0, 3, 4, 3) => 1,
+            Tup4(0, 4, 6, 4) => 1,
+            Tup4(1, 2, 1, 1) => 1,
+            Tup4(1, 3, 3, 2) => 1,
+            Tup4(1, 4, 5, 3) => 1,
+            Tup4(2, 3, 2, 1) => 1,
+            Tup4(2, 4, 4, 2) => 1,
+            Tup4(3, 4, 2, 1) => 1,
+        },
+        // These paths are removed in the second step.
+        zset! {
+            Tup4(0, 2, 2, 2) => -1,
+            Tup4(0, 3, 4, 3) => -1,
+            Tup4(0, 4, 6, 4) => -1,
+            Tup4(1, 2, 1, 1) => -1,
+            Tup4(1, 3, 3, 2) => -1,
+            Tup4(1, 4, 5, 3) => -1,
+        },
+        // This does not matter, as the computation does not terminate
+        // anymore due to the cycle.
+        // zset! {},
+    ] as [_; STEPS])
         .into_iter();
-
-        let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
-
-        // Create a base stream with all paths of length 1.
-        let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
-
-        let closure = root_circuit.recursive(
-            |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Tup4<usize, usize, usize, usize>>>| {
-                // Import the `edges` and `len_1` stream from the parent circuit.
-                let edges = edges.delta0(child_circuit);
-                let len_1 = len_1.delta0(child_circuit);
-
-                // Perform an iterative step (n-1 to n) through joining the
-                // paths of length n-1 with the edges.
-                let len_n = len_n_minus_1
-                    .map_index(|Tup4(start, end, cum_weight, hopcnt)| {
-                        (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
-                    })
-                    .join(
-                        &edges
-                            .map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
-                        |_end_from,
-                         Tup4(start, _end, cum_weight, hopcnt),
-                         Tup3(_from, to, weight)| {
-                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
-                        },
-                    )
-                    .plus(&len_1);
-
-                Ok(len_n)
-            },
-        )?;
-
-        let mut expected_outputs = ([
-            // We expect the full transitive closure in the first step.
-            zset! {
-                Tup4(0, 1, 1, 1) => 1,
-                Tup4(0, 2, 2, 2) => 1,
-                Tup4(0, 3, 4, 3) => 1,
-                Tup4(0, 4, 6, 4) => 1,
-                Tup4(1, 2, 1, 1) => 1,
-                Tup4(1, 3, 3, 2) => 1,
-                Tup4(1, 4, 5, 3) => 1,
-                Tup4(2, 3, 2, 1) => 1,
-                Tup4(2, 4, 4, 2) => 1,
-                Tup4(3, 4, 2, 1) => 1,
-            },
-            // These paths are removed in the second step.
-            zset! {
-                Tup4(0, 2, 2, 2) => -1,
-                Tup4(0, 3, 4, 3) => -1,
-                Tup4(0, 4, 6, 4) => -1,
-                Tup4(1, 2, 1, 1) => -1,
-                Tup4(1, 3, 3, 2) => -1,
-                Tup4(1, 4, 5, 3) => -1,
-            },
-            // This does not matter, as the computation does not terminate
-            // anymore due to the cycle.
-            // zset! {},
-        ] as [_; STEPS])
-            .into_iter();
-
-        closure.inspect(move |output| {
-            assert_eq!(*output, expected_outputs.next().unwrap());
-        });
-
-        Ok(closure.output())
-    })?;
 
     for i in 0..STEPS {
         let iteration = i + 1;
         println!("Iteration {} starts...", iteration);
         circuit_handle.step()?;
-        output_handle.consolidate().iter().for_each(
-            |(Tup4(start, end, cum_weight, hopcnt), _, z_weight)| {
+        let output = output_handle.consolidate();
+        assert_eq!(output, expected_outputs.next().unwrap());
+        output
+            .iter()
+            .for_each(|(Tup4(start, end, cum_weight, hopcnt), _, z_weight)| {
                 println!(
                     "{start} -> {end} (cum weight: {cum_weight}, hops: {hopcnt}) => {z_weight}"
                 );
-            },
-        );
+            });
         println!("Iteration {} finished.", iteration);
     }
 

--- a/crates/dbsp/examples/tutorial/tutorial10.rs
+++ b/crates/dbsp/examples/tutorial/tutorial10.rs
@@ -1,0 +1,115 @@
+use anyhow::Result;
+use dbsp::{
+    operator::Generator,
+    utils::{Tup3, Tup4},
+    zset, zset_set, Circuit, OrdZSet, RootCircuit, Stream,
+};
+
+fn main() -> Result<()> {
+    // Set this value to 3 and uncomment the data in the arrays the Rust compiler
+    // points out, to see a fixed-point computation which does _not_ terminate.
+    const STEPS: usize = 2;
+
+    let (circuit_handle, output_handle) = RootCircuit::build(move |root_circuit| {
+        let mut edges_data = ([
+            // The first step adds a graph of four nodes:
+            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+            zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
+            // The second step removes the edge |1| -1-> |2|.
+            zset! { Tup3(1, 2, 1) => -1 },
+            // The third step would introduce a cycle but that would
+            // cause the fixed-point computation to never terminate because we keep
+            // on finding new paths with a higher cumulative weight and hopcount.
+            // In total, we have the following graph:
+            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+            //  ^                                   |
+            //  |                                   |
+            //  ------------------3------------------
+            // zset_set! { Tup3(1,2,1), Tup3(4, 0, 3)}
+        ] as [_; STEPS])
+        .into_iter();
+
+        let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
+
+        // Create a base stream with all paths of length 1.
+        let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
+
+        let closure = root_circuit.recursive(
+            |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Tup4<usize, usize, usize, usize>>>| {
+                // Import the `edges` and `len_1` stream from the parent circuit.
+                let edges = edges.delta0(child_circuit);
+                let len_1 = len_1.delta0(child_circuit);
+
+                // Perform an iterative step (n-1 to n) through joining the
+                // paths of length n-1 with the edges.
+                let len_n = len_n_minus_1
+                    .map_index(|Tup4(start, end, cum_weight, hopcnt)| {
+                        (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                    })
+                    .join(
+                        &edges
+                            .map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
+                        |_end_from,
+                         Tup4(start, _end, cum_weight, hopcnt),
+                         Tup3(_from, to, weight)| {
+                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
+                        },
+                    )
+                    .plus(&len_1);
+
+                Ok(len_n)
+            },
+        )?;
+
+        let mut expected_outputs = ([
+            // We expect the full transitive closure in the first clock cycle.
+            zset! {
+                Tup4(0, 1, 1, 1) => 1,
+                Tup4(0, 2, 2, 2) => 1,
+                Tup4(0, 3, 4, 3) => 1,
+                Tup4(0, 4, 6, 4) => 1,
+                Tup4(1, 2, 1, 1) => 1,
+                Tup4(1, 3, 3, 2) => 1,
+                Tup4(1, 4, 5, 3) => 1,
+                Tup4(2, 3, 2, 1) => 1,
+                Tup4(2, 4, 4, 2) => 1,
+                Tup4(3, 4, 2, 1) => 1,
+            },
+            // These paths are removed in the second clock cycle.
+            zset! {
+                Tup4(0, 2, 2, 2) => -1,
+                Tup4(0, 3, 4, 3) => -1,
+                Tup4(0, 4, 6, 4) => -1,
+                Tup4(1, 2, 1, 1) => -1,
+                Tup4(1, 3, 3, 2) => -1,
+                Tup4(1, 4, 5, 3) => -1,
+            },
+            // This does not matter, as the computation does not terminate
+            // anymore due to the cycle.
+            // zset! {},
+        ] as [_; STEPS])
+            .into_iter();
+
+        closure.inspect(move |output| {
+            assert_eq!(*output, expected_outputs.next().unwrap());
+        });
+
+        Ok(closure.output())
+    })?;
+
+    for i in 0..STEPS {
+        let iteration = i + 1;
+        println!("Iteration {} starts...", iteration);
+        circuit_handle.step()?;
+        output_handle.consolidate().iter().for_each(
+            |(Tup4(start, end, cum_weight, hopcnt), _, z_weight)| {
+                println!(
+                    "{start} -> {end} (cum weight: {cum_weight}, hops: {hopcnt}) => {z_weight}"
+                );
+            },
+        );
+        println!("Iteration {} finished.", iteration);
+    }
+
+    Ok(())
+}

--- a/crates/dbsp/examples/tutorial/tutorial10.rs
+++ b/crates/dbsp/examples/tutorial/tutorial10.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
         )?;
 
         let mut expected_outputs = ([
-            // We expect the full transitive closure in the first clock cycle.
+            // We expect the full transitive closure in the first step.
             zset! {
                 Tup4(0, 1, 1, 1) => 1,
                 Tup4(0, 2, 2, 2) => 1,
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
                 Tup4(2, 4, 4, 2) => 1,
                 Tup4(3, 4, 2, 1) => 1,
             },
-            // These paths are removed in the second clock cycle.
+            // These paths are removed in the second step.
             zset! {
                 Tup4(0, 2, 2, 2) => -1,
                 Tup4(0, 3, 4, 3) => -1,

--- a/crates/dbsp/examples/tutorial/tutorial11.rs
+++ b/crates/dbsp/examples/tutorial/tutorial11.rs
@@ -1,0 +1,123 @@
+use anyhow::Result;
+use dbsp::{
+    indexed_zset,
+    operator::{Generator, Min},
+    utils::{Tup2, Tup3, Tup4},
+    zset_set, Circuit, NestedCircuit, OrdIndexedZSet, RootCircuit, Stream,
+};
+
+type Accumulator =
+    Stream<NestedCircuit, OrdIndexedZSet<Tup2<usize, usize>, Tup4<usize, usize, usize, usize>>>;
+
+fn main() -> Result<()> {
+    const STEPS: usize = 2;
+
+    let (circuit_handle, output_handle) = RootCircuit::build(move |root_circuit| {
+        let mut edges_data = ([
+            // The first step adds a graph of four nodes, just like before:
+            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+            zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
+            // The second step introduces a cycle. Due to the code changes below,
+            // the query does terminate though. In total, the graph now looks
+            // like this:
+            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+            //  ^                                   |
+            //  |                                   |
+            //  ------------------3------------------
+            zset_set! { Tup3(4, 0, 3)}
+        ] as [_; STEPS])
+        .into_iter();
+
+        let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
+
+        // Create a base stream with all paths of length 1.
+        let len_1 = edges
+            .map_index(|Tup3(from, to, weight)| (Tup2(*from, *to), Tup4(*from, *to, *weight, 1)));
+
+        let closure = root_circuit.recursive(|child_circuit, len_n_minus_1: Accumulator| {
+            // Import the `edges` and `len_1` stream from the parent circuit.
+            let edges = edges.delta0(child_circuit);
+            let len_1 = len_1.delta0(child_circuit);
+
+            // Perform an iterative step (n-1 to n) through joining the
+            // paths of length n-1 with the edges.
+            let len_n = len_n_minus_1
+                .map_index(
+                    |(Tup2(_start, _end), Tup4(start, end, cum_weight, hopcnt))| {
+                        (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                    },
+                )
+                .join_index(
+                    &edges.map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
+                    |_end_from, Tup4(start, _end, cum_weight, hopcnt), Tup3(_from, to, weight)| {
+                        Some((
+                            Tup2(*start, *to),
+                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1),
+                        ))
+                    },
+                )
+                .plus(&len_1)
+                .aggregate(Min);
+
+            Ok(len_n)
+        })?;
+
+        let mut expected_outputs = ([
+            // The transitive closure in the first step remains the same as in
+            // `tutorial10.rs`.
+            indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
+                Tup2(0, 1) => { Tup4(0, 1, 1, 1) => 1 },
+                Tup2(0, 2) => { Tup4(0, 2, 2, 2) => 1 },
+                Tup2(0, 3) => { Tup4(0, 3, 4, 3) => 1 },
+                Tup2(0, 4) => { Tup4(0, 4, 6, 4) => 1 },
+                Tup2(1, 2) => { Tup4(1, 2, 1, 1) => 1 },
+                Tup2(1, 3) => { Tup4(1, 3, 3, 2) => 1 },
+                Tup2(1, 4) => { Tup4(1, 4, 5, 3) => 1 },
+                Tup2(2, 3) => { Tup4(2, 3, 2, 1) => 1 },
+                Tup2(2, 4) => { Tup4(2, 4, 4, 2) => 1 },
+                Tup2(3, 4) => { Tup4(3, 4, 2, 1) => 1 },
+            },
+            // The second step's introduction of a cycle yields these new paths.
+            indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
+                Tup2(0, 0) => { Tup4(0, 0, 9, 5) => 1 },
+                Tup2(1, 0) => { Tup4(1, 0, 8, 4) => 1 },
+                Tup2(1, 1) => { Tup4(1, 1, 9, 5) => 1 },
+                Tup2(2, 0) => { Tup4(2, 0, 7, 3) => 1 },
+                Tup2(2, 1) => { Tup4(2, 1, 8, 4) => 1 },
+                Tup2(2, 2) => { Tup4(2, 2, 9, 5) => 1 },
+                Tup2(3, 0) => { Tup4(3, 0, 5, 2) => 1 },
+                Tup2(3, 1) => { Tup4(3, 1, 6, 3) => 1 },
+                Tup2(3, 2) => { Tup4(3, 2, 7, 4) => 1 },
+                Tup2(3, 3) => { Tup4(3, 3, 9, 5) => 1 },
+                Tup2(4, 0) => { Tup4(4, 0, 3, 1) => 1 },
+                Tup2(4, 1) => { Tup4(4, 1, 4, 2) => 1 },
+                Tup2(4, 2) => { Tup4(4, 2, 5, 3) => 1 },
+                Tup2(4, 3) => { Tup4(4, 3, 7, 4) => 1 },
+                Tup2(4, 4) => { Tup4(4, 4, 9, 5) => 1 },
+            },
+        ] as [_; STEPS])
+            .into_iter();
+
+        closure.inspect(move |output| {
+            assert_eq!(*output, expected_outputs.next().unwrap());
+        });
+
+        Ok(closure.output())
+    })?;
+
+    for i in 0..STEPS {
+        let iteration = i + 1;
+        println!("Iteration {} starts...", iteration);
+        circuit_handle.step()?;
+        output_handle.consolidate().iter().for_each(
+            |(Tup2(_start, _end), Tup4(start, end, cum_weight, hopcnt), z_weight)| {
+                println!(
+                    "{start} -> {end} (cum weight: {cum_weight}, hops: {hopcnt}) => {z_weight}"
+                );
+            },
+        );
+        println!("Iteration {} finished.", iteration);
+    }
+
+    Ok(())
+}

--- a/crates/dbsp/examples/tutorial/tutorial11.rs
+++ b/crates/dbsp/examples/tutorial/tutorial11.rs
@@ -3,7 +3,7 @@ use dbsp::{
     indexed_zset,
     operator::{Generator, Min},
     utils::{Tup2, Tup3, Tup4},
-    zset_set, Circuit, NestedCircuit, OrdIndexedZSet, RootCircuit, Stream,
+    zset_set, Circuit, NestedCircuit, OrdIndexedZSet, Runtime, Stream,
 };
 
 type Accumulator =
@@ -12,104 +12,113 @@ type Accumulator =
 fn main() -> Result<()> {
     const STEPS: usize = 2;
 
-    let (circuit_handle, output_handle) = RootCircuit::build(move |root_circuit| {
-        let mut edges_data = ([
-            // The first step adds a graph of four nodes, just like before:
-            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
-            zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
-            // The second step introduces a cycle. Due to the code changes below,
-            // the query does terminate though. In total, the graph now looks
-            // like this:
-            // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
-            //  ^                                   |
-            //  |                                   |
-            //  ------------------3------------------
-            zset_set! { Tup3(4, 0, 3)}
-        ] as [_; STEPS])
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+
+    let (mut circuit_handle, output_handle) = Runtime::init_circuit(
+        threads,
+        move |root_circuit| {
+            let mut edges_data = ([
+                // The first step adds a graph of four nodes, just like before:
+                // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+                zset_set! { Tup3(0_usize, 1_usize, 1_usize), Tup3(1, 2, 1), Tup3(2, 3, 2), Tup3(3, 4, 2) },
+                // The second step introduces a cycle. Due to the code changes below,
+                // the query does terminate though. In total, the graph now looks
+                // like this:
+                // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
+                //  ^                                   |
+                //  |                                   |
+                //  ------------------3------------------
+                zset_set! { Tup3(4, 0, 3)}
+            ] as [_; STEPS])
+                .into_iter();
+
+            let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
+
+            // Create a base stream with all paths of length 1.
+            let len_1 = edges.map_index(|Tup3(from, to, weight)| {
+                (Tup2(*from, *to), Tup4(*from, *to, *weight, 1))
+            });
+
+            let closure = root_circuit.recursive(|child_circuit, len_n_minus_1: Accumulator| {
+                // Import the `edges` and `len_1` stream from the parent circuit.
+                let edges = edges.delta0(child_circuit);
+                let len_1 = len_1.delta0(child_circuit);
+
+                // Perform an iterative step (n-1 to n) through joining the
+                // paths of length n-1 with the edges.
+                let len_n = len_n_minus_1
+                    .map_index(
+                        |(Tup2(_start, _end), Tup4(start, end, cum_weight, hopcnt))| {
+                            (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                        },
+                    )
+                    .join_index(
+                        &edges
+                            .map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
+                        |_end_from,
+                         Tup4(start, _end, cum_weight, hopcnt),
+                         Tup3(_from, to, weight)| {
+                            Some((
+                                Tup2(*start, *to),
+                                Tup4(*start, *to, cum_weight + weight, hopcnt + 1),
+                            ))
+                        },
+                    )
+                    .plus(&len_1)
+                    .aggregate(Min);
+
+                Ok(len_n)
+            })?;
+
+            Ok(closure.output())
+        },
+    )?;
+
+    let mut expected_outputs = ([
+        // The transitive closure in the first step remains the same as in
+        // `tutorial10.rs`.
+        indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
+            Tup2(0, 1) => { Tup4(0, 1, 1, 1) => 1 },
+            Tup2(0, 2) => { Tup4(0, 2, 2, 2) => 1 },
+            Tup2(0, 3) => { Tup4(0, 3, 4, 3) => 1 },
+            Tup2(0, 4) => { Tup4(0, 4, 6, 4) => 1 },
+            Tup2(1, 2) => { Tup4(1, 2, 1, 1) => 1 },
+            Tup2(1, 3) => { Tup4(1, 3, 3, 2) => 1 },
+            Tup2(1, 4) => { Tup4(1, 4, 5, 3) => 1 },
+            Tup2(2, 3) => { Tup4(2, 3, 2, 1) => 1 },
+            Tup2(2, 4) => { Tup4(2, 4, 4, 2) => 1 },
+            Tup2(3, 4) => { Tup4(3, 4, 2, 1) => 1 },
+        },
+        // The second step's introduction of a cycle yields these new paths.
+        indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
+            Tup2(0, 0) => { Tup4(0, 0, 9, 5) => 1 },
+            Tup2(1, 0) => { Tup4(1, 0, 8, 4) => 1 },
+            Tup2(1, 1) => { Tup4(1, 1, 9, 5) => 1 },
+            Tup2(2, 0) => { Tup4(2, 0, 7, 3) => 1 },
+            Tup2(2, 1) => { Tup4(2, 1, 8, 4) => 1 },
+            Tup2(2, 2) => { Tup4(2, 2, 9, 5) => 1 },
+            Tup2(3, 0) => { Tup4(3, 0, 5, 2) => 1 },
+            Tup2(3, 1) => { Tup4(3, 1, 6, 3) => 1 },
+            Tup2(3, 2) => { Tup4(3, 2, 7, 4) => 1 },
+            Tup2(3, 3) => { Tup4(3, 3, 9, 5) => 1 },
+            Tup2(4, 0) => { Tup4(4, 0, 3, 1) => 1 },
+            Tup2(4, 1) => { Tup4(4, 1, 4, 2) => 1 },
+            Tup2(4, 2) => { Tup4(4, 2, 5, 3) => 1 },
+            Tup2(4, 3) => { Tup4(4, 3, 7, 4) => 1 },
+            Tup2(4, 4) => { Tup4(4, 4, 9, 5) => 1 },
+        },
+    ] as [_; STEPS])
         .into_iter();
-
-        let edges = root_circuit.add_source(Generator::new(move || edges_data.next().unwrap()));
-
-        // Create a base stream with all paths of length 1.
-        let len_1 = edges
-            .map_index(|Tup3(from, to, weight)| (Tup2(*from, *to), Tup4(*from, *to, *weight, 1)));
-
-        let closure = root_circuit.recursive(|child_circuit, len_n_minus_1: Accumulator| {
-            // Import the `edges` and `len_1` stream from the parent circuit.
-            let edges = edges.delta0(child_circuit);
-            let len_1 = len_1.delta0(child_circuit);
-
-            // Perform an iterative step (n-1 to n) through joining the
-            // paths of length n-1 with the edges.
-            let len_n = len_n_minus_1
-                .map_index(
-                    |(Tup2(_start, _end), Tup4(start, end, cum_weight, hopcnt))| {
-                        (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
-                    },
-                )
-                .join_index(
-                    &edges.map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
-                    |_end_from, Tup4(start, _end, cum_weight, hopcnt), Tup3(_from, to, weight)| {
-                        Some((
-                            Tup2(*start, *to),
-                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1),
-                        ))
-                    },
-                )
-                .plus(&len_1)
-                .aggregate(Min);
-
-            Ok(len_n)
-        })?;
-
-        let mut expected_outputs = ([
-            // The transitive closure in the first step remains the same as in
-            // `tutorial10.rs`.
-            indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
-                Tup2(0, 1) => { Tup4(0, 1, 1, 1) => 1 },
-                Tup2(0, 2) => { Tup4(0, 2, 2, 2) => 1 },
-                Tup2(0, 3) => { Tup4(0, 3, 4, 3) => 1 },
-                Tup2(0, 4) => { Tup4(0, 4, 6, 4) => 1 },
-                Tup2(1, 2) => { Tup4(1, 2, 1, 1) => 1 },
-                Tup2(1, 3) => { Tup4(1, 3, 3, 2) => 1 },
-                Tup2(1, 4) => { Tup4(1, 4, 5, 3) => 1 },
-                Tup2(2, 3) => { Tup4(2, 3, 2, 1) => 1 },
-                Tup2(2, 4) => { Tup4(2, 4, 4, 2) => 1 },
-                Tup2(3, 4) => { Tup4(3, 4, 2, 1) => 1 },
-            },
-            // The second step's introduction of a cycle yields these new paths.
-            indexed_zset! { Tup2<usize, usize> => Tup4<usize, usize, usize, usize>:
-                Tup2(0, 0) => { Tup4(0, 0, 9, 5) => 1 },
-                Tup2(1, 0) => { Tup4(1, 0, 8, 4) => 1 },
-                Tup2(1, 1) => { Tup4(1, 1, 9, 5) => 1 },
-                Tup2(2, 0) => { Tup4(2, 0, 7, 3) => 1 },
-                Tup2(2, 1) => { Tup4(2, 1, 8, 4) => 1 },
-                Tup2(2, 2) => { Tup4(2, 2, 9, 5) => 1 },
-                Tup2(3, 0) => { Tup4(3, 0, 5, 2) => 1 },
-                Tup2(3, 1) => { Tup4(3, 1, 6, 3) => 1 },
-                Tup2(3, 2) => { Tup4(3, 2, 7, 4) => 1 },
-                Tup2(3, 3) => { Tup4(3, 3, 9, 5) => 1 },
-                Tup2(4, 0) => { Tup4(4, 0, 3, 1) => 1 },
-                Tup2(4, 1) => { Tup4(4, 1, 4, 2) => 1 },
-                Tup2(4, 2) => { Tup4(4, 2, 5, 3) => 1 },
-                Tup2(4, 3) => { Tup4(4, 3, 7, 4) => 1 },
-                Tup2(4, 4) => { Tup4(4, 4, 9, 5) => 1 },
-            },
-        ] as [_; STEPS])
-            .into_iter();
-
-        closure.inspect(move |output| {
-            assert_eq!(*output, expected_outputs.next().unwrap());
-        });
-
-        Ok(closure.output())
-    })?;
 
     for i in 0..STEPS {
         let iteration = i + 1;
         println!("Iteration {} starts...", iteration);
         circuit_handle.step()?;
-        output_handle.consolidate().iter().for_each(
+        let output = output_handle.consolidate();
+        assert_eq!(output, expected_outputs.next().unwrap());
+        output.iter().for_each(
             |(Tup2(_start, _end), Tup4(start, end, cum_weight, hopcnt), z_weight)| {
                 println!(
                     "{start} -> {end} (cum weight: {cum_weight}, hops: {hopcnt}) => {z_weight}"

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -2105,9 +2105,10 @@ pub trait Circuit: WithClock + Clone + 'static {
     /// use dbsp::{
     ///     operator::{Generator, Z1},
     ///     Circuit, RootCircuit,
+    ///     Error as DbspError,
     /// };
     ///
-    /// let circuit = RootCircuit::build(|circuit| {
+    /// let (circuit_handle, _output_handle) = RootCircuit::build(|circuit| {
     ///     // Generate sequence 0, 1, 2, ...
     ///     let mut n: usize = 0;
     ///     let source = circuit.add_source(Generator::new(move || {
@@ -2136,7 +2137,13 @@ pub trait Circuit: WithClock + Clone + 'static {
     ///         .unwrap();
     ///     fact.inspect(|n| eprintln!("Output: {}", n));
     ///     Ok(())
-    /// });
+    /// })?;
+    ///
+    /// for i in 0..3 {
+    ///     circuit_handle.step()?;
+    /// }
+    ///
+    /// Ok::<(), DbspError>(())
     /// ```
     fn iterate<F, C, T>(&self, constructor: F) -> Result<T, SchedulerError>
     where

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -2098,14 +2098,10 @@
 //! }
 //! ```
 //!
-//! Finally, we point out that introducing a cycle to the graph prevents
-//! this fixed-point computation to stop terminating because then
-//! there is no fixed-point anymore. So pay attention to your data and
-//! your queries, if using more powerful (but somewhat more dangerous) iterative
-//! queries.
-//!
+//! We point out that introducing a cycle to the graph prevents this fixed-point
+//! computation from terminating because then there is no fixed-point anymore.
 //! To demonstrate this, we introduce a third step which feeds back in the
-//! previously removed edge `|1| -1-> |2|` and additionally introduces
+//! previously removed edge `|1| -1-> |2|` and, additionally, introduces
 //! the edge `|4| -3-> |0|`, forming a cyclic graph. In total,
 //! we obtain the following graph:
 //!
@@ -2240,8 +2236,6 @@
 //! recursive queries with aggregates are not guaranteed to converge to the
 //! optimum of the aggregation function (here, the minimum function),
 //! even though there exists a finite solution.
-//! If the problem at hand is not _monotonic_, the computed fixed-point may
-//! not be the optimal solution to the aggregation function.
 //!
 //! # Next steps
 //!


### PR DESCRIPTION
Hi 👋

As I've recently said on Discord, I have found some areas where the documentation around recursion/iteration could be improved, while digging into these topics for my Master's thesis. Here's what I've changed:

1. The `Circuit::iterate` code example panicked if executed (which it wasn't previously upon doc tests).
2. The `ChildCircuit<P>::recursive()` code example is a bit more friendly towards copying and then playing around with (using arrays instead of `Vec`s leads to compile time checks if the lengths of the inputs and expected outputs don't match anymore).
3. I added a tutorial dedicated to fixed-point computations by showing how to compute a transitive closure. I suspect this is a problem readers may be familiar with.

Hope you find it helpful!

What I would be interested in beyond this: How would you resolve the issue mentioned in the new tutorial about not dealing with a fixed point in case of cyclic graphs. For instance, is there a way to exclude "columns" (here the cumulated weight and hop count) from the consideration of what a fixed-point entails? Or is there a way to keep track of discovered paths and then abort the search if a new path is just an extension of a previously discovered path, through e.g. DBSP's support of iteration with arbitrary conditions?