### PR TITLE
py: bugfix: give full errors for RustError and SystemError

### DIFF
--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -138,7 +138,17 @@ class FelderaClient:
                             err_msg += f"Code snippet:\n{sql_error['snippet']}"
                         raise RuntimeError(err_msg)
 
-                raise RuntimeError(f"The program failed to compile: {status}")
+                error_message = f"The program failed to compile: {status}\n"
+
+                rust_error = p.program_error.get("rust_compilation")
+                if rust_error is not None:
+                    error_message += f"Rust Error: {rust_error}\n"
+
+                system_error = p.program_error.get("system_error")
+                if system_error is not None:
+                    error_message += f"System Error: {system_error}"
+
+                raise RuntimeError(error_message)
 
             logging.debug("still compiling %s, waiting for 100 more milliseconds", name)
             time.sleep(0.1)

--- a/python/tests/negative_test.py
+++ b/python/tests/negative_test.py
@@ -29,6 +29,17 @@ Code snippet:
         pipeline = Pipeline.get("sql_error", TEST_CLIENT)
         pipeline.clear_storage()
 
+    def test_rust_error(self):
+        pipeline_name = "rust_error"
+        sql = ""
+
+        with self.assertRaises(Exception) as err:
+            PipelineBuilder(
+                TEST_CLIENT, name=pipeline_name, sql=sql, udf_rust="Davy Jones"
+            ).create_or_replace()
+
+        assert "Davy Jones" in err.exception.args[0].strip()
+
     def test_program_error0(self):
         sql = "create taabl;"
         name = "test_program_error0"


### PR DESCRIPTION
Fixes: #4512

Bugfix

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
