### PR TITLE
Upgrade to feldera-size-of 1.6.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "feldera-size-of"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d32b0525ecf8a0e65a7440e99046fd94e20ee209ee69d02e6b7ed6e6048952"
+checksum = "455f1fb701df8cf0a60bf9000342e90fe3eb5f22bfaa843cd047f3f1e8deeb0e"
 dependencies = [
  "arcstr",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ serde_with = "3.0.0"
 serde_yaml = "0.9.34"
 serial_test = "3"
 sha2 = "0.10.8"
-size-of = { version = "0.1.5", features = ["time-std", "ordered-float"], package = "feldera-size-of" }
+size-of = { version = "0.1.6", features = ["time-std", "ordered-float"], package = "feldera-size-of" }
 sltsqlvalue = { path = "sql-to-dbsp-compiler/lib/sltsqlvalue" }
 snap = "1.1.1"
 static-files = "0.2.3"


### PR DESCRIPTION
Fixes future-incompat warnings on Rust 1.87.