### PR TITLE
[WebConsole] Redirect users ending up on '/pipelines/' URL to '/'

### DIFF
--- a/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/+page.ts
+++ b/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/+page.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = () => {
+  throw redirect(308, '/')
+}


### PR DESCRIPTION
This PR fixes the bad UX resulting from the confusion when navigating the WebConsole.

The issue was some users occasionally experiencing a 404 not found error.
The reason was when the users had some issue with the pipeline on a page e.g. https://cluster.staging.com/pipelines/broken-pipeline/, where the page would become unresponsive.
They then would edit the url in the browser by hand, removing the last path element - to end up with http://cluster.staging.com/pipelines/ and hit Enter.
This is not a home page of the WebConsole - that would be located on http://cluster.staging.com/
So they would end up requesting a non-existing page and getting a 404 page.
Then the browser would store the URL http://cluster.staging.com/pipelines/ and suggest it as an auto-complete when people would start typing the URL to come back to web-console - landing them in the 404 page again