### PR TITLE
[adapters] Fix lir test.

### DIFF
--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -1537,25 +1537,7 @@ storage_config: null
 storage: null
 clock_resolution_usecs: null
 inputs:
-    test_input1:
-        stream: test_input1
-        transport:
-            name: file_input
-            config:
-                path: "path"
-                follow: true
-        format:
-            name: csv
 outputs:
-    test_output1:
-        stream: test_output1
-        transport:
-            name: file_output
-            config:
-                path: "path"
-        format:
-            name: csv
-            config:
         "#
     .to_string();
 


### PR DESCRIPTION
Depending on the order of connector initialization, the test randomly failed because of the missing input file. Remove bogus input connectors from the test pipeline config.