### PR TITLE
[SQL] Use calcite rules to optimize away some useless ORDER BY/LIMIT operations

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -192,11 +192,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apiguardian</groupId>
-            <artifactId>apiguardian-api</artifactId>
-            <version>1.1.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
             <version>2.12.0</version>
@@ -206,11 +201,13 @@
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
         </dependency>
+        <!-- For unsigned integers -->
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>joou-java-6</artifactId>
             <version>0.9.4</version>
         </dependency>
+        <!-- Janino used by Calcite; here we control the version -->
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
@@ -221,11 +218,13 @@
             <artifactId>commons-compiler</artifactId>
             <version>${janino.version}</version>
         </dependency>
+        <!-- Jetbrains annotations Used for @Contract -->
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>26.0.2</version>
         </dependency>
+        <!-- Needed by Calcite -->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
@@ -294,7 +293,7 @@
         <dependency>
             <groupId>org.apache.calcite.avatica</groupId>
             <artifactId>avatica-core</artifactId>
-            <version>1.25.0</version>
+            <version>1.26.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -316,7 +315,7 @@
             <artifactId>jcommander</artifactId>
             <version>2.0</version>
         </dependency>
-        <!-- HyperSQL Java database -->
+        <!-- HyperSQL Java database; used in a few tests -->
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteOptimizer.java
@@ -206,6 +206,10 @@ public class CalciteOptimizer implements IWritesLogs {
                 CoreRules.MINUS_FILTER_TO_FILTER,
                 CoreRules.UNION_FILTER_TO_FILTER
         ));
+        this.addStep(new SimpleOptimizerStep("Useless sort removal", 0,
+                CoreRules.SORT_REMOVE,
+                CoreRules.SORT_REMOVE_REDUNDANT,
+                CoreRules.SORT_REMOVE_CONSTANT_KEYS));
         this.addStep(new SimpleOptimizerStep("Decorrelate inner queries 1", 2,
                 new InnerDecorrelator(InnerDecorrelator.Config.DEFAULT)));
         this.addStep(new SimpleOptimizerStep("Correlate/Union", 2,


### PR DESCRIPTION
This was discovered by visual inspection
In particular, this will optimize significantly programs that do
`SELECT aggregate(...) LIMIT 1`