### PR TITLE
[fda] Add `metrics` command for retrieving metrics.

### DIFF
--- a/crates/fda/src/adhoc.rs
+++ b/crates/fda/src/adhoc.rs
@@ -153,6 +153,10 @@ pub(crate) async fn handle_adhoc_query(
         }
         OutputFormat::ArrowIpc => AdHocResultFormat::ArrowIpc,
         OutputFormat::Parquet => AdHocResultFormat::Parquet,
+        OutputFormat::Prometheus => {
+            eprintln!("`query` command does not support Prometheus output format");
+            std::process::exit(1);
+        }
     };
     let sql = sql.unwrap_or_else(|| {
         if stdin {

--- a/crates/fda/src/bench/mod.rs
+++ b/crates/fda/src/bench/mod.rs
@@ -324,7 +324,7 @@ impl Benchmark {
         match format {
             OutputFormat::Json => serde_json::to_string_pretty(&self.as_map()).unwrap(),
             OutputFormat::Text => self.format_as_text(),
-            OutputFormat::ArrowIpc | OutputFormat::Parquet => {
+            OutputFormat::ArrowIpc | OutputFormat::Parquet | OutputFormat::Prometheus => {
                 warn!("Format '{}' is not supported for benchmark results, falling back to text format", format);
                 self.format_as_text()
             }

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -112,6 +112,10 @@ pub enum OutputFormat {
     ///
     /// This format can only be specified for SQL queries.
     Parquet,
+    /// Returns the output in Prometheus format.
+    ///
+    /// This format can only be specified for the `metrics` command.
+    Prometheus,
 }
 
 impl Display for OutputFormat {
@@ -121,6 +125,7 @@ impl Display for OutputFormat {
             OutputFormat::Json => "json",
             OutputFormat::ArrowIpc => "arrow_ipc",
             OutputFormat::Parquet => "parquet",
+            OutputFormat::Prometheus => "prometheus",
         };
         write!(f, "{}", output)
     }
@@ -353,6 +358,14 @@ pub enum PipelineAction {
     /// Retrieve the runtime statistics of a pipeline.
     #[clap(aliases = &["statistics"])]
     Stats {
+        /// The name of the pipeline.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        name: String,
+    },
+    /// Retrieve the pipeline metrics.
+    ///
+    /// Metrics are available in `json` and `prometheus` output formats.
+    Metrics {
         /// The name of the pipeline.
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
         name: String,

--- a/crates/fda/src/shell.rs
+++ b/crates/fda/src/shell.rs
@@ -153,6 +153,7 @@ pub async fn shell(format: OutputFormat, name: String, client: Client) {
                                 OutputFormat::Json => "json",
                                 OutputFormat::ArrowIpc => "arrow",
                                 OutputFormat::Parquet => "parquet",
+                                OutputFormat::Prometheus => "prometheus",
                             };
                             match client
                                 .pipeline_adhoc_sql()

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -522,7 +522,7 @@ pub(crate) async fn get_pipeline_stats(
     responses(
         (status = OK
             , description = "Pipeline circuit metrics retrieved successfully"
-            , body = Object),
+            , body = Vec<u8>),
         (status = NOT_FOUND
             , description = "Pipeline with that name does not exist"
             , body = ErrorResponse

--- a/openapi.json
+++ b/openapi.json
@@ -2606,9 +2606,10 @@
           "200": {
             "description": "Pipeline circuit metrics retrieved successfully",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }


### PR DESCRIPTION
This required updating the definition of the pipeline metrics API at the pipeline manager, since it defined /metrics to return JSON but that's not always the case.