### PR TITLE
[adapters] Fix nexmark input connector resume from checkpoint.

### DIFF
--- a/crates/adapters/src/transport/nexmark.rs
+++ b/crates/adapters/src/transport/nexmark.rs
@@ -76,7 +76,9 @@ impl InputGenerator {
         parser: Box<dyn Parser>,
         resume_info: Option<serde_json::Value>,
     ) -> AnyResult<Self> {
-        let resume_info = if let Some(resume_info) = resume_info {
+        let resume_info = if config.table != NexmarkTable::Bid {
+            None
+        } else if let Some(resume_info) = resume_info {
             Some(parse_resume_info::<Metadata>(&resume_info)?)
         } else {
             None


### PR DESCRIPTION
Commit 6f345f03a925 ("[adapters] Provide resume info on initialization.") broke resume for the nexmark connector, because only one of the nexmark tables (Bid) writes nonempty resume info, but the commit tried to parse it from the other tables too.  This fixes the problem by ignoring resume info except on Bid.