### PR TITLE
Fail the circuit on background thread panics

### DIFF
--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -739,7 +739,7 @@ impl DBSPHandle {
     fn panicked(&self) -> bool {
         self.runtime
             .as_ref()
-            .map_or(false, |runtime| runtime.panicked())
+            .is_some_and(|runtime| runtime.panicked())
     }
 
     fn broadcast_command<F>(&mut self, command: Command, mut handler: F) -> Result<(), DbspError>
@@ -778,7 +778,7 @@ impl DBSPHandle {
             let panic_info = this.collect_panic_info().unwrap_or_default();
             this.kill_async();
 
-            return Err(DbspError::Runtime(RuntimeError::WorkerPanic { panic_info }));
+            Err(DbspError::Runtime(RuntimeError::WorkerPanic { panic_info }))
         }
         for _ in 0..self.status_receivers.len() {
             let ready = select.select();

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1,4 +1,5 @@
 use crate::circuit::checkpointer::Checkpointer;
+use crate::circuit::runtime::ThreadType;
 use crate::monitor::visual_graph::Graph;
 use crate::storage::backend::StorageError;
 use crate::trace::MergerType;
@@ -729,7 +730,7 @@ impl DBSPHandle {
         self.runtime.take().unwrap().kill_async()
     }
 
-    fn collect_panic_info(&self) -> Option<Vec<(usize, WorkerPanicInfo)>> {
+    fn collect_panic_info(&self) -> Option<Vec<(usize, ThreadType, WorkerPanicInfo)>> {
         self.runtime
             .as_ref()
             .map(|runtime| runtime.collect_panic_info())

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -798,6 +798,7 @@ impl Runtime {
         if let Ok(guard) = self.inner().panic_info[worker][thread_type].read() {
             guard.clone()
         } else {
+            warn!("poisoned panic_lock lock for {thread_type} worker {worker}");
             None
         }
     }


### PR DESCRIPTION
This causes the circuit as a whole to abort if a background thread panics (e.g. if the merger runs out of storage).