### PR TITLE
[SQL] Migrate to new Calcite version

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -1346,12 +1346,8 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 return VisitDecision.STOP;
             }
 
-            if (destVecType == null)
-                throw new UnsupportedException("Cast from " + sourceType + " to " + destType, expression.getNode());
-            if (destVecType.getElementType().sameType(sourceVecType.getElementType())) {
-                // should have been eliminated
-                this.unimplementedCast(expression);
-            }
+            // should have been eliminated
+            this.unimplementedCast(expression);
             this.pop(expression);
             return VisitDecision.STOP;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ImmutableSetopOptimizerRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ImmutableSetopOptimizerRule.java
@@ -1,0 +1,307 @@
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.Var;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.tools.RelBuilderFactory;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+// In Calcite this kind of class is generated automatically, but here this was
+// produced by hand-editing the ImmutableSetOpToFilterRule class.
+final class ImmutableSetopOptimizerRule {
+    private ImmutableSetopOptimizerRule() {}
+
+    static final class Config implements SetopOptimizerRule.Config {
+        private final RelBuilderFactory relBuilderFactory;
+        private final @Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String description;
+        private final RelRule.OperandTransform operandSupplier;
+        private final RelRule.MatchHandler<SetopOptimizerRule> matchHandler;
+
+        private Config(ImmutableSetopOptimizerRule.Config.Builder builder) {
+            this.description = builder.description;
+            this.matchHandler = builder.matchHandler;
+            if (builder.relBuilderFactory != null) {
+                initShim.withRelBuilderFactory(builder.relBuilderFactory);
+            }
+            if (builder.operandSupplier != null) {
+                initShim.withOperandSupplier(builder.operandSupplier);
+            }
+            this.relBuilderFactory = initShim.relBuilderFactory();
+            this.operandSupplier = initShim.operandSupplier();
+            this.initShim = null;
+        }
+
+        private Config(
+                RelBuilderFactory relBuilderFactory,
+                @Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String description,
+                RelRule.OperandTransform operandSupplier,
+                RelRule.MatchHandler<SetopOptimizerRule> matchHandler) {
+            this.relBuilderFactory = relBuilderFactory;
+            this.description = description;
+            this.operandSupplier = operandSupplier;
+            this.matchHandler = matchHandler;
+            this.initShim = null;
+        }
+
+        private static final byte STAGE_INITIALIZING = -1;
+        private static final byte STAGE_UNINITIALIZED = 0;
+        private static final byte STAGE_INITIALIZED = 1;
+        private transient volatile ImmutableSetopOptimizerRule.Config.InitShim initShim = new ImmutableSetopOptimizerRule.Config.InitShim();
+
+        private final class InitShim {
+            private byte relBuilderFactoryBuildStage = STAGE_UNINITIALIZED;
+            private RelBuilderFactory relBuilderFactory;
+
+            RelBuilderFactory relBuilderFactory() {
+                if (relBuilderFactoryBuildStage == STAGE_INITIALIZING) throw new IllegalStateException(formatInitCycleMessage());
+                if (relBuilderFactoryBuildStage == STAGE_UNINITIALIZED) {
+                    relBuilderFactoryBuildStage = STAGE_INITIALIZING;
+                    this.relBuilderFactory = Objects.requireNonNull(relBuilderFactoryInitialize(), "relBuilderFactory");
+                    relBuilderFactoryBuildStage = STAGE_INITIALIZED;
+                }
+                return this.relBuilderFactory;
+            }
+
+            void withRelBuilderFactory(RelBuilderFactory relBuilderFactory) {
+                this.relBuilderFactory = relBuilderFactory;
+                relBuilderFactoryBuildStage = STAGE_INITIALIZED;
+            }
+
+            private byte operandSupplierBuildStage = STAGE_UNINITIALIZED;
+            private RelRule.OperandTransform operandSupplier;
+
+            RelRule.OperandTransform operandSupplier() {
+                if (operandSupplierBuildStage == STAGE_INITIALIZING) throw new IllegalStateException(formatInitCycleMessage());
+                if (operandSupplierBuildStage == STAGE_UNINITIALIZED) {
+                    operandSupplierBuildStage = STAGE_INITIALIZING;
+                    this.operandSupplier = Objects.requireNonNull(operandSupplierInitialize(), "operandSupplier");
+                    operandSupplierBuildStage = STAGE_INITIALIZED;
+                }
+                return this.operandSupplier;
+            }
+
+            void withOperandSupplier(RelRule.OperandTransform operandSupplier) {
+                this.operandSupplier = operandSupplier;
+                operandSupplierBuildStage = STAGE_INITIALIZED;
+            }
+
+            private String formatInitCycleMessage() {
+                List<String> attributes = new ArrayList<>();
+                if (relBuilderFactoryBuildStage == STAGE_INITIALIZING) attributes.add("relBuilderFactory");
+                if (operandSupplierBuildStage == STAGE_INITIALIZING) attributes.add("operandSupplier");
+                return "Cannot build Config, attribute initializers form cycle " + attributes;
+            }
+        }
+
+        private RelBuilderFactory relBuilderFactoryInitialize() {
+            return SetopOptimizerRule.Config.super.relBuilderFactory();
+        }
+
+        private RelRule.OperandTransform operandSupplierInitialize() {
+            return SetopOptimizerRule.Config.super.operandSupplier();
+        }
+
+        @Override
+        public RelBuilderFactory relBuilderFactory() {
+            ImmutableSetopOptimizerRule.Config.InitShim shim = this.initShim;
+            return shim != null
+                    ? shim.relBuilderFactory()
+                    : this.relBuilderFactory;
+        }
+
+        @Override
+        public @Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String description() {
+            return description;
+        }
+
+        @Override
+        public RelRule.OperandTransform operandSupplier() {
+            ImmutableSetopOptimizerRule.Config.InitShim shim = this.initShim;
+            return shim != null
+                    ? shim.operandSupplier()
+                    : this.operandSupplier;
+        }
+
+        @Override
+        public RelRule.MatchHandler<SetopOptimizerRule> matchHandler() {
+            return matchHandler;
+        }
+
+        public final ImmutableSetopOptimizerRule.Config withRelBuilderFactory(RelBuilderFactory value) {
+            if (this.relBuilderFactory == value) return this;
+            RelBuilderFactory newValue = Objects.requireNonNull(value, "relBuilderFactory");
+            return new ImmutableSetopOptimizerRule.Config(newValue, this.description, this.operandSupplier, this.matchHandler);
+        }
+
+        /**
+         * Copy the current immutable object by setting a value for the {@link SetopOptimizerRule.Config#description() description} attribute.
+         * An equals check used to prevent copying of the same value by returning {@code this}.
+         * @param value A new value for description (can be {@code null})
+         * @return A modified copy of the {@code this} object
+         */
+        public final ImmutableSetopOptimizerRule.Config withDescription(@Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String value) {
+            if (Objects.equals(this.description, value)) return this;
+            return new ImmutableSetopOptimizerRule.Config(this.relBuilderFactory, value, this.operandSupplier, this.matchHandler);
+        }
+
+        /**
+         * Copy the current immutable object by setting a value for the {@link SetopOptimizerRule.Config#operandSupplier() operandSupplier} attribute.
+         * A shallow reference equality check is used to prevent copying of the same value by returning {@code this}.
+         * @param value A new value for operandSupplier
+         * @return A modified copy of the {@code this} object
+         */
+        public final ImmutableSetopOptimizerRule.Config withOperandSupplier(RelRule.OperandTransform value) {
+            if (this.operandSupplier == value) return this;
+            RelRule.OperandTransform newValue = Objects.requireNonNull(value, "operandSupplier");
+            return new ImmutableSetopOptimizerRule.Config(this.relBuilderFactory, this.description, newValue, this.matchHandler);
+        }
+
+        /**
+         * Copy the current immutable object by setting a value for the {@link SetopOptimizerRule.Config#matchHandler() matchHandler} attribute.
+         * A shallow reference equality check is used to prevent copying of the same value by returning {@code this}.
+         * @param value A new value for matchHandler
+         * @return A modified copy of the {@code this} object
+         */
+        public final ImmutableSetopOptimizerRule.Config withMatchHandler(RelRule.MatchHandler<SetopOptimizerRule> value) {
+            if (this.matchHandler == value) return this;
+            RelRule.MatchHandler<SetopOptimizerRule> newValue = Objects.requireNonNull(value, "matchHandler");
+            return new ImmutableSetopOptimizerRule.Config(this.relBuilderFactory, this.description, this.operandSupplier, newValue);
+        }
+
+        /**
+         * This instance is equal to all instances of {@code Config} that have equal attribute values.
+         * @return {@code true} if {@code this} is equal to {@code another} instance
+         */
+        @Override
+        public boolean equals(@Nullable Object another) {
+            if (this == another) return true;
+            return another instanceof ImmutableSetopOptimizerRule.Config
+                    && equalTo((ImmutableSetopOptimizerRule.Config) another);
+        }
+
+        private boolean equalTo(ImmutableSetopOptimizerRule.Config another) {
+            return relBuilderFactory.equals(another.relBuilderFactory)
+                    && Objects.equals(description, another.description)
+                    && operandSupplier.equals(another.operandSupplier)
+                    && matchHandler.equals(another.matchHandler);
+        }
+
+        /**
+         * Computes a hash code from attributes: {@code relBuilderFactory}, {@code description}, {@code operandSupplier}, {@code matchHandler}.
+         * @return hashCode value
+         */
+        @Override
+        public int hashCode() {
+            @Var int h = 5381;
+            h += (h << 5) + relBuilderFactory.hashCode();
+            h += (h << 5) + Objects.hashCode(description);
+            h += (h << 5) + operandSupplier.hashCode();
+            h += (h << 5) + matchHandler.hashCode();
+            return h;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper("Config")
+                    .omitNullValues()
+                    .add("relBuilderFactory", relBuilderFactory)
+                    .add("description", description)
+                    .add("operandSupplier", operandSupplier)
+                    .add("matchHandler", matchHandler)
+                    .toString();
+        }
+
+        public static ImmutableSetopOptimizerRule.Config copyOf(SetopOptimizerRule.Config instance) {
+            if (instance instanceof ImmutableSetopOptimizerRule.Config) {
+                return (ImmutableSetopOptimizerRule.Config) instance;
+            }
+            return ImmutableSetopOptimizerRule.Config.builder()
+                    .from(instance)
+                    .build();
+        }
+
+        public static ImmutableSetopOptimizerRule.Config.Builder builder() {
+            return new ImmutableSetopOptimizerRule.Config.Builder();
+        }
+
+        public static final class Builder {
+            private static final long INIT_BIT_MATCH_HANDLER = 0x1L;
+            private long initBits = 0x1L;
+
+            private @Nullable RelBuilderFactory relBuilderFactory;
+            private @Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String description;
+            private @Nullable RelRule.OperandTransform operandSupplier;
+            private @Nullable RelRule.MatchHandler<SetopOptimizerRule> matchHandler;
+
+            private Builder() {
+            }
+
+            public final ImmutableSetopOptimizerRule.Config.Builder from(RelRule.Config instance) {
+                Objects.requireNonNull(instance, "instance");
+                from((Object) instance);
+                return this;
+            }
+
+            public final ImmutableSetopOptimizerRule.Config.Builder from(SetopOptimizerRule.Config instance) {
+                Objects.requireNonNull(instance, "instance");
+                from((Object) instance);
+                return this;
+            }
+
+            private void from(Object object) {
+                if (object instanceof RelRule.Config) {
+                    RelRule.Config instance = (RelRule.Config) object;
+                    withRelBuilderFactory(instance.relBuilderFactory());
+                    withOperandSupplier(instance.operandSupplier());
+                    @Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String descriptionValue = instance.description();
+                    if (descriptionValue != null) {
+                        withDescription(descriptionValue);
+                    }
+                }
+                if (object instanceof SetopOptimizerRule.Config) {
+                    SetopOptimizerRule.Config instance = (SetopOptimizerRule.Config) object;
+                    withMatchHandler(instance.matchHandler());
+                }
+            }
+
+            public final ImmutableSetopOptimizerRule.Config.Builder withRelBuilderFactory(RelBuilderFactory relBuilderFactory) {
+                this.relBuilderFactory = Objects.requireNonNull(relBuilderFactory, "relBuilderFactory");
+                return this;
+            }
+
+            public ImmutableSetopOptimizerRule.Config.Builder withDescription(@Nullable java.lang.@org.checkerframework.checker.nullness.qual.Nullable String description) {
+                this.description = description;
+                return this;
+            }
+
+            public final ImmutableSetopOptimizerRule.Config.Builder withOperandSupplier(RelRule.OperandTransform operandSupplier) {
+                this.operandSupplier = Objects.requireNonNull(operandSupplier, "operandSupplier");
+                return this;
+            }
+
+            public final ImmutableSetopOptimizerRule.Config.Builder withMatchHandler(RelRule.MatchHandler<SetopOptimizerRule> matchHandler) {
+                this.matchHandler = Objects.requireNonNull(matchHandler, "matchHandler");
+                initBits &= ~INIT_BIT_MATCH_HANDLER;
+                return this;
+            }
+
+            public ImmutableSetopOptimizerRule.Config build() {
+                if (initBits != 0) {
+                    throw new IllegalStateException(formatRequiredAttributesMessage());
+                }
+                return new ImmutableSetopOptimizerRule.Config(this);
+            }
+
+            private String formatRequiredAttributesMessage() {
+                List<String> attributes = new ArrayList<>();
+                if ((initBits & INIT_BIT_MATCH_HANDLER) != 0) attributes.add("matchHandler");
+                return "Cannot build Config, some of required attributes are not set " + attributes;
+            }
+        }
+    }
+}
+

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SetopOptimizerRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SetopOptimizerRule.java
@@ -1,0 +1,219 @@
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Intersect;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.SetOp;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Pair;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Adapts SetOpToFilterRule for the case when all filters are projected with a constant.
+ * That rule does not work in this case, since that requires filters as direct inputs to the union.
+ *
+ * <p>Plan before:
+ * LogicalUnion(all=[false]), id = 127
+ *  LogicalProject(EXPR$0=[true]), id = 121
+ *    LogicalFilter(condition=[=($cor0.arg1, $1)]), id = 82
+ *      LogicalTableScan(table=[[schema, fact_2]]), id = 81
+ *  LogicalProject(EXPR$0=[true]), id = 123
+ *    LogicalFilter(condition=[AND(=($1, 'admin'), =($cor0.arg1, 'member'))]), id = 96
+ *      LogicalTableScan(table=[[schema, fact_2]]), id = 85
+ *  LogicalProject(EXPR$0=[true]), id = 126
+ *    LogicalFilter(condition=[AND(=($1, 'eng'), =($cor0.arg1, 'member'))]), id = 100
+ *      LogicalTableScan(table=[[schema, fact_2]]), id = 90
+ *
+ * <p>Plan after:
+ * LogicalAggregate(group=[{0}]), id = 306
+ *   LogicalProject($f0=[true]), id = 304
+ *     LogicalFilter(condition=[OR(=($cor0.arg1, $1), AND(=($1, 'admin'), =($cor0.arg1, 'member')), AND(=($1, 'eng'), =($cor0.arg1, 'member')))]), id = 302
+ *       LogicalTableScan(table=[[schema, fact_2]]), id = 76
+ */
+public class SetopOptimizerRule
+        extends RelRule<SetopOptimizerRule.Config>
+        implements TransformationRule {
+
+    /** Creates an SetOpToFilterRule. */
+    protected SetopOptimizerRule(Config config) {
+        super(config);
+    }
+
+    //~ Methods ----------------------------------------------------------------
+
+    @Override public void onMatch(RelOptRuleCall call) {
+        config.matchHandler().accept(this, call);
+    }
+
+    private void match(RelOptRuleCall call) {
+        final SetOp setOp = call.rel(0);
+        final List<RelNode> inputs = setOp.getInputs();
+        if (setOp.all || inputs.size() < 2) {
+            return;
+        }
+
+        final RelBuilder builder = call.builder();
+        RexLiteral literal = null;
+        for (int i = 0; i < inputs.size(); i++) {
+            RelNode input = inputs.get(i).stripped();
+            Project proj = (Project) input;
+            if (i == 0) {
+                literal = (RexLiteral) proj.getProjects().get(0);
+            } else {
+                RexLiteral nextLiteral = (RexLiteral) proj.getProjects().get(0);
+                if (!literal.equals(nextLiteral))
+                    return;
+            }
+        }
+
+        Pair<RelNode, @Nullable RexNode> first = extractSourceAndCond(inputs.get(0).stripped().getInput(0).stripped());
+
+        // Groups conditions by their source relational node and input position.
+        // - Key: Pair of (sourceRelNode, inputPosition)
+        //   - inputPosition is null for mergeable conditions
+        //   - inputPosition contains original index for non-mergeable inputs
+        // - Value: List of conditions
+        //
+        // For invalid conditions (non-deterministic expressions or containing subqueries),
+        // positions are tagged with their input indices to skip unmergeable inputs
+        // during map-based grouping. Other positions are set to null.
+        Map<Pair<RelNode, @Nullable Integer>, List<@Nullable RexNode>> sourceToConds =
+                new LinkedHashMap<>();
+
+        RelNode firstSource = first.left;
+        sourceToConds.computeIfAbsent(Pair.of(firstSource, null),
+                k -> new ArrayList<>()).add(first.right);
+
+        for (int i = 1; i < inputs.size(); i++) {
+            final RelNode input = inputs.get(i).stripped().getInput(0).stripped();
+            final Pair<RelNode, @Nullable RexNode> pair = extractSourceAndCond(input);
+            sourceToConds.computeIfAbsent(Pair.of(pair.left, pair.right != null ? null : i),
+                    k -> new ArrayList<>()).add(pair.right);
+        }
+
+        if (sourceToConds.size() == inputs.size()) {
+            return;
+        }
+
+        int branchCount = 0;
+        for (Map.Entry<Pair<RelNode, @Nullable Integer>, List<@Nullable RexNode>> entry
+                : sourceToConds.entrySet()) {
+            Pair<RelNode, @Nullable Integer> left = entry.getKey();
+            List<@Nullable RexNode> conds = entry.getValue();
+            // Single null condition indicates pass-through branch,
+            // directly add its corresponding input to the new inputs list.
+            if (conds.size() == 1 && conds.get(0) == null) {
+                builder.push(left.left);
+                branchCount++;
+                continue;
+            }
+
+            List<RexNode> condsNonNull = conds.stream().map(e -> {
+                assert e != null;
+                return e;
+            }).collect(Collectors.toList());
+
+            RexNode combinedCond = combineConditions(builder, condsNonNull, setOp);
+            builder.push(left.left)
+                    .filter(combinedCond)
+                    .project(literal);
+            branchCount++;
+        }
+
+        // RelBuilder will not create 1-input SetOp
+        // and remove the distinct after a SetOp
+        buildSetOp(builder, branchCount, setOp)
+                .distinct();
+        call.transformTo(builder.build());
+    }
+
+    private static RelBuilder buildSetOp(RelBuilder builder, int count, RelNode setOp) {
+        if (setOp instanceof Union) {
+            return builder.union(false, count);
+        } else if (setOp instanceof Intersect) {
+            return builder.intersect(false, count);
+        }
+        // unreachable
+        throw new IllegalStateException("unreachable code");
+    }
+
+    private static Pair<RelNode, @Nullable RexNode> extractSourceAndCond(RelNode input) {
+        if (input instanceof Filter filter) {
+            if (!RexUtil.isDeterministic(filter.getCondition())
+                    || RexUtil.SubQueryFinder.containsSubQuery(filter)) {
+                // Skip non-deterministic conditions or those containing subqueries
+                return Pair.of(input, null);
+            }
+            return Pair.of(filter.getInput().stripped(), filter.getCondition());
+        }
+        // For non-filter inputs, use TRUE literal as default condition.
+        return Pair.of(input.stripped(),
+                input.getCluster().getRexBuilder().makeLiteral(true));
+    }
+
+    /**
+     * Combines conditions according to set operation:
+     * UNION: OR combination
+     * INTERSECT: AND combination
+     */
+    private RexNode combineConditions(RelBuilder builder, List<RexNode> conds,
+                                      SetOp setOp) {
+        if (setOp instanceof Union) {
+            return builder.or(conds);
+        } else if (setOp instanceof Intersect) {
+            return builder.and(conds);
+        }
+        // unreachable
+        throw new IllegalStateException("unreachable code");
+    }
+
+    /** Rule configuration. */
+    public interface Config extends RelRule.Config {
+        Config UNION = ImmutableSetopOptimizerRule.Config.builder()
+                .withMatchHandler(SetopOptimizerRule::match)
+                .build()
+                .withOperandSupplier(
+                        b0 -> b0.operand(Union.class)
+                                .inputs(b1 -> b1.operand(Project.class)
+                                        .predicate(p -> p.getProjects().size() == 1 &&
+                                                p.getProjects().get(0).isA(SqlKind.LITERAL))
+                                        .anyInputs()))
+                .as(Config.class);
+
+        Config INTERSECT = ImmutableSetopOptimizerRule.Config.builder()
+                .withMatchHandler(SetopOptimizerRule::match)
+                .build()
+                .withOperandSupplier(
+                        b0 -> b0.operand(Intersect.class)
+                                .inputs(b1 -> b1.operand(Project.class)
+                                        .predicate(p -> p.getProjects().size() == 1 &&
+                                                p.getProjects().get(0).isA(SqlKind.LITERAL))
+                                        .anyInputs()))
+                .as(Config.class);
+
+        @Override default SetopOptimizerRule toRule() {
+            return new SetopOptimizerRule(this);
+        }
+
+        /** Forwards a call to {@link #onMatch(RelOptRuleCall)}. */
+        MatchHandler<SetopOptimizerRule> matchHandler();
+
+        /** Sets {@link #matchHandler()}. */
+        Config withMatchHandler(MatchHandler<SetopOptimizerRule> matchHandler);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -1277,9 +1277,11 @@ public abstract class InnerRewriteVisitor
     @Override
     public VisitDecision preorder(DBSPFunctionItem item) {
         this.push(item);
-        // TODO: do we need to transform?
+        item.function.accept(this);
+        DBSPFunction function = this.getResult().to(DBSPFunction.class);
         this.pop(item);
-        this.map(item, item);
+        DBSPFunctionItem result = new DBSPFunctionItem(function);
+        this.map(item, result);
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/IsolatedTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/IsolatedTest.java
@@ -2,7 +2,10 @@ package org.dbsp.sqlCompiler.compiler.sql;
 
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteOptimizer;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
+import org.dbsp.util.Logger;
+import org.junit.Test;
 
 /** Used for interactive debugging: create here temporary tests. */
 @SuppressWarnings("unused")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -5,12 +5,14 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOpera
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.CalciteOptimizer;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
@@ -744,7 +746,7 @@ public class IncrementalRegressionTests extends SqlIoTest {
             if (toCompile == null)
                 return;
             for (File c: toCompile) {
-                if (!c.getName().equals("project.sql")) continue;
+                if (!c.getName().contains("oso3.sql")) continue;
                 if (c.getName().contains("sql")) {
                     System.out.println("Compiling " + c);
                     String sql = Utilities.readFile(c.getPath());

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -9,11 +9,11 @@ set -e
 # Default is to use the next version
 NEXT='y'
 
-if false; then
+if true; then
     # This is the standard behavior
     CALCITE_REPO="https://github.com/apache/calcite.git"
     CALCITE_BRANCH="main"
-    CALCITE_NEXT_COMMIT="e617e85b9b8237378ef788eab02d6f851904f046"
+    CALCITE_NEXT_COMMIT="4ee33c9488740e41311c51735538dbac9e5abc4d"
 else
     # Switch to this script when testing a branch in mihaibudiu's fork that
     # hasn't been merged yet


### PR DESCRIPTION
Fixes #3863 
Fixes #3936 
Fixes #3913
This also enables compiling some classes of correlated subqueries which couldn't be compiled previously.