### PR TITLE
py: add aditional aggregate tests

### DIFF
--- a/python/tests/aggregate_tests/test_arg_max.py
+++ b/python/tests/aggregate_tests/test_arg_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_int_arg_max(TstView):

--- a/python/tests/aggregate_tests/test_arg_min.py
+++ b/python/tests/aggregate_tests/test_arg_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_int_arg_min(TstView):

--- a/python/tests/aggregate_tests/test_decimal_arg_max.py
+++ b/python/tests/aggregate_tests/test_decimal_arg_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 from decimal import Decimal
 
 

--- a/python/tests/aggregate_tests/test_decimal_arg_min.py
+++ b/python/tests/aggregate_tests/test_decimal_arg_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 from decimal import Decimal
 
 

--- a/python/tests/aggregate_tests/test_decimal_max.py
+++ b/python/tests/aggregate_tests/test_decimal_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 from decimal import Decimal
 
 

--- a/python/tests/aggregate_tests/test_decimal_min.py
+++ b/python/tests/aggregate_tests/test_decimal_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 from decimal import Decimal
 
 

--- a/python/tests/aggregate_tests/test_max.py
+++ b/python/tests/aggregate_tests/test_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_int_max(TstView):

--- a/python/tests/aggregate_tests/test_min.py
+++ b/python/tests/aggregate_tests/test_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_int_min(TstView):

--- a/python/tests/aggregate_tests/test_row_arg_max.py
+++ b/python/tests/aggregate_tests/test_row_arg_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_row_arg_max_value(TstView):

--- a/python/tests/aggregate_tests/test_row_arg_min.py
+++ b/python/tests/aggregate_tests/test_row_arg_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_row_arg_min_value(TstView):

--- a/python/tests/aggregate_tests/test_row_max.py
+++ b/python/tests/aggregate_tests/test_row_max.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_row_max_value(TstView):

--- a/python/tests/aggregate_tests/test_row_min.py
+++ b/python/tests/aggregate_tests/test_row_min.py
@@ -1,4 +1,4 @@
-from .aggtst_base import TstView
+from tests.aggregate_tests.aggtst_base import TstView
 
 
 class aggtst_row_min_value(TstView):

--- a/python/tests/aggregate_tests5/main.py
+++ b/python/tests/aggregate_tests5/main.py
@@ -1,0 +1,45 @@
+## Add here import statements for all files with tests
+
+from tests.aggregate_tests.aggtst_base import *  # noqa: F403
+from tests.aggregate_tests.atest_run import run  # noqa: F403
+from tests.aggregate_tests5.table import *  # noqa: F403
+from tests.aggregate_tests5.test_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_charn_argmax_append import *  # noqa: F403
+from tests.aggregate_tests5.test_charn_argmin_append import *  # noqa: F403
+from tests.aggregate_tests5.test_charn_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_charn_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_date_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_date_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_date_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_date_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_decimal_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_decimal_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_decimal_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_decimal_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_time_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_time_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_time_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_time_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_timestamp_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_timestamp_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_timestamp_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_timestamp_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varchar_argmax_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varchar_argmin_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varchar_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varchar_min_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varcharn_argmax_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varcharn_argmin_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varcharn_max_append import *  # noqa: F403
+from tests.aggregate_tests5.test_varcharn_min_append import *  # noqa: F403
+
+
+def main():
+    run("aggtst_", "aggregate_tests5")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/aggregate_tests5/table.py
+++ b/python/tests/aggregate_tests5/table.py
@@ -1,0 +1,209 @@
+from tests.aggregate_tests.aggtst_base import TstTable, TstView
+
+
+class aggtst_int0_table(TstTable):
+    def __init__(self):
+        self.sql = """CREATE TABLE int0_tbl(
+                      id INT NOT NULL,
+                      c1 TINYINT,
+                      c2 TINYINT NOT NULL,
+                      c3 INT2,
+                      c4 INT2 NOT NULL,
+                      c5 INT,
+                      c6 INT NOT NULL,
+                      c7 BIGINT,
+                      c8 BIGINT NOT NULL)WITH ('append_only' = 'true')"""
+
+        self.data = [
+            {
+                "id": 0,
+                "c1": 5,
+                "c2": 2,
+                "c3": None,
+                "c4": 4,
+                "c5": 5,
+                "c6": 6,
+                "c7": None,
+                "c8": 8,
+            },
+            {
+                "id": 1,
+                "c1": 4,
+                "c2": 3,
+                "c3": 4,
+                "c4": 6,
+                "c5": 2,
+                "c6": 3,
+                "c7": 4,
+                "c8": 2,
+            },
+            {
+                "id": 0,
+                "c1": None,
+                "c2": 2,
+                "c3": 3,
+                "c4": 2,
+                "c5": 3,
+                "c6": 4,
+                "c7": 3,
+                "c8": 3,
+            },
+            {
+                "id": 1,
+                "c1": None,
+                "c2": 5,
+                "c3": 6,
+                "c4": 2,
+                "c5": 2,
+                "c6": 1,
+                "c7": None,
+                "c8": 5,
+            },
+        ]
+
+
+class aggtst_decimal_table(TstTable):
+    """Define the table used by all decimal tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE decimal_tbl(
+                      id INT, c1 DECIMAL(6,2), c2 DECIMAL(6,2) NOT NULL
+                      )WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": 1111.52, "c2": 2231.90},
+            {"id": 0, "c1": None, "c2": 3802.71},
+            {"id": 1, "c1": 5681.08, "c2": 7689.88},
+            {"id": 1, "c1": 5681.08, "c2": 7335.88},
+        ]
+
+
+class aggtst_row_tbl(TstTable):
+    """Define the table used by the ROW tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE row_tbl(
+                      id INT,
+                      c1 INT NOT NULL,
+                      c2 VARCHAR,
+                      c3 VARCHAR)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": 4, "c2": None, "c3": "adios"},
+            {"id": 0, "c1": 3, "c2": "ola", "c3": "ciao"},
+            {"id": 1, "c1": 7, "c2": "hi", "c3": "hiya"},
+            {"id": 1, "c1": 2, "c2": "elo", "c3": "ciao"},
+            {"id": 1, "c1": 2, "c2": "elo", "c3": "ciao"},
+        ]
+
+
+class aggtst_varchar_table(TstTable):
+    """Define the table used by the varchar tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE varchar_tbl(
+                      id INT,
+                      c1 VARCHAR,
+                      c2 VARCHAR NULL)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": None, "c2": "abc   d"},
+            {"id": 0, "c1": "hello", "c2": "fred"},
+            {"id": 1, "c1": "@abc", "c2": "variable-length"},
+            {"id": 1, "c1": "hello", "c2": "exampl e"},
+        ]
+
+
+class aggtst_atbl_varcharn(TstView):
+    def __init__(self):
+        # Validated on Postgres
+        self.data = [
+            {"id": 0, "f_c1": None, "f_c2": "abc  "},
+            {"id": 0, "f_c1": "hello", "f_c2": "fred"},
+            {"id": 1, "f_c1": "@abc", "f_c2": "varia"},
+            {"id": 1, "f_c1": "hello", "f_c2": "examp"},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW atbl_varcharn AS SELECT
+                      id,
+                      CAST(c1 AS VARCHAR(5)) AS f_c1,
+                      CAST(c2 AS VARCHAR(5)) AS f_c2
+                      FROM varchar_tbl"""
+
+
+class aggtst_atbl_charn(TstView):
+    def __init__(self):
+        # Validated on Postgres
+        self.data = [
+            {"id": 0, "f_c1": None, "f_c2": "abc   d"},
+            {"id": 0, "f_c1": "hello  ", "f_c2": "fred   "},
+            {"id": 1, "f_c1": "@abc   ", "f_c2": "variabl"},
+            {"id": 1, "f_c1": "hello  ", "f_c2": "exampl "},
+        ]
+        self.sql = """CREATE MATERIALIZED VIEW atbl_charn AS SELECT
+                      id,
+                      CAST(c1 AS CHAR(7)) AS f_c1,
+                      CAST(c2 AS CHAR(7)) AS f_c2
+                      FROM varchar_tbl"""
+
+
+class aggtst_date_table(TstTable):
+    """Define the table used by DATE tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE date_tbl(
+                      id INT,
+                      c1 DATE NOT NULL,
+                      c2 DATE)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": "2014-11-05", "c2": "2024-12-05"},
+            {"id": 0, "c1": "2020-06-21", "c2": None},
+            {"id": 1, "c1": "2024-12-05", "c2": "2014-11-05"},
+            {"id": 1, "c1": "2020-06-21", "c2": "2023-02-26"},
+            {"id": 1, "c1": "1969-03-17", "c2": "2015-09-07"},
+        ]
+
+
+class aggtst_time_table(TstTable):
+    """Define the table used by the time tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE time_tbl(
+                      id INT,
+                      c1 TIME NOT NULL,
+                      c2 TIME)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": "08:30:00", "c2": "12:45:00"},
+            {"id": 0, "c1": "14:00:00", "c2": None},
+            {"id": 1, "c1": "09:15:00", "c2": "16:30:00"},
+            {"id": 1, "c1": "14:00:00", "c2": "18:00:00"},
+        ]
+
+
+class aggtst_timestamp_table(TstTable):
+    """Define the table used by the timestamp tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE timestamp_tbl(
+                      id INT,
+                      c1 TIMESTAMP NOT NULL,
+                      c2 TIMESTAMP)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": "2014-11-05 08:27:00", "c2": "2024-12-05 12:45:00"},
+            {"id": 0, "c1": "2020-06-21 14:00:00", "c2": None},
+            {"id": 1, "c1": "2024-12-05 09:15:00", "c2": "2014-11-05 16:30:00"},
+            {"id": 1, "c1": "2020-06-21 14:00:00", "c2": "2023-02-26 18:00:00"},
+        ]
+
+
+class aggtst_timestamp1_table(TstTable):
+    """Define the table used by some of the timestamp tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE timestamp1_tbl(
+                      id INT,
+                      c1 TIMESTAMP NOT NULL,
+                      c2 TIMESTAMP)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": "2014-11-05 08:27:00", "c2": "2024-12-05 12:45:00"},
+            {"id": 0, "c1": "2020-06-21 14:00:00", "c2": None},
+            {"id": 1, "c1": "2024-12-05 09:15:00", "c2": "2014-11-05 16:30:00"},
+            {"id": 1, "c1": "2020-06-21 14:00:00", "c2": "2023-02-26 18:00:00"},
+            {"id": 1, "c1": "1969-03-17 11:32:00", "c2": "2015-09-07 18:57:00"},
+        ]

--- a/python/tests/aggregate_tests5/test_arg_max_append.py
+++ b/python/tests/aggregate_tests5/test_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_arg_max.py

--- a/python/tests/aggregate_tests5/test_arg_min_append.py
+++ b/python/tests/aggregate_tests5/test_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_arg_min.py

--- a/python/tests/aggregate_tests5/test_charn_argmax_append.py
+++ b/python/tests/aggregate_tests5/test_charn_argmax_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_charn_argmax.py

--- a/python/tests/aggregate_tests5/test_charn_argmin_append.py
+++ b/python/tests/aggregate_tests5/test_charn_argmin_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_charn_argmin.py

--- a/python/tests/aggregate_tests5/test_charn_max_append.py
+++ b/python/tests/aggregate_tests5/test_charn_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_charn_max.py

--- a/python/tests/aggregate_tests5/test_charn_min_append.py
+++ b/python/tests/aggregate_tests5/test_charn_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_charn_min.py

--- a/python/tests/aggregate_tests5/test_date_arg_max_append.py
+++ b/python/tests/aggregate_tests5/test_date_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_date_arg_max.py

--- a/python/tests/aggregate_tests5/test_date_arg_min_append.py
+++ b/python/tests/aggregate_tests5/test_date_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_date_arg_min.py

--- a/python/tests/aggregate_tests5/test_date_max_append.py
+++ b/python/tests/aggregate_tests5/test_date_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_date_max.py

--- a/python/tests/aggregate_tests5/test_date_min_append.py
+++ b/python/tests/aggregate_tests5/test_date_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_date_min.py

--- a/python/tests/aggregate_tests5/test_decimal_arg_max_append.py
+++ b/python/tests/aggregate_tests5/test_decimal_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_decimal_arg_max.py

--- a/python/tests/aggregate_tests5/test_decimal_arg_min_append.py
+++ b/python/tests/aggregate_tests5/test_decimal_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_decimal_arg_min.py

--- a/python/tests/aggregate_tests5/test_decimal_max_append.py
+++ b/python/tests/aggregate_tests5/test_decimal_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_decimal_max.py

--- a/python/tests/aggregate_tests5/test_decimal_min_append.py
+++ b/python/tests/aggregate_tests5/test_decimal_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_decimal_min.py

--- a/python/tests/aggregate_tests5/test_max_append.py
+++ b/python/tests/aggregate_tests5/test_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_max.py

--- a/python/tests/aggregate_tests5/test_min_append.py
+++ b/python/tests/aggregate_tests5/test_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_min.py

--- a/python/tests/aggregate_tests5/test_time_arg_max_append.py
+++ b/python/tests/aggregate_tests5/test_time_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_time_arg_max.py

--- a/python/tests/aggregate_tests5/test_time_arg_min_append.py
+++ b/python/tests/aggregate_tests5/test_time_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_time_arg_min.py

--- a/python/tests/aggregate_tests5/test_time_max_append.py
+++ b/python/tests/aggregate_tests5/test_time_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_time_max.py

--- a/python/tests/aggregate_tests5/test_time_min_append.py
+++ b/python/tests/aggregate_tests5/test_time_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_time_min.py

--- a/python/tests/aggregate_tests5/test_timestamp_arg_max_append.py
+++ b/python/tests/aggregate_tests5/test_timestamp_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_timestamp_arg_max.py

--- a/python/tests/aggregate_tests5/test_timestamp_arg_min_append.py
+++ b/python/tests/aggregate_tests5/test_timestamp_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_timestamp_arg_min.py

--- a/python/tests/aggregate_tests5/test_timestamp_max_append.py
+++ b/python/tests/aggregate_tests5/test_timestamp_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_timestamp_max.py

--- a/python/tests/aggregate_tests5/test_timestamp_min_append.py
+++ b/python/tests/aggregate_tests5/test_timestamp_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_timestamp_min.py

--- a/python/tests/aggregate_tests5/test_varchar_argmax_append.py
+++ b/python/tests/aggregate_tests5/test_varchar_argmax_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varchar_argmax.py

--- a/python/tests/aggregate_tests5/test_varchar_argmin_append.py
+++ b/python/tests/aggregate_tests5/test_varchar_argmin_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varchar_argmin.py

--- a/python/tests/aggregate_tests5/test_varchar_max_append.py
+++ b/python/tests/aggregate_tests5/test_varchar_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varchar_max.py

--- a/python/tests/aggregate_tests5/test_varchar_min_append.py
+++ b/python/tests/aggregate_tests5/test_varchar_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varchar_min.py

--- a/python/tests/aggregate_tests5/test_varcharn_argmax_append.py
+++ b/python/tests/aggregate_tests5/test_varcharn_argmax_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varcharn_argmax.py

--- a/python/tests/aggregate_tests5/test_varcharn_argmin_append.py
+++ b/python/tests/aggregate_tests5/test_varcharn_argmin_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varcharn_argmin.py

--- a/python/tests/aggregate_tests5/test_varcharn_max_append.py
+++ b/python/tests/aggregate_tests5/test_varcharn_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varcharn_max.py

--- a/python/tests/aggregate_tests5/test_varcharn_min_append.py
+++ b/python/tests/aggregate_tests5/test_varcharn_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_varcharn_min.py

--- a/python/tests/aggregate_tests6/main.py
+++ b/python/tests/aggregate_tests6/main.py
@@ -1,0 +1,41 @@
+## Add here import statements for all files with tests
+
+from tests.aggregate_tests.aggtst_base import *  # noqa: F403
+from tests.aggregate_tests.atest_run import run  # noqa: F403
+from tests.aggregate_tests6.table import *  # noqa: F403
+from tests.aggregate_tests6.test_array_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_array_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_array_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_array_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_binary_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_binary_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_binary_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_binary_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_interval_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_interval_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_interval_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_interval_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_map_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_map_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_map_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_map_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_row_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_row_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_row_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_row_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_un_int_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_un_int_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_un_int_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_un_int_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_varbinary_arg_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_varbinary_arg_min_append import *  # noqa: F403
+from tests.aggregate_tests6.test_varbinary_max_append import *  # noqa: F403
+from tests.aggregate_tests6.test_varbinary_min_append import *  # noqa: F403
+
+
+def main():
+    run("aggtst_", "aggregate_tests6")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/aggregate_tests6/table.py
+++ b/python/tests/aggregate_tests6/table.py
@@ -1,0 +1,305 @@
+from tests.aggregate_tests.aggtst_base import TstTable, TstView
+
+
+class aggtst_interval_table(TstTable):
+    """Define the table used by the view atbl_interval"""
+
+    def __init__(self):
+        self.sql = """CREATE FUNCTION d()
+                      RETURNS TIMESTAMP NOT NULL AS
+                      CAST('1970-01-01 00:00:00' AS TIMESTAMP);
+
+                      CREATE TABLE interval_tbl(
+                      id INT NOT NULL,
+                      c1 TIMESTAMP,
+                      c2 TIMESTAMP,
+                      c3 TIMESTAMP)WITH ('append_only' = 'true')"""
+
+        self.data = [
+            {
+                "id": 0,
+                "c1": "2014-11-05 08:27:00",
+                "c2": "2024-12-05 12:45:00",
+                "c3": "2020-03-14 15:41:00",
+            },
+            {
+                "id": 0,
+                "c1": "2020-06-21 14:00:00",
+                "c2": "1970-01-01 14:33:00",
+                "c3": "2023-04-19 11:25:00",
+            },
+            {
+                "id": 1,
+                "c1": "1969-03-17 07:01:00",
+                "c2": "2015-09-07 01:20:00",
+                "c3": "1987-04-29 02:14:00",
+            },
+            {
+                "id": 1,
+                "c1": "2020-06-21 14:00:00",
+                "c2": "1970-01-01 14:33:00",
+                "c3": "2021-11-03 06:33:00",
+            },
+            {
+                "id": 1,
+                "c1": "2024-12-05 09:15:00",
+                "c2": "2014-11-05 16:30:00",
+                "c3": "2017-08-25 16:15:00",
+            },
+        ]
+
+
+class aggtst_atbl_interval_seconds(TstView):
+    """Define the view used by interval tests as input"""
+
+    def __init__(self):
+        # Result validation is not required for local views
+        self.data = []
+
+        self.sql = """CREATE LOCAL VIEW atbl_interval_seconds AS SELECT
+                      id,
+                      (c1 - c2)SECOND AS c1_minus_c2,
+                      (c2 - c1)SECOND AS c2_minus_c1,
+                      (c1 - c3)SECOND AS c1_minus_c3,
+                      (c3 - c1)SECOND AS c3_minus_c1,
+                      (c2 - c3)SECOND AS c2_minus_c3,
+                      (c3 - c2)SECOND AS c3_minus_c2
+                      FROM interval_tbl"""
+
+
+class aggtst_atbl_interval_months(TstView):
+    """Define the view used by interval tests as input"""
+
+    def __init__(self):
+        # Result validation is not required for local views
+        self.data = []
+
+        self.sql = """CREATE LOCAL VIEW atbl_interval_months AS SELECT
+                      id,
+                      (c1 - c2)MONTH AS c1_minus_c2,
+                      (c2 - c1)MONTH AS c2_minus_c1,
+                      (c1 - c3)MONTH AS c1_minus_c3,
+                      (c3 - c1)MONTH AS c3_minus_c1,
+                      (c2 - c3)MONTH AS c2_minus_c3,
+                      (c3 - c2)MONTH AS c3_minus_c2
+                      FROM interval_tbl"""
+
+
+# Equivalent SQL for Postgres
+
+# CREATE TABLE interval_tbl (
+#     id INT,
+#     c1 TIMESTAMPTZ NOT NULL,
+#     c2 TIMESTAMPTZ,
+#     c3 TIMESTAMPTZ
+# );
+
+# INSERT INTO interval_tbl (id, c1, c2, c3) VALUES
+# (0, '2014-11-05 08:27:00+00', '2024-12-05 12:45:00+00', '2020-03-14 15:41:00+00'),
+# (0, '2020-06-21 14:00:00+00', '1970-01-01 14:33:00+00', '2023-04-19 11:25:00+00'),
+# (1, '1969-03-17 07:01:00+00', '2015-09-07 01:20:00+00', '1987-04-29 02:14:00+00'),
+# (1, '2020-06-21 14:00:00+00', '1970-01-01 14:33:00+00', '2021-11-03 06:33:00+00'),
+# (1, '2024-12-05 09:15:00+00', '2014-11-05 16:30:00+00', '2017-08-25 16:15:00+00');
+
+# CREATE TABLE atbl_interval AS
+# SELECT
+#     id,
+#     (c1 - c2) AS c1_minus_c2,
+#     (c2 - c1) AS c2_minus_c1,
+#     (c1 - c3) AS c1_minus_c3,
+#     (c3 - c1) AS c3_minus_c1,
+#     (c2 - c3) AS c2_minus_c3,
+#     (c3 - c2) AS c3_minus_c2
+# FROM interval_tbl;
+
+# CREATE TABLE agg_view AS
+# SELECT
+#     aggregate(c1_minus_c2) AS f_c1,
+#     aggregate(c2_minus_c1) AS f_c2,
+#     aggregate(c1_minus_c3) AS f_c3,
+#     aggregate(c3_minus_c1) AS f_c4,
+#     aggregate(c2_minus_c3) AS f_c5,
+#     aggregate(c3_minus_c2) AS f_c6
+# FROM atbl_interval;
+
+# SELECT
+#     EXTRACT(EPOCH FROM f_c1) AS m_c1_seconds,
+#     EXTRACT(EPOCH FROM f_c2) AS m_c2_seconds,
+#     EXTRACT(EPOCH FROM f_c3) AS m_c3_seconds,
+#     EXTRACT(EPOCH FROM f_c4) AS m_c4_seconds,
+#     EXTRACT(EPOCH FROM f_c5) AS m_c5_seconds,
+#     EXTRACT(EPOCH FROM f_c6) AS m_c6_seconds
+# FROM agg_view;
+
+
+class aggtst_binary_table(TstTable):
+    """Define the table used by the binary tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE binary_tbl(
+                      id INT,
+                      c1 BINARY(4),
+                      c2 BINARY(4) NULL)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": [12, 22, 32], "c2": None},
+            {"id": 0, "c1": [23, 56, 33, 21], "c2": [55, 66, 77, 88]},
+            {"id": 1, "c1": [23, 56, 33, 21], "c2": [99, 20, 31, 77]},
+            {"id": 1, "c1": [49, 43, 84, 29], "c2": [32, 34, 22, 12]},
+        ]
+
+        # Equivalent SQL for Postgres
+
+        # CREATE TABLE binary_tbl (
+        #     id INT,
+        #     c1 BYTEA,
+        #     c2 BYTEA NULL
+        # );
+
+        # INSERT INTO binary_tbl (id, c1, c2) VALUES
+        #     (0, '\x0c1620', NULL),
+        #     (0, '\x17382115', '\x37424d58'),
+        #     (1, '\x17382115', '\x63141f4d'),
+        #     (1, '\x312b541d', '\x2022160c');
+
+
+class aggtst_unsigned_int_table(TstTable):
+    def __init__(self):
+        self.sql = """CREATE TABLE un_int_tbl(
+                      id INT NOT NULL,
+                      c1 TINYINT UNSIGNED,
+                      c2 TINYINT UNSIGNED NOT NULL,
+                      c3 SMALLINT UNSIGNED,
+                      c4 SMALLINT UNSIGNED NOT NULL,
+                      c5 INT UNSIGNED,
+                      c6 INT UNSIGNED NOT NULL,
+                      c7 BIGINT UNSIGNED,
+                      c8 BIGINT UNSIGNED NOT NULL)WITH ('append_only' = 'true')"""
+
+        self.data = [
+            {
+                "id": 0,
+                "c1": 72,
+                "c2": 64,
+                "c3": None,
+                "c4": 16002,
+                "c5": 781245123,
+                "c6": 651238977,
+                "c7": None,
+                "c8": 284792878783,
+            },
+            {
+                "id": 1,
+                "c1": 61,
+                "c2": 64,
+                "c3": 14257,
+                "c4": 15342,
+                "c5": 963218731,
+                "c6": 749321014,
+                "c7": 367192837461,
+                "c8": 265928374652,
+            },
+            {
+                "id": 0,
+                "c1": None,
+                "c2": 45,
+                "c3": 13450,
+                "c4": 14123,
+                "c5": 812347981,
+                "c6": 698123417,
+                "c7": 419283746512,
+                "c8": 283746512983,
+            },
+            {
+                "id": 1,
+                "c1": None,
+                "c2": 48,
+                "c3": 12876,
+                "c4": 13532,
+                "c5": 709123456,
+                "c6": 786452310,
+                "c7": None,
+                "c8": 274839201928,
+            },
+        ]
+
+
+class aggtst_varbinary_table(TstTable):
+    """Define the table used by the varbinary tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE varbinary_tbl(
+                      id INT,
+                      c1 VARBINARY,
+                      c2 VARBINARY NULL)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": [12, 22, 32], "c2": None},
+            {"id": 0, "c1": [23, 56, 33, 21], "c2": [55, 66, 77, 88]},
+            {"id": 1, "c1": [23, 56, 33, 21], "c2": [99, 20, 31, 77]},
+            {"id": 1, "c1": [49, 43, 84, 29, 11], "c2": [32, 34]},
+        ]
+
+        # Equivalent SQL for Postgres
+
+        # CREATE TABLE varbinary_tbl (
+        #     id INT,
+        #     c1 BYTEA,
+        #     c2 BYTEA NULL
+        # );
+
+        # INSERT INTO varbinary_tbl (id, c1, c2) VALUES
+        #     (0, '\x0c1620', NULL),
+        #     (0, '\x17382115', '\x37424d58'),
+        #     (1, '\x17382115', '\x63141f4d'),
+        #     (1, '\x312b541d0b', '\x2022');
+
+
+class aggtst_array_tbl(TstTable):
+    """Define the table used by the array tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE array_tbl(
+                      id INT,
+                      c1 INT ARRAY NOT NULL,
+                      c2 INT ARRAY,
+                      c3 MAP<VARCHAR, INT> ARRAY)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": [12, 22], "c2": None, "c3": [{"a": 5, "b": 66}]},
+            {"id": 0, "c1": [23, 56, 16], "c2": [55, 66, None], "c3": [{"c": 2}]},
+            {"id": 1, "c1": [23, 56, 16], "c2": [99], "c3": None},
+            {"id": 1, "c1": [49], "c2": [32, 34, 22, 12], "c3": [{"x": 1}]},
+        ]
+
+
+class aggtst_map_tbl(TstTable):
+    """Define the table used by the MAP tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE map_tbl(
+                      id INT,
+                      c1 MAP<VARCHAR, INT> NOT NULL,
+                      c2 MAP<VARCHAR, INT>)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": {"a": 75, "b": 66}, "c2": None},
+            {"id": 0, "c1": {"q": 11, "v": 66}, "c2": {"q": 22}},
+            {"id": 1, "c1": {"x": 8, "y": 6}, "c2": {"i": 5, "j": 66}},
+            {"id": 1, "c1": {"f": 45, "h": 66}, "c2": {"f": 1}},
+            {"id": 1, "c1": {"q": 11, "v": 66}, "c2": {"q": 11, "v": 66, "x": None}},
+        ]
+
+
+class aggtst_row_tbl(TstTable):
+    """Define the table used by the ROW tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE row_tbl(
+                      id INT,
+                      c1 INT NOT NULL,
+                      c2 VARCHAR,
+                      c3 VARCHAR)WITH ('append_only' = 'true')"""
+        self.data = [
+            {"id": 0, "c1": 4, "c2": None, "c3": "adios"},
+            {"id": 0, "c1": 3, "c2": "ola", "c3": "ciao"},
+            {"id": 1, "c1": 7, "c2": "hi", "c3": "hiya"},
+            {"id": 1, "c1": 2, "c2": "elo", "c3": "ciao"},
+            {"id": 1, "c1": 2, "c2": "elo", "c3": "ciao"},
+        ]

--- a/python/tests/aggregate_tests6/test_array_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_array_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_array_arg_max.py

--- a/python/tests/aggregate_tests6/test_array_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_array_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_array_arg_min.py

--- a/python/tests/aggregate_tests6/test_array_max_append.py
+++ b/python/tests/aggregate_tests6/test_array_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_array_max.py

--- a/python/tests/aggregate_tests6/test_array_min_append.py
+++ b/python/tests/aggregate_tests6/test_array_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_array_min.py

--- a/python/tests/aggregate_tests6/test_binary_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_binary_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_binary_arg_max.py

--- a/python/tests/aggregate_tests6/test_binary_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_binary_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_binary_arg_min.py

--- a/python/tests/aggregate_tests6/test_binary_max_append.py
+++ b/python/tests/aggregate_tests6/test_binary_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_binary_max.py

--- a/python/tests/aggregate_tests6/test_binary_min_append.py
+++ b/python/tests/aggregate_tests6/test_binary_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_binary_min.py

--- a/python/tests/aggregate_tests6/test_interval_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_interval_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_interval_arg_max.py

--- a/python/tests/aggregate_tests6/test_interval_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_interval_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_interval_arg_min.py

--- a/python/tests/aggregate_tests6/test_interval_max_append.py
+++ b/python/tests/aggregate_tests6/test_interval_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_interval_max.py

--- a/python/tests/aggregate_tests6/test_interval_min_append.py
+++ b/python/tests/aggregate_tests6/test_interval_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests2/test_interval_min.py

--- a/python/tests/aggregate_tests6/test_map_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_map_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_map_arg_max.py

--- a/python/tests/aggregate_tests6/test_map_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_map_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_map_arg_min.py

--- a/python/tests/aggregate_tests6/test_map_max_append.py
+++ b/python/tests/aggregate_tests6/test_map_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_map_max.py

--- a/python/tests/aggregate_tests6/test_map_min_append.py
+++ b/python/tests/aggregate_tests6/test_map_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests4/test_map_min.py

--- a/python/tests/aggregate_tests6/test_row_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_row_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_row_arg_max.py

--- a/python/tests/aggregate_tests6/test_row_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_row_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_row_arg_min.py

--- a/python/tests/aggregate_tests6/test_row_max_append.py
+++ b/python/tests/aggregate_tests6/test_row_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_row_max.py

--- a/python/tests/aggregate_tests6/test_row_min_append.py
+++ b/python/tests/aggregate_tests6/test_row_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests/test_row_min.py

--- a/python/tests/aggregate_tests6/test_un_int_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_un_int_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_un_int_arg_max.py

--- a/python/tests/aggregate_tests6/test_un_int_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_un_int_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_un_int_arg_min.py

--- a/python/tests/aggregate_tests6/test_un_int_max_append.py
+++ b/python/tests/aggregate_tests6/test_un_int_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_un_int_max.py

--- a/python/tests/aggregate_tests6/test_un_int_min_append.py
+++ b/python/tests/aggregate_tests6/test_un_int_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_un_int_min.py

--- a/python/tests/aggregate_tests6/test_varbinary_arg_max_append.py
+++ b/python/tests/aggregate_tests6/test_varbinary_arg_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_varbinary_arg_max.py

--- a/python/tests/aggregate_tests6/test_varbinary_arg_min_append.py
+++ b/python/tests/aggregate_tests6/test_varbinary_arg_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_varbinary_arg_min.py

--- a/python/tests/aggregate_tests6/test_varbinary_max_append.py
+++ b/python/tests/aggregate_tests6/test_varbinary_max_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_varbinary_max.py

--- a/python/tests/aggregate_tests6/test_varbinary_min_append.py
+++ b/python/tests/aggregate_tests6/test_varbinary_min_append.py
@@ -1,0 +1,1 @@
+../aggregate_tests3/test_varbinary_min.py


### PR DESCRIPTION
**Additional tests for ARG_MAX, ARG_MIN, MAX, MIN aggregates applied to append-only tables**

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

No incompatible changes
