### PR TITLE
[feldera-types] Fix deserialization of noninteger number as core counts.

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -21,7 +21,7 @@ use crate::transport::redis::RedisOutputConfig;
 use crate::transport::s3::S3InputConfig;
 use crate::transport::url::UrlInputConfig;
 use core::fmt;
-use serde::de::{self, MapAccess, Visitor};
+use serde::de::{self, DeserializeOwned, Error as _, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
@@ -1370,10 +1370,12 @@ pub struct FormatConfig {
 pub struct ResourceConfig {
     /// The minimum number of CPU cores to reserve
     /// for an instance of this pipeline
+    #[serde(deserialize_with = "deserialize_via_value")]
     pub cpu_cores_min: Option<f64>,
 
     /// The maximum number of CPU cores to reserve
     /// for an instance of this pipeline
+    #[serde(deserialize_with = "deserialize_via_value")]
     pub cpu_cores_max: Option<f64>,
 
     /// The minimum memory in Megabytes to reserve
@@ -1391,4 +1393,18 @@ pub struct ResourceConfig {
     /// Storage class to use for an instance of this pipeline.
     /// The class determines storage performance such as IOPS and throughput.
     pub storage_class: Option<String>,
+}
+
+/// Use this as a serde deserialization function to work around `serde_json`
+/// [issues] with nested `f64`.  It works in two steps, first deserializing a
+/// `serde_json::Value` from `deserializer`, then deserializing `T` from that
+/// `serde_json::Value`.
+///
+/// [issues]: https://github.com/serde-rs/json/issues/1157
+fn deserialize_via_value<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: DeserializeOwned,
+{
+    serde_json::from_value(serde_json::Value::deserialize(deserializer)?).map_err(D::Error::custom)
 }


### PR DESCRIPTION
This fixes a bug parsing core counts that contain decimal points.  Newer Feldera will write even if the value is an integer, so that means any cpu_cores_min or cpu_cores_max other than `None`/`null` triggers the bug. The bug caused failure with a message like this on resume from a checkpoint:

> Operation failed because the pipeline failed to initialize.
> Error details: 'Error parsing checkpoint file:
> invalid type: map, expected f64 at line 1 column 2821'.

This fixes the problem, which works around this bug in serde/serde_json: https://github.com/serde-rs/json/issues/1157

This has no breaking changes but it should unbreak users :-)