### PR TITLE
[dbsp] Fix invalid assumption in list merger.

### DIFF
--- a/crates/dbsp/src/trace/spine_async/list_merger.rs
+++ b/crates/dbsp/src/trace/spine_async/list_merger.rs
@@ -215,11 +215,13 @@ where
                         break;
                     }
                 }
-                debug_assert!(any_values, "This assertion should fail only if B::Cursor is a spine or a CursorList, but we shouldn't be merging those");
-                if self.has_mut[index] {
-                    builder.push_key_mut(self.cursors[index].key_mut());
-                } else {
-                    builder.push_key(self.cursors[index].key());
+                debug_assert!(time_map_func.is_some() || any_values, "This assertion should fail only if B::Cursor is a spine or a CursorList, but we shouldn't be merging those");
+                if any_values {
+                    if self.has_mut[index] {
+                        builder.push_key_mut(self.cursors[index].key_mut());
+                    } else {
+                        builder.push_key(self.cursors[index].key());
+                    }
                 }
                 self.cursors[index].step_key();
                 if !self.cursors[index].key_valid() {


### PR DESCRIPTION
The ListMerger algorithm assumed that an individual batch cannot contain zero-weight entries. This is correct, except when applying a map function to times in the batch, which can map records with different timestamps to the same timestamp, in which case such entries can cancel each other out.  This happens as part of lazy trace compaction where we consolidate entries with old timestamps that are no longer distinguishable to the algorithm.

Fixes #4028 