### PR TITLE
pipeline-manager: propagate license information to API server

### DIFF
--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -623,7 +623,7 @@ mod test {
     use cached::Cached;
     use chrono::Utc;
     use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, RwLock};
     use uuid::Uuid;
 
     use super::AuthError;
@@ -750,9 +750,14 @@ mod test {
         }
         let db = Arc::new(Mutex::new(conn));
         let state = actix_web::web::Data::new(
-            ServerState::new(common_config, manager_config, db)
-                .await
-                .unwrap(),
+            ServerState::new(
+                common_config,
+                manager_config,
+                db,
+                Arc::new(RwLock::new(None)),
+            )
+            .await
+            .unwrap(),
         );
         if decoding_key.is_some() {
             state

--- a/crates/pipeline-manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline-manager/src/bin/pipeline-manager.rs
@@ -16,7 +16,7 @@ use pipeline_manager::runner::local_runner::LocalRunner;
 use pipeline_manager::runner::main::runner_main;
 use pipeline_manager::{ensure_default_crypto_provider, init_fd_limit};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use utoipa::OpenApi;
 
 #[tokio::main]
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
     });
     pipeline_manager::metrics::create_endpoint(metrics_handle, db.clone()).await;
     // The api-server blocks forever
-    pipeline_manager::api::main::run(db, common_config, api_config)
+    pipeline_manager::api::main::run(db, common_config, api_config, Arc::new(RwLock::new(None)))
         .await
         .expect("API server main failed");
     Ok(())

--- a/crates/pipeline-manager/src/license.rs
+++ b/crates/pipeline-manager/src/license.rs
@@ -1,6 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use utoipa::ToSchema;
+
+/// The license information lock is held very shortly for both read and write.
+pub const LICENSE_INFO_READ_LOCK_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, PartialEq)]
 #[allow(dead_code)]
@@ -15,7 +19,7 @@ pub enum DisplaySchedule {
     Always,
 }
 
-#[derive(Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema, Clone, PartialEq)]
 pub struct LicenseInformation {
     /// Timestamp at which the license expires
     pub expires_at: DateTime<Utc>,


### PR DESCRIPTION
The configuration endpoint can now acquire the lock for it and read from it, which will have it serve the latest license information. A timeout is added on the lock to prevent any potential endpoint unresponsiveness.