### PR TITLE
[SQL] Fix incorrect non-linear aggregate result for empty sets

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -528,7 +528,7 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPVariablePath postVar = this.partialResultType.var();
             DBSPClosureExpression postProcess = postVar.cast(this.node, this.nullableResultType, false).closure(postVar);
             this.setResult(new NonLinearAggregate(
-                    node, this.partialResultType.to(IsNumericType.class).getZero(), this.makeRowClosure(increment, accumulator), postProcess, zero, semigroup));
+                    node, DBSPLiteral.none(this.partialResultType), this.makeRowClosure(increment, accumulator), postProcess, zero, semigroup));
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -990,7 +990,16 @@ public class EndToEndTests extends BaseSQLTests {
         String query = "SELECT SUM(T.COL1) FROM T WHERE FALSE";
         this.testConstantOutput(query, new DBSPZSetExpression(
                  new DBSPTupleExpression(
-                        DBSPLiteral.none(new DBSPTypeInteger(CalciteObject.EMPTY, 32, true,true)))));
+                        DBSPLiteral.none(DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true)))));
+    }
+
+    @Test
+    public void sumNullTest() {
+        String query = "SELECT SUM(CAST(NULL AS INTEGER)), SUM(CAST(NULL AS DOUBLE)) FROM T";
+        this.testConstantOutput(query, new DBSPZSetExpression(
+                new DBSPTupleExpression(
+                        DBSPLiteral.none(DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true)),
+                        DBSPLiteral.none(new DBSPTypeDouble(CalciteObject.EMPTY, true)))));
     }
 
     @Test


### PR DESCRIPTION
Fixes a regression introduced with the UNSIGNED numbers PR in the computation of non-linear aggregates.
Bug found by nightly SLT tests.