### PR TITLE
[adapters] Bump serde-arrow crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9459,8 +9459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.13.0-rc.1"
-source = "git+https://github.com/ryzhyk/serde_arrow.git?rev=dbab218#dbab218949c6c3e4495ef07d6c7e94a9e65f22cb"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221bea57dc6cb0aec429ab73af67b4a46cfdef464082e391cd609f7c5b50be4f"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ rustyline = "15.0"
 ryu = "1.0.20"
 schema_registry_converter = "4.2.0"
 serde = "1.0.213"
-serde_arrow = { git = "https://github.com/ryzhyk/serde_arrow.git", rev = "dbab218" }
+serde_arrow = { version = "0.13.4" }
 serde_bytes = "0.11.15"
 serde_json = { version = "1.0.132", features = ["arbitrary_precision"] }
 serde_urlencoded = "0.7.1"


### PR DESCRIPTION
Use v0.13.4, which includes this fix:
https://github.com/chmp/serde_arrow/pull/277.