### PR TITLE
[SQL] Improve policy for inlining functions

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPClosureExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPClosureExpression.java
@@ -32,6 +32,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.Expensive;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.Projection;
 import org.dbsp.sqlCompiler.ir.DBSPParameter;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
@@ -166,12 +167,18 @@ public final class DBSPClosureExpression extends DBSPExpression {
             throw new InternalCompilerError("Expected closure with 1 parameter", this);
 
         if (inline == MAYBE) {
-            Expensive expensive = new Expensive(compiler);
-            expensive.apply(before);
-            if (expensive.isExpensive())
-                inline = NO;
-            else
+            Projection projection = new Projection(compiler);
+            projection.apply(this);
+            if (projection.isProjection) {
                 inline = YES;
+            } else {
+                Expensive expensive = new Expensive(compiler);
+                expensive.apply(before);
+                if (expensive.isExpensive())
+                    inline = NO;
+                else
+                    inline = YES;
+            }
         }
 
         if (inline == YES) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/InliningTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ir/InliningTests.java
@@ -1,0 +1,57 @@
+package org.dbsp.sqlCompiler.compiler.ir;
+
+import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.CanonicalForm;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.util.Maybe;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InliningTests {
+    @Test
+    public void testInlining() {
+        DBSPCompiler compiler = new DBSPCompiler(new CompilerOptions());
+        DBSPType i32 = DBSPTypeInteger.getType(CalciteObject.EMPTY, DBSPTypeCode.INT32, true);
+
+        DBSPType twice = new DBSPTypeTuple(i32, i32);
+        DBSPVariablePath x = twice.ref().var();
+        // inner = |x: Tup2<i32, i32>| Tup3::new(f(x), x.0, x.1)
+        DBSPClosureExpression inner = new DBSPTupleExpression(
+                new DBSPApplyExpression("f", i32, x.deref().field(0)),
+                x.deref().field(0),
+                x.deref().field(1)).closure(x);
+
+        DBSPVariablePath var = inner.getResultType().ref().var();
+        // project = |x: Tup3<i32, i32, i32>| Tup2::new(x.0, x.2)
+        DBSPClosureExpression project = new DBSPTupleExpression(
+                var.deref().field(0),
+                var.deref().field(2)).closure(var);
+
+        DBSPClosureExpression compose = project.applyAfter(compiler, inner, Maybe.NO);
+        CanonicalForm cf = new CanonicalForm(compiler);
+        Assert.assertEquals("""
+                (|p0: &Tup2<i32?, i32?>|
+                {let p1 = &Tup3::new(f(((*p0).0)), ((*p0).0), ((*p0).1), );
+                Tup2::new(((*p1).0), ((*p1).2), )})""", cf.apply(compose).toString());
+
+        compose = project.applyAfter(compiler, inner, Maybe.YES);
+        Assert.assertEquals("""
+                (|p0: &Tup2<i32?, i32?>|
+                Tup2::new(f(((*p0).0)), ((*p0).1), ))""", cf.apply(compose).toString());
+
+        // Will inline because outer is a projection
+        DBSPClosureExpression compose2 = project.applyAfter(compiler, inner, Maybe.MAYBE);
+        EquivalenceContext context = new EquivalenceContext();
+        Assert.assertTrue(context.equivalent(compose, compose2));
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -776,7 +776,6 @@ public class IncrementalRegressionTests extends SqlIoTest {
     // Tests that are not in the repository; run manually
     @Test @Ignore
     public void extraTests() throws IOException {
-        Logger.INSTANCE.setLoggingLevel(Passes.class, 1);
         String dir = "../extra";
         File file = new File(dir);
         if (file.exists()) {


### PR DESCRIPTION
We will always inline the call `f(g(x))` when f is a projection.
This has big benefits for some programs, especially improving the detection of unused fields if g projects away many fields of f.