### PR TITLE
[adapters] Support for indexes in delta output.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -295,6 +295,17 @@ pub trait SerCursor: Send {
         dst: &mut ArrayBuilder,
     ) -> AnyResult<()>;
 
+    /// Serialize current value into arrow format. Panics if invalid.
+    fn serialize_val_to_arrow(&mut self, dst: &mut ArrayBuilder) -> AnyResult<()>;
+
+    /// Serialize current value into arrow format, adding additional metadata columns.
+    /// `metadata` must be a struct or a map.
+    fn serialize_val_to_arrow_with_metadata(
+        &mut self,
+        metadata: &dyn erased_serde::Serialize,
+        dst: &mut ArrayBuilder,
+    ) -> AnyResult<()>;
+
     #[cfg(feature = "with-avro")]
     /// Convert current key to an Avro value.
     fn key_to_avro(&mut self, schema: &AvroSchema, refs: &NamesRef<'_>) -> AnyResult<AvroValue>;
@@ -472,6 +483,19 @@ impl SerCursor for CursorWithPolarity<'_> {
     ) -> AnyResult<()> {
         self.cursor
             .serialize_key_to_arrow_with_metadata(metadata, dst)
+    }
+
+    fn serialize_val_to_arrow(&mut self, dst: &mut ArrayBuilder) -> AnyResult<()> {
+        self.cursor.serialize_val_to_arrow(dst)
+    }
+
+    fn serialize_val_to_arrow_with_metadata(
+        &mut self,
+        metadata: &dyn erased_serde::Serialize,
+        dst: &mut ArrayBuilder,
+    ) -> AnyResult<()> {
+        self.cursor
+            .serialize_val_to_arrow_with_metadata(metadata, dst)
     }
 
     fn serialize_val(&mut self, dst: &mut Vec<u8>) -> AnyResult<()> {

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -4,9 +4,10 @@ use crate::format::parquet::relation_to_arrow_fields;
 use crate::format::parquet::test::load_parquet_file;
 use crate::format::relation_to_parquet_schema;
 use crate::integrated::delta_table::{delta_input_serde_config, register_storage_handlers};
+use crate::test::data::DeltaTestKey;
 use crate::test::{
-    file_to_zset, list_files_recursive, test_circuit, wait, DatabricksPeople, DeltaTestStruct,
-    MockDeZSet, MockUpdate,
+    file_to_zset, list_files_recursive, test_circuit, test_circuit_with_index, wait,
+    DatabricksPeople, DeltaTestStruct, MockDeZSet, MockUpdate,
 };
 use crate::{Controller, ControllerError, InputFormat};
 use anyhow::anyhow;
@@ -27,7 +28,7 @@ use deltalake::operations::create::CreateBuilder;
 use deltalake::protocol::SaveMode;
 use deltalake::{DeltaOps, DeltaTable, DeltaTableBuilder};
 use feldera_adapterlib::catalog::{OutputCollectionHandles, RecordFormat};
-use feldera_adapterlib::utils::datafusion::execute_singleton_query;
+use feldera_adapterlib::utils::datafusion::{execute_query_collect, execute_singleton_query};
 use feldera_types::config::PipelineConfig;
 use feldera_types::format::json::JsonFlavor;
 use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
@@ -170,27 +171,49 @@ async fn wait_for_output_records<T>(
 }
 
 /// Wait until materialized table contains exactly `expected_count` records.
-async fn wait_for_count_records_materialized(
+async fn wait_for_records_materialized<T>(
     pipeline: &Controller,
     table: &SqlIdentifier,
-    expected_count: usize,
-) {
+    expected_output: &[T],
+) where
+    T: for<'a> DeserializeWithContext<'a, SqlSerdeConfig> + DBData,
+{
     let start = Instant::now();
     loop {
-        let count = execute_singleton_query(
+        let data = execute_query_collect(
             &pipeline.session_context().unwrap(),
-            &format!("select cast(count(*) as varchar) from {table}"),
+            &format!("select * from {table}"),
         )
         .await
         .unwrap();
 
-        info!("expected output table size: {expected_count}, current size: {count}");
+        let mut result = Vec::new();
 
-        if count == format!("{expected_count}") {
-            break;
+        for batch in data.iter() {
+            let deserializer = serde_arrow::Deserializer::from_record_batch(batch).unwrap();
+            let mut records =
+                Vec::<T>::deserialize_with_context(deserializer, &delta_input_serde_config())
+                    .unwrap();
+
+            result.append(&mut records);
         }
 
-        if start.elapsed() > Duration::from_millis(30_000) {
+        info!(
+            "expected output table size: {}, current size: {}",
+            expected_output.len(),
+            result.len()
+        );
+
+        if result.len() == expected_output.len() {
+            result.sort();
+            let mut expected_output = expected_output.to_vec();
+            expected_output.sort();
+            if result == expected_output {
+                break;
+            }
+        }
+
+        if start.elapsed() > Duration::from_millis(20_000) {
             panic!("timeout");
         }
 
@@ -378,9 +401,11 @@ outputs:
 }
 
 /// Build a pipeline that reads from a delta table.
-fn delta_read_pipeline<T>(
+fn delta_read_pipeline<T, K, KF>(
     input_table_uri: &str,
     input_config: &HashMap<String, String>,
+    key_fields: &[SqlIdentifier],
+    key_func: KF,
     storage_dir: &Path,
 ) -> Controller
 where
@@ -388,6 +413,11 @@ where
         + SerializeWithContext<SqlSerdeConfig>
         + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
         + Sync,
+    K: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+    KF: Fn(&T) -> K + Clone + Send + Sync + 'static,
 {
     info!("creating a pipeline to read delta table '{input_table_uri}'");
 
@@ -416,11 +446,15 @@ inputs:
 
     let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
 
+    let key_fields = key_fields.to_vec();
+
     Controller::with_config(
-        |workers| {
-            Ok(test_circuit::<T>(
+        move |workers| {
+            Ok(test_circuit_with_index::<T, K, _>(
                 workers,
                 &DeltaTestStruct::schema(),
+                &key_fields,
+                key_func,
                 &[Some("output")],
             ))
         },
@@ -432,9 +466,12 @@ inputs:
 
 /// Build a pipeline that continuously follows a JSON file and writes changes
 /// (both inserts and deletes) to a delta table.
-fn delta_write_pipeline<T>(
+fn delta_write_pipeline<T, K, KF>(
     input_file_path: &str,
     table_uri: &str,
+    key_fields: &[SqlIdentifier],
+    key_func: KF,
+    index: bool,
     config: &HashMap<String, String>,
 ) -> Controller
 where
@@ -442,6 +479,11 @@ where
         + SerializeWithContext<SqlSerdeConfig>
         + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
         + Sync,
+    K: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+    KF: Fn(&T) -> K + Clone + Send + Sync + 'static,
 {
     info!("creating a pipeline to write delta table '{table_uri}'");
 
@@ -449,6 +491,8 @@ where
     for (key, val) in config.iter() {
         storage_options += &format!("                {key}: {val}\n");
     }
+
+    let index = if index { "        index: \"idx1\"" } else { "" };
 
     // Create controller.
     let config_str = format!(
@@ -476,18 +520,22 @@ outputs:
             name: "delta_table_output"
             config:
                 uri: "{table_uri}"
-{}"#,
+{}
+{index}"#,
         storage_options,
     );
 
     println!("config:\n{config_str}");
     let config: PipelineConfig = serde_yaml::from_str(&config_str).unwrap();
+    let key_fields = key_fields.to_vec();
 
     Controller::with_config(
-        |workers| {
-            Ok(test_circuit::<T>(
+        move |workers| {
+            Ok(test_circuit_with_index::<T, K, _>(
                 workers,
                 &DeltaTestStruct::schema(),
+                &key_fields,
+                key_func,
                 &[None],
             ))
         },
@@ -933,6 +981,7 @@ async fn test_cdc(
     storage_options: &HashMap<String, String>,
     data: Vec<DeltaTestStruct>,
     suspend: bool,
+    index: bool,
 ) {
     init_logging();
 
@@ -953,7 +1002,14 @@ async fn test_cdc(
     output_config.insert("mode".to_string(), "\"truncate\"".to_string());
 
     let write_pipeline = tokio::task::spawn_blocking(move || {
-        delta_write_pipeline::<DeltaTestStruct>(&input_file_path, &table_uri_clone, &output_config)
+        delta_write_pipeline::<DeltaTestStruct, DeltaTestKey, _>(
+            &input_file_path,
+            &table_uri_clone,
+            &[SqlIdentifier::from("bigint")],
+            |x: &DeltaTestStruct| DeltaTestKey { bigint: x.bigint },
+            index,
+            &output_config,
+        )
     })
     .await
     .unwrap();
@@ -977,9 +1033,11 @@ async fn test_cdc(
     let storage_dir_path = storage_dir.path().to_path_buf();
     let input_config_clone: HashMap<String, String> = input_config.clone();
     let mut read_pipeline = tokio::task::spawn_blocking(move || {
-        delta_read_pipeline::<DeltaTestStruct>(
+        delta_read_pipeline::<DeltaTestStruct, DeltaTestKey, _>(
             &table_uri_clone,
             &input_config_clone,
+            &[SqlIdentifier::from("bigint")],
+            |x: &DeltaTestStruct| DeltaTestKey { bigint: x.bigint },
             &storage_dir_path,
         )
     })
@@ -1016,9 +1074,11 @@ async fn test_cdc(
             let storage_dir_path = storage_dir.path().to_path_buf();
 
             read_pipeline = tokio::task::spawn_blocking(move || {
-                delta_read_pipeline::<DeltaTestStruct>(
+                delta_read_pipeline::<DeltaTestStruct, DeltaTestKey, _>(
                     &table_uri_clone,
                     &input_config_clone,
+                    &[SqlIdentifier::from("bigint")],
+                    |x: &DeltaTestStruct| DeltaTestKey { bigint: x.bigint },
                     &storage_dir_path,
                 )
             })
@@ -1028,12 +1088,62 @@ async fn test_cdc(
             read_pipeline.start();
         }
 
-        wait_for_count_records_materialized(
+        wait_for_records_materialized(
             &read_pipeline,
             &SqlIdentifier::from("test_output1"),
-            total_count.div_ceil(2),
+            &data[0..total_count]
+                .iter()
+                .filter_map(|x| {
+                    if x.bigint % 2 == 0 {
+                        Some(x.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>(),
         )
         .await;
+    }
+
+    // Modify all records by negating the `boolean` field.
+    println!("Applying updates");
+    let mut updated_count = 0;
+    if index {
+        for chunk in data.chunks(std::cmp::max(data.len() / 10, 1)) {
+            let chunk = chunk
+                .iter()
+                .map(|x| {
+                    let mut x = x.clone();
+                    x.boolean = !x.boolean;
+                    x
+                })
+                .collect::<Vec<_>>();
+            write_updates_as_json(input_file.as_file_mut(), &chunk, true);
+            updated_count += chunk.len();
+
+            let expected = data[0..total_count]
+                .iter()
+                .enumerate()
+                .flat_map(|(i, x)| {
+                    let mut x = x.clone();
+                    if x.bigint % 2 == 0 {
+                        if i < updated_count {
+                            x.boolean = !x.boolean;
+                        }
+                        Some(x)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            wait_for_records_materialized(
+                &read_pipeline,
+                &SqlIdentifier::from("test_output1"),
+                &expected,
+            )
+            .await;
+        }
     }
 
     let mut deleted_count = 0;
@@ -1043,10 +1153,23 @@ async fn test_cdc(
 
         deleted_count += chunk.len();
 
-        wait_for_count_records_materialized(
+        wait_for_records_materialized(
             &read_pipeline,
             &SqlIdentifier::from("test_output1"),
-            total_count.div_ceil(2) - deleted_count.div_ceil(2),
+            &data[deleted_count..total_count]
+                .iter()
+                .filter_map(|x| {
+                    if x.bigint % 2 == 0 {
+                        let mut x = x.clone();
+                        if index {
+                            x.boolean = !x.boolean;
+                        }
+                        Some(x.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>(),
         )
         .await;
     }
@@ -1119,6 +1242,33 @@ async fn delta_table_cdc_file_test() {
         &HashMap::new(),
         data,
         false,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_cdc_file_indexed_test() {
+    // We cannot use proptest macros in `async` context, so generate
+    // some random data manually.
+    let mut runner = TestRunner::default();
+    let data = delta_data(20_000).new_tree(&mut runner).unwrap().current();
+
+    let relation_schema = DeltaTestStruct::schema();
+
+    let input_table_dir = TempDir::new().unwrap();
+    let input_table_uri = input_table_dir.path().display().to_string();
+
+    let output_table_dir: TempDir = TempDir::new().unwrap();
+    let output_table_uri = output_table_dir.path().display().to_string();
+
+    test_cdc(
+        &relation_schema,
+        &input_table_uri,
+        &HashMap::new(),
+        data,
+        false,
+        true,
     )
     .await;
 }
@@ -1145,6 +1295,7 @@ async fn delta_table_cdc_file_suspend_test() {
         &HashMap::new(),
         data,
         true,
+        false,
     )
     .await;
 }

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -677,6 +677,25 @@ where
         )
     }
 
+    fn serialize_val_to_arrow(&mut self, dst: &mut ArrayBuilder) -> AnyResult<()> {
+        self.serializer.serialize_arrow(
+            &SerializeWithContextWrapper::new(self.val.as_ref().unwrap(), &self.serde_config),
+            dst,
+        )
+    }
+
+    fn serialize_val_to_arrow_with_metadata(
+        &mut self,
+        metadata: &dyn erased_serde::Serialize,
+        dst: &mut ArrayBuilder,
+    ) -> AnyResult<()> {
+        self.serializer.serialize_arrow_with_metadata(
+            &SerializeWithContextWrapper::new(self.val.as_ref().unwrap(), &self.serde_config),
+            metadata,
+            dst,
+        )
+    }
+
     #[cfg(feature = "with-avro")]
     fn key_to_avro(&mut self, schema: &AvroSchema, refs: &NamesRef<'_>) -> AnyResult<AvroValue> {
         Ok(self.serializer.serialize_avro(

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -1236,3 +1236,31 @@ deserialize_table_record!(DeltaTestStruct["DeltaTestStruct", 20] {
     (variant, "variant", false, Variant, None),
     (uuid, "uuid", false, Uuid, None)
 });
+
+/// Struct will all types supported by the DeltaLake connector.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+pub struct DeltaTestKey {
+    pub bigint: i64,
+}
+
+serialize_table_record!(DeltaTestKey[1]{
+    bigint["bigint"]: i64
+});
+
+deserialize_table_record!(DeltaTestKey["DeltaTestKey", 1] {
+    (bigint, "bigint", false, i64, None)
+});

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -62,7 +62,7 @@ pub use data::{
 use dbsp::circuit::{CircuitConfig, NodeId};
 use dbsp::utils::Tup2;
 use feldera_types::format::json::{JsonFlavor, JsonLines, JsonParserConfig, JsonUpdateFormat};
-use feldera_types::program_schema::{Field, Relation};
+use feldera_types::program_schema::{Field, Relation, SqlIdentifier};
 pub use mock_dezset::{wait_for_output_ordered, wait_for_output_unordered, MockDeZSet, MockUpdate};
 pub use mock_input_consumer::{MockInputConsumer, MockInputParser};
 pub use mock_output_consumer::MockOutputConsumer;
@@ -271,6 +271,96 @@ where
                 input,
                 &output_schema,
             );
+        }
+        Ok(catalog)
+    })
+    .unwrap();
+    (circuit, Box::new(catalog))
+}
+
+/// Similar to `test_circuit`, but the input stream has a primary key, and the output
+/// stream has an index associated with it.
+pub fn test_circuit_with_index<T, K, KF>(
+    config: CircuitConfig,
+    schema: &[Field],
+    key_fields: &[SqlIdentifier],
+    key_func: KF,
+    persistent_output_ids: &[Option<&str>],
+) -> (DBSPHandle, Box<dyn CircuitCatalog>)
+where
+    KF: Fn(&T) -> K + Clone + Send + Sync + 'static,
+    T: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+    K: DBData
+        + SerializeWithContext<SqlSerdeConfig>
+        + for<'de> DeserializeWithContext<'de, SqlSerdeConfig>
+        + Sync,
+{
+    let schema = schema.to_vec();
+
+    let persistent_output_ids = persistent_output_ids
+        .iter()
+        .map(|id| id.map(|s| s.to_string()))
+        .collect::<Vec<_>>();
+
+    let key_fields = key_fields.to_vec();
+
+    let (circuit, catalog) = Runtime::init_circuit(config, move |circuit| {
+        let mut catalog = Catalog::new();
+        let n = persistent_output_ids.len();
+
+        for (persistent_output_id, i) in persistent_output_ids.iter().zip(1..) {
+            let (input, hinput) =
+                circuit.add_input_map::<K, T, T, _>(|val, upd| *val = upd.clone());
+            if n > 1 {
+                input.set_persistent_mir_id(&format!("input{i}"));
+            } else {
+                input.set_persistent_mir_id("input");
+            }
+
+            let input_schema = serde_json::to_string(&Relation::new(
+                format!("test_input{i}").into(),
+                schema.clone(),
+                false,
+                BTreeMap::new(),
+            ))
+            .unwrap();
+
+            let output_schema = serde_json::to_string(&Relation::new(
+                format!("test_output{i}").into(),
+                schema.clone(),
+                false,
+                BTreeMap::new(),
+            ))
+            .unwrap();
+
+            catalog.register_materialized_input_map(
+                input.clone(),
+                hinput,
+                key_func.clone(),
+                key_func.clone(),
+                &input_schema,
+            );
+
+            catalog.register_materialized_output_map_persistent(
+                persistent_output_id.as_ref().map(|s| s.as_str()),
+                input.clone(),
+                &output_schema,
+            );
+
+            let persistent_index_id = persistent_output_id.as_ref().map(|id| format!("{id}.idx"));
+
+            catalog
+                .register_index_persistent::<K, K, T, T>(
+                    persistent_index_id.as_deref(),
+                    input.clone(),
+                    &SqlIdentifier::from(&format!("idx{i}")),
+                    &SqlIdentifier::from(&format!("test_output{i}")),
+                    &key_fields.iter().collect::<Vec<_>>(),
+                )
+                .expect("failed to register index");
         }
         Ok(catalog)
     })

--- a/docs.feldera.com/docs/connectors/sinks/delta.md
+++ b/docs.feldera.com/docs/connectors/sinks/delta.md
@@ -25,7 +25,7 @@ Delta table:
 
 | Column         | Type      | Description                                                                   |
 |----------------|-----------|-------------------------------------------------------------------------------|
-| `__feldera_op` | `VARCHAR` | Operation that this record represents: `i` for "insert" or `d` for "delete".  |
+| `__feldera_op` | `VARCHAR` | Operation that this record represents: `i` for "insert", `d` for "delete", or `u` for "update".  |
 | `__feldera_ts` | `BIGINT`  | Timestamp of the update, used to establish the order of updates. Updates with smaller timestamps are applied before those with larger timestamps. |
 
 Effectively, we treat the table as a change log, where every record corresponds to
@@ -52,6 +52,17 @@ backend-specific documentation for details:
 * [Amazon S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html)
 * [Azure Blob Storage options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html)
 * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
+
+### Views with unique keys
+
+If the SQL view contains a **unique key**—a set of columns that uniquely identify each record—the Delta Lake connector can optimize updates by combining a delete and insert with the same key into a single **atomic update**. In such cases, the connector emits a record with the `__feldera_op` field set to `'u'` (for **update**).
+
+To enable this optimization:
+
+* Use the `CREATE INDEX` statement to define the unique key on the view.
+* Set the connector's `index` property to reference this index.
+
+For more information, see the [documentation on views with unique keys](/connectors/unique_keys#views-with-unique-keys).
 
 ## Data type mapping
 

--- a/docs.feldera.com/docs/connectors/unique_keys.md
+++ b/docs.feldera.com/docs/connectors/unique_keys.md
@@ -39,6 +39,7 @@ as follows:
 The specific behavior of this transformation depends on the data format and transport protocol used. Currently, the `index` property is supported only for:
 - Kafka output connectors configured with the [Avro format](/formats/avro/)
 - [Postgres output connector](/connectors/sinks/postgresql)
+- [Delta Lake output connector](/connectors/sinks/delta)
 
 :::info
 


### PR DESCRIPTION
Close #4241.

- Support for views with unique keys in delta output connectors.
- Enhance delta test harness. Some of the tests only checked output table sizes. They now check the actual table contents instead.