### PR TITLE
[fxp] Set version in top-level Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ fastbloom = "0.8.0"
 fdlimit = "0.3.0"
 feldera-adapterlib = { path = "crates/adapterlib" }
 feldera-datagen = { path = "crates/datagen" }
-feldera-fxp = { path = "crates/fxp", features = ["dbsp"] }
+feldera-fxp = { version = "0.107.0", path = "crates/fxp", features = ["dbsp"] }
 feldera-iceberg = { path = "crates/iceberg" }
 feldera-sqllib = { path = "crates/sqllib" }
 feldera-storage = { version = "0.107.0", path = "crates/storage" }


### PR DESCRIPTION
Should fix this error from cargo publish:

```
    Uploaded feldera-fxp v0.106.0 to registry `crates-io`
note: waiting for `feldera-fxp v0.106.0` to be available at registry `crates-io`.
You may press ctrl-c to skip waiting; the crate should be available shortly.
   Published feldera-fxp v0.106.0 at registry `crates-io`
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `feldera-fxp` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```