### PR TITLE
[SQL] Remove dependency from Calcite babel package

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -270,11 +270,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.calcite</groupId>
-            <artifactId>calcite-babel</artifactId>
-            <version>${calcite.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-server</artifactId>
             <version>${calcite.version}</version>
         </dependency>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -7,8 +7,6 @@ data: {
     class: "DbspParserImpl",
 
     imports: [
-      "org.apache.calcite.sql.babel.SqlBabelCreateTable",
-      "org.apache.calcite.sql.babel.TableCollectionType",
       "org.apache.calcite.schema.ColumnStrategy"
       "org.apache.calcite.sql.SqlCreate"
       "org.apache.calcite.sql.SqlDrop"
@@ -391,17 +389,17 @@ data: {
       "TYPE"
 
       # not in core, added in babel
-      "DISCARD"
+      # "DISCARD"
       "IF"
-      "PLANS"
-      "SEED"
-      "SEMI"
-      "SEQUENCES"
-      "TEMP"
+      # "PLANS"
+      # "SEED"
+      # "SEMI"
+      # "SEQUENCES"
+      # "TEMP"
 
       # The following keywords are reserved in core Calcite,
       # are reserved in some version of SQL,
-      # but are not reserved in Babel.
+      # but are not reserved for us.
       #
       # Words that are commented out (e.g. "AND") are still reserved.
       # These are the most important reserved words, and SQL cannot be

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/parserImpls.ftl
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/parserImpls.ftl
@@ -62,17 +62,6 @@ boolean IfNotExistsOpt() :
     { return false; }
 }
 
-TableCollectionType TableCollectionTypeOpt() :
-{
-}
-{
-    <MULTISET> { return TableCollectionType.MULTISET; }
-|
-    <SET> { return TableCollectionType.SET; }
-|
-    { return TableCollectionType.UNSPECIFIED; }
-}
-
 /* Extra operators */
 
 <DEFAULT, DQID, BTID> TOKEN :

--- a/sql-to-dbsp-compiler/build.sh
+++ b/sql-to-dbsp-compiler/build.sh
@@ -69,7 +69,7 @@ if [ ${NEXT} = 'y' ]; then
     VERSION=${CALCITE_NEXT}
 
     ./gradlew build -x test -x checkStyleMain -x autoStyleJavaCheck build --console=plain -Dorg.gradle.logging.level=quiet
-    for DIR in core babel server linq4j
+    for DIR in core server linq4j
     do
         ARTIFACT=calcite-${DIR}
         mvn install:install-file -Dfile=${DIR}/build/libs/${ARTIFACT}-${VERSION}-SNAPSHOT.jar -DgroupId=${GROUP} -DartifactId=${ARTIFACT} -Dversion=${VERSION} -Dpackaging=jar -DgeneratePom=true -q -B


### PR DESCRIPTION
Turns out we don't really use anything from the Calcite babel package.
This should make building Calcite and the SQL compiler a bit faster.