### PR TITLE
[adapters] Force the first step.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -773,6 +773,10 @@ impl CircuitThread {
 
         self.finish_replaying();
 
+        // Request the first step even if there is no explicit trigger to make sure
+        // the pipeline initializes output snapshots used by ad hoc queries.
+        self.controller.request_step();
+
         loop {
             // Run received commands.  Commands can initiate checkpoint
             // requests, so attempt to execute those afterward.  Executing a

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -563,7 +563,7 @@ where
             val: None,
             phantom: PhantomData,
         };
-        debug_assert!(!result.cursor.key_valid() || !result.weight() != 0);
+        debug_assert!(!result.cursor.key_valid() || result.weight() != 0);
 
         result.update_key();
         result.update_val();


### PR DESCRIPTION
After restarting from a checkpoint, a pipeline that doesn't have
anything to replay and doesn't have any external inputs could remain
idle forever.  As a result output view snapshots used by ad hoc queries,
which get refreshed at the end of each step, would never be initialized.
In the past, the controller issued a periodic clock tick, which
guaranteed that the pipeline performed the first step at some point.
With the new implementation of the clock as a connector, the clock is only
attached to the pipeline if it uses NOW().

As a result, FT tests that checked the output of the pipeline after a
checkpoint using ad hoc queries failed.