### PR TITLE
[adapters] Support for internal backfill. 

### DIFF
--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -292,7 +292,7 @@ inputs:
     let schema = schema.to_vec();
 
     Controller::with_config(
-        move |workers| Ok(test_circuit::<T>(workers, &schema)),
+        move |workers| Ok(test_circuit::<T>(workers, &schema, None)),
         &config,
         Box::new(move |e| panic!("delta_table_input_test: error: {e}")),
     )
@@ -359,7 +359,7 @@ outputs:
     let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
 
     Controller::with_config(
-        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema())),
+        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema(), None)),
         &config,
         Box::new(move |e| panic!("delta_to_delta pipeline: error: {e}")),
     )
@@ -403,7 +403,7 @@ inputs:
     let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
 
     Controller::with_config(
-        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema())),
+        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema(), None)),
         &config,
         Box::new(move |e| panic!("delta_read pipeline: error: {e}")),
     )
@@ -463,7 +463,7 @@ outputs:
     let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
 
     Controller::with_config(
-        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema())),
+        |workers| Ok(test_circuit::<T>(workers, &DeltaTestStruct::schema(), None)),
         &config,
         Box::new(move |e| panic!("delta_write pipeline: error: {e}")),
     )
@@ -557,6 +557,7 @@ outputs:
             Ok(test_circuit::<DeltaTestStruct>(
                 workers,
                 &DeltaTestStruct::schema(),
+                None,
             ))
         },
         &config,

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -1232,7 +1232,13 @@ outputs:
         thread::spawn(move || {
             bootstrap(
                 args,
-                Box::new(|workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema()))),
+                Box::new(|workers| {
+                    Ok(test_circuit::<TestStruct>(
+                        workers,
+                        &TestStruct::schema(),
+                        None,
+                    ))
+                }),
                 state_clone,
                 std::sync::mpsc::channel().0,
             )

--- a/crates/adapters/src/test/iceberg.rs
+++ b/crates/adapters/src/test/iceberg.rs
@@ -141,7 +141,7 @@ inputs:
     let (err_sender, err_receiver) = crossbeam::channel::unbounded();
 
     let controller = Controller::with_config(
-        move |workers| Ok(test_circuit::<T>(workers, &schema)),
+        move |workers| Ok(test_circuit::<T>(workers, &schema, None)),
         &config,
         Box::new(move |e| {
             let msg = format!("iceberg_input_test: error: {e}");

--- a/crates/adapters/src/test/kafka.rs
+++ b/crates/adapters/src/test/kafka.rs
@@ -6,6 +6,7 @@ use crate::test::{wait, MockDeZSet, MockUpdate, TestStruct, DEFAULT_TIMEOUT_MS};
 use crate::InputBuffer;
 use anyhow::{anyhow, bail, Result as AnyResult};
 use csv::WriterBuilder as CsvWriterBuilder;
+use dbsp::circuit::NodeId;
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::kafka::default_redpanda_server;
 use futures::executor::block_on;
@@ -279,7 +280,7 @@ impl BufferConsumer {
         let mut parser = format
             .new_parser(
                 "BaseConsumer",
-                &InputCollectionHandle::new(schema, buffer.clone()),
+                &InputCollectionHandle::new(schema, buffer.clone(), NodeId::new(0)),
                 &serde_yaml::from_str::<serde_yaml::Value>(format_config_yaml).unwrap(),
             )
             .unwrap();

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -95,7 +95,13 @@ outputs:
     let config: PipelineConfig = serde_yaml::from_str(config_str).unwrap();
 
     match Controller::with_config(
-        |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
+        |workers| {
+            Ok(test_circuit::<TestStruct>(
+                workers,
+                &TestStruct::schema(),
+                None,
+            ))
+        },
         &config,
         Box::new(|e| panic!("error: {e}")),
     ) {
@@ -912,7 +918,13 @@ outputs:
         // Start pipeline.
         println!("start pipeline");
         let controller = Controller::with_config(
-            |circuit_config| Ok(test_circuit::<TestStruct>(circuit_config, &[])),
+            |circuit_config| {
+                Ok(test_circuit::<TestStruct>(
+                    circuit_config,
+                    &[],
+                    Some("output"),
+                ))
+            },
             &config,
             Box::new(|e| panic!("error: {e}")),
         )
@@ -1344,7 +1356,7 @@ outputs:
     let test_name_clone = test_name.to_string();
 
     let controller = Controller::with_config(
-        |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
+        |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema(), None)),
         &config,
         Box::new(move |e| if running_clone.load(Ordering::Acquire) {
             panic!("{test_name_clone}: error: {e}")
@@ -1580,7 +1592,7 @@ outputs:
     let running_clone = running.clone();
 
     let controller = Controller::with_config(
-        |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
+        |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema(), None)),
         &config,
         Box::new(move |e| if running_clone.load(Ordering::Acquire) {
             panic!("buffer_test: error: {e}")

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -253,7 +253,13 @@ outputs:
         let config: PipelineConfig = serde_yaml::from_str(config_str).unwrap();
 
         match Controller::with_config(
-            |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema())),
+            |workers| {
+                Ok(test_circuit::<TestStruct>(
+                    workers,
+                    &TestStruct::schema(),
+                    None,
+                ))
+            },
             &config,
             Box::new(|e| panic!("error: {e}")),
         ) {

--- a/crates/adapters/src/transport/redis/test.rs
+++ b/crates/adapters/src/transport/redis/test.rs
@@ -179,7 +179,7 @@ outputs:
     let (err_sender, err_receiver) = crossbeam::channel::unbounded();
 
     let controller = Controller::with_config(
-        move |workers| Ok(test_circuit::<DeltaTestStruct>(workers, &schema)),
+        move |workers| Ok(test_circuit::<DeltaTestStruct>(workers, &schema, None)),
         &config,
         Box::new(move |e| {
             let msg = format!("redis_output_test: error: {e}");
@@ -302,7 +302,7 @@ outputs:
     let schema = schema.to_vec();
 
     let Err(err) = Controller::with_config(
-        move |workers| Ok(test_circuit::<TestStruct>(workers, &schema)),
+        move |workers| Ok(test_circuit::<TestStruct>(workers, &schema, None)),
         &config,
         Box::new(move |e| {
             let msg = format!("redis_output_test: error: {e}");

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -885,7 +885,6 @@ impl DBSPHandle {
     fn send_complete_bootstrap(&mut self) -> Result<(), DbspError> {
         self.broadcast_command(Command::CompleteBootstrap, |_, _| {})?;
 
-        info!("Boostrap complete");
         self.bootstrap_info = None;
 
         Ok(())

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ViewMetadata.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/ViewMetadata.java
@@ -48,8 +48,7 @@ public class ViewMetadata implements IJson {
         return Linq.any(this.columns, m -> m.lateness != null);
     }
 
-    @Override
-    public void asJson(ToJsonInnerVisitor visitor) {
+    public void asJson(ToJsonInnerVisitor visitor, boolean ignoreProperties) {
         JsonStream stream = visitor.stream;
         stream.beginObject();
         stream.label("viewName");
@@ -63,11 +62,18 @@ public class ViewMetadata implements IJson {
         stream.endArray();
         stream.label("recursive").append(this.recursive);
         stream.label("system").append(this.system);
-        if (this.properties != null) {
-            stream.label("properties");
-            this.properties.asJson(visitor);
+        if (!ignoreProperties) {
+            if (this.properties != null) {
+                stream.label("properties");
+                this.properties.asJson(visitor);
+            }
         }
         stream.endObject();
+    }
+
+    @Override
+    public void asJson(ToJsonInnerVisitor visitor) {
+        this.asJson(visitor, false);
     }
 
     public static ViewMetadata fromJson(JsonNode node, JsonDecoder decoder) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -94,7 +94,7 @@
         "final": 1
       },
       "positions": [],
-      "persistent_id": "ab7ba64d3de62f8105f8d9ad92b71271274bc6e04fd17c459ce7bec4ddcb869f"
+      "persistent_id": "85d3be099bcdebe0526badcd00e9b67c6d0af371016b1b4c6772a67ff289cb03"
     }, "s3": {
       "operation": "map_index",
       "inputs": [
@@ -109,7 +109,7 @@
           }]
       },
       "positions": [],
-      "persistent_id": "1e7ec9af3140a9c03cd72189f54e5173d8e2898db245947ec5fe63fcd57f01d0"
+      "persistent_id": "564bce2aa69c19f2c72a9739b54898f669e961acebc6a739296519670ee08012"
     }, "s4": {
       "operation": "differentiate",
       "inputs": [
@@ -119,7 +119,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "7ff9e7087aac79f5694df3b30ca0f417f387862e78c97c518bf5d8919d04f2a4"
+      "persistent_id": "0fb4f4ccd7857006ccde731281b17f8f041272f88846c9625eb06ac75eabc875"
     }, "s5": {
       "operation": "aggregate_linear_postprocess",
       "inputs": [
@@ -131,7 +131,7 @@
       "positions": [
         {"start_line_number":2,"start_column":25,"end_line_number":2,"end_column":33}
       ],
-      "persistent_id": "acf4333e87c8a9c0ee6a52dbc14b59ade23dcf57589c01056a35a23bea4bbe28"
+      "persistent_id": "44e8c67f70555fe6a6cc21c9bce08e4ebc1571922e5cc1aea2e5bffc94e61efb"
     }, "s6": {
       "operation": "map",
       "inputs": [
@@ -141,7 +141,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "1411be44836dd4fa829a3ced8abd64b9137bf43e65350ec03053f67e04396437"
+      "persistent_id": "18046d5db41026ba848803c10d01b4a880c90b6f2c4bf78f09f8625df546d1a6"
     }, "s7": {
       "operation": "map",
       "inputs": [
@@ -151,7 +151,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "d5cdd7219fb8d20e372821140e915df906b5759012c73961d68235a11493b48d"
+      "persistent_id": "83f54c1df95bf906dcd1e3f743997065c71b42a5ae136adbccfb5dda3fe2647f"
     }, "s8": {
       "operation": "neg",
       "inputs": [
@@ -161,7 +161,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "a9a52124256e347f4fe90ccaa7ea975b84999d408c32107b6694816fa19db793"
+      "persistent_id": "2583f1e67204ec6dd948a315585ad61215e973e76930ac9b7def12487ada639d"
     }, "s9": {
       "operation": "integrate",
       "inputs": [
@@ -171,7 +171,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "43585b3a8427060c16490f77964e3ec7606469004ea00f59b2769b584c498211"
+      "persistent_id": "d631f1b7e91a62665bd4a7dae792e86082989852027cfa24b8a962fc49978ca6"
     }, "s10": {
       "operation": "integrate",
       "inputs": [
@@ -181,7 +181,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "6bb9b96f3d58ee381084d28fd16d09e183ce304bcd6f2d6695bc9129f861c9f9"
+      "persistent_id": "8a251e911c21e32064a5dd44d6b2b98156882a82fc69e9287d024024e7e209c4"
     }, "s11": {
       "operation": "sum",
       "inputs": [
@@ -193,7 +193,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "d838e77e8e11928839dec855d5a03330e556d13b0e9e8a901af8259ffd5bab1c"
+      "persistent_id": "7d2b8751188ddf7ac2221c0829f64b3f4a04b60761ee61d85ac9e14c5283130a"
     }, "s12": {
       "operation": "inspect",
       "inputs": [
@@ -203,7 +203,7 @@
         "final": 3
       },
       "positions": [],
-      "persistent_id": "6ade4797370fb9bb7fcfd441733a88e0f5cd6b64815a3c0e0dce0aee3ef839d0"
+      "persistent_id": "5f774924e3fb4db3291f347d0ac93a66ab954794a3865306f5cec7691718faa8"
     }, "s13": {
       "operation": "inspect",
       "inputs": [

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
@@ -289,7 +289,7 @@
           "final": 2
         },
         "positions": [],
-        "persistent_id": "f760e73e7ed394ea9ce4a311c3b97958ab15a13bb2f360a259e45f6984ff7ac5"
+        "persistent_id": "1e2457b8fe4b330049c5987e07bca2651eff848afac67f6f115c21ab079c7b3f"
       },
       "s4": {
         "operation": "flat_map_index",
@@ -308,7 +308,7 @@
           {"start_line_number":1,"start_column":1,"end_line_number":1,"end_column":50},
           {"start_line_number":20,"start_column":27,"end_line_number":20,"end_column":37}
         ],
-        "persistent_id": "c1c5233542d6daeb994aa33dcf954af8a5df15c2e5879b4d9e52a64c557fa144"
+        "persistent_id": "e792295a71de546b843e15787e0f6ffa8c368c20ee4cc6a090e14822c5fa642b"
       },
       "s5": {
         "operation": "flat_map_index",
@@ -330,7 +330,7 @@
           {"start_line_number":19,"start_column":17,"end_line_number":19,"end_column":26},
           {"start_line_number":20,"start_column":11,"end_line_number":20,"end_column":21}
         ],
-        "persistent_id": "83809e87c5f3080f95a60dccd59210486fabab0d0cff6f6212bd628a8281bda4"
+        "persistent_id": "1763ad26d5bfc9ec3fcb9e6441bfcaa8abeaa719e0e84864d5a0139a9905df5d"
       },
       "s6": {
         "operation": "delta0",
@@ -369,7 +369,7 @@
           {"start_line_number":16,"start_column":9,"end_line_number":16,"end_column":33},
           {"start_line_number":15,"start_column":9,"end_line_number":15,"end_column":18}
         ],
-        "persistent_id": "87e06cf7a2cafb547f1832b80cda3a373d93a74ba60797ea2ef78d4d1cd24b68"
+        "persistent_id": "101eaea4beb94e1643bb0442df1c72cf5418ac33dfa65d055f6a86a28fc652ed"
       },
       "s9": {
         "operation": "sum",
@@ -381,7 +381,7 @@
           "final": 8
         },
         "positions": [],
-        "persistent_id": "662552a13949639939a6cb7b9a34e1b99a5e106f65544446cd3bda636f517f27"
+        "persistent_id": "852714b86adb94788b54ff1ff19142fc974a771ab4e103006b9332c78d8f987f"
       }
     }, "s10": {
       "operation": "inspect",
@@ -392,7 +392,7 @@
         "final": 8
       },
       "positions": [],
-      "persistent_id": "79e9e16c49264531840e6128f9bb18cb9633098f56199c923c7083a93508fe57"
+      "persistent_id": "52cfeb75247c4ca459ccb2e1e33496ec57d9854b0a45e45f5462877a12477080"
     }, "s11": {
       "operation": "inspect",
       "inputs": [


### PR DESCRIPTION
- Add bootstrap_in_progress pipeline state, which is a substate of RUNNING.
  Some API endpoints are disabled in this state: checkpoint, suspend, add input endpoint.
- Disable FT journal while bootstrapping; reenable it on the first checkpoint after bootstrapping.
- Disable input connectors during bootstrapping.
- Add `_persistent` versions of `register_XXX` catalog operators, which attach a persistent label to the output stream.

@blp , can you look at the changes in `controller/mod.rs` wrt how the new changes interact with FT. 

@mihaibudiu , this needs changes to the SQL compiler. All `register_input_` and `register_output_` methods now have `_persistent` variants, which is the unique label attached to the output operator. We should only use these variants in the generated SQL code.