### PR TITLE
Fix pipeline stalls due to background merger slowness

### DIFF
--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -230,20 +230,12 @@ $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))
     /// Returns a Zip archive containing all the profile `.dot` files.
     pub fn as_zip(&self) -> Vec<u8> {
         let mut zip = ZipWriter::new(IoCursor::new(Vec::with_capacity(65536)));
-        let elapsed = self.elapsed_time.as_micros();
         for (worker, graph) in self.worker_graphs.iter().enumerate() {
-            zip.start_file(
-                format!("profile/{elapsed}/{worker}.dot"),
-                FileOptions::default(),
-            )
-            .unwrap();
+            zip.start_file(format!("{worker}.dot"), FileOptions::default())
+                .unwrap();
             zip.write_all(graph.to_dot().as_bytes()).unwrap();
         }
-        zip.start_file(
-            format!("profile/{elapsed}/Makefile"),
-            FileOptions::default(),
-        )
-        .unwrap();
+        zip.start_file("Makefile", FileOptions::default()).unwrap();
         zip.write_all(Self::MAKEFILE.as_bytes()).unwrap();
         zip.finish().unwrap().into_inner()
     }

--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -222,6 +222,7 @@ $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))
         create_dir_all(&dir_path)?;
         for (worker, graph) in self.worker_graphs.iter().enumerate() {
             fs::write(dir_path.join(format!("{worker}.dot")), graph.to_dot())?;
+            fs::write(dir_path.join(format!("{worker}.txt")), graph.to_string())?;
         }
         fs::write(dir_path.join("Makefile"), Self::MAKEFILE)?;
         Ok(dir_path)
@@ -234,6 +235,10 @@ $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))
             zip.start_file(format!("{worker}.dot"), FileOptions::default())
                 .unwrap();
             zip.write_all(graph.to_dot().as_bytes()).unwrap();
+
+            zip.start_file(format!("{worker}.txt"), FileOptions::default())
+                .unwrap();
+            zip.write_all(graph.to_string().as_bytes()).unwrap();
         }
         zip.start_file("Makefile", FileOptions::default()).unwrap();
         zip.write_all(Self::MAKEFILE.as_bytes()).unwrap();

--- a/crates/dbsp/src/trace/spine_async/index_set.rs
+++ b/crates/dbsp/src/trace/spine_async/index_set.rs
@@ -1,4 +1,7 @@
-use std::ops::{BitOr, BitOrAssign};
+use std::{
+    fmt::Debug,
+    ops::{BitOr, BitOrAssign},
+};
 
 /// A set of indexes (numbers) in the range 0..=63.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -9,6 +12,12 @@ impl IndexSet {
     pub fn for_index(index: usize) -> Self {
         debug_assert!(index < 64);
         Self(1 << index)
+    }
+
+    /// Returns a bit-set with the bits in `mask`.
+    #[cfg(test)]
+    pub fn for_mask(mask: impl Into<u64>) -> Self {
+        Self(mask.into())
     }
 
     /// Returns an empty set.
@@ -65,6 +74,19 @@ impl IndexSet {
     /// Removes `index` from the set.
     pub fn remove(&mut self, index: usize) {
         self.0 &= !(1 << index);
+    }
+}
+
+impl Debug for IndexSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IndexSet[")?;
+        for (index, bit) in self.into_iter().enumerate() {
+            if index > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{bit}")?;
+        }
+        write!(f, "]")
     }
 }
 

--- a/crates/dbsp/src/trace/spine_async/list_merger.rs
+++ b/crates/dbsp/src/trace/spine_async/list_merger.rs
@@ -74,6 +74,7 @@ where
     B: Batch,
 {
     cursors: Vec<C>,
+    any_values: bool,
     has_mut: Vec<bool>,
     tmp_weight: Box<B::R>,
     time_diffs: Option<Box<DynWeightedPairs<DynDataTyped<B::Time>, B::R>>>,
@@ -102,6 +103,7 @@ where
 
         ListMerger {
             cursors,
+            any_values: false,
             has_mut,
             tmp_weight: factories.weight_factory().default_box(),
             time_diffs,
@@ -141,9 +143,20 @@ where
                     .map(|index| (index, self.cursors[index].key())),
             );
 
+            // If we're resuming after stopping due to running out of fuel in a
+            // previous call, then we might have exhausted the values in some of
+            // the keys, so drop them.  We still need them in `orig_min_keys` so
+            // we can advance the key for all of them later.
+            let mut min_keys = if self.any_values {
+                orig_min_keys
+                    .into_iter()
+                    .filter(|index| self.cursors[*index].val_valid())
+                    .collect::<IndexSet>()
+            } else {
+                orig_min_keys
+            };
+
             // As long as there is more than one cursor with minimum keys...
-            let mut any_values = false;
-            let mut min_keys = orig_min_keys;
             while min_keys.is_long() {
                 // ...Find the indexes of the cursors with minimum values, among
                 // those with minimum keys, and copy their time-diff pairs and
@@ -153,7 +166,8 @@ where
                         .into_iter()
                         .map(|index| (index, self.cursors[index].val())),
                 );
-                any_values = self.copy_times(builder, time_map_func, min_vals, fuel) || any_values;
+                self.any_values =
+                    self.copy_times(builder, time_map_func, min_vals, fuel) || self.any_values;
 
                 // Then go on to the next value in each cursor, dropping the keys
                 // for which we've exhausted the values.
@@ -163,15 +177,21 @@ where
                         min_keys.remove(index);
                     }
                 }
+                if *fuel <= 0 {
+                    return;
+                }
             }
 
             // If there's exactly one cursor left with minimum key, copy its
             // values into the output.
             if let Some(index) = min_keys.first() {
                 loop {
-                    any_values =
-                        self.copy_times(builder, time_map_func, min_keys, fuel) || any_values;
+                    self.any_values =
+                        self.copy_times(builder, time_map_func, min_keys, fuel) || self.any_values;
                     self.cursors[index].step_val();
+                    if *fuel <= 0 {
+                        return;
+                    }
                     if !self.cursors[index].val_valid() {
                         break;
                     }
@@ -179,13 +199,14 @@ where
             }
 
             // If we wrote any values for these minimum keys, write the key.
-            if any_values {
+            if self.any_values {
                 let index = orig_min_keys.first().unwrap();
                 if self.has_mut[index] {
                     builder.push_key_mut(self.cursors[index].key_mut());
                 } else {
                     builder.push_key(self.cursors[index].key());
                 }
+                self.any_values = false;
             }
 
             // Advance each minimum-key cursor, dropping the cursors for which
@@ -202,17 +223,21 @@ where
         // directly to the output.
         if let Some(index) = remaining_cursors.first() {
             while *fuel > 0 {
-                let mut any_values = false;
                 loop {
-                    any_values = self.copy_times(builder, time_map_func, remaining_cursors, fuel)
-                        || any_values;
+                    self.any_values =
+                        self.copy_times(builder, time_map_func, remaining_cursors, fuel)
+                            || self.any_values;
                     self.cursors[index].step_val();
                     if !self.cursors[index].val_valid() {
                         break;
                     }
+                    if *fuel <= 0 {
+                        return;
+                    }
                 }
-                debug_assert!(time_map_func.is_some() || any_values, "This assertion should fail only if B::Cursor is a spine or a CursorList, but we shouldn't be merging those");
-                if any_values {
+                debug_assert!(time_map_func.is_some() || self.any_values, "This assertion should fail only if B::Cursor is a spine or a CursorList, but we shouldn't be merging those");
+                if self.any_values {
+                    self.any_values = false;
                     if self.has_mut[index] {
                         builder.push_key_mut(self.cursors[index].key_mut());
                     } else {

--- a/docs.feldera.com/docs/connectors/sources/datagen.md
+++ b/docs.feldera.com/docs/connectors/sources/datagen.md
@@ -131,12 +131,12 @@ In case the field type is a string, various strategies can be used to generate d
 - Name: `first_name`, `last_name`, `title`, `suffix`, `name`, `name_with_title`, `phone_number`, `cell_number`
 - Internet: `domain_suffix`, `email`, `username`, `password`, `ipv4`, `ipv6`, `ip`, `mac_address`, `user_agent`
 
-Company: `company_suffix`, `company_name`, `buzzword`, `buzzword_middle`, `buzzword_tail`, `catch_phrase`, `bs_verb`, `bs_adj`, `bs_noun`, `bs`, `profession`, `industry`
+- Company: `company_suffix`, `company_name`, `buzzword`, `buzzword_middle`, `buzzword_tail`, `catch_phrase`, `bs_verb`, `bs_adj`, `bs_noun`, `bs`, `profession`, `industry`
 
 - Currency: `currency_code`, `currency_name`, `currency_symbol`
 - Finance: `credit_card_number`
 
-Address: `city_prefix`, `city_suffix`, `city_name`, `country_name`, `country_code`, `street_suffix`, `street_name`, `time_zone`, `state_name`, `state_abbr`, `secondary_address_type`, `secondary_address`, `zip_code`, `post_code`, `building_number`, `latitude`, `longitude`
+- Address: `city_prefix`, `city_suffix`, `city_name`, `country_name`, `country_code`, `street_suffix`, `street_name`, `time_zone`, `state_name`, `state_abbr`, `secondary_address_type`, `secondary_address`, `zip_code`, `post_code`, `building_number`, `latitude`, `longitude`
 
 - Barcode: `isbn10`, `isbn13`, `isbn`
 - Files: `file_path`, `file_name`, `file_extension`, `dir_path`


### PR DESCRIPTION
Some pipelines stall during execution because the background merger cannot keep up. I diagnosed this problem as primarily due to two causes:
* Our mergers did not do a good job of honoring their "fuel" argument in a granular fashion (the pushmerger ignored it entirely). This PR fixes that, so that only the amount of data meant to be merged at one time is really done.
* The asynchronous driver for the merger did not use a reasoned view of how much fuel to supply to each merge. It would often supply too much for higher-level merges, which meant that they could run for hundreds or thousands of milliseconds at a time, blocking any other merges during that time. This PR fixes that too.
* We didn't have enough statistics for insight into the merge behavior. This adds statistics.
* This PR adds comprehensive (exhaustive, even) tests for the mergers.

I tested this PR as fixing the smoothness of pipeline performance in a case where the merger behavior was at fault. Otherwise, in cases where the merger performance wasn't a problem, it is approximately performance neutral in my testing.