### PR TITLE
Improvements to suspend/resume functionality.

### DIFF
--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -26,7 +26,7 @@ impl CachedPipelineDescr {
     /// status to be interacted with (i.e., running or paused).
     fn deployment_location_based_on_status(&self) -> Result<String, ManagerError> {
         match self.pipeline.deployment_status {
-            PipelineStatus::Running | PipelineStatus::Paused => {}
+            PipelineStatus::Running | PipelineStatus::Paused | PipelineStatus::SuspendingCircuit => {}
             PipelineStatus::Unavailable => Err(RunnerError::PipelineInteractionUnreachable {
                 error: "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again".to_string()
             })?,

--- a/web-console/src/lib/compositions/useAggregatePipelineStats.svelte.ts
+++ b/web-console/src/lib/compositions/useAggregatePipelineStats.svelte.ts
@@ -39,6 +39,10 @@ export const useAggregatePipelineStats = (
       getMetrics = () => metrics
       return Promise.resolve()
     }
+    if (metricsAvailable === 'missing') {
+      getMetrics = () => metrics
+      return Promise.resolve()
+    }
     let requestTimestamp = Date.now()
     return api.getPipelineStats(pipelineName).then((stats) => {
       let responseTimestamp = Date.now()

--- a/web-console/src/lib/functions/pipelines/status.ts
+++ b/web-console/src/lib/functions/pipelines/status.ts
@@ -137,7 +137,7 @@ export const isMetricsAvailable = (status: PipelineStatus) => {
       { CompilingRust: P.any },
       () => 'no' as const
     )
-    .with('Unavailable', () => 'soon' as const)
+    .with('Unavailable', () => 'missing' as const)
     .with('SqlError', () => 'no' as const)
     .with('RustError', () => 'no' as const)
     .with('SystemError', () => 'no' as const)


### PR DESCRIPTION
- [x] WebConsole: show "normal" content of the performance tab (with all graphs and connector stats) while the pipeline is in the SuspendingCircuit state. 