### PR TITLE
py: use TLS in python tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -188,6 +188,7 @@ jobs:
         working-directory: python
         env:
           FELDERA_HOST: http://localhost:8080
+          TEST_FELDERA_HTTPS_TLS_CERT_PATH: test-tls/tls_test.crt
           IN_CI: 1 # We use this flag to skip some kafka tests in the python code base
 
       - name: Run python tests
@@ -197,3 +198,4 @@ jobs:
         env:
           FELDERA_HOST: http://localhost:8080
           PYTHONPATH: ${{ github.workspace }}/python
+          TEST_FELDERA_HTTPS_TLS_CERT_PATH: test-tls/tls_test.crt

--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -33,6 +33,18 @@ Connecting to Feldera on localhost
 
     pipeline = PipelineBuilder(client, name, sql).create()
 
+TLS with Self Signed Certificates
+=================================
+
+To use TLS with self signed certificates, set to the path of the CA bundle or
+the directory that contains the CA certificates.
+
+.. code-block:: python
+
+   from feldera import FelderaClient
+
+   client = FelderaClient('https://cluster.feldera.com', verify='path/to/cert')
+
 Setting HTTP Connection Timeouts
 ================================
 
@@ -354,7 +366,7 @@ This example shows creating and running a pipeline with Feldera's internal data 
     pipeline.delete(True)
 
 Retrieve a support-bundle for a pipeline
-==================================
+========================================
 
 This example shows how to download a support bundle for a pipeline using the Python SDK.
 

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -26,7 +26,7 @@ class HttpRequests:
         self.headers = {"User-Agent": "feldera-python-sdk/v1"}
         self.requests_verify = config.requests_verify
 
-        if not self.requests_verify:
+        if isinstance(self.requests_verify, bool) and not self.requests_verify:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         if self.config.api_key:

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -12,7 +12,7 @@ class Config:
         api_key: Optional[str] = None,
         version: Optional[str] = None,
         timeout: Optional[float] = None,
-        requests_verify: bool = True,
+        requests_verify: bool | str = True,
     ) -> None:
         """
         :param url: The url to the Feldera API (ex: https://try.feldera.com)
@@ -27,4 +27,4 @@ class Config:
         self.api_key: Optional[str] = api_key
         self.version: Optional[str] = version or "v0"
         self.timeout: Optional[float] = timeout
-        self.requests_verify: bool = requests_verify
+        self.requests_verify: bool | str = requests_verify

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -46,16 +46,16 @@ class FelderaClient:
         url: str,
         api_key: Optional[str] = None,
         timeout: Optional[float] = None,
-        requests_verify: bool = True,
+        requests_verify: bool | str = True,
     ) -> None:
         """
         :param url: The url to Feldera API (ex: https://try.feldera.com)
         :param api_key: The optional API key for Feldera
-        :param timeout: (optional) The amount of time in seconds that the client
-            will wait for a response before timing
-            out.
+        :param timeout: (optional) The amount of time in seconds that the
+            client will wait for a response before timing out.
         :param requests_verify: The `verify` parameter passed to the requests
-            library. `True` by default.
+            library. `True` by default. To use a self signed certificate, set
+            it to the path to the certificate.
         """
 
         self.config = Config(

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -13,7 +13,8 @@ PIPELINE_TO_KAFKA_SERVER = os.environ.get(
     "FELDERA_PIPELINE_TO_KAFKA_SERVER", "redpanda:9092"
 )
 
-TEST_CLIENT = FelderaClient(BASE_URL, api_key=API_KEY, requests_verify=False)
+REQUESTS_VERIFY = os.environ.get("TEST_FELDERA_HTTPS_TLS_CERT_PATH", False)
+TEST_CLIENT = FelderaClient(BASE_URL, api_key=API_KEY, requests_verify=REQUESTS_VERIFY)
 
 
 def enterprise_only(fn):


### PR DESCRIPTION
Allows setting TLS certificates to use in the python SDK.

## Checklist

- [x] Documentation updated

## Breaking Changes?

No

