### PR TITLE
Support bundle v0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_adapters"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_nexmark"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "anyhow",
  "ascii_table",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "fda"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-adapterlib"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-datagen"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-fxp"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "bytecheck",
  "dbsp",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-iceberg"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-ir"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "feldera-types",
  "serde",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-rest-api"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "chrono",
  "feldera-types",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-sqllib"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "arcstr",
  "base58",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-storage"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "anyhow",
  "feldera-types",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-types"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7828,7 +7828,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline-manager"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -7895,6 +7895,7 @@ dependencies = [
  "uuid",
  "vergen-gitcl",
  "wiremock",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -8839,7 +8840,7 @@ dependencies = [
 
 [[package]]
 name = "readers"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "async-std",
  "csv",
@@ -10237,7 +10238,7 @@ dependencies = [
 
 [[package]]
 name = "sltsqlvalue"
-version = "0.121.0"
+version = "0.120.0"
 dependencies = [
  "dbsp",
  "feldera-sqllib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_adapters"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "actix",
  "actix-codec",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "dbsp_nexmark"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "anyhow",
  "ascii_table",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "fda"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-adapterlib"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-datagen"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-fxp"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "bytecheck",
  "dbsp",
@@ -4749,7 +4749,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-iceberg"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-ir"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "feldera-types",
  "serde",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-rest-api"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "chrono",
  "feldera-types",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-sqllib"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "arcstr",
  "base58",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-storage"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "anyhow",
  "feldera-types",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "feldera-types"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -7828,7 +7828,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline-manager"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -8840,7 +8840,7 @@ dependencies = [
 
 [[package]]
 name = "readers"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "async-std",
  "csv",
@@ -10238,7 +10238,7 @@ dependencies = [
 
 [[package]]
 name = "sltsqlvalue"
-version = "0.120.0"
+version = "0.121.0"
 dependencies = [
  "dbsp",
  "feldera-sqllib",

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -479,6 +479,15 @@ pub enum PipelineAction {
         #[arg(value_hint = ValueHint::FilePath, long, short = 'o')]
         output: Option<PathBuf>,
     },
+    /// Download a support bundle which contains debug information about the pipeline.
+    SupportBundle {
+        /// The name of the pipeline.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        name: String,
+        /// The ZIP file to write the bundle to.
+        #[arg(value_hint = ValueHint::FilePath, long, short = 'o')]
+        output: Option<PathBuf>,
+    },
     /// Enter the ad-hoc SQL shell for a pipeline.
     Shell {
         /// The name of the pipeline.
@@ -765,12 +774,6 @@ pub enum ProgramAction {
     },
     /// Retrieve the compilation status of the program.
     Status {
-        /// The name of the pipeline.
-        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
-        name: String,
-    },
-    /// Return compile-time information about the program.
-    Info {
         /// The name of the pipeline.
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
         name: String,

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -1356,7 +1356,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 .await
                 .map_err(handle_errors_fatal(
                     client.baseurl().clone(),
-                    "Failed to obtain circuit profile",
+                    "Failed to obtain support bundle",
                     1,
                 ))
                 .unwrap();

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -59,6 +59,7 @@ regex = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
 base64 = { workspace = true }
+zip = { workspace = true }
 
 # Command-line interaction
 clap = { workspace = true }

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/mod.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/mod.rs
@@ -20,6 +20,8 @@ use feldera_types::query_params::MetricsParameters;
 use log::{debug, info};
 use std::time::Duration;
 
+pub mod support_bundle;
+
 /// Push data to a SQL table.
 ///
 /// The client sends data encoded using the format specified in the `?format=`

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
@@ -1,0 +1,411 @@
+// API to read from tables/views and write into tables using HTTP
+use actix_web::rt::time::timeout;
+use futures_util::StreamExt;
+use std::io::Write;
+use std::time::Duration;
+use zip::{CompressionMethod, ZipWriter};
+
+use crate::api::endpoints::config::Configuration;
+use crate::api::error::ApiError;
+use crate::api::examples;
+use crate::api::main::ServerState;
+use crate::db::{storage::Storage, types::tenant::TenantId};
+use crate::error::ManagerError;
+use actix_web::{
+    get,
+    http::Method,
+    web::{self, Data as WebData, ReqData},
+    HttpResponse,
+};
+use feldera_types::program_schema::SqlIdentifier;
+
+/// Generate a support bundle containing diagnostic information from a pipeline.
+///
+/// This endpoint collects various diagnostic data from the pipeline including
+/// circuit profile, heap profile, metrics, logs, stats, and connector statistics,
+/// and packages them into a single ZIP file for support purposes.
+#[utoipa::path(
+    context_path = "/v0",
+    security(("JSON web token (JWT) or API key" = [])),
+    params(
+        ("pipeline_name" = String, Path, description = "Unique pipeline name"),
+    ),
+    responses(
+        (status = OK
+            , description = "Support bundle containing diagnostic information"
+            , content_type = "application/zip"
+            , body = Vec<u8>),
+        (status = NOT_FOUND
+            , description = "Pipeline with that name does not exist"
+            , body = ErrorResponse
+            , example = json!(examples::error_unknown_pipeline_name())),
+        (status = SERVICE_UNAVAILABLE
+            , body = ErrorResponse
+            , examples(
+                ("Pipeline is not deployed" = (value = json!(examples::error_pipeline_interaction_not_deployed()))),
+                ("Pipeline is currently unavailable" = (value = json!(examples::error_pipeline_interaction_currently_unavailable()))),
+                ("Disconnected during response" = (value = json!(examples::error_pipeline_interaction_disconnected()))),
+                ("Response timeout" = (value = json!(examples::error_pipeline_interaction_timeout())))
+            )
+        ),
+        (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
+    ),
+    tag = "Pipeline interaction"
+)]
+#[get("/pipelines/{pipeline_name}/support_bundle")]
+pub(crate) async fn get_pipeline_support_bundle(
+    state: WebData<ServerState>,
+    client: WebData<awc::Client>,
+    tenant_id: ReqData<TenantId>,
+    path: web::Path<String>,
+) -> Result<HttpResponse, ManagerError> {
+    let pipeline_name = path.into_inner();
+    let mut zip_buffer = Vec::new();
+    let mut zip = ZipWriter::new(std::io::Cursor::new(&mut zip_buffer));
+
+    // Helper function to fetch data from pipeline
+    let fetch_data = |endpoint: &str, timeout: Option<Duration>| {
+        let state = state.clone();
+        let client = client.clone();
+        let tenant_id = *tenant_id;
+        let pipeline_name = pipeline_name.clone();
+        let endpoint = endpoint.to_string();
+
+        async move {
+            state
+                .runner
+                .forward_http_request_to_pipeline_by_name(
+                    client.as_ref(),
+                    tenant_id,
+                    &pipeline_name,
+                    Method::GET,
+                    &endpoint,
+                    "",
+                    timeout,
+                )
+                .await
+        }
+    };
+
+    // Helper function to fetch data from pipeline
+    let stream_logs = || {
+        let state = state.clone();
+        let client = client.clone();
+        let tenant_id = *tenant_id;
+        let pipeline_name = pipeline_name.clone();
+
+        // The log endpoint is a stream that never ends. However, we want to be able for
+        // fda to exit after a certain amount of time without any new logs to emulate
+        // a log snapshot functionality.
+        let mut first_line = true;
+        let next_line_timeout = Duration::from_millis(250);
+        let mut logs = String::with_capacity(4096);
+        async move {
+            let response = state
+                .runner
+                .get_logs_from_pipeline(&client, tenant_id, &pipeline_name)
+                .await;
+            match response {
+                Ok(mut response) => {
+                    while let Ok(Some(chunk)) = timeout(
+                        if first_line {
+                            Duration::from_secs(5)
+                        } else {
+                            next_line_timeout
+                        },
+                        response.next(),
+                    )
+                    .await
+                    {
+                        match chunk {
+                            Ok(chunk) => {
+                                let text = String::from_utf8_lossy(&chunk);
+                                logs.push_str(&text);
+                                first_line = false;
+                            }
+                            Err(e) => {
+                                logs.push_str(&format!(
+                                    "ERROR: Unable to read server response: {}",
+                                    e
+                                ));
+                            }
+                        }
+                    }
+                    return Ok(logs);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    };
+
+    // Helper function to get local manager data
+    let get_pipeline_config = async {
+        state
+            .db
+            .lock()
+            .await
+            .get_pipeline(*tenant_id, &pipeline_name)
+            .await
+            .map(|pipeline| serde_json::to_vec_pretty(&pipeline))
+    };
+
+    let get_system_config = async {
+        let config = Configuration::gather(&state).await;
+        Ok::<_, serde_json::Error>(serde_json::to_vec_pretty(&config)?)
+    };
+
+    // Launch all data collection tasks in parallel (including local ones)
+    let (
+        circuit_profile_result,
+        heap_profile_result,
+        metrics_result,
+        logs_result,
+        stats_result,
+        pipeline_config_result,
+        system_config_result,
+    ) = tokio::join!(
+        fetch_data("dump_profile", Some(Duration::from_secs(120))),
+        fetch_data("heap_profile", None),
+        fetch_data("metrics", None),
+        stream_logs(),
+        fetch_data("stats", None),
+        get_pipeline_config,
+        get_system_config,
+    );
+
+    // Helper function to add content to zip
+    let mut add_to_zip =
+        |filename: &str, content: Vec<u8>| -> Result<(), Box<dyn std::error::Error>> {
+            let options =
+                zip::write::FileOptions::default().compression_method(CompressionMethod::Deflated);
+            zip.start_file(filename, options)?;
+            zip.write_all(&content)?;
+            Ok(())
+        };
+
+    // Process circuit profile result
+    match circuit_profile_result {
+        Ok(response) if response.status().is_success() => {
+            if let Ok(body) = actix_web::body::to_bytes(response.into_body()).await {
+                let _ = add_to_zip("circuit_profile.zip", body.to_vec());
+            }
+        }
+        _ => {
+            let _ = add_to_zip(
+                "circuit_profile_error.txt",
+                b"Failed to retrieve circuit profile".to_vec(),
+            );
+        }
+    }
+
+    // Process heap profile result
+    match heap_profile_result {
+        Ok(response) if response.status().is_success() => {
+            if let Ok(body) = actix_web::body::to_bytes(response.into_body()).await {
+                let _ = add_to_zip("heap_profile.pb.gz", body.to_vec());
+            }
+        }
+        _ => {
+            let _ = add_to_zip(
+                "heap_profile_error.txt",
+                b"Failed to retrieve heap profile".to_vec(),
+            );
+        }
+    }
+
+    // Process metrics result
+    match metrics_result {
+        Ok(response) if response.status().is_success() => {
+            if let Ok(body) = actix_web::body::to_bytes(response.into_body()).await {
+                let _ = add_to_zip("metrics.txt", body.to_vec());
+            }
+        }
+        _ => {
+            let _ = add_to_zip("metrics_error.txt", b"Failed to retrieve metrics".to_vec());
+        }
+    }
+
+    // Process logs result
+    match logs_result {
+        Ok(body) => {
+            let _ = add_to_zip("logs.txt", body.as_bytes().to_vec());
+        }
+        _ => {
+            let _ = add_to_zip("logs_error.txt", b"Failed to retrieve logs".to_vec());
+        }
+    }
+
+    // Process pipeline config result
+    match pipeline_config_result {
+        Ok(Ok(config_json)) => {
+            let _ = add_to_zip("pipeline_config.json", config_json);
+        }
+        _ => {
+            let _ = add_to_zip(
+                "pipeline_config_error.txt",
+                b"Failed to retrieve pipeline configuration".to_vec(),
+            );
+        }
+    }
+
+    // Process system config result
+    match system_config_result {
+        Ok(config_json) => {
+            let _ = add_to_zip("system_config.json", config_json);
+        }
+        Err(_) => {
+            let _ = add_to_zip(
+                "system_config_error.txt",
+                b"Failed to retrieve system configuration".to_vec(),
+            );
+        }
+    }
+
+    // Process stats result and use it to discover connectors
+    let stats_body = match stats_result {
+        Ok(response) if response.status().is_success() => {
+            match actix_web::body::to_bytes(response.into_body()).await {
+                Ok(body) => {
+                    let body_vec = body.to_vec();
+                    let _ = add_to_zip("stats.json", body_vec.clone());
+                    Some(body_vec)
+                }
+                Err(_) => {
+                    let _ = add_to_zip("stats_error.txt", b"Failed to retrieve stats".to_vec());
+                    None
+                }
+            }
+        }
+        _ => {
+            let _ = add_to_zip("stats_error.txt", b"Failed to retrieve stats".to_vec());
+            None
+        }
+    };
+
+    // Collect connector stats in parallel if we have stats data
+    if let Some(stats_body) = stats_body {
+        if let Ok(stats_str) = std::str::from_utf8(&stats_body) {
+            if let Ok(stats_json) = serde_json::from_str::<serde_json::Value>(stats_str) {
+                let mut connector_tasks = Vec::new();
+
+                // Collect input connector endpoints
+                if let Some(inputs) = stats_json.get("inputs").and_then(|v| v.as_object()) {
+                    for (table_connector, _) in inputs {
+                        if let Some((table_name, connector_name)) = table_connector.split_once('.')
+                        {
+                            let actual_table_name = SqlIdentifier::from(table_name).name();
+                            let endpoint_name = format!("{}.{}", actual_table_name, connector_name);
+                            let encoded_endpoint_name =
+                                urlencoding::encode(&endpoint_name).to_string();
+                            let endpoint =
+                                format!("input_endpoints/{}/stats", encoded_endpoint_name);
+                            let filename = format!(
+                                "connectors/input_{}_{}_stats.json",
+                                table_name, connector_name
+                            );
+                            let error_filename = format!(
+                                "connectors/input_{}_{}_stats_error.txt",
+                                table_name, connector_name
+                            );
+
+                            connector_tasks.push((
+                                fetch_data(&endpoint, None),
+                                filename,
+                                error_filename,
+                            ));
+                        }
+                    }
+                }
+
+                // Collect output connector endpoints
+                if let Some(outputs) = stats_json.get("outputs").and_then(|v| v.as_object()) {
+                    for (view_connector, _) in outputs {
+                        if let Some((view_name, connector_name)) = view_connector.split_once('.') {
+                            let actual_view_name = SqlIdentifier::from(view_name).name();
+                            let endpoint_name = format!("{}.{}", actual_view_name, connector_name);
+                            let encoded_endpoint_name =
+                                urlencoding::encode(&endpoint_name).to_string();
+                            let endpoint =
+                                format!("output_endpoints/{}/stats", encoded_endpoint_name);
+                            let filename = format!(
+                                "connectors/output_{}_{}_stats.json",
+                                view_name, connector_name
+                            );
+                            let error_filename = format!(
+                                "connectors/output_{}_{}_stats_error.txt",
+                                view_name, connector_name
+                            );
+
+                            connector_tasks.push((
+                                fetch_data(&endpoint, None),
+                                filename,
+                                error_filename,
+                            ));
+                        }
+                    }
+                }
+
+                // Execute all connector requests in parallel
+                let connector_results =
+                    futures_util::future::join_all(connector_tasks.into_iter().map(
+                        |(task, filename, error_filename)| async move {
+                            let result = task.await;
+                            (result, filename, error_filename)
+                        },
+                    ))
+                    .await;
+
+                // Process connector results
+                for (result, filename, error_filename) in connector_results {
+                    match result {
+                        Ok(response) if response.status().is_success() => {
+                            if let Ok(body) = actix_web::body::to_bytes(response.into_body()).await
+                            {
+                                let _ = add_to_zip(&filename, body.to_vec());
+                            } else {
+                                let _ = add_to_zip(
+                                    &error_filename,
+                                    b"Failed to read connector stats response".to_vec(),
+                                );
+                            }
+                        }
+                        _ => {
+                            let _ = add_to_zip(
+                                &error_filename,
+                                b"Failed to retrieve connector stats".to_vec(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Add a manifest file with collection timestamp
+    let manifest = format!(
+        "Support Bundle for Pipeline: {}\nGenerated at: {}\nContents:\n- pipeline_config.json (SQL program and pipeline configuration)\n- system_config.json (Platform configuration and build info)\n- circuit_profile.zip\n- heap_profile.pb.gz\n- metrics.txt\n- logs.txt\n- stats.json\n- connectors/*/stats.json\n",
+        pipeline_name,
+        chrono::Utc::now().to_rfc3339()
+    );
+    let _ = add_to_zip("manifest.txt", manifest.into_bytes());
+
+    // Finalize the zip
+    if let Err(e) = zip.finish() {
+        return Err(ManagerError::from(ApiError::UnableToCreateSupportBundle {
+            reason: format!("Failed to create support bundle: {}", e),
+        }));
+    }
+
+    drop(zip);
+
+    Ok(HttpResponse::Ok()
+        .content_type("application/zip")
+        .insert_header((
+            "Content-Disposition",
+            format!(
+                "attachment; filename=\"{}_support_bundle.zip\"",
+                pipeline_name
+            ),
+        ))
+        .body(zip_buffer))
+}

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
@@ -55,7 +55,7 @@ async fn collect_pipeline_logs(
     pipeline_name: &str,
 ) -> Result<String, ManagerError> {
     let mut first_line = true;
-    let next_line_timeout = Duration::from_millis(250);
+    let next_line_timeout = Duration::from_millis(500);
     let mut logs = String::with_capacity(4096);
 
     let response = state
@@ -66,7 +66,7 @@ async fn collect_pipeline_logs(
     let mut response = response;
     while let Ok(Some(chunk)) = timeout(
         if first_line {
-            Duration::from_secs(5)
+            Duration::from_secs(20)
         } else {
             next_line_timeout
         },
@@ -412,7 +412,7 @@ impl SupportBundleZip {
     }
 }
 
-/// Generate a support bundle containing diagnostic information from a pipeline.
+/// Generate a support bundle for a pipeline.
 ///
 /// This endpoint collects various diagnostic data from the pipeline including
 /// circuit profile, heap profile, metrics, logs, stats, and connector statistics,

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
@@ -98,8 +98,8 @@ fn json_prettify(data: Vec<u8>) -> Vec<u8> {
     }
 }
 
-/// Convert and augment the HTTP response into a bundle result which
-/// has string based error reporting for embedding errors within the bundle.
+/// Convert the HTTP response from a pipeline to a bundle result or
+/// a string error message in case of an error.
 async fn response_to_bundle_result(
     response: Result<HttpResponse, ManagerError>,
 ) -> BundleResult<Vec<u8>> {
@@ -334,7 +334,7 @@ struct SupportBundleZip {
 }
 
 impl SupportBundleZip {
-    /// Create a ZIP file from support bundle data.
+    /// Create a ZIP archive from support bundle data.
     async fn create(
         pipeline: &ExtendedPipelineDescr,
         bundles: Vec<SupportBundleData>,

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -553,45 +553,6 @@ pub(crate) async fn get_pipeline(
         .json(&returned_pipeline))
 }
 
-/// Retrieve the program info of a pipeline.
-#[utoipa::path(
-    context_path = "/v0",
-    security(("JSON web token (JWT) or API key" = [])),
-    params(
-        ("pipeline_name" = String, Path, description = "Unique pipeline name"),
-    ),
-    responses(
-        (status = OK
-            , description = "Pipeline retrieved successfully"
-            , body = ProgramInfo
-            , example = json!(examples::pipeline_1_selected_info())),
-        (status = NOT_FOUND
-            , description = "Pipeline with that name does not exist"
-            , body = ErrorResponse
-            , example = json!(examples::error_unknown_pipeline_name())),
-        (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
-    ),
-    tag = "Pipeline management"
-)]
-#[get("/pipelines/{pipeline_name}/program_info")]
-pub(crate) async fn get_program_info(
-    state: WebData<ServerState>,
-    tenant_id: ReqData<TenantId>,
-    path: web::Path<String>,
-) -> Result<HttpResponse, ManagerError> {
-    let pipeline_name = path.into_inner();
-    log::error!("pipeline_name {:?}", pipeline_name);
-    let pipeline = state
-        .db
-        .lock()
-        .await
-        .get_pipeline(*tenant_id, &pipeline_name)
-        .await?;
-    Ok(HttpResponse::Ok()
-        .insert_header(CacheControl(vec![CacheDirective::NoCache]))
-        .json(&pipeline.program_info))
-}
-
 /// Create a new pipeline.
 #[utoipa::path(
     context_path = "/v0",

--- a/crates/pipeline-manager/src/api/error.rs
+++ b/crates/pipeline-manager/src/api/error.rs
@@ -23,6 +23,7 @@ pub enum ApiError {
     InvalidConnectorAction { action: String },
     UnableToConnect { reason: String },
     LockTimeout { value: String, timeout: Duration },
+    UnableToCreateSupportBundle { reason: String },
 }
 
 impl DetailedError for ApiError {
@@ -37,6 +38,7 @@ impl DetailedError for ApiError {
             Self::InvalidConnectorAction { .. } => Cow::from("InvalidConnectorAction"),
             Self::UnableToConnect { .. } => Cow::from("UnableToConnect"),
             Self::LockTimeout { .. } => Cow::from("LockTimeout"),
+            Self::UnableToCreateSupportBundle { .. } => Cow::from("UnableToCreateSupportBundle"),
         }
     }
 }
@@ -78,6 +80,9 @@ impl Display for ApiError {
                     timeout.as_secs_f64()
                 )
             }
+            Self::UnableToCreateSupportBundle { reason } => {
+                write!(f, "Unable to create support bundle: {reason}")
+            }
         }
     }
 }
@@ -102,6 +107,7 @@ impl ResponseError for ApiError {
             Self::InvalidConnectorAction { .. } => StatusCode::BAD_REQUEST,
             Self::UnableToConnect { .. } => StatusCode::BAD_REQUEST,
             Self::LockTimeout { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::UnableToCreateSupportBundle { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -77,7 +77,6 @@ only the program-related core fields, and is used by the compiler to discern whe
         endpoints::pipeline_management::post_pipeline_stop,
         endpoints::pipeline_management::post_pipeline_clear,
         endpoints::pipeline_management::get_pipeline_logs,
-        endpoints::pipeline_management::get_program_info,
 
         // Pipeline interaction endpoints
         endpoints::pipeline_interaction::http_input,
@@ -287,7 +286,6 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_management::post_pipeline_stop)
         .service(endpoints::pipeline_management::post_pipeline_clear)
         .service(endpoints::pipeline_management::get_pipeline_logs)
-        .service(endpoints::pipeline_management::get_program_info)
         // Pipeline interaction endpoints
         .service(endpoints::pipeline_interaction::http_input)
         .service(endpoints::pipeline_interaction::http_output)

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -88,6 +88,7 @@ only the program-related core fields, and is used by the compiler to discern whe
         endpoints::pipeline_interaction::get_pipeline_metrics,
         endpoints::pipeline_interaction::get_pipeline_circuit_profile,
         endpoints::pipeline_interaction::get_pipeline_heap_profile,
+        endpoints::pipeline_interaction::support_bundle::get_pipeline_support_bundle,
         endpoints::pipeline_interaction::pipeline_adhoc_sql,
         endpoints::pipeline_interaction::checkpoint_pipeline,
         endpoints::pipeline_interaction::get_checkpoint_status,
@@ -301,6 +302,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_interaction::get_pipeline_time_series)
         .service(endpoints::pipeline_interaction::get_pipeline_circuit_profile)
         .service(endpoints::pipeline_interaction::get_pipeline_heap_profile)
+        .service(endpoints::pipeline_interaction::support_bundle::get_pipeline_support_bundle)
         .service(endpoints::pipeline_interaction::pipeline_adhoc_sql)
         .service(endpoints::pipeline_interaction::completion_token)
         .service(endpoints::pipeline_interaction::completion_status)

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -450,7 +450,7 @@ pub struct PipelineDescr {
 
 /// Pipeline descriptor which besides the basic fields in direct regular control of the user
 /// also has all additional fields generated and maintained by the back-end.
-#[derive(Eq, PartialEq, Debug, Clone)]
+#[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct ExtendedPipelineDescr {
     /// Assigned globally unique pipeline identifier.
     pub id: PipelineId,

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -20,9 +20,6 @@ use tokio::sync::Mutex;
 use tokio::time::Instant;
 
 use actix_http::encoding::Decoder;
-//use actix_web::web::Bytes;
-//use std::pin::Pin;
-//use futures_util::Stream;
 
 /// Max non-streaming HTTP response body returned by the pipeline.
 /// The awc default is 2MiB, which is not enough to, for example, retrieve

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -31,6 +31,12 @@ cd crates/fda
 cargo install --path .
 ```
 
+### Binary installation
+
+We supply pre-built binaries for `fda` as part of our release artifacts. You can find them in the
+`feldera-binaries` ZIP file in the [github release page](https://github.com/feldera/feldera/releases/latest).
+Note that currently only Linux binaries for amd64 and aarch64 architectures are provided.
+
 ### Optional: Shell completion
 
 Once the `fda` binary is installed, you can enable shell command completion for `fda`
@@ -146,10 +152,16 @@ Retrieve the stats for `p1`:
 fda stats p1
 ```
 
-Retrieve the latest logging statements for `p1`:
+Retrieve the latest log messages for `p1`:
 
 ```bash
 fda logs p1
+```
+
+Download the support bundle for `p1`:
+
+```bash
+fda support-bundle p1
 ```
 
 Shutdown and delete the pipeline `p1`:

--- a/docs.feldera.com/docs/operations/guide.md
+++ b/docs.feldera.com/docs/operations/guide.md
@@ -127,12 +127,25 @@ making them eviction candidates. To raise their priority:
 
 ## Diagnosing Performance Issues
 
-When investigating pipeline performance, Feldera support will typically request:
+When investigating pipeline performance, Feldera support will typically request a support-bundle.
+The bundle can be downloaded from your installation with the following [fda](/interface/cli) command:
 
-1. **Performance Tab**: screenshots of the `Performance` tab in the UI to see memory usage, record counts, and processing times
+```bash
+fda support-bundle affected-pipeline-name
+```
 
-2. **Pipeline Logs Tab**: for warnings and errors
+Note that a corresponding function, `support_bundle` is [available in the Python SDK](https://docs.feldera.com/python/examples.html#retrieve-a-support-bundle-for-a-pipeline).
 
-3. **Circuit Profile**: from the [circuit profile](https://docs.feldera.com/api/retrieve-the-circuit-performance-profile-of-a-running-or-paused-pipeline) API.
+The support bundle contains the following content:
 
-4. **Heap Profile**: from [heap usage](https://docs.feldera.com/api/retrieve-the-heap-profile-of-a-running-or-paused-pipeline) API.
+1. **Pipeline Logs**: for warnings and errors from the [logs](https://docs.feldera.com/api/retrieve-logs-of-a-pipeline-as-a-stream) endpoint.
+
+2. **Pipeline Configuration**: the [pipeline configuration](https://docs.feldera.com/api/retrieve-a-pipeline), including the SQL code and connector settings.
+
+3. **Pipeline Metrics**: from the [pipeline metrics](https://docs.feldera.com/api/retrieve-circuit-metrics-of-a-running-or-paused-pipeline) endpoint.
+
+3. **Endpoint Stats**: from the [stats](https://docs.feldera.com/api/retrieve-statistics-e-g-performance-counters-of-a-running-or-paused-pipeline) endpoint.
+
+4. **Circuit Profile**: from the [circuit profile](https://docs.feldera.com/api/retrieve-the-circuit-performance-profile-of-a-running-or-paused-pipeline) endpoint.
+
+5. **Heap Profile**: from [heap usage](https://docs.feldera.com/api/retrieve-the-heap-profile-of-a-running-or-paused-pipeline) endpoint.

--- a/openapi.json
+++ b/openapi.json
@@ -3449,7 +3449,7 @@
         "tags": [
           "Pipeline interaction"
         ],
-        "summary": "Generate a support bundle containing diagnostic information from a pipeline.",
+        "summary": "Generate a support bundle for a pipeline.",
         "description": "This endpoint collects various diagnostic data from the pipeline including\ncircuit profile, heap profile, metrics, logs, stats, and connector statistics,\nand packages them into a single ZIP file for support purposes.",
         "operationId": "get_pipeline_support_bundle",
         "parameters": [

--- a/openapi.json
+++ b/openapi.json
@@ -2875,140 +2875,6 @@
         ]
       }
     },
-    "/v0/pipelines/{pipeline_name}/program_info": {
-      "get": {
-        "tags": [
-          "Pipeline management"
-        ],
-        "summary": "Retrieve the program info of a pipeline.",
-        "operationId": "get_program_info",
-        "parameters": [
-          {
-            "name": "pipeline_name",
-            "in": "path",
-            "description": "Unique pipeline name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Pipeline retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProgramInfo"
-                },
-                "example": {
-                  "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
-                  "name": "example1",
-                  "description": "Description of the pipeline example1",
-                  "created_at": "1970-01-01T00:00:00Z",
-                  "version": 4,
-                  "platform_version": "v0",
-                  "runtime_config": {
-                    "workers": 16,
-                    "storage": {
-                      "backend": {
-                        "name": "default"
-                      },
-                      "min_storage_bytes": null,
-                      "min_step_storage_bytes": null,
-                      "compression": "default",
-                      "cache_mib": null
-                    },
-                    "fault_tolerance": {
-                      "model": "none",
-                      "checkpoint_interval_secs": 60
-                    },
-                    "cpu_profiler": true,
-                    "tracing": false,
-                    "tracing_endpoint_jaeger": "",
-                    "min_batch_size_records": 0,
-                    "max_buffering_delay_usecs": 0,
-                    "resources": {
-                      "cpu_cores_min": null,
-                      "cpu_cores_max": null,
-                      "memory_mb_min": null,
-                      "memory_mb_max": null,
-                      "storage_mb_max": null,
-                      "storage_class": null
-                    },
-                    "clock_resolution_usecs": 1000000,
-                    "pin_cpus": [],
-                    "provisioning_timeout_secs": null,
-                    "max_parallel_connector_init": null,
-                    "init_containers": null,
-                    "checkpoint_during_suspend": true,
-                    "http_workers": null,
-                    "io_workers": null,
-                    "dev_tweaks": {},
-                    "logging": null
-                  },
-                  "program_code": "CREATE TABLE table1 ( col1 INT );",
-                  "udf_rust": "",
-                  "udf_toml": "",
-                  "program_config": {
-                    "profile": "optimized",
-                    "cache": true,
-                    "runtime_version": null
-                  },
-                  "program_version": 2,
-                  "program_status": "Pending",
-                  "program_status_since": "1970-01-01T00:00:00Z",
-                  "program_error": {
-                    "sql_compilation": null,
-                    "rust_compilation": null,
-                    "system_error": null
-                  },
-                  "program_info": null,
-                  "deployment_status": "Stopped",
-                  "deployment_status_since": "1970-01-01T00:00:00Z",
-                  "deployment_desired_status": "Stopped",
-                  "deployment_error": null,
-                  "refresh_version": 4,
-                  "storage_status": "Cleared"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Pipeline with that name does not exist",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                },
-                "example": {
-                  "message": "Unknown pipeline name 'non-existent-pipeline'",
-                  "error_code": "UnknownPipelineName",
-                  "details": {
-                    "pipeline_name": "non-existent-pipeline"
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "JSON web token (JWT) or API key": []
-          }
-        ]
-      }
-    },
     "/v0/pipelines/{pipeline_name}/query": {
       "get": {
         "tags": [
@@ -3566,6 +3432,121 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
+    "/v0/pipelines/{pipeline_name}/support_bundle": {
+      "get": {
+        "tags": [
+          "Pipeline interaction"
+        ],
+        "summary": "Generate a support bundle containing diagnostic information from a pipeline.",
+        "description": "This endpoint collects various diagnostic data from the pipeline including\ncircuit profile, heap profile, metrics, logs, stats, and connector statistics,\nand packages them into a single ZIP file for support purposes.",
+        "operationId": "get_pipeline_support_bundle",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Support bundle containing diagnostic information",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Disconnected during response": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
+                      }
+                    }
+                  },
+                  "Pipeline is currently unavailable": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
+                      }
+                    }
+                  },
+                  "Pipeline is not deployed": {
+                    "value": {
+                      "message": "Unable to interact with pipeline because the deployment status ('stopped') is not one of the deployed statuses ('running', 'paused' or 'unavailable') -- to resolve this: wait for the pipeline to become running or paused",
+                      "error_code": "PipelineInteractionNotDeployed",
+                      "details": {
+                        "status": "Stopped",
+                        "desired_status": "Running"
+                      }
+                    }
+                  },
+                  "Response timeout": {
+                    "value": {
+                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1071,7 +1071,7 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
 
         :param output_path: Optional path to save the support bundle file. If None,
             the support bundle is only returned as bytes.
-        :return: The support bundle as bytes (ZIP file)
+        :return: The support bundle as bytes (ZIP archive)
         :raises FelderaAPIError: If the pipeline does not exist or if there's an error
         """
 

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from datetime import datetime
+import pathlib
 
 import pandas
 from uuid import UUID
@@ -1059,3 +1060,33 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         if derr:
             errors.append(derr)
         return errors
+
+    def support_bundle(self, output_path: Optional[str] = None) -> bytes:
+        """
+        Generate a support bundle containing diagnostic information from this pipeline.
+
+        This method collects various diagnostic data from the pipeline including
+        circuit profile, heap profile, metrics, logs, stats, and connector statistics,
+        and packages them into a single ZIP file for support purposes.
+
+        :param output_path: Optional path to save the support bundle file. If None,
+            the support bundle is only returned as bytes.
+        :return: The support bundle as bytes (ZIP file)
+        :raises FelderaAPIError: If the pipeline does not exist or if there's an error
+        """
+
+        support_bundle_bytes = self.client.get_pipeline_support_bundle(self.name)
+
+        if output_path is not None:
+            path = pathlib.Path(output_path)
+
+            # Ensure the file has .zip extension
+            if path.suffix != ".zip":
+                path = path.with_suffix(".zip")
+
+            with open(path, "wb") as f:
+                f.write(support_bundle_bytes)
+
+            print(f"Support bundle written to {path}")
+
+        return support_bundle_bytes

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -951,3 +951,28 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         resp = self.http.get(path="/config")
 
         return FelderaConfig(resp)
+
+    def get_pipeline_support_bundle(self, pipeline_name: str) -> bytes:
+        """
+        Generate a support bundle containing diagnostic information from a pipeline.
+
+        This endpoint collects various diagnostic data from the pipeline including
+        circuit profile, heap profile, metrics, logs, stats, and connector statistics,
+        and packages them into a single ZIP file for support purposes.
+
+        :param pipeline_name: The name of the pipeline
+        :return: The support bundle as bytes (ZIP file)
+        :raises FelderaAPIError: If the pipeline does not exist or if there's an error
+        """
+
+        resp = self.http.get(
+            path=f"/pipelines/{pipeline_name}/support_bundle",
+            stream=True,
+        )
+
+        buffer = b""
+        for chunk in resp.iter_content(chunk_size=1024):
+            if chunk:
+                buffer += chunk
+
+        return buffer


### PR DESCRIPTION
Adds a support-bundle endpoint to gather various metrics/logs/and profiles of a pipeline.

This should be complete in terms of the data it gathers, but future PRs will improve this to 

- [ ] make it more configurable to exclude certain data from the bundle
- [ ] contain the last `x` collections over a time period of `y` minutes when the pipeline was running (currently only one collection is performed at the time the REST call to support-bundle is initiated).
- [x] support for python sdk
- [x] docs


### Describe Incompatible Changes

None, purely additive feature (it does remove the program-info endpoint which I think was added by accident a few weeks ago and shouldn't be in use anyways)