### PR TITLE
[SQL] Alternative implementation of NOW using chain_aggregates

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -15,6 +15,9 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        Values that are late in the NOW stream are no longer logged to the
+        error stream.
+
         We have changed the documentation for the SUBSTR and SUBSTRING
         function to specify correctly their behaviors when arguments are
         negative.  Their behavior has not changed, but the documentation

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainAggregateOperator.java
@@ -12,6 +12,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeWeight;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
@@ -29,9 +30,14 @@ public class DBSPChainAggregateOperator extends DBSPUnaryOperator {
         Utilities.enforce(init.parameters.length == 2);
         Utilities.enforce(function.parameters.length == 3);
         Utilities.enforce(init.getResultType().sameType(function.getResultType()));
+        Utilities.enforce(init.getResultType().sameType(function.parameters[0].getType()));
+        Utilities.enforce(init.parameters[0].getType().sameType(function.parameters[1].getType()));
+        Utilities.enforce(init.parameters[1].getType().sameType(DBSPTypeWeight.INSTANCE));
+        Utilities.enforce(function.parameters[2].getType().sameType(DBSPTypeWeight.INSTANCE));
         Utilities.enforce(outputType.is(DBSPTypeIndexedZSet.class));
         Utilities.enforce(source.outputType().is(DBSPTypeIndexedZSet.class));
         Utilities.enforce(source.getOutputIndexedZSetType().keyType.sameType(this.getOutputIndexedZSetType().keyType));
+        Utilities.enforce(source.getOutputIndexedZSetType().elementType.ref().sameType(init.parameters[0].getType()));
         this.checkResultType(function, this.getOutputIndexedZSetType().elementType);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
@@ -31,7 +31,7 @@ import static org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator.commonInf
 
 /**
  * The {@link DBSPControlledKeyFilterOperator} is an operator with 2 outputs, including
- * an error stream.  The left input is a stream of ZSets, while the
+ * an error stream.  The left input is a stream of ZSets/Indexed ZSets, while the
  * right input is a stream of scalars.  {@code function} is a boolean function
  * that takes a scalar and an input element; when the function returns 'true'
  * the input element makes it to the output.  The {@code error} function takes

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -16,6 +16,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.util.Utilities;
@@ -52,6 +53,8 @@ public final class DBSPIntegrateTraceRetainKeysOperator
         DBSPExpression compare0 = controlArg.deref().field(0).not();
         if (data.outputType().is(DBSPTypeIndexedZSet.class)) {
             DBSPType keyType = data.getOutputIndexedZSetType().keyType;
+            if (keyType.sameType(DBSPTypeTuple.EMPTY))
+                return null;
             DBSPVariablePath dataArg = keyType.ref().var();
             param = new DBSPParameter(dataArg.variable, dataArg.getType());
             IMaybeMonotoneType dataField0 = dataProjection

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -195,6 +195,7 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
         @Parameter(names = "--jdbcSource",
                 description = "Connection string to a database that contains table metadata")
         public String metadataSource = "";
+        // The pipeline manager uses --nowstream
         @Parameter(names = "--nowstream",
                 description = "Implement NOW as a stream (true) or as an internal operator (false)")
         public boolean nowStream = false;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/DBSPCompiler.java
@@ -237,7 +237,7 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         // Declare the system tables
         this.compileInternal(
                 """
-                CREATE TABLE NOW(now TIMESTAMP NOT NULL LATENESS INTERVAL 0 SECONDS);
+                CREATE TABLE NOW(now TIMESTAMP NOT NULL); -- LATENESS INTERVAL 0 SECONDS
                 -- next table will be deleted after view is hooked to proper inputs
                 CREATE TABLE FELDERA_ERROR_TABLE(table_or_view_name VARCHAR NOT NULL, message VARCHAR NOT NULL, metadata VARCHAR NOT NULL);
                 CREATE VIEW ERROR_VIEW AS SELECT * FROM FELDERA_ERROR_TABLE;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -899,7 +899,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                     var.field(0).deref().applyCloneIfNeeded(),
                     new DBSPTupleExpression());
             DBSPSimpleOperator ix2 = new DBSPMapIndexOperator(node, addEmpty.closure(var),
-                    makeIndexedZSet(localGroupType, new DBSPTypeTuple()), indexedInput.outputPort());
+                    makeIndexedZSet(localGroupType, DBSPTypeTuple.EMPTY), indexedInput.outputPort());
             this.addOperator(ix2);
             result = new DBSPStreamDistinctOperator(node, ix2.outputPort());
             this.addOperator(result);
@@ -2184,7 +2184,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 new DBSPTupleExpression(),
                         new DBSPTupleExpression(DBSPTypeTuple.flatten(row.deref()), false));
         DBSPSimpleOperator index = new DBSPMapIndexOperator(node, indexingFunction.closure(row),
-                new DBSPTypeIndexedZSet(node, new DBSPTypeTuple(), inputRowType), opInput.outputPort());
+                new DBSPTypeIndexedZSet(node, DBSPTypeTuple.EMPTY, inputRowType), opInput.outputPort());
         this.addOperator(index);
 
         switch (collect.getCollectionType()) {
@@ -2262,7 +2262,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         }
         DBSPAggregateList aggregate = new DBSPAggregateList(node, row, Linq.list(agg));
         DBSPSimpleOperator aggregateOperator = new DBSPAggregateOperator(
-                node, new DBSPTypeIndexedZSet(node, new DBSPTypeTuple(), type), null, aggregate, index.outputPort());
+                node, new DBSPTypeIndexedZSet(node, DBSPTypeTuple.EMPTY, type), null, aggregate, index.outputPort());
         this.addOperator(aggregateOperator);
 
         DBSPSimpleOperator deindex = new DBSPDeindexOperator(node.getFinal(), aggregateOperator.outputPort());
@@ -2352,21 +2352,21 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 new DBSPRawTupleExpression(
                         DBSPTupleExpression.flatten(t.deref()),
                         new DBSPTupleExpression()).closure(t);
-        DBSPVariablePath l = new DBSPTypeTuple().ref().var();
-        DBSPVariablePath r = new DBSPTypeTuple().ref().var();
+        DBSPVariablePath l = DBSPTypeTuple.EMPTY.ref().var();
+        DBSPVariablePath r = DBSPTypeTuple.EMPTY.ref().var();
         DBSPVariablePath k = inputRowType.ref().var();
 
         DBSPClosureExpression closure = DBSPTupleExpression.flatten(k.deref()).closure(k, l, r);
         for (int i = 1; i < inputs.size(); i++) {
             DBSPSimpleOperator previousIndex = new DBSPMapIndexOperator(
                     node, entireKey,
-                    makeIndexedZSet(inputRowType, new DBSPTypeTuple()),
+                    makeIndexedZSet(inputRowType, DBSPTypeTuple.EMPTY),
                     previous.outputPort());
             this.addOperator(previousIndex);
             DBSPSimpleOperator inputI = this.getInputAs(intersect.getInput(i), false);
             DBSPSimpleOperator index = new DBSPMapIndexOperator(
                     node, entireKey.to(DBSPClosureExpression.class),
-                    makeIndexedZSet(inputRowType, new DBSPTypeTuple()),
+                    makeIndexedZSet(inputRowType, DBSPTypeTuple.EMPTY),
                     inputI.outputPort());
             this.addOperator(index);
             previous = new DBSPStreamJoinOperator(node, this.makeZSet(resultType),
@@ -3429,7 +3429,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                         DBSPTupleExpression.flatten(t.deref())).closure(t);
         DBSPSimpleOperator index = new DBSPMapIndexOperator(
                 node, emptyGroupKeys,
-                makeIndexedZSet(new DBSPTypeTuple(), inputRowType),
+                makeIndexedZSet(DBSPTypeTuple.EMPTY, inputRowType),
                 opInput.outputPort());
         this.addOperator(index);
 
@@ -3502,7 +3502,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         DBSPClosureExpression post = new DBSPApplyMethodExpression("into", arrayType, var).closure(var);
         DBSPFold folder = new DBSPFold(node, semigroup, zero, push, post);
         DBSPStreamAggregateOperator agg = new DBSPStreamAggregateOperator(node,
-                makeIndexedZSet(new DBSPTypeTuple(), arrayType),
+                makeIndexedZSet(DBSPTypeTuple.EMPTY, arrayType),
                 folder, null, index.outputPort());
         this.addOperator(agg);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPForExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPForExpression.java
@@ -42,7 +42,7 @@ public final class DBSPForExpression extends DBSPExpression implements IDBSPDecl
     public final DBSPBlockExpression block;
 
     public DBSPForExpression(String variable, DBSPExpression iterated, DBSPBlockExpression block) {
-        super(iterated.getNode(), new DBSPTypeRawTuple());
+        super(iterated.getNode(), DBSPTypeRawTuple.EMPTY);
         this.variable = variable;
         this.iterated = iterated;
         this.block = block;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
@@ -62,7 +62,7 @@ public final class DBSPSortExpression extends DBSPExpression {
                 new DBSPTypeArray(elementType, false),
                 // Argument type
                 new DBSPTypeRawTuple(
-                        new DBSPTypeTuple().ref(),
+                        DBSPTypeTuple.EMPTY.ref(),
                         new DBSPTypeArray(elementType, false).ref())));
         this.comparator = comparator;
         this.elementType = elementType;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRawTuple.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRawTuple.java
@@ -41,6 +41,8 @@ import java.util.List;
 
 /** A Raw Rust tuple.  Very seldom can be nullable. */
 public class DBSPTypeRawTuple extends DBSPTypeTupleBase {
+    public static final DBSPTypeRawTuple EMPTY = new DBSPTypeRawTuple();
+
     private DBSPTypeRawTuple(CalciteObject node, DBSPTypeCode code, boolean mayBeNull, DBSPType... tupArgs) {
         super(node, code, mayBeNull, tupArgs);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeTuple.java
@@ -45,6 +45,8 @@ import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.TUPLE;
 
 /** Our own version of a tuple */
 public class DBSPTypeTuple extends DBSPTypeTupleBase {
+    public static final DBSPTypeTuple EMPTY = new DBSPTypeTuple();
+
     /** If the type is produced from a struct type, keep here original type.
      * WARNING: this field is ignored by sameType! */
     @Nullable


### PR DESCRIPTION
Now is implemented as a stream that feeds user-controlled clock values.
There is an adapter which provides these values, but users do not have to use it.
Not every NOW stream is valid, though (NOW is supposed to have LATENESS 0).
This implementation is more robust to incorrect external NOW streams; instead of using the previous LATENESS-based mechanism with WATERLINE operators it uses a DBSP `chain_aggregate` operator. 
Apparently this will play better with transactions.