### PR TITLE
sync: prevent syncing checkpoints from being GCed

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -1478,11 +1478,7 @@ impl CircuitThread {
             CHECKPOINT_WRITTEN.record((written_after - written_before) / 1_000_000);
             CHECKPOINT_PROCESSED_RECORDS.store(processed_records, Ordering::Relaxed);
 
-            let sync_requested = this
-                .sync_checkpoint_request
-                .as_ref()
-                .map(|s| s.uuid())
-                .flatten();
+            let sync_requested = this.sync_checkpoint_request.as_ref().and_then(|s| s.uuid());
 
             if sync_requested.is_none() {
                 if let Err(error) = this.circuit.gc_checkpoint() {
@@ -1910,7 +1906,7 @@ impl CircuitThread {
             return;
         };
 
-        let Some(uuid) = uuid_lock.blocking_lock().clone() else {
+        let Some(uuid) = *uuid_lock.blocking_lock() else {
             return;
         };
 

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -25,6 +25,10 @@ import TabItem from '@theme/TabItem';
         the pipeline is initializing. Instead it returns status OK with message
         body containing the "Initializing" string.
 
+        ### Changes to Python SDK `feldera`:
+        - `Pipeline.sync_checkpoint` will now raise a runtime error if `wait`
+          is set to `True` and pushing this checkpoint fails.
+
         ## 0.129.0
 
         Values that are late in the NOW stream are no longer logged to the

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -986,7 +986,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             stream=True,
         )
 
-        for chunk in resp.iter_lines(chunk_size=50000000):
+        for chunk in resp.iter_lines(chunk_size=1024):
             if chunk:
                 yield json.loads(chunk, parse_float=Decimal)
 


### PR DESCRIPTION
Only clears the `sync_checkpoint_request` once the sync has actually completed. Checkpoints will only get GCed once the sync process has completed.

Add a brief description of the pull request.

## Checklist

- [x] Documentation updated (python function docs)
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))

### Describe Incompatible Changes

`Pipeline.sync_checkpoint(wait=True)` will now panic if syncing the checkpoint fails.
