### PR TITLE
[dbsp] Fix deadlock w multiple recursive fragments

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -1039,7 +1039,7 @@ mod tests {
                                 n
                             }))
                             .inspect(|_: &usize| {});
-                        Ok((|| Ok(false), ()))
+                        Ok((async || Ok(false), ()))
                     })
                     .unwrap();
                 Ok(())

--- a/crates/dbsp/src/circuit/schedule/mod.rs
+++ b/crates/dbsp/src/circuit/schedule/mod.rs
@@ -169,7 +169,7 @@ impl<F, S> IterativeExecutor<F, S> {
 
 impl<C, F, S> Executor<C> for IterativeExecutor<F, S>
 where
-    F: Fn() -> Result<bool, Error> + 'static,
+    F: AsyncFn() -> Result<bool, Error> + 'static,
     C: Circuit,
     S: Scheduler + 'static,
 {
@@ -181,7 +181,7 @@ where
 
             loop {
                 self.scheduler.step(&circuit).await?;
-                if (self.termination_check)()? {
+                if (self.termination_check)().await? {
                     break;
                 }
             }

--- a/crates/dbsp/src/operator/condition.rs
+++ b/crates/dbsp/src/operator/condition.rs
@@ -55,7 +55,7 @@ where
     {
         self.iterate(|child| {
             let (condition, res) = constructor(child)?;
-            Ok((move || Ok(condition.check()), res))
+            Ok((async move || Ok(condition.check()), res))
         })
     }
 
@@ -73,7 +73,7 @@ where
     {
         self.iterate_with_scheduler::<_, _, _, S>(|child| {
             let (condition, res) = constructor(child)?;
-            Ok((move || Ok(condition.check()), res))
+            Ok((async move || Ok(condition.check()), res))
         })
     }
 
@@ -91,7 +91,10 @@ where
     {
         self.iterate(|child| {
             let (conditions, res) = constructor(child)?;
-            Ok((move || Ok(conditions.iter().all(Condition::check)), res))
+            Ok((
+                async move || Ok(conditions.iter().all(Condition::check)),
+                res,
+            ))
         })
     }
 
@@ -109,7 +112,10 @@ where
     {
         self.iterate_with_scheduler::<_, _, _, S>(|child| {
             let (conditions, res) = constructor(child)?;
-            Ok((move || Ok(conditions.iter().all(Condition::check)), res))
+            Ok((
+                async move || Ok(conditions.iter().all(Condition::check)),
+                res,
+            ))
         })
     }
 }

--- a/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
@@ -1250,7 +1250,7 @@ pub mod test {
                     });
 
                 Ok((
-                    move || {
+                    async move || {
                         *counter.borrow_mut() += 1;
                         Ok(*counter.borrow() == MAX_ITERATIONS)
                     },

--- a/crates/dbsp/src/operator/dynamic/distinct.rs
+++ b/crates/dbsp/src/operator/dynamic/distinct.rs
@@ -1209,7 +1209,7 @@ mod test {
                         .inspect(|(d1, d2)| assert_eq!(d1, d2));
 
                     Ok((
-                        move || {
+                        async move || {
                             *counter.borrow_mut() += 1;
                             Ok(*counter.borrow() == 4)
                         },
@@ -1443,7 +1443,7 @@ mod test {
                 });
 
                 Ok((
-                    move || {
+                    async move || {
                         *counter.borrow_mut() += 1;
                         Ok(*counter.borrow() == MAX_ITERATIONS)
                     },


### PR DESCRIPTION
Fixes #4168.

A DBSP circuit with multiple independent recursive fragments (which schedulable at the same time) could deadlock.

What happened:
- Worker thread 1 starts executing recursive fragment 1.
- At the end of each iteration it checks termination condition, which requires waiting for a notification from all other workers.
- Worker thread 2 picks a different recursive fragment and blocks waiting for a notification from thread 1.

The fix uses async notifications instead of sync blocking, which allows the circuit to continue evaluating other operators while waiting for other threads. This way in the above scenario worker 1 can evaluate the second recursive fragment and unblock worker 2.