### PR TITLE
pipeline-manager: include error source of reqwest error for additional context

### DIFF
--- a/crates/fda/src/adhoc.rs
+++ b/crates/fda/src/adhoc.rs
@@ -29,7 +29,7 @@ fn handle_ws_errors_fatal(
                 error!("Failed to establish a websocket connection to {server}.");
             }
             reqwest_websocket::Error::Reqwest(e) => {
-                eprintln!("{}: {e}", msg);
+                eprintln!("{}: {e}, source: {}", msg, source_error(&e));
             }
             reqwest_websocket::Error::Tungstenite(e) => {
                 eprintln!("{}: {e}", msg);
@@ -229,4 +229,12 @@ pub(crate) async fn handle_adhoc_query(
             println!("Query result saved to '{}'", path.display());
         }
     }
+}
+
+// helper method to get nested source error
+fn source_error(mut err: &dyn std::error::Error) -> &dyn std::error::Error {
+    while let Some(src) = err.source() {
+        err = src;
+    }
+    err
 }

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -16,6 +16,7 @@ use crate::db::types::program::{
 use crate::db::types::tenant::TenantId;
 use crate::db::types::utils::validate_program_config;
 use crate::db::types::version::Version;
+use crate::error::source_error;
 use crate::has_unstable_feature;
 use feldera_types::program_schema::ProgramSchema;
 use futures_util::StreamExt;
@@ -364,9 +365,10 @@ async fn fetch_sql_compiler(
 
     let response = client.get(&jar_cache_url).send().await.map_err(|e| {
         SqlCompilationError::SystemError(format!(
-            "Unable to fetch SQL-to-DBSP compiler at '{}': {}. If possible, fall-back to platform version or change `runtime_version` in the program config.",
+            "Unable to fetch SQL-to-DBSP compiler at '{}': {}, source error: {}. If possible, fall-back to platform version or change `runtime_version` in the program config.",
             &jar_cache_url,
-            e
+            e,
+            source_error(&e)
         ))
     })?;
 

--- a/crates/pipeline-manager/src/error.rs
+++ b/crates/pipeline-manager/src/error.rs
@@ -143,3 +143,11 @@ impl DetailedError for ManagerError {
         }
     }
 }
+
+// helper method to get nested source error
+pub(crate) fn source_error(mut err: &dyn StdError) -> &dyn StdError {
+    while let Some(src) = err.source() {
+        err = src;
+    }
+    err
+}

--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -5,7 +5,7 @@ use crate::common_error::CommonError;
 use crate::config::{CommonConfig, LocalRunnerConfig};
 use crate::db::types::pipeline::PipelineId;
 use crate::db::types::version::Version;
-use crate::error::ManagerError;
+use crate::error::{source_error, ManagerError};
 use crate::runner::error::RunnerError;
 use crate::runner::pipeline_executor::PipelineExecutor;
 use crate::runner::pipeline_logs::{LogMessage, LogsSender};
@@ -221,7 +221,10 @@ impl LocalRunner {
                 Ok(())
             }
             Err(e) => Err(RunnerError::RunnerProvisionError {
-                error: format!("pipeline binary retrieval failed: unable to get response: {e}"),
+                error: format!(
+                    "pipeline binary retrieval failed: unable to get response: {e}, source: {}",
+                    source_error(&e)
+                ),
             }
             .into()),
         }

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -12,7 +12,7 @@ use crate::db::types::tenant::TenantId;
 use crate::db::types::utils::{
     validate_deployment_config, validate_program_info, validate_runtime_config,
 };
-use crate::error::ManagerError;
+use crate::error::{source_error, ManagerError};
 use crate::runner::error::RunnerError;
 use crate::runner::interaction::{format_pipeline_url, format_timeout_error_message};
 use crate::runner::pipeline_executor::PipelineExecutor;
@@ -660,7 +660,10 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     }
                 } else {
                     RunnerError::PipelineInteractionUnreachable {
-                        error: format!("unable to send request due to: {e}"),
+                        error: format!(
+                            "unable to send request due to: {e}, source: {}",
+                            source_error(&e)
+                        ),
                     }
                 }
             })?;


### PR DESCRIPTION
fixes #4469 

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

^ not required.

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

shoudn't be anything that's an breaking change, only error messages are changed.
