### PR TITLE
[SQL] Do not report an internal compiler error for exceptions that derive from BaseCompilerException

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -458,7 +458,12 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
             } catch (CalciteException e) {
                 this.messages.reportError(e);
                 this.rethrow(e);
-            } catch (Throwable e) {
+            } catch (BaseCompilerException e) {
+                this.messages.reportError(e);
+                this.rethrow(new RuntimeException(e));
+                parsed.clear();
+            }
+            catch (Throwable e) {
                 this.messages.reportError(e);
                 this.rethrow(new RuntimeException(e));
                 parsed.clear();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -690,10 +690,16 @@ public class IncrementalRegressionTests extends SqlIoTest {
         Assert.assertEquals(2, calls[0]);
     }
 
+    @Test
+    public void illegalDecimalTest() {
+        this.statementsFailingInCompilation("""
+                CREATE TABLE T(c DECIMAL(38, 18));""",
+                "Maximum precision supported for DECIMAL");
+    }
+
     // Tests that are not in the repository
     @Test @Ignore
     public void extraTests() throws IOException {
-        Logger.INSTANCE.setLoggingLevel(DBSPCompiler.class, 2);
         String dir = "../extra";
         File file = new File(dir);
         if (file.exists()) {


### PR DESCRIPTION
Fixes a bug reported on Slack