### PR TITLE
pipeline-manager: refactor regular database probe

### DIFF
--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -606,5 +606,5 @@ Version: {} v{}{}
 #[get("/healthz")]
 async fn healthz(state: WebData<ServerState>) -> Result<HttpResponse, ManagerError> {
     let probe = state.probe.lock().await;
-    probe.status_as_http_response()
+    Ok(probe.as_http_response())
 }

--- a/crates/pipeline-manager/src/compiler/main.rs
+++ b/crates/pipeline-manager/src/compiler/main.rs
@@ -102,7 +102,7 @@ async fn get_binary(
 /// Health check which returns success if it is able to reach the database.
 #[get("/healthz")]
 async fn healthz(probe: web::Data<Arc<Mutex<DbProbe>>>) -> Result<impl Responder, ManagerError> {
-    probe.lock().await.status_as_http_response()
+    Ok(probe.lock().await.as_http_response())
 }
 
 /// Creates the compiler working directory if it does not exist.

--- a/crates/pipeline-manager/src/db/probe.rs
+++ b/crates/pipeline-manager/src/db/probe.rs
@@ -1,68 +1,88 @@
 use crate::db::storage::Storage;
 use crate::db::storage_postgres::StoragePostgres;
 use crate::error::ManagerError;
-use actix_web::{HttpResponse, ResponseError};
-use chrono::{DateTime, Local};
-use log::{error, trace};
+use actix_web::HttpResponse;
+use chrono::{DateTime, Utc};
+use log::{error, info};
+use serde_json::json;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
-#[derive(Debug)]
+/// Interval at which the database is probed in the background.
+const DATABASE_PROBE_INTERVAL: Duration = Duration::from_secs(5);
+
 pub struct DbProbe {
-    pub last_checked: DateTime<Local>,
+    pub last_checked: DateTime<Utc>,
     pub last_error: Option<ManagerError>,
 }
 
-async fn check_if_db_reachable(
+impl DbProbe {
+    /// Creates a new database probe that runs in the background.
+    /// The background thread regularly updates the returned shared mutex.
+    pub async fn new(db: Arc<Mutex<StoragePostgres>>) -> Arc<Mutex<DbProbe>> {
+        let probe = DbProbe {
+            last_checked: Utc::now(),
+            last_error: None,
+        };
+        let probe = Arc::new(Mutex::new(probe));
+        tokio::spawn(regular_database_probe(
+            probe.clone(),
+            db,
+            DATABASE_PROBE_INTERVAL,
+        ));
+        probe
+    }
+
+    /// Converts the database probe status to an HTTP response that can be returned by health check
+    /// endpoints.
+    pub fn as_http_response(&self) -> HttpResponse {
+        match &self.last_error {
+            Some(_e) => HttpResponse::InternalServerError().json(json!({
+                "status": "unhealthy: unable to reach database (see logs for further details)"
+            })),
+            None => HttpResponse::Ok().json(json!({
+                "status": "healthy"
+            })),
+        }
+    }
+}
+
+/// Regularly probes the database connection at an interval.
+/// Each time the result is used to update the shared mutex.
+async fn regular_database_probe(
     probe: Arc<Mutex<DbProbe>>,
     db: Arc<Mutex<StoragePostgres>>,
     interval: Duration,
 ) {
     loop {
-        let now = Local::now();
-        let res = db.lock().await.check_connection().await;
-        let mut probe = probe.lock().await;
-        probe.last_checked = now;
-        probe.last_error = res.err().map(|e| e.into());
-        if probe.last_error.is_some() {
-            trace!("DB reachability probe returned an error: {:?}", probe);
-        }
-        drop(probe);
-        tokio::time::sleep(interval).await;
-    }
-}
-
-impl DbProbe {
-    pub async fn new(db: Arc<Mutex<StoragePostgres>>) -> Arc<Mutex<DbProbe>> {
-        let probe = DbProbe {
-            last_checked: Local::now(),
-            last_error: None,
-        };
-        let probe = Arc::new(Mutex::new(probe));
-        tokio::spawn(check_if_db_reachable(
-            probe.clone(),
-            db,
-            Duration::from_secs(5),
-        ));
-        probe
-    }
-
-    pub fn status_as_http_response(&self) -> Result<HttpResponse, ManagerError> {
-        match &self.last_error {
-            Some(e) => {
+        // Perform probe
+        let probe_at = Utc::now();
+        let probe_error = match db.lock().await.check_connection().await {
+            Ok(()) => None,
+            Err(e) => {
                 error!(
-                    "/healthz probe returning error (last_checked: {:?}, last_error: {})",
-                    self.last_checked, e
+                    "Regular database connection probe failed (retry in {}s) -- is the database available? Error: {e}",
+                    interval.as_secs(),
                 );
-                Ok(e.error_response())
+                Some(e.into())
             }
-            None => {
-                trace!(
-                    "/healthz probe returning ok (last_checked: {:?})",
-                    self.last_checked,
-                );
-                Ok(HttpResponse::Ok().into())
-            }
+        };
+
+        // Update the mutex
+        let mut probe = probe.lock().await;
+        let has_recovered = probe_error.is_none() && probe.last_error.is_some();
+        *probe = DbProbe {
+            last_checked: probe_at,
+            last_error: probe_error,
+        };
+        drop(probe);
+
+        // Log if the database connection recovered
+        if has_recovered {
+            info!("Regular database connection probe succeeded (recovered)");
         }
+
+        // Sleep until next attempt
+        tokio::time::sleep(interval).await;
     }
 }

--- a/crates/pipeline-manager/src/runner/main.rs
+++ b/crates/pipeline-manager/src/runner/main.rs
@@ -54,7 +54,7 @@ type PipelinesState = BTreeMap<PipelineId, (Arc<Notify>, Sender<Sender<String>>)
 /// The health check consults the continuous probe of database reachability.
 #[get("/healthz")]
 async fn get_healthz(data: web::Data<Arc<Mutex<DbProbe>>>) -> Result<impl Responder, ManagerError> {
-    data.lock().await.status_as_http_response()
+    Ok(data.lock().await.as_http_response())
 }
 
 /// Produces a continuous stream of logs which are received from the pipeline runner.


### PR DESCRIPTION
- Log error if the regular probe fails, and also log when it recovers
- The API already logs when errors are returned by it, as such it is not necessary to every time also have the HTTP response conversion function log it
- Refer to the logs for details regarding the health status

**PR information**
- Documentation is not updated, changelog is not updated
- No breaking changes: health checks still returns OK upon success and INTERNAL_SERVER_ERROR upon failure
- Backward incompatible changes: health check endpoint is different, but its guarantees remain the same