### PR TITLE
[pipeline-manager] Eliminate unnecessary I/O.

### DIFF
--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -73,8 +73,7 @@ pub async fn rust_compiler_task(
         let mut unexpected_error = false;
 
         // Clean up
-        if last_cleanup.is_none() || last_cleanup.is_some_and(|ts| ts.elapsed() >= CLEANUP_INTERVAL)
-        {
+        if last_cleanup.is_none_or(|ts| ts.elapsed() >= CLEANUP_INTERVAL) {
             if let Err(e) = cleanup_rust_compilation(&config, db.clone()).await {
                 match e {
                     RustCompilationCleanupError::Database(e) => {


### PR DESCRIPTION
The pipeline manager was issuing up to 3 `stat` system calls per directory entry, instead of 0.  It was showing up in `samply` traces of an idle pipeline manager for me.

Bonus minor logic simplification in rust_compiler_task.

(I was trying to track down why the pipeline manager sometimes used a lot of CPU when it should be.  This isn't that, but it's still nice.)
