### PR TITLE
adapters: remove configuration from `/stats`

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -21,6 +21,9 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download Test Binaries
         uses: actions/download-artifact@v4
         with:

--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -703,6 +703,11 @@ pub enum ControllerError {
 
     /// Cannot checkpoint or suspend.
     SuspendError(SuspendError),
+
+    /// An unexpected JSON serialized structure was encountered while processing the /stats endpoint.
+    UnexpectedJsonStructure {
+        reason: String,
+    },
 }
 
 impl ResponseError for ControllerError {
@@ -847,6 +852,7 @@ impl DbspDetailedError for ControllerError {
             Self::EnterpriseFeature(_) => Cow::from("EnterpriseFeature"),
             Self::StorageError { .. } => Cow::from("StorageError"),
             Self::SuspendError(_) => Cow::from("SuspendError"),
+            Self::UnexpectedJsonStructure { .. } => Cow::from("UnexpectedJsonStructure"),
         }
     }
 }
@@ -981,6 +987,9 @@ impl Display for ControllerError {
                 write!(f, "I/O error {context}: {error}")
             }
             Self::SuspendError(error) => write!(f, "{error}"),
+            Self::UnexpectedJsonStructure { reason } => {
+                write!(f, "An unexpected JSON structure was detected: {reason}")
+            }
         }
     }
 }
@@ -1283,7 +1292,8 @@ impl ControllerError {
             | Self::DbspPanic
             | Self::ControllerPanic
             | Self::ControllerExit
-            | Self::EnterpriseFeature(_) => ErrorKind::Other,
+            | Self::EnterpriseFeature(_)
+            | Self::UnexpectedJsonStructure { .. } => ErrorKind::Other,
         }
     }
 }

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -106,7 +106,9 @@ class TestPipeline(unittest.TestCase):
         stats = TEST_CLIENT.get_pipeline_stats(name)
 
         assert stats is not None
-        assert stats.get("pipeline_config") is not None
+        assert stats.get("global_metrics") is not None
+        assert stats.get("inputs") is not None
+        assert stats.get("outputs") is not None
 
         TEST_CLIENT.pause_pipeline(name)
         TEST_CLIENT.shutdown_pipeline(name)


### PR DESCRIPTION
Remove the pipeline and connector configuration from the `/stats` response. Only for the connector configuration the `stream` field remains as it is used by the Web Console Performance tab for aggregating statistics across tables and views.