### PR TITLE
sync: dont stop pipeline if pulling checkpoint fails

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -2199,7 +2199,7 @@ impl ControllerInit {
                         .pull(storage.backend.clone(), sync.to_owned())
                         .map_err(|e| ControllerError::checkpoint_fetch_error(e.to_string()))
                     {
-                        if sync.strict_start_from {
+                        if sync.fail_if_no_checkpoint {
                             return Err(err);
                         } else {
                             tracing::error!("{}", err.to_string())

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -397,7 +397,7 @@ pub struct SyncConfig {
     /// When set, the pipeline will try fetch the specified checkpoint from the
     /// object store.
     ///
-    /// If `strict_start_from` is `true`, the pipeline will fail to initialize.
+    /// If `fail_if_no_checkpoint` is `true`, the pipeline will fail to initialize.
     pub start_from_checkpoint: Option<StartFromCheckpoint>,
 
     /// When true, the pipeline will fail to initialize if fetching the
@@ -407,7 +407,7 @@ pub struct SyncConfig {
     /// False by default.
     #[schema(default = std::primitive::bool::default)]
     #[serde(default)]
-    pub strict_start_from: bool,
+    pub fail_if_no_checkpoint: bool,
 
     /// The number of file transfers to run in parallel.
     /// Default: 20

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -26,7 +26,7 @@ Here is a sample configuration:
         "access_key": "ACCESS_KEY",
         "secret_key": "SECRET_KEY",
         "start_from_checkpoint": "latest",
-        "strict_start_from": false,
+        "fail_if_no_checkpoint": false,
         "flags": ["--s3-server-side-encryption", "aws:kms"]
       }
     }
@@ -45,7 +45,7 @@ Here is a sample configuration:
 | `access_key`            | `string`        |             | S3 access key. Not required if using environment-based auth (e.g., IRSA).                                                                                                                                        |
 | `secret_key`            | `string`        |             | S3 secret key. Not required if using environment-based auth.                                                                                                                                                     |
 | `start_from_checkpoint` | `string`        |             | Checkpoint UUID to resume from, or `latest` to restore from the latest checkpoint.                                                                                                                               |
-| `strict_start_from`     | `boolean`       | `false`     | When `true` the pipeline will fail to initialize if fetching the specified checkpoint fails. <p> When `false`, the pipeline will start from scratch instead. Ignored if `start_from_checkpoint` is not set. </p> |
+| `fail_if_no_checkpoint` | `boolean`       | `false`     | When `true` the pipeline will fail to initialize if fetching the specified checkpoint fails. <p> When `false`, the pipeline will start from scratch instead. Ignored if `start_from_checkpoint` is not set. </p> |
 | `transfers`             | `integer (u8)`  | `20`        | Number of concurrent file transfers.                                                                                                                                                                             |
 | `checkers`              | `integer (u8)`  | `20`        | Number of parallel checkers for verification.                                                                                                                                                                    |
 | `ignore_checksum`       | `boolean`       | `false`     | Skip checksum verification after transfer and only check the file size. Might improve throughput.                                                                                                                |

--- a/openapi.json
+++ b/openapi.json
@@ -7441,6 +7441,11 @@
             "description": "The endpoint URL for the storage service.\n\nThis is typically required for custom or local S3-compatible storage providers like MinIO.\nExample: `http://localhost:9000`\n\nRelevant rclone config key: [`endpoint`](https://rclone.org/s3/#s3-endpoint)",
             "nullable": true
           },
+          "fail_if_no_checkpoint": {
+            "type": "boolean",
+            "description": "When true, the pipeline will fail to initialize if fetching the\nspecified checkpoint fails (missing, download error).\nWhen false, the pipeline will start from scratch instead.\n\nFalse by default.",
+            "default": false
+          },
           "flags": {
             "type": "array",
             "items": {
@@ -7488,11 +7493,6 @@
               }
             ],
             "nullable": true
-          },
-          "strict_start_from": {
-            "type": "boolean",
-            "description": "When true, the pipeline will fail to initialize if fetching the\nspecified checkpoint fails (missing, download error).\nWhen false, the pipeline will start from scratch instead.\n\nFalse by default.",
-            "default": false
           },
           "transfers": {
             "type": "integer",

--- a/python/tests/test_shared_pipeline1.py
+++ b/python/tests/test_shared_pipeline1.py
@@ -33,7 +33,7 @@ def storage_cfg(
                     "provider": "Minio",
                     "endpoint": endpoint or DEFAULT_ENDPOINT,
                     "start_from_checkpoint": start_from_checkpoint,
-                    "strict_start_from": strict,
+                    "fail_if_no_checkpoint": strict,
                 }
             },
         }


### PR DESCRIPTION
Introduces a new config flag `strict_start_from`, that determines if the pipeline starts from scratch or fails when pulling the checkpoint specified by `start_from_checkpoint` fails.

When `start_from_checkpoint` is set, and `strict_start_from` is `true`, the pipeline will fail if the checkpoint doesn't exist, there is an auth error or just downloading the checkpoint fails. If `strict_start_from` is `false` (default), pipeline will log this error and start from scratch.