### PR TITLE
pipeline-manager: suspend without checkpoint

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1864,6 +1864,7 @@ impl ControllerInit {
                 provisioning_timeout_secs: config.global.provisioning_timeout_secs,
                 max_parallel_connector_init: config.global.max_parallel_connector_init,
                 init_containers: config.global.init_containers,
+                checkpoint_during_suspend: config.global.checkpoint_during_suspend,
             },
 
             // Adapter configuration has to come from the checkpoint.

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -421,6 +421,14 @@ pub struct RuntimeConfig {
 
     /// Specification of additional (sidecar) containers.
     pub init_containers: Option<serde_yaml::Value>,
+
+    /// * If `true`, the suspend operation will first atomically checkpoint the pipeline before
+    ///   deprovisioning the compute resources. When resuming, the pipeline will start from this
+    ///   checkpoint.
+    /// * If `false`, then the pipeline will be suspended without creating an additional checkpoint.
+    ///   When resuming, it will pick up the latest checkpoint made by the periodic checkpointer or
+    ///   by invoking the `/checkpoint` API.
+    pub checkpoint_during_suspend: bool,
 }
 
 /// Accepts "true" and "false" and converts them to the new format.
@@ -551,6 +559,7 @@ impl Default for RuntimeConfig {
             provisioning_timeout_secs: None,
             max_parallel_connector_init: None,
             init_containers: None,
+            checkpoint_during_suspend: true,
         }
     }
 }

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -101,6 +101,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
             provisioning_timeout_secs: Some(1200),
             max_parallel_connector_init: Some(10),
             init_containers: None,
+            checkpoint_during_suspend: false,
         })
         .unwrap(),
         program_code: "CREATE TABLE table2 ( col2 VARCHAR );".to_string(),

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -201,6 +201,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::transport::postgres::PostgresWriterConfig,
         feldera_types::transport::redis::RedisOutputConfig,
         feldera_types::transport::http::Chunk,
+        feldera_types::transport::clock::ClockConfig,
         feldera_types::query::AdhocQueryArgs,
         feldera_types::query::AdHocResultFormat,
         feldera_types::format::json::JsonUpdateFormat,

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -226,7 +226,12 @@ impl Storage for StoragePostgres {
                 PipelineDesiredStatus::Paused | PipelineDesiredStatus::Running,
                 _,
                 false
-            )
+            ) | (
+                PipelineStatus::Paused | PipelineStatus::Running | PipelineStatus::Unavailable,
+                PipelineDesiredStatus::Suspended,
+                _,
+                _
+            ),
         ) {
             ExtendedPipelineDescrRunner::Complete(
                 operations::pipeline::get_pipeline_by_id(&txn, tenant_id, pipeline_id).await?,

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -60,9 +60,9 @@ impl Display for PipelineId {
 ///          │       Paused  ◄──────► Unavailable │                  │                         │                 │
 ///          │       │    ▲                ▲      │                  │                         │                 │
 ///          │ /start│    │/pause          │      │──────────> SuspendingCircuit ───> SuspendingCompute ───> Suspended
-///          │       ▼    │                │      │ /suspend                                                     │ /start or /pause
-///          │      Running ◄──────────────┘      │                                                              ▼
-///          └────────────────────────────────────┘                                                        ⌛Provisioning
+///          │       ▼    │                │      │ /suspend                            ▲                        │ /start or /pause
+///          │      Running ◄──────────────┘      │─────────────────────────────────────┘                        ▼
+///          └────────────────────────────────────┘ (if runtime_config.checkpoint_during_suspend=false)    ⌛Provisioning
 /// ```
 ///
 /// ### Desired and actual status
@@ -151,8 +151,9 @@ pub enum PipelineStatus {
     ///    The runner asynchronously passes the request to the pipeline;
     ///    transitions to the [`Running`](`Self::Running`) state.
     /// 2. The user suspends the pipeline by invoking the `/suspend` endpoint.
-    ///    The runner transitions to the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
-    ///    state.
+    ///    The runner transitions to either the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
+    ///    or [`SuspendingCompute`](`Self::SuspendingCompute`) depending on whether
+    ///    `runtime_config.checkpoint_during_suspend` is respectively set to `true` or `false`.
     /// 3. The user cancels the pipeline by invoking the `/shutdown` endpoint,
     ///    after which it transitions to the [`ShuttingDown`](`Self::ShuttingDown`) state.
     /// 4. An unexpected deployment or runtime error renders the pipeline
@@ -168,8 +169,9 @@ pub enum PipelineStatus {
     ///    The runner asynchronously passes the request to the pipeline;
     ///    transitions to the [`Paused`](`Self::Paused`) state.
     /// 2. The user suspends the pipeline by invoking the `/suspend` endpoint.
-    ///    The runner transitions to the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
-    ///    state.
+    ///    The runner transitions to either the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
+    ///    or [`SuspendingCompute`](`Self::SuspendingCompute`) depending on whether
+    ///    `runtime_config.checkpoint_during_suspend` is respectively set to `true` or `false`.
     /// 3. The user cancels the pipeline by invoking the `/shutdown` endpoint,
     ///    after which it transitions to the [`ShuttingDown`](`Self::ShuttingDown`) state.
     /// 4. An unexpected deployment or runtime error renders the pipeline
@@ -185,8 +187,9 @@ pub enum PipelineStatus {
     ///    [`Paused`](`Self::Paused`) or [`Running`](`Self::Running`) state
     ///    depending on the check outcome.
     /// 2. The user suspends the pipeline by invoking the `/suspend` endpoint.
-    ///    The runner transitions to the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
-    ///    state.
+    ///    The runner transitions to either the [`SuspendingCircuit`](`Self::SuspendingCircuit`)
+    ///    or [`SuspendingCompute`](`Self::SuspendingCompute`) depending on whether
+    ///    `runtime_config.checkpoint_during_suspend` is respectively set to `true` or `false`.
     /// 3. The user cancels the pipeline by invoking the `/shutdown` endpoint,
     ///    after which it transitions to the [`ShuttingDown`](`Self::ShuttingDown`) state.
     /// 4. An unexpected deployment or runtime error renders the pipeline

--- a/openapi.json
+++ b/openapi.json
@@ -405,7 +405,8 @@
                       "pin_cpus": [],
                       "provisioning_timeout_secs": null,
                       "max_parallel_connector_init": null,
-                      "init_containers": null
+                      "init_containers": null,
+                      "checkpoint_during_suspend": true
                     },
                     "program_code": "CREATE TABLE table1 ( col1 INT );",
                     "udf_rust": "",
@@ -468,7 +469,8 @@
                       "pin_cpus": [],
                       "provisioning_timeout_secs": 1200,
                       "max_parallel_connector_init": 10,
-                      "init_containers": null
+                      "init_containers": null,
+                      "checkpoint_during_suspend": false
                     },
                     "program_code": "CREATE TABLE table2 ( col2 VARCHAR );",
                     "udf_rust": "",
@@ -560,7 +562,8 @@
                   "pin_cpus": [],
                   "provisioning_timeout_secs": null,
                   "max_parallel_connector_init": null,
-                  "init_containers": null
+                  "init_containers": null,
+                  "checkpoint_during_suspend": true
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -621,7 +624,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -777,7 +781,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -896,7 +901,8 @@
                   "pin_cpus": [],
                   "provisioning_timeout_secs": null,
                   "max_parallel_connector_init": null,
-                  "init_containers": null
+                  "init_containers": null,
+                  "checkpoint_during_suspend": true
                 },
                 "program_code": "CREATE TABLE table1 ( col1 INT );",
                 "udf_rust": null,
@@ -957,7 +963,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -1030,7 +1037,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -1270,7 +1278,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -2618,7 +2627,8 @@
                     "pin_cpus": [],
                     "provisioning_timeout_secs": null,
                     "max_parallel_connector_init": null,
-                    "init_containers": null
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true
                   },
                   "program_code": "CREATE TABLE table1 ( col1 INT );",
                   "udf_rust": "",
@@ -3780,6 +3790,19 @@
             "type": "string",
             "description": "Text payload, e.g., CSV.",
             "nullable": true
+          }
+        }
+      },
+      "ClockConfig": {
+        "type": "object",
+        "required": [
+          "clock_resolution_usecs"
+        ],
+        "properties": {
+          "clock_resolution_usecs": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -5215,6 +5238,11 @@
             "type": "object",
             "description": "Global pipeline configuration settings. This is the publicly\nexposed type for users to configure pipelines.",
             "properties": {
+              "checkpoint_during_suspend": {
+                "type": "boolean",
+                "description": "* If `true`, the suspend operation will first atomically checkpoint the pipeline before\ndeprovisioning the compute resources. When resuming, the pipeline will start from this\ncheckpoint.\n* If `false`, then the pipeline will be suspended without creating an additional checkpoint.\nWhen resuming, it will pick up the latest checkpoint made by the periodic checkpointer or\nby invoking the `/checkpoint` API.",
+                "default": true
+              },
               "clock_resolution_usecs": {
                 "type": "integer",
                 "format": "int64",
@@ -5612,7 +5640,7 @@
       },
       "PipelineStatus": {
         "type": "string",
-        "description": "Pipeline status.\n\nThis type represents the state of the pipeline tracked by the pipeline\nrunner and observed by the API client via the `GET /v0/pipelines/{name}` endpoint.\n\n### The lifecycle of a pipeline\n\nThe following automaton captures the lifecycle of the pipeline.\nIndividual states and transitions of the automaton are described below.\n\n* States labeled with the hourglass symbol (⌛) are **timed** states. The\nautomaton stays in timed state until the corresponding operation completes\nor until it transitions to become failed after the pre-defined timeout\nperiod expires.\n\n* State transitions labeled with API endpoint names (`/start`, `/pause`,\n`/suspend`, `/shutdown`) are triggered by invoking corresponding endpoint,\ne.g., `POST /v0/pipelines/{name}/start`. Note that these only express\ndesired state, and are applied asynchronously by the automata.\n\n```text\nShutdown◄────────────────────┐\n│                        │\n/start or /pause │                   ShuttingDown ◄─────── Failed\n│                        ▲                  ▲\n▼              /shutdown │                  │\n⌛Provisioning ──────────────────┤     All states except ShuttingDown\n│                        │        can transition to Failed\n│                        │\n▼                        │\n⌛Initializing ──────────────────┤\n│                        │────────────────────────────────────────────────────────────────┐\n┌─────────┼────────────────────────┴─┐                  │                         │                 │\n│         ▼                          │                  │                         │                 │\n│       Paused  ◄──────► Unavailable │                  │                         │                 │\n│       │    ▲                ▲      │                  │                         │                 │\n│ /start│    │/pause          │      │──────────> SuspendingCircuit ───> SuspendingCompute ───> Suspended\n│       ▼    │                │      │ /suspend                                                     │ /start or /pause\n│      Running ◄──────────────┘      │                                                              ▼\n└────────────────────────────────────┘                                                        ⌛Provisioning\n```\n\n### Desired and actual status\n\nWe use the desired state model to manage the lifecycle of a pipeline.\nIn this model, the pipeline has two status attributes associated with\nit at runtime: the **desired** status, which represents what the user\nwould like the pipeline to do, and the **current** status, which\nrepresents the actual state of the pipeline.  The pipeline runner\nservice continuously monitors both fields and steers the pipeline\ntowards the desired state specified by the user.\n\nOnly four of the states in the pipeline automaton above can be\nused as desired statuses: `Paused`, `Running`, `Suspended` and\n`Shutdown`. These statuses are selected by invoking REST endpoints\nshown in the diagram (respectively, `/pause`, `/start`, `/suspend`\nand `/shutdown`).\n\nThe user can monitor the current state of the pipeline via the\n`GET /v0/pipelines/{name}` endpoint. In a typical scenario,\nthe user first sets the desired state, e.g., by invoking the\n`/start` endpoint, and then polls the `GET /v0/pipelines/{name}`\nendpoint to monitor the actual status of the pipeline until its\n`deployment_status` attribute changes to `Running` indicating\nthat the pipeline has been successfully initialized and is\nprocessing data, or `Failed`, indicating an error.",
+        "description": "Pipeline status.\n\nThis type represents the state of the pipeline tracked by the pipeline\nrunner and observed by the API client via the `GET /v0/pipelines/{name}` endpoint.\n\n### The lifecycle of a pipeline\n\nThe following automaton captures the lifecycle of the pipeline.\nIndividual states and transitions of the automaton are described below.\n\n* States labeled with the hourglass symbol (⌛) are **timed** states. The\nautomaton stays in timed state until the corresponding operation completes\nor until it transitions to become failed after the pre-defined timeout\nperiod expires.\n\n* State transitions labeled with API endpoint names (`/start`, `/pause`,\n`/suspend`, `/shutdown`) are triggered by invoking corresponding endpoint,\ne.g., `POST /v0/pipelines/{name}/start`. Note that these only express\ndesired state, and are applied asynchronously by the automata.\n\n```text\nShutdown◄────────────────────┐\n│                        │\n/start or /pause │                   ShuttingDown ◄─────── Failed\n│                        ▲                  ▲\n▼              /shutdown │                  │\n⌛Provisioning ──────────────────┤     All states except ShuttingDown\n│                        │        can transition to Failed\n│                        │\n▼                        │\n⌛Initializing ──────────────────┤\n│                        │────────────────────────────────────────────────────────────────┐\n┌─────────┼────────────────────────┴─┐                  │                         │                 │\n│         ▼                          │                  │                         │                 │\n│       Paused  ◄──────► Unavailable │                  │                         │                 │\n│       │    ▲                ▲      │                  │                         │                 │\n│ /start│    │/pause          │      │──────────> SuspendingCircuit ───> SuspendingCompute ───> Suspended\n│       ▼    │                │      │ /suspend                            ▲                        │ /start or /pause\n│      Running ◄──────────────┘      │─────────────────────────────────────┘                        ▼\n└────────────────────────────────────┘ (if runtime_config.checkpoint_during_suspend=false)    ⌛Provisioning\n```\n\n### Desired and actual status\n\nWe use the desired state model to manage the lifecycle of a pipeline.\nIn this model, the pipeline has two status attributes associated with\nit at runtime: the **desired** status, which represents what the user\nwould like the pipeline to do, and the **current** status, which\nrepresents the actual state of the pipeline.  The pipeline runner\nservice continuously monitors both fields and steers the pipeline\ntowards the desired state specified by the user.\n\nOnly four of the states in the pipeline automaton above can be\nused as desired statuses: `Paused`, `Running`, `Suspended` and\n`Shutdown`. These statuses are selected by invoking REST endpoints\nshown in the diagram (respectively, `/pause`, `/start`, `/suspend`\nand `/shutdown`).\n\nThe user can monitor the current state of the pipeline via the\n`GET /v0/pipelines/{name}` endpoint. In a typical scenario,\nthe user first sets the desired state, e.g., by invoking the\n`/start` endpoint, and then polls the `GET /v0/pipelines/{name}`\nendpoint to monitor the actual status of the pipeline until its\n`deployment_status` attribute changes to `Running` indicating\nthat the pipeline has been successfully initialized and is\nprocessing data, or `Failed`, indicating an error.",
         "enum": [
           "Shutdown",
           "Provisioning",
@@ -6191,6 +6219,11 @@
         "type": "object",
         "description": "Global pipeline configuration settings. This is the publicly\nexposed type for users to configure pipelines.",
         "properties": {
+          "checkpoint_during_suspend": {
+            "type": "boolean",
+            "description": "* If `true`, the suspend operation will first atomically checkpoint the pipeline before\ndeprovisioning the compute resources. When resuming, the pipeline will start from this\ncheckpoint.\n* If `false`, then the pipeline will be suspended without creating an additional checkpoint.\nWhen resuming, it will pick up the latest checkpoint made by the periodic checkpointer or\nby invoking the `/checkpoint` API.",
+            "default": true
+          },
           "clock_resolution_usecs": {
             "type": "integer",
             "format": "int64",

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -42,6 +42,9 @@ import type {
   CheckpointPipelineData,
   CheckpointPipelineError,
   CheckpointPipelineResponse,
+  GetCheckpointStatusData,
+  GetCheckpointStatusError,
+  GetCheckpointStatusResponse,
   GetPipelineCircuitProfileData,
   GetPipelineCircuitProfileError,
   GetPipelineCircuitProfileResponse,
@@ -238,12 +241,24 @@ export const patchPipeline = (options: Options<PatchPipelineData>) => {
 }
 
 /**
- * Checkpoint a running or paused pipeline.
+ * Initiates checkpoint for a running or paused pipeline.
+ * Returns a checkpoint sequence number that can be used with `/checkpoint_status` to
+ * determine when the checkpoint has completed.
  */
 export const checkpointPipeline = (options: Options<CheckpointPipelineData>) => {
   return (options?.client ?? client).post<CheckpointPipelineResponse, CheckpointPipelineError>({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/checkpoint'
+  })
+}
+
+/**
+ * Retrieve status of checkpoint activity in a pipeline.
+ */
+export const getCheckpointStatus = (options: Options<GetCheckpointStatusData>) => {
+  return (options?.client ?? client).get<GetCheckpointStatusResponse, GetCheckpointStatusError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/checkpoint_status'
   })
 }
 


### PR DESCRIPTION
Add the `checkpoint_during_suspend` field (default: `true`) to the runtime configuration. This boolean field determines during suspend whether the circuit is first checkpointed and terminated, before the compute resources are deprovisioned (i.e., the `SuspendingCircuit` phase). If it is `false`, that phase is skipped while transitioning towards `Suspended`, going immediately to `SuspendingCompute`.