### PR TITLE
[dbsp] Spill to storage very large batches at insertion into the spine.

### DIFF
--- a/crates/dbsp/src/trace/ord/fallback/mod.rs
+++ b/crates/dbsp/src/trace/ord/fallback/mod.rs
@@ -7,3 +7,4 @@ pub mod key_batch;
 mod utils;
 pub mod val_batch;
 pub mod wset;
+pub use utils::pick_merge_destination;

--- a/crates/dbsp/src/trace/ord/fallback/utils.rs
+++ b/crates/dbsp/src/trace/ord/fallback/utils.rs
@@ -25,7 +25,7 @@ where
     }
 }
 
-pub(super) fn pick_merge_destination<'a, B, I>(
+pub fn pick_merge_destination<'a, B, I>(
     batches: I,
     dst_hint: Option<BatchLocation>,
 ) -> BatchLocation


### PR DESCRIPTION
A user has a workload that produces very large batches in intermediate operators that can in some cases exceed the memory size.  This commit adds a stopgap measure to spill those batches to disk before they would first be merged in the ordinary course of operations for merger, which should make it less likely that they will run the system out of memory.