### PR TITLE
[SQL] Optimized implementation of ARG_MIN

### DIFF
--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -353,6 +353,7 @@ mod test {
     }
 
     #[test]
+    #[ignore = "https://github.com/feldera/feldera/issues/4516"]
     fn test_clock() {
         let tempdir = TempDir::new().unwrap();
         let tempdir_path = tempdir.path();

--- a/crates/dbsp/src/operator/dynamic/aggregate/min.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/min.rs
@@ -140,3 +140,92 @@ where
         accumulator
     }
 }
+
+/// Given a tuple Tup1<(Option<K>, V)>, this aggregator that returns
+/// the smallest V for the smallest value K that is not None.  This is
+/// useful for implementing the SQL ARG_MIN operator.  Notice that the
+/// ARG_MIN(a, b) function returns the smallest a for the smallest b
+/// in the collection (it compares first on b); however, the compiler
+/// swaps the arguments when using this aggregator, so type Option<K>
+/// below is the type of b, and V is the type of A.  (This aggregator
+/// is used only when b is nullable, otherwise the regular Min
+/// aggregator is fine.)
+#[derive(Clone)]
+pub struct ArgMinSome;
+
+#[derive(Clone)]
+pub struct ArgMinSomeSemigroup<K, V>(PhantomData<(K, V)>);
+
+impl<K, V> Semigroup<Tup1<(Option<K>, V)>> for ArgMinSomeSemigroup<K, V>
+where
+    K: DBData,
+    V: DBData,
+{
+    fn combine(left: &Tup1<(Option<K>, V)>, right: &Tup1<(Option<K>, V)>) -> Tup1<(Option<K>, V)> {
+        match (&left.0 .0, &right.0 .0) {
+            (None, None) => min(left, right).clone(),
+            (Some(_), None) => left.clone(),
+            (None, Some(_)) => right.clone(),
+            (Some(_), Some(_)) => min(left, right).clone(),
+        }
+    }
+}
+
+impl<V, K, T, R> Aggregator<Tup1<(Option<K>, V)>, T, R> for ArgMinSome
+where
+    K: DBData,
+    V: DBData,
+    T: Timestamp,
+    R: DBWeight + MonoidValue,
+{
+    type Accumulator = Tup1<(Option<K>, V)>;
+    type Output = Tup1<V>;
+    type Semigroup = ArgMinSomeSemigroup<K, V>;
+
+    fn aggregate<VTrait, RTrait>(
+        &self,
+        cursor: &mut dyn Cursor<VTrait, DynUnit, T, RTrait>,
+    ) -> Option<Self::Accumulator>
+    where
+        VTrait: DataTrait + ?Sized,
+        RTrait: WeightTrait + ?Sized,
+        Tup1<(Option<K>, V)>: Erase<VTrait>,
+        R: Erase<RTrait>,
+    {
+        // Result will be None if the cursor points to an empty collection
+        let mut result = None;
+
+        while cursor.key_valid() {
+            // FIXME: This could be more succinct if we had an `Add<&Self, Output = Self>`
+            // bound on `R`
+            let mut weight: R = HasZero::zero();
+            cursor.map_times(&mut |_, w| {
+                weight.add_assign_by_ref(unsafe { w.downcast() });
+            });
+            if !weight.is_zero() {
+                let current = unsafe { cursor.key().downcast::<Tup1<(Option<K>, V)>>() };
+                match current.0 {
+                    (Some(_), _) => return Some(current.clone()),
+                    (None, _) => {
+                        if result.is_none() {
+                            // remember first value, this may be the final result if
+                            // all tuples have None in the first field
+                            result = Some(current.clone());
+                            // skip to first non-None in the first field, if it exists
+                            cursor.seek_key_with(&|key| {
+                                let typed = unsafe { key.downcast::<Tup1<(Option<K>, V)>>() };
+                                typed.0 .0.is_some()
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    fn finalize(&self, accumulator: Self::Accumulator) -> Self::Output {
+        Tup1::new(accumulator.0 .1)
+    }
+}

--- a/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/mod.rs
@@ -48,7 +48,7 @@ pub use aggregator::{
 pub use average::{Avg, AvgFactories, DynAverage};
 pub use fold::Fold;
 pub use max::{Max, MaxSemigroup};
-pub use min::{Min, MinSemigroup, MinSome1, MinSome1Semigroup};
+pub use min::{ArgMinSome, Min, MinSemigroup, MinSome1, MinSome1Semigroup};
 
 use super::MonoIndexedZSet;
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/BaseRustCodeGenerator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/BaseRustCodeGenerator.java
@@ -104,7 +104,7 @@ public abstract class BaseRustCodeGenerator implements ICodeGenerator {
                 },
                 circuit::{checkpointer::Checkpoint, ChildCircuit, Circuit, CircuitConfig, RootCircuit, Stream},
                 operator::{
-                    dynamic::aggregate::{Max, Min, MinSome1, Postprocess},
+                    dynamic::aggregate::{ArgMinSome, Max, Min, MinSome1, Postprocess},
                     Generator,
                     Fold,
                     group::WithCustomOrd,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPMinMax.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPMinMax.java
@@ -19,8 +19,13 @@ import javax.annotation.Nullable;
 public class DBSPMinMax extends DBSPAggregator {
     public enum Aggregation {
         Min,
+        Max,
+        // Special hand-crafted DBSP aggregator for Min(Option<T>).
+        // None values are ignored.
         MinSome1,
-        Max
+        // Special hand-crafted DBSP aggregator for ARG_MIN(V, Option<K>).
+        // None values in the second component are ignored.
+        ArgMinSome
     }
     public final Aggregation aggregation;
     @Nullable

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -32,6 +32,8 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
@@ -47,6 +49,9 @@ public final class DBSPCastExpression extends DBSPExpression {
         super(node, to);
         this.source = source;
         this.safe = safe;
+        Utilities.enforce(source.getType().is(DBSPTypeTupleBase.class) == to.is(DBSPTypeTupleBase.class)
+                || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class),
+                "Cast to/from tuple from/to non-tuple " + source.getType() + " to " + to);
         Utilities.enforce(to.code != DBSPTypeCode.INTERNED_STRING, "Cast to INTERNED");
         Utilities.enforce(source.getType().code != DBSPTypeCode.INTERNED_STRING, "Cast from INTERNED");
         Utilities.enforce(!safe || to.mayBeNull);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -647,6 +647,43 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         }
     }
 
+    @Test
+    public void argMinDate() {
+        this.getCCS("""
+                CREATE TABLE date_tbl(
+                id INT,
+                c1 DATE NOT NULL,
+                c2 DATE);
+                
+                CREATE VIEW V0 AS SELECT
+                id, ARG_MIN(c1, c2) AS c1, ARG_MIN(c2, c1) AS c2
+                FROM date_tbl
+                GROUP BY id;
+                
+                CREATE VIEW V1 AS SELECT
+                ARG_MIN(c1, c2) AS c1, ARG_MIN(c2, c1) AS c2
+                FROM date_tbl;""");
+    }
+
+    @Test
+    public void argMinString() {
+        this.getCCS("""
+                CREATE TABLE varchar_tbl(
+                id INT,
+                c1 VARCHAR,
+                c2 VARCHAR NULL);
+                
+                CREATE VIEW atbl_charn AS SELECT
+                id,
+                CAST(c1 AS CHAR(7)) AS f_c1,
+                CAST(c2 AS CHAR(7)) AS f_c2
+                FROM varchar_tbl;
+                
+                CREATE VIEW V2 AS SELECT id, ARG_MIN(f_c1, f_c2) AS c1, ARG_MIN(f_c2, f_c1) AS c2
+                FROM atbl_charn
+                GROUP BY id;""");
+    }
+
     @Test @Ignore("To be invoked manually every time a new function is added")
     public void generateFunctionIndex() throws IOException {
         // When invoked it generates documentation for the supported functions and operators

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/EndToEndTests.java
@@ -904,13 +904,16 @@ public class EndToEndTests extends BaseSQLTests {
 
     @Test
     public void minTest() {
-        String query = "SELECT MIN(T.COL1) FROM T";
+        String query = "SELECT MIN(T.COL1), MIN(T.COL5) FROM T";
         this.testAggregate(query,
                 new DBSPZSetExpression(
-                        new DBSPTupleExpression(new DBSPI32Literal(10, true))),
+                        new DBSPTupleExpression(
+                                new DBSPI32Literal(10, true),
+                                new DBSPI32Literal(1, true))),
                 new DBSPZSetExpression(
-                        new DBSPTupleExpression(DBSPLiteral.none(
-                                DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true)))));
+                        new DBSPTupleExpression(
+                                DBSPLiteral.none(DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true)),
+                                DBSPLiteral.none(DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true)))));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -1,6 +1,5 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;


### PR DESCRIPTION
This introduces a new DBSP Aggregator, which is very tailored towards the needs of `ARG_MIN`.
What doesn't one do for performance?
