### PR TITLE
[adapters] Re-implement the NOW() clock as a connector.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -21,6 +21,7 @@ use crate::catalog::OutputCollectionHandles;
 use crate::controller::checkpoint::CheckpointOffsets;
 use crate::controller::journal::Journal;
 use crate::create_integrated_output_endpoint;
+use crate::transport::clock::now_endpoint_config;
 use crate::transport::Step;
 use crate::transport::{input_transport_config_to_endpoint, output_transport_config_to_endpoint};
 use crate::util::run_on_thread_pool;
@@ -781,11 +782,10 @@ impl CircuitThread {
             if self.checkpoint_requested() {
                 self.checkpoint();
             }
-            let running = match self.controller.state() {
-                PipelineState::Running => true,
-                PipelineState::Paused => false,
-                PipelineState::Terminated => break,
-            };
+
+            if self.controller.state() == PipelineState::Terminated {
+                break;
+            }
 
             // Backpressure in the output pipeline: wait for room in output buffers to
             // become available.
@@ -800,7 +800,6 @@ impl CircuitThread {
                 self.last_checkpoint,
                 self.replaying(),
                 self.circuit.bootstrap_in_progress(),
-                running,
                 self.checkpoint_requested(),
             ) {
                 Action::Step => {
@@ -1599,9 +1598,6 @@ impl FtState {
 
 /// Decides when to trigger a step.
 struct StepTrigger {
-    /// Time when `clock_resolution` expires.
-    tick: Option<Instant>,
-
     /// Time when `max_buffering_delay` expires.
     buffer_timeout: Option<Instant>,
 
@@ -1614,9 +1610,6 @@ struct StepTrigger {
     /// Minimum number of records to receive before unconditionally triggering a
     /// step.
     min_batch_size_records: u64,
-
-    /// Time between clock ticks.
-    clock_resolution: Option<Duration>,
 
     /// Time between automatic checkpoints.
     checkpoint_interval: Option<Duration>,
@@ -1641,15 +1634,12 @@ impl StepTrigger {
         let config = &controller.status.pipeline_config.global;
         let max_buffering_delay = Duration::from_micros(config.max_buffering_delay_usecs);
         let min_batch_size_records = config.min_batch_size_records;
-        let clock_resolution = config.clock_resolution_usecs.map(Duration::from_micros);
         let checkpoint_interval = config.fault_tolerance.checkpoint_interval();
         Self {
             controller,
-            tick: clock_resolution.map(|delay| Instant::now() + delay),
             buffer_timeout: None,
             max_buffering_delay,
             min_batch_size_records,
-            clock_resolution,
             checkpoint_interval,
         }
     }
@@ -1668,7 +1658,6 @@ impl StepTrigger {
         last_checkpoint: Instant,
         replaying: bool,
         bootstrapping: bool,
-        running: bool,
         checkpoint_requested: bool,
     ) -> Action {
         // If any input endpoints are blocking suspend, then those are the only
@@ -1687,36 +1676,32 @@ impl StepTrigger {
             buffered_records[false]
         };
 
-        // `self.tick` but `None` if we're not running.
-        let tick = running.then_some(self.tick).flatten();
-
         // Time of the next checkpoint.
         let checkpoint = self
             .checkpoint_interval
             .map(|interval| last_checkpoint + interval);
 
-        fn step(trigger: &mut StepTrigger, now: Instant) -> Action {
-            trigger.tick = trigger.clock_resolution.map(|delay| now + delay);
+        fn step(trigger: &mut StepTrigger) -> Action {
             trigger.buffer_timeout = None;
             Action::Step
         }
 
         let now = Instant::now();
+
         if replaying || bootstrapping {
-            step(self, now)
+            step(self)
         } else if checkpoint.is_some_and(|t| now >= t) && !checkpoint_requested {
             Action::Checkpoint
         } else if self.controller.status.unset_step_requested()
             || buffered_records > self.min_batch_size_records
-            || tick.is_some_and(|t| now >= t)
             || self.buffer_timeout.is_some_and(|t| now >= t)
         {
-            step(self, now)
+            step(self)
         } else {
             if buffered_records > 0 && self.buffer_timeout.is_none() {
                 self.buffer_timeout = Some(now + self.max_buffering_delay);
             }
-            let wakeup = [tick, self.buffer_timeout, checkpoint]
+            let wakeup = [self.buffer_timeout, checkpoint]
                 .into_iter()
                 .flatten()
                 .min();
@@ -2379,6 +2364,8 @@ impl ControllerInner {
             pool_size as usize,
             source_tasks.chain(sink_tasks),
         )?;
+
+        let _ = controller.connect_input("now", &now_endpoint_config(&config));
 
         let backpressure_thread =
             BackpressureThread::new(controller.clone(), backpressure_thread_parker);

--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -1,0 +1,441 @@
+//! Real-time clock connector.
+//!
+//! An instance of this connector is created automatically for each pipeline.
+//! The connector assumes that the `now` stream has the following schema:
+//! `Clock{ now: Timestamp }`, i.e., it's a struct with a single field named `now`
+//! of type `Timestamp`.
+//!
+//! The connector triggers a step every `clock_resolution_usecs`, rounded to the nearest
+//! millisecond boundary, if it's not triggered by some other connector. On every step
+//! it feeds precisely one record to the pipeline, containing the current time rounded
+//! to clock resolution.  The rounding is important, because it prevents the pipeline
+//! from recomputing queries that depend on time more often than requested by the user via
+//! the clock resolution pipeline property.
+//!
+//! The connector supports exactly-once FT.
+
+use anyhow::{anyhow, Result as AnyResult};
+use dbsp::circuit::tokio::TOKIO;
+use feldera_adapterlib::{
+    format::Parser,
+    transport::{
+        InputConsumer, InputEndpoint, InputReader, InputReaderCommand, Resume,
+        TransportInputEndpoint,
+    },
+};
+use feldera_types::{
+    config::{
+        ConnectorConfig, FormatConfig, FtModel, InputEndpointConfig, OutputBufferConfig,
+        PipelineConfig, TransportConfig, DEFAULT_CLOCK_RESOLUTION_USECS,
+    },
+    format::json::{JsonFlavor, JsonLines, JsonParserConfig, JsonUpdateFormat},
+    program_schema::Relation,
+    transport::clock::ClockConfig,
+};
+use rmpv::Value as RmpValue;
+use std::{
+    borrow::Cow,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::{
+    select,
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    time::{sleep_until, Instant},
+};
+
+/// The controller uses this configuration to add a clock input connector to each pipeline.
+pub fn now_endpoint_config(config: &PipelineConfig) -> InputEndpointConfig {
+    InputEndpointConfig {
+        stream: Cow::Borrowed("now"),
+        connector_config: ConnectorConfig {
+            transport: TransportConfig::ClockInput(ClockConfig {
+                clock_resolution_usecs: config
+                    .global
+                    .clock_resolution_usecs
+                    .unwrap_or(DEFAULT_CLOCK_RESOLUTION_USECS),
+            }),
+            format: Some(FormatConfig {
+                name: Cow::Borrowed("json"),
+                config: serde_yaml::to_value(JsonParserConfig {
+                    update_format: JsonUpdateFormat::Raw,
+                    json_flavor: JsonFlavor::ClockInput,
+                    array: false,
+                    lines: JsonLines::Single,
+                })
+                .unwrap(),
+            }),
+            index: None,
+            output_buffer_config: OutputBufferConfig::default(),
+            max_batch_size: 1,
+            // This must be >1; otherwise the controller will pause the connector after every input.
+            max_queued_records: 2,
+            paused: false,
+            labels: vec![],
+            start_after: None,
+        },
+    }
+}
+
+pub struct ClockEndpoint {
+    config: Arc<ClockConfig>,
+}
+
+impl ClockEndpoint {
+    pub fn new(config: ClockConfig) -> AnyResult<Self> {
+        Ok(Self {
+            config: Arc::new(config),
+        })
+    }
+}
+
+impl InputEndpoint for ClockEndpoint {
+    fn fault_tolerance(&self) -> Option<FtModel> {
+        Some(FtModel::ExactlyOnce)
+    }
+}
+
+impl TransportInputEndpoint for ClockEndpoint {
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        _schema: Relation,
+    ) -> AnyResult<Box<dyn InputReader>> {
+        Ok(Box::new(ClockReader::new(
+            self.config.clone(),
+            consumer,
+            parser,
+        )))
+    }
+}
+
+struct ClockReader {
+    sender: UnboundedSender<InputReaderCommand>,
+}
+
+impl ClockReader {
+    fn new(
+        config: Arc<ClockConfig>,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+    ) -> Self {
+        let (sender, receiver) = unbounded_channel::<InputReaderCommand>();
+
+        let config_clone = config.clone();
+        TOKIO.spawn(async {
+            let _ = Self::worker_task(config_clone, parser, consumer, receiver).await;
+        });
+
+        Self { sender }
+    }
+
+    /// Current timestamp in milliseconds, rounded to `clock_resolution_ms`.
+    fn current_time(config: &ClockConfig) -> u64 {
+        let now = SystemTime::now();
+        let now_millis = now
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let clock_resolution_ms = config.clock_resolution_ms();
+        now_millis - now_millis % clock_resolution_ms
+    }
+
+    /// Time when we want to trigger the next clock tick, assuming we triggered one at `previous_tick`.
+    ///
+    /// Returns time as `Instant`, so it can be used with `sleep_until`. This also ensures that
+    /// we don't need to worry about timezone or daylight changes.
+    fn next_tick_time(config: &ClockConfig, previous_tick: &u64) -> Instant {
+        let next_tick = previous_tick + config.clock_resolution_ms();
+
+        let target_time = UNIX_EPOCH + Duration::from_millis(next_tick);
+        let now = SystemTime::now();
+        let duration_until = target_time.duration_since(now).unwrap_or(Duration::ZERO);
+
+        Instant::now() + duration_until
+    }
+
+    /// Convert timestamp to a JSON object that can be fed to the parser.
+    fn timestamp_to_record(ts_millis: u64) -> String {
+        format!("{{\"now\":{ts_millis}}}")
+    }
+
+    async fn worker_task(
+        config: Arc<ClockConfig>,
+        mut parser: Box<dyn Parser>,
+        consumer: Box<dyn InputConsumer>,
+        mut receiver: UnboundedReceiver<InputReaderCommand>,
+    ) {
+        let mut next_tick: Option<Instant> = None;
+        loop {
+            select! {
+                // When the next clock tick is scheduled, wakeup at `next_tick` time.
+                _ = sleep_until(next_tick.unwrap_or_else(Instant::now)), if next_tick.is_some() => {
+                    next_tick = None;
+                    consumer.request_step();
+                }
+                message = receiver.recv() => match message {
+                    None => {
+                        // channel closed
+                        break;
+                    }
+                    // Nothing to do for Seek: the connector simply starts from the current timestamp.
+                    Some(InputReaderCommand::Seek(..)) => {}
+                    Some(InputReaderCommand::Replay { data, .. }) => {
+                        // Parse serialized timestamp, push it to the circuit.
+                        let Some(ts_millis) = (match data {
+                            RmpValue::Integer(int) => int.as_u64(),
+                            _ => None,
+                        }) else {
+                            consumer.error(true, anyhow!("Invalid timestamp in replay log: {data:?}"));
+                            continue;
+                        };
+                        consumer.buffered(1, std::mem::size_of::<u64>());
+                        let mut buffer = parser.parse(Self::timestamp_to_record(ts_millis).as_bytes()).0.unwrap();
+                        buffer.flush();
+                        consumer.replayed(1, 0);
+                    }
+                    Some(InputReaderCommand::Extend) => {
+                        // Schedule a step, so we can feed the initial timestamp to the circuit.
+                        consumer.request_step();
+                    }
+                    Some(InputReaderCommand::Pause) => {
+                        // Stop timer.
+                        next_tick = None;
+                    }
+                    Some(InputReaderCommand::Queue { .. }) => {
+                        // Push current time;
+                        consumer.buffered(1, std::mem::size_of::<u64>());
+                        let now = Self::current_time(&config);
+                        let mut buffer = parser.parse(Self::timestamp_to_record(now).as_bytes()).0.unwrap();
+                        buffer.flush();
+                        consumer.extended(1, Some(Resume::Replay {
+                             seek: serde_json::Value::Null,
+                             replay: RmpValue::from(now),
+                             hash: 0
+                        }));
+
+                        // Schedule next tick.
+                        next_tick = Some(Self::next_tick_time(&config, &now));
+                    }
+                    Some(InputReaderCommand::Disconnect) => {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl InputReader for ClockReader {
+    fn request(&self, command: InputReaderCommand) {
+        let _ = self.sender.send(command);
+    }
+
+    fn is_closed(&self) -> bool {
+        self.sender.is_closed()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        collections::BTreeMap,
+        fs::create_dir,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread::sleep,
+        time::Duration,
+    };
+
+    use dbsp::{circuit::CircuitConfig, utils::Tup1, DBSPHandle, Runtime};
+    use feldera_adapterlib::catalog::CircuitCatalog;
+    use feldera_sqllib::Timestamp;
+    use feldera_types::{
+        config::PipelineConfig,
+        deserialize_table_record,
+        program_schema::{ColumnType, Field, Relation, SqlIdentifier},
+        serialize_table_record,
+    };
+    use tempfile::TempDir;
+
+    use crate::{Catalog, Controller};
+
+    struct ClockStats {
+        ticks: AtomicUsize,
+    }
+
+    impl ClockStats {
+        fn new() -> Self {
+            Self {
+                ticks: AtomicUsize::new(0),
+            }
+        }
+
+        fn ticks(&self) -> usize {
+            self.ticks.load(Ordering::Acquire)
+        }
+
+        fn clear(&self) {
+            self.ticks.store(0, Ordering::Release);
+        }
+    }
+
+    /// Create a simple test circuit that passes each of a number of streams right
+    /// through to the corresponding output.  The number of streams is the length of
+    /// `persistent_output_ids`, which also specifies optional persistent output ids.
+    fn clock_test_circuit(
+        config: CircuitConfig,
+        test_stats: Arc<ClockStats>,
+    ) -> (DBSPHandle, Box<dyn CircuitCatalog>) {
+        let (circuit, catalog) = Runtime::init_circuit(config, move |circuit| {
+            let mut catalog = Catalog::new();
+
+            let input_schema = Relation::new(
+                "now".into(),
+                vec![Field::new(
+                    SqlIdentifier::from("now"),
+                    ColumnType::timestamp(false),
+                )],
+                false,
+                BTreeMap::new(),
+            );
+
+            let input_schema_str = serde_json::to_string(&input_schema).unwrap();
+
+            let (now_stream, now_handle) = circuit.add_input_zset::<Tup1<Timestamp>>();
+
+            now_stream.map(move |x| {
+                test_stats.ticks.fetch_add(1, Ordering::AcqRel);
+                *x
+            });
+
+            now_stream.set_persistent_id(Some("now"));
+
+            #[derive(Clone, Debug, Eq, PartialEq, Default, PartialOrd, Ord)]
+            pub struct Clock {
+                now: Timestamp,
+            }
+            impl From<Clock> for Tup1<Timestamp> {
+                fn from(t: Clock) -> Self {
+                    Tup1::new(t.now)
+                }
+            }
+            impl From<Tup1<Timestamp>> for Clock {
+                fn from(t: Tup1<Timestamp>) -> Self {
+                    Self { now: t.0 }
+                }
+            }
+            deserialize_table_record!(Clock["now", 1] {
+                (now, "now", false, Timestamp, None)
+            });
+            serialize_table_record!(Clock[1]{
+                now["now"]: Timestamp
+            });
+
+            catalog.register_input_zset::<_, Clock>(
+                now_stream.clone(),
+                now_handle,
+                &input_schema_str,
+            );
+
+            Ok(catalog)
+        })
+        .unwrap();
+        (circuit, Box::new(catalog))
+    }
+
+    #[test]
+    fn test_clock() {
+        let tempdir = TempDir::new().unwrap();
+        let tempdir_path = tempdir.path();
+
+        //let tempdir_path = tempdir.into_path();
+        //println!("{}", tempdir_path.display());
+
+        let storage_dir = tempdir_path.join("storage");
+        create_dir(&storage_dir).unwrap();
+
+        // Create controller.
+        let config_str = format!(
+            r#"
+name: test
+workers: 4
+storage_config:
+    path: {storage_dir:?}
+fault_tolerance: {{}}
+inputs:
+"#
+        );
+
+        let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+        println!("Pipeline config: {config:?}");
+
+        let test_stats = Arc::new(ClockStats::new());
+        let test_stats_clone = test_stats.clone();
+
+        let controller = Controller::with_config(
+            move |workers| Ok(clock_test_circuit(workers, test_stats_clone)),
+            &config,
+            Box::new(move |e| panic!("clock_test pipeline 1: error: {e}")),
+        )
+        .unwrap();
+
+        controller.start();
+
+        sleep(Duration::from_secs(5));
+
+        // The clock is the only input connector, so there should be one step/s.
+        let ticks = test_stats.ticks();
+        assert!((3..=10).contains(&ticks));
+
+        // No clock ticks in the paused state, except whatever slipped in before the controller is paused.
+        controller.pause();
+        sleep(Duration::from_secs(5));
+
+        let old_ticks = ticks;
+        let ticks = test_stats.ticks();
+
+        assert!(ticks <= old_ticks + 2);
+
+        // Checkpoint the controller; let it run for a few seconds
+        // after the checkpoint to accumulate several new changes.
+        controller.checkpoint().unwrap();
+        controller.start();
+
+        sleep(Duration::from_secs(5));
+
+        let old_ticks = ticks;
+        let ticks_after_checkpoint = test_stats.ticks() - old_ticks;
+
+        println!("{ticks_after_checkpoint} additional ticks after the checkpoint");
+
+        println!("Stopping the pipeline");
+        controller.stop().unwrap();
+
+        test_stats.clear();
+
+        // The connector should replay the exact number of clock ticks.
+        println!("Restarting from checkpoint");
+
+        let test_stats_clone = test_stats.clone();
+
+        let controller = Controller::with_config(
+            move |workers| Ok(clock_test_circuit(workers, test_stats_clone)),
+            &config,
+            Box::new(move |e| panic!("clock_test pipeline 2: error: {e}")),
+        )
+        .unwrap();
+
+        sleep(Duration::from_secs(5));
+
+        let ticks = test_stats.ticks();
+        println!("{ticks} ticks replayed after restart");
+        assert_eq!(ticks, ticks_after_checkpoint);
+
+        controller.stop().unwrap();
+        println!("Clock test is finished");
+    }
+}

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -22,6 +22,7 @@
 //! ```
 use adhoc::AdHocInputEndpoint;
 use anyhow::Result as AnyResult;
+use clock::ClockEndpoint;
 use http::HttpInputEndpoint;
 #[cfg(feature = "with-pubsub")]
 use pubsub::PubSubInputEndpoint;
@@ -32,6 +33,7 @@ pub mod http;
 
 pub mod url;
 
+pub mod clock;
 mod s3;
 
 #[cfg(feature = "with-kafka")]
@@ -92,6 +94,7 @@ pub fn input_transport_config_to_endpoint(
         TransportConfig::Nexmark(_) => return Ok(None),
         TransportConfig::HttpInput(config) => Box::new(HttpInputEndpoint::new(config)),
         TransportConfig::AdHocInput(config) => Box::new(AdHocInputEndpoint::new(config)),
+        TransportConfig::ClockInput(config) => Box::new(ClockEndpoint::new(config)?),
         TransportConfig::FileOutput(_)
         | TransportConfig::KafkaOutput(_)
         | TransportConfig::DeltaTableInput(_)

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -6,6 +6,7 @@
 //! that the entire configuration tree can be deserialized from a JSON file.
 
 use crate::transport::adhoc::AdHocInputConfig;
+use crate::transport::clock::ClockConfig;
 use crate::transport::datagen::DatagenInputConfig;
 use crate::transport::delta_table::{DeltaTableReaderConfig, DeltaTableWriterConfig};
 use crate::transport::file::{FileInputConfig, FileOutputConfig};
@@ -45,6 +46,8 @@ pub const fn default_max_queued_records() -> u64 {
 pub const fn default_max_batch_size() -> u64 {
     10_000
 }
+
+pub const DEFAULT_CLOCK_RESOLUTION_USECS: u64 = 1_000_000;
 
 /// Pipeline deployment configuration.
 /// It represents configuration entries directly provided by the user
@@ -385,7 +388,7 @@ pub struct RuntimeConfig {
     /// inputs.  The pipeline will update the clock value and trigger incremental recomputation
     /// at most each `clock_resolution_usecs` microseconds.
     ///
-    /// It is set to 100 milliseconds (100,000 microseconds) by default.
+    /// It is set to 1 second (1,000,000 microseconds) by default.
     ///
     /// Set to `null` to disable periodic clock updates.
     pub clock_resolution_usecs: Option<u64>,
@@ -410,7 +413,7 @@ pub struct RuntimeConfig {
     /// At startup, the pipeline must initialize all of its input and output connectors.
     /// Depending on the number and types of connectors, this can take a long time.
     /// To accelerate the process, multiple connectors are initialized concurrently.
-    /// This option controls the maximum number of connectors that can be intitialized
+    /// This option controls the maximum number of connectors that can be initialized
     /// in parallel.
     ///
     /// The default is 10.
@@ -540,10 +543,7 @@ impl Default for RuntimeConfig {
             min_batch_size_records: 0,
             max_buffering_delay_usecs: 0,
             resources: ResourceConfig::default(),
-            clock_resolution_usecs: {
-                // Every 100 ms.
-                Some(100_000)
-            },
+            clock_resolution_usecs: { Some(DEFAULT_CLOCK_RESOLUTION_USECS) },
             pin_cpus: Vec::new(),
             provisioning_timeout_secs: None,
             max_parallel_connector_init: None,
@@ -1057,6 +1057,7 @@ pub enum TransportConfig {
     HttpOutput,
     /// Ad hoc input: cannot be instantiated through API
     AdHocInput(AdHocInputConfig),
+    ClockInput(ClockConfig),
 }
 
 impl TransportConfig {
@@ -1080,6 +1081,7 @@ impl TransportConfig {
             TransportConfig::HttpOutput => "http_output".to_string(),
             TransportConfig::AdHocInput(_) => "adhoc_input".to_string(),
             TransportConfig::RedisOutput(_) => "redis_output".to_string(),
+            TransportConfig::ClockInput(_) => "clock".to_string(),
         }
     }
 }

--- a/crates/feldera-types/src/format/json.rs
+++ b/crates/feldera-types/src/format/json.rs
@@ -209,6 +209,8 @@ pub enum JsonFlavor {
     /// (For internal use only)
     #[serde(skip)]
     ParquetConverter,
+    /// Used by the clock input connector.
+    ClockInput,
     /// Datagen format.
     /// (For internal use only)
     #[serde(rename = "datagen")]

--- a/crates/feldera-types/src/serde_with_context/serde_config.rs
+++ b/crates/feldera-types/src/serde_with_context/serde_config.rs
@@ -261,6 +261,9 @@ impl From<JsonFlavor> for SqlSerdeConfig {
                 binary_format: BinaryFormat::Base64,
                 uuid_format: UuidFormat::String,
             },
+            JsonFlavor::ClockInput => {
+                SqlSerdeConfig::default().with_timestamp_format(TimestampFormat::MillisSinceEpoch)
+            }
             JsonFlavor::Postgres => Self {
                 time_format: TimeFormat::default(), // H-M-S
                 date_format: DateFormat::default(), // Y-m-d

--- a/crates/feldera-types/src/transport/clock.rs
+++ b/crates/feldera-types/src/transport/clock.rs
@@ -1,0 +1,16 @@
+use std::cmp::max;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, ToSchema)]
+pub struct ClockConfig {
+    pub clock_resolution_usecs: u64,
+}
+
+impl ClockConfig {
+    pub fn clock_resolution_ms(&self) -> u64 {
+        // Refuse to set 0 clock resolution.
+        max((self.clock_resolution_usecs + 500) / 1_000, 1)
+    }
+}

--- a/crates/feldera-types/src/transport/mod.rs
+++ b/crates/feldera-types/src/transport/mod.rs
@@ -1,4 +1,5 @@
 pub mod adhoc;
+pub mod clock;
 pub mod datagen;
 pub mod delta_table;
 pub mod file;

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -390,6 +390,7 @@ pub(crate) async fn perform_sql_compilation(
         .arg("-je")
         .arg("--alltables")
         .arg("--ignoreOrder")
+        .arg("--nowstream")
         .arg("--crates") // Generate multiple crates instead of a single main.rs
         .arg(crate_name_pipeline_base(pipeline_id));
     #[cfg(feature = "feldera-enterprise")]

--- a/openapi.json
+++ b/openapi.json
@@ -397,7 +397,7 @@
                         "storage_mb_max": null,
                         "storage_class": null
                       },
-                      "clock_resolution_usecs": 100000,
+                      "clock_resolution_usecs": 1000000,
                       "pin_cpus": [],
                       "provisioning_timeout_secs": null,
                       "max_parallel_connector_init": null
@@ -550,7 +550,7 @@
                     "storage_mb_max": null,
                     "storage_class": null
                   },
-                  "clock_resolution_usecs": 100000,
+                  "clock_resolution_usecs": 1000000,
                   "pin_cpus": [],
                   "provisioning_timeout_secs": null,
                   "max_parallel_connector_init": null
@@ -610,7 +610,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -765,7 +765,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -883,7 +883,7 @@
                     "storage_mb_max": null,
                     "storage_class": null
                   },
-                  "clock_resolution_usecs": 100000,
+                  "clock_resolution_usecs": 1000000,
                   "pin_cpus": [],
                   "provisioning_timeout_secs": null,
                   "max_parallel_connector_init": null
@@ -943,7 +943,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -1015,7 +1015,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -1254,7 +1254,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -2601,7 +2601,7 @@
                       "storage_mb_max": null,
                       "storage_class": null
                     },
-                    "clock_resolution_usecs": 100000,
+                    "clock_resolution_usecs": 1000000,
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null
@@ -5207,8 +5207,8 @@
               "clock_resolution_usecs": {
                 "type": "integer",
                 "format": "int64",
-                "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 100 milliseconds (100,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
-                "default": 100000,
+                "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 1 second (1,000,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
+                "default": 1000000,
                 "nullable": true,
                 "minimum": 0
               },
@@ -5238,7 +5238,7 @@
               "max_parallel_connector_init": {
                 "type": "integer",
                 "format": "int64",
-                "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be intitialized\nin parallel.\n\nThe default is 10.",
+                "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be initialized\nin parallel.\n\nThe default is 10.",
                 "default": null,
                 "nullable": true,
                 "minimum": 0
@@ -6179,8 +6179,8 @@
           "clock_resolution_usecs": {
             "type": "integer",
             "format": "int64",
-            "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 100 milliseconds (100,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
-            "default": 100000,
+            "description": "Real-time clock resolution in microseconds.\n\nThis parameter controls the execution of queries that use the `NOW()` function.  The output of such\nqueries depends on the real-time clock and can change over time without any external\ninputs.  The pipeline will update the clock value and trigger incremental recomputation\nat most each `clock_resolution_usecs` microseconds.\n\nIt is set to 1 second (1,000,000 microseconds) by default.\n\nSet to `null` to disable periodic clock updates.",
+            "default": 1000000,
             "nullable": true,
             "minimum": 0
           },
@@ -6210,7 +6210,7 @@
           "max_parallel_connector_init": {
             "type": "integer",
             "format": "int64",
-            "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be intitialized\nin parallel.\n\nThe default is 10.",
+            "description": "The maximum number of connectors initialized in parallel during pipeline\nstartup.\n\nAt startup, the pipeline must initialize all of its input and output connectors.\nDepending on the number and types of connectors, this can take a long time.\nTo accelerate the process, multiple connectors are initialized concurrently.\nThis option controls the maximum number of connectors that can be initialized\nin parallel.\n\nThe default is 10.",
             "default": null,
             "nullable": true,
             "minimum": 0
@@ -7069,6 +7069,24 @@
                 "type": "string",
                 "enum": [
                   "ad_hoc_input"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "config"
+            ],
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/ClockConfig"
+              },
+              "name": {
+                "type": "string",
+                "enum": [
+                  "clock_input"
                 ]
               }
             }


### PR DESCRIPTION
Fixes #3987
Fixes #2803

This PR re-implements the clock that drives the value of NOW() as an input connector, and also enforces clock resolution more strictly.

Previous design
---------------

The value of NOW() used to be provided by a generator running inside the circuit. In addition, the circuit controller had the logic to trigger a step every `clock_resolution_usecs`. There were two problems with this design:

* It didn't work with fault tolerance as there was no way to deterministically replay clock ticks (issue #2803)

* The clock resolution setting only controlled the frequency of the steps, but not the actual resolution at which the clock changed. Even if clock resolution was set to 1 hour, the value of NOW() was still updated on every invocation. This could trigger very expensive computations in programs that used NOW() in a way other that in a temporal filter.

New design
----------

* We use the feature already avaiable in the compiler, which allows feeding the value of NOW() as an input stream instead of a generator.

* We add a new clock connector, which feeds precisely one value to the circuit on each step. The connector forces periodic steps every clock_resolution time units and it rounds the time value to clock_resolution. The connector supports exactly-once FT and can replay clock ticks deterministically.

* The clock connector is instantiated automatically by the controller, so the user doesn't need to specify it.

One consequence of this design is that `now` appears in the list of tables in the web console. Values ingested from the clock connector are reflected in the number of ingested records and in the throughput graph. Do we want to disable this behavior and hide this input?

----

I also changed default clock resolution to 1s, which seems like a better choice for most use cases.