### PR TITLE
Record ingested bytes in datagen.

### DIFF
--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -573,7 +573,7 @@ impl InputGenerator {
             while let Ok(completion) = completion_receiver.try_recv() {
                 let batch = &completion.batch;
                 in_flight[batch.plan_idx].remove_range(batch.rows.start..=batch.rows.end - 1);
-                consumer.buffered(completion.buffer.len(), 0);
+                consumer.buffered(completion.buffer.len(), completion.num_bytes);
                 completed.push_back(completion);
             }
 

--- a/crates/pipeline-manager/tests/integration_test.rs
+++ b/crates/pipeline-manager/tests/integration_test.rs
@@ -3697,7 +3697,7 @@ async fn pipeline_stats() {
             "end_of_input": true,
             "num_parse_errors": 0,
             "num_transport_errors": 0,
-            "total_bytes": 0,
+            "total_bytes": 46,
             "total_records": 5
         })
     );


### PR DESCRIPTION
Makes it easier to measure storage amplification in benchmarks. Thanks @blp for pointing out the mistake.