### PR TITLE
[types] Support fractional CPUs.

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -55,7 +55,7 @@ pub const DEFAULT_CLOCK_RESOLUTION_USECS: u64 = 1_000_000;
 /// (e.g., runtime configuration) and entries derived from the schema
 /// of the compiled program (e.g., connectors). Storage configuration,
 /// if applicable, is set by the runner.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub struct PipelineConfig {
     /// Global controller configuration.
     #[serde(flatten)]
@@ -538,7 +538,7 @@ pub struct FileBackendConfig {
 
 /// Global pipeline configuration settings. This is the publicly
 /// exposed type for users to configure pipelines.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(default)]
 pub struct RuntimeConfig {
     /// Number of DBSP worker threads.
@@ -1365,16 +1365,16 @@ pub struct FormatConfig {
     pub config: YamlValue,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, ToSchema)]
 #[serde(default)]
 pub struct ResourceConfig {
     /// The minimum number of CPU cores to reserve
     /// for an instance of this pipeline
-    pub cpu_cores_min: Option<u64>,
+    pub cpu_cores_min: Option<f64>,
 
     /// The maximum number of CPU cores to reserve
     /// for an instance of this pipeline
-    pub cpu_cores_max: Option<u64>,
+    pub cpu_cores_max: Option<f64>,
 
     /// The minimum memory in Megabytes to reserve
     /// for an instance of this pipeline

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -67,7 +67,7 @@ fn remove_large_fields_from_program_info(
 
 /// Pipeline information.
 /// It both includes fields which are user-provided and system-generated.
-#[derive(Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
+#[derive(Serialize, ToSchema, PartialEq, Debug, Clone)]
 pub struct PipelineInfo {
     pub id: PipelineId,
     pub name: String,
@@ -160,7 +160,7 @@ impl PipelineInfoInternal {
 /// Pipeline information which has a selected subset of optional fields.
 /// It both includes fields which are user-provided and system-generated.
 /// If an optional field is not selected (i.e., is `None`), it will not be serialized.
-#[derive(Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
+#[derive(Serialize, ToSchema, PartialEq, Debug, Clone)]
 pub struct PipelineSelectedInfo {
     pub id: PipelineId,
     pub name: String,

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -223,7 +223,7 @@ pub(crate) fn limited_uuid() -> impl Strategy<Value = Uuid> {
 type PipelineNamePropVal = u8;
 // This had to be a struct because there is a limit on the number
 // of tuple fields for the automatic implementation of Arbitrary.
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 struct RuntimeConfigPropVal {
     invalid0: u8,
@@ -234,8 +234,8 @@ struct RuntimeConfigPropVal {
     val4: bool,
     val5: bool,
     val6: String,
-    val7: Option<u64>,
-    val8: Option<u64>,
+    val7: Option<f64>,
+    val8: Option<f64>,
     val9: Option<u64>,
     val10: Option<u64>,
     val11: Option<u64>,

--- a/crates/pipeline-manager/tests/integration_test.rs
+++ b/crates/pipeline-manager/tests/integration_test.rs
@@ -473,7 +473,7 @@ async fn pipeline_runtime_config() {
             serde_json::to_value(RuntimeConfig {
                 workers: 100,
                 resources: ResourceConfig {
-                    cpu_cores_min: Some(5),
+                    cpu_cores_min: Some(5.0),
                     storage_mb_max: Some(2000),
                     storage_class: Some("normal".to_string()),
                     ..Default::default()
@@ -539,7 +539,7 @@ async fn pipeline_runtime_config() {
             workers: 100,
             storage: Some(StorageOptions::default()),
             resources: ResourceConfig {
-                cpu_cores_min: Some(2),
+                cpu_cores_min: Some(2.0),
                 storage_mb_max: Some(500),
                 storage_class: Some("fast".to_string()),
                 ..Default::default()

--- a/openapi.json
+++ b/openapi.json
@@ -6743,20 +6743,18 @@
         "type": "object",
         "properties": {
           "cpu_cores_max": {
-            "type": "integer",
-            "format": "int64",
+            "type": "number",
+            "format": "double",
             "description": "The maximum number of CPU cores to reserve\nfor an instance of this pipeline",
             "default": null,
-            "nullable": true,
-            "minimum": 0
+            "nullable": true
           },
           "cpu_cores_min": {
-            "type": "integer",
-            "format": "int64",
+            "type": "number",
+            "format": "double",
             "description": "The minimum number of CPU cores to reserve\nfor an instance of this pipeline",
             "default": null,
-            "nullable": true,
-            "minimum": 0
+            "nullable": true
           },
           "memory_mb_max": {
             "type": "integer",


### PR DESCRIPTION
Basically nothing in the tree uses this, so it didn't require much change.

I had to remove some `Eq` and `Ord` derivations, but that broke nothing, so it seemed better than the alternatives.

I don't think this breaks anything.