### PR TITLE
[SQL] Compose functions before implementing chain operators

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
@@ -138,7 +138,6 @@ public class DBSPChainOperator extends DBSPUnaryOperator {
         }
 
         public DBSPClosureExpression collapse(DBSPCompiler compiler) {
-            Utilities.enforce(this.computations.size() > 1);
             DBSPVariablePath inputVar;
             DBSPExpression currentArg;
             if (this.inputType.is(DBSPTypeZSet.class)) {
@@ -213,7 +212,9 @@ public class DBSPChainOperator extends DBSPUnaryOperator {
         @Override
         public String toString() {
             IndentStreamBuilder builder = new IndentStreamBuilder();
-            builder.append("Chain:[").increase();
+            builder.append("Chain[")
+                    .append(this.size())
+                    .append("]: [").increase();
             for (var op: this.computations)
                 builder.append(op.toString()).newline();
             builder.decrease().newline();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementChains.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementChains.java
@@ -5,8 +5,16 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.Expensive;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
+import org.dbsp.util.Maybe;
+import org.dbsp.util.Utilities;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** Implement {@link org.dbsp.sqlCompiler.circuit.operator.DBSPChainOperator} */
 public class ImplementChains extends CircuitCloneVisitor {
@@ -14,9 +22,53 @@ public class ImplementChains extends CircuitCloneVisitor {
         super(compiler, false);
     }
 
+    /** Compose pairs of maps that can be efficiently composed, taking into advantage
+     * the fact that function composition is associative. */
+    DBSPChainOperator.ComputationChain shrink(DBSPChainOperator.ComputationChain chain) {
+        List<DBSPChainOperator.Computation> result = new ArrayList<>();
+        for (DBSPChainOperator.Computation comp: chain.computations()) {
+            if (result.isEmpty() || comp.kind() == DBSPChainOperator.ComputationKind.Filter) {
+                result.add(comp);
+            } else {
+                DBSPChainOperator.Computation last = Utilities.removeLast(result);
+                if (last.kind() == DBSPChainOperator.ComputationKind.Filter) {
+                    result.add(last);
+                    result.add(comp);
+                    continue;
+                }
+
+                Expensive expensive = new Expensive(compiler);
+                expensive.apply(last.closure());
+                if (expensive.isExpensive()) {
+                    result.add(last);
+                } else {
+                    DBSPClosureExpression composed;
+                    if (last.kind() == DBSPChainOperator.ComputationKind.Map) {
+                        composed = comp.closure().applyAfter(compiler, last.closure(), Maybe.MAYBE);
+                    } else {
+                        DBSPClosureExpression lastFunction = last.closure();
+                        DBSPExpression argument = new DBSPRawTupleExpression(
+                                lastFunction.body.field(0).borrow(),
+                                lastFunction.body.field(1).borrow());
+                        DBSPExpression apply = comp.closure().call(argument);
+                        composed = apply.closure(lastFunction.parameters)
+                                .reduce(this.compiler()).to(DBSPClosureExpression.class);
+                    }
+                    comp = new DBSPChainOperator.Computation(comp.kind(), composed);
+                }
+                result.add(comp);
+            }
+        }
+
+        if (result.size() == chain.size())
+            return chain;
+        return new DBSPChainOperator.ComputationChain(chain.inputType(), result);
+    }
+
     @Override
     public void postorder(DBSPChainOperator node) {
-        DBSPClosureExpression function = node.chain.collapse(this.compiler);
+        DBSPChainOperator.ComputationChain chain = this.shrink(node.chain);
+        DBSPClosureExpression function = chain.collapse(this.compiler);
         DBSPSimpleOperator result;
         if (node.outputType.is(DBSPTypeZSet.class)) {
             result = new DBSPFlatMapOperator(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -747,7 +747,7 @@ public class IncrementalRegressionTests extends SqlIoTest {
             for (File c: toCompile) {
                 if (!c.getName().contains("grouped_orders.sql")) continue;
                 if (c.getName().contains("sql")) {
-                    // System.out.println("Compiling " + c);
+                    System.out.println("Compiling " + c);
                     String sql = Utilities.readFile(c.getPath());
                     this.compileRustTestCase(sql);
                 }


### PR DESCRIPTION
Fixes #4246 

The compiler uses an abstraction of a "ChainOperator" to represent a sequence of linear operations (map, filter, mapindex). Such chains in the end are implemented as a single linear `flat_map` (or `flat_map_index`) operator in DBSP.

This PR adds an optimization which attempts to compose consecutive map/mapindex functions that appear in a chain before implementing the chain (the composition essentially inlines the callee into the caller, so it is not always beneficial, some heuristics are used to decide whether the inlining is performed). But the example in #4246 is addressed. (I have checked this, but it's not easy to craft a unit test to exhibit this, since this optimization happens after many other code rewrites.)