### PR TITLE
[adapters] Make collecting memory stats cheaper.

### DIFF
--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -130,7 +130,7 @@ num-traits = { workspace = true } # Used by num-derive derive macro, which cargo
 postgres = { workspace = true }
 dyn-clone = { workspace = true }
 cpu-time = "1.0.0"
-memory-stats = "1.2.0"
+memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
 feldera-ir = { workspace = true }
 base64 = {workspace = true }
 aws-msk-iam-sasl-signer = "1.0.0"


### PR DESCRIPTION
By default, `memory-stats` tries to read `/proc/$pid/smaps`, which for our pipeline process could be over a megabyte and for which the kernel does a lot of computation.  Use the `always_use_statm` feature to avoid that, so that it only read `/proc/$pid/statm`, which is only a few bytes long and easy for the kernel to compute.

I found that I was seeing a lot of calls to the `/stats` endpoint blocking in memory_stats, and this fixed that.