### PR TITLE
Upgrade feldera platform to use mold to 2.40.1.

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -60,10 +60,10 @@ COPY --chown=ubuntu sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp lib/sql-to-dbs
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.87.0
 # The download URL for mold uses x86_64/aarch64 whereas dpkg --print-architecture says amd64/arm64
 RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
-  curl -LO https://github.com/rui314/mold/releases/download/v2.32.1/mold-2.32.1-$arch-linux.tar.gz \
-  && tar -xzvf mold-2.32.1-$arch-linux.tar.gz \
-  && mv mold-2.32.1-$arch-linux $HOME/mold \
-  && rm mold-2.32.1-$arch-linux.tar.gz
+  curl -LO https://github.com/rui314/mold/releases/download/v2.40.1/mold-2.40.1-$arch-linux.tar.gz \
+  && tar -xzvf mold-2.40.1-$arch-linux.tar.gz \
+  && mv mold-2.40.1-$arch-linux $HOME/mold \
+  && rm mold-2.40.1-$arch-linux.tar.gz
 ENV PATH="$PATH:/home/ubuntu/.cargo/bin:/home/ubuntu/mold/bin"
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 


### PR DESCRIPTION
We ran into a segfault when using mold 2.32.1 with some updated rust dependencies in java-tests.

Upgrading to 2.40 fixes the problem for java-tests. This updates the linker for the pipeline compilation too so we avoid surprises in the future.