### PR TITLE
[SQL] Implement a set of MIN/MAX/ARG_MIN/ARG_MAX operators as a sequence of individual operators

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAggregateOperator.java
@@ -34,6 +34,7 @@ import org.dbsp.sqlCompiler.ir.aggregate.DBSPAggregateList;
 import org.dbsp.sqlCompiler.ir.aggregate.DBSPAggregator;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeFunction;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.util.Utilities;
 
@@ -51,7 +52,16 @@ public final class DBSPStreamAggregateOperator extends DBSPAggregateOperatorBase
         Utilities.enforce(aggregateList == null || !aggregateList.isLinear());
         Utilities.enforce(aggregateList == null ||
                 aggregateList.rowVar.getType().sameType(input.getOutputIndexedZSetType().elementType.ref()));
+        Utilities.enforce(aggregateList == null ||
+                aggregateList.getType().to(DBSPTypeFunction.class).resultType.sameType(outputType.elementType));
         Utilities.enforce(input.getOutputIndexedZSetType().keyType.sameType(outputType.keyType));
+        /*
+        TODO: this requires some cleanup; types are not used consistently
+        Utilities.enforce(function == null ||
+                (outputType.getElementTypeTuple().size() == 1 &&
+                 outputType.getElementTypeTuple().sameType(
+                         function.type.to(DBSPTypeFunction.class).resultType)));
+         */
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -81,24 +81,29 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
 
     /**
      * The output that used to be computed by 'old' is now
-     * computed by 'newOp',
-     * @param old    Operator in the previous circuit.
-     * @param newOp  Operator replacing it in the new circuit.
-     * @param add    If true add the operator to the new circuit.
-     *               This may not be necessary if the operator has already been added. */
-    protected void map(OutputPort old, OutputPort newOp, boolean add) {
-        if (!old.equals(newOp)) {
+     * computed by 'newPort',
+     * @param oldPort  Port in the previous circuit.
+     * @param newPort  Port replacing it in the new circuit.
+     * @param add      If true add the newPort.node() operator to the new circuit.
+     *                 This may not be necessary if the operator has already been added. */
+    protected void map(OutputPort oldPort, OutputPort newPort, boolean add) {
+        if (!oldPort.equals(newPort)) {
+            if (this.preservesTypes && oldPort.exists() && newPort.exists()) {
+                Utilities.enforce(oldPort.outputType().sameType(newPort.outputType()),
+                        "Replacing operator with type\n" + oldPort.outputType() +
+                                " with new type\n" + newPort.outputType());
+            }
             Logger.INSTANCE.belowLevel(this, 1)
                     .appendSupplier(this::toString)
                     .append(":")
-                    .appendSupplier(old::toString)
+                    .appendSupplier(oldPort::toString)
                     .append(" -> ")
-                    .appendSupplier(newOp::toString)
+                    .appendSupplier(newPort::toString)
                     .newline();
         }
-        Utilities.putNew(this.remap, old, newOp);
+        Utilities.putNew(this.remap, oldPort, newPort);
         if (add)
-            this.addOperator(newOp.node());
+            this.addOperator(newPort.node());
     }
 
     protected void map(DBSPSimpleOperator old, DBSPSimpleOperator newOp, boolean add) {
@@ -120,11 +125,6 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
         if (!old.equals(newOp)) {
             long derivedFrom = old.node().derivedFrom;
             newOp.node().setDerivedFrom(derivedFrom);
-            if (this.preservesTypes) {
-                Utilities.enforce(old.outputType().sameType(newOp.outputType()),
-                        "Replacing operator with type\n" + old.outputType() +
-                                " with new type\n" + newOp.outputType());
-            }
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPFold.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPFold.java
@@ -96,11 +96,11 @@ public class DBSPFold extends DBSPAggregator {
 
     @SuppressWarnings("unused")
     public static DBSPFold fromJson(JsonNode node, JsonDecoder decoder) {
-        DBSPTypeSemigroup semigroup = DBSPTypeSemigroup.fromJson(node, decoder);
+        DBSPTypeSemigroup semigroup = fromJsonInner(node, "semigroup", decoder, DBSPTypeSemigroup.class);
         DBSPExpression zero = fromJsonInner(node, "zero", decoder, DBSPExpression.class);
         DBSPClosureExpression increment = fromJsonInner(node, "increment", decoder, DBSPClosureExpression.class);
-        DBSPClosureExpression postProcessing = fromJsonInner(
-                node, "postProcessing", decoder, DBSPClosureExpression.class);
-        return new DBSPFold(CalciteObject.EMPTY, semigroup, zero, increment, postProcessing);
+        DBSPClosureExpression postProcess = fromJsonInner(
+                node, "postProcess", decoder, DBSPClosureExpression.class);
+        return new DBSPFold(CalciteObject.EMPTY, semigroup, zero, increment, postProcess);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/NonLinearAggregate.java
@@ -1,7 +1,6 @@
 package org.dbsp.sqlCompiler.ir.aggregate;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.calcite.rel.core.Aggregate;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeSemigroup.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/user/DBSPTypeSemigroup.java
@@ -42,7 +42,7 @@ public class DBSPTypeSemigroup extends DBSPTypeUser {
         super(CalciteObject.EMPTY, DBSPTypeCode.SEMIGROUP, "Semigroup" + elementTypes.length, false,
                 Linq.concat(semigroupTypes, elementTypes));
         if (elementTypes.length != semigroupTypes.length)
-            throw new InternalCompilerError("Each element must have a corresponding semigroup, but I have " +
+            throw new InternalCompilerError("Each element must have a corresponding semigroup, but there are " +
                     elementTypes.length + " and " + semigroupTypes.length, this);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -766,7 +766,7 @@ public class IncrementalRegressionTests extends SqlIoTest {
                 if (operator.right().operator.is(DBSPJoinIndexOperator.class))
                     depth = Math.max(depth, depthMap.get(operator.right().operator) + 1);
                 depthMap.put(operator, depth);
-                Assert.assertTrue(depth < 3);
+                Assert.assertTrue(depth <= 3);
             }
         });
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -55,8 +55,8 @@ public class Regression1Tests extends SqlIoTest {
 
             @Override
             public void endVisit() {
-                // 1 combined max
-                Assert.assertEquals(1, this.streamAggregates);
+                // 3 separate max
+                Assert.assertEquals(3, this.streamAggregates);
                 // 1 for the two sums
                 Assert.assertEquals(1, this.linearAggregates);
             }


### PR DESCRIPTION
Generally it's more efficient to implement MIN(a), MIN(b) as two operators followed by a join rather than a single scan.
This PR makes this choice when there are no other non-linear aggregates that scan the same collection.

Note: this plan used to be generated in a previous version of the compiler, but the optimizations related to chain aggregates no longer produce such plans.