### PR TITLE
pipeline-manager: name unnamed connector using index

### DIFF
--- a/docs.feldera.com/docs/connectors/index.mdx
+++ b/docs.feldera.com/docs/connectors/index.mdx
@@ -90,7 +90,8 @@ The following attributes are common to all connectors:
   unique among the connectors of the table or view. This is particularly
   useful to define when wanting to refer to it, for example to
   [start or pause it at runtime](/connectors/orchestration).
-  By default, this is randomly generated.
+  By default, it will be named `unnamed-{index}`, with the zero-based index
+  within the list of connectors of its table/view.
 
 * `paused` - If set to to true the connector will not fetch or push data to the pipeline when started
    unless [explicitly enabled through the API](/api/start-resume-or-pause-the-input-connector).


### PR DESCRIPTION
Before this commit, an unnamed connector would get assigned a randomly generated unique name. However, this name would be regenerated every time SQL compilation occurred. This is particularly inconvenient for attributing state to the corresponding connector across stop and resume.

This commit instead assigns unnamed connectors within a table or view the names `unnamed-{index}`. For example, if a table has four connectors: `abc`, (unnamed), `def` and (unnamed), the SQL compilation will produce the names `abc`, `unnamed-1`, `def` and `unnamed-3` in the `program_info` it outputs. Note that the indexes are per table/view, as connector names are only unique in the scope of a table/view not across all.

**PR information**
- Checklist: documentation updated, changelog is not updated
- Breaking changes: none
- Backward incompatible changes: it is no longer possible to dependent on the connector names to be randomly generated each SQL compilation, as they are generated based on their position in the list of connectors.
- Fixes: https://github.com/feldera/feldera/issues/4407