### PR TITLE
[adapters] Fix EOI handling in datagen.

### DIFF
--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -577,12 +577,12 @@ impl InputGenerator {
                 completed.push_back(completion);
             }
 
-            if running && !work_sender.is_full() {
+            if running && !eoi && !work_sender.is_full() {
                 if let Some(work) =
                     assign_work(&mut unassigned, &mut in_flight, &config, seed, true)
                 {
                     let _ = work_sender.send_blocking(work);
-                } else if in_flight.iter().all(|set| set.is_empty()) && !eoi {
+                } else if in_flight.iter().all(|set| set.is_empty()) {
                     eoi = true;
                     running = false;
                     consumer.eoi();


### PR DESCRIPTION
The adapter relied on the `running` flag to decide when to stop polling. However setting `running` to false after EOI doesn't guarantee it will stay there, since the controller can still send an Extend request to the adapter, setting `running` to true. The fix is to additionally check for the `eoi` flag and to park the thread if it's true.