### PR TITLE
[dbsp] add_input_map_with_waterline operator.

### DIFF
--- a/crates/dbsp/src/operator/controlled_filter.rs
+++ b/crates/dbsp/src/operator/controlled_filter.rs
@@ -81,7 +81,7 @@ where
     ///
     /// Returns a pair of output streams.
     ///
-    /// **Filtered putput stream**: (key, value, weight) tuples that pass the check are sent to the
+    /// **Filtered output stream**: (key, value, weight) tuples that pass the check are sent to the
     /// first output stream unmodified.
     ///
     /// **Error stream**: Tuples that don't pass the check are transformed by `report_func` and sent

--- a/crates/dbsp/src/operator/dynamic/time_series/mod.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/mod.rs
@@ -16,3 +16,4 @@ pub use rolling_aggregate::{
     PartitionedRollingAggregateLinearFactories, PartitionedRollingAggregateWithWaterlineFactories,
     PartitionedRollingAverageFactories,
 };
+pub use waterline::LeastUpperBoundFunc;


### PR DESCRIPTION
Resolves #4457, #2669

The new operator allows enforcing lateness and performing GC on tables with primary keys.

It is similar to `add_input_map`, but additionally tracks a waterline of the input collection and rejects inputs that are below the waterline. An input is rejected if the input record itself is below the waterline or if the existing record it replaces is below the waterline.

This operator supports waterlines over both key and value components of the tuple.  In case the waterline is applied to the key component, the internal index maintained by the operator can be GC'd by calling `integrate_trace_retain_keys` on the output stream returned by the operator. The operator facilitates this by also returning a stream of waterline values.

Finally the operator returns an error stream with one event per rejected update.

Add a brief description of the pull request.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] Feldera SQL (Syntax, Semantics)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
