### PR TITLE
pipeline-manager: networking fixes

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -234,7 +234,7 @@ pub struct ServerArgs {
     pub(crate) storage_location: Option<PathBuf>,
 
     /// TCP bind address
-    #[arg(short, long, default_value = "0.0.0.0")]
+    #[arg(short, long, default_value = "127.0.0.1")]
     bind_address: String,
 
     /// Run the server on this port if it is available. If the port is in

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -713,19 +713,22 @@ mod test {
         let auth_middleware = HttpAuthentication::with_fn(closure);
 
         let common_config = CommonConfig {
+            bind_address: "127.0.0.1".to_string(),
+            api_port: 0,
+            compiler_host: "127.0.0.1".to_string(),
+            compiler_port: 8085,
+            runner_host: "127.0.0.1".to_string(),
+            runner_port: 8089,
             platform_version: "v0".to_string(),
         };
 
         let manager_config = ApiServerConfig {
-            port: 0,
-            bind_address: "0.0.0.0".to_owned(),
             auth_provider: crate::config::AuthProviderType::AwsCognito,
             dev_mode: false,
             dump_openapi: false,
             allowed_origins: None,
             demos_dir: vec![],
             telemetry: "".to_owned(),
-            runner_hostname_port: "127.0.0.1:8089".to_string(),
         };
 
         let (conn, _temp) = crate::db::test::setup_pg().await;

--- a/crates/pipeline-manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline-manager/src/bin/pipeline-manager.rs
@@ -94,14 +94,9 @@ async fn main() -> anyhow::Result<()> {
     let db_clone = db.clone();
     let common_config_clone = common_config.clone();
     let _local_runner = tokio::spawn(async move {
-        runner_main::<LocalRunner>(
-            db_clone,
-            common_config_clone,
-            local_runner_config.clone(),
-            local_runner_config.runner_main_port,
-        )
-        .await
-        .expect("Local runner main failed");
+        runner_main::<LocalRunner>(db_clone, common_config_clone, local_runner_config.clone())
+            .await
+            .expect("Local runner main failed");
     });
     // The api-server blocks forever
     pipeline_manager::api::main::run(db, common_config, api_config, Arc::new(RwLock::new(None)))

--- a/crates/pipeline-manager/src/compiler/main.rs
+++ b/crates/pipeline-manager/src/compiler/main.rs
@@ -249,7 +249,7 @@ pub async fn compiler_main(
     ));
 
     // Spawn HTTP server thread
-    let port = config.binary_ref_port;
+    let port = common_config.compiler_port;
     let config = web::Data::new(config.clone());
     let probe = web::Data::new(DbProbe::new(db.clone()).await);
     let http_server = spawn(
@@ -260,7 +260,7 @@ pub async fn compiler_main(
                 .service(get_binary)
                 .service(healthz)
         })
-        .bind(("0.0.0.0", port))
+        .bind((common_config.bind_address, port))
         .unwrap_or_else(|_| panic!("Unable to bind compiler HTTP server on port {port}"))
         .run(),
     );
@@ -322,8 +322,6 @@ mod test {
             compilation_cargo_lock_path: "".to_string(),
             dbsp_override_path: "".to_string(),
             precompile: false,
-            binary_ref_host: "".to_string(),
-            binary_ref_port: 0,
         })
         .await
         .unwrap();
@@ -340,8 +338,6 @@ mod test {
             compilation_cargo_lock_path: "".to_string(),
             dbsp_override_path: "".to_string(),
             precompile: false,
-            binary_ref_host: "".to_string(),
-            binary_ref_port: 0,
         })
         .await
         .unwrap();

--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -467,8 +467,8 @@ pub async fn perform_rust_compilation(
     // URL where the program binary can be downloaded from
     let program_binary_url = format!(
         "http://{}:{}/binary/{}/{}/{}/{}",
-        config.binary_ref_host,
-        config.binary_ref_port,
+        common_config.compiler_host,
+        common_config.compiler_port,
         pipeline_id,
         program_version,
         source_checksum,

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -34,6 +34,12 @@ impl CompilerTest {
         let workdir = compiler_tempdir.path().to_str().unwrap();
         let platform_version = "v0";
         let common_config = CommonConfig {
+            bind_address: "127.0.0.1".to_string(),
+            api_port: 8080,
+            compiler_host: "127.0.0.1".to_string(),
+            compiler_port: 8085,
+            runner_host: "127.0.0.1".to_string(),
+            runner_port: 8089,
             platform_version: platform_version.to_string(),
         };
         let compiler_config = CompilerConfig {
@@ -46,8 +52,6 @@ impl CompilerTest {
             compilation_profile: CompilationProfile::Optimized,
             precompile: false,
             compiler_working_directory: workdir.to_owned(),
-            binary_ref_host: "127.0.0.1".to_string(),
-            binary_ref_port: 8085,
         };
 
         // Test in-memory database

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -1416,6 +1416,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
 #[cfg(test)]
 mod test {
     use crate::auth::TenantRecord;
+    use crate::config::CommonConfig;
     use crate::db::storage::Storage;
     use crate::db::storage_postgres::StoragePostgres;
     use crate::db::types::pipeline::{
@@ -1452,6 +1453,7 @@ mod test {
 
         fn new(
             _pipeline_id: PipelineId,
+            _common_config: CommonConfig,
             _config: Self::Config,
             _client: reqwest::Client,
             _logs_sender: Sender<LogMessage>,

--- a/crates/pipeline-manager/src/runner/pipeline_executor.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_executor.rs
@@ -1,3 +1,4 @@
+use crate::config::CommonConfig;
 use crate::db::types::pipeline::PipelineId;
 use crate::db::types::version::Version;
 use crate::error::ManagerError;
@@ -20,6 +21,7 @@ pub trait PipelineExecutor: Sync + Send {
     /// Constructs a new runner for the provided pipeline and starts rejection logging.
     fn new(
         pipeline_id: PipelineId,
+        common_config: CommonConfig,
         config: Self::Config,
         client: reqwest::Client,
         logs_sender: mpsc::Sender<LogMessage>,


### PR DESCRIPTION
API server, compiler, runner and pipelines now all bind to the same address, which is `127.0.0.1` when running from source and `0.0.0.0` when as a Docker image.

Hosts and ports are now commonly known to all via the CLI configuration.