### PR TITLE
pipeline-manager: move `program_error` away from status

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -170,7 +170,8 @@ pub struct PipelineSelectedInfo {
     pub program_version: Version,
     pub program_status: ProgramStatus,
     pub program_status_since: DateTime<Utc>,
-    pub program_error: ProgramError,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub program_error: Option<ProgramError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub program_info: Option<Option<PartialProgramInfo>>,
     pub deployment_status: PipelineStatus,
@@ -208,7 +209,8 @@ pub struct PipelineSelectedInfoInternal {
     pub program_version: Version,
     pub program_status: ProgramStatus,
     pub program_status_since: DateTime<Utc>,
-    pub program_error: ProgramError,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub program_error: Option<ProgramError>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub program_info: Option<Option<serde_json::Value>>,
     pub deployment_status: PipelineStatus,
@@ -235,7 +237,7 @@ impl PipelineSelectedInfoInternal {
             program_version: extended_pipeline.program_version,
             program_status: extended_pipeline.program_status,
             program_status_since: extended_pipeline.program_status_since,
-            program_error: extended_pipeline.program_error,
+            program_error: Some(extended_pipeline.program_error),
             program_info: Some(remove_large_fields_from_program_info(
                 extended_pipeline.program_info,
             )),
@@ -263,7 +265,7 @@ impl PipelineSelectedInfoInternal {
             program_version: extended_pipeline.program_version,
             program_status: extended_pipeline.program_status,
             program_status_since: extended_pipeline.program_status_since,
-            program_error: extended_pipeline.program_error,
+            program_error: None,
             program_info: None,
             deployment_status: extended_pipeline.deployment_status,
             deployment_status_since: extended_pipeline.deployment_status_since,

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -215,6 +215,7 @@ impl CompilerTest {
         assert_eq!(
             content_pipeline_dir,
             vec![
+                "dataflow.json",
                 "program.sql",
                 "rust",
                 "schema.json",

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -171,7 +171,7 @@ fn row_to_extended_pipeline_descriptor(row: &Row) -> Result<ExtendedPipelineDesc
 /// Pipeline columns relevant to monitoring.
 const RETRIEVE_PIPELINE_MONITORING_COLUMNS: &str =
     "p.id, p.tenant_id, p.name, p.description, p.created_at, p.version, p.platform_version,
-     p.program_version, p.program_status, p.program_status_since, p.program_error,
+     p.program_version, p.program_status, p.program_status_since,
      p.deployment_status, p.deployment_status_since, p.deployment_desired_status,
      p.deployment_error, p.deployment_location, p.refresh_version";
 
@@ -179,12 +179,9 @@ const RETRIEVE_PIPELINE_MONITORING_COLUMNS: &str =
 fn row_to_extended_pipeline_descriptor_monitoring(
     row: &Row,
 ) -> Result<ExtendedPipelineDescrMonitoring, DBError> {
-    assert_eq!(row.len(), 17);
-    // Program error: ProgramError
-    let program_error = deserialize_program_error_with_default(&row.get::<_, String>(10));
-
+    assert_eq!(row.len(), 16);
     // Deployment error: ErrorResponse
-    let deployment_error = match row.get::<_, Option<String>>(14) {
+    let deployment_error = match row.get::<_, Option<String>>(13) {
         None => None,
         Some(s) => Some(deserialize_error_response(&s)?),
     };
@@ -199,13 +196,12 @@ fn row_to_extended_pipeline_descriptor_monitoring(
         program_version: Version(row.get(7)),
         program_status: row.get::<_, String>(8).try_into()?,
         program_status_since: row.get(9),
-        program_error,
-        deployment_status: row.get::<_, String>(11).try_into()?,
-        deployment_status_since: row.get(12),
-        deployment_desired_status: row.get::<_, String>(13).try_into()?,
+        deployment_status: row.get::<_, String>(10).try_into()?,
+        deployment_status_since: row.get(11),
+        deployment_desired_status: row.get::<_, String>(12).try_into()?,
         deployment_error,
-        deployment_location: row.get(15),
-        refresh_version: Version(row.get(16)),
+        deployment_location: row.get(14),
+        refresh_version: Version(row.get(15)),
     })
 }
 
@@ -771,7 +767,7 @@ pub(crate) async fn set_program_status(
                 new_program_binary_source_checksum.clone(),
                 new_program_binary_integrity_checksum.clone(),
                 new_program_binary_url.clone(),
-                false,
+                true,
             )
         }
         ProgramStatus::SqlError => {
@@ -792,7 +788,7 @@ pub(crate) async fn set_program_status(
                 None,
                 None,
                 None,
-                false,
+                true,
             )
         }
         ProgramStatus::RustError => {
@@ -813,7 +809,7 @@ pub(crate) async fn set_program_status(
                 None,
                 None,
                 None,
-                false,
+                true,
             )
         }
         ProgramStatus::SystemError => {
@@ -834,7 +830,7 @@ pub(crate) async fn set_program_status(
                 None,
                 None,
                 None,
-                false,
+                true,
             )
         }
     };

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -33,7 +33,6 @@ impl ExtendedPipelineDescrRunner {
                 program_version: pipeline.program_version,
                 program_status: pipeline.program_status,
                 program_status_since: pipeline.program_status_since,
-                program_error: pipeline.program_error.clone(),
                 deployment_status: pipeline.deployment_status,
                 deployment_status_since: pipeline.deployment_status_since,
                 deployment_desired_status: pipeline.deployment_desired_status,

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -478,9 +478,10 @@ pub struct ExtendedPipelineDescr {
     pub deployment_location: Option<String>,
 
     /// Refresh version, incremented for the same fields as `version` but also including
-    /// `program_info` as it contains information of interest to the user regarding the pipeline.
-    /// It is a notification mechanism for users. If a user detects it changed while monitoring
-    /// only the status fields, it should refresh fully (retrieve all fields).
+    /// `program_info` and `program_error` as it contains information of interest to the user
+    /// regarding the pipeline. It is a notification mechanism for users. If a user detects
+    /// it changed while monitoring only the status fields, it should refresh fully (retrieve
+    /// all fields).
     pub refresh_version: Version,
 }
 
@@ -501,7 +502,6 @@ pub struct ExtendedPipelineDescrMonitoring {
     pub program_version: Version,
     pub program_status: ProgramStatus,
     pub program_status_since: DateTime<Utc>,
-    pub program_error: ProgramError,
     pub deployment_status: PipelineStatus,
     pub deployment_status_since: DateTime<Utc>,
     pub deployment_desired_status: PipelineDesiredStatus,

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -699,16 +699,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     version_guard: pipeline.version,
                     error: ErrorResponse::from_error_nolog(
                         &DBError::StartFailedDueToFailedCompilation {
-                            compiler_error: pipeline
-                                .program_error
-                                .sql_compilation
-                                .as_ref()
-                                .map(|v| v.messages.clone())
-                                .unwrap_or_default()
-                                .iter()
-                                .map(|s| s.to_string())
-                                .collect::<Vec<String>>()
-                                .join("\n"),
+                            compiler_error:
+                                "SQL error occurred (see `program_error` for more information)"
+                                    .to_string(),
                         },
                     ),
                 });
@@ -718,12 +711,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     version_guard: pipeline.version,
                     error: ErrorResponse::from_error_nolog(
                         &DBError::StartFailedDueToFailedCompilation {
-                            compiler_error: pipeline
-                                .program_error
-                                .rust_compilation
-                                .as_ref()
-                                .map(|v| v.to_string())
-                                .unwrap_or("".to_string()),
+                            compiler_error:
+                                "Rust error occurred (see `program_error` for more information)"
+                                    .to_string(),
                         },
                     ),
                 });
@@ -733,11 +723,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     version_guard: pipeline.version,
                     error: ErrorResponse::from_error_nolog(
                         &DBError::StartFailedDueToFailedCompilation {
-                            compiler_error: pipeline
-                                .program_error
-                                .system_error
-                                .clone()
-                                .unwrap_or("".to_string()),
+                            compiler_error:
+                                "System error occurred (see `program_error` for more information)"
+                                    .to_string(),
                         },
                     ),
                 });

--- a/crates/pipeline-manager/tests/integration_test.rs
+++ b/crates/pipeline-manager/tests/integration_test.rs
@@ -875,7 +875,7 @@ const PIPELINE_FIELD_SELECTOR_ALL_FIELDS: [&str; 21] = [
 ];
 
 /// Fields included in the `status` selector.
-const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 15] = [
+const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 14] = [
     "id",
     "name",
     "description",
@@ -885,7 +885,6 @@ const PIPELINE_FIELD_SELECTOR_STATUS_FIELDS: [&str; 15] = [
     "program_version",
     "program_status",
     "program_status_since",
-    "program_error",
     "deployment_status",
     "deployment_status_since",
     "deployment_desired_status",
@@ -3084,14 +3083,14 @@ async fn refresh_version() {
     let value: Value = response.json().await.unwrap();
     assert_eq!(value["refresh_version"], json!(1));
 
-    // After compilation, refresh version should be 2
+    // After compilation, refresh version should be 3
     config
         .wait_for_compilation("test", 1, config.compilation_timeout)
         .await;
     let mut response = config.get("/v0/pipelines/test").await;
     assert_eq!(response.status(), StatusCode::OK);
     let value: Value = response.json().await.unwrap();
-    assert_eq!(value["refresh_version"], json!(2));
+    assert_eq!(value["refresh_version"], json!(3));
 
     // Starting and shutting down should have no effect on the refresh version
     let response = config.post_no_body("/v0/pipelines/test/pause").await;
@@ -3107,9 +3106,9 @@ async fn refresh_version() {
     let mut response = config.get("/v0/pipelines/test").await;
     assert_eq!(response.status(), StatusCode::OK);
     let value: Value = response.json().await.unwrap();
-    assert_eq!(value["refresh_version"], json!(2));
+    assert_eq!(value["refresh_version"], json!(3));
 
-    // Edits should have an impact, incrementing refresh version to 3
+    // Edits should have an impact, incrementing refresh version to 4
     let mut response = config
         .patch(
             "/v0/pipelines/test",
@@ -3118,16 +3117,16 @@ async fn refresh_version() {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     let value: Value = response.json().await.unwrap();
-    assert_eq!(value["refresh_version"], json!(3));
+    assert_eq!(value["refresh_version"], json!(4));
 
-    // After compilation, refresh version should be 4
+    // After compilation, refresh version should be 6
     config
         .wait_for_compilation("test", 2, config.compilation_timeout)
         .await;
     let mut response = config.get("/v0/pipelines/test").await;
     assert_eq!(response.status(), StatusCode::OK);
     let value: Value = response.json().await.unwrap();
-    assert_eq!(value["refresh_version"], json!(4));
+    assert_eq!(value["refresh_version"], json!(6));
 }
 
 /// Tests that circuit metrics can be retrieved from the pipeline.

--- a/openapi.json
+++ b/openapi.json
@@ -4939,7 +4939,6 @@
           "program_version",
           "program_status",
           "program_status_since",
-          "program_error",
           "deployment_status",
           "deployment_status_since",
           "deployment_desired_status",
@@ -4993,7 +4992,12 @@
             "nullable": true
           },
           "program_error": {
-            "$ref": "#/components/schemas/ProgramError"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProgramError"
+              }
+            ],
+            "nullable": true
           },
           "program_info": {
             "allOf": [

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -2328,7 +2328,6 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
     'program_version',
     'program_status',
     'program_status_since',
-    'program_error',
     'deployment_status',
     'deployment_status_since',
     'deployment_desired_status',
@@ -2382,7 +2381,12 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
       nullable: true
     },
     program_error: {
-      $ref: '#/components/schemas/ProgramError'
+      allOf: [
+        {
+          $ref: '#/components/schemas/ProgramError'
+        }
+      ],
+      nullable: true
     },
     program_info: {
       allOf: [

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -1666,7 +1666,7 @@ export type PipelineSelectedInfo = {
   platform_version: string
   program_code?: string | null
   program_config?: ProgramConfig | null
-  program_error: ProgramError
+  program_error?: ProgramError | null
   program_info?: PartialProgramInfo | null
   program_status: ProgramStatus
   program_status_since: string

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -89,7 +89,7 @@ export const programStatusOf = (status: PipelineStatus) =>
     .exhaustive()
 
 const toPipelineThumb = (
-  pipeline: Omit<ExtendedPipelineDescr, 'program_code' | 'udf_rust' | 'udf_toml'>
+  pipeline: Omit<ExtendedPipelineDescr, 'program_code' | 'program_error' | 'udf_rust' | 'udf_toml'>
 ) => ({
   name: pipeline.name,
   description: pipeline.description,
@@ -99,7 +99,6 @@ const toPipelineThumb = (
     pipeline.deployment_desired_status,
     pipeline.deployment_error
   ),
-  compilerOutput: toCompilerOutput(pipeline.program_error),
   deploymentStatusSince: pipeline.deployment_status_since,
   refreshVersion: pipeline.refresh_version
 })
@@ -272,11 +271,11 @@ export const getPipelineStats = async (pipeline_name: string) => {
     })
 }
 
-const toCompilerOutput = (programError: ProgramError) => {
+const toCompilerOutput = (programError: ProgramError | null | undefined) => {
   return {
-    sql: programError.sql_compilation,
-    rust: programError.rust_compilation,
-    systemError: programError.system_error
+    sql: programError?.sql_compilation,
+    rust: programError?.rust_compilation,
+    systemError: programError?.system_error
   }
 }
 


### PR DESCRIPTION
The `program_error` field contains further compilation details including logs, which are better not to include in the status as the details can be on the larger side and are not directly relevant to display of status. This commit moves the `program_error` to only the complete retrieval. In addition, whenever `program_error` is changed, there also is an increment of `refresh_version`.

**Related issues**
- Fixes: https://github.com/feldera/feldera/issues/3965
