### PR TITLE
Increase stack size of tokio tasks.

### DIFF
--- a/crates/storage/src/tokio.rs
+++ b/crates/storage/src/tokio.rs
@@ -1,7 +1,19 @@
 use once_cell::sync::Lazy;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 
 /// The process running dbsp can share a single Tokio runtime.
 ///
 /// This is `pub` so it can be used in dbsp and adapters too for IO.
-pub static TOKIO: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
+pub static TOKIO: Lazy<Runtime> = Lazy::new(|| {
+    Builder::new_multi_thread()
+        .thread_name_fn(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+            format!("feldera-tokio-{}", id)
+        })
+        .thread_stack_size(6 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap()
+});


### PR DESCRIPTION
This may help with stack-overflow happening in ad-hoc queries.