### PR TITLE
[adapters] Delta: add root cause to error message.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -708,7 +708,11 @@ impl DeltaTableInputEndpointInner {
         let delta_table = table_builder.load().await.map_err(|e| {
             ControllerError::invalid_transport_configuration(
                 &self.endpoint_name,
-                &format!("error opening delta table '{}': {e}", &self.config.uri),
+                &format!(
+                    "error opening delta table '{}': {e} (root cause: {})",
+                    &self.config.uri,
+                    root_cause(&e)
+                ),
             )
         })?;
 


### PR DESCRIPTION
Output root cause of the error when opening a delta table fails. This is likely to generate error messages that report the same error twice, but can also produce some useful additional information in some cases.