### PR TITLE
[dbsp] Skip bounded_memory test.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/time_series/window.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/window.rs
@@ -689,7 +689,9 @@ mod test {
         }
     }
 
+    // It's hard to make this test reliable with async background compactor threads.
     #[test]
+    #[ignore]
     fn bounded_memory() {
         let (mut dbsp, input_handle) = Runtime::init_circuit(8, |circuit| {
             let (input, input_handle) = circuit.add_input_indexed_zset::<i64, i64>();


### PR DESCRIPTION
When this test was created, trace bounds were enforced synchronously. It is no longer reliable with background compactors.