### PR TITLE
pipeline-manager: automaton and runner fixes

### DIFF
--- a/crates/pipeline-manager/src/runner/main.rs
+++ b/crates/pipeline-manager/src/runner/main.rs
@@ -9,7 +9,7 @@ use crate::error::ManagerError;
 use crate::runner::error::RunnerError;
 use crate::runner::pipeline_automata::PipelineAutomaton;
 use crate::runner::pipeline_executor::PipelineExecutor;
-use crate::runner::pipeline_logs::LogMessage;
+use crate::runner::pipeline_logs::{LogMessage, LogsSender};
 use actix_web::HttpResponse;
 use actix_web::Responder;
 use actix_web::{get, web, HttpRequest, HttpServer};
@@ -237,7 +237,8 @@ async fn reconcile<E: PipelineExecutor + 'static>(
                             let (follow_request_sender, follow_request_receiver) =
                                 channel::<Sender<String>>(MAXIMUM_OUTSTANDING_LOG_FOLLOW_REQUESTS);
                             let (logs_sender, logs_receiver) =
-                                channel::<LogMessage>(MAXIMUM_OUTSTANDING_LOG_FOLLOW_REQUESTS);
+                                channel::<LogMessage>(MAXIMUM_BUFFERED_LINES_PER_FOLLOWER);
+                            let logs_sender = LogsSender::new(logs_sender);
                             let pipeline_handle = E::new(
                                 pipeline_id,
                                 common_config.clone(),

--- a/crates/pipeline-manager/src/runner/pipeline_executor.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_executor.rs
@@ -2,11 +2,10 @@ use crate::config::CommonConfig;
 use crate::db::types::pipeline::PipelineId;
 use crate::db::types::version::Version;
 use crate::error::ManagerError;
-use crate::runner::pipeline_logs::LogMessage;
+use crate::runner::pipeline_logs::LogsSender;
 use async_trait::async_trait;
 use feldera_types::config::{PipelineConfig, StorageConfig};
 use std::time::Duration;
-use tokio::sync::mpsc;
 
 /// Trait to be implemented by any pipeline runner.
 /// The `PipelineAutomaton` invokes these methods per pipeline.
@@ -24,7 +23,7 @@ pub trait PipelineExecutor: Sync + Send {
         common_config: CommonConfig,
         config: Self::Config,
         client: reqwest::Client,
-        logs_sender: mpsc::Sender<LogMessage>,
+        logs_sender: LogsSender,
     ) -> Self;
 
     /// Generates the storage configuration of the pipeline if storage is enabled.


### PR DESCRIPTION
- Wrap sending logs messages in function that writes in the regular logs when the receiver buffer is full and retries a set number of times, rather than simply blocking without writing anything to regular logs
- Fix logs buffer size
- Increase request timeout of `/suspend` from 5s to 600s
- Documentation fixes