### PR TITLE
Add `fda bench` command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4614,6 +4614,7 @@ name = "fda"
 version = "0.68.0"
 dependencies = [
  "arrow",
+ "chrono",
  "clap",
  "clap_complete",
  "directories",
@@ -4624,16 +4625,21 @@ dependencies = [
  "futures-util",
  "json_to_table",
  "log",
+ "prettyplease",
+ "progenitor",
  "progenitor-client 0.9.1",
  "reqwest 0.12.20",
  "reqwest-websocket",
  "rmpv",
  "rustyline",
+ "serde",
  "serde_json",
+ "syn 2.0.101",
  "tabled",
  "tempfile",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -34,3 +34,12 @@ tokio-util = { workspace = true }
 tempfile = { workspace = true }
 rmpv = { workspace = true, features = ["with-serde"] }
 arrow = { workspace = true, features = ["ipc", "prettyprint"] }
+serde = { workspace = true, features = ["derive"] }
+uuid = { workspace = true, features = ["serde", "v4"] }
+chrono = { workspace = true, features = ["serde"] }
+
+[build-dependencies]
+prettyplease = { workspace = true }
+progenitor = { workspace = true }
+serde_json = { workspace = true }
+syn = { workspace = true }

--- a/crates/fda/bench_openapi.json
+++ b/crates/fda/bench_openapi.json
@@ -1,0 +1,1259 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Benchmark API Minified Using https://www.npmjs.com/package/openapi-format at https://openapi-format-playground.vercel.app",
+    "version": "0.5.1"
+  },
+  "paths": {
+    "/v0/run": {
+      "post": {
+        "operationId": "run_post",
+        "summary": "Create a run",
+        "description": "Create a run. The user does not need have an account yet or be authenticated. The project may or may not exist yet.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonNewRun"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "headers": {
+              "access-control-allow-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-methods": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-allow-origin": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "access-control-expose-headers": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-total-count": {
+                "style": "simple",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonReport"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "tags": ["run", "reports"]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Adapter": {
+        "type": "string",
+        "enum": [
+          "magic",
+          "json",
+          "rust",
+          "rust_bench",
+          "rust_criterion",
+          "rust_iai",
+          "rust_iai_callgrind",
+          "cpp",
+          "cpp_google",
+          "cpp_catch2",
+          "go",
+          "go_bench",
+          "java",
+          "java_jmh",
+          "c_sharp",
+          "c_sharp_dot_net",
+          "js",
+          "js_benchmark",
+          "js_time",
+          "python",
+          "python_asv",
+          "python_pytest",
+          "ruby",
+          "ruby_benchmark",
+          "shell",
+          "shell_hyperfine"
+        ]
+      },
+      "AlertStatus": {
+        "oneOf": [
+          {
+            "description": "The alert is active.",
+            "type": "string",
+            "enum": ["active"]
+          },
+          {
+            "description": "The alert has been dismissed by a user.",
+            "type": "string",
+            "enum": ["dismissed"]
+          },
+          {
+            "description": "The alert has been silenced by the system.",
+            "type": "string",
+            "enum": ["silenced"]
+          }
+        ]
+      },
+      "AlertUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "BenchmarkName": {
+        "type": "string"
+      },
+      "BenchmarkUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "Boundary": {
+        "type": "number",
+        "format": "double"
+      },
+      "BoundaryLimit": {
+        "type": "string",
+        "enum": ["lower", "upper"]
+      },
+      "BranchName": {
+        "type": "string"
+      },
+      "BranchUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "DateTime": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "Error": {
+        "description": "Error information from a response.",
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": ["message", "request_id"]
+      },
+      "GitHash": {
+        "type": "string"
+      },
+      "HeadUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "Iteration": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      },
+      "JsonAlert": {
+        "type": "object",
+        "properties": {
+          "benchmark": {
+            "$ref": "#/components/schemas/JsonBenchmark"
+          },
+          "boundary": {
+            "$ref": "#/components/schemas/JsonBoundary"
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "iteration": {
+            "$ref": "#/components/schemas/Iteration"
+          },
+          "limit": {
+            "$ref": "#/components/schemas/BoundaryLimit"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/JsonMetric"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "report": {
+            "$ref": "#/components/schemas/ReportUuid"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AlertStatus"
+          },
+          "threshold": {
+            "$ref": "#/components/schemas/JsonThreshold"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/AlertUuid"
+          }
+        },
+        "required": [
+          "benchmark",
+          "boundary",
+          "created",
+          "iteration",
+          "limit",
+          "metric",
+          "modified",
+          "report",
+          "status",
+          "threshold",
+          "uuid"
+        ]
+      },
+      "JsonAverage": {
+        "type": "string",
+        "enum": ["mean", "median"]
+      },
+      "JsonBenchmark": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "name": {
+            "$ref": "#/components/schemas/BenchmarkName"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/BenchmarkUuid"
+          }
+        },
+        "required": ["created", "modified", "name", "project", "slug", "uuid"]
+      },
+      "JsonBoundary": {
+        "type": "object",
+        "properties": {
+          "baseline": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "lower_limit": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "upper_limit": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        }
+      },
+      "JsonBranch": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "head": {
+            "$ref": "#/components/schemas/JsonHead"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "name": {
+            "$ref": "#/components/schemas/BranchName"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/BranchUuid"
+          }
+        },
+        "required": [
+          "created",
+          "head",
+          "modified",
+          "name",
+          "project",
+          "slug",
+          "uuid"
+        ]
+      },
+      "JsonFold": {
+        "type": "string",
+        "enum": ["min", "max", "mean", "median"]
+      },
+      "JsonHead": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "replaced": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "start_point": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonStartPoint"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/HeadUuid"
+          },
+          "version": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonVersion"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": ["created", "uuid"]
+      },
+      "JsonMeasure": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "units": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/MeasureUuid"
+          }
+        },
+        "required": [
+          "created",
+          "modified",
+          "name",
+          "project",
+          "slug",
+          "units",
+          "uuid"
+        ]
+      },
+      "JsonMetric": {
+        "type": "object",
+        "properties": {
+          "lower_value": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "upper_value": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/MetricUuid"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": ["uuid", "value"]
+      },
+      "JsonModel": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "lower_boundary": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Boundary"
+              }
+            ],
+            "nullable": true
+          },
+          "max_sample_size": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SampleSize"
+              }
+            ],
+            "nullable": true
+          },
+          "min_sample_size": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SampleSize"
+              }
+            ],
+            "nullable": true
+          },
+          "replaced": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "test": {
+            "$ref": "#/components/schemas/ModelTest"
+          },
+          "upper_boundary": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Boundary"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ModelUuid"
+          },
+          "window": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Window"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": ["created", "test", "uuid"]
+      },
+      "JsonNewRun": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "description": "Branch UUID, slug, or name. If the branch is not provided or does not exist, it will be created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameId"
+              }
+            ],
+            "nullable": true
+          },
+          "context": {
+            "description": "Context for the report.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunContext"
+              }
+            ],
+            "nullable": true
+          },
+          "end_time": {
+            "description": "End time for the report. Must be an ISO 8601 formatted string.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ]
+          },
+          "hash": {
+            "description": "Full `git` commit hash. All reports with the same `git` commit hash will be considered part of the same branch version. This can be useful for tracking the performance of a specific commit across multiple testbeds.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHash"
+              }
+            ],
+            "nullable": true
+          },
+          "project": {
+            "description": "Project UUID or slug. If the project is not provided or does not exist, it will be created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceId"
+              }
+            ],
+            "nullable": true
+          },
+          "results": {
+            "description": "An array of benchmarks results.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "settings": {
+            "description": "Settings for how to handle the results.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonReportSettings"
+              }
+            ],
+            "nullable": true
+          },
+          "start_point": {
+            "description": "The start point for the report branch. If the branch does not exist, the start point will be used to create a new branch. If the branch already exists and the start point is not provided, the current branch will be used. If the branch already exists and the start point provided is different, a new branch head will be created from the new start point. If a new branch or new branch head is created with a start point, historical branch versions from the start point branch will be shallow copied over to the new branch. That is, historical metrics data for the start point branch will appear in queries for the branch. For example, pull request branches often use their base branch as their start point branch. If a new branch is created, it is not kept in sync with the start point branch.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonUpdateStartPoint"
+              }
+            ],
+            "nullable": true
+          },
+          "start_time": {
+            "description": "Start time for the report. Must be an ISO 8601 formatted string.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ]
+          },
+          "testbed": {
+            "description": "Testbed UUID, slug, or name. If the testbed is not provided or does not exist, it will be created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameId"
+              }
+            ],
+            "nullable": true
+          },
+          "thresholds": {
+            "description": "Thresholds to use for the branch, testbed, and measures in the report. If a threshold does not exist, it will be created. If a threshold exists and the model is different, it will be updated with the new model. If a measure name or slug is provided, the measure will be created if it does not exist.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonReportThresholds"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": ["end_time", "results", "start_time"]
+      },
+      "JsonProject": {
+        "type": "object",
+        "properties": {
+          "claimed": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/OrganizationUuid"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "url": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Url"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/Visibility"
+          }
+        },
+        "required": [
+          "created",
+          "modified",
+          "name",
+          "organization",
+          "slug",
+          "uuid",
+          "visibility"
+        ]
+      },
+      "JsonPubUser": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/UserName"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/UserUuid"
+          }
+        },
+        "required": ["name", "slug", "uuid"]
+      },
+      "JsonReport": {
+        "type": "object",
+        "properties": {
+          "adapter": {
+            "$ref": "#/components/schemas/Adapter"
+          },
+          "alerts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JsonAlert"
+            }
+          },
+          "branch": {
+            "$ref": "#/components/schemas/JsonBranch"
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "end_time": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "project": {
+            "$ref": "#/components/schemas/JsonProject"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/JsonReportResult"
+              }
+            }
+          },
+          "start_time": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "testbed": {
+            "$ref": "#/components/schemas/JsonTestbed"
+          },
+          "user": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonPubUser"
+              }
+            ],
+            "nullable": true
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ReportUuid"
+          }
+        },
+        "required": [
+          "adapter",
+          "alerts",
+          "branch",
+          "created",
+          "end_time",
+          "project",
+          "results",
+          "start_time",
+          "testbed",
+          "uuid"
+        ]
+      },
+      "JsonReportMeasure": {
+        "type": "object",
+        "properties": {
+          "boundary": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonBoundary"
+              }
+            ],
+            "nullable": true
+          },
+          "measure": {
+            "$ref": "#/components/schemas/JsonMeasure"
+          },
+          "metric": {
+            "$ref": "#/components/schemas/JsonMetric"
+          },
+          "threshold": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonThresholdModel"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": ["measure", "metric"]
+      },
+      "JsonReportResult": {
+        "type": "object",
+        "properties": {
+          "benchmark": {
+            "$ref": "#/components/schemas/JsonBenchmark"
+          },
+          "iteration": {
+            "$ref": "#/components/schemas/Iteration"
+          },
+          "measures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JsonReportMeasure"
+            }
+          }
+        },
+        "required": ["benchmark", "iteration", "measures"]
+      },
+      "JsonReportSettings": {
+        "type": "object",
+        "properties": {
+          "adapter": {
+            "description": "The benchmark harness adapter for parsing the benchmark results. If no adapter is specified, then the Magic adapter will be used.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Adapter"
+              }
+            ],
+            "nullable": true
+          },
+          "average": {
+            "description": "Benchmark harness suggested central tendency (ie average). Some benchmarking harnesses provide multiple averages, such as mean and median.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonAverage"
+              }
+            ],
+            "nullable": true
+          },
+          "fold": {
+            "description": "Fold multiple results into a single result using the selected operation. This can be useful for taking the min, max, mean, or median of the benchmark results.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonFold"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "JsonReportThresholds": {
+        "type": "object",
+        "properties": {
+          "models": {
+            "description": "Map of measure UUID, slug, or name to the threshold model to use. If a measure name or slug is provided, the measure will be created if it does not exist.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Model"
+            },
+            "nullable": true
+          },
+          "reset": {
+            "description": "Reset all thresholds for the branch and testbed. Any models present in the `models` field will still be updated accordingly. If a threshold already exists and is not present in the `models` field, its current model will be removed.",
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      },
+      "JsonStartPoint": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "$ref": "#/components/schemas/BranchUuid"
+          },
+          "head": {
+            "$ref": "#/components/schemas/HeadUuid"
+          },
+          "version": {
+            "$ref": "#/components/schemas/JsonVersion"
+          }
+        },
+        "required": ["branch", "head", "version"]
+      },
+      "JsonTestbed": {
+        "type": "object",
+        "properties": {
+          "archived": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DateTime"
+              }
+            ],
+            "nullable": true
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "name": {
+            "$ref": "#/components/schemas/ResourceName"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "slug": {
+            "$ref": "#/components/schemas/Slug"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/TestbedUuid"
+          }
+        },
+        "required": ["created", "modified", "name", "project", "slug", "uuid"]
+      },
+      "JsonThreshold": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "$ref": "#/components/schemas/JsonBranch"
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "measure": {
+            "$ref": "#/components/schemas/JsonMeasure"
+          },
+          "model": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonModel"
+              }
+            ],
+            "nullable": true
+          },
+          "modified": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "testbed": {
+            "$ref": "#/components/schemas/JsonTestbed"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ThresholdUuid"
+          }
+        },
+        "required": [
+          "branch",
+          "created",
+          "measure",
+          "modified",
+          "project",
+          "testbed",
+          "uuid"
+        ]
+      },
+      "JsonThresholdModel": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "model": {
+            "$ref": "#/components/schemas/JsonModel"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectUuid"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/ThresholdUuid"
+          }
+        },
+        "required": ["created", "model", "project", "uuid"]
+      },
+      "JsonUpdateStartPoint": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "description": "The UUID, slug, or name of the branch to use as the start point.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NameId"
+              }
+            ],
+            "nullable": true
+          },
+          "clone_thresholds": {
+            "description": "If set to `true`, the thresholds from the start point branch will be deep copied to the branch. This can be useful for pull request branches that should have the same thresholds as their target branch. Requires the `branch` field to be set.",
+            "type": "boolean",
+            "nullable": true
+          },
+          "hash": {
+            "description": "The full git hash of the branch to use as the start point. Requires the `branch` field to be set.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHash"
+              }
+            ],
+            "nullable": true
+          },
+          "max_versions": {
+            "description": "The maximum number of historical branch versions to include. Versions beyond this number will be omitted. The default is 255. Requires the `branch` field to be set.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "nullable": true
+          },
+          "reset": {
+            "description": "Reset the branch head to an empty state. If the start point `branch` is specified, the new branch head will begin at that start point. Otherwise, the branch head will be reset to an empty state.",
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      },
+      "JsonVersion": {
+        "type": "object",
+        "properties": {
+          "hash": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHash"
+              }
+            ],
+            "nullable": true
+          },
+          "number": {
+            "$ref": "#/components/schemas/VersionNumber"
+          }
+        },
+        "required": ["number"]
+      },
+      "MeasureUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "MetricUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "Model": {
+        "type": "object",
+        "properties": {
+          "lower_boundary": {
+            "description": "The lower boundary used to calculate the lower boundary limit. The requirements for this field depend on which `test` is selected.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Boundary"
+              }
+            ],
+            "nullable": true
+          },
+          "max_sample_size": {
+            "description": "The maximum number of samples used to perform the test. Only the most recent samples will be used if there are more.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SampleSize"
+              }
+            ],
+            "nullable": true
+          },
+          "min_sample_size": {
+            "description": "The minimum number of samples required to perform the test. If there are fewer samples, the test will not be performed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SampleSize"
+              }
+            ],
+            "nullable": true
+          },
+          "test": {
+            "description": "The test used by the threshold model to calculate the baseline and boundary limits.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ModelTest"
+              }
+            ]
+          },
+          "upper_boundary": {
+            "description": "The upper boundary used to calculate the upper boundary limit. The requirements for this field depend on which `test` is selected.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Boundary"
+              }
+            ],
+            "nullable": true
+          },
+          "window": {
+            "description": "The window of time for samples used to perform the test, in seconds. Samples outside of this window will be omitted.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Window"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": ["test"]
+      },
+      "ModelTest": {
+        "type": "string",
+        "enum": [
+          "static",
+          "percentage",
+          "z_score",
+          "t_test",
+          "log_normal",
+          "iqr",
+          "delta_iqr"
+        ]
+      },
+      "ModelUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "NameId": {
+        "type": "string"
+      },
+      "OrganizationUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "ProjectUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "ReportUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "ResourceId": {
+        "type": "string"
+      },
+      "ResourceName": {
+        "type": "string"
+      },
+      "RunContext": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "SampleSize": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      },
+      "Slug": {
+        "type": "string"
+      },
+      "TestbedUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "ThresholdUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "Url": {
+        "type": "string"
+      },
+      "UserName": {
+        "type": "string"
+      },
+      "UserUuid": {
+        "type": "string",
+        "format": "uuid"
+      },
+      "VersionNumber": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      },
+      "Visibility": {
+        "type": "string",
+        "enum": ["public", "private"]
+      },
+      "Window": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "alerts",
+      "description": "Alerts"
+    },
+    {
+      "name": "allowed"
+    },
+    {
+      "name": "auth",
+      "description": "Auth"
+    },
+    {
+      "name": "benchmarks",
+      "description": "Benchmarks"
+    },
+    {
+      "name": "branches",
+      "description": "Branches"
+    },
+    {
+      "name": "checkout"
+    },
+    {
+      "name": "measures",
+      "description": "Measures"
+    },
+    {
+      "name": "members"
+    },
+    {
+      "name": "metrics",
+      "description": "Metrics"
+    },
+    {
+      "name": "models",
+      "description": "Models"
+    },
+    {
+      "name": "organizations",
+      "description": "Organizations"
+    },
+    {
+      "name": "perf",
+      "description": "Perf Metrics"
+    },
+    {
+      "name": "plan"
+    },
+    {
+      "name": "plots",
+      "description": "Plots"
+    },
+    {
+      "name": "projects",
+      "description": "Projects"
+    },
+    {
+      "name": "reports",
+      "description": "Reports"
+    },
+    {
+      "name": "run",
+      "description": "Run"
+    },
+    {
+      "name": "server",
+      "description": "Server"
+    },
+    {
+      "name": "stats"
+    },
+    {
+      "name": "testbeds",
+      "description": "Testbeds"
+    },
+    {
+      "name": "thresholds",
+      "description": "Thresholds"
+    },
+    {
+      "name": "tokens",
+      "description": "API Tokens"
+    },
+    {
+      "name": "usage"
+    },
+    {
+      "name": "users",
+      "description": "Users"
+    }
+  ]
+}

--- a/crates/fda/build.rs
+++ b/crates/fda/build.rs
@@ -1,0 +1,21 @@
+use progenitor::{GenerationSettings, InterfaceStyle};
+use std::{env, fs, path::Path};
+
+fn main() {
+    let openapi = include_bytes!("bench_openapi.json");
+    println!("cargo:rerun-if-changed=bench_openapi.json");
+
+    let spec = serde_json::from_reader(&openapi[..]).unwrap();
+    let mut settings = GenerationSettings::new();
+    settings.with_interface(InterfaceStyle::Builder);
+    let mut generator = progenitor::Generator::new(&settings);
+
+    let tokens = generator.generate_tokens(&spec).unwrap();
+    let ast = syn::parse2(tokens).unwrap();
+    let content = prettyplease::unparse(&ast);
+
+    let mut out_file = Path::new(&env::var("OUT_DIR").unwrap()).to_path_buf();
+    out_file.push("codegen.rs");
+
+    fs::write(out_file, content).unwrap();
+}

--- a/crates/fda/src/bench/api.rs
+++ b/crates/fda/src/bench/api.rs
@@ -1,0 +1,2 @@
+#![allow(clippy::all, unused)]
+include!(concat!(env!("OUT_DIR"), "/codegen.rs"));

--- a/crates/fda/src/bench/mod.rs
+++ b/crates/fda/src/bench/mod.rs
@@ -1,0 +1,662 @@
+use chrono::{DateTime, Utc};
+use feldera_rest_api::types::{CompilationProfile, Configuration};
+use feldera_rest_api::Client;
+use feldera_types::error::ErrorResponse;
+use log::{error, info, warn};
+use progenitor_client::Error as ProgenitorError;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::{cmp, collections::HashMap, error::Error};
+use tabled::builder::Builder;
+use tabled::settings::Style;
+use tokio::time::{sleep, Duration, Instant};
+
+mod api;
+use crate::bench::api::types::JsonUpdateStartPoint;
+use crate::handle_errors_fatal;
+use crate::{
+    bench::api::types::{Adapter, GitHash, JsonNewRun, JsonReportSettings, NameId, ResourceId},
+    cli::{BenchmarkArgs, OutputFormat, PipelineAction},
+};
+use api::Client as BenchClient;
+
+pub fn human_readable_bytes(n: i64) -> String {
+    const DELIMITER: f64 = 1024_f64;
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB"];
+
+    let n: f64 = n as f64;
+    assert!(n >= 0f64, "No negative bytes");
+
+    let n = n.abs();
+    if n < 1_f64 {
+        return format!("{} {}", n, "B");
+    }
+    let exp = cmp::min(
+        (n.ln() / DELIMITER.ln()).floor() as i32,
+        (UNITS.len() - 1) as i32,
+    );
+    let bytes = format!("{:.2}", n / DELIMITER.powi(exp))
+        .parse::<f64>()
+        .unwrap()
+        * 1_f64;
+    let unit = UNITS[exp as usize];
+    format!("{} {}", bytes, unit)
+}
+
+/// Raw metrics collected from a single measurement
+#[derive(Debug)]
+struct RawMetrics {
+    rss_bytes: i64,
+    uptime_msecs: i64,
+    incarnation_uuid: String,
+    storage_bytes: i64,
+    total_processed_records: i64,
+    input_bytes: i64,
+    input_errors: bool,
+}
+
+/// JSON representation of input connector metrics
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct InputMetrics {
+    buffered_records: i64,
+    end_of_input: bool,
+    num_parse_errors: i64,
+    num_transport_errors: i64,
+    total_bytes: i64,
+    total_records: i64,
+}
+
+/// JSON representation of an input connector
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct InputConnector {
+    barrier: bool,
+    config: Map<String, Value>,
+    endpoint_name: String,
+    fatal_error: Option<String>,
+    metrics: InputMetrics,
+    paused: bool,
+}
+
+/// JSON representation of pipeline stats
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct PipelineStats {
+    global_metrics: Map<String, Value>,
+    inputs: Vec<InputConnector>,
+    outputs: Vec<Value>,
+    suspend_error: Option<Value>,
+}
+
+impl From<&Map<String, Value>> for RawMetrics {
+    fn from(stats: &Map<String, Value>) -> Self {
+        let pipeline_stats: PipelineStats =
+            serde_json::from_value(Value::Object(stats.clone())).unwrap();
+        let global_metrics = &pipeline_stats.global_metrics;
+
+        // Check for input errors
+        let input_errors = pipeline_stats.inputs.iter().any(|input| {
+            input.fatal_error.is_some()
+                || input.metrics.num_parse_errors > 0
+                || input.metrics.num_transport_errors > 0
+        });
+
+        // Calculate total input bytes
+        let input_bytes = pipeline_stats
+            .inputs
+            .iter()
+            .map(|input| input.metrics.total_bytes)
+            .sum();
+
+        Self {
+            rss_bytes: global_metrics
+                .get("rss_bytes")
+                .and_then(|v| v.as_i64())
+                .unwrap(),
+            uptime_msecs: global_metrics
+                .get("uptime_msecs")
+                .and_then(|v| v.as_i64())
+                .unwrap(),
+            incarnation_uuid: global_metrics
+                .get("incarnation_uuid")
+                .and_then(|v| v.as_str())
+                .unwrap()
+                .to_string(),
+            storage_bytes: global_metrics
+                .get("storage_bytes")
+                .and_then(|v| v.as_i64())
+                .unwrap(),
+            total_processed_records: global_metrics
+                .get("total_processed_records")
+                .and_then(|v| v.as_i64())
+                .unwrap(),
+            input_bytes,
+            input_errors,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Metric<T> {
+    value: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lower_value: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    upper_value: Option<T>,
+}
+
+impl<T> Metric<T> {
+    fn simple(value: T) -> Self {
+        Self {
+            value,
+            lower_value: None,
+            upper_value: None,
+        }
+    }
+}
+
+/// Aggregated benchmark metrics in BMF format
+#[derive(Debug, Serialize)]
+struct PipelineMetrics {
+    /// Throughput in records per second
+    throughput: Metric<i64>,
+    /// Max. memory usage in bytes
+    memory: Metric<i64>,
+    /// Max. storage usage in bytes
+    storage: Metric<i64>,
+    /// Uptime in milliseconds
+    uptime: Metric<i64>,
+    /// State amplification factor (storage_bytes / input_bytes)
+    #[serde(
+        rename = "state-amplification",
+        skip_serializing_if = "Option::is_none"
+    )]
+    state_amplification: Option<Metric<f64>>,
+}
+
+impl PipelineMetrics {
+    fn new(metrics: Vec<RawMetrics>) -> Self {
+        if metrics.is_empty() {
+            eprintln!("No measurements were recorded? Maybe try to increase `duration`.");
+            std::process::exit(1);
+        }
+
+        // Calculate throughput (records per second)
+        let last = metrics.last().unwrap();
+        let throughput =
+            (last.total_processed_records as f64 / (last.uptime_msecs as f64 / 1000.0)) as i64;
+
+        // Calculate memory metrics
+        let memory = Metric {
+            value: metrics
+                .iter()
+                .map(|m| m.rss_bytes)
+                .max_by(|a, b| a.cmp(b))
+                .unwrap(),
+            lower_value: Some(
+                metrics
+                    .iter()
+                    .map(|m| m.rss_bytes)
+                    .min_by(|a, b| a.cmp(b))
+                    .unwrap(),
+            ),
+            upper_value: None,
+        };
+
+        let storage = Metric {
+            value: metrics
+                .iter()
+                .map(|m| m.storage_bytes)
+                .max_by(|a, b| a.cmp(b))
+                .unwrap(),
+            lower_value: Some(
+                metrics
+                    .iter()
+                    .map(|m| m.storage_bytes)
+                    .min_by(|a, b| a.cmp(b))
+                    .unwrap(),
+            ),
+            upper_value: None,
+        };
+
+        // Calculate input bytes for state amplification
+        let input_bytes = metrics.iter().last().map(|m| m.input_bytes).unwrap();
+
+        // Calculate state amplification (storage_bytes / input_bytes)
+        let state_amplification = if input_bytes > 0 {
+            Some(Metric::simple(storage.value as f64 / input_bytes as f64))
+        } else {
+            None
+        };
+
+        Self {
+            throughput: Metric::simple(throughput),
+            memory,
+            storage,
+            state_amplification,
+            uptime: Metric::simple(last.uptime_msecs),
+        }
+    }
+}
+
+/// A benchmark in BMF form
+#[derive(Debug, Serialize)]
+struct Benchmark {
+    name: String,
+    #[serde(flatten)]
+    metrics: PipelineMetrics,
+}
+
+impl Benchmark {
+    fn new(name: String, metrics: PipelineMetrics) -> Self {
+        Self { name, metrics }
+    }
+
+    fn as_map(&self) -> Map<String, Value> {
+        let mut map = Map::new();
+        map.insert(
+            self.name.clone(),
+            serde_json::to_value(&self.metrics).unwrap(),
+        );
+        map
+    }
+
+    fn format_as_text(&self) -> String {
+        let mut rows = vec![];
+        rows.push([
+            "Metric".to_string(),
+            "Value".to_string(),
+            "Lower".to_string(),
+            "Upper".to_string(),
+        ]);
+
+        // Add throughput
+        rows.push([
+            "Throughput (records/s)".to_string(),
+            format!("{}", self.metrics.throughput.value),
+            "-".to_string(),
+            "-".to_string(),
+        ]);
+
+        // Add memory bytes
+        rows.push([
+            "Memory".to_string(),
+            human_readable_bytes(self.metrics.memory.value),
+            human_readable_bytes(self.metrics.memory.lower_value.unwrap()),
+            "-".to_string(),
+        ]);
+
+        // Add storage bytes
+        rows.push([
+            "Storage".to_string(),
+            human_readable_bytes(self.metrics.storage.value),
+            human_readable_bytes(self.metrics.storage.lower_value.unwrap()),
+            "-".to_string(),
+        ]);
+
+        // Add uptime
+        rows.push([
+            "Uptime [ms]".to_string(),
+            self.metrics.uptime.value.to_string(),
+            "-".to_string(),
+            "-".to_string(),
+        ]);
+
+        // Add state amplification if present
+        if let Some(amp) = &self.metrics.state_amplification {
+            rows.push([
+                "State Amplification".to_string(),
+                format!("{:.2}", amp.value),
+                "-".to_string(),
+                "-".to_string(),
+            ]);
+        }
+
+        format!(
+            "Benchmark Results:\n{}",
+            Builder::from_iter(rows).build().with(Style::rounded())
+        )
+    }
+
+    fn format(&self, format: OutputFormat) -> String {
+        match format {
+            OutputFormat::Json => serde_json::to_string_pretty(&self.as_map()).unwrap(),
+            OutputFormat::Text => self.format_as_text(),
+            OutputFormat::ArrowIpc | OutputFormat::Parquet => {
+                warn!("Format '{}' is not supported for benchmark results, falling back to text format", format);
+                self.format_as_text()
+            }
+        }
+    }
+}
+
+/// Collect metrics from a pipeline over time.
+///
+/// Returns a vector of collected metrics and whether the pipeline completed.
+async fn collect_metrics(
+    client: &Client,
+    pipeline_name: &str,
+    duration_secs: Option<u64>,
+) -> Vec<Map<String, Value>> {
+    let mut metrics = Vec::new();
+    let start_time = Instant::now();
+    let duration = duration_secs.map(Duration::from_secs);
+
+    loop {
+        sleep(Duration::from_secs(1)).await;
+        match client
+            .get_pipeline_stats()
+            .pipeline_name(pipeline_name.to_string())
+            .send()
+            .await
+        {
+            Ok(stats) => {
+                let stats = stats.into_inner();
+                metrics.push(stats.clone());
+                info!("Collected metrics at {}s", start_time.elapsed().as_secs());
+
+                // Check if pipeline is complete
+                if let Some(global_metrics) = stats.get("global_metrics") {
+                    if let Some(complete) = global_metrics.get("pipeline_complete") {
+                        if complete.as_bool().unwrap_or(false) {
+                            println!("Pipeline completed, stopping benchmark");
+                            break;
+                        }
+                    }
+                }
+
+                // Check if we've reached the duration limit
+                if let Some(duration) = duration {
+                    if start_time.elapsed() >= duration {
+                        println!("Reached duration limit of {}s", duration_secs.unwrap());
+                        break;
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to collect metrics: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    metrics
+}
+
+/// Transform metrics into Bencher Metric Format (BMF)
+async fn transform_to_bmf(
+    client: &Client,
+    name: String,
+    format: OutputFormat,
+    metrics: Vec<Map<String, Value>>,
+) -> Benchmark {
+    // Convert raw JSON metrics to structured data
+    let raw_metrics: Vec<RawMetrics> = metrics.iter().map(RawMetrics::from).collect();
+
+    // Verify incarnation_uuid is consistent
+    if let Some(first) = raw_metrics.first() {
+        for metric in &raw_metrics {
+            if metric.incarnation_uuid != first.incarnation_uuid {
+                error!("Inconsistent incarnation_uuid detected during benchmark, did the program restart while measuring?");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Check if any metrics had input errors
+    if raw_metrics.iter().any(|m| m.input_errors) {
+        let _r = Box::pin(crate::pipeline(
+            format,
+            PipelineAction::Logs { name, watch: false },
+            client.clone(),
+        ))
+        .await;
+        eprintln!("Detected errors in input connectors during result processing, abort benchmark.");
+        std::process::exit(1);
+    }
+
+    Benchmark::new(name, PipelineMetrics::new(raw_metrics))
+}
+
+/// Benchmark the performance of a pipeline.
+pub(crate) async fn bench(client: Client, format: OutputFormat, args: BenchmarkArgs) {
+    let pipeline_name = args.name.clone();
+    println!("Benchmarking {pipeline_name}");
+    let recompile = !args.no_recompile;
+
+    // Check compilation profile and storage configuration
+    let pipeline = match client
+        .get_pipeline()
+        .pipeline_name(pipeline_name.clone())
+        .send()
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            handle_errors_fatal(client.baseurl().clone(), "Failed to get pipeline status", 1)(e);
+            unreachable!()
+        }
+    };
+
+    // Check compilation profile
+    let compilation_profile = pipeline
+        .as_ref()
+        .program_config
+        .as_ref()
+        .and_then(|cp| cp.profile)
+        .unwrap_or(CompilationProfile::Optimized);
+    if compilation_profile != CompilationProfile::Optimized {
+        warn!(
+                "Compilation profile was set to `{:?}`. This is most likely not what you want to benchmark with. Set it to `optimized` for best performance.",
+                compilation_profile
+            );
+    }
+
+    // Check storage configuration
+    if let Some(runtime_config) = &pipeline.runtime_config {
+        if runtime_config.storage.is_none() {
+            warn!(
+                "Storage is not enabled for this pipeline. This may affect benchmark performance."
+            );
+        }
+    }
+
+    // Stop pipeline if running and restart with recompile
+    let _ = Box::pin(crate::pipeline(
+        OutputFormat::Text,
+        PipelineAction::Shutdown {
+            name: pipeline_name.clone(),
+            no_wait: false,
+        },
+        client.clone(),
+    ))
+    .await;
+
+    // Restart the pipeline with recompile if requested
+    let _ = Box::pin(crate::pipeline(
+        OutputFormat::Text,
+        PipelineAction::Start {
+            name: pipeline_name.clone(),
+            recompile,
+            no_wait: false,
+        },
+        client.clone(),
+    ))
+    .await;
+
+    let start_time: chrono::DateTime<chrono::Utc> = chrono::Utc::now();
+    // Collect metrics over time
+    println!("Collecting metrics...");
+    let metrics = collect_metrics(&client, &pipeline_name, args.duration).await;
+    let end_time: chrono::DateTime<chrono::Utc> = chrono::Utc::now();
+
+    // Shutdown the pipeline after collecting metrics
+    let _ = Box::pin(crate::pipeline(
+        OutputFormat::Text,
+        PipelineAction::Shutdown {
+            name: pipeline_name.clone(),
+            no_wait: true,
+        },
+        client.clone(),
+    ))
+    .await;
+
+    let bmf_benchmark = transform_to_bmf(&client, pipeline_name, format, metrics).await;
+    println!("{}", bmf_benchmark.format(format));
+
+    if args.upload {
+        let feldera_instance_config = get_config(&client)
+            .await
+            .map_err(handle_errors_fatal(
+                client.baseurl().clone(),
+                "Unable to fetch config of feldera instance",
+                1,
+            ))
+            .unwrap();
+        let feldera_testbed = Url::parse(client.baseurl())
+            .ok()
+            .and_then(|url| url.host_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| client.baseurl().to_string());
+
+        upload_result(
+            args,
+            feldera_testbed,
+            feldera_instance_config,
+            bmf_benchmark,
+            start_time,
+            end_time,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            error!("Failed to upload benchmark result: {}", e);
+            std::process::exit(1);
+        });
+    }
+}
+
+async fn get_config(client: &Client) -> Result<Configuration, ProgenitorError<ErrorResponse>> {
+    let config = client.get_config().send().await?;
+    let config_map = config.into_inner();
+    Ok(config_map)
+}
+
+async fn upload_result(
+    args: BenchmarkArgs,
+    feldera_testbed: String,
+    feldera_instance_config: Configuration,
+    benchmark_data: Benchmark,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+) -> Result<(), Box<dyn Error>> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(token) = &args.benchmark_token {
+        let authorization_header = format!("Bearer {}", token);
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            authorization_header.parse().unwrap(),
+        );
+    } else {
+        warn!("No benchmark token provided, trying to upload without one.");
+    }
+
+    let client_with_benchmark_auth = reqwest::ClientBuilder::new()
+        .connect_timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(15))
+        .default_headers(headers)
+        .build()
+        .unwrap();
+    let client = BenchClient::new_with_client(&args.benchmark_host, client_with_benchmark_auth);
+
+    let mut run_context: HashMap<String, String> = HashMap::new();
+    // Augment from `feldera_instance_config`, if available:
+    run_context.insert(
+        "bencher.dev/v0/repo/name".to_string(),
+        format!("feldera {}", feldera_instance_config.edition),
+    );
+    run_context.insert(
+        "bencher.dev/v0/branch/hash".to_string(),
+        feldera_instance_config.revision.clone(),
+    );
+    run_context.insert(
+        "bencher.dev/v0/branch/ref/name".to_string(),
+        args.branch.clone(),
+    );
+    match feldera_instance_config.edition.as_str() {
+        "Open source" => {
+            run_context.insert(
+                "bencher.dev/v0/repo/hash".to_string(),
+                "de8879fbda0c9e9392e3b94064c683a1b4bae216".to_string(),
+            );
+        }
+        "Enterprise" => {
+            run_context.insert(
+                "bencher.dev/v0/repo/hash".to_string(),
+                "751db38ff821d73bcc67c836af421d76d4d42bdd".to_string(),
+            );
+        }
+        _ => {
+            warn!(
+                "Unknown edition '{}', not setting repo hash",
+                feldera_instance_config.edition
+            );
+        }
+    }
+
+    // TODO: augment with more context, e.g.:
+    //"bencher.dev/v0/testbed/os": "macOS",
+    //"bencher.dev/v0/branch/ref": "refs/heads/benchmarks",
+    //"bencher.dev/v0/testbed/fingerprint": "rkn4va8erzzh3",
+
+    let git_hash: GitHash = GitHash(feldera_instance_config.revision.clone());
+    let project = ResourceId(args.project.unwrap_or_else(|| {
+        match feldera_instance_config.edition.as_str() {
+            "Enterprise" => "feldera",
+            "Open source" => "feldera-oss",
+            _ => "feldera-unknown",
+        }
+        .to_string()
+    }));
+    let testbed = NameId(feldera_testbed);
+    let result = benchmark_data.format(OutputFormat::Json);
+    let settings: JsonReportSettings = JsonReportSettings::builder()
+        .adapter(Adapter::Json)
+        .try_into()?;
+    let branch = NameId(args.branch);
+
+    let json_start_point = args.start_point.map(|st| {
+        JsonUpdateStartPoint::builder()
+            .branch(NameId(st))
+            .clone_thresholds(args.start_point_clone_thresholds)
+            .hash(args.start_point_hash.map(GitHash))
+            .max_versions(args.start_point_max_versions)
+            .reset(args.start_point_reset)
+            .try_into()
+            .expect("Unable to build JsonUpdateStartPoint")
+    });
+    let thresholds = None;
+
+    let run: JsonNewRun = JsonNewRun::builder()
+        .branch(branch)
+        .project(project)
+        .context(Some(run_context.into()))
+        .start_time(start_time)
+        .end_time(end_time)
+        .hash(git_hash)
+        .results(vec![result])
+        .settings(settings)
+        .start_point(json_start_point)
+        .testbed(testbed)
+        .thresholds(thresholds)
+        .try_into()?;
+
+    let r = client.run_post().body(run).send().await?;
+    if r.status().is_success() {
+        info!("Benchmark result uploaded successfully.");
+    } else {
+        warn!("Failed to upload benchmark result: {}", r.status());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This adds a benchmark command for fda which makes it easier to track basic metrics (memory, storage and throughput) in CI.

Also fixes a bug with the cache-disabler that tried to change the pipeline settings in the Drop handler which no longer works since we changed the part
where we can modify the pipeline settings at any time.