### PR TITLE
[adapters] Use serde_json_path_to_error to get better error messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,6 +3845,7 @@ dependencies = [
  "serde_arrow",
  "serde_bytes",
  "serde_json",
+ "serde_json_path_to_error",
  "serde_urlencoded",
  "serde_yaml",
  "serial_test",
@@ -4696,6 +4697,7 @@ dependencies = [
  "serde",
  "serde_arrow",
  "serde_json",
+ "serde_json_path_to_error",
  "serde_yaml",
  "thiserror 2.0.12",
  "tokio",
@@ -9984,6 +9986,27 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_json_path_to_error"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131f9e72e503904612f46028049e1c873b7b4d725baccedf8a00e3e67904cb1a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ serde = "1.0.213"
 serde_arrow = { version = "0.13.4", features = ["arrow-55"] }
 serde_bytes = "0.11.15"
 serde_json = { version = "1.0.132", features = ["arbitrary_precision"] }
+serde_json_path_to_error = "0.1.5"
 serde_urlencoded = "0.7.1"
 serde_with = "3.0.0"
 serde_yaml = "0.9.34"

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true, features = ["sync"] }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 datafusion = { workspace = true }
 thiserror = { workspace = true }
+serde_json_path_to_error = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["num-traits"]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -139,6 +139,7 @@ inventory = { workspace = true }
 backtrace = { workspace = true }
 itertools = { workspace = true }
 metrics-process = { version = "2.4.0", default-features = false }
+serde_json_path_to_error = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["num-traits"]

--- a/crates/adapters/src/adhoc/mod.rs
+++ b/crates/adapters/src/adhoc/mod.rs
@@ -190,16 +190,13 @@ pub async fn adhoc_websocket(
             match msg {
                 Ok(AggregatedMessage::Text(text)) => {
                     let sql_request = text.to_string();
-                    let maybe_args =
-                        serde_json::from_str::<AdhocQueryArgs>(&sql_request).map_err(|e| {
-                            PipelineError::AdHocQueryError {
-                                error: format!(
-                                    "Unable to parse adhoc query from the provided JSON: {}",
-                                    e
-                                ),
-                                df: None,
-                            }
-                        });
+                    let maybe_args = serde_json_path_to_error::from_str::<AdhocQueryArgs>(
+                        &sql_request,
+                    )
+                    .map_err(|e| PipelineError::AdHocQueryError {
+                        error: format!("Unable to parse adhoc query from the provided JSON: {}", e),
+                        df: None,
+                    });
 
                     match maybe_args {
                         Ok(args) => {

--- a/crates/adapters/src/controller/checkpoint.rs
+++ b/crates/adapters/src/controller/checkpoint.rs
@@ -47,7 +47,7 @@ impl Checkpoint {
         let data = storage.read(path).map_err(|error| {
             ControllerError::storage_error(format!("{path}: failed to read checkpoint"), error)
         })?;
-        serde_json::from_slice::<Checkpoint>(&data).map_err(|e| {
+        serde_json_path_to_error::from_slice::<Checkpoint>(&data).map_err(|e| {
             ControllerError::CheckpointParseError {
                 error: e.to_string(),
             }

--- a/crates/adapters/src/controller/journal.rs
+++ b/crates/adapters/src/controller/journal.rs
@@ -155,7 +155,7 @@ mod as_json_string {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        serde_json::from_str(&s).map_err(serde::de::Error::custom)
+        serde_json_path_to_error::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -109,7 +109,7 @@ impl CompletionToken {
         let json = BASE64_URL_SAFE_NO_PAD
             .decode(token)
             .map_err(|e| anyhow!("completion token is not a valid base64 string: {e}"))?;
-        serde_json::from_slice::<Self>(&json)
+        serde_json_path_to_error::from_slice::<Self>(&json)
             .map_err(|e| anyhow!("error parsing completion token: {e}"))
     }
 }

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -28,7 +28,7 @@ const INTERNED_STRING_RELATION_NAME: &str = "feldera_interned_strings";
 
 impl Catalog {
     fn parse_relation_schema(schema: &str) -> Result<Relation, ControllerError> {
-        serde_json::from_str(schema).map_err(|e| {
+        serde_json_path_to_error::from_str(schema).map_err(|e| {
             ControllerError::schema_parse_error(&format!(
                 "error parsing relation schema: '{e}'. Invalid schema: '{schema}'"
             ))

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -227,7 +227,7 @@ impl FileInputReader {
                         consumer.extended(total, Some(resume));
                     }
                     Ok(InputReaderCommand::Replay { metadata, .. }) => {
-                        let Metadata { offsets } = serde_json::from_value(metadata)?;
+                        let Metadata { offsets } = serde_json_path_to_error::from_value(metadata)?;
                         file.seek(SeekFrom::Start(offsets.start))?;
                         splitter.seek(offsets.start);
                         let mut remainder = (offsets.end - offsets.start) as usize;

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -297,7 +297,7 @@ impl UrlInputReader {
 
         let mut command_receiver = InputCommandReceiver::<Metadata, ()>::new(command_receiver);
         let offset = if let Some(metadata) = seek {
-            let metadata = serde_json::from_value::<Metadata>(metadata)
+            let metadata = serde_json_path_to_error::from_value::<Metadata>(metadata)
                 .map_err(|e| anyhow!("error deserializing checkpointed connector metadata: {e}"))?;
             metadata.offsets.end
         } else {


### PR DESCRIPTION
serde_json produces poor error messages for deserialization.  This commit uses the serde_json_path_to_error crate to add paths to most kinds of errors.  This is a fairly simple crate that generally works as a drop-in replacement for serde_json (it is a wrapper for it, not a reimplementation).

This commit introduces use of serde_json_path_to_error for deserialzing metadata such as checkpoint information, but it does not introduce it for data parsing for two reasons.  First, it has a performance hit because it clones names within the paths as it traverses them.  Second, we don't yet know whether it introduces any incompatibilities.
