### PR TITLE
[sqllib] Fix panic in string interner.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ url = "2.5.0"
 urlencoding = "2.1.3"
 utoipa = "4.2"
 utoipa-swagger-ui = { version = "7.1", features = ["vendored"] }
-uuid = { version = "1.16.0", features = ["serde"] }
+uuid = { version = "1.17.0", features = ["serde"] }
 wiremock = "0.6"
 xxhash-rust = "0.8.6"
 zip = "0.6.2"

--- a/crates/sqllib/src/string_interner.rs
+++ b/crates/sqllib/src/string_interner.rs
@@ -62,9 +62,10 @@ impl Hasher for IdentityHasher {
     }
 
     #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.hash = i;
-    }
+    fn write_u64(&mut self, _i: u64) {}
+
+    #[inline]
+    fn write_usize(&mut self, _i: usize) {}
 
     #[inline]
     fn finish(&self) -> u64 {


### PR DESCRIPTION
The IdentityHasher is intended to only hash uuids, so it only expected 16-byte inputs. However, in the previous version of the uuid crate (1.16.0) the Hash implementation for UUID first calls Hasher::write_length_prefix, which calls Hasher::write_usize, which hashes an 8-byte number. As a result the `debug_assert_eq!(bytes.len(), 16, "Expected 16 bytes")` assertion failed.  This doesn't happen with the latest uuid (1.17.0), which our Cargo.lock points to, but to be safe in case the implementation of Hash changes again in the future this commit prevents the panic.