### PR TITLE
[WebConsole] Fix page crashing when any connector error happens

### DIFF
--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1448,9 +1448,14 @@ pub(crate) mod tests {
         cconf.storage.as_mut().unwrap().init_checkpoint = Some(Uuid::now_v7()); // this checkpoint doesn't exist
 
         let res = mkcircuit(&cconf);
+        let Err(err) = res else {
+            panic!("revert_to_unknown_checkpoint is supposed to fail");
+        };
+
+        println!("revert_to_unknown_checkpoint: result: {err:?}");
         assert!(matches!(
-            res,
-            Err(DbspError::Storage(StorageError::CheckpointNotFound(_)))
+            err,
+            DbspError::Storage(StorageError::CheckpointNotFound(_))
         ));
     }
 

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -195,6 +195,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::transport::iceberg::RestCatalogConfig,
         feldera_types::transport::iceberg::GlueCatalogConfig,
         feldera_types::transport::postgres::PostgresReaderConfig,
+        feldera_types::transport::postgres::PostgresWriterConfig,
         feldera_types::transport::redis::RedisOutputConfig,
         feldera_types::transport::http::Chunk,
         feldera_types::query::AdhocQueryArgs,

--- a/openapi.json
+++ b/openapi.json
@@ -5113,6 +5113,24 @@
           }
         }
       },
+      "PostgresWriterConfig": {
+        "type": "object",
+        "description": "Postgres output connector configuration.",
+        "required": [
+          "uri",
+          "table"
+        ],
+        "properties": {
+          "table": {
+            "type": "string",
+            "description": "The table to write the output to."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Postgres URI.\nSee: <https://docs.rs/tokio-postgres/0.7.12/tokio_postgres/config/struct.Config.html>"
+          }
+        }
+      },
       "ProgramConfig": {
         "type": "object",
         "description": "Program configuration.",

--- a/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
@@ -71,7 +71,8 @@
           ...Object.keys(input[0]).map((name) => ({
             name,
             case_sensitive: false,
-            columntype: { nullable: true }
+            columntype: { nullable: true },
+            unused: false
           }))
         )
       }

--- a/web-console/src/lib/compositions/health/systemErrors.ts
+++ b/web-console/src/lib/compositions/health/systemErrors.ts
@@ -339,14 +339,14 @@ export const extractPipelineXgressErrors = ({
         ? [
             {
               name: `${input.metrics.num_parse_errors} connector parse errors in ${pipelineName}`,
-              message: `${input.metrics.num_parse_errors} parse errors in ${input.config.transport.name} connector ${input.endpoint_name} of ${pipelineName}`,
+              message: `${input.metrics.num_parse_errors} parse errors in the input connector ${input.endpoint_name} of ${pipelineName}`,
               cause: {
                 entityName: pipelineName,
                 tag: 'xgressError',
                 source,
                 report: {
                   ...defaultGithubReportSections,
-                  name: `Report: ${input.config.transport.name} connector parse errors`,
+                  name: `Report: input connector parse errors`,
                   '6-extra': stringifyConfig(input.config)
                 } as ReportDetails,
                 body: ''
@@ -358,14 +358,14 @@ export const extractPipelineXgressErrors = ({
         ? [
             {
               name: `${input.metrics.num_transport_errors} connector transport errors in ${pipelineName}`,
-              message: `${input.metrics.num_transport_errors} transport errors in ${input.config.transport.name} connector ${input.endpoint_name} of ${pipelineName}`,
+              message: `${input.metrics.num_transport_errors} transport errors in the input connector ${input.endpoint_name} of ${pipelineName}`,
               cause: {
                 entityName: pipelineName,
                 tag: 'xgressError',
                 source,
                 report: {
                   ...defaultGithubReportSections,
-                  name: `Report: ${input.config.transport.name} connector transport errors`,
+                  name: `Report: input connector transport errors`,
                   '6-extra': stringifyConfig(input.config)
                 } as ReportDetails,
                 body: ''
@@ -380,14 +380,14 @@ export const extractPipelineXgressErrors = ({
           ? [
               {
                 name: `${output.metrics.num_encode_errors} connector encode errors in ${pipelineName}`,
-                message: `${output.metrics.num_encode_errors} encode errors in ${output.config.transport.name} connector ${output.endpoint_name} of ${pipelineName}`,
+                message: `${output.metrics.num_encode_errors} encode errors in the output connector ${output.endpoint_name} of ${pipelineName}`,
                 cause: {
                   entityName: pipelineName,
                   tag: 'xgressError',
                   source,
                   report: {
                     ...defaultGithubReportSections,
-                    name: `Report: ${output.config.transport.name} connector encode errors`,
+                    name: `Report: output connector encode errors`,
                     '6-extra': stringifyConfig(output.config)
                   } as ReportDetails,
                   body: ''
@@ -399,14 +399,14 @@ export const extractPipelineXgressErrors = ({
           ? [
               {
                 name: `${output.metrics.num_transport_errors} connector transport errors in ${pipelineName}`,
-                message: `${output.metrics.num_transport_errors} transport errors in ${output.config.transport.name} connector ${output.endpoint_name} of ${pipelineName}`,
+                message: `${output.metrics.num_transport_errors} transport errors in the output connector ${output.endpoint_name} of ${pipelineName}`,
                 cause: {
                   entityName: pipelineName,
                   tag: 'xgressError',
                   source,
                   report: {
                     ...defaultGithubReportSections,
-                    name: `Report: ${output.config.transport.name} connector transport errors`,
+                    name: `Report: output connector transport errors`,
                     '6-extra': stringifyConfig(output.config)
                   } as ReportDetails,
                   body: ''
@@ -431,12 +431,12 @@ export const extractPipelineXgressStderr = ({
       .flatMap((input) => [
         ...(input.metrics.num_parse_errors
           ? [
-              `${input.metrics.num_parse_errors} parse errors in ${input.config.transport.name} connector ${input.endpoint_name} of ${pipelineName}`
+              `${input.metrics.num_parse_errors} parse errors in the input connector ${input.endpoint_name} of ${pipelineName}`
             ]
           : []),
         ...(input.metrics.num_transport_errors
           ? [
-              `${input.metrics.num_transport_errors} transport errors in ${input.config.transport.name} connector ${input.endpoint_name} of ${pipelineName}`
+              `${input.metrics.num_transport_errors} transport errors in the input connector ${input.endpoint_name} of ${pipelineName}`
             ]
           : [])
       ])
@@ -444,12 +444,12 @@ export const extractPipelineXgressStderr = ({
         stats.outputs.flatMap((output) => [
           ...(output.metrics.num_encode_errors
             ? [
-                `${output.metrics.num_encode_errors} encode errors in ${output.config.transport.name} connector ${output.endpoint_name} of ${pipelineName}`
+                `${output.metrics.num_encode_errors} encode errors in the output connector ${output.endpoint_name} of ${pipelineName}`
               ]
             : []),
           ...(output.metrics.num_transport_errors
             ? [
-                `${output.metrics.num_transport_errors} transport errors in ${output.config.transport.name} connector ${output.endpoint_name} of ${pipelineName}`
+                `${output.metrics.num_transport_errors} transport errors in the output connector ${output.endpoint_name} of ${pipelineName}`
               ]
             : [])
         ])

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -60,6 +60,9 @@ import type {
   GetPipelineMetricsData,
   GetPipelineMetricsError,
   GetPipelineMetricsResponse,
+  GetProgramInfoData,
+  GetProgramInfoError,
+  GetProgramInfoResponse,
   PipelineAdhocSqlData,
   PipelineAdhocSqlError,
   PipelineAdhocSqlResponse,
@@ -323,6 +326,16 @@ export const getPipelineMetrics = (options: Options<GetPipelineMetricsData>) => 
   return (options?.client ?? client).get<GetPipelineMetricsResponse, GetPipelineMetricsError>({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/metrics'
+  })
+}
+
+/**
+ * Retrieve the program info of a pipeline.
+ */
+export const getProgramInfo = (options: Options<GetProgramInfoData>) => {
+  return (options?.client ?? client).get<GetProgramInfoResponse, GetProgramInfoError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/program_info'
   })
 }
 

--- a/web-console/src/lib/types/pipelineManager.ts
+++ b/web-console/src/lib/types/pipelineManager.ts
@@ -6,11 +6,11 @@ import type {
 import type { BigNumber } from 'bignumber.js/bignumber.js'
 
 export type ControllerStatus = {
-  pipeline_config: RuntimeConfig
   global_metrics: GlobalMetrics
   inputs: InputEndpointStatus[]
   outputs: OutputEndpointStatus[]
   metrics: ControllerMetric[]
+  suspend_error: any
 }
 
 type ControllerMetric = {
@@ -89,9 +89,12 @@ export type GlobalMetricsTimestamp = GlobalMetrics & {
 
 export type InputEndpointStatus = {
   endpoint_name: string
-  config: InputEndpointConfig
+  config: Pick<InputEndpointConfig, 'stream'>
   metrics: InputEndpointMetrics
-  is_fault_tolerant: boolean
+  is_fault_tolerant?: boolean
+  paused?: boolean
+  barrier?: boolean
+  fatal_error?: boolean
 }
 
 export interface InputEndpointMetrics {
@@ -105,9 +108,9 @@ export interface InputEndpointMetrics {
 
 export type OutputEndpointStatus = {
   endpoint_name: string
-  config: OutputEndpointConfig
+  config: Pick<OutputEndpointConfig, 'stream'>
   metrics: OutputEndpointMetrics
-  is_fault_tolerant: boolean
+  is_fault_tolerant?: boolean
 }
 
 export interface OutputEndpointMetrics {


### PR DESCRIPTION
Fix mocked /pipeline/{x}/stats endpoint response types not up to date

This is a regression after the /stats endpoint was changed. It is untyped, so manually mocked types went out-of-sync, so the type error due to a breaking change did not occur.

To reproduce, try running the fololwing program:
```
CREATE TABLE binary_data ( 
    entry VARBINARY
) WITH (
    'materialized' = 'true',
    'connectors' = '[{
        "transport": {
            "name": "datagen",
            "config": {
                "plan": [{
                    "limit": 1,
                    "fields": {
                        "entry": { "values": ["a"] }
                    }
                }]
            }
        }
    }]'
);
```