### PR TITLE
[pipeline-manager] Allow storage options to change without clearing s…

### DIFF
--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -565,9 +565,6 @@ pub(crate) async fn update_pipeline(
             if runtime_config.get("workers") != current.runtime_config.get("workers") {
                 not_allowed.push("`runtime_config.workers`");
             }
-            if runtime_config.get("storage") != current.runtime_config.get("storage") {
-                not_allowed.push("`runtime_config.storage`");
-            }
             if runtime_config.get("fault_tolerance")
                 != current.runtime_config.get("fault_tolerance")
             {


### PR DESCRIPTION
…torage.

Until now, the pipeline-manager hasn't allowed storage options to change without clearing storage, but this is unnecessarily restrictive:

* Pipelines fully support changes to min_storage_bytes, min_step_storage_bytes, compression, and cache_mib.

* It's reasonable to change from one storage backend to another if work has been done to copy files around.  Switching from "default" to "file" is also reasonable if one wants to configure some settings (they both use the same backend code).

* Given the file backend, the pipeline fully supports changing all of its options from one run to another.

* Given the object storage backend, it totally makes sense to change its options from one run to another if there's some reason to do so; for example, the necessary authorization might have changed.

Thus, one could nitpick, but I don't see a reason to restrict this, and in particular adding or changing the sync-to-s3 options for a pipeline (under `FileBackend::sync`) make a lot of sense for either taking a local pipeline and setting up sync for it, or taking a synced pipeline and configuring it to start from a synced checkpoint.