### PR TITLE
[sql] Fix persistent id assignment.

### DIFF
--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -135,8 +135,8 @@
 //!
 //! * A fault-tolerant input endpoint divides input into steps that can be
 //!   replayed repeatedly with the same content, despite crashes.
-//!   [`InputEndpoint::is_fault_tolerant`] reports whether an input endpoint is
-//!   fault tolerant.
+//!   [`InputEndpoint::fault_tolerance`] reports the exact FT level the
+//!   endpoint supports.
 //!
 //! * A fault-tolerant output endpoint divides its output into numbered
 //!   [`Step`]s such that, if a step with a given number is output more than

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -615,6 +615,9 @@ public class ToRustVisitor extends CircuitVisitor {
                     .append(";")
                     .newline();
         }
+
+        this.tagStream(operator);
+
         if (!this.useHandles) {
             this.generateStructHelpers(type, operator.metadata);
             this.generateStructHelpers(keyStructType, operator.metadata);
@@ -653,7 +656,6 @@ public class ToRustVisitor extends CircuitVisitor {
             this.builder.append(");")
                     .newline();
         }
-        this.tagStream(operator);
         return VisitDecision.STOP;
     }
 


### PR DESCRIPTION
The compiler issued dbsp calls in this order:

1. circuit.add_input_map_persistent
2. catalog.register_materialized_input_map
3. operator_355307ae9ebfd547.set_persistent_id

2 and 3 being in the wrong order.  This resulted in the two output
streams created by register_materialized_input_map not getting
persistent ids.