### PR TITLE
[SQL] Improve detection of unused fields

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
@@ -197,13 +197,13 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
 
         Utilities.enforce(closure.parameters.length == 1);
         closure = this.find.findUnusedFields(closure);
-        if (!this.find.foundUnusedFields(1)) {
-            super.postorder(operator);
-            return;
-        }
-
         int size = closure.getType().getToplevelFieldCount();
+
         if (operator.input().outputType().is(DBSPTypeZSet.class)) {
+            if (!this.find.foundUnusedFields(1)) {
+                super.postorder(operator);
+                return;
+            }
             RewriteFields rw = this.find.getFieldRewriter(1);
             FieldUseMap fm = rw.getUseMap(closure.parameters[0]);
             DBSPClosureExpression projection = Objects.requireNonNull(fm.getProjection(1));
@@ -224,6 +224,10 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
                     operator.getRelNode(), compressed, operator.getOutputZSetType(), adjust.outputPort());
             this.map(operator, result);
         } else {
+            if (!this.find.foundUnusedFields(2)) {
+                super.postorder(operator);
+                return;
+            }
             // closure = compressed \circ projection
             RewriteFields rw = this.find.getFieldRewriter(2);
             FieldUseMap fm = rw.getUseMap(closure.parameters[0]);
@@ -262,13 +266,13 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
         }
 
         closure = this.find.findUnusedFields(closure);
-        if (!this.find.foundUnusedFields(1)) {
-            super.postorder(operator);
-            return;
-        }
-
         int size = closure.getType().getToplevelFieldCount();
+
         if (operator.input().outputType().is(DBSPTypeZSet.class)) {
+            if (!this.find.foundUnusedFields(1)) {
+                super.postorder(operator);
+                return;
+            }
             RewriteFields rw = this.find.getFieldRewriter(1);
             FieldUseMap fm = rw.getUseMap(closure.parameters[0]);
             DBSPClosureExpression compressed = rw.rewriteClosure(closure);
@@ -287,6 +291,10 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
                     operator.getRelNode(), compressed, operator.getOutputIndexedZSetType(), adjust.outputPort());
             this.map(operator, result);
         } else {
+            if (!this.find.foundUnusedFields(2)) {
+                super.postorder(operator);
+                return;
+            }
             // closure = compressed \circ projection
             RewriteFields rw = this.find.getFieldRewriter(2);
             FieldUseMap fm = rw.getUseMap(closure.parameters[0]);


### PR DESCRIPTION
In the INTERNED PR #4245 we have fixed a bug in a method related to unused field detection: https://github.com/feldera/feldera/pull/4245/files#diff-40713b22f9615bf15b15c6bce9e96efc46326e1634a9d4ab23579edc22b3a397

The bug was genuine, but it was masking another bug: we were not looking for enough unused fields. This has caused a regression for some programs with unused fields.

This PR fixes the regression by looking for the right unused fields; I have checked with some test programs that the same output is produced as with the previous version of the code.