### PR TITLE
[adapters] Make suspend stop the circuit but not shut down the process.

### DIFF
--- a/crates/adapters/src/server/error.rs
+++ b/crates/adapters/src/server/error.rs
@@ -176,6 +176,7 @@ pub enum PipelineError {
         #[serde(skip)]
         df: Option<DataFusionError>,
     },
+    Suspended,
 }
 
 impl From<ControllerError> for PipelineError {
@@ -264,6 +265,9 @@ impl Display for PipelineError {
             Self::AdHocQueryError {error, df: _} => {
                 write!(f, "Error during query processing: {error}.")
             }
+            Self::Suspended => {
+                write!(f, "Operation failed because the pipeline has been suspended.")
+            }
         }
     }
 }
@@ -282,6 +286,7 @@ impl DetailedError for PipelineError {
             Self::ControllerError { error } => error.error_code(),
             Self::HeapProfilerError { .. } => Cow::from("HeapProfilerError"),
             Self::AdHocQueryError { .. } => Cow::from("AdHocQueryError"),
+            Self::Suspended => Cow::from("Suspended"),
         }
     }
 
@@ -311,6 +316,7 @@ impl ResponseError for PipelineError {
             Self::HeapProfilerError { .. } => StatusCode::BAD_REQUEST,
             Self::ControllerError { error } => error.status_code(),
             Self::AdHocQueryError { .. } => StatusCode::BAD_REQUEST,
+            Self::Suspended => StatusCode::SERVICE_UNAVAILABLE,
         }
     }
 

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -924,7 +924,7 @@ async fn suspend(state: WebData<ServerState>) -> Result<impl Responder, Pipeline
         }
     };
     receiver.await.unwrap()?;
-    do_shutdown(state).await
+    Ok(HttpResponse::Ok().json("Pipeline suspended"))
 }
 
 #[get("/shutdown")]


### PR DESCRIPTION
When the pipeline manager triggers a suspend, it would prefer to shut down the process itself, rather than to have the process exit on its own.
