### PR TITLE
Properly feature gate `runtime_version` setting.

### DIFF
--- a/crates/adapters/build.rs
+++ b/crates/adapters/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=FELDERA_RUNTIME_OVERRIDE");
+    Ok(())
+}

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -653,6 +653,12 @@ fn do_bootstrap(
     *state.controller.write().unwrap() = Some(controller);
 
     info!("Pipeline initialization complete");
+    if let Some(runtime_override) = option_env!("FELDERA_RUNTIME_OVERRIDE") {
+        warn!(
+            "Pipeline runtime version was overridden and does not match platform version: {}",
+            runtime_override
+        );
+    }
     *state.phase.write().unwrap() = PipelinePhase::InitializationComplete;
 
     Ok(())

--- a/crates/pipeline-manager/src/api/endpoints/config.rs
+++ b/crates/pipeline-manager/src/api/endpoints/config.rs
@@ -7,6 +7,7 @@ use crate::api::error::ApiError;
 use crate::api::main::ServerState;
 use crate::error::ManagerError;
 use crate::license::{DisplaySchedule, LicenseValidity, LICENSE_INFO_READ_LOCK_TIMEOUT};
+use crate::unstable_features;
 
 #[derive(Serialize, ToSchema)]
 pub(crate) struct UpdateInformation {
@@ -72,6 +73,8 @@ pub(crate) struct Configuration {
     pub revision: String,
     /// Specific revision corresponding to the default runtime version of the platform (e.g., git commit hash).
     pub runtime_revision: String,
+    /// List of unstable features that are enabled.
+    pub unstable_features: Option<String>,
     /// URL that navigates to the changelog of the current version
     pub changelog_url: String,
     /// Information about the checked Enterprise license
@@ -144,6 +147,8 @@ pub(crate) async fn get_config(
         version: version.clone(),
         revision: revision.to_string(),
         runtime_revision: runtime_revision.to_string(),
+        unstable_features: unstable_features()
+            .map(|features| features.iter().cloned().collect::<Vec<&str>>().join(",")),
         changelog_url: if cfg!(feature = "feldera-enterprise") {
             "https://docs.feldera.com/changelog/".to_string()
         } else {

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -7,6 +7,7 @@ use crate::db::storage_postgres::StoragePostgres;
 use crate::error::ManagerError;
 use crate::license::LicenseCheck;
 use crate::runner::interaction::RunnerInteraction;
+use crate::unstable_features;
 use actix_http::body::BoxBody;
 use actix_http::StatusCode;
 use actix_web::body::MessageBody;
@@ -527,7 +528,7 @@ Web console URL: {}
 API server URL: {}
 Documentation: https://docs.feldera.com/
 Version: {} v{}{}
-        ",
+",
             url,
             url,
             if cfg!(feature = "feldera-enterprise") {
@@ -540,10 +541,16 @@ Version: {} v{}{}
                 "".to_string()
             } else {
                 format!(" ({})", env!("FELDERA_PLATFORM_VERSION_SUFFIX"))
-            }
+            },
         )
         .as_bytes(),
     );
+    if let Some(features) = unstable_features() {
+        println!(
+            "Unstable Features: {}",
+            features.iter().cloned().collect::<Vec<&str>>().join(", ")
+        );
+    }
     drop(out_lock);
     drop(err_lock);
 

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -721,6 +721,7 @@ mod test {
             runner_port: 8089,
             platform_version: "v0".to_string(),
             http_workers: 1,
+            unstable_features: None,
         };
 
         let manager_config = ApiServerConfig {

--- a/crates/pipeline-manager/src/bin/pipeline-manager.rs
+++ b/crates/pipeline-manager/src/bin/pipeline-manager.rs
@@ -14,7 +14,7 @@ use pipeline_manager::config::{
 use pipeline_manager::db::storage_postgres::StoragePostgres;
 use pipeline_manager::runner::local_runner::LocalRunner;
 use pipeline_manager::runner::main::runner_main;
-use pipeline_manager::{ensure_default_crypto_provider, init_fd_limit};
+use pipeline_manager::{ensure_default_crypto_provider, init_fd_limit, platform_enable_unstable};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use utoipa::OpenApi;
@@ -40,6 +40,9 @@ async fn main() -> anyhow::Result<()> {
     let common_config = CommonConfig::from_arg_matches(&matches)
         .map_err(|err| err.exit())
         .unwrap();
+    if let Some(features) = &common_config.unstable_features {
+        platform_enable_unstable(features);
+    }
     #[cfg(feature = "postgresql_embedded")]
     let pg_embed_config = PgEmbedConfig::from_arg_matches(&matches)
         .map_err(|err| err.exit())

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -42,6 +42,7 @@ impl CompilerTest {
             runner_port: 8089,
             platform_version: platform_version.to_string(),
             http_workers: 1,
+            unstable_features: None,
         };
         let compiler_config = CompilerConfig {
             sql_compiler_path:

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -217,6 +217,15 @@ pub struct CommonConfig {
     /// - `1500m` -> 1 thread
     #[arg(verbatim_doc_comment, long, default_value_t = default_http_workers(), env = "FELDERA_HTTP_WORKERS", value_parser = cpu_quantity_to_workers)]
     pub http_workers: usize,
+
+    /// Enable experimental platform features.
+    ///
+    /// These features are not yet stable and may change or be removed in the future.
+    ///
+    /// Currently supported features:
+    /// - `runtime_version`: Allows to override the runtime version of a pipeline on the platform.
+    #[arg(verbatim_doc_comment, long, env = "FELDERA_UNSTABLE_FEATURES")]
+    pub unstable_features: Option<String>,
 }
 
 /// Embedded Postgres configuration.

--- a/crates/pipeline-manager/src/lib.rs
+++ b/crates/pipeline-manager/src/lib.rs
@@ -1,5 +1,7 @@
-use log::debug;
+use log::{debug, warn};
 use rustls::crypto::CryptoProvider;
+use std::collections::HashSet;
+use std::sync::OnceLock;
 
 mod auth;
 
@@ -12,6 +14,38 @@ pub mod error;
 pub mod license;
 pub mod logging;
 pub mod runner;
+
+/// Feature gate for new/unstable features that aren't rolled out or will change
+/// substantially in the future.
+static UNSTABLE_FEATURES: OnceLock<HashSet<&'static str>> = OnceLock::new();
+
+/// Initialization function to set the platform's unstable feature gate.
+pub fn platform_enable_unstable(requested_features: &str) {
+    let all_features: HashSet<&'static str> = HashSet::from_iter(vec!["runtime_version"]);
+    let mut enabled = HashSet::new();
+    for requested_feature in requested_features.split(',') {
+        if let Some(supported_feature) = all_features.get(requested_feature) {
+            enabled.insert(*supported_feature);
+        } else {
+            warn!("Requested unstable feature '{requested_feature}' is not supported by the platform.");
+        }
+    }
+    UNSTABLE_FEATURES
+        .set(enabled)
+        .expect("UNSTABLE_FEATURES already initialized");
+}
+
+pub fn unstable_features() -> Option<&'static HashSet<&'static str>> {
+    UNSTABLE_FEATURES.get()
+}
+
+/// To query whether the platform enabled a certain unstable feature.
+pub fn has_unstable_feature(feature: &str) -> bool {
+    UNSTABLE_FEATURES
+        .get()
+        .map(|features| features.contains(feature))
+        .unwrap_or(false)
+}
 
 /// Some dependencies of this crate use the `rustls` library. This library has two features
 /// `ring` and `aws-lc-rs`. When both are enabled, the library requires a process-wide default

--- a/openapi.json
+++ b/openapi.json
@@ -4323,6 +4323,11 @@
             "type": "string",
             "description": "Telemetry key."
           },
+          "unstable_features": {
+            "type": "string",
+            "description": "List of unstable features that are enabled.",
+            "nullable": true
+          },
           "update_info": {
             "allOf": [
               {
@@ -6256,7 +6261,7 @@
           },
           "runtime_version": {
             "type": "string",
-            "description": "Override runtime version of the pipeline being executed.\n\nWarning: This option is experimental and may change in the future.\nShould only be used for CI/testing purposes, and requires network access.\n\nA runtime version can be specified in the form of a version\nor SHA taken from the `feldera/feldera` repository main branch.\n\nExamples: `v0.96.0` or `f4dcac0989ca0fda7d2eb93602a49d007cb3b0ae`\n\nA platform of version `0.x.y` may be capable of running future and past\nruntimes with versions `>=0.x.y` and `<=0.x.y` until breaking API changes happen,\nthe exact bounds for each platform version are unspecified until we reach a\nstable version. Compatibility is only guaranteed if platform and runtime version\nare exact matches.\n\nNote that any enterprise features are currently considered to be part of\nthe platform.\n\nIf not set (null), the runtime version will be the same as the platform version.",
+            "description": "Override runtime version of the pipeline being executed.\n\nWarning: This setting is experimental and may change in the future.\nRequires the platform to run with the unstable feature `runtime_version`\nenabled. Should only be used for testing purposes, and requires\nnetwork access.\n\nA runtime version can be specified in the form of a version\nor SHA taken from the `feldera/feldera` repository main branch.\n\nExamples: `v0.96.0` or `f4dcac0989ca0fda7d2eb93602a49d007cb3b0ae`\n\nA platform of version `0.x.y` may be capable of running future and past\nruntimes with versions `>=0.x.y` and `<=0.x.y` until breaking API changes happen,\nthe exact bounds for each platform version are unspecified until we reach a\nstable version. Compatibility is only guaranteed if platform and runtime version\nare exact matches.\n\nNote that any enterprise features are currently considered to be part of\nthe platform.\n\nIf not set (null), the runtime version will be the same as the platform version.",
             "default": null,
             "nullable": true
           }


### PR DESCRIPTION
This setting was disabled in the past, we bring it back in this PR, but only if it gets explicitly enabled by setting the `--unstable-features` CLI arg (which also got added to help add more gated features to the platform in the future).