### PR TITLE
[adapters] Print details of unique key violations.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -273,6 +273,10 @@ pub trait SerCursor: Send {
     /// Serialize current key. Panics if invalid.
     fn serialize_key(&mut self, dst: &mut Vec<u8>) -> AnyResult<()>;
 
+    /// Convert key to JSON. Used for error reporting to generate a human-readable
+    /// representation of the key.
+    fn key_to_json(&mut self) -> AnyResult<serde_json::Value>;
+
     /// Like `serialize_key`, but only serializes the specified fields of the key.
     fn serialize_key_fields(
         &mut self,
@@ -303,6 +307,10 @@ pub trait SerCursor: Send {
 
     /// Serialize current value. Panics if invalid.
     fn serialize_val(&mut self, dst: &mut Vec<u8>) -> AnyResult<()>;
+
+    /// Convert value to JSON. Used for error reporting to generate a human-readable
+    /// representation of the value.
+    fn val_to_json(&mut self) -> AnyResult<serde_json::Value>;
 
     #[cfg(feature = "with-avro")]
     /// Convert current value to Avro.
@@ -432,6 +440,10 @@ impl SerCursor for CursorWithPolarity<'_> {
         self.cursor.serialize_key(dst)
     }
 
+    fn key_to_json(&mut self) -> AnyResult<serde_json::Value> {
+        self.cursor.key_to_json()
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -464,6 +476,10 @@ impl SerCursor for CursorWithPolarity<'_> {
 
     fn serialize_val(&mut self, dst: &mut Vec<u8>) -> AnyResult<()> {
         self.cursor.serialize_val(dst)
+    }
+
+    fn val_to_json(&mut self) -> AnyResult<serde_json::Value> {
+        self.cursor.val_to_json()
     }
 
     #[cfg(feature = "with-avro")]

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -5,7 +5,7 @@ use crate::{
     catalog::{RecordFormat, SerBatch, SerCollectionHandle, SerCursor},
     ControllerError,
 };
-use anyhow::Result as AnyResult;
+use anyhow::{anyhow, Result as AnyResult};
 #[cfg(feature = "with-avro")]
 use apache_avro::schema::NamesRef;
 #[cfg(feature = "with-avro")]
@@ -635,6 +635,14 @@ where
         )
     }
 
+    fn key_to_json(&mut self) -> AnyResult<serde_json::Value> {
+        serde_json::to_value(SerializeWithContextWrapper::new(
+            self.key.as_ref().unwrap(),
+            &self.serde_config,
+        ))
+        .map_err(|e| anyhow!("Failed to serialize key to JSON: {}", e))
+    }
+
     fn serialize_key_fields(
         &mut self,
         fields: &HashSet<String>,
@@ -692,6 +700,14 @@ where
             &SerializeWithContextWrapper::new(&self.val.as_ref().unwrap(), &self.serde_config),
             dst,
         )
+    }
+
+    fn val_to_json(&mut self) -> AnyResult<serde_json::Value> {
+        serde_json::to_value(SerializeWithContextWrapper::new(
+            self.val.as_ref().unwrap(),
+            &self.serde_config,
+        ))
+        .map_err(|e| anyhow!("Failed to serialize value to JSON: {}", e))
     }
 
     #[cfg(feature = "with-avro")]


### PR DESCRIPTION
Output detailed information about unique key violations in output connectors, including:

* key that had non-unique outputs
* error type: duplicate records, or multiple unique records for the same key.
* list all updates associated with the key.