### PR TITLE
py: add new orderby tests

### DIFF
--- a/python/tests/orderby_tests/automate_orderby_views.py
+++ b/python/tests/orderby_tests/automate_orderby_views.py
@@ -2,14 +2,6 @@ from itertools import product
 from tests.aggregate_tests.aggtst_base import TstView
 
 
-# list of table names where column c1 gets cast to varchar
-convert_vchar_tbl = [
-    "orderby_tbl_sqlite_decimal_char",
-    "orderby_tbl_sqlite_real_date",
-    "orderby_tbl_sqlite_double_date",
-]
-
-
 def create_orderby_clause(col: str, direction: str, nulls: str):
     """Attach the ORDER BY fragment for each column in the view query"""
     clause = f"{col} {direction}"
@@ -45,13 +37,9 @@ class AutomateOrderByTests:
             )
             # Assign names to views based on the table name and the value of the counter
             view_name = f"view_{self.table_name}{count}"
-            if self.table_name in convert_vchar_tbl:
-                sql1 = "CAST(c1 AS VARCHAR) AS c1, c2"
-            else:
-                sql1 = "*"
             sql = f"""CREATE MATERIALIZED VIEW {view_name} AS
                           SELECT
-                          {sql1}
+                          *
                           FROM {self.table_name}
                           ORDER BY {order_clause}
                           LIMIT 3"""

--- a/python/tests/orderby_tests/automate_orderby_views.py
+++ b/python/tests/orderby_tests/automate_orderby_views.py
@@ -2,6 +2,14 @@ from itertools import product
 from tests.aggregate_tests.aggtst_base import TstView
 
 
+# list of table names where column c1 gets cast to varchar
+convert_vchar_tbl = [
+    "orderby_tbl_sqlite_decimal_char",
+    "orderby_tbl_sqlite_real_date",
+    "orderby_tbl_sqlite_double_date",
+]
+
+
 def create_orderby_clause(col: str, direction: str, nulls: str):
     """Attach the ORDER BY fragment for each column in the view query"""
     clause = f"{col} {direction}"
@@ -37,11 +45,16 @@ class AutomateOrderByTests:
             )
             # Assign names to views based on the table name and the value of the counter
             view_name = f"view_{self.table_name}{count}"
+            if self.table_name in convert_vchar_tbl:
+                sql1 = "CAST(c1 AS VARCHAR) AS c1, c2"
+            else:
+                sql1 = "*"
             sql = f"""CREATE MATERIALIZED VIEW {view_name} AS
-                      SELECT *
-                      FROM {self.table_name}
-                      ORDER BY {order_clause}
-                      LIMIT 3"""
+                          SELECT
+                          {sql1}
+                          FROM {self.table_name}
+                          ORDER BY {order_clause}
+                          LIMIT 3"""
             self.views.append((view_name, sql))
             count += 1
 

--- a/python/tests/orderby_tests/main.py
+++ b/python/tests/orderby_tests/main.py
@@ -3,9 +3,11 @@
 
 from tests.aggregate_tests.aggtst_base import *  # noqa: F403
 from tests.orderby_tests.sqlite_runner import discover_sqlite_tests  # noqa: F403
-from tests.orderby_tests.orderby_tbl import *  # noqa: F403
+from tests.orderby_tests.orderby_tbl_sqlite import *  # noqa: F403
+from tests.orderby_tests.orderby_tbl_manual import *  # noqa: F403
 from tests.orderby_tests.orderby_int import *  # noqa: F403
 from tests.orderby_tests.orderby_varchar import *  # noqa: F403
+from tests.orderby_tests.orderby_binary_ts import *  # noqa: F403
 
 
 def main():

--- a/python/tests/orderby_tests/orderby_binary_ts.py
+++ b/python/tests/orderby_tests/orderby_binary_ts.py
@@ -1,0 +1,490 @@
+from tests.aggregate_tests.aggtst_base import TstView
+
+
+class orderby_binary_timestamp1(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp1 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 ASC
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp2(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp2 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 ASC NULLS FIRST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp3(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp3 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 ASC NULLS LAST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp4(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp4 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 ASC
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp5(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp5 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 ASC NULLS FIRST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp6(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp6 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 ASC NULLS LAST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp7(TstView):
+    def __init__(self):
+        # checked manually
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp7 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 ASC
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp8(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp8 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 ASC NULLS FIRST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp9(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp9 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 ASC NULLS LAST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp10(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp10 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 DESC
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp11(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp11 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 DESC NULLS FIRST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp12(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp12 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC, c2 DESC NULLS LAST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp13(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp13 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 DESC
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp14(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp14 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 DESC NULLS FIRST
+                       LIMIT 3"""
+
+
+class orderby_binary_timestamp15(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp15 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS FIRST, c2 DESC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp16(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp16 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 DESC LIMIT 3"""
+
+
+class orderby_binary_timestamp17(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp17 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 DESC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp18(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp18 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 ASC NULLS LAST, c2 DESC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp19(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp19 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 ASC LIMIT 3"""
+
+
+class orderby_binary_timestamp20(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp20 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 ASC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp21(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp21 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 ASC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp22(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp22 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 ASC LIMIT 3"""
+
+
+class orderby_binary_timestamp23(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp23 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 ASC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp24(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp24 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 ASC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp25(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp25 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 ASC LIMIT 3"""
+
+
+class orderby_binary_timestamp26(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp26 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 ASC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp27(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp27 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 ASC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp28(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp28 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 DESC LIMIT 3"""
+
+
+class orderby_binary_timestamp29(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp29 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 DESC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp30(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp30 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC, c2 DESC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp31(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp31 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 DESC LIMIT 3"""
+
+
+class orderby_binary_timestamp32(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp32 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 DESC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp33(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp33 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS FIRST, c2 DESC NULLS LAST LIMIT 3"""
+
+
+class orderby_binary_timestamp34(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp34 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 DESC LIMIT 3"""
+
+
+class orderby_binary_timestamp35(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp35 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 DESC NULLS FIRST LIMIT 3"""
+
+
+class orderby_binary_timestamp36(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_timestamp36 AS
+                       SELECT c1, c2
+                       FROM orderby_tbl_manual_binary_ts
+                       ORDER BY c1 DESC NULLS LAST, c2 DESC NULLS LAST LIMIT 3"""

--- a/python/tests/orderby_tests/orderby_int.py
+++ b/python/tests/orderby_tests/orderby_int.py
@@ -7,7 +7,7 @@ class orderby_asc_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 ASC"""
 
 
@@ -17,7 +17,7 @@ class orderby_asc_limit3_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_limit3_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 ASC
                        LIMIT 3"""
 
@@ -28,7 +28,7 @@ class orderby_asc_nulls_last_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_nulls_last_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 ASC
                        NULLS LAST
                        LIMIT 3"""
@@ -40,7 +40,7 @@ class orderby_asc_no_nulls_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_no_nulls_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        WHERE c1 IS NOT NULL
                        ORDER BY c1 ASC"""
 
@@ -51,7 +51,7 @@ class orderby_desc_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 DESC"""
 
 
@@ -61,7 +61,7 @@ class orderby_desc_limit3_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_limit3_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 DESC
                        LIMIT 3"""
 
@@ -72,7 +72,7 @@ class orderby_desc_nulls_first_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_nulls_first_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 DESC
                        NULLS FIRST
                        LIMIT 3"""
@@ -84,7 +84,7 @@ class orderby_nulls_first_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_nulls_first_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 NULLS FIRST
                        LIMIT 3"""
 
@@ -95,7 +95,7 @@ class orderby_desc_no_nulls_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_no_nulls_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        WHERE c1 IS NOT NULL
                        ORDER BY c1 DESC"""
 
@@ -106,6 +106,6 @@ class orderby_nulls_last_int(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_nulls_last_int AS
                        SELECT c1
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c1 NULLS LAST
                        LIMIT 9"""

--- a/python/tests/orderby_tests/orderby_tbl_manual.py
+++ b/python/tests/orderby_tests/orderby_tbl_manual.py
@@ -1,0 +1,45 @@
+## Contains tables definition for tables containing columns with data types supported only in Feldera
+
+from tests.aggregate_tests.aggtst_base import TstTable, TstView
+
+
+class orderby_tbl_manual_binary_ts(TstTable):
+    """Define the table used by the order by/limit tests with Binary and Timestamp values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_manual_binary_ts(
+                      c1 BINARY(4),
+                      c2 TIMESTAMP)"""
+        self.data = [
+            {"c1": [12, 22, 32], "c2": None},
+            {"c1": [12, 22, 32], "c2": "1987-06-05 06:43:00"},
+            {"c1": None, "c2": "2020-06-21 14:00:00"},
+            {"c1": [23, 56, 33, 21], "c2": "2014-11-05 08:27:00"},
+            {"c1": [23, 56, 33, 21], "c2": "2020-06-21 14:00:00"},
+            {"c1": [55, 66, 77, 88], "c2": "2024-12-05 12:45:00"},
+            {"c1": [99, 20, 31, 77], "c2": None},
+            {"c1": [49, 43, 84, 29], "c2": "2014-11-15 23:45:00"},
+            {"c1": [32, 34, 22, 12], "c2": "2014-11-05 08:27:00"},
+            {"c1": None, "c2": "1965-12-11 17:22:00"},
+            {"c1": [10, 12, 28, 14], "c2": "2007-12-15 20:20:00"},
+        ]
+
+
+class orderby_binary_ts_v(TstView):
+    def __init__(self):
+        self.data = [
+            {"c1": "0a0c1c0e", "c2": "2007-12-15T20:20:00"},
+            {"c1": "0c1620", "c2": "1987-06-05T06:43:00"},
+            {"c1": "0c1620", "c2": None},
+            {"c1": "17382115", "c2": "2020-06-21T14:00:00"},
+            {"c1": "17382115", "c2": "2014-11-05T08:27:00"},
+            {"c1": "2022160c", "c2": "2014-11-05T08:27:00"},
+            {"c1": "312b541d", "c2": "2014-11-15T23:45:00"},
+            {"c1": "37424d58", "c2": "2024-12-05T12:45:00"},
+            {"c1": "63141f4d", "c2": None},
+            {"c1": None, "c2": "1965-12-11T17:22:00"},
+            {"c1": None, "c2": "2020-06-21T14:00:00"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW orderby_binary_ts_v AS
+                       SELECT *
+                       FROM orderby_tbl_manual_binary_ts"""

--- a/python/tests/orderby_tests/orderby_tbl_sqlite.py
+++ b/python/tests/orderby_tests/orderby_tbl_sqlite.py
@@ -1,0 +1,134 @@
+## Contains tables definition for tables containing columns with data types supported in Feldera AND SQLITE
+from tests.aggregate_tests.aggtst_base import TstTable
+
+
+class orderby_tbl_sqlite_int_varchar(TstTable):
+    """Define the table used by the order by/limit tests with INT and VARCHAR values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_int_varchar(
+                      c1 INT,
+                      c2 VARCHAR)"""
+        self.data = [
+            {"c1": 3, "c2": "hello"},
+            {"c1": 2, "c2": "bye bye, friend!!"},
+            {"c1": None, "c2": "see you later"},
+            {"c1": 2, "c2": None},
+            {"c1": 1, "c2": "ferris says ciao"},
+            {"c1": 14, "c2": "meet you @ 5"},
+            {"c1": 3, "c2": None},
+            {"c1": 6, "c2": "see you"},
+            {"c1": 1, "c2": "hello"},
+            {"c1": None, "c2": "fred says konichiwa"},
+            {"c1": 4, "c2": "see you"},
+        ]
+
+
+class orderby_tbl_sqlite_smallint_varchar(TstTable):
+    """Define the table used by the order by/limit tests with SMALLINT and VARCHAR values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_smallint_varchar(
+                      c1 SMALLINT,
+                      c2 VARCHAR)"""
+        self.data = [
+            {"c1": 3, "c2": "hello"},
+            {"c1": 2, "c2": "bye bye, friend!!"},
+            {"c1": None, "c2": "see you later"},
+            {"c1": 2, "c2": None},
+            {"c1": 1, "c2": "ferris says ciao"},
+            {"c1": 14, "c2": "meet you @ 5"},
+            {"c1": 3, "c2": None},
+            {"c1": 6, "c2": "see you"},
+            {"c1": 1, "c2": "hello"},
+            {"c1": None, "c2": "fred says konichiwa"},
+            {"c1": 4, "c2": "see you"},
+        ]
+
+
+class orderby_tbl_sqlite_char_tinyint(TstTable):
+    """Define the table used by the order by/limit tests with CHAR and TINYINT values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_char_tinyint(
+                      c1 CHAR,
+                      c2 TINYINT)"""
+        self.data = [
+            {"c1": "hello", "c2": 3},
+            {"c1": "bye bye, friend!!", "c2": 2},
+            {"c1": "see you later", "c2": None},
+            {"c1": None, "c2": 2},
+            {"c1": "ferris says ciao", "c2": 1},
+            {"c1": "meet you @ 5", "c2": 14},
+            {"c1": None, "c2": 3},
+            {"c1": "see you", "c2": 6},
+            {"c1": "hello", "c2": 1},
+            {"c1": "fred says konichiwa", "c2": None},
+            {"c1": "see you", "c2": 4},
+        ]
+
+
+class orderby_tbl_sqlite_decimal_char(TstTable):
+    """Define the table used by the order by/limit tests with Decimal and CHAR values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_decimal_char(
+                      c1 DECIMAL(6,2),
+                      c2 CHAR)"""
+        self.data = [
+            {"c1": 1111.52, "c2": "hello"},
+            {"c1": 4567.17, "c2": "bye bye, friend!!"},
+            {"c1": None, "c2": "see you later"},
+            {"c1": 4567.17, "c2": None},
+            {"c1": 1111.52, "c2": "ferris says ciao"},
+            {"c1": 1445.19, "c2": "meet you @ 5"},
+            {"c1": 3902.44, "c2": None},
+            {"c1": 9831.66, "c2": "see you"},
+            {"c1": 1616.45, "c2": "hello"},
+            {"c1": None, "c2": "fred says konichiwa"},
+            {"c1": 4538.22, "c2": "see you"},
+        ]
+
+
+class orderby_tbl_sqlite_real_date(TstTable):
+    """Define the table used by the order by/limit tests with REAL and DATE values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_real_date(
+                      c1 REAL,
+                      c2 DATE)"""
+        self.data = [
+            {"c1": 57681.18, "c2": "2014-11-05"},
+            {"c1": 34561.22, "c2": "2014-11-05"},
+            {"c1": None, "c2": "1999-01-25"},
+            {"c1": 34561.22, "c2": None},
+            {"c1": 11111.23, "c2": "1999-01-25"},
+            {"c1": 12145.67, "c2": "2026-10-14"},
+            {"c1": 57681.18, "c2": None},
+            {"c1": 17879.12, "c2": "2009-08-19"},
+            {"c1": -1234.34, "c2": "1965-04-21"},
+            {"c1": None, "c2": "2018-01-12"},
+            {"c1": 88890.23, "c2": "2011-11-18"},
+        ]
+
+
+class orderby_tbl_sqlite_double_date(TstTable):
+    """Define the table used by the order by/limit tests with DOUBLE and DATE values"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE orderby_tbl_sqlite_double_date(
+                      c1 DOUBLE,
+                      c2 DATE)"""
+        self.data = [
+            {"c1": 57681.1800001234, "c2": "2014-11-05"},
+            {"c1": 34561.2200006789, "c2": "2014-11-05"},
+            {"c1": None, "c2": "1999-01-25"},
+            {"c1": 34561.2200006789, "c2": None},
+            {"c1": 11111.2300001111, "c2": "1999-01-25"},
+            {"c1": 12145.6700002222, "c2": "2026-10-14"},
+            {"c1": 57681.1800001234, "c2": None},
+            {"c1": 17879.1200003333, "c2": "2009-08-19"},
+            {"c1": -1234.3400004444, "c2": "1965-04-21"},
+            {"c1": None, "c2": "2018-01-12"},
+            {"c1": 88890.2300005555, "c2": "2011-11-18"},
+        ]

--- a/python/tests/orderby_tests/orderby_varchar.py
+++ b/python/tests/orderby_tests/orderby_varchar.py
@@ -7,7 +7,7 @@ class orderby_asc_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 ASC"""
 
 
@@ -17,7 +17,7 @@ class orderby_asc_limit3_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_limit3_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 ASC
                        LIMIT 3"""
 
@@ -28,7 +28,7 @@ class orderby_asc_nulls_last_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_nulls_last_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 ASC
                        NULLS LAST
                        LIMIT 3"""
@@ -40,7 +40,7 @@ class orderby_asc_no_nulls_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_asc_no_nulls_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        WHERE c2 IS NOT NULL
                        ORDER BY c1 ASC"""
 
@@ -51,7 +51,7 @@ class orderby_desc_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 DESC"""
 
 
@@ -61,7 +61,7 @@ class orderby_desc_limit3_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_limit3_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 DESC
                        LIMIT 3"""
 
@@ -72,7 +72,7 @@ class orderby_desc_nulls_first_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_nulls_first_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 DESC
                        NULLS FIRST
                        LIMIT 3"""
@@ -84,7 +84,7 @@ class orderby_nulls_first_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_nulls_first_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 NULLS FIRST
                        LIMIT 3"""
 
@@ -95,7 +95,7 @@ class orderby_desc_no_nulls_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_desc_no_nulls_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        WHERE c2 IS NOT NULL
                        ORDER BY c1 DESC"""
 
@@ -106,6 +106,6 @@ class orderby_nulls_last_varchar(TstView):
         self.data = []
         self.sql = """CREATE MATERIALIZED VIEW orderby_nulls_last_varchar AS
                        SELECT c2
-                       FROM orderby_tbl_int_varchar
+                       FROM orderby_tbl_sqlite_int_varchar
                        ORDER BY c2 NULLS LAST
                        LIMIT 9"""

--- a/python/tests/orderby_tests/sqlite_runner.py
+++ b/python/tests/orderby_tests/sqlite_runner.py
@@ -4,6 +4,7 @@ import re
 from tests.aggregate_tests.aggtst_base import Table, View, DEBUG
 from tests.aggregate_tests.atest_run import discover_tests
 from tests.orderby_tests.automate_orderby_views import AutomateOrderByTests
+from decimal import Decimal
 
 
 sqlite_db_path = ":memory:"  # Create an in-memory database
@@ -100,4 +101,14 @@ def discover_sqlite_tests(class_name: str, dir_name: str, extra_register=bool):
 
 def normalize_sqlite_rows(columns, rows):
     """Convert result from SQLite to lists of dicts with column names"""
-    return [dict(zip(columns, row)) for row in rows]
+    result = []
+    for row in rows:
+        row_dict = {}
+        for col, value in zip(columns, row):
+            # If output contains Floating Point values for any column, convert them to Decimal values
+            if isinstance(value, float):
+                row_dict[col] = Decimal(str(value))
+            else:
+                row_dict[col] = value
+        result.append(row_dict)
+    return result


### PR DESCRIPTION
**Changes:**

1. Added mechanism to skip table creation in SQLite for unsupported data types
2. Modified the table name in view definition for views that reference the table `orderby_tbl_sqlite_int_varchar`(was previously `orderby_tbl_int_varchar`)
3. Added manual tests for data types unsupported in SQLite but supported in Feldera
4. Added automated tests for data types supported in both SQLite and Feldera
