### PR TITLE
[SQL] Code generation improvements

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -36,6 +36,7 @@ import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.IsIntervalLiteral;
 import org.dbsp.sqlCompiler.ir.IsNumericLiteral;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyMethodExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBaseTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
@@ -170,7 +171,12 @@ public class Simplify extends ExpressionTranslator {
     public void postorder(DBSPCloneExpression expression) {
         DBSPExpression source = this.getE(expression.expression);
         DBSPExpression result = source.applyCloneIfNeeded();
-        if (source.is(DBSPCloneExpression.class)) {
+        if (source.is(DBSPCloneExpression.class) ||
+            source.is(DBSPApplyMethodExpression.class) ||
+            source.is(DBSPApplyExpression.class) ||
+            source.is(DBSPIfExpression.class) ||
+            source.is(DBSPCastExpression.class)
+        ) {
             result = source;
         }
         this.map(expression, result);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ValueNumbering.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ValueNumbering.java
@@ -8,6 +8,7 @@ import org.dbsp.sqlCompiler.ir.expression.*;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
@@ -222,7 +223,9 @@ public class ValueNumbering extends InnerVisitor {
     @Override public void postorder(DBSPCastExpression expression) {
         Representation repr = new Representation("(" + expression.type + "," + expression.safe + ")", false)
                 .add(this.getId(expression.source, expression, 0));
-        this.checkRepresentation(expression, repr, false);
+        boolean expensive = expression.type.is(DBSPTypeString.class)
+                || expression.source.type.is(DBSPTypeString.class);
+        this.checkRepresentation(expression, repr, expensive);
     }
 
     @Override public void postorder(DBSPCloneExpression expression) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AdjustSqlIndex.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AdjustSqlIndex.java
@@ -24,6 +24,10 @@ public class AdjustSqlIndex extends ExpressionTranslator {
             super.postorder(expression);
             return;
         }
+        if (this.maybeGet(expression) != null) {
+            // Already translated
+            return;
+        }
 
         DBSPExpression left = this.getE(expression.left);
         DBSPExpression right = this.getE(expression.right);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CSE.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CSE.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** Common-subexpression elimination */
+/** Common-subexpression elimination at the level of circuit operators */
 public class CSE extends Repeat {
     public CSE(DBSPCompiler compiler) {
         super(compiler, new OneCSEPass(compiler));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerAsof.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerAsof.java
@@ -88,6 +88,11 @@ public class LowerAsof implements CircuitTransform {
         return "LowerAsof";
     }
 
+    @Override
+    public String toString() {
+        return this.getName();
+    }
+
     /** Move the integrate trace operator to the new join */
     static class MoveGC extends CircuitCloneVisitor {
         final Map<DBSPIntegrateTraceRetainValuesOperator, DBSPConcreteAsofJoinOperator> gces;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Passes.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Passes.java
@@ -64,14 +64,14 @@ public class Passes implements IWritesLogs, CircuitTransform, ICompilerComponent
 
     @Override
     public DBSPCircuit apply(DBSPCircuit circuit) {
-        int details = this.getDebugLevel();
+        int details = Math.max(0, this.getDebugLevel() - 2);
         if (this.getDebugLevel() >= 3) {
             String name = String.format("%02d-", dumped++) + "before" +
                     this.toString().replace(" ", "_") + ".png";
             ToDot.dump(this.compiler, name, details, "png", circuit);
         }
         long begin = System.currentTimeMillis();
-        Logger.INSTANCE.belowLevel(this, 2)
+        Logger.INSTANCE.belowLevel(this, 1)
                 .append(this.toString())
                 .append(" starting ")
                 .append(this.passes.size())

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FieldUseMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FieldUseMap.java
@@ -125,7 +125,8 @@ public class FieldUseMap {
 
         @Override
         public FieldInfo project(int depth) {
-            return new Ref(this.type, this.field.project(depth));
+            var proj = this.field.project(depth);
+            return new Ref(this.type, proj);
         }
 
         @Override
@@ -340,7 +341,7 @@ public class FieldUseMap {
         @Override
         public FieldInfo project(int depth) {
             if (depth == 0) {
-                if (this.size() > 1 && this.anyUsed())
+                if (this.anyUsed())
                     return FieldInfo.create(this.type, true);
                 return this;
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
@@ -205,7 +205,7 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
                 .reduce(this.compiler)
                 .to(DBSPClosureExpression.class);
 
-        int size = projection.getType().getToplevelFieldCount();
+        int size = operator.getType().getToplevelFieldCount();
         DBSPMapIndexOperator adjust = new DBSPMapIndexOperator(operator.getRelNode(), projection, source)
                 .addAnnotation(new IsProjection(size), DBSPMapIndexOperator.class);
         this.addOperator(adjust);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
@@ -49,7 +49,8 @@ public final class DBSPTupleExpression extends DBSPBaseTupleExpression {
         Utilities.enforce(type.size() == expressions.length, "Tuple expression has size " + expressions.length +
                 " but the declared type is " + type);
         for (int i = 0; i < type.size(); i++) {
-            Utilities.enforce(type.tupFields[i].sameType(expressions[i].getType()), "Tuple field " + expressions[i] + " has type " + expressions[i].getType() +
+            Utilities.enforce(type.tupFields[i].sameType(expressions[i].getType()),
+                    "Tuple field " + expressions[i] + " has type " + expressions[i].getType() +
                     " that does not match the declared field type " + type.tupFields[i]);
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
@@ -76,6 +76,11 @@ public class DBSPTypeMillisInterval
     }
 
     @Override
+    public String toString() {
+        return super.toString() + "(" + this.units + ")";
+    }
+
+    @Override
     public DBSPExpression getMinValue() {
         return new DBSPIntervalMillisLiteral(this.units, Long.MIN_VALUE, this.mayBeNull);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMonthsInterval.java
@@ -124,8 +124,7 @@ public class DBSPTypeMonthsInterval
                     default -> "";
                 } +
                 switch (this.units) {
-                    case YEARS_TO_MONTHS -> "M";
-                    case MONTHS -> "Y";
+                    case YEARS_TO_MONTHS, MONTHS -> "M";
                     default -> "";
                 } +
                 ")";

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Logger.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Logger.java
@@ -116,6 +116,8 @@ public class Logger {
     }
 
     public <T> int getLoggingLevel(Class<T> clazz) {
+        if (this.loggingLevel.isEmpty())
+            return 0;
         for (var e: this.loggingLevel.entrySet()) {
             Class<?> c = e.getKey();
             if (c.isAssignableFrom(clazz))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -9,9 +9,11 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.Passes;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.util.Logger;
 import org.dbsp.util.Utilities;
 import org.junit.Assert;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
@@ -20,6 +22,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -773,12 +776,14 @@ public class IncrementalRegressionTests extends SqlIoTest {
     // Tests that are not in the repository; run manually
     @Test @Ignore
     public void extraTests() throws IOException {
+        Logger.INSTANCE.setLoggingLevel(Passes.class, 1);
         String dir = "../extra";
         File file = new File(dir);
         if (file.exists()) {
             File[] toCompile = file.listFiles();
             if (toCompile == null)
                 return;
+            Arrays.sort(toCompile);
             for (File c: toCompile) {
                 if (!c.getName().contains("grouped_orders.sql")) continue;
                 if (c.getName().contains("sql")) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -273,7 +273,7 @@ public class BaseSQLTests {
         } else {
             directory = RUST_CRATES_DIRECTORY;
             MultiCratesWriter multiWriter = new MultiCratesWriter(directory, "x", true);
-            testCrate = multiWriter.getTestName();
+            testCrate = MultiCratesWriter.getTestName();
             String globals = multiWriter.getGlobalsName();
             writer = multiWriter;
             stubsDir = Paths.get(directory).resolve(globals).resolve("src");


### PR DESCRIPTION
Fixes #4577 

- Avoids some clones
- Considers casts to/from strings expensive, so it can CSE identical casts
