### PR TITLE
[dbsp] Account for full FBuf capacity in the buffer cache.

### DIFF
--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -440,7 +440,7 @@ where
     A: DataTrait + ?Sized,
 {
     fn cost(&self) -> usize {
-        size_of::<Self>() + self.raw.len()
+        size_of::<Self>() + self.raw.capacity()
     }
 
     fn as_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
@@ -714,7 +714,7 @@ where
     K: DataTrait + ?Sized,
 {
     fn cost(&self) -> usize {
-        size_of::<Self>() + self.raw.len()
+        size_of::<Self>() + self.raw.capacity()
     }
     fn as_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self


### PR DESCRIPTION
We used FBuf length to measure the amount of cache capacity occupied by an FBuf; however FBuf's actual heap usage is determined by its capacity, which can be larger than size.