### PR TITLE
[adapters] Serialize desired `ControllerStatus` instead of post-editing.

### DIFF
--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -341,6 +341,7 @@ where
 #[derive(Serialize)]
 pub struct ControllerStatus {
     /// Global controller configuration.
+    #[serde(skip_serializing)]
     pub pipeline_config: PipelineConfig,
 
     /// Global controller metrics.
@@ -1373,6 +1374,7 @@ pub struct InputEndpointStatus {
     pub endpoint_name: String,
 
     /// Endpoint configuration (doesn't change).
+    #[serde(serialize_with = "serialize_input_endpoint_config")]
     pub config: InputEndpointConfig,
 
     /// Performance metrics.
@@ -1414,6 +1416,25 @@ pub struct InputEndpointStatus {
     /// Completion tokens associated with the endpoint.
     #[serde(skip)]
     completion_tokens: TokenList,
+}
+
+#[derive(Serialize)]
+struct StreamOnly<'a> {
+    stream: &'a str,
+}
+
+/// Serialize only `config.stream`, omitting other fields.
+fn serialize_input_endpoint_config<S>(
+    config: &InputEndpointConfig,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    StreamOnly {
+        stream: &config.stream,
+    }
+    .serialize(serializer)
 }
 
 impl InputEndpointStatus {
@@ -1618,6 +1639,7 @@ pub struct OutputEndpointStatus {
     pub endpoint_name: String,
 
     /// Endpoint configuration (doesn't change).
+    #[serde(serialize_with = "serialize_output_endpoint_config")]
     pub config: OutputEndpointConfig,
 
     /// Performance metrics.
@@ -1625,6 +1647,20 @@ pub struct OutputEndpointStatus {
 
     /// The first fatal error that occurred at the endpoint.
     pub fatal_error: Mutex<Option<String>>,
+}
+
+/// Serialize only `config.stream`, omitting other fields.
+fn serialize_output_endpoint_config<S>(
+    config: &OutputEndpointConfig,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    StreamOnly {
+        stream: &config.stream,
+    }
+    .serialize(serializer)
 }
 
 /// Public read API.

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -47,7 +47,6 @@ use feldera_types::{query::AdhocQueryArgs, transport::http::SERVER_PORT_FILE};
 use futures_util::FutureExt;
 use minitrace::collector::Config;
 use serde::Deserialize;
-use serde_json::json;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, DefaultHasher};
@@ -768,140 +767,7 @@ async fn query(
 #[get("/stats")]
 async fn stats(state: WebData<ServerState>) -> impl Responder {
     match &*state.controller.read().unwrap() {
-        Some(controller) => {
-            let Ok(mut json_value) = serde_json::to_value(controller.status()) else {
-                return Err(ControllerError::UnexpectedJsonStructure {
-                    reason: "could not serialize controller status to JSON".to_string(),
-                }
-                .into());
-            };
-            // Remove unnecessary configuration information
-            let Some(json_object) = json_value.as_object_mut() else {
-                return Err(ControllerError::UnexpectedJsonStructure {
-                    reason: "controller status is not an JSON object".to_string(),
-                }
-                .into());
-            };
-            // Remove: .pipeline_config
-            if json_object.remove("pipeline_config").is_none() {
-                return Err(ControllerError::UnexpectedJsonStructure {
-                    reason: ".pipeline_config was not found and thus could not be removed"
-                        .to_string(),
-                }
-                .into());
-            }
-            // Remove: .inputs[i].config except its stream field
-            let Some(inputs) = json_value
-                .get_mut("inputs")
-                .and_then(|value| value.as_array_mut())
-            else {
-                return Err(ControllerError::UnexpectedJsonStructure {
-                    reason: ".inputs is missing or is not an JSON array".to_string(),
-                }
-                .into());
-            };
-            for input in inputs {
-                let Some(input_object) = input.as_object_mut() else {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".inputs[i] is not an JSON object".to_string(),
-                    }
-                    .into());
-                };
-                // Retrieve the .inputs[i].config.stream field before deleting its parent
-                let Some(stream) = input_object
-                    .get_mut("config")
-                    .and_then(|v| v.as_object_mut())
-                    .and_then(|v| v.get("stream"))
-                    .and_then(|v| v.as_str())
-                    .map(|v| v.to_string())
-                else {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".inputs[i].config does not exist or is not an JSON object, or does not have the stream field which is a string".to_string(),
-                    }
-                    .into());
-                };
-                // Delete: .inputs[i].config
-                if input_object.remove("config").is_none() {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".inputs[i].config could not be removed".to_string(),
-                    }
-                    .into());
-                };
-                // Put back: .inputs[i].config.stream
-                if input_object
-                    .insert(
-                        "config".to_string(),
-                        json!({
-                            "stream": stream
-                        }),
-                    )
-                    .is_some()
-                {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".inputs[i].config already existed even though it was removed"
-                            .to_string(),
-                    }
-                    .into());
-                }
-            }
-            // Remove: .outputs[i].config except its stream field
-            let Some(outputs) = json_value
-                .get_mut("outputs")
-                .and_then(|value| value.as_array_mut())
-            else {
-                return Err(ControllerError::UnexpectedJsonStructure {
-                    reason: ".outputs is missing or is not an JSON array".to_string(),
-                }
-                .into());
-            };
-            for output in outputs {
-                let Some(output_object) = output.as_object_mut() else {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".outputs[i] is not an JSON object".to_string(),
-                    }
-                    .into());
-                };
-                // Retrieve the .outputs[i].config.stream field before deleting its parent
-                let Some(stream) = output_object
-                    .get_mut("config")
-                    .and_then(|v| v.as_object_mut())
-                    .and_then(|v| v.get("stream"))
-                    .and_then(|v| v.as_str())
-                    .map(|v| v.to_string())
-                else {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".outputs[i].config does not exist or is not an JSON object, or does not have the stream field which is a string".to_string(),
-                    }
-                    .into());
-                };
-                // Delete: .outputs[i].config
-                if output_object.remove("config").is_none() {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".outputs[i].config could not be removed".to_string(),
-                    }
-                    .into());
-                };
-                // Put back: .outputs[i].config.stream
-                if output_object
-                    .insert(
-                        "config".to_string(),
-                        json!({
-                            "stream": stream
-                        }),
-                    )
-                    .is_some()
-                {
-                    return Err(ControllerError::UnexpectedJsonStructure {
-                        reason: ".outputs[i].config already existed even though it was removed"
-                            .to_string(),
-                    }
-                    .into());
-                }
-            }
-            Ok(HttpResponse::Ok()
-                .content_type(mime::APPLICATION_JSON)
-                .body(json_value.to_string()))
-        }
+        Some(controller) => Ok(HttpResponse::Ok().json(controller.status())),
         None => Err(missing_controller_error(&state)),
     }
 }


### PR DESCRIPTION
The code for `/stats` in the server generated the controller status then edited it to remove configuration details.  I assumed this was because there are other code paths that do want to serialize those configuration details, but I couldn't find any (even by removing the `Serialize` implementation and then checking the compiler errors).  Therefore, this commit simply changes the Serialize implementation to avoid serializing the data we don't want.