### PR TITLE
[SQL] Generate simpler keys when indexing the output of PartitionedWindowAggregates

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
@@ -61,7 +61,7 @@ public class Projection extends InnerVisitor {
     @Nullable
     List<Integer> shuffle;
 
-    /** A pair containing an input (paramter) number (0, 1, 2, etc)
+    /** A pair containing an input (parameter) number (0, 1, 2, etc.)
      * and an index field in the tuple of the corresponding input .*/
     public record InputAndFieldIndex(int inputIndex, int fieldIndex) {}
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -790,4 +790,27 @@ public class IncrementalRegressionTests extends SqlIoTest {
             }
         }
     }
+
+    @Test
+    public void issue4503() {
+        this.getCC("""
+                CREATE TABLE T (
+                    id VARCHAR NOT NULL,
+                    h VARCHAR NOT NULL,
+                    b BIGINT NOT NULL LATENESS 2,
+                    r INTEGER
+                ) WITH ('append_only'='true');
+                
+                CREATE VIEW V AS
+                SELECT *
+                FROM (
+                    SELECT
+                        *,
+                        SUM(r) OVER (
+                            PARTITION BY id, h
+                            ORDER BY b
+                        ) AS rn
+                    FROM T
+                ) WHERE rn = 1;""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -713,7 +713,7 @@ public class Regression1Tests extends SqlIoTest {
     }
 
     @Test
-    public void t() {
+    public void argMin() {
         var ccs = this.getCCS("""
                 CREATE TABLE int0_tbl(
                 id INT NOT NULL,


### PR DESCRIPTION
We used to generated nested tuples `Tup2<Tup2<>, ...>`, for the keys of some index operators when compiling window aggregates, which could not be analyzed by the monotonicity analyzer, which never expected complex keys in joins. We now flatten the inner keys, generating `Tup3<...>` instead. The results should be indistinguishable, but the program should be easier to analyze.

