### PR TITLE
[python] Use FELDERA_HOST instead of FELDERA_BASE_URL for tests.

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -187,7 +187,7 @@ jobs:
         run: uv run --locked pytest . --timeout=600
         working-directory: python
         env:
-          FELDERA_BASE_URL: http://localhost:8080
+          FELDERA_HOST: http://localhost:8080
           IN_CI: 1 # We use this flag to skip some kafka tests in the python code base
 
       - name: Run python tests
@@ -195,5 +195,5 @@ jobs:
         run: uv run --locked ./tests/run-all-tests.sh
         working-directory: python
         env:
-          FELDERA_BASE_URL: http://localhost:8080
+          FELDERA_HOST: http://localhost:8080
           PYTHONPATH: ${{ github.workspace }}/python

--- a/python/README.md
+++ b/python/README.md
@@ -61,7 +61,7 @@ cd python && python3 -m pytest tests/
 - This will detect and run all test files that match the pattern `test_*.py` or
   `*_test.py`.
 - By default, the tests expect a running Feldera instance at `http://localhost:8080`.
-  To override the default endpoint, set the `FELDERA_BASE_URL` environment variable.
+  To override the default endpoint, set the `FELDERA_HOST` environment variable.
 
 To run tests from a specific file:
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -3,7 +3,11 @@ import os
 import unittest
 
 API_KEY = os.environ.get("FELDERA_API_KEY")
-BASE_URL = os.environ.get("FELDERA_BASE_URL", "http://localhost:8080")
+BASE_URL = (
+    os.environ.get("FELDERA_BASE_URL")  # deprecated
+    or os.environ.get("FELDERA_HOST")
+    or "http://localhost:8080"
+)
 KAFKA_SERVER = os.environ.get("FELDERA_KAFKA_SERVER", "localhost:19092")
 PIPELINE_TO_KAFKA_SERVER = os.environ.get(
     "FELDERA_PIPELINE_TO_KAFKA_SERVER", "redpanda:9092"

--- a/python/tests/integration_tests/util.py
+++ b/python/tests/integration_tests/util.py
@@ -10,7 +10,11 @@ from feldera.runtime_config import RuntimeConfig
 
 
 API_KEY = os.environ.get("FELDERA_API_KEY")
-BASE_URL = os.environ.get("FELDERA_BASE_URL", "http://localhost:8080")
+BASE_URL = (
+    os.environ.get("FELDERA_BASE_URL")  # deprecated
+    or os.environ.get("FELDERA_HOST")
+    or "http://localhost:8080"
+)
 TEST_CLIENT = FelderaClient(BASE_URL, api_key=API_KEY)
 
 


### PR DESCRIPTION
This leaves vestigial FELDERA_BASE_URL support until dependents can be updated.

Fixes https://github.com/feldera/feldera/issues/4484.
