### PR TITLE
[WebConsole] Fix white lines in AdHoc query results in dark mode

### DIFF
--- a/web-console/src/lib/components/adhoc/Query.svelte
+++ b/web-console/src/lib/components/adhoc/Query.svelte
@@ -207,7 +207,7 @@
             {#snippet item({ index, style }: { index: number; style?: string })}
               {@const row = rows[index]}
               {#if !row}{:else if 'cells' in row}
-                <tr {style} class="{itemHeight} whitespace-nowrap odd:bg-white odd:even:bg-black">
+                <tr {style} class="{itemHeight} whitespace-nowrap odd:bg-white odd:dark:bg-black">
                   {#each row.cells as value}
                     <SQLValue
                       {value}

--- a/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
@@ -2,7 +2,7 @@
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
 
   import { Chart } from 'svelte-echarts'
-  import { init, use } from 'echarts/core'
+  import { init, use, type EChartsType } from 'echarts/core'
   import { LineChart } from 'echarts/charts'
   import {
     GridComponent,
@@ -52,9 +52,57 @@
   let primaryColor = rgbToHex(
     getComputedStyle(document.body).getPropertyValue('--color-primary-500').trim()
   )
-  let options: EChartsOption = $derived({
+
+  let ref: EChartsType | undefined = $state()
+
+  $effect(() => {
+    metrics.global
+    if (!ref) {
+      return
+    }
+    ref.setOption({
+      series: [
+        {
+          data: metrics.global.map((m) => ({
+            name: m.timeMs.toString(),
+            value: tuple(m.timeMs, m.rss_bytes ?? 0)
+          }))
+        }
+      ],
+      xAxis: {
+        min: Date.now() - keepMs,
+        max: Date.now()
+      },
+      yAxis: {
+        interval: (yMax - yMin) / 2,
+        min: yMin,
+        max: yMax
+      }
+    })
+  })
+
+  $effect(() => {
+    if (!ref) {
+      return
+    }
+    ref.setOption({
+      series: [
+        {
+          markline: {
+            data: maxMemoryMb
+              ? [
+                  { yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } } // example 1
+                ]
+              : []
+          }
+        }
+      ]
+    })
+  })
+
+  let options: EChartsOption = {
     animationDuration: 0,
-    animationDurationUpdate: refetchMs * 1.5,
+    animationDurationUpdate: refetchMs,
     animationEasingUpdate: 'linear' as const,
     grid: {
       top: 10,
@@ -64,18 +112,21 @@
     },
     xAxis: {
       type: 'time' as const,
-      min: Date.now() - keepMs,
-      max: Date.now(),
+      min: Date.now() - keepMs - refetchMs,
+      max: Date.now() - refetchMs,
       minInterval: 25000,
       maxInterval: 25000,
       axisLabel: {
         formatter: (ms: number) => new Date(ms).toLocaleTimeString()
-      }
+      },
+      animation: true // optional, makes axis transitions smoother
     },
     yAxis: {
       type: 'value' as const,
+      // svelte-ignore state_referenced_locally
       interval: (yMax - yMin) / 2,
       min: yMin,
+      // svelte-ignore state_referenced_locally
       max: yMax,
       axisLabel: {
         showMinLabel: true,
@@ -119,6 +170,7 @@
           },
           emphasis: { disabled: true },
           symbol: ['none', 'none'],
+          // svelte-ignore state_referenced_locally
           data: maxMemoryMb
             ? [
                 { yAxis: maxMemoryMb * 1000 * 1000, lineStyle: { color: 'red', cap: 'square' } } // example 1
@@ -128,7 +180,7 @@
         triggerLineEvent: true
       }
     ]
-  })
+  }
 
   const handleSeriesHover = <T,>(setValue: (value: T | null) => void) => ({
     mouseover: (e: CustomEvent<ECMouseEvent>) => {
@@ -149,6 +201,6 @@
     Used memory: {humanSize(metrics.global.at(-1)?.rss_bytes ?? 0)}
   </div>
   {#key pipelineName}
-    <Chart {init} {options} />
+    <Chart init={(dom, theme, opts) => (ref = init(dom, theme, opts))} {options} />
   {/key}
 </div>

--- a/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
@@ -9,8 +9,7 @@
 
 <script lang="ts">
   import { type ExtendedPipeline } from '$lib/services/pipelineManager'
-  import Query, { type Row } from '$lib/components/adhoc/Query.svelte'
-  import { type QueryData } from '$lib/components/adhoc/Query.svelte'
+  import Query, { type Row, type QueryData } from '$lib/components/adhoc/Query.svelte'
   import { isPipelineInteractive } from '$lib/functions/pipelines/status'
   import type { SQLValueJS } from '$lib/types/sql.ts'
   import {


### PR DESCRIPTION
Make performance graphs scroll smoothly

Fix https://github.com/feldera/feldera/issues/4012: adhoc query table in dark mode is white cell bg with white text