### PR TITLE
sync: support continuous sync (standby mode)

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -21,10 +21,14 @@ use crate::catalog::OutputCollectionHandles;
 use crate::controller::checkpoint::CheckpointOffsets;
 use crate::controller::journal::Journal;
 use crate::controller::stats::{InputEndpointMetrics, OutputEndpointMetrics};
+#[cfg(feature = "feldera-enterprise")]
+use crate::controller::sync::continuous_pull;
+use crate::controller::sync::SYNCHRONIZER;
 use crate::create_integrated_output_endpoint;
 use crate::server::metrics::{
     HistogramDiv, LabelStack, MetricsFormatter, MetricsWriter, ValueType,
 };
+use crate::server::ServerState;
 use crate::transport::clock::now_endpoint_config;
 use crate::transport::Step;
 use crate::transport::{input_transport_config_to_endpoint, output_transport_config_to_endpoint};
@@ -59,7 +63,6 @@ use enum_map::EnumMap;
 use feldera_adapterlib::transport::Resume;
 use feldera_adapterlib::utils::datafusion::execute_query_text;
 use feldera_ir::LirCircuit;
-use feldera_storage::checkpoint_synchronizer::CheckpointSynchronizer;
 use feldera_storage::histogram::ExponentialHistogram;
 use feldera_storage::metrics::{
     READ_BLOCKS_BYTES, READ_LATENCY_MICROSECONDS, SYNC_LATENCY_MICROSECONDS, WRITE_BLOCKS_BYTES,
@@ -86,7 +89,7 @@ use std::io::ErrorKind;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, sync_channel, Receiver, SendError, Sender};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Weak};
 use std::thread;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -107,6 +110,7 @@ mod checkpoint;
 mod error;
 mod journal;
 mod stats;
+mod sync;
 mod validate;
 
 use crate::adhoc::create_session_context;
@@ -309,9 +313,10 @@ impl Controller {
     ///   transport or data format.
     ///
     /// * One or more of the endpoints fails to initialize.
-    pub fn with_config<F>(
+    pub(crate) fn with_config<F>(
         circuit_factory: F,
         config: &PipelineConfig,
+        weak_state_ref: Weak<ServerState>,
         error_cb: Box<dyn Fn(Arc<ControllerError>) + Send + Sync>,
     ) -> Result<Self, ControllerError>
     where
@@ -334,7 +339,7 @@ impl Controller {
             let handle = thread::Builder::new()
                 .name("circuit-thread".to_string())
                 .spawn(move || {
-                    match CircuitThread::new(circuit_factory, config, error_cb) {
+                    match CircuitThread::new(circuit_factory, config, weak_state_ref, error_cb) {
                         Err(error) => {
                             let _ = init_status_sender.send(Err(error));
                             Ok(())
@@ -1026,6 +1031,7 @@ impl CircuitThread {
     fn new<F>(
         circuit_factory: F,
         config: PipelineConfig,
+        weak_state_ref: Weak<ServerState>,
         error_cb: Box<dyn Fn(Arc<ControllerError>) + Send + Sync>,
     ) -> Result<Self, ControllerError>
     where
@@ -1038,7 +1044,7 @@ impl CircuitThread {
             processed_records,
             step,
             input_metadata,
-        } = ControllerInit::new(config.clone())?;
+        } = ControllerInit::new(config.clone(), weak_state_ref)?;
         let storage = circuit_config
             .storage
             .as_ref()
@@ -1792,16 +1798,6 @@ impl CircuitThread {
             return;
         };
 
-        let Some(synchronizer) = inventory::iter::<&dyn CheckpointSynchronizer>
-            .into_iter()
-            .next()
-        else {
-            cb(Err(Arc::new(ControllerError::checkpoint_push_error(
-                "no checkpoint synchronizer found; are enterprise features enabled?".to_owned(),
-            ))));
-            return;
-        };
-
         let Some(ref storage) = self.storage else {
             tracing::error!("storage is set to None");
             cb(Err(Arc::new(ControllerError::checkpoint_push_error(
@@ -1816,7 +1812,7 @@ impl CircuitThread {
         thread::Builder::new()
             .name("s3-synchronizer".to_string())
             .spawn(move || {
-                if let Err(err) = synchronizer.push(uuid, storage.clone(), config.clone()) {
+                if let Err(err) = SYNCHRONIZER.push(uuid, storage.clone(), config.clone()) {
                     cb(Err(Arc::new(ControllerError::checkpoint_push_error(
                         err.to_string(),
                     ))));
@@ -2293,7 +2289,11 @@ impl ControllerInit {
             input_metadata: None,
         })
     }
-    fn new(config: PipelineConfig) -> Result<Self, ControllerError> {
+
+    fn new(
+        config: PipelineConfig,
+        _weak_state_ref: Weak<ServerState>,
+    ) -> Result<Self, ControllerError> {
         let Some((storage_config, storage_options)) = config.storage() else {
             if !config.global.fault_tolerance.is_enabled() {
                 info!("storage not configured, so suspend-and-resume and fault tolerance will not be available");
@@ -2311,39 +2311,7 @@ impl ControllerInit {
                 })?;
 
         #[cfg(feature = "feldera-enterprise")]
-        {
-            use feldera_storage::checkpoint_synchronizer::CheckpointSynchronizer;
-            use feldera_types::config::FileBackendConfig;
-
-            if let feldera_types::config::StorageBackendConfig::File(FileBackendConfig {
-                sync: Some(ref sync),
-                ..
-            }) = storage.options.backend
-            {
-                if sync.start_from_checkpoint.is_some() {
-                    let Some(synchronizer) = inventory::iter::<&dyn CheckpointSynchronizer>
-                        .into_iter()
-                        .next()
-                    else {
-                        return Err(ControllerError::checkpoint_fetch_error(
-                            "no checkpoint synchronizer found; are enterprise features enabled?"
-                                .to_owned(),
-                        ));
-                    };
-
-                    if let Err(err) = synchronizer
-                        .pull(storage.backend.clone(), sync.to_owned())
-                        .map_err(|e| ControllerError::checkpoint_fetch_error(e.to_string()))
-                    {
-                        if sync.fail_if_no_checkpoint {
-                            return Err(err);
-                        } else {
-                            tracing::error!("{}", err.to_string())
-                        }
-                    }
-                }
-            }
-        }
+        continuous_pull(&storage, _weak_state_ref)?;
 
         // Try to read a checkpoint.
         let checkpoint = match Checkpoint::read(&*storage.backend, &StoragePath::from(STATE_FILE)) {

--- a/crates/adapters/src/controller/sync.rs
+++ b/crates/adapters/src/controller/sync.rs
@@ -1,0 +1,124 @@
+#![allow(unused_imports)]
+use anyhow::Context;
+use std::sync::{Arc, LazyLock, Weak};
+
+use dbsp::circuit::CircuitStorageConfig;
+use feldera_adapterlib::errors::journal::ControllerError;
+use feldera_storage::{
+    checkpoint_synchronizer::CheckpointSynchronizer, StorageBackend, StoragePath,
+};
+use feldera_types::{
+    config::{FileBackendConfig, StorageBackendConfig, SyncConfig},
+    constants::ACTIVATION_MARKER_FILE,
+};
+
+use crate::server::ServerState;
+
+/// Lazily resolves the checkpoint synchronizer.
+///
+/// This panic is safe as all enterprise builds must include the checkpoint-sync
+/// crate.
+pub(super) static SYNCHRONIZER: LazyLock<&'static dyn CheckpointSynchronizer> =
+    LazyLock::new(|| {
+        let Some(synchronizer) = inventory::iter::<&dyn CheckpointSynchronizer>
+            .into_iter()
+            .next()
+        else {
+            unreachable!("no checkpoint synchronizer found; are enterprise features enabled?");
+        };
+
+        *synchronizer
+    });
+
+#[cfg(feature = "feldera-enterprise")]
+fn upgrade_state(weak: Weak<ServerState>) -> Result<Arc<ServerState>, ControllerError> {
+    weak.upgrade()
+        .ok_or(ControllerError::checkpoint_fetch_error(
+            "unreachable: failed to upgrade server state".to_owned(),
+        ))
+}
+
+/// Pulls the checkpoint specified by the sync config and garbage collects all
+/// older checkpoints.
+#[cfg(feature = "feldera-enterprise")]
+fn pull_and_gc(storage: Arc<dyn StorageBackend>, sync: &SyncConfig) -> Result<(), ControllerError> {
+    match SYNCHRONIZER
+        .pull(storage.clone(), sync.to_owned())
+        .map_err(|e| ControllerError::checkpoint_fetch_error(format!("{e:?}")))
+    {
+        Err(err) => {
+            tracing::error!("{:?}", err.to_string());
+            if sync.fail_if_no_checkpoint {
+                return Err(err);
+            }
+        }
+        Ok(cpm) => {
+            _ = storage
+                .gc_startup(&vec![cpm].into())
+                .map_err(|e| ControllerError::dbsp_error(e.into()))?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "feldera-enterprise")]
+pub fn continuous_pull(
+    storage: &CircuitStorageConfig,
+    weak: Weak<ServerState>,
+) -> Result<(), ControllerError> {
+    let StorageBackendConfig::File(FileBackendConfig {
+        sync: Some(ref sync),
+        ..
+    }) = storage.options.backend
+    else {
+        return Ok(());
+    };
+
+    sync.validate()
+        .map_err(ControllerError::checkpoint_fetch_error)?;
+
+    if sync.start_from_checkpoint.is_none() {
+        return Ok(());
+    }
+
+    let state = upgrade_state(weak)?;
+    while !state.activated() {
+        let previously_activated = storage
+            .backend
+            .exists(&StoragePath::default().child(ACTIVATION_MARKER_FILE))
+            .unwrap_or(false);
+
+        if previously_activated {
+            tracing::info!("time pipeline was previously activated, skipping standby mode");
+            return Ok(());
+        }
+
+        pull_and_gc(storage.backend.clone(), sync)?;
+
+        if !sync.standby {
+            return Ok(());
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(sync.pull_interval));
+    }
+
+    if state.activated() {
+        if let Err(marker_err) = storage
+            .backend
+            .write_json(&StoragePath::default().child(ACTIVATION_MARKER_FILE), &"")
+            .context("failed to write activation marker file")
+        {
+            tracing::error!("{marker_err:?}");
+            if sync.fail_if_no_checkpoint {
+                return Err(ControllerError::checkpoint_fetch_error(format!(
+                    "{marker_err:?}"
+                )));
+            }
+        }
+
+        tracing::info!("pipeline activated");
+    }
+
+    Ok(())
+}

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -74,6 +74,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     ) else {
         panic!("expected to fail")
@@ -146,6 +147,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     )
     .unwrap();
@@ -237,6 +239,7 @@ outputs:
         let controller = Controller::with_config(
                 |circuit_config| Ok(test_circuit::<TestStruct>(circuit_config, &[], &[None])),
                 &config,
+                std::sync::Weak::new(),
                 Box::new(|e| panic!("error: {e}")),
             )
             .unwrap();
@@ -577,6 +580,7 @@ outputs:
                 ))
             },
             &config,
+            std::sync::Weak::new(),
             Box::new(|e| panic!("error: {e}")),
         )
         .unwrap();
@@ -755,6 +759,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     )
     .unwrap();
@@ -849,6 +854,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     );
 
@@ -1057,6 +1063,7 @@ outputs:
                 ))
             },
             &config,
+            std::sync::Weak::new(),
             Box::new(|e| panic!("error: {e}")),
         )
         .unwrap();
@@ -1170,6 +1177,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     )
     .unwrap();
@@ -1218,6 +1226,7 @@ outputs:
                 ))
             },
             &config,
+            std::sync::Weak::new(),
             Box::new(|e| panic!("error: {e}")),
         )
         .unwrap();
@@ -1395,6 +1404,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     )
     .unwrap();
@@ -1709,6 +1719,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     )
     .unwrap();

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -318,6 +318,7 @@ inputs:
     Controller::with_config(
         move |workers| Ok(test_circuit::<T>(workers, &schema, &[None])),
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| panic!("delta_table_input_test: error: {e}")),
     )
     .unwrap()
@@ -397,6 +398,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| panic!("delta_to_delta pipeline: error: {e}")),
     )
     .unwrap()
@@ -461,6 +463,7 @@ inputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| panic!("delta_read pipeline: error: {e}")),
     )
     .unwrap()
@@ -542,6 +545,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| panic!("delta_write pipeline: error: {e}")),
     )
     .unwrap()
@@ -638,6 +642,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| panic!("delta_table_output_test: error: {e}")),
     )
     .unwrap();

--- a/crates/adapters/src/integrated/postgres/test.rs
+++ b/crates/adapters/src/integrated/postgres/test.rs
@@ -395,6 +395,7 @@ CREATE TABLE {name} (
                     })
                 },
                 &config,
+                std::sync::Weak::new(),
                 Box::new(move |e| {
                     let msg = format!("postgres_output_test: error: {}", e);
                     println!("{msg}");
@@ -1021,6 +1022,7 @@ outputs:
             })
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| {
             let msg = format!("postgres_output_test: error: {e}");
             println!("{msg}");

--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -384,6 +384,7 @@ inputs:
         let controller = Controller::with_config(
             move |workers| Ok(clock_test_circuit(workers, test_stats_clone)),
             &config,
+            std::sync::Weak::new(),
             Box::new(move |e| panic!("clock_test pipeline 1: error: {e}")),
         )
         .unwrap();
@@ -430,6 +431,7 @@ inputs:
         let controller = Controller::with_config(
             move |workers| Ok(clock_test_circuit(workers, test_stats_clone)),
             &config,
+            std::sync::Weak::new(),
             Box::new(move |e| panic!("clock_test pipeline 2: error: {e}")),
         )
         .unwrap();

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -105,6 +105,7 @@ outputs:
             ))
         },
         &config,
+        std::sync::Weak::new(),
         Box::new(|e| panic!("error: {e}")),
     ) {
         Ok(_) => panic!("expected an error"),
@@ -947,6 +948,7 @@ outputs:
                 ))
             },
             &config,
+            std::sync::Weak::new(),
             Box::new(|e| panic!("error: {e}")),
         )
         .unwrap();
@@ -1381,6 +1383,7 @@ outputs:
     let controller = Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema(), &[None])),
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| if running_clone.load(Ordering::Acquire) {
             panic!("{test_name_clone}: error: {e}")
         } else {
@@ -1961,6 +1964,7 @@ outputs:
     let controller = Controller::with_config(
         |workers| Ok(test_circuit::<TestStruct>(workers, &TestStruct::schema(), &[None])),
         &config,
+                std::sync::Weak::new(),
         Box::new(move |e| if running_clone.load(Ordering::Acquire) {
             panic!("buffer_test: error: {e}")
         } else {

--- a/crates/adapters/src/transport/kafka/nonft/output.rs
+++ b/crates/adapters/src/transport/kafka/nonft/output.rs
@@ -292,6 +292,7 @@ outputs:
                 ))
             },
             &config,
+            std::sync::Weak::new(),
             Box::new(|e| panic!("error: {e}")),
         ) {
             Ok(_) => panic!("expected an error"),

--- a/crates/adapters/src/transport/redis/test.rs
+++ b/crates/adapters/src/transport/redis/test.rs
@@ -180,6 +180,7 @@ outputs:
     let controller = Controller::with_config(
         move |workers| Ok(test_circuit::<DeltaTestStruct>(workers, &schema, &[None])),
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| {
             let msg = format!("redis_output_test: error: {e}");
             println!("{msg}");
@@ -303,6 +304,7 @@ outputs:
     let Err(err) = Controller::with_config(
         move |workers| Ok(test_circuit::<TestStruct>(workers, &schema, &[None])),
         &config,
+        std::sync::Weak::new(),
         Box::new(move |e| {
             let msg = format!("redis_output_test: error: {e}");
             println!("{msg}");

--- a/crates/feldera-types/src/constants.rs
+++ b/crates/feldera-types/src/constants.rs
@@ -9,3 +9,14 @@ pub const STATE_FILE: &str = "state.json";
 pub const STEPS_FILE: &str = "steps.bin";
 
 pub const CHECKPOINT_DEPENDENCIES: &str = "dependencies.json";
+
+pub const ADHOC_TEMP_DIR: &str = "adhoc-tmp";
+
+/// A slice of all file-extension the system can create.
+pub const DBSP_FILE_EXTENSION: &[&str] = &["mut", "feldera"];
+
+/// Extension for batch files used by the engine.
+pub const CREATE_FILE_EXTENSION: &str = ".feldera";
+
+/// File that marks the activation of a pipeline.
+pub const ACTIVATION_MARKER_FILE: &str = "activated.feldera";

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -956,6 +956,72 @@ pub(crate) async fn get_pipeline_heap_profile(
         .await
 }
 
+/// Activates the pipeline if it is currently in standby mode.
+///
+/// This endpoint is only applicable when the pipeline is configured to start
+/// from object store and launched in standby mode (`sync.standby: true`).
+#[utoipa::path(
+    context_path = "/v0",
+    security(("JSON web token (JWT) or API key" = [])),
+    params(
+        ("pipeline_name" = String, Path, description = "Unique pipeline name"),
+    ),
+    responses(
+        (status = ACCEPTED
+            , description = "Pipeline activation initiated"
+            , body = CheckpointResponse),
+        (status = NOT_FOUND
+            , description = "Pipeline with that name does not exist"
+            , body = ErrorResponse
+            , example = json!(examples::error_unknown_pipeline_name())),
+        (status = SERVICE_UNAVAILABLE
+            , body = ErrorResponse
+            , examples(
+                ("Pipeline is not deployed" = (value = json!(examples::error_pipeline_interaction_not_deployed()))),
+                ("Pipeline is currently unavailable" = (value = json!(examples::error_pipeline_interaction_currently_unavailable()))),
+                ("Disconnected during response" = (value = json!(examples::error_pipeline_interaction_disconnected()))),
+                ("Response timeout" = (value = json!(examples::error_pipeline_interaction_timeout())))
+            )
+        ),
+        (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
+    ),
+    tag = "Pipeline interaction"
+)]
+#[post("/pipelines/{pipeline_name}/activate")]
+pub(crate) async fn activate_pipeline(
+    state: WebData<ServerState>,
+    _client: WebData<awc::Client>,
+    tenant_id: ReqData<TenantId>,
+    path: web::Path<String>,
+    request: HttpRequest,
+) -> Result<HttpResponse, ManagerError> {
+    #[cfg(not(feature = "feldera-enterprise"))]
+    {
+        let _ = (state, tenant_id, path.into_inner(), request);
+        Err(CommonError::EnterpriseFeature {
+            feature: "start from object store (S3)".to_string(),
+        }
+        .into())
+    }
+
+    #[cfg(feature = "feldera-enterprise")]
+    {
+        let pipeline_name = path.into_inner();
+        state
+            .runner
+            .forward_http_request_to_pipeline_by_name(
+                _client.as_ref(),
+                *tenant_id,
+                &pipeline_name,
+                Method::POST,
+                "activate",
+                request.query_string(),
+                Some(Duration::from_secs(120)),
+            )
+            .await
+    }
+}
+
 /// Check if the request is a WebSocket upgrade request.
 fn request_is_websocket(request: &HttpRequest) -> bool {
     request

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -92,6 +92,9 @@ only the program-related core fields, and is used by the compiler to discern whe
         endpoints::pipeline_interaction::pipeline_adhoc_sql,
         endpoints::pipeline_interaction::checkpoint_pipeline,
         endpoints::pipeline_interaction::get_checkpoint_status,
+        endpoints::pipeline_interaction::sync_checkpoint,
+        endpoints::pipeline_interaction::get_checkpoint_sync_status,
+        endpoints::pipeline_interaction::activate_pipeline,
         endpoints::pipeline_interaction::completion_token,
         endpoints::pipeline_interaction::completion_status,
         endpoints::pipeline_interaction::start_transaction,
@@ -295,6 +298,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_interaction::sync_checkpoint)
         .service(endpoints::pipeline_interaction::get_checkpoint_status)
         .service(endpoints::pipeline_interaction::get_checkpoint_sync_status)
+        .service(endpoints::pipeline_interaction::activate_pipeline)
         .service(endpoints::pipeline_interaction::post_pipeline_input_connector_action)
         .service(endpoints::pipeline_interaction::get_pipeline_input_connector_status)
         .service(endpoints::pipeline_interaction::get_pipeline_output_connector_status)

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -35,7 +35,7 @@ impl CachedPipelineDescr {
     /// status to be interacted with (i.e., running or paused).
     fn deployment_location_based_on_status(&self) -> Result<String, ManagerError> {
         match self.pipeline.deployment_status {
-            PipelineStatus::Running | PipelineStatus::Paused | PipelineStatus::Suspending => {}
+            PipelineStatus::Initializing | PipelineStatus::Running | PipelineStatus::Paused | PipelineStatus::Suspending => {}
             PipelineStatus::Unavailable => Err(RunnerError::PipelineInteractionUnreachable {
                 error: "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again".to_string()
             })?,

--- a/crates/storage/src/checkpoint_synchronizer.rs
+++ b/crates/storage/src/checkpoint_synchronizer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use feldera_types::config::SyncConfig;
+use feldera_types::{checkpoint::CheckpointMetadata, config::SyncConfig};
 
 use crate::StorageBackend;
 
@@ -16,7 +16,7 @@ pub trait CheckpointSynchronizer: Sync {
         &self,
         storage: Arc<dyn StorageBackend>,
         remote_config: SyncConfig,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<CheckpointMetadata>;
 }
 
 inventory::collect!(&'static dyn CheckpointSynchronizer);

--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -27,6 +27,7 @@ Here is a sample configuration:
         "secret_key": "SECRET_KEY",
         "start_from_checkpoint": "latest",
         "fail_if_no_checkpoint": false,
+        "standby": false,
         "flags": ["--s3-server-side-encryption", "aws:kms"]
       }
     }
@@ -36,23 +37,25 @@ Here is a sample configuration:
 
 ### `sync` configuration fields
 
-| Field                   | Type            | Default     | Description                                                                                                                                                                                                      |
-|-------------------------|-----------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `endpoint`              | `string`        |             | The S3-compatible object store endpoint (e.g., `http://localhost:9000` for MinIO).                                                                                                                               |
-| `bucket` \*             | `string`        |             | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`).                                                                                                                         |
-| `region`                | `string`        | `us-east-1` | The region of the bucket. Leave empty for MinIO. If `provider` is AWS, and no region is specified, `us-east-1` is used.                                                                                          |
-| `provider` \*           | `string`        |             | The S3 provider identifier. Must match [rclone’s list](https://rclone.org/s3/#providers). Case-sensitive. Use `"Other"` if unsure.                                                                               |
-| `access_key`            | `string`        |             | S3 access key. Not required if using environment-based auth (e.g., IRSA).                                                                                                                                        |
-| `secret_key`            | `string`        |             | S3 secret key. Not required if using environment-based auth.                                                                                                                                                     |
-| `start_from_checkpoint` | `string`        |             | Checkpoint UUID to resume from, or `latest` to restore from the latest checkpoint.                                                                                                                               |
-| `fail_if_no_checkpoint` | `boolean`       | `false`     | When `true` the pipeline will fail to initialize if fetching the specified checkpoint fails. <p> When `false`, the pipeline will start from scratch instead. Ignored if `start_from_checkpoint` is not set. </p> |
-| `transfers`             | `integer (u8)`  | `20`        | Number of concurrent file transfers.                                                                                                                                                                             |
-| `checkers`              | `integer (u8)`  | `20`        | Number of parallel checkers for verification.                                                                                                                                                                    |
-| `ignore_checksum`       | `boolean`       | `false`     | Skip checksum verification after transfer and only check the file size. Might improve throughput.                                                                                                                |
-| `multi_thread_streams`  | `integer (u8)`  | `10`        | Number of streams for multi-threaded downloads.                                                                                                                                                                  |
-| `multi_thread_cutoff`   | `string`        | `100M`      | File size threshold to enable multi-threaded downloads (e.g., `100M`, `1G`). Supported suffixes: `k`, `M`, `G`, `T`.                                                                                             |
-| `upload_concurrency`    | `integer (u8)`  | `10`        | Number of concurrent chunks to upload during multipart uploads.                                                                                                                                                  |
-| `flags`                 | `array[string]` |             | Extra flags to pass to `rclone`.<p> ⚠️ Incorrect or conflicting flags may break behavior. See [rclone flags](https://rclone.org/flags/) and [S3 flags](https://rclone.org/s3/). </p>                             |
+| Field                   | Type            | Default     | Description                                                                                                                                                                                                                                                                                                   |
+|-------------------------|-----------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `endpoint`              | `string`        |             | The S3-compatible object store endpoint (e.g., `http://localhost:9000` for MinIO).                                                                                                                                                                                                                            |
+| `bucket` \*             | `string`        |             | The bucket name and optional prefix to store checkpoints (e.g., `mybucket/checkpoints`).                                                                                                                                                                                                                      |
+| `region`                | `string`        | `us-east-1` | The region of the bucket. Leave empty for MinIO. If `provider` is AWS, and no region is specified, `us-east-1` is used.                                                                                                                                                                                       |
+| `provider` \*           | `string`        |             | The S3 provider identifier. Must match [rclone’s list](https://rclone.org/s3/#providers). Case-sensitive. Use `"Other"` if unsure.                                                                                                                                                                            |
+| `access_key`            | `string`        |             | S3 access key. Not required if using environment-based auth (e.g., IRSA).                                                                                                                                                                                                                                     |
+| `secret_key`            | `string`        |             | S3 secret key. Not required if using environment-based auth.                                                                                                                                                                                                                                                  |
+| `start_from_checkpoint` | `string`        |             | Checkpoint UUID to resume from, or `latest` to restore from the latest checkpoint.                                                                                                                                                                                                                            |
+| `fail_if_no_checkpoint` | `boolean`       | `false`     | When `true` the pipeline will fail to initialize if fetching the specified checkpoint fails. <p> When `false`, the pipeline will start from scratch instead. Ignored if `start_from_checkpoint` is not set. </p>                                                                                              |
+| `standby`               | `boolean`       | `false`     | When `true`, the pipeline starts in **standby** mode. <p> To start processing the data the pipeline must be activated (`POST /activate`). </p> <p> If a previously activated pipeline is restarted without clearing storage, it auto-activates. </p> `start_from_checkpoint` must be set to use standby mode. |
+| `pull_interval`         | `integer(u64)`  | `10`        | Interval (in seconds) between fetch attempts for the latest checkpoint while standby.                                                                                                                                                                                                                         |
+| `transfers`             | `integer (u8)`  | `20`        | Number of concurrent file transfers.                                                                                                                                                                                                                                                                          |
+| `checkers`              | `integer (u8)`  | `20`        | Number of parallel checkers for verification.                                                                                                                                                                                                                                                                 |
+| `ignore_checksum`       | `boolean`       | `false`     | Skip checksum verification after transfer and only check the file size. Might improve throughput.                                                                                                                                                                                                             |
+| `multi_thread_streams`  | `integer (u8)`  | `10`        | Number of streams for multi-threaded downloads.                                                                                                                                                                                                                                                               |
+| `multi_thread_cutoff`   | `string`        | `100M`      | File size threshold to enable multi-threaded downloads (e.g., `100M`, `1G`). Supported suffixes: `k`, `M`, `G`, `T`.                                                                                                                                                                                          |
+| `upload_concurrency`    | `integer (u8)`  | `10`        | Number of concurrent chunks to upload during multipart uploads.                                                                                                                                                                                                                                               |
+| `flags`                 | `array[string]` |             | Extra flags to pass to `rclone`.<p> ⚠️ Incorrect or conflicting flags may break behavior. See [rclone flags](https://rclone.org/flags/) and [S3 flags](https://rclone.org/s3/). </p>                                                                                                                          |
 
 
 *Fields marked with an asterisk are required.
@@ -107,6 +110,50 @@ For more details, refer to [rclone S3 permissions](https://rclone.org/s3/#s3-per
 
 To use **IRSA** (IAM Roles for Service Accounts) **omit** fields `access_key`
 and `secret_key`. This loads credentials from the environment.
+
+## Standby mode
+
+Pipelines can be configured to start in **standby** mode by setting `standby` to
+true. When in standby mode, the pipeline does not process any data but continuously
+pulls the latest (or the checkpoint with the specified UUID based on `start_from_checkpoint`)
+checkpoint at the interval specified by `pull_interval`.
+
+Pipelines in **standby** mode must be explicitly activated via:
+
+```sh
+curl -X POST https://{FELDERA_HOST}/v0/pipelines/{PIPELINE_NAME}/activate
+```
+
+:::important
+Pipelines that were previously activated, and have the storage intact will auto-activate
+from the latest local checkpoint. This is to avoid unintential behavior in case of the
+pipeline getting rescheduled or restarted.
+:::
+
+Standby mode is incredibly useful to have a backup pipeline (**B**) ready to process data
+in case the primary pipeline (**A**) fails. Consider the following example. These are two
+pipelines running side by side: Pipeline **A** (Primary) actively processes data and creates
+checkpoints, while Pipeline **B** (Standby) stays in standby mode, pulling checkpoints and
+ready to activate if needed.
+
+When Pipeline **A** fails, you can trigger Pipeline **B** to activate and start processing from
+the latest checkpoint (Checkpoint 2 in this case).
+
+| Time    | Pipeline A (Primary) | Pipeline B (Standby)          |
+|---------|----------------------|-------------------------------|
+| Step 1  | **Start**            | **Standby Start**             |
+| Step 2  | *Processing*         | *Standby*                     |
+| Step 3  | *Checkpoint 1*       | *Standby*                     |
+| Step 4  | *Sync 1 to S3*       | *Standby*                     |
+| Step 5  | *Processing*         | *Pulls Checkpoint 1*          |
+| Step 6  | *Checkpoint 2*       | *Standby*                     |
+| Step 7  | *Sync 2 to S3*       | *Standby*                     |
+| Step 8  | *Processing*         | *Pulls Checkpoint 2*          |
+| Step 9  | *Failed*             | *Standby*                     |
+| Step 10 |                      | **Activate**                  |
+| Step 11 |                      | **Running From Checkpoint 2** |
+
+
 
 ## Buckets with server side encryption
 

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -473,6 +473,19 @@ metrics"""
                 raise RuntimeError(f"waiting for idle reached timeout ({timeout_s}s)")
             time.sleep(poll_interval_s)
 
+    def activate(self, wait: bool = True, timeout_s: Optional[float] = None):
+        """
+        Activates the pipeline when starting from STANDBY mode. Only applicable
+        when the pipeline is starting from a checkpoint in object store.
+
+        :param wait: Set True to wait for the pipeline to activate. True by
+            default
+        :param timeout_s: The maximum time (in seconds) to wait for the
+            pipeline to pause.
+        """
+
+        self.client.activate_pipeline(self.name, wait=wait, timeout_s=timeout_s)
+
     def pause(self, wait: bool = True, timeout_s: Optional[float] = None):
         """
         Pause the pipeline.

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -258,6 +258,58 @@ class FelderaClient:
                 if chunk:
                     yield chunk.decode("utf-8")
 
+    def activate_pipeline(
+        self, pipeline_name: str, wait: bool = True, timeout_s: Optional[float] = 300
+    ):
+        """
+
+        :param pipeline_name: The name of the pipeline to activate
+        :param wait: Set True to wait for the pipeline to activate. True by default
+        :param timeout_s: The amount of time in seconds to wait for the pipeline
+            to activate. 300 seconds by default.
+        """
+
+        if timeout_s is None:
+            timeout_s = 300
+
+        self.http.post(
+            path=f"/pipelines/{pipeline_name}/activate",
+        )
+
+        if not wait:
+            return
+
+        start_time = time.monotonic()
+
+        while True:
+            if timeout_s is not None:
+                elapsed = time.monotonic() - start_time
+                if elapsed > timeout_s:
+                    raise TimeoutError(
+                        f"Timed out waiting for pipeline {pipeline_name} to activate"
+                    )
+
+            resp = self.get_pipeline(pipeline_name)
+            status = resp.deployment_status
+
+            if status == "Running":
+                break
+            elif (
+                status == "Stopped"
+                and len(resp.deployment_error or {}) > 0
+                and resp.deployment_desired_status == "Stopped"
+            ):
+                raise RuntimeError(
+                    f"""Unable to ACTIVATE the pipeline.
+Reason: The pipeline is in a STOPPED state due to the following error:
+{resp.deployment_error.get("message", "")}"""
+                )
+
+            logging.debug(
+                "still starting %s, waiting for 100 more milliseconds", pipeline_name
+            )
+            time.sleep(0.1)
+
     def start_pipeline(
         self, pipeline_name: str, wait: bool = True, timeout_s: Optional[float] = 300
     ):

--- a/python/tests/shared_test_pipeline.py
+++ b/python/tests/shared_test_pipeline.py
@@ -45,3 +45,8 @@ class SharedTestPipeline(unittest.TestCase):
     @property
     def pipeline(self) -> Pipeline:
         return self.p
+
+    def new_pipeline_with_suffix(self, suffix: str) -> Pipeline:
+        return PipelineBuilder(
+            self.client, f"{self._testMethodName}_{suffix}", sql=self.ddl
+        ).create_or_replace()


### PR DESCRIPTION
Adds `standby` param to sync config to enable starting a pipeline in standby mode. This pipeline will remain in standby mode, fetching the latest (or the checkpoint with the provided uuid) until the pipeline is activated (`POST /activate`). It is possible to configure the `pull_interval` by setting it in the sync config.

Add a brief description of the pull request.

## Checklist

- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
