### PR TITLE
[dbsp] Add slot occupancy information in circuit profiles.

### DIFF
--- a/crates/dbsp/src/trace/mod.rs
+++ b/crates/dbsp/src/trace/mod.rs
@@ -34,6 +34,7 @@ pub use crate::storage::file::{Deserializable, Deserializer, Rkyv, Serializer};
 use crate::{dynamic::ArchivedDBData, storage::buffer_cache::FBuf};
 use cursor::{FilteredMergeCursor, UnfilteredMergeCursor};
 use dyn_clone::DynClone;
+use enum_map::Enum;
 use feldera_storage::StoragePath;
 use rand::Rng;
 use rkyv::ser::Serializer as _;
@@ -324,13 +325,22 @@ pub trait Trace: BatchReader {
 }
 
 /// Where a batch is stored.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Enum)]
 pub enum BatchLocation {
     /// In RAM.
     Memory,
 
     /// On disk.
     Storage,
+}
+
+impl BatchLocation {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Storage => "storage",
+        }
+    }
 }
 
 /// A set of `(key, value, time, diff)` tuples whose contents may be read in

--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -87,7 +87,7 @@ impl From<&str> for SqlString {
 
 impl SizeOf for SqlString {
     fn size_of_children(&self, context: &mut Context) {
-        self.str().size_of_children(context)
+        self.0.size_of_children(context);
     }
 }
 
@@ -714,6 +714,7 @@ mod tests {
     use crate::SqlString;
     use dbsp::storage::file::to_bytes;
     use rkyv::from_bytes;
+    use size_of::SizeOf;
 
     #[test]
     fn rkyv_serialize_deserialize_sqlstring() {
@@ -721,5 +722,15 @@ mod tests {
         let archived = to_bytes(&s).unwrap();
         let deserialized: SqlString = from_bytes(&archived).unwrap();
         assert_eq!(s.str(), deserialized.str());
+    }
+
+    #[test]
+    fn sizeof_sqlstring() {
+        let s = SqlString::from_ref("abcdefghijklmnopqrstuvwxyz");
+        let total_size = SizeOf::size_of(&s);
+
+        // The exact size may depend on the architecture's pointer size.
+        assert!(total_size.total_bytes() > 26);
+        assert!(total_size.shared_bytes() >= 26);
     }
 }


### PR DESCRIPTION
This adds information on per-slot occupancy and merging batches to circuit profiles for spines, to aid in debugging.