### PR TITLE
[adapters] Name all spawned threads.

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -343,9 +343,10 @@ pub fn run_server(
     // will create a `Controller` instance and store it in `state.controller`.
     {
         let config = config.clone();
-        thread::spawn(move || {
-            bootstrap(args, config, circuit_factory, state_clone, loginit_sender)
-        });
+        thread::Builder::new()
+            .name("pipeline-init".to_string())
+            .spawn(move || bootstrap(args, config, circuit_factory, state_clone, loginit_sender))
+            .expect("failed to spawn pipeline initialization thread");
         let _ = loginit_receiver.recv();
     }
 

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -514,7 +514,7 @@ mod test {
         // its socket address as `addr`.
         let (sender, receiver) = channel();
         thread::Builder::new()
-            .name(format!("url-connector-test"))
+            .name("url-connector-test".to_string())
             .spawn(move || {
                 System::new().block_on(async {
                     let server = HttpServer::new(move || {


### PR DESCRIPTION
Make sure that all threads we spawn are assigned names to help debug panics and crashes. The next step would be adding endpoint name to thread name (we currently only do this for the delta connector).