### PR TITLE
[dbsp] Use JSON for `pspine-batches-*` and `checkpoint.feldera`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,6 +4658,7 @@ dependencies = [
  "once_cell",
  "rkyv",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,7 @@ libc = { workspace = true }
 rkyv = { workspace = true, features = ["std", "size_64", "validation", "uuid"] }
 object_store = { workspace = true, features = ["aws", "gcp", "azure", "http"] }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror =  { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 inventory = { workspace = true }

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -64,6 +64,9 @@ pub enum StorageError {
         backend: String,
         config: StorageBackendConfig,
     },
+
+    #[error("Error deserializing JSON: {0}")]
+    JsonError(String),
 }
 
 impl From<std::io::Error> for StorageError {
@@ -136,6 +139,7 @@ impl StorageError {
             StorageError::ObjectStore { kind, .. } => *kind,
             StorageError::BackendNotSupported(_) => ErrorKind::Other,
             StorageError::InvalidBackendConfig { .. } => ErrorKind::Other,
+            StorageError::JsonError(_) => ErrorKind::Other,
         }
     }
 


### PR DESCRIPTION
JSON is easier for outside tools and humans and, unlike `rkyv`, it is stable and doesn't change from one release to another.