### PR TITLE
[datagen] Use crossbeam::Parker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4709,6 +4709,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.3.1",
  "chrono",
+ "crossbeam",
  "dbsp",
  "fake",
  "feldera-adapterlib",

--- a/crates/datagen/Cargo.toml
+++ b/crates/datagen/Cargo.toml
@@ -29,3 +29,4 @@ async-channel = { workspace = true }
 range-set = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 uuid = { workspace = true, features = ["v4", "std"] }
+crossbeam = { workspace = true }

--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -442,18 +442,21 @@ impl InputGenerator {
             plan.fields = normalized_plan_names;
         }
 
-        let join_handle = std::thread::spawn(move || {
-            if let Err(error) = Self::datagen_thread(
-                command_receiver,
-                consumer.clone(),
-                parser,
-                config,
-                schema,
-                seek,
-            ) {
-                consumer.error(true, error);
-            }
-        });
+        let join_handle = std::thread::Builder::new()
+            .name("datagen".to_string())
+            .spawn(move || {
+                if let Err(error) = Self::datagen_thread(
+                    command_receiver,
+                    consumer.clone(),
+                    parser,
+                    config,
+                    schema,
+                    seek,
+                ) {
+                    consumer.error(true, error);
+                }
+            })
+            .expect("failed to spawn datagen thread");
         let datagen_thread = join_handle.thread().clone();
 
         Ok(Self {


### PR DESCRIPTION
Datagen used std::thread::park/unpark, which brittle and I believe I saw an instance where it caused datagen to get stuck. The problem is that if thread 1 calls `unpark` before thread 2 calls `park`, and there is another instance of `park` in thread 2 before it hits the `park` in question, including anywhere in a library, then the `unpark` will have no effect. The crossbeam parker doesn't have this issue.