### PR TITLE
[dbsp] Avoid double counting in profiles.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -5572,11 +5572,13 @@ where
     }
 
     fn metrics(&self) {
-        self.operator.borrow().metrics()
+        // Avoid producing duplicate metrics for input and output parts of the operator;
+        // otherwise it will be double-counted in circuit-level metrics.
     }
 
-    fn metadata(&self, output: &mut OperatorMeta) {
-        self.operator.borrow().metadata(output)
+    fn metadata(&self, _output: &mut OperatorMeta) {
+        // Avoid producing duplicate metadata for input and output parts of the operator;
+        // otherwise it will be double-counted in circuit-level metrics.
     }
 
     fn fixedpoint(&self, scope: Scope) -> bool {


### PR DESCRIPTION
Feedback operators like Z1 appear in the circuit twice: as a source node that feeds the value from the previous step back to the circuit and a sink node that consumes the updated value at the end of the step. Internally, both operators point to the same Z1 instance. We used to report the same metrics and metadata for both nodes, which resulted in double counting when aggregating the results in circuit-level stats for metrics like storage and memory usage.

This commit eliminates double counting by returning empty stats from the output node.  This doesn't affect operator per-operator profiles, since only the input node shows up in the profile.