### PR TITLE
[fda] Add `fda debug metrics` utility command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
 name = "fda"
 version = "0.128.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "chrono",
  "clap",
@@ -4648,8 +4649,10 @@ dependencies = [
  "feldera-types",
  "futures",
  "futures-util",
+ "itertools 0.14.0",
  "json_to_table",
  "log",
+ "ordered-float 4.6.0",
  "prettyplease",
  "progenitor",
  "progenitor-client 0.9.1",

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -37,6 +37,9 @@ arrow = { workspace = true, features = ["ipc", "prettyprint"] }
 serde = { workspace = true, features = ["derive"] }
 uuid = { workspace = true, features = ["serde", "v4"] }
 chrono = { workspace = true, features = ["serde"] }
+anyhow = { workspace = true }
+ordered-float.workspace = true
+itertools.workspace = true
 
 [build-dependencies]
 prettyplease = { workspace = true }

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -189,6 +189,13 @@ pub enum DebugActions {
         #[arg(value_hint = ValueHint::FilePath)]
         path: PathBuf,
     },
+
+    /// Reads metrics from a file and prints them in an easier-to-read form..
+    Metrics {
+        /// The Prometheus metrics file to read.
+        #[arg(value_hint = ValueHint::FilePath)]
+        path: PathBuf,
+    },
 }
 
 /// A list of possible configuration options.

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -2,9 +2,10 @@
 
 use std::collections::BTreeMap;
 use std::convert::Infallible;
+use std::fmt::Write as _;
 use std::fs::File;
-use std::io::{stdout, ErrorKind, Read, Write};
-use std::path::PathBuf;
+use std::io::{stdout, BufRead, BufReader, ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
 
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -14,8 +15,10 @@ use feldera_rest_api::*;
 use feldera_types::config::{FtModel, RuntimeConfig, StorageOptions};
 use feldera_types::error::ErrorResponse;
 use futures_util::StreamExt;
+use itertools::Itertools;
 use json_to_table::json_to_table;
 use log::{debug, error, info, trace, warn};
+use ordered_float::OrderedFloat;
 use reqwest::header::{HeaderMap, HeaderValue, InvalidHeaderValue};
 use reqwest::StatusCode;
 use serde_json::json;
@@ -2026,6 +2029,152 @@ async fn program(format: OutputFormat, action: ProgramAction, client: Client) {
     }
 }
 
+fn parse_metrics(file_name: &Path) -> anyhow::Result<()> {
+    #[derive(Clone, Debug, Default)]
+    struct Metric {
+        values: BTreeMap<Vec<(String, String)>, MetricValue>,
+    }
+
+    #[derive(Clone, Debug)]
+    enum MetricValue {
+        Number(f64),
+        Histogram(Histogram),
+    }
+
+    impl MetricValue {
+        fn as_histogram_mut(&mut self) -> Option<&mut Histogram> {
+            match self {
+                MetricValue::Histogram(histogram) => Some(histogram),
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct Histogram {
+        sum: f64,
+        buckets: BTreeMap<OrderedFloat<f64>, f64>,
+    }
+
+    fn read_metrics<R>(reader: R) -> anyhow::Result<BTreeMap<String, Metric>>
+    where
+        R: BufRead,
+    {
+        fn get_metric<'a>(metrics: &'a mut BTreeMap<String, Metric>, name: &str) -> &'a mut Metric {
+            metrics.entry(String::from(name)).or_insert(Metric {
+                ..Metric::default()
+            })
+        }
+
+        let mut metrics = BTreeMap::new();
+        for line in reader.lines() {
+            let line = line?;
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (name, rest) = line.split_once('{').unwrap();
+            let (pairs, rest) = rest.split_once('}').unwrap();
+            let mut fields = pairs
+                .split(',')
+                .map(|pair| pair.split_once('=').unwrap())
+                .filter(|(key, _value)| *key != "pipeline")
+                .map(|(key, value)| (String::from(key), String::from(value.trim_matches('"'))))
+                .collect::<Vec<_>>();
+            let value: f64 = rest.trim().parse().unwrap();
+
+            if let Some(name) = name.strip_suffix("_bucket") {
+                let (key, le) = fields.pop().unwrap();
+                assert_eq!(&key, "le");
+                let le: f64 = le.parse().unwrap();
+                let metric = get_metric(&mut metrics, name);
+                metric
+                    .values
+                    .entry(fields)
+                    .or_insert_with(|| MetricValue::Histogram(Histogram::default()))
+                    .as_histogram_mut()
+                    .unwrap()
+                    .buckets
+                    .insert(OrderedFloat(le), value);
+            } else if let Some(name) = name.strip_suffix("_sum") {
+                let metric = get_metric(&mut metrics, name);
+                metric
+                    .values
+                    .entry(fields)
+                    .or_insert_with(|| MetricValue::Histogram(Histogram::default()))
+                    .as_histogram_mut()
+                    .unwrap()
+                    .sum = value;
+            } else if name.starts_with("_count") {
+                // Ignore.
+            } else {
+                let metric = get_metric(&mut metrics, name);
+                metric.values.insert(fields, MetricValue::Number(value));
+            }
+        }
+        Ok(metrics)
+    }
+
+    let metrics = read_metrics(BufReader::new(File::open(file_name)?))?;
+    let mut by_fields: BTreeMap<&[(String, String)], String> = BTreeMap::new();
+    for (name, metric) in &metrics {
+        for (fields, value) in &metric.values {
+            let s = by_fields.entry(fields.as_slice()).or_default();
+            write!(s, "{name:<40}: ").unwrap();
+
+            match value {
+                MetricValue::Number(number) => writeln!(s, "{number:15.2}").unwrap(),
+                MetricValue::Histogram(histogram) => {
+                    let max = histogram.buckets.last_key_value().unwrap().1.clone();
+                    let mut sequence = histogram
+                        .buckets
+                        .values()
+                        .copied()
+                        .map(|value| ((value / max * 4.0 + 0.5) as usize).clamp(0, 4))
+                        .collect::<Vec<_>>();
+
+                    // Convert the histogram into a sequence of [Braille
+                    // pattern] characters, with two buckets per Braille character.
+                    //
+                    // [Braille pattern]: https://en.wikipedia.org/wiki/Braille_Patterns
+                    if sequence.len() % 2 == 1 {
+                        sequence.push(0);
+                    }
+                    for (a, b) in sequence.into_iter().tuples() {
+                        s.push(
+                            ([
+                                a >= 4, // ⠁ (dot 1)
+                                a >= 3, // ⠂ (dot 2)
+                                a >= 2, // ⠄ (dot 3)
+                                b >= 4, // ⠈ (dot 4)
+                                b >= 3, // ⠐ (dot 5)
+                                b >= 2, // ⠠ (dot 6)
+                                a >= 1, // ⡀ (dot 7)
+                                b >= 1, // ⢀ (dot 8)
+                            ]
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(|(index, on)| on.then_some(1u32 << index))
+                            .sum::<u32>()
+                                + 0x2800)
+                                .try_into()
+                                .unwrap(),
+                        );
+                    }
+                    writeln!(s, " (count{:13.0}) (sum{:15.2})", histogram.sum, max).unwrap();
+                }
+            }
+        }
+    }
+    for (fields, output) in by_fields {
+        if !fields.is_empty() {
+            println!("\n{fields:?}");
+        }
+        print!("{output}");
+    }
+    Ok(())
+}
+
 fn debug(_format: OutputFormat, action: DebugActions) {
     match action {
         DebugActions::MsgpCat { path } => {
@@ -2050,6 +2199,12 @@ fn debug(_format: OutputFormat, action: DebugActions) {
                     }
                 };
                 println!("{value}");
+            }
+        }
+        DebugActions::Metrics { path } => {
+            if let Err(error) = parse_metrics(&path) {
+                eprintln!("{}", error);
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
Excerpt of sample output:

```
records_input_buffered                  :            0.00
records_input_buffered_bytes            :            0.00
records_input_bytes_total               :   3078734795.00
records_input_total                     :      9999500.00
records_late_total                      :            0.00
records_processed_bytes_total           :   3078734795.00
records_processed_total                 :      9999500.00
storage_read_block_bytes                : ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣤⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ (count   4108113408) (sum     1090004.00)
storage_read_block_bytes_count          :      1090004.00
storage_read_latency_seconds            : ⢀⣴⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ (count            6) (sum     1090004.00)
storage_read_latency_seconds_count      :      1090004.00
storage_sync_latency_seconds            : ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣠⣤⣶⣶⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ (count          362) (sum       35766.00)
storage_sync_latency_seconds_count      :        35766.00
storage_write_block_bytes               : ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ (count  36422033920) (sum     2009141.00)
storage_write_block_bytes_count         :      2009141.00
storage_write_latency_seconds           : ⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿ (count           96) (sum     2009141.00)
storage_write_latency_seconds_count     :      2009141.00

[("endpoint", "erc20_holders_current_json.unnamed-0")]
output_buffered_batches                 :            0.00
output_connector_buffered_records       :            0.00
output_connector_bytes_total            :   3702157628.00
output_connector_errors_encode_total    :            0.00
output_connector_errors_transport_total :            0.00
output_connector_records_total          :     31972168.00

[("endpoint", "erc20_transfers.unnamed-0")]
input_connector_buffered_records        :            0.00
input_connector_buffered_records_bytes  :            0.00
input_connector_bytes_total             :   3078734795.00
input_connector_errors_parse_total      :            0.00
input_connector_errors_transport_total  :            0.00
input_connector_records_total           :      9999500.00
```

