### PR TITLE
[docs] Correct documentation for secret resolution.

### DIFF
--- a/docs.feldera.com/docs/pipelines/fault-tolerance.md
+++ b/docs.feldera.com/docs/pipelines/fault-tolerance.md
@@ -65,8 +65,8 @@ later restart it from the same point:
   A fault-tolerant pipeline can also be suspended and resumed.
 
 > ⚠️ Feldera resolves [secrets](../connectors/secret-references.md)
-> once at pipeline startup.  Checkpointed state for fault tolerant pipelines and
-> suspended pipelines will contain resolved secrets.
+> each time a pipeline starts or resumes, without saving resolved
+> secrets to checkpoints or journals.
 
 The following sections describes these features in more detail.
 


### PR DESCRIPTION
Feldera has not written secrets to checkpoints or journals since v0.110, but the documentation was not updated.
