### PR TITLE
[ci] enable adapter tests on aarch64.

### DIFF
--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -12,10 +12,9 @@ jobs:
           - runner: ubuntu-latest
             arch: x86_64
             target: x86_64-unknown-linux-gnu
-          # needs 2404 images which supposedly ship next week
-          #- runner: blacksmith-16vcpu-ubuntu-2204-arm
-          #  arch: aarch64
-          #  target: aarch64-unknown-linux-gnu
+          - runner: blacksmith-16vcpu-ubuntu-2404-arm
+            arch: aarch64
+            target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     # can't run in container because see below
     # For some dumb reason we can't run these tests in the dev container


### PR DESCRIPTION
This wasn't previously possible because blacksmith didn't have ubuntu 24.04 runners for arm, but now they added them.