### PR TITLE
Re-enable -T sql compiler flag to control logging

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
@@ -44,6 +44,7 @@ import org.dbsp.sqlCompiler.compiler.errors.CompilerMessages;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.IndentStream;
+import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
@@ -60,6 +61,7 @@ import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Map;
 
 /** Main entry point of the SQL compiler. */
 public class CompilerMain {
@@ -99,7 +101,6 @@ public class CompilerMain {
             return 1;
         }
 
-        /*
         for (Map.Entry<String, String> entry: options.ioOptions.loggingLevel.entrySet()) {
             try {
                 int level = Integer.parseInt(entry.getValue());
@@ -109,7 +110,6 @@ public class CompilerMain {
                 return 1;
             }
         }
-         */
 
         return 0;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler;
 
+import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import org.apache.calcite.avatica.util.Casing;
@@ -34,6 +35,8 @@ import org.dbsp.util.IValidate;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Command-line options for the SQL compiler */
 @SuppressWarnings("CanBeFinal")
@@ -154,11 +157,9 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
     /** Options related to input and output. */
     @SuppressWarnings("CanBeFinal")
     public static class IO implements IDiff<IO>, IValidate {
-        /*
         @DynamicParameter(names = "-T",
                 description = "Specify logging level for a class (can be repeated)")
         public Map<String, String> loggingLevel = new HashMap<>();
-         */
         @Parameter(names = "--noRust", description = "Do not generate Rust output files")
         public boolean noRust = false;
         @Parameter(names = "--enterprise", description = "Generate code supporting enterprise features")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -192,7 +192,7 @@ import java.util.stream.Collectors;
  * The front-end offers several APIs, invoked in this order:
  * - parse SQL (using {@link SqlToRelCompiler#parse})
  * - compile SqlNode to RelNode (using {@link SqlToRelCompiler#compile})
- * - optimize RelNode (using {@link SqlToRelCompiler#optimize(RelNode)})
+ * - optimize RelNode (using {@link SqlToRelCompiler#optimize(RelNode, boolean)})
  *   Optimize is called automatically from compile().
  */
 public class SqlToRelCompiler implements IWritesLogs {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -769,6 +769,10 @@ public class MetadataTests extends BaseSQLTests {
                     -O
                       Optimization level (0, 1, or 2)
                       Default: 2
+                    -T
+                      Specify logging level for a class (can be repeated)
+                      Syntax: -Tkey=value
+                      Default: {}
                     -i
                       Generate an incremental circuit
                       Default: false

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -169,7 +169,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
     }
 
     // Test the -T command-line parameter
-    @Test @Ignore("-T parameter disabled")
+    @Test
     public void loggingParameter() throws IOException, InterruptedException, SQLException {
         StringBuilder builder = new StringBuilder();
         Appendable save = Logger.INSTANCE.setDebugStream(builder);

--- a/sql-to-dbsp-compiler/using.md
+++ b/sql-to-dbsp-compiler/using.md
@@ -110,6 +110,10 @@ Usage: sql-to-dbsp [options] Input file to compile
     -O
       Optimization level (0, 1, or 2)
       Default: 2
+    -T
+      Specify logging level for a class (can be repeated)
+      Syntax: -Tkey=value
+      Default: {}
     -i
       Generate an incremental circuit
       Default: false


### PR DESCRIPTION
A while ago I have disabled the -T SQL compiler flag, which is used to control logging (you specify an instrumented class in the compiler and a logging level). I find myself missing it while debugging compiler problems, so this PR brings it back.
