### PR TITLE
[SQL] Speed-up Java tests by avoiding generating repeated Rust code for inputs common to many tests

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -2253,7 +2253,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 i++;
             }
             DBSPTupleExpression expression = new DBSPTupleExpression(node, expressions);
-            result.add(expression);
+            result.append(expression);
         }
 
         if (this.modifyTableTranslation != null) {
@@ -3660,7 +3660,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                     if (result == null)
                         result = lit;
                     else
-                        result.add(lit);
+                        result.append(lit);
                 }
             }
             Utilities.enforce(result != null);
@@ -3913,7 +3913,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         }
 
         DBSPExpression exp = new DBSPTupleExpression(node, resultColumns);
-        result.add(exp);
+        result.append(exp);
         return result;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
@@ -122,7 +122,7 @@ class ModifyTableTranslation {
         DBSPZSetExpression result = DBSPZSetExpression.emptyWithElementType(this.resultType);
         for (Map.Entry<DBSPExpression, Long> e : source.data.entrySet()) {
             DBSPExpression perm = this.permuteColumns(e.getKey());
-            result.add(perm, e.getValue());
+            result.append(perm, e.getValue());
         }
         return result;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -748,7 +748,7 @@ public abstract class InnerRewriteVisitor
                 DBSPZSetExpression.emptyWithElementType(zType.getElementType());
         for (Map.Entry<DBSPExpression, Long> entry: expression.data.entrySet()) {
             DBSPExpression row = this.transform(entry.getKey());
-            result.add(row, entry.getValue());
+            result.append(row, entry.getValue());
         }
         this.pop(expression);
         this.map(expression, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -25,6 +25,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.inner;
 
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
 import org.apache.commons.lang3.StringUtils;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
@@ -59,6 +60,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimeLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU128Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU16Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
@@ -74,6 +76,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeNull;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 
@@ -169,7 +172,7 @@ public class Simplify extends ExpressionTranslator {
                         LocalDate.parse(str.value, dateFormatter); // executed for exception
                         result = new DBSPDateLiteral(lit.getNode(), type, new DateString(str.value));
                     } catch (DateTimeParseException ex) {
-                        this.compiler.reportWarning(expression.getSourcePosition(), "Not a date",
+                        this.compiler.reportWarning(expression.getSourcePosition(), "Not a DATE",
                                 " String " + Utilities.singleQuote(str.value) +
                                         " cannot be interpreted as a date");
                     }
@@ -178,9 +181,19 @@ public class Simplify extends ExpressionTranslator {
                         TimeString ts = new TimeString(str.value);
                         result = new DBSPTimeLiteral(lit.getNode(), type, ts);
                     } catch (DateTimeParseException | IllegalArgumentException ex) {
-                        this.compiler.reportWarning(expression.getSourcePosition(), "Not a number",
+                        this.compiler.reportWarning(expression.getSourcePosition(), "Not a TIME",
                                 " String " + Utilities.singleQuote(str.value) +
                                         " cannot be interpreted as a time");
+                    }
+                } else if (type.is(DBSPTypeTimestamp.class)) {
+                    try {
+                        TimestampString ts = new TimestampString(str.value);
+                        ts = Utilities.roundMillis(ts);
+                        result = new DBSPTimestampLiteral(lit.getNode(), type, ts);
+                    } catch (DateTimeParseException | IllegalArgumentException ex) {
+                        this.compiler.reportWarning(expression.getSourcePosition(), "Not a TIMESTAMP",
+                                " String " + Utilities.singleQuote(str.value) +
+                                        " cannot be interpreted as a timestamp");
                     }
                 } else if (type.is(DBSPTypeDecimal.class)) {
                     try {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPMinMax.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPMinMax.java
@@ -15,13 +15,13 @@ import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 
-/** Represents the built-in SQL Aggregator from DBSP; could be MinSone or Max. */
+/** Represents the built-in SQL Aggregator from DBSP. */
 public class DBSPMinMax extends DBSPAggregator {
     public enum Aggregation {
         Min,
         MinSome1,
         Max
-    };
+    }
     public final Aggregation aggregation;
     @Nullable
     public final DBSPClosureExpression postProcessing;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
@@ -54,14 +54,14 @@ public class NonLinearAggregate extends IAggregate {
     public final DBSPTypeUser semigroup;
 
     public NonLinearAggregate(
-            CalciteObject origin,
+            CalciteObject node,
             DBSPExpression zero,
             DBSPClosureExpression increment,
             @Nullable
             DBSPClosureExpression postProcess,
             DBSPExpression emptySetResult,
             DBSPTypeUser semigroup) {
-        super(origin, emptySetResult.getType());
+        super(node, emptySetResult.getType());
         this.zero = zero;
         this.increment = increment;
         Utilities.enforce(increment.parameters.length == 3);
@@ -71,12 +71,12 @@ public class NonLinearAggregate extends IAggregate {
     }
 
     public NonLinearAggregate(
-            CalciteObject operator,
+            CalciteObject node,
             DBSPExpression zero,
             DBSPClosureExpression increment,
             DBSPExpression emptySetResult,
             DBSPTypeUser semigroup) {
-        this(operator, zero, increment, null, emptySetResult, semigroup);
+        this(node, zero, increment, null, emptySetResult, semigroup);
     }
 
     /** Result produced for an empty set. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
@@ -72,7 +72,7 @@ public final class DBSPArrayExpression extends DBSPExpression
                 if (!e.getType().sameType(data.get(0).getType()))
                     throw new InternalCompilerError("Not all values of vector have the same type:" +
                             e.getType() + " vs " + data.get(0).getType(), this);
-                this.add(e);
+                this.append(e);
             }
         } else {
             this.data = null;
@@ -87,7 +87,7 @@ public final class DBSPArrayExpression extends DBSPExpression
             if (!e.getType().sameType(data[0].getType()))
                 throw new InternalCompilerError("Not all values of vector have the same type:" +
                         e.getType() + " vs " + data[0].getType(), this);
-            this.add(e);
+            this.append(e);
         }
     }
 
@@ -99,20 +99,19 @@ public final class DBSPArrayExpression extends DBSPExpression
         return this.vecType.getTypeArg(0);
     }
 
-    public IDBSPContainer add(DBSPExpression expression) {
+    public void append(DBSPExpression expression) {
         // We expect the expression to be a constant value (a literal)
         if (!expression.getType().sameType(this.getElementType()))
             throw new InternalCompilerError("Added element " + expression + " type " +
                     expression.getType() + " does not match vector type " + this.getElementType(), this);
         Objects.requireNonNull(this.data).add(expression);
-        return this;
     }
 
-    public void add(DBSPArrayExpression other) {
+    public void append(DBSPArrayExpression other) {
         if (!this.getType().sameType(other.getType()))
             throw new InternalCompilerError("Added vectors do not have the same type " +
                     this.getElementType() + " vs " + other.getElementType(), this);
-        Objects.requireNonNull(other.data).forEach(this::add);
+        Objects.requireNonNull(other.data).forEach(this::append);
     }
 
     public int size() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
@@ -81,11 +81,6 @@ public final class DBSPIndexedZSetExpression extends DBSPExpression
     }
 
     @Override
-    public IDBSPContainer add(DBSPExpression expression) {
-        throw new UnimplementedException("Not yet implemented: IndexedZSet literals", expression);
-    }
-
-    @Override
     public IIndentStream toString(IIndentStream builder) {
         return builder.append("indexed_zset!()");
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/IDBSPContainer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/IDBSPContainer.java
@@ -23,6 +23,6 @@
 
 package org.dbsp.sqlCompiler.ir.expression;
 
-public interface IDBSPContainer {
-    IDBSPContainer add(DBSPExpression expression);
-}
+import org.dbsp.util.ICastable;
+
+public interface IDBSPContainer extends ICastable  { }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
 import org.apache.commons.io.IOUtils;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
@@ -92,6 +93,21 @@ public class Utilities {
     public static void enforce(boolean expression, String message) {
         if (!expression)
             throw new InternalCompilerError(message + System.lineSeparator() + getCurrentStackTrace());
+    }
+
+    public static TimestampString roundMillis(TimestampString ts) {
+        long millis = ts.getMillisSinceEpoch();
+        String str = ts.toString();
+        if (str.length() > 23) {
+            String next = str.substring(23, 24);
+            int nextDigit = Integer.parseInt(next);
+            if (nextDigit > 5) {
+                millis += 1;
+            }
+            return TimestampString.fromMillisSinceEpoch(millis);
+        } else {
+            return ts;
+        }
     }
 
     /** Delete a file/directory recursively

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimestampTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresTimestampTests.java
@@ -755,7 +755,7 @@ public class PostgresTimestampTests extends SqlIoTest {
                    EXTRACT(quarter FROM d1) AS 'quarter', EXTRACT(MILLISECOND FROM d1) AS 'msec',
                    EXTRACT(MICROSECOND FROM d1) AS 'usec'
                    FROM TIMESTAMP_TBL;
-                          timestamp          | quarter | msec  |   usec  \s
+                          timestamp          | quarter | msec  |   usec
                 -----------------------------+---------+-------+----------
                  Thu Jan 01 00:00:00 1970    |       1 |     0 |        0
                  Mon Feb 10 17:32:01 1997    |       1 |  1000 |  1000000
@@ -1153,7 +1153,7 @@ public class PostgresTimestampTests extends SqlIoTest {
                    -- round(extract(julian from d1)) AS julian,
                    extract(epoch from d1) AS 'epoch'
                    FROM TIMESTAMP_TBL;
-                          timestamp          | microseconds | milliseconds |  seconds  |    epoch  \s
+                          timestamp          | microseconds | milliseconds |  seconds  |    epoch
                 -----------------------------+--------------+--------------+-----------+------------
                  Thu Jan 01 00:00:00 1970    |            0 |        0     |  0        |            0
                  Mon Feb 10 17:32:01 1997    |      1000000 |     1000     |  1        |    855595921

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayTests.java
@@ -108,7 +108,7 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
 
         this.testQuery("", query, new InputOutputChange(
@@ -124,7 +124,7 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
 
         this.testQuery("", query, new InputOutputChange(
@@ -140,9 +140,9 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
-        result.add(new DBSPTupleExpression(
+        result.append(new DBSPTupleExpression(
                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true))));
         this.testQuery("", query, new InputOutputChange(
                 new Change(), new Change(result)).toStream());
@@ -159,7 +159,7 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
         this.testQuery("", query, new InputOutputChange(
                 new Change(), new Change(result)).toStream());
@@ -176,9 +176,9 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
-        result.add(new DBSPTupleExpression(
+        result.append(new DBSPTupleExpression(
                 DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)),
                 new DBSPI32Literal(6)));
 
@@ -198,7 +198,7 @@ public class ArrayTests extends BaseSQLTests {
             if (i == 1)
                 result = new DBSPZSetExpression(tuple);
             else
-                Objects.requireNonNull(result).add(tuple);
+                Objects.requireNonNull(result).append(tuple);
         }
 
         this.testQuery("", query, new InputOutputChange(
@@ -280,7 +280,7 @@ public class ArrayTests extends BaseSQLTests {
                         new DBSPI32Literal(i, true),
                         new DBSPI32Literal(j, true),
                         new DBSPI32Literal(7));
-                result.add(tuple);
+                result.append(tuple);
             }
         for (int i = 8; i < 11; i++)
             for (int j = 11; j < 14; j++) {
@@ -288,7 +288,7 @@ public class ArrayTests extends BaseSQLTests {
                         new DBSPI32Literal(i, true),
                         new DBSPI32Literal(j, true),
                         new DBSPI32Literal(14));
-                result.add(tuple);
+                result.append(tuple);
             }
         this.testQuery(ddl, query, new InputOutputChange(new Change(input), new Change(result)).toStream());
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MultiViewTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/MultiViewTests.java
@@ -49,7 +49,7 @@ public class MultiViewTests extends BaseSQLTests {
         compiler.submitStatementForCompilation(query2);
 
         CompilerCircuitStream ccs = this.getCCS(compiler);
-        Change inputChange = EndToEndTests.createInput();
+        Change inputChange = EndToEndTests.INPUT;
         Change outputChange = new Change(
                 new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
@@ -73,7 +73,7 @@ public class MultiViewTests extends BaseSQLTests {
         CompilerCircuitStream ccs = this.getCCS(compiler);
 
         InputOutputChange change = new InputOutputChange(
-                EndToEndTests.createInput(),
+                EndToEndTests.INPUT,
                 new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))),
@@ -97,7 +97,7 @@ public class MultiViewTests extends BaseSQLTests {
 
         CompilerCircuitStream ccs = this.getCCS(compiler);
         InputOutputChange change = new InputOutputChange(
-                EndToEndTests.createInput(),
+                EndToEndTests.INPUT,
                 new Change(new DBSPZSetExpression(
                         new DBSPTupleExpression(new DBSPBoolLiteral(true)),
                         new DBSPTupleExpression(new DBSPBoolLiteral(false))),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/NaiveIncrementalTests.java
@@ -41,20 +41,19 @@ public class NaiveIncrementalTests extends EndToEndTests {
 
     @Override
     public void testQuery(String query, DBSPZSetExpression firstOutput) {
-        Change input = createInput();
         Change secondOutput = Change.singleEmptyWithElementType(firstOutput.getElementType());
         Change thirdOutput = new Change(secondOutput.getSet(0).minus(firstOutput));
         this.invokeTestQueryBase(query,
                 new InputOutputChangeStream()
-                        .addPair(input, new Change(firstOutput))  // Add first input
+                        .addPair(INPUT, new Change(firstOutput))  // Add first input
                         .addPair(new Change(empty), secondOutput) // Add an empty input
-                        .addPair(new Change(input.getSet(0).negate()), thirdOutput) // Subtract the first input
+                        .addPair(new Change(INPUT.getSet(0).negate()), thirdOutput) // Subtract the first input
         );
     }
 
     @Override
     void testConstantOutput(String query, DBSPZSetExpression output) {
-        Change input = createInput();
+        Change input = INPUT;
         Change e = Change.singleEmptyWithElementType(output.getElementType());
         this.invokeTestQueryBase(query,
                 new InputOutputChangeStream()
@@ -67,7 +66,7 @@ public class NaiveIncrementalTests extends EndToEndTests {
     void testAggregate(String query,
                        DBSPZSetExpression firstOutput,
                        DBSPZSetExpression outputForEmptyInput) {
-        Change input = createInput();
+        Change input = INPUT;
         Change secondOutput = Change.singleEmptyWithElementType(firstOutput.getElementType());
         Change thirdOutput = new Change(outputForEmptyInput.minus(firstOutput));
         this.invokeTestQueryBase(query,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -1935,24 +1935,21 @@ public class StreamingTests extends StreamingTestBase {
                         )))));
         // Insert tuple after waterline, should change average.
         // Waterline is advanced
+        var set = new DBSPZSetExpression(
+                new DBSPTupleExpression(
+                        new DBSPDoubleLiteral(15.0, true),
+                        new DBSPDateLiteral("2023-12-30", false)));
+        set.append(new DBSPZSetExpression(
+                new DBSPTupleExpression(
+                        new DBSPDoubleLiteral(10.0, true),
+                        new DBSPDateLiteral("2023-12-30", false))).negate());
         ccs.addChange(new InputOutputChange(
                 new Change(
                         new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(20.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:10:00", false)))),
-                new Change(
-                        new DBSPZSetExpression(
-                                new DBSPTupleExpression(
-                                        new DBSPDoubleLiteral(15.0, true),
-                                        new DBSPDateLiteral("2023-12-30", false)))
-                                .add(
-                                        new DBSPZSetExpression(
-                                                new DBSPTupleExpression(
-                                                        new DBSPDoubleLiteral(10.0, true),
-                                                        new DBSPDateLiteral("2023-12-30", false))).negate()
-                                ),
-                        DBSPZSetExpression.emptyWithElementType(error))));
+                new Change(set, DBSPZSetExpression.emptyWithElementType(error))));
         // Insert tuple before last waterline, should be dropped
         ccs.addChange(new InputOutputChange(
                 new Change(
@@ -1986,24 +1983,21 @@ public class StreamingTests extends StreamingTestBase {
                                         new DBSPStringLiteral("(Some(10.0), 2023-12-29 09:10:00)")
                                 )))));
         // Insert tuple in the past, but before the last waterline
+        var set1 = new DBSPZSetExpression(
+                new DBSPTupleExpression(
+                        new DBSPDoubleLiteral(13.333333333333334, true),
+                        new DBSPDateLiteral("2023-12-30", false)));
+        set1.append(new DBSPZSetExpression(
+                new DBSPTupleExpression(
+                    new DBSPDoubleLiteral(15.0, true),
+                    new DBSPDateLiteral("2023-12-30", false))).negate());
         ccs.addChange(new InputOutputChange(
                 new Change(
                         new DBSPZSetExpression(
                                 new DBSPTupleExpression(
                                         new DBSPDoubleLiteral(10.0, true),
                                         new DBSPTimestampLiteral("2023-12-30 10:00:00", false)))),
-                new Change(
-                        new DBSPZSetExpression(
-                                new DBSPTupleExpression(
-                                        new DBSPDoubleLiteral(13.333333333333334, true),
-                                        new DBSPDateLiteral("2023-12-30", false)))
-                                .add(
-                                        new DBSPZSetExpression(
-                                                new DBSPTupleExpression(
-                                                        new DBSPDoubleLiteral(15.0, true),
-                                                        new DBSPDateLiteral("2023-12-30", false))).negate()
-                                ),
-                        DBSPZSetExpression.emptyWithElementType(error))));
+                new Change(set1, DBSPZSetExpression.emptyWithElementType(error))));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/slt/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -260,7 +260,10 @@ public class DBSPExecutor extends SqlSltTestExecutor {
             fields.add(field);
             col++;
             if (col == outputElementType.size()) {
-                container.add(new DBSPTupleExpression(CalciteObject.EMPTY, fields));
+                if (container.is(DBSPZSetExpression.class))
+                    container.to(DBSPZSetExpression.class).append(new DBSPTupleExpression(CalciteObject.EMPTY, fields));
+                else
+                    container.to(DBSPArrayExpression.class).append(new DBSPTupleExpression(CalciteObject.EMPTY, fields));
                 fields = new ArrayList<>();
                 col = 0;
             }


### PR DESCRIPTION
Didn't mean to do this, but I got fed up.
This may speed up the Java tests by roughly 2x