### PR TITLE
[adapters] Rephrase message about resuming without a checkpoint.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1806,7 +1806,7 @@ impl ControllerInit {
         // Try to read a checkpoint.
         let checkpoint = match Checkpoint::read(&*storage.backend, &StoragePath::from(STATE_FILE)) {
             Err(error) if error.kind() == ErrorKind::NotFound => {
-                info!("no checkpoint found for resume ({error})",);
+                info!("starting fresh pipeline without resuming from checkpoint");
                 return Self::without_resume(config, Some(storage));
             }
             Err(error) => return Err(error),


### PR DESCRIPTION
This resembled an error message.