### PR TITLE
[SQL] Combine MIN/MAX/ARG_MIN/ARG_MAX more often in a single aggregate

### DIFF
--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -630,14 +630,6 @@ impl Neg for LongInterval {
     }
 }
 
-/*
-some_operator!(lt, LongInterval, &LongInterval, bool);
-some_operator!(gt, LongInterval, &LongInterval, bool);
-some_operator!(eq, LongInterval, &LongInterval, bool);
-some_operator!(neq, LongInterval, &LongInterval, bool);
-some_operator!(gte, LongInterval, &LongInterval, bool);
-some_operator!(lte, LongInterval, &LongInterval, bool);
-*/
 some_operator!(lt, LongInterval, LongInterval, bool);
 some_operator!(gt, LongInterval, LongInterval, bool);
 some_operator!(eq, LongInterval, LongInterval, bool);

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -689,14 +689,6 @@ some_operator!(eq, Timestamp, Timestamp, bool);
 some_operator!(neq, Timestamp, Timestamp, bool);
 some_operator!(gte, Timestamp, Timestamp, bool);
 some_operator!(lte, Timestamp, Timestamp, bool);
-/*
-some_operator!(lt, Timestamp, &Timestamp, bool);
-some_operator!(gt, Timestamp, &Timestamp, bool);
-some_operator!(eq, Timestamp, &Timestamp, bool);
-some_operator!(neq, Timestamp, &Timestamp, bool);
-some_operator!(gte, Timestamp, &Timestamp, bool);
-some_operator!(lte, Timestamp, &Timestamp, bool);
-*/
 
 #[doc(hidden)]
 pub fn floor_week_Timestamp(value: Timestamp) -> Timestamp {
@@ -1064,14 +1056,6 @@ some_operator!(eq, Date, Date, bool);
 some_operator!(neq, Date, Date, bool);
 some_operator!(gte, Date, Date, bool);
 some_operator!(lte, Date, Date, bool);
-/*
-some_operator!(lt, Date, &Date, bool);
-some_operator!(gt, Date, &Date, bool);
-some_operator!(eq, Date, &Date, bool);
-some_operator!(neq, Date, &Date, bool);
-some_operator!(gte, Date, &Date, bool);
-some_operator!(lte, Date, &Date, bool);
-*/
 
 // right - left
 #[doc(hidden)]
@@ -1688,14 +1672,6 @@ some_operator!(eq, Time, Time, bool);
 some_operator!(neq, Time, Time, bool);
 some_operator!(gte, Time, Time, bool);
 some_operator!(lte, Time, Time, bool);
-/*
-some_operator!(lt, Time, &Time, bool);
-some_operator!(gt, Time, &Time, bool);
-some_operator!(eq, Time, &Time, bool);
-some_operator!(neq, Time, &Time, bool);
-some_operator!(gte, Time, &Time, bool);
-some_operator!(lte, Time, &Time, bool);
-*/
 
 #[doc(hidden)]
 pub fn extract_millisecond_Time(value: Time) -> i64 {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -2217,10 +2217,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
                     this.builder.append("x.");
                 }
                 this.builder.append(expression.fieldNo);
-                if (fieldTypeIsNullable &&
-                        expression.getType().mayBeNull &&
-                        !expression.getType().hasCopy() &&
-                        !avoidRef) {
+                if (fieldTypeIsNullable && !expression.getType().hasCopy() && !avoidRef) {
                     this.builder.append(".as_ref()");
                 }
                 this.builder.append(")").decrease();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/IAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/IAggregate.java
@@ -31,7 +31,6 @@ public abstract class IAggregate extends DBSPExpression implements IDBSPInnerNod
     /** True if these two aggregates are "compatible", i.e. they
      * can be implemented in a single operator.  For example, all linear
      * aggregates are compatible with each other.
-     * @param other   Aggregate to check compatibility with.
-     * @param appendOnlySources  True if the current aggregate may depend on some append-only sources. */
-    public abstract boolean compatible(IAggregate other, boolean appendOnlySources);
+     * @param other   Aggregate to check compatibility with. */
+    public abstract boolean compatible(IAggregate other);
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/LinearAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/LinearAggregate.java
@@ -113,7 +113,7 @@ public class LinearAggregate extends IAggregate {
     }
 
     @Override
-    public boolean compatible(IAggregate other, boolean appendOnlySources) {
+    public boolean compatible(IAggregate other) {
         return other.is(LinearAggregate.class);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
@@ -68,8 +68,8 @@ public class MinMaxAggregate extends NonLinearAggregate {
     }
 
     @Override
-    public boolean compatible(IAggregate other, boolean appendOnlySources) {
-        return appendOnlySources && other.is(MinMaxAggregate.class);
+    public boolean compatible(IAggregate other) {
+        return other.is(MinMaxAggregate.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
@@ -100,7 +100,7 @@ public class NonLinearAggregate extends IAggregate {
     }
 
     @Override
-    public boolean compatible(IAggregate other, boolean appendOnlySources) {
+    public boolean compatible(IAggregate other) {
         return other.is(NonLinearAggregate.class) &&
                 !other.is(MinMaxAggregate.class);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -38,24 +38,29 @@ public class Regression1Tests extends SqlIoTest {
                  MAX(t1),
                  MAX(t0 + t1)
                 FROM tbl;""");
-        int[] streamAggregates = { 0 };
-        int[] linearAggregates = { 0 };
         CircuitVisitor visitor = new CircuitVisitor(cc.compiler) {
+            int streamAggregates = 0;
+            int linearAggregates = 0;
+
             @Override
             public void postorder(DBSPStreamAggregateOperator operator) {
-                streamAggregates[0]++;
+                this.streamAggregates++;
             }
 
             @Override
             public void postorder(DBSPAggregateLinearPostprocessOperator operator) {
-                linearAggregates[0]++;
+                this.linearAggregates++;
+            }
+
+            @Override
+            public void endVisit() {
+                // 1 combined max
+                Assert.assertEquals(1, this.streamAggregates);
+                // 1 for the two sums
+                Assert.assertEquals(1, this.linearAggregates);
             }
         };
         cc.visit(visitor);
-        // 3 max
-        Assert.assertEquals(3, streamAggregates[0]);
-        // 1 for the two sums
-        Assert.assertEquals(1, linearAggregates[0]);
     }
 
     @Test


### PR DESCRIPTION
Improve plans generated for MAX/MIN/ARG_MAX/ARG_MIN.
If possible multiple operations will be performed in one operator.
This essentially removes an old heuristic which was incomplete and is no longer necessary after optimizing these aggregates.