### PR TITLE
[adapters] Fix FT tests.

### DIFF
--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -540,6 +540,9 @@ outputs:
                 1000,
             )
             .unwrap();
+
+            // Make sure the step gets executed.
+            sleep(Duration::from_millis(1000));
         }
 
         // Checkpoint, if requested.
@@ -1314,7 +1317,7 @@ fn suspend_barrier() {
 
     // Suspend should now succeed, because we crossed the barrier.
     receiver
-        .recv_timeout(Duration::from_millis(1000))
+        .recv_timeout(Duration::from_millis(10000))
         .unwrap()
         .unwrap();
 
@@ -1364,7 +1367,7 @@ fn suspend_barrier() {
 
     // Suspend should now succeed, because we crossed the barrier.
     receiver
-        .recv_timeout(Duration::from_millis(1000))
+        .recv_timeout(Duration::from_millis(10000))
         .unwrap()
         .unwrap();
 }
@@ -1473,7 +1476,7 @@ fn suspend_multiple_barriers(n_inputs: usize) {
 
     // Suspend should now succeed, because we crossed the barrier.
     receiver
-        .recv_timeout(Duration::from_millis(1000))
+        .recv_timeout(Duration::from_millis(10000))
         .unwrap()
         .unwrap();
 


### PR DESCRIPTION
Fixes #3950.

- controller::test::ft_without_checkpoints_with_pauses was failing because of a race condition. The test needs to wait for the pause connector command to get written out to the journal. It did this by waiting for the step_requested flag, which doesn't actually guarantee that the step is started. I added an extra sleep, which isn't ideal, but seems to do the trick.

- Three other tests were failing on my MacOS laptop because their checkpointing timeouts were too short.