### PR TITLE
[SQL] Make UTF-8 the default character set

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -20,6 +20,11 @@ import TabItem from '@theme/TabItem';
         negative.  Their behavior has not changed, but the documentation
         was incorrect.
 
+        Changed the default character set from ISO-8859-1 to UTF-8.
+        Removed from the documentation the ability to specify a different
+        charater set for strings.  Removed mentions of trailing space
+        trimming from strings.
+
         ## 0.105.0
 
         Changed the semantics of functions `ARRAY_CONTAINS`,

--- a/docs.feldera.com/docs/sql/string.md
+++ b/docs.feldera.com/docs/sql/string.md
@@ -1,5 +1,8 @@
 # String Operations
 
+The default character set for all strings is
+[UTF-8](https://en.wikipedia.org/wiki/UTF-8).
+
 SQL defines two primary character types: `character varying(n)` and
 `character(n)`, where n is a positive integer.  Both of these types
 can store strings up to n characters (not bytes) in length. An attempt
@@ -13,11 +16,6 @@ simply store the shorter string.
 
 In addition, we provide the `text`, or `varchar` type, which stores
 strings of any length.
-
-Trailing spaces are removed when converting a character value to one
-of the other string types.  Note that trailing spaces are semantically
-significant in character varying and text values, and when using
-pattern matching (e.g., LIKE  and regular expressions).
 
 ## String constants (literals)
 

--- a/docs.feldera.com/docs/sql/types.md
+++ b/docs.feldera.com/docs/sql/types.md
@@ -168,8 +168,8 @@ typeName:
   |   ROW ( columnDecl [, columnDecl ]* )
 
 sqlTypeName:
-      char [ precision ] [ charSet ]
-  |   varchar [ precision ] [ charSet ]
+      char [ precision ]
+  |   varchar [ precision ]
   |   DATE
   |   time
   |   timestamp
@@ -212,9 +212,6 @@ time:
 
 timestamp:
       TIMESTAMP [ precision ] [ timeZone ]
-
-charSet:
-      CHARACTER SET charSetName
 
 timeZone:
       WITHOUT TIME ZONE

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
 
+import com.google.common.base.Charsets;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
@@ -165,6 +166,7 @@ import org.dbsp.util.Properties;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
+import java.nio.charset.Charset;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -367,6 +369,11 @@ public class SqlToRelCompiler implements IWritesLogs {
 
         public RelStruct createRelStruct(SqlIdentifier name, List<RelDataTypeField> fields, boolean nullable) {
             return new RelStruct(this.id, name, fields, nullable);
+        }
+
+        @Override
+        public Charset getDefaultCharset() {
+            return Charsets.UTF_8;
         }
 
         @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -383,13 +383,11 @@ public class RegressionTests extends SqlIoTest {
 
     @Test
     public void issue3071() {
-        this.statementsFailingInCompilation("""
+        this.getCC("""
                 CREATE TABLE t0(c0 char) with ('materialized' = 'true');
-                CREATE MATERIALIZED VIEW v100_optimized AS (SELECT * FROM t0 WHERE (t0.c0) NOT BETWEEN ('Y') AND ('䤈'));""",
-                "Failed to encode");
-        this.statementsFailingInCompilation("""
-                CREATE MATERIALIZED VIEW v73_optimized AS SELECT 'a'>'헊';""",
-                "Failed to encode");
+                CREATE MATERIALIZED VIEW v100_optimized AS (SELECT * FROM t0 WHERE (t0.c0) NOT BETWEEN ('Y') AND ('䤈'));""");
+        this.getCC("""
+                CREATE MATERIALIZED VIEW v73_optimized AS SELECT 'a'>'헊';""");
     }
 
     @Test
@@ -651,9 +649,11 @@ public class RegressionTests extends SqlIoTest {
 
     @Test
     public void issue2942() {
-        this.statementsFailingInCompilation(
-                "CREATE VIEW v1(c0) AS (SELECT '9,\uE8C7voz[*');",
-                "Failed to encode");
+        var ccs = this.getCCS("CREATE VIEW v1(c0) AS SELECT '9,\uE8C7voz[*'");
+        ccs.step("", """
+         c0 | weight
+        -------------
+         9,voz[*|1""");
     }
 
     @Test


### PR DESCRIPTION
I didn't realize that Calcite by default uses ISO-8859-1. Switched to using UTF-8.

Fixes #4559 

## Checklist

- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] Feldera SQL (Syntax, Semantics)

### Describe Incompatible Changes

If programs were relying on the character set being ISO-8859-1 they may now break.
Previously we documented that each string column could have a different charset; I have removed this from the documentation (but not the implementation). If anyone asks for it, we can consider adding it back, but for now it is unsupported. To support it we have to test it thoroughly and figure out what happens when you try to mix char types with different charsets.