### PR TITLE
[adapters] Delta connector suspend/resume support.

### DIFF
--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -153,7 +153,7 @@ pub enum InputReaderCommand {
     /// Tells a fault-tolerant input reader to seek past the data already read
     /// in the step whose metadata is given by the value.
     ///
-    /// # Contraints
+    /// # Constraints
     ///
     /// Only fault-tolerant input readers need to accept this. If it is given,
     /// it will be issued only once and before any of the other commands.
@@ -169,7 +169,7 @@ pub enum InputReaderCommand {
     /// The input reader doesn't have to process other commands while it does
     /// the replay.
     ///
-    /// # Contraints
+    /// # Constraints
     ///
     /// Only fault-tolerant input readers need to accept this. It will be issued
     /// zero or more times, after [InputReaderCommand::Seek] but before any

--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -283,6 +283,7 @@ pub enum NonFtInputReaderCommand {
 /// Commonly used by `InputReader` implementations for staging buffers from
 /// worker threads.
 pub struct InputQueue<A = ()> {
+    #[allow(clippy::type_complexity)]
     pub queue: Mutex<VecDeque<(Option<Box<dyn InputBuffer>>, A)>>,
     pub consumer: Box<dyn InputConsumer>,
 }

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -782,7 +782,6 @@ impl CircuitThread {
             self.run_commands();
             if self.checkpoint_requested() {
                 self.checkpoint();
-                break;
             }
             let running = match self.controller.state() {
                 PipelineState::Running => true,

--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -3247,6 +3247,10 @@ impl InputConsumer for InputProbe {
         self.controller.eoi(self.endpoint_id);
     }
 
+    fn request_step(&self) {
+        self.controller.request_step();
+    }
+
     fn error(&self, fatal: bool, error: AnyError) {
         self.controller
             .input_transport_error(self.endpoint_id, &self.endpoint_name, fatal, error);

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -1506,25 +1506,21 @@ fn suspend_multiple_barriers(n_inputs: usize) {
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)]
 fn suspend_barrier2() {
     suspend_multiple_barriers(2);
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)]
 fn suspend_barrier3() {
     suspend_multiple_barriers(3);
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)]
 fn suspend_barrier4() {
     suspend_multiple_barriers(4);
 }
 
 #[test]
-#[cfg_attr(target_arch = "aarch64", ignore)]
 fn suspend_barrier5() {
     suspend_multiple_barriers(5);
 }

--- a/crates/adapters/src/format/parquet/test.rs
+++ b/crates/adapters/src/format/parquet/test.rs
@@ -100,7 +100,7 @@ format:
     endpoint.extend();
     wait(
         || {
-            endpoint.queue();
+            endpoint.queue(false);
             zset.state().flushed.len() == test_data.len()
         },
         DEFAULT_TIMEOUT_MS,

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -353,7 +353,8 @@ struct DeltaTableInputEndpointInner {
     /// The latest resume status of this endpoint:
     /// * Initialized to `None`.
     /// * Updated to `Some(version)` when a Seek command is received when resuming from a checkpoint.
-    /// * Updated to `Some(version)`
+    /// * Updated to `Some(new_version)` after advancing to the next table version in the transaction log
+    ///   in follow mode or after ingesting the initial snapshot.
     last_resume_status: Mutex<Option<DeltaResumeInfo>>,
     queue: Arc<InputQueue<Option<DeltaResumeInfo>>>,
 }

--- a/crates/adapters/src/test/datagen.rs
+++ b/crates/adapters/src/test/datagen.rs
@@ -116,7 +116,7 @@ fn wait_for_data(endpoint: &dyn InputReader, consumer: &MockInputConsumer) {
     while !consumer.state().eoi {
         thread::sleep(Duration::from_millis(20));
     }
-    endpoint.queue();
+    endpoint.queue(false);
     while consumer.state().n_extended == 0 {
         thread::sleep(Duration::from_millis(20));
     }

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -109,6 +109,8 @@ impl InputConsumer for MockInputConsumer {
 
     fn replayed(&self, _num_records: usize, _hash: u64) {}
 
+    fn request_step(&self) {}
+
     fn extended(&self, _num_records: usize, _resume: Option<Resume>) {
         self.state().n_extended += 1;
     }

--- a/crates/adapters/src/transport/adhoc.rs
+++ b/crates/adapters/src/transport/adhoc.rs
@@ -282,7 +282,7 @@ impl InputReader for AdHocInputEndpoint {
             }
             InputReaderCommand::Extend => self.set_state(PipelineState::Running),
             InputReaderCommand::Pause => self.set_state(PipelineState::Paused),
-            InputReaderCommand::Queue => {
+            InputReaderCommand::Queue { .. } => {
                 let mut guard = self.inner.details.lock().unwrap();
                 let details = guard.as_mut().unwrap();
                 let (num_records, hasher, batches) = details.queue.flush_with_aux();

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -144,7 +144,7 @@ impl FileInputReader {
                     Ok(InputReaderCommand::Pause) => {
                         extending = false;
                     }
-                    Ok(InputReaderCommand::Queue) => {
+                    Ok(InputReaderCommand::Queue { .. }) => {
                         let mut total = 0;
                         let mut hasher = consumer.hasher();
                         let limit = consumer.max_batch_size();
@@ -405,7 +405,7 @@ format:
         endpoint.extend();
         wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 zset.state().flushed.len() == test_data.len()
             },
             DEFAULT_TIMEOUT_MS,
@@ -469,7 +469,7 @@ format:
             // Unpause the endpoint, wait for the data to appear at the output.
             wait(
                 || {
-                    endpoint.queue();
+                    endpoint.queue(false);
                     zset.state().flushed.len() == test_data.len()
                 },
                 DEFAULT_TIMEOUT_MS,
@@ -492,7 +492,7 @@ format:
 
         wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 let state = parser.state();
                 // println!("result: {:?}", state.parser_result);
                 state.parser_result.is_some() && !state.parser_result.as_ref().unwrap().is_empty()

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -113,7 +113,7 @@ impl HttpInputEndpointInner {
                 }
                 InputReaderCommand::Extend => self.set_state(PipelineState::Running),
                 InputReaderCommand::Pause => self.set_state(PipelineState::Paused),
-                InputReaderCommand::Queue => {
+                InputReaderCommand::Queue { .. } => {
                     let mut guard = self.details.lock().unwrap();
                     let details = guard.as_mut().unwrap();
                     let (num_records, hasher, chunks) = details.queue.flush_with_aux();

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -350,7 +350,7 @@ impl KafkaFtInputReaderInner {
                     }
                     InputReaderCommand::Extend => running = true,
                     InputReaderCommand::Pause => running = false,
-                    InputReaderCommand::Queue => {
+                    InputReaderCommand::Queue { .. } => {
                         let mut total = 0;
                         let mut hasher = KafkaFtHasher::new(n_partitions);
                         let mut offsets = receivers

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -533,6 +533,8 @@ impl InputConsumer for DummyInputConsumer {
         self.called(ConsumerCall::Error(fatal));
     }
 
+    fn request_step(&self) {}
+
     fn eoi(&self) {
         self.called(ConsumerCall::Eoi);
     }

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -213,7 +213,7 @@ fn test_input(topic: &str, batch_sizes: &[u32]) {
 
         // Tell the adapter to queue the batch and wait for it to do it.
         println!("queuing and expecting {batch_size} records");
-        reader.queue();
+        reader.queue(false);
         receiver.expect(vec![ConsumerCall::Extended {
             num_records: batch.len(),
             metadata: metadata(batch),
@@ -262,7 +262,7 @@ fn test_input(topic: &str, batch_sizes: &[u32]) {
             println!("- reading the rest ({final_batch:?})");
             reader.extend();
             receiver.expect_n_buffers((final_batch.end - batches[seek].start) as usize);
-            reader.queue();
+            reader.queue(false);
             receiver.expect(vec![ConsumerCall::Extended {
                 num_records: final_batch.len(),
                 metadata: metadata(&final_batch),
@@ -1183,7 +1183,7 @@ fn test_offset(
     info!("proptest_kafka_input: Test: Receive from topic");
 
     let flush = || {
-        endpoint.queue();
+        endpoint.queue(false);
     };
     if let Some(expected) = expected {
         wait_for_output_unordered(&zset, expected, flush);
@@ -1485,7 +1485,7 @@ max_batch_size: 10000000
     producer.send_to_topic(&data, topic);
 
     let flush = || {
-        endpoint.queue();
+        endpoint.queue(false);
     };
     if poller_threads == 1 {
         // Make sure all records arrive in the original order.

--- a/crates/adapters/src/transport/nexmark.rs
+++ b/crates/adapters/src/transport/nexmark.rs
@@ -102,7 +102,7 @@ impl InputReader for InputGenerator {
                 InputReaderCommand::Replay { .. } => self.consumer.replayed(0, 0),
                 InputReaderCommand::Extend => (),
                 InputReaderCommand::Pause => (),
-                InputReaderCommand::Queue => {
+                InputReaderCommand::Queue { .. } => {
                     self.consumer.extended(
                         0,
                         Some(Resume::Replay {
@@ -337,7 +337,7 @@ fn worker_thread(
             }
             Some(InputReaderCommand::Extend) => running = true,
             Some(InputReaderCommand::Pause) => running = false,
-            Some(InputReaderCommand::Queue) => {
+            Some(InputReaderCommand::Queue { .. }) => {
                 let mut total = 0;
                 let mut hasher = consumers[NexmarkTable::Bid].hasher();
                 let n = options.max_step_size_per_thread as usize * options.threads;

--- a/crates/adapters/src/transport/pubsub/test.rs
+++ b/crates/adapters/src/transport/pubsub/test.rs
@@ -256,7 +256,7 @@ fn test_pubsub_input(
     // Send data to a topic with a single partition;
     publisher.send(&data, false, label_func);
 
-    wait_for_output_unordered(&zset, &data, || endpoint.queue());
+    wait_for_output_unordered(&zset, &data, || endpoint.queue(false));
     zset.reset();
 
     info!("test_pubsub_input: Test: pause/resume");
@@ -273,7 +273,7 @@ fn test_pubsub_input(
 
     // Receive everything after unpause.
     endpoint.extend();
-    wait_for_output_ordered(&zset, &data, || endpoint.queue());
+    wait_for_output_ordered(&zset, &data, || endpoint.queue(false));
     zset.reset();
 
     info!("test_pubsub_input: Test: Disconnect");
@@ -358,14 +358,14 @@ fn test_pubsub_multiple_subscribers(data: Vec<Vec<TestStruct>>, topic: &str) {
         .collect::<Vec<_>>();
 
     wait_for_output_unordered(&zset1, &data1, || {
-        endpoint1.queue();
-        endpoint2.queue();
+        endpoint1.queue(false);
+        endpoint2.queue(false);
     });
     zset1.reset();
 
     wait_for_output_unordered(&zset2, &data2, || {
-        endpoint1.queue();
-        endpoint2.queue();
+        endpoint1.queue(false);
+        endpoint2.queue(false);
     });
     zset2.reset();
 

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -362,7 +362,7 @@ impl S3InputReader {
                             }
                         Some(InputReaderCommand::Extend) => running = true,
                         Some(InputReaderCommand::Pause) => running = false,
-                        Some(InputReaderCommand::Queue) => {
+                        Some(InputReaderCommand::Queue{..}) => {
                             let mut total = 0;
                             let mut hasher = consumer.hasher();
                             let mut offsets = BTreeMap::<String, (u64, Option<u64>)>::new();
@@ -600,7 +600,7 @@ format:
         reader.extend();
         wait(
             || {
-                reader.queue();
+                reader.queue(false);
                 input_handle.state().flushed.len() == test_data.len()
             },
             10000,
@@ -703,7 +703,7 @@ format:
         reader.extend();
         wait(
             || {
-                reader.queue();
+                reader.queue(false);
                 input_handle.state().flushed.len() == test_data.len()
             },
             10000,

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -349,7 +349,7 @@ impl UrlInputReader {
                         InputReaderCommand::Pause => {
                             extending = false;
                         }
-                        InputReaderCommand::Queue => {
+                        InputReaderCommand::Queue{..} => {
                             let mut total = 0;
                             let mut hasher = consumer.hasher();
                             let limit = consumer.max_batch_size();
@@ -562,7 +562,7 @@ bar,false,-10
         endpoint.extend();
         wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 n_recs(&zset) == test_data.len()
             },
             DEFAULT_TIMEOUT_MS,
@@ -594,7 +594,7 @@ bar,false,-10
         endpoint.extend();
         wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 consumer.state().endpoint_error.is_some()
             },
             DEFAULT_TIMEOUT_MS,
@@ -646,7 +646,7 @@ bar,false,-10
         let timeout_ms = 2000;
         let n1_time = wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 n_recs(&zset) >= 10
             },
             timeout_ms,
@@ -657,7 +657,7 @@ bar,false,-10
 
         // After another 100 ms, there should be more records.
         sleep(Duration::from_millis(100));
-        endpoint.queue(); // XXX need to wait for it to be processed.
+        endpoint.queue(false); // XXX need to wait for it to be processed.
         let n2 = n_recs(&zset);
         println!("100 ms later, {n2} records arrived");
         assert!(n2 > n1, "After 100 ms longer, no more records arrived");
@@ -666,7 +666,7 @@ bar,false,-10
         // check that we've got at least 10 more than `n1` (really it should be
         // 20).
         sleep(Duration::from_millis(100));
-        endpoint.queue();
+        endpoint.queue(false);
         sleep(Duration::from_millis(10));
         let n3 = n_recs(&zset);
         println!("100 ms later, {n3} records arrived");
@@ -679,7 +679,7 @@ bar,false,-10
         // Wait for the first 50 records to arrive.
         let n4_time = wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 n_recs(&zset) >= 50
             },
             350,
@@ -696,7 +696,7 @@ bar,false,-10
         println!("pausing...");
         endpoint.pause();
         sleep(Duration::from_millis(100));
-        endpoint.queue(); // XXX need to wait for it to be processed.
+        endpoint.queue(false); // XXX need to wait for it to be processed.
         let n5 = n_recs(&zset);
         println!("100 ms later, {n5} records arrived");
 
@@ -704,7 +704,7 @@ bar,false,-10
         for _ in 0..2 {
             sleep(Duration::from_millis(100));
             let n = n_recs(&zset);
-            endpoint.queue(); // XXX need to wait for it to be processed.
+            endpoint.queue(false); // XXX need to wait for it to be processed.
             println!("100 ms later, {n} records arrived");
             assert_eq!(n5, n);
         }
@@ -720,7 +720,7 @@ bar,false,-10
             // there should be no new data.  Since real life is full of races,
             // let's only wait 400 ms.
             for _ in 0..4 {
-                endpoint.queue();
+                endpoint.queue(false);
                 sleep(Duration::from_millis(100));
                 let n = n_recs(&zset);
                 println!("100 ms later, {n} records arrived");
@@ -729,7 +729,7 @@ bar,false,-10
         } else {
             // The records should start arriving again immediately.
             sleep(Duration::from_millis(200));
-            endpoint.queue();
+            endpoint.queue(false);
             sleep(Duration::from_millis(100));
             let n = n_recs(&zset);
             println!("200 ms later, {n} records arrived");
@@ -740,7 +740,7 @@ bar,false,-10
         // 1000 ms.
         let n6_time = wait(
             || {
-                endpoint.queue();
+                endpoint.queue(false);
                 n_recs(&zset) >= 100
             },
             1000,

--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -509,7 +509,7 @@ impl InputGenerator {
                 }
                 Some(InputReaderCommand::Extend) => running = true,
                 Some(InputReaderCommand::Pause) => running = false,
-                Some(InputReaderCommand::Queue) => {
+                Some(InputReaderCommand::Queue { .. }) => {
                     let mut num_records = 0;
                     let mut hasher = consumer.hasher();
                     let n = consumer.max_batch_size();


### PR DESCRIPTION
Support suspend/resume and at-least-once FT in the delta connector.  The state of the connector is checkpointable after the initial snapshot at the boundary between transaction log entries.

Fixes #3884 
Fixes #4026 

@blp , I tried my best to use the new barrier API correctly, but this needs your review.