### PR TITLE
[adapters] Honor pause requests in s3 input connector.

### DIFF
--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -533,6 +533,11 @@ impl S3InputReader {
                             splitter.seek(start_offset);
                             let mut eoi = false;
                             while !eoi {
+                                if wait_running(&mut status_receiver).await.is_err() {
+                                    // channel closed
+                                    return;
+                                }
+
                                 match object.body.next().await {
                                     Some(Err(e)) => consumer.error(
                                         false,


### PR DESCRIPTION
The input connector only checked for pause requests between objects. Objects can be multiple gigabytes, so this is not granular enough.  This commit fixes the problem.

Fixes https://github.com/feldera/feldera/issues/4217.