### PR TITLE
Align version of OSS and enterprise version.

### DIFF
--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -25,7 +25,6 @@ jobs:
       options: --user=ubuntu
       volumes:
         - /sccache:/sccache
-    needs: [publish-crates, publish-python]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,7 +50,8 @@ jobs:
       - name: List changes
         run: |
           git diff
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
         with:
           message: "ci: Prepare for v${{ env.NEXT_VERSION }}"
           push: origin main

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,12 +1,8 @@
 name: Create a new release
 
 on:
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "SHA to release (a recent commit from main that hasn't been released yet)"
-  schedule:
-    - cron: "11 7 * * *" # Runs at 07:11 UTC daily
+  repository_dispatch:
+    types: [trigger-oss-release]
 
 env:
   REGISTRY: ghcr.io
@@ -15,11 +11,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set SHA_TO_RELEASE
+      - name: Set SHA_TO_RELEASE and CURRENT_VERSION
         run: |
-          echo "SHA_TO_RELEASE=${{ github.event.inputs.sha || '' }}" >> $GITHUB_ENV
-          if [ -z "${{ github.event.inputs.sha }}" ]; then
-            echo "SHA_TO_RELEASE=${{ github.sha }}" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_ENV
+          echo "SHA_TO_RELEASE=${{ github.event.client_payload.sha_to_release }}" >> $GITHUB_ENV
+
+      - name: Check SHA and version inputs
+        run: |
+          if [ -z "${SHA_TO_RELEASE}" ] || [ -z "${CURRENT_VERSION}" ]; then
+            echo "Missing required release parameters"
+            exit 1
           fi
 
       - name: Checkout
@@ -28,24 +29,9 @@ jobs:
           fetch-tags: true
           ref: ${{ env.SHA_TO_RELEASE }}
 
-      - name: Determine version to release based on pipeline-manager
-        run: |
-          echo "CURRENT_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[]|select(.name == "pipeline-manager")|.version')" >> $GITHUB_ENV
-
-      - name: Check if version is already released (do we have git tag for this version?)
-        run: |
-          if git tag -l | grep -q "^v${{ env.CURRENT_VERSION }}$"; then
-            echo "Version ${CURRENT_VERSION} is already released"
-            echo "version_exists=true" >> $GITHUB_ENV
-          else
-            echo "Version ${CURRENT_VERSION} is not released yet"
-            echo "version_exists=false" >> $GITHUB_ENV
-          fi
-
       - name: Download artifact
-        if: env.version_exists == 'false'
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
           workflow: ci.yml
           workflow_conclusion: success
@@ -56,7 +42,6 @@ jobs:
           if_no_artifact_found: fail
 
       - name: Attach version to binaries
-        if: env.version_exists == 'false'
         run: |
           mv feldera-binaries-aarch64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
           mv feldera-binaries-x86_64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
@@ -64,10 +49,10 @@ jobs:
           mv feldera-docs.zip feldera-docs-v${{ env.CURRENT_VERSION }}.zip
 
       - name: Release on GitHub
-        if: env.version_exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
           tag_name: v${{ env.CURRENT_VERSION }}
+          draft: ${{ vars.RELEASE_DRY_RUN }}
           generate_release_notes: true
           make_latest: true
           files: |
@@ -83,6 +68,7 @@ jobs:
         run: unzip feldera-docs-v${{ env.CURRENT_VERSION }}.zip -d docs
 
       - name: Deploy docs.feldera.com
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs
@@ -107,6 +93,7 @@ jobs:
           version: latest
 
       - name: Tag docker image with version and latest
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
         run: |
           docker buildx imagetools create -t ${{ vars.FELDERA_IMAGE_NAME }}:${{ env.CURRENT_VERSION }} ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ env.SHA_TO_RELEASE }}
           docker buildx imagetools create -t ${{ vars.FELDERA_IMAGE_NAME }}:latest ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ env.SHA_TO_RELEASE }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run cargo publish
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
         run: |
           cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-types
           cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-storage

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           uv build
       - name: Publish package
-        if: github.repository == 'feldera/feldera'
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         with:
           packages_dir: ./python/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_adapters"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_nexmark"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "ascii_table",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "fda"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-adapterlib"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-datagen"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-iceberg"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-ir"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "feldera-types",
  "serde",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-rest-api"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "chrono",
  "feldera-types",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-sqllib"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "arcstr",
  "base58",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-storage"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "feldera-types",
  "inventory",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-types"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7763,7 +7763,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline-manager"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -8756,7 +8756,7 @@ dependencies = [
 
 [[package]]
 name = "readers"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "async-std",
  "csv",
@@ -10138,7 +10138,7 @@ dependencies = [
 
 [[package]]
 name = "sltsqlvalue"
-version = "0.70.0"
+version = "0.90.0"
 dependencies = [
  "dbsp",
  "feldera-sqllib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 authors = ["Feldera Team <dev@feldera.com>"]
-version = "0.70.0"
+version = "0.90.0"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/feldera/feldera"
 repository = "https://github.com/feldera/feldera"
@@ -86,7 +86,7 @@ crossbeam-utils = "0.8.6"
 csv = "1.2.2"
 csv-core = "0.1.10"
 datafusion = "47"
-dbsp = { path = "crates/dbsp", version = "0.70.0" }
+dbsp = { path = "crates/dbsp", version = "0.90.0" }
 dbsp_nexmark = { path = "crates/nexmark" }
 deadpool-postgres = "0.10.5"
 dec = { version = "0.4.9", features = ["serde"] }
@@ -104,10 +104,10 @@ feldera-adapterlib = { path = "crates/adapterlib" }
 feldera-datagen = { path = "crates/datagen" }
 feldera-iceberg = { path = "crates/iceberg" }
 feldera-sqllib = { path = "crates/sqllib" }
-feldera-storage = { version = "0.70.0", path = "crates/storage" }
-feldera-types = { version = "0.70.0", path = "crates/feldera-types" }
-feldera-rest-api = { version = "0.70.0", path = "crates/rest-api" }
-feldera-ir = { version = "0.70.0", path = "crates/ir" }
+feldera-storage = { version = "0.90.0", path = "crates/storage" }
+feldera-types = { version = "0.90.0", path = "crates/feldera-types" }
+feldera-rest-api = { version = "0.90.0", path = "crates/rest-api" }
+feldera-ir = { version = "0.90.0", path = "crates/ir" }
 flate2 = "1.1.0"
 form_urlencoded = "1.2.0"
 futures = "0.3.30"

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "MIT OR Apache-2.0"
     },
-    "version": "0.70.0"
+    "version": "0.90.0"
   },
   "paths": {
     "/config/authentication": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "setuptools.build_meta"
 name = "feldera"
 readme = "README.md"
 description = "The feldera python client"
-version = "0.70.0"
+version = "0.90.0"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 authors = [
-    { "name" = "Abhinav", "email" = "abhinav.gyawali@feldera.com" },
+    { "name" = "Feldera Team", "email" = "dev@feldera.com" },
 ]
 keywords = [
     "feldera",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "feldera"
-version = "0.70.0"
+version = "0.90.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
- Bumps OSS version to 0.90 to align with next enterprise release.
- From now on feldera/feldera release is triggered from enterprise repo
- Makes sure enterprise release and OSS release use the same sha for feldera/feldera for a given version (from 0.90 onwards).