### PR TITLE
[SQL] Implement (partially) `FIRST_VALUE` and `LAST_VALUE` window aggregation functions

### DIFF
--- a/crates/sqllib/src/operators.rs
+++ b/crates/sqllib/src/operators.rs
@@ -3,6 +3,7 @@ use std::ops::{Add, Div, Mul, Sub};
 use dbsp::algebra::{HasZero, F32, F64};
 use num::PrimInt;
 use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ToPrimitive};
+use std::cmp::Ordering;
 
 use crate::{for_all_int_operator, some_existing_operator, some_operator};
 
@@ -96,6 +97,52 @@ where
 }
 
 for_all_compare!(neq, bool, T where Eq);
+
+#[doc(hidden)]
+pub fn compareN<T>(
+    left: &Option<T>,
+    right: &Option<T>,
+    ascending: bool,
+    nullsFirst: bool,
+) -> std::cmp::Ordering
+where
+    T: Ord,
+{
+    if nullsFirst {
+        match (left, right) {
+            (&None, &None) => Ordering::Equal,
+            (&None, _) => Ordering::Less,
+            (_, &None) => Ordering::Greater,
+            (Some(left), Some(right)) => compare_(left, right, ascending, nullsFirst),
+        }
+    } else {
+        match (left, right) {
+            (&None, &None) => Ordering::Equal,
+            (&None, _) => Ordering::Greater,
+            (_, &None) => Ordering::Less,
+            (Some(left), Some(right)) => compare_(left, right, ascending, nullsFirst),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn compare_<T>(
+    left: &T,
+    right: &T,
+    ascending: bool,
+    // There can be no nulls
+    _nullsFirst: bool,
+) -> std::cmp::Ordering
+where
+    T: Ord,
+{
+    let result = left.cmp(right);
+    if ascending {
+        result
+    } else {
+        result.reverse()
+    }
+}
 
 #[doc(hidden)]
 #[inline(always)]
@@ -499,6 +546,7 @@ where
 for_all_compare!(min, T, Ord + Clone);
 */
 
+#[doc(hidden)]
 pub fn blackbox<T>(value: T) -> T {
     value
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -640,6 +640,8 @@ public class ToJsonInnerVisitor extends InnerVisitor {
     public void postorder(DBSPFieldComparatorExpression node) {
         this.property("ascending");
         this.stream.append(node.ascending);
+        this.property("nullsFirst");
+        this.stream.append(node.nullsFirst);
         this.property("fieldNo");
         this.stream.append(node.fieldNo);
         super.postorder(node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler.backend.dot;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperatorBase;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
@@ -217,6 +218,34 @@ public class ToDotNodesVisitor extends CircuitVisitor {
                     .append("(")
                     .append(this.getFunction(node))
                     .append(")\\l");
+        }
+        this.stream.append("\" ]")
+                .newline();
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPIndexedTopKOperator node) {
+        this.stream.append(node.getNodeName(false))
+                .append(" [ shape=box")
+                .append(this.getColor(node))
+                .append(" label=\"")
+                .append(node.getIdString())
+                .append(isMultiset(node))
+                .append(annotations(node))
+                .append(" ")
+                .append(shorten(node.operation))
+                .append(node.comment != null ? node.comment : "");
+        if (this.details > 3) {
+            this.stream
+                    .append("(")
+                    .append(this.getFunction(node));
+            if (node.outputProducer != null) {
+                this.stream
+                        .append(", ")
+                        .append(this.convertFunction(node.outputProducer));
+            }
+            this.stream.append(")\\l");
         }
         this.stream.append("\" ]")
                 .newline();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/MultiCrates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/MultiCrates.java
@@ -18,7 +18,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.IDBSPNode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
@@ -115,7 +115,7 @@ public class MultiCrates {
             super(compiler);
         }
 
-        public VisitDecision preorder(DBSPTypeComparator type) {
+        public VisitDecision preorder(DBSPComparatorType type) {
             this.found = true;
             return VisitDecision.STOP;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -217,7 +217,8 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
     public void postorder(DBSPFieldComparatorExpression node) {
         DBSPExpression source = this.getE(node.source);
         this.map(node, new DBSPFieldComparatorExpression(
-                node.getNode(), source.to(DBSPComparatorExpression.class), node.fieldNo, node.ascending));
+                node.getNode(), source.to(DBSPComparatorExpression.class),
+                node.fieldNo, node.ascending, node.nullsFirst));
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -10,56 +10,12 @@ import org.dbsp.sqlCompiler.ir.DBSPParameter;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.aggregate.LinearAggregate;
 import org.dbsp.sqlCompiler.ir.aggregate.NonLinearAggregate;
-import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPApplyMethodExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPAssignmentExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPBorrowExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPCloneExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPComparatorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPConditionalAggregateExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPConstructorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPCustomOrdExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPDerefExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPCustomOrdField;
-import org.dbsp.sqlCompiler.ir.expression.DBSPDirectComparatorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPEnumValue;
-import org.dbsp.sqlCompiler.ir.expression.DBSPEqualityComparatorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPFieldComparatorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPFieldExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPFlatmap;
-import org.dbsp.sqlCompiler.ir.expression.DBSPForExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPIsNullExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPLazyCellExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPLetExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPNoComparatorExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPQualifyTypeExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPQuestionExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPReturnExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPSomeExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPSortExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPStaticExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedUnwrapExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedWrapExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnwrapCustomOrdExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPUnwrapExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
-import org.dbsp.sqlCompiler.ir.expression.DBSPWindowBoundExpression;
+import org.dbsp.sqlCompiler.ir.expression.*;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBinaryLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDateLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDecimalLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPGeoPointConstructor;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI128Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI16Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
@@ -68,7 +24,6 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPISizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMonthsLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPKeywordLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPNullLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPRealLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
@@ -80,10 +35,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU16Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPVariantExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
-import org.dbsp.sqlCompiler.ir.expression.DBSPArrayExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
 import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
@@ -101,7 +53,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeRuntimeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeBTreeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRef;
@@ -431,7 +383,7 @@ public abstract class InnerRewriteVisitor
     }
 
     @Override
-    public VisitDecision preorder(DBSPTypeComparator type) {
+    public VisitDecision preorder(DBSPComparatorType type) {
         this.map(type, type);
         return VisitDecision.STOP;
     }
@@ -965,7 +917,7 @@ public abstract class InnerRewriteVisitor
         this.pop(expression);
         DBSPExpression result = new DBSPFieldComparatorExpression(
                     expression.getNode(), source.to(DBSPComparatorExpression.class),
-                    expression.fieldNo, expression.ascending);
+                    expression.fieldNo, expression.ascending, expression.nullsFirst);
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -117,7 +117,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUuid;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeBTreeMap;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeLazy;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
@@ -466,7 +466,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPTypeUser) node);
     }
 
-    public VisitDecision preorder(DBSPTypeComparator node) {
+    public VisitDecision preorder(DBSPComparatorType node) {
         return this.preorder((DBSPTypeUser) node);
     }
 
@@ -1082,7 +1082,7 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         this.postorder((DBSPTypeUser) node);
     }
 
-    public void postorder(DBSPTypeComparator node) {
+    public void postorder(DBSPComparatorType node) {
         this.postorder((DBSPTypeUser) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/NonMonotoneType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/NonMonotoneType.java
@@ -10,7 +10,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRef;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWithCustomOrd;
@@ -33,7 +33,7 @@ public class NonMonotoneType extends ScalarMonotoneType {
     public static IMaybeMonotoneType nonMonotone(DBSPType type) {
         if (type.is(DBSPTypeBaseType.class) || type.is(DBSPTypeArray.class) ||
                 type.is(DBSPTypeMap.class) || type.is(DBSPTypeAny.class) ||
-                type.is(DBSPTypeComparator.class) || (type.is(DBSPTypeFunction.class)) ||
+                type.is(DBSPComparatorType.class) || (type.is(DBSPTypeFunction.class)) ||
                 type.is(DBSPTypeWithCustomOrd.class)) {
             return new NonMonotoneType(type);
         } else if (type.is(DBSPTypeTupleBase.class)) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitRewriter.java
@@ -243,9 +243,7 @@ public class CircuitRewriter extends CircuitCloneVisitor {
     @Override
     public void postorder(DBSPIndexedTopKOperator operator) {
         DBSPExpression function = this.transform(operator.getFunction());
-        @Nullable DBSPClosureExpression outputProducer = null;
-        if (operator.outputProducer != null)
-            outputProducer = this.transform(operator.outputProducer)
+        DBSPClosureExpression outputProducer = this.transform(operator.outputProducer)
                     .to(DBSPClosureExpression.class);
         DBSPExpression limit = this.transform(operator.limit);
         DBSPEqualityComparatorExpression equalityComparator =

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPComparatorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPComparatorExpression.java
@@ -23,16 +23,15 @@
 
 package org.dbsp.sqlCompiler.ir.expression;
 
-import org.dbsp.sqlCompiler.compiler.backend.MerkleInner;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 
 /** A base class representing a comparator used for sorting. */
 public abstract class DBSPComparatorExpression extends DBSPExpression {
-    protected DBSPComparatorExpression(CalciteObject node, DBSPTypeComparator type) {
+    protected DBSPComparatorExpression(CalciteObject node, DBSPComparatorType type) {
         super(node, type);
     }
 
@@ -45,18 +44,22 @@ public abstract class DBSPComparatorExpression extends DBSPExpression {
         visitor.postorder(this);
     }
 
-    public DBSPTypeComparator getComparatorType() {
-        return this.type.to(DBSPTypeComparator.class);
+    public DBSPComparatorType getComparatorType() {
+        return this.type.to(DBSPComparatorType.class);
     }
 
     /** Type of value that is being compared. */
     public abstract DBSPType comparedValueType();
 
+    public DBSPComparatorExpression field(int index, boolean ascending, boolean nullsFirst) {
+        return new DBSPFieldComparatorExpression(this.getNode(), this, index, ascending, nullsFirst);
+    }
+
     public DBSPComparatorExpression field(int index, boolean ascending) {
-        return new DBSPFieldComparatorExpression(this.getNode(), this, index, ascending);
+        return new DBSPFieldComparatorExpression(this.getNode(), this, index, ascending, true);
     }
 
     public String getComparatorStructName() {
-        return this.type.to(DBSPTypeComparator.class).name;
+        return this.type.to(DBSPComparatorType.class).name;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCustomOrdExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCustomOrdExpression.java
@@ -7,7 +7,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWithCustomOrd;
 import org.dbsp.util.IIndentStream;
 
@@ -21,7 +21,7 @@ public final class DBSPCustomOrdExpression extends DBSPExpression {
             CalciteObject node, DBSPExpression source,
             DBSPExpression comparator) {
         super(node, new DBSPTypeWithCustomOrd(
-                node, source.getType(), comparator.getType().to(DBSPTypeComparator.class)));
+                node, source.getType(), comparator.getType().to(DBSPComparatorType.class)));
         this.source = source;
         this.comparator = comparator;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPDirectComparatorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPDirectComparatorExpression.java
@@ -8,7 +8,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
@@ -20,7 +20,7 @@ public final class DBSPDirectComparatorExpression extends DBSPComparatorExpressi
 
     public DBSPDirectComparatorExpression(
             CalciteObject node, DBSPComparatorExpression source, boolean ascending) {
-        super(node, DBSPTypeComparator.generateType(source.getComparatorType(), ascending));
+        super(node, DBSPComparatorType.generateType(source.getComparatorType(), ascending));
         this.source = source;
         this.ascending = ascending;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldComparatorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldComparatorExpression.java
@@ -31,7 +31,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
@@ -41,13 +41,18 @@ import org.dbsp.util.Utilities;
 public final class DBSPFieldComparatorExpression extends DBSPComparatorExpression {
     public final DBSPComparatorExpression source;
     public final boolean ascending;
+    /** This is considered after ascending */
+    public final boolean nullsFirst;
     public final int fieldNo;
 
-    public DBSPFieldComparatorExpression(CalciteObject node, DBSPComparatorExpression source, int fieldNo, boolean ascending) {
-        super(node, DBSPTypeComparator.generateType(source.getComparatorType(), fieldNo, ascending));
+    public DBSPFieldComparatorExpression(
+            CalciteObject node, DBSPComparatorExpression source, int fieldNo,
+            boolean ascending, boolean nullsFirst) {
+        super(node, DBSPComparatorType.generateType(source.getComparatorType(), fieldNo, ascending, nullsFirst));
         this.source = source;
         this.fieldNo = fieldNo;
         this.ascending = ascending;
+        this.nullsFirst = nullsFirst;
     }
 
     @Override
@@ -72,7 +77,8 @@ public final class DBSPFieldComparatorExpression extends DBSPComparatorExpressio
             return false;
         return this.source == o.source &&
                 this.ascending == o.ascending &&
-                this.fieldNo == o.fieldNo;
+                this.fieldNo == o.fieldNo &&
+                this.nullsFirst == o.nullsFirst;
     }
 
     @Override
@@ -88,7 +94,7 @@ public final class DBSPFieldComparatorExpression extends DBSPComparatorExpressio
     @Override
     public DBSPExpression deepCopy() {
         return this.source.deepCopy().to(DBSPComparatorExpression.class)
-                .field(this.fieldNo, this.ascending);
+                .field(this.fieldNo, this.ascending, this.nullsFirst);
     }
 
     @Override
@@ -98,6 +104,7 @@ public final class DBSPFieldComparatorExpression extends DBSPComparatorExpressio
             return false;
         return this.ascending == otherExpression.ascending &&
                 this.fieldNo == otherExpression.fieldNo &&
+                this.nullsFirst == otherExpression.nullsFirst &&
                 this.source.equivalent(context, otherExpression.source);
     }
 
@@ -106,6 +113,7 @@ public final class DBSPFieldComparatorExpression extends DBSPComparatorExpressio
         DBSPComparatorExpression source = fromJsonInner(node, "source", decoder, DBSPComparatorExpression.class);
         int fieldNo = Utilities.getIntProperty(node, "fieldNo");
         boolean ascending = Utilities.getBooleanProperty(node, "ascending");
-        return new DBSPFieldComparatorExpression(CalciteObject.EMPTY, source, fieldNo, ascending);
+        boolean nullsFirst = Utilities.getBooleanProperty(node, "nullsFirst");
+        return new DBSPFieldComparatorExpression(CalciteObject.EMPTY, source, fieldNo, ascending, nullsFirst);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPNoComparatorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPNoComparatorExpression.java
@@ -31,7 +31,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
-import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeComparator;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPComparatorType;
 import org.dbsp.util.IIndentStream;
 
 /** A comparator that does not compare any fields. */
@@ -39,7 +39,7 @@ public final class DBSPNoComparatorExpression extends DBSPComparatorExpression {
     public final DBSPType tupleType;
 
     public DBSPNoComparatorExpression(CalciteObject node, DBSPType tupleType) {
-        super(node, DBSPTypeComparator.generateType(tupleType));
+        super(node, DBSPComparatorType.generateType(tupleType));
         this.tupleType = tupleType;
     }
 
@@ -50,7 +50,10 @@ public final class DBSPNoComparatorExpression extends DBSPComparatorExpression {
 
     @Override
     public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
-        return other.is(DBSPNoComparatorExpression.class);
+        if (!other.is(DBSPNoComparatorExpression.class))
+            return false;
+        DBSPNoComparatorExpression otherComparator = other.to(DBSPNoComparatorExpression.class);
+        return this.tupleType.sameType(otherComparator.tupleType);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPComparatorType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPComparatorType.java
@@ -10,12 +10,10 @@ import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.util.Utilities;
 
-import java.util.List;
-
-/** The type of a comparator.  In Rust it's just a struct,
+/** The type of a comparator.  In Rust, it's just a struct,
  * but which implements a CmpFun trait. */
-public class DBSPTypeComparator extends DBSPTypeUser {
-    DBSPTypeComparator(String name) {
+public class DBSPComparatorType extends DBSPTypeUser {
+    DBSPComparatorType(String name) {
         super(CalciteObject.EMPTY, DBSPTypeCode.COMPARATOR, name, false);
     }
 
@@ -26,31 +24,31 @@ public class DBSPTypeComparator extends DBSPTypeUser {
         return MerkleInner.hash(tuple.toString()).makeIdentifier("CMP");
     }
 
-    public static DBSPTypeComparator
+    public static DBSPComparatorType
     generateType(DBSPType tuple) {
-        return new DBSPTypeComparator(generateName(tuple));
+        return new DBSPComparatorType(generateName(tuple));
     }
 
     /** The name of a comparator that compares an extra field in addition to
      * another comparator.  This is the name of a
      * {@link org.dbsp.sqlCompiler.ir.expression.DBSPFieldComparatorExpression}. */
     static String generateName(
-            DBSPTypeComparator comparator,
-            int field, boolean ascending) {
-        return MerkleInner.hash(comparator.name + "." + field + " " + ascending)
+            DBSPComparatorType comparator,
+            int field, boolean ascending, boolean nullsFirst) {
+        return MerkleInner.hash(comparator.name + "." + field + " " + ascending + " " + nullsFirst)
                 .makeIdentifier("CMP");
     }
 
-    public static DBSPTypeComparator
-    generateType(DBSPTypeComparator type, int field, boolean ascending) {
-        return new DBSPTypeComparator(generateName(type, field, ascending));
+    public static DBSPComparatorType
+    generateType(DBSPComparatorType type, int field, boolean ascending, boolean nullsFirst) {
+        return new DBSPComparatorType(generateName(type, field, ascending, nullsFirst));
     }
 
     /** The name of a comparator that compares an extra field in addition to
      * another comparator.  This is the name of a
      * {@link org.dbsp.sqlCompiler.ir.expression.DBSPDirectComparatorExpression}. */
     static String generateName(
-            DBSPTypeComparator comparator,
+            DBSPComparatorType comparator,
             boolean ascending) {
         return MerkleInner.hash(comparator.name + " " + ascending)
                 .makeIdentifier("CMP");
@@ -65,15 +63,15 @@ public class DBSPTypeComparator extends DBSPTypeUser {
         visitor.postorder(this);
     }
 
-    public static DBSPTypeComparator
-    generateType(DBSPTypeComparator type, boolean ascending) {
-        return new DBSPTypeComparator(generateName(type, ascending));
+    public static DBSPComparatorType
+    generateType(DBSPComparatorType type, boolean ascending) {
+        return new DBSPComparatorType(generateName(type, ascending));
     }
 
     @SuppressWarnings("unused")
-    public static DBSPTypeComparator fromJson(JsonNode node, JsonDecoder decoder) {
+    public static DBSPComparatorType fromJson(JsonNode node, JsonDecoder decoder) {
         String name = Utilities.getStringProperty(node, "name");
         DBSPTypeCode code = DBSPTypeCode.valueOf(Utilities.getStringProperty(node, "code"));
-        return new DBSPTypeComparator(name);
+        return new DBSPComparatorType(name);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeWithCustomOrd.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeWithCustomOrd.java
@@ -27,8 +27,8 @@ public class DBSPTypeWithCustomOrd extends DBSPTypeUser {
     }
 
     /** The type of the data that is wrapped.  Always a tuple type */
-    public DBSPTypeComparator getComparatorType() {
-        return this.typeArgs[1].to(DBSPTypeComparator.class);
+    public DBSPComparatorType getComparatorType() {
+        return this.typeArgs[1].to(DBSPComparatorType.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/CalciteJdbcTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/CalciteJdbcTests.java
@@ -1,0 +1,45 @@
+package org.dbsp.sqlCompiler.compiler.sql.quidem;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/** Not based on quidem tests, but on JdbcTest */
+public class CalciteJdbcTests extends HrBaseTests {
+    @Test @Ignore("FIRST_VALUE only supported with unbounded range")
+    public void testWinAggFirstValue() {
+        this.qs("""
+                 select deptno, empid, commission,
+                 first_value(commission) over (partition by deptno order by empid) as r
+                 from emps;
+                  deptno | empid | commission | R
+                 ---------------------------------
+                  10    | 100   | 1000       | 1000
+                  10    | 110   | 250        | 1000
+                  10    | 150   | null       | 1000
+                  20    | 200   | 500        | 500
+                 (4 rows)
+                 
+                 select  deptno, empid, commission,
+                 first_value(commission) over (partition by deptno order by empid desc) as r
+                 from emps;
+                  deptno | empid | commission | R
+                 ---------------------------------
+                  10     | 100   | 1000       | NULL
+                  10     | 110   | 250        | NULL
+                  10     | 150   | NULL       | NULL
+                  20     | 200   | 500        | 500
+                 (4 rows)
+                 
+                 select deptno, empid, commission,
+                 first_value(commission) over
+                 (partition by deptno order by empid desc range between 1000 preceding and 999 preceding) as r
+                 from emps;
+                  deptno | empid | commission | R
+                 -----------------------------------
+                  10     | 100   | 1000       | NULL
+                  10     | 110   | 250        | NULL
+                  10     | 150   | null       | NULL
+                  20     | 200   | 500        | NULL
+                 (4 rows)""");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HRWinAggTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/HRWinAggTests.java
@@ -35,11 +35,11 @@ public class HRWinAggTests extends HrBaseTests {
                 select a."empid", a."deptno", a."commission", a.r as ar, b.r as br
                 from (
                   select "empid", "deptno", "commission", first_value("empid") over w as r
-                  from "hr"."emps"
+                  from "emps"
                   window w as (partition by "deptno" order by "commission")) a
                 join (
                   select "empid", "deptno", "commission", last_value("empid") over w as r
-                  from "hr"."emps"
+                  from "emps"
                   window w as (partition by "deptno" order by "commission")) b
                 on a."empid" = b."empid"
                 limit 5;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/RedshiftTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/RedshiftTests.java
@@ -6,9 +6,26 @@ import org.junit.Test;
 // https://github.com/apache/calcite/blob/main/babel/src/test/resources/sql/redshift.iq
 public class RedshiftTests extends ScottBaseTests {
     @Test
+    public void testFirstValue() {
+        this.qs("""
+                select empno, first_value(sal) over (order by empno range between unbounded preceding and unbounded following)
+                from emp where deptno = 30 order by 1;
+                EMPNO | EXPR$1
+                ---------------
+                7499 | 1600.00
+                7521 | 1600.00
+                7654 | 1600.00
+                7698 | 1600.00
+                7844 | 1600.00
+                7900 | 1600.00
+                (6 rows)""");
+    }
+
+    @Test
     public void testLag() {
         this.qs("""
-                select empno, lag(sal) respect nulls over (order by empno) from emp where deptno = 30 order by 1;
+                select empno, lag(sal) respect nulls over (order by empno)
+                from emp where deptno = 30 order by 1;
                 EMPNO | EXPR$1
                 -------------
                 7499 | null
@@ -19,7 +36,8 @@ public class RedshiftTests extends ScottBaseTests {
                 7900 | 1500.00
                 (6 rows)
 
-                select empno, lag(sal, 2) respect nulls over (order by empno) from emp where deptno = 30 order by 1;
+                select empno, lag(sal, 2) respect nulls over (order by empno)
+                from emp where deptno = 30 order by 1;
                 EMPNO | EXPR$1
                 -------------
                 7499 | null

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SubQueryTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SubQueryTests.java
@@ -1,0 +1,165 @@
+package org.dbsp.sqlCompiler.compiler.sql.quidem;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SubQueryTests extends ScottBaseTests {
+    @Test
+    public void testOrderByLimit() {
+        // Validated using MySQL
+        this.qs("""
+                SELECT comm AS comm
+                FROM EMP where 30 = EMP.deptno
+                ORDER BY comm limit 1;
+                +------------+
+                | comm       |
+                +------------+
+                |            |
+                +------------+
+                (1 rows)
+                
+                SELECT comm AS comm
+                FROM EMP where 30 = EMP.deptno
+                ORDER BY comm desc limit 1;
+                +------------+
+                | comm       |
+                +------------+
+                | 1400       |
+                +------------+
+                (1 rows)""");
+    }
+
+    @Test
+    public void firstValueTests() {
+        // All these produce calls to FIRST_VALUE from the expansion
+        // Modified and tested on MySQL, since Calcite treats NULLs differently.
+        this.qs("""
+                SELECT dname FROM DEPT WHERE 2000 > (SELECT EMP.sal FROM EMP where
+                DEPT.deptno = EMP.deptno ORDER BY year(hiredate), EMP.sal limit 1);
+                +----------+
+                | DNAME    |
+                +----------+
+                | RESEARCH |
+                | SALES    |
+                +----------+
+                (2 rows)
+                
+                SELECT dname
+                FROM DEPT
+                WHERE 2000 > (SELECT EMP.sal
+                              FROM EMP where DEPT.deptno = EMP.deptno and mgr > 8000
+                              ORDER BY year(hiredate), EMP.sal limit 1);
+                +-------+
+                | DNAME |
+                +-------+
+                +-------+
+                (0 rows)
+                
+                SELECT dname,
+                     (SELECT EMP.comm
+                      FROM EMP where DEPT.deptno = EMP.deptno
+                      ORDER BY EMP.comm desc limit 1)
+                FROM DEPT;
+                +------------+--------+
+                | DNAME      | EXPR$1 |
+                +------------+--------+
+                | ACCOUNTING |        |
+                | OPERATIONS |        |
+                | RESEARCH   |        |
+                | SALES      | 1400   |
+                +------------+--------+
+                (4 rows)
+                
+                SELECT dname,
+                    (SELECT EMP.sal
+                     FROM EMP where DEPT.deptno = EMP.deptno
+                     ORDER BY year(hiredate), EMP.sal limit 1)
+                FROM DEPT;
+                +------------+---------+
+                | DNAME      | EXPR$1  |
+                +------------+---------+
+                | ACCOUNTING | 2450.00 |
+                | OPERATIONS |         |
+                | RESEARCH   |  800.00 |
+                | SALES      |  950.00 |
+                +------------+---------+
+                (4 rows)
+                
+                SELECT dname,
+                   (SELECT EMP.sal
+                    FROM EMP where DEPT.deptno = EMP.deptno and mgr > 8000
+                    ORDER BY year(hiredate), EMP.sal limit 1)
+                FROM DEPT;
+                +------------+--------+
+                | DNAME      | EXPR$1 |
+                +------------+--------+
+                | ACCOUNTING |        |
+                | OPERATIONS |        |
+                | RESEARCH   |        |
+                | SALES      |        |
+                +------------+--------+
+                (4 rows)""");
+    }
+
+    @Test @Ignore("Cannot be decorrelated")
+    public void testFirst1() {
+        this.qs("""
+                select sal from EMP e
+                where mod(cast(rand() as int), 2) = 3 OR 123 IN (
+                    select cast(null as int)
+                    from DEPT d
+                    where d.deptno = e.deptno);
+                 SAL
+                -----
+                (0 rows)
+                
+                select sal from EMP e
+                where 123 NOT IN (
+                    select cast(null as int)
+                    from DEPT d
+                    where e.deptno=d.deptno);
+                 SAL
+                -----
+                (0 rows)
+                
+                select sal from EMP e
+                where 10 NOT IN (
+                    select deptno
+                    from DEPT d
+                    where e.deptno=d.deptno);
+                 SAL
+                ---------
+                 1100.00
+                 1250.00
+                 1250.00
+                 1500.00
+                 1600.00
+                 2850.00
+                 2975.00
+                 3000.00
+                 3000.00
+                  800.00
+                  950.00
+                (11 rows)
+                
+                select sal from EMP e
+                where 10 NOT IN (
+                    select case when true then deptno else null end
+                    from DEPT d
+                    where e.deptno=d.deptno);
+                 SAL
+                ---------
+                 1100.00
+                 1250.00
+                 1250.00
+                 1500.00
+                 1600.00
+                 2850.00
+                 2975.00
+                 3000.00
+                 3000.00
+                  800.00
+                  950.00
+                (11 rows)""");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/WinAggPostTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/WinAggPostTests.java
@@ -200,73 +200,54 @@ public class WinAggPostTests extends PostBaseTests {
                 (9 rows)""");
     }
 
-    @Test @Ignore("First_value aggregate")
+    @Test
     public void test2() {
+        // These tests are non-deterministic in SQL; they are
+        // deterministic in our implementation, but they give a different result
+        // than other SQL dialects.
+        // Here the sorting is implicit on ename, deptno, gender
         this.qs("""
                 select *, first_value(deptno) over () from emp;
                  ename | deptno | gender | first_value
                 -------+--------+--------+-------------
-                 Jane  |     10 | F      |          10
-                 Bob   |     10 | M      |          10
-                 Eric  |     20 | M      |          10
-                 Susan |     30 | F      |          10
-                 Alice |     30 | F      |          10
-                 Adam  |     50 | M      |          10
-                 Eve   |     50 | F      |          10
-                 Grace |     60 | F      |          10
-                (8 rows)
-
+                 Jane  |     10 | F|                50
+                 Bob   |     10 | M|                50
+                 Eric  |     20 | M|                50
+                 Susan |     30 | F|                50
+                 Alice |     30 | F|                50
+                 Adam  |     50 | M|                50
+                 Eve   |     50 | F|                50
+                 Grace |     60 | F|                50
+                 Wilma |        | F|                50
+                (9 rows)""");
+        this.qs("""
                 select *, first_value(ename) over () from emp;
                  ename | deptno | gender | first_value
                 -------+--------+--------+-------------
-                 Jane  |     10 | F      | Jane
-                 Bob   |     10 | M      | Jane
-                 Eric  |     20 | M      | Jane
-                 Susan |     30 | F      | Jane
-                 Alice |     30 | F      | Jane
-                 Adam  |     50 | M      | Jane
-                 Eve   |     50 | F      | Jane
-                 Grace |     60 | F      | Jane
-                (8 rows)
+                 Jane  |     10 | F| Adam
+                 Bob   |     10 | M| Adam
+                 Eric  |     20 | M| Adam
+                 Susan |     30 | F| Adam
+                 Alice |     30 | F| Adam
+                 Adam  |     50 | M| Adam
+                 Eve   |     50 | F| Adam
+                 Grace |     60 | F| Adam
+                 Wilma |        | F| Adam
+                (9 rows)
 
                 select *, first_value(ename) over (partition by deptno) from emp;
                  ename | deptno | gender | first_value
                 -------+--------+--------+-------------
-                 Jane  |     10 | F      | Jane
-                 Bob   |     10 | M      | Jane
-                 Eric  |     20 | M      | Eric
-                 Susan |     30 | F      | Susan
-                 Alice |     30 | F      | Susan
-                 Adam  |     50 | M      | Adam
-                 Eve   |     50 | F      | Adam
-                 Grace |     60 | F      | Grace
-                (8 rows)
-
-                select *, first_value(ename) over (partition by deptno range current row) from emp;
-                 ename | deptno | gender | first_value
-                -------+--------+--------+-------------
-                 Jane  |     10 | F      | Jane
-                 Bob   |     10 | M      | Jane
-                 Eric  |     20 | M      | Eric
-                 Susan |     30 | F      | Susan
-                 Alice |     30 | F      | Susan
-                 Adam  |     50 | M      | Adam
-                 Eve   |     50 | F      | Adam
-                 Grace |     60 | F      | Grace
-                (8 rows)
-
-                select *, first_value(ename) over (partition by deptno range unbounded preceding) from emp;
-                 ename | deptno | gender | first_value
-                -------+--------+--------+-------------
-                 Jane  |     10 | F      | Jane
-                 Bob   |     10 | M      | Jane
-                 Eric  |     20 | M      | Eric
-                 Susan |     30 | F      | Susan
-                 Alice |     30 | F      | Susan
-                 Adam  |     50 | M      | Adam
-                 Eve   |     50 | F      | Adam
-                 Grace |     60 | F      | Grace
-                (8 rows)""");
+                 Jane  |     10 | F| Bob
+                 Bob   |     10 | M| Bob
+                 Eric  |     20 | M| Eric
+                 Susan |     30 | F| Alice
+                 Alice |     30 | F| Alice
+                 Adam  |     50 | M| Adam
+                 Eve   |     50 | F| Adam
+                 Grace |     60 | F| Grace
+                 Wilma |        | F| Wilma
+                (9 rows)""");
     }
 
     @Test
@@ -499,19 +480,20 @@ public class WinAggPostTests extends PostBaseTests {
 
     @Test
     public void testWindows1() {
+        // Adjusted and validated using MySQL
         this.qs("""
                 select *, count(*) over (order by deptno) as c from emp;
                  ENAME | DEPTNO | GENDER | C
                 -------+--------+--------+---
-                 Jane  |     10 | F| 2
-                 Bob   |     10 | M| 2
-                 Eric  |     20 | M| 3
-                 Susan |     30 | F| 5
-                 Alice |     30 | F| 5
-                 Adam  |     50 | M| 7
-                 Eve   |     50 | F| 7
-                 Grace |     60 | F| 8
-                 Wilma |        | F| 9
+                 Jane  |     10 | F| 3
+                 Bob   |     10 | M| 3
+                 Eric  |     20 | M| 4
+                 Susan |     30 | F| 6
+                 Alice |     30 | F| 6
+                 Adam  |     50 | M| 8
+                 Eve   |     50 | F| 8
+                 Grace |     60 | F| 9
+                 Wilma |        | F| 1
                 (9 rows)""");
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -232,7 +232,6 @@ public class EndToEndTests extends BaseSQLTests {
         this.testQuery(query, new DBSPZSetExpression(t, t));
     }
 
-
     @Test
     public void overAvgTest() {
         String query = "SELECT T.COL1, AVG(T.COL6) OVER (ORDER BY T.COL1 RANGE UNBOUNDED PRECEDING) FROM T";

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -11,7 +11,6 @@ import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
-import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
@@ -695,6 +694,32 @@ public class IncrementalRegressionTests extends SqlIoTest {
         this.statementsFailingInCompilation("""
                 CREATE TABLE T(c DECIMAL(38, 18));""",
                 "Maximum precision supported for DECIMAL");
+    }
+
+    @Test @Ignore("https://issues.apache.org/jira/browse/CALCITE-6978")
+    public void calciteIssue6978() {
+        String sql = """
+                CREATE TABLE T(x DECIMAL(6, 2), z INT);
+                CREATE TABLE S(y INT);
+                CREATE VIEW V AS SELECT
+                   y,
+                   coalesce((select sum(X) from T
+                             where y = T.z limit 1), 0) as w
+                FROM S;""";
+        this.getCCS(sql);
+    }
+
+    @Test
+    public void issue3918() {
+        String sql = """
+                CREATE TABLE T(x DECIMAL(6, 2), z INT);
+                CREATE TABLE S(y INT);
+                CREATE VIEW V AS SELECT
+                   y,
+                   (select sum(X) from T
+                             where y = T.z limit 1) as w
+                FROM S;""";
+        this.getCCS(sql);
     }
 
     // Tests that are not in the repository


### PR DESCRIPTION
We support `FIRST_VALUE` and `LAST_VALUE` only if they are used with an `UNLIMITED RANGE`.
This is still useful, because `FIRST_VALUE` is generated by the Calcite decorrelator when decorrelating queries that contain `(ORDER BY ... LIMIT 1)`. This enables us to support such queries.

This partially fixes #3918.

Testing this has uncovered some bugs related to the sorting of `NULL` values and the handling of `NULLS LAST` and `NULLS FIRST`. Some tests were passing although they were incorrect, because they were tested on a system where `NULL`s compare largest. In our SQL dialect `NULL`s compare smallest (conveniently matches Rust, and cannot be easily changed).

We will write more tests for sorting as part of #3922 