### PR TITLE
py: add requests connection timeout

### DIFF
--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -12,6 +12,7 @@ class Config:
         api_key: Optional[str] = None,
         version: Optional[str] = None,
         timeout: Optional[float] = None,
+        connection_timeout: Optional[float] = None,
         requests_verify: bool = True,
     ) -> None:
         """
@@ -19,6 +20,7 @@ class Config:
         :param api_key: The optional API key to access Feldera
         :param version: The version of the API to use
         :param timeout: The timeout for the HTTP requests
+        :param connection_timeout: The connection timeout for the HTTP requests
         :param requests_verify: The `verify` parameter passed to the requests
             library. `True` by default.
         """
@@ -27,4 +29,5 @@ class Config:
         self.api_key: Optional[str] = api_key
         self.version: Optional[str] = version or "v0"
         self.timeout: Optional[float] = timeout
+        self.connection_timeout: Optional[float] = connection_timeout
         self.requests_verify: bool = requests_verify

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -46,20 +46,26 @@ class FelderaClient:
         url: str,
         api_key: Optional[str] = None,
         timeout: Optional[float] = None,
+        connection_timeout: Optional[float] = None,
         requests_verify: bool = True,
     ) -> None:
         """
         :param url: The url to Feldera API (ex: https://try.feldera.com)
         :param api_key: The optional API key for Feldera
-        :param timeout: (optional) The amount of time in seconds that the client
-            will wait for a response before timing
-            out.
+        :param timeout: (optional) The amount of time in seconds that the
+            client will wait for a response before timing out.
+        :param timeout: (optional) The amount of time in seconds that the
+            client will wait to establish connection before timing out.
         :param requests_verify: The `verify` parameter passed to the requests
             library. `True` by default.
         """
 
         self.config = Config(
-            url, api_key, timeout=timeout, requests_verify=requests_verify
+            url,
+            api_key,
+            timeout=timeout,
+            connection_timeout=connection_timeout,
+            requests_verify=requests_verify,
         )
         self.http = HttpRequests(self.config)
 

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -13,7 +13,10 @@ PIPELINE_TO_KAFKA_SERVER = os.environ.get(
     "FELDERA_PIPELINE_TO_KAFKA_SERVER", "redpanda:9092"
 )
 
-TEST_CLIENT = FelderaClient(BASE_URL, api_key=API_KEY, requests_verify=False)
+TEST_CLIENT = FelderaClient(
+    BASE_URL, api_key=API_KEY,
+    connection_timeout=10, requests_verify=False
+)
 
 
 def enterprise_only(fn):


### PR DESCRIPTION
Adds an explicit timeout to requests. If the request times out, retry for up to 3 times.

