### PR TITLE
Fix the release sha for release page.

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Release on GitHub
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
+          target_commitish: ${{ env.SHA_TO_RELEASE }}
           tag_name: v${{ env.CURRENT_VERSION }}
           draft: ${{ vars.RELEASE_DRY_RUN }}
           generate_release_notes: true


### PR DESCRIPTION
While the release took the right SHA for container and artifacts, it didn't actually use the right SHA for the release page on github and instead created it on the latest HEAD.