### PR TITLE
[SQLLIB] Different implementation of Hash for decimals

### DIFF
--- a/crates/adapters/src/adhoc/table.rs
+++ b/crates/adapters/src/adhoc/table.rs
@@ -494,7 +494,7 @@ use `with ('materialized' = 'true')` for tables, or `create materialized view` f
                     // Skip deleted records.
                     if w < 0 {
                         cursor.step_key();
-                        continue;
+                        panic!("Unexpected key with negative weight encountered while processing ad-hoc query");
                     }
 
                     while w != 0 {

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -404,8 +404,7 @@ impl Encoder for ParquetEncoder {
                 bail!("Unable to output record with very large weight {w}. Consider adjusting your SQL queries to avoid duplicate output records, e.g., using 'SELECT DISTINCT'.");
             }
             if w < 0 {
-                // TODO: we don't support deletes in the parquet format yet.
-                continue;
+                panic!("Deletes for the parquet format are not yet supported.");
             }
 
             while w != 0 {

--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -441,6 +441,9 @@ pub fn cast_to_SqlDecimal_SqlDecimal(
     cx.set_rounding(Rounding::Down);
     cx.set_precision(precision as usize).unwrap();
     let mut result = value.get_dec();
+    if result.is_negative() && result.is_zero() {
+        cx.abs(&mut result);
+    }
     cx.rescale(&mut result, &LargeDecimal::from(-(scale as i32)));
     if is_error(&cx) {
         Err(SqlRuntimeError::from_string(

--- a/crates/sqllib/src/dec.rs
+++ b/crates/sqllib/src/dec.rs
@@ -193,7 +193,9 @@ impl SqlDecimal {
 
 impl Hash for SqlDecimal {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.to_raw_parts().hash::<H>(state);
+        let data = self.value.clone().to_packed_bcd().unwrap();
+        data.0.hash::<H>(state);
+        data.1.hash::<H>(state);
     }
 }
 


### PR DESCRIPTION
I am not 100% this is foolproof either, but we plan to replace the entire implementation of decimals anyway.

I don't understand why https://docs.rs/dec/latest/dec/struct.Decimal.html#method.to_packed_bcd requires a mut self - this is also very expensive.