### PR TITLE
docs: fix broken docker-compose.yml download links.

### DIFF
--- a/docs/get-started/docker.md
+++ b/docs/get-started/docker.md
@@ -20,14 +20,14 @@ Feldera with auxiliary services included in the Docker Compose file
 like Redpanda, Prometheus and Grafana.
 
 ```
-curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
 docker compose -f - up
 ```
 
 You can enable specific services from the Docker Compose file as follows:
 
 ```
-curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
 docker compose -f - up pipeline-manager redpanda
 ```
 

--- a/docs/tutorials/basics/part3.md
+++ b/docs/tutorials/basics/part3.md
@@ -97,7 +97,7 @@ the Redpanda container should already be running.  Otherwise, you can start it
 using the following command:
 
 ```bash
-curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | docker compose -f - up redpanda
+curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | docker compose -f - up redpanda
 ```
 
 Next, you will need to install `rpk`, the Redpanda CLI, by following the instructions on

--- a/docs/tutorials/rest_api/index.md
+++ b/docs/tutorials/rest_api/index.md
@@ -26,7 +26,7 @@ language (e.g., in Python using the `requests` module).
 3. **Feldera instance:**  If you haven't done so already, you can start Feldera locally using
    [**docker**](https://docs.docker.com/engine/install/):
    ```
-   curl -L https://github.com/feldera/feldera/releases/latest/download/docker-compose.yml | \
+   curl -L https://raw.githubusercontent.com/feldera/feldera/main/deploy/docker-compose.yml | \
    docker compose -f - up
    ```
    (leave it running in a separate terminal while going through this tutorial)


### PR DESCRIPTION
This is no longer included in the release artifacts, so pull it straight off the `main` branch.