### PR TITLE
s3_sync: start from any checkpoint in object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,6 +4844,7 @@ dependencies = [
 name = "feldera-storage"
 version = "0.106.0"
 dependencies = [
+ "anyhow",
  "feldera-types",
  "inventory",
  "libc",

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -931,9 +931,12 @@ async fn checkpoint_sync(state: WebData<ServerState>) -> Result<impl Responder, 
             };
 
             let state = state.sync_checkpoint_state.clone();
-            controller.start_sync_checkpoint(Box::new(move |result| {
-                state.lock().unwrap().completed(last_checkpoint, result);
-            }));
+            controller.start_sync_checkpoint(
+                last_checkpoint,
+                Box::new(move |result| {
+                    state.lock().unwrap().completed(last_checkpoint, result);
+                }),
+            );
             last_checkpoint
         }
     };

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -80,16 +80,12 @@ pub struct CheckpointMetadata {
     pub identifier: Option<String>,
     /// Fingerprint of the circuit at the time of the checkpoint.
     pub fingerprint: u64,
-}
-
-impl CheckpointMetadata {
-    pub fn new(uuid: Uuid, identifier: Option<String>, fingerprint: u64) -> Self {
-        CheckpointMetadata {
-            uuid,
-            identifier,
-            fingerprint,
-        }
-    }
+    /// Total size of the checkpoint files in bytes.
+    pub size: Option<u64>,
+    /// Total number of steps made.
+    pub steps: Option<u64>,
+    /// Total number of records processed.
+    pub processed_records: Option<u64>,
 }
 
 /// Format of `pspine-batches-*.dat` in storage.

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -349,8 +349,9 @@ pub struct SyncConfig {
     /// this can be left empty to allow automatic authentication via the pod's service account.
     pub secret_key: Option<String>,
 
-    /// When set, the pipeline will fetch either the specified checkpoint
-    /// from the object store.
+    /// When set, the pipeline will fetch the specified checkpoint from the
+    /// object store. If the checkpoint doesn't exist, the pipeline will fail
+    /// to initialize.
     ///
     /// If the checkpoint doesn't exist in object store, the pipeline will
     /// fail to initialize.

--- a/crates/feldera-types/src/constants.rs
+++ b/crates/feldera-types/src/constants.rs
@@ -7,3 +7,5 @@ pub const CHECKPOINT_FILE_NAME: &str = "checkpoints.feldera";
 pub const STATE_FILE: &str = "state.json";
 
 pub const STEPS_FILE: &str = "steps.bin";
+
+pub const CHECKPOINT_DEPENDENCIES: &str = "dependencies.json";

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -166,6 +166,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         feldera_types::config::StorageOptions,
         feldera_types::config::StorageBackendConfig,
         feldera_types::config::SyncConfig,
+        feldera_types::config::StartFromCheckpoint,
         feldera_types::config::FileBackendConfig,
         feldera_types::config::StorageCompression,
         feldera_types::config::RuntimeConfig,

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,6 +12,7 @@ authors = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 feldera-types = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 libc = { workspace = true }

--- a/crates/storage/src/checkpoint_synchronizer.rs
+++ b/crates/storage/src/checkpoint_synchronizer.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
-use std::{error::Error, fmt::Display};
 
 use feldera_types::config::SyncConfig;
 
-use crate::error::StorageError;
 use crate::StorageBackend;
 
 pub trait CheckpointSynchronizer: Sync {
@@ -12,52 +10,13 @@ pub trait CheckpointSynchronizer: Sync {
         checkpoint: uuid::Uuid,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
-    ) -> Result<(), SyncError>;
+    ) -> anyhow::Result<()>;
 
     fn pull(
         &self,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
-    ) -> Result<(), SyncError>;
-}
-
-#[derive(Debug)]
-pub enum SyncError {
-    Io(std::io::Error),
-    Serde(serde_json::Error),
-    RcloneExitCode(String),
-    Storage(String),
-}
-
-impl Error for SyncError {}
-
-impl Display for SyncError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SyncError::Io(error) => write!(f, "synchronizer IO err: {error}",),
-            SyncError::Serde(error) => write!(f, "synchronizer: serde error: {error}",),
-            SyncError::RcloneExitCode(error) => write!(f, "synchronizer: rclone: '{error}'"),
-            SyncError::Storage(error) => write!(f, "synchronizer: storage error: '{error}'"),
-        }
-    }
-}
-
-impl From<std::io::Error> for SyncError {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<serde_json::Error> for SyncError {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Serde(value)
-    }
-}
-
-impl From<StorageError> for SyncError {
-    fn from(value: StorageError) -> Self {
-        Self::Storage(value.to_string())
-    }
+    ) -> anyhow::Result<()>;
 }
 
 inventory::collect!(&'static dyn CheckpointSynchronizer);

--- a/crates/storage/src/checkpoint_synchronizer.rs
+++ b/crates/storage/src/checkpoint_synchronizer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::{error::Error, fmt::Display};
 
-use feldera_types::{checkpoint::CheckpointMetadata, config::SyncConfig};
+use feldera_types::config::SyncConfig;
 
 use crate::error::StorageError;
 use crate::StorageBackend;
@@ -9,7 +9,7 @@ use crate::StorageBackend;
 pub trait CheckpointSynchronizer: Sync {
     fn push(
         &self,
-        checkpoint: &CheckpointMetadata,
+        checkpoint: uuid::Uuid,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
     ) -> Result<(), SyncError>;
@@ -35,10 +35,7 @@ impl Display for SyncError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SyncError::Io(error) => write!(f, "synchronizer IO err: {error}",),
-            SyncError::Serde(error) => write!(
-                f,
-                "synchronizer: error parsing checkpoint metadata: {error}",
-            ),
+            SyncError::Serde(error) => write!(f, "synchronizer: serde error: {error}",),
             SyncError::RcloneExitCode(error) => write!(f, "synchronizer: rclone: '{error}'"),
             SyncError::Storage(error) => write!(f, "synchronizer: storage error: '{error}'"),
         }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -185,14 +185,14 @@ impl dyn StorageBackend {
         }
     }
 
-    pub fn gather_batches_for_checkpoint(
+    pub fn gather_batches_for_checkpoint_uuid(
         &self,
-        cpm: &CheckpointMetadata,
+        cpm: uuid::Uuid,
     ) -> Result<HashSet<StoragePath>, StorageError> {
-        assert!(!cpm.uuid.is_nil());
+        assert!(!cpm.is_nil());
 
         let mut spines = Vec::new();
-        self.list(&cpm.uuid.to_string().into(), &mut |path, _file_type| {
+        self.list(&cpm.to_string().into(), &mut |path, _file_type| {
             if path
                 .filename()
                 .is_some_and(|filename| filename.starts_with("pspine-batches"))
@@ -210,6 +210,13 @@ impl dyn StorageBackend {
         }
 
         Ok(batch_files_in_commit)
+    }
+
+    pub fn gather_batches_for_checkpoint(
+        &self,
+        cpm: &CheckpointMetadata,
+    ) -> Result<HashSet<StoragePath>, StorageError> {
+        self.gather_batches_for_checkpoint_uuid(cpm.uuid)
     }
 
     /// Writes `content` to `name` as JSON, automatically creating any parent

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -1,5 +1,9 @@
 # Synchronizing checkpoints to object store
 
+:::caution Experimental feature
+Synchronizing checkpoints to object store is a highly experimental feature.
+:::
+
 Feldera allows synchronizing pipeline checkpoints to an object store and
 restoring them at startup.
 
@@ -21,7 +25,7 @@ Here is a sample configuration:
         "provider": "AWS",
         "access_key": "ACCESS_KEY",
         "secret_key": "SECRET_KEY",
-        "start_from_checkpoint": true
+        "start_from_checkpoint": false
       }
     }
   }
@@ -32,12 +36,12 @@ Here is a sample configuration:
 
 | Field                     | Type      | Description                                                                                                                        |
 | ------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `endpoint`                | `string`  | The S3-compatible object store endpoint (e.g., for MinIO, AWS).                                                                    |
-| `bucket`\*                | `string`  | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`).                                           |
-| `provider`\*              | `string`  | The S3 provider identifier. Must match [rclone's list](https://rclone.org/s3/#providers). Case-sensitive. Use `"Other"` if unsure. |
-| `access_key`              | `string`  | Your S3 access key. Not required if using environment-based authentication (e.g., IRSA).                                           |
-| `secret_key`              | `string`  | Your S3 secret key. Same rules as `access_key`.                                                                                    |
-| `start_from_checkpoint`\* | `boolean` | If `true`, Feldera will restore the latest checkpoint from the object store on startup.                                            |
+| `endpoint`                | `string`  | The S3-compatible object store endpoint (e.g., for MinIO, AWS).                                                                               |
+| `bucket`\*                | `string`  | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`).                                                      |
+| `provider`\*              | `string`  | The S3 provider identifier. Must match [rclone's list](https://rclone.org/s3/#providers). Case-sensitive. Use `"Other"` if unsure.            |
+| `access_key`              | `string`  | Your S3 access key. Not required if using environment-based authentication (e.g., IRSA).                                                      |
+| `secret_key`              | `string`  | Your S3 secret key. Same rules as `access_key`.                                                                                               |
+| `start_from_checkpoint`   | `string`  | Provide a checkpoint UUID to resume from it, or use `latest` to restore from the latest one. The provided UUID must exist in object store.    |
 
 ## S3 permissions
 

--- a/openapi.json
+++ b/openapi.json
@@ -7228,6 +7228,28 @@
         ],
         "description": "The available SQL types as specified in `CREATE` statements."
       },
+      "StartFromCheckpoint": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "Latest"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "Uuid"
+            ],
+            "properties": {
+              "Uuid": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
       "StorageBackendConfig": {
         "oneOf": [
           {
@@ -7376,8 +7398,7 @@
       "SyncConfig": {
         "type": "object",
         "required": [
-          "bucket",
-          "start_from_checkpoint"
+          "bucket"
         ],
         "properties": {
           "access_key": {
@@ -7410,8 +7431,12 @@
             "nullable": true
           },
           "start_from_checkpoint": {
-            "type": "boolean",
-            "description": "If `true`, will try to pull the latest checkpoint from the configured\nobject store and resume from that point."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StartFromCheckpoint"
+              }
+            ],
+            "nullable": true
           }
         }
       },

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 
 import pandas
+from uuid import UUID
 
 from typing import List, Dict, Callable, Optional, Generator, Mapping, Any
 from collections import deque
@@ -636,6 +637,8 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         resp = self.client.sync_checkpoint_status(self.name)
         success = resp.get("success")
 
+        fail = resp.get("failure") or {}
+
         if uuid == success:
             return CheckpointStatus.Success
 
@@ -644,6 +647,9 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
             failure = CheckpointStatus.Failure
             failure.error = fail.get("error", "")
             return failure
+
+        if (success is None) or UUID(uuid) > UUID(success):
+            return CheckpointStatus.InProgress
 
         return CheckpointStatus.Unknown
 

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -621,7 +621,7 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
                 time.sleep(0.1)
                 continue
 
-            return status
+            break
 
         return uuid
 

--- a/python/tests/test_shared_pipeline1.py
+++ b/python/tests/test_shared_pipeline1.py
@@ -12,7 +12,7 @@ SECRET_KEY = "miniopasswd"
 
 def storage_cfg(
     endpoint: Optional[str] = None,
-    start_from_checkpoint: bool = False,
+    start_from_checkpoint: Optional[str] = None,
     auth_err: bool = False,
 ) -> dict:
     return {
@@ -56,7 +56,7 @@ class TestCheckpointSync(SharedTestPipeline):
         self.pipeline.clear_storage()
 
         # Restart pipeline from checkpoint
-        storage_config = storage_cfg(start_from_checkpoint=True, auth_err=auth_err)
+        storage_config = storage_cfg(start_from_checkpoint="latest", auth_err=auth_err)
         self.set_runtime_config(RuntimeConfig(storage=Storage(config=storage_config)))
         self.pipeline.start()
         got_after = list(self.pipeline.query("SELECT * FROM v0"))

--- a/python/tests/test_shared_pipeline1.py
+++ b/python/tests/test_shared_pipeline1.py
@@ -1,3 +1,5 @@
+import random
+import time
 from typing import Optional
 from feldera.runtime_config import RuntimeConfig, Storage
 from tests import enterprise_only
@@ -44,7 +46,8 @@ class TestCheckpointSync(SharedTestPipeline):
         self.set_runtime_config(RuntimeConfig(storage=Storage(config=storage_config)))
         self.pipeline.start()
 
-        data = [{"c0": i, "c1": str(i)} for i in range(1, 4)]
+        random.seed(time.time())
+        data = [{"c0": i, "c1": str(i)} for i in range(1, random.randint(10, 20))]
         self.pipeline.input_json("t0", data)
         self.pipeline.execute("INSERT INTO t0 VALUES (4, 'exists')")
         got_before = list(self.pipeline.query("SELECT * FROM v0"))


### PR DESCRIPTION
* `sync.start_from_checkpoint` takes either a UUID to a checkpoint or `latest` which just pulls the latest checkpoint
* checkpoints now include state.json inside the checkpoint directory as well
* syncs individual pipelines to object store, as now they are self contained