### PR TITLE
Data staging for DBSP with support from some input adapters

### DIFF
--- a/crates/adapters/src/format/avro/input.rs
+++ b/crates/adapters/src/format/avro/input.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use actix_web::HttpRequest;
 use apache_avro::{from_avro_datum, types::Value as AvroValue, Schema as AvroSchema};
+use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_types::{
     format::avro::{AvroParserConfig, AvroUpdateFormat},
@@ -475,5 +476,9 @@ impl Parser for AvroParser {
             last_event_number: 0,
             schema_cache: self.schema_cache.clone(),
         })
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.input_stream.as_ref().unwrap().stage(buffers)
     }
 }

--- a/crates/adapters/src/format/csv.rs
+++ b/crates/adapters/src/format/csv.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use actix_web::HttpRequest;
 use anyhow::{bail, Result as AnyResult};
+use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_types::{
     config::ConnectorConfig,
@@ -155,6 +156,10 @@ impl Parser for CsvParser {
             self.parse_record(data, &mut errors);
         }
         (self.input_stream.take_all(), errors)
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.input_stream.stage(buffers)
     }
 }
 

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -9,6 +9,7 @@ use crate::{
     ControllerError,
 };
 use actix_web::HttpRequest;
+use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_adapterlib::format::Splitter;
 use feldera_types::format::json::{JsonLines, JsonParserConfig, JsonUpdateFormat};
@@ -369,6 +370,10 @@ impl Parser for JsonParser {
         }
 
         (self.input_stream.take_all(), errors)
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.input_stream.stage(buffers)
     }
 
     fn fork(&self) -> Box<dyn Parser> {

--- a/crates/adapters/src/format/mod.rs
+++ b/crates/adapters/src/format/mod.rs
@@ -2,7 +2,6 @@ use crate::format::parquet::{ParquetInputFormat, ParquetOutputFormat};
 #[cfg(feature = "with-avro")]
 use avro::input::AvroInputFormat;
 use once_cell::sync::Lazy;
-use std::hash::Hasher;
 use std::ops::Range;
 use std::{
     cmp::max,
@@ -68,23 +67,6 @@ static OUTPUT_FORMATS: Lazy<BTreeMap<&'static str, Box<dyn OutputFormat>>> = Laz
 
 pub fn get_output_format(name: &str) -> Option<&'static dyn OutputFormat> {
     OUTPUT_FORMATS.get(name).map(|f| &**f)
-}
-
-/// An empty [InputBuffer].
-pub struct EmptyInputBuffer;
-
-impl InputBuffer for EmptyInputBuffer {
-    fn flush(&mut self) {}
-
-    fn hash(&self, _hasher: &mut dyn Hasher) {}
-
-    fn len(&self) -> BufferSize {
-        BufferSize::empty()
-    }
-
-    fn take_some(&mut self, _n: usize) -> Option<Box<dyn InputBuffer>> {
-        None
-    }
 }
 
 /// A [Splitter] that never breaks data into records.

--- a/crates/adapters/src/format/parquet/mod.rs
+++ b/crates/adapters/src/format/parquet/mod.rs
@@ -9,6 +9,7 @@ use arrow::datatypes::{
     TimeUnit,
 };
 use bytes::Bytes;
+use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_adapterlib::catalog::ArrowStream;
 use feldera_types::config::ConnectorConfig;
@@ -158,6 +159,10 @@ impl Parser for ParquetParser {
 
     fn splitter(&self) -> Box<dyn super::Splitter> {
         Box::new(Sponge)
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.input_stream.stage(buffers)
     }
 }
 

--- a/crates/adapters/src/format/raw.rs
+++ b/crates/adapters/src/format/raw.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use actix_web::HttpRequest;
 use core::str;
+use dbsp::operator::StagedBuffers;
 use erased_serde::Serialize as ErasedSerialize;
 use feldera_types::{
     format::raw::{RawParserConfig, RawParserMode},
@@ -152,6 +153,10 @@ impl Parser for RawParser {
         }
 
         (self.input_stream.take_all(), errors)
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.input_stream.stage(buffers)
     }
 }
 

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -273,13 +273,12 @@ where
         Self {
             buffers: buffers
                 .into_iter()
-                .map(|buffer| {
+                .flat_map(|buffer| {
                     (buffer as Box<dyn Any>)
                         .downcast::<MockDeZSetStreamBuffer<T, U>>()
                         .unwrap()
                         .updates
                 })
-                .flatten()
                 .collect(),
             handle: zset.clone(),
         }

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -2,6 +2,7 @@ use crate::catalog::InputCollectionHandle;
 use crate::format::{get_input_format, InputBuffer, Splitter};
 use crate::{controller::FormatConfig, InputConsumer, ParseError, Parser};
 use anyhow::{anyhow, Error as AnyError};
+use dbsp::operator::StagedBuffers;
 use feldera_adapterlib::format::BufferSize;
 use feldera_adapterlib::transport::Resume;
 use feldera_types::config::FtModel;
@@ -204,5 +205,9 @@ impl Parser for MockInputParser {
     fn splitter(&self) -> Box<dyn Splitter> {
         let state = self.0.lock().unwrap();
         state.parser.splitter()
+    }
+
+    fn stage(&self, buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        self.0.lock().unwrap().parser.stage(buffers)
     }
 }

--- a/crates/adapters/src/transport/adhoc.rs
+++ b/crates/adapters/src/transport/adhoc.rs
@@ -294,7 +294,7 @@ impl InputReader for AdHocInputEndpoint {
                         })
                         .unwrap()
                     },
-                    hasher,
+                    hasher.map(|h| h.finish()),
                 );
                 details.consumer.extended(num_records, Some(resume));
             }

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -216,7 +216,7 @@ impl FileInputReader {
                         .unwrap();
 
                         let resume = match get_barrier(&path) {
-                            None => Resume::new_metadata_only(seek, hasher),
+                            None => Resume::new_metadata_only(seek, hasher.map(|h| h.finish())),
                             Some(barrier) => {
                                 num_records += total.records;
                                 if num_records < barrier {

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -124,7 +124,7 @@ impl HttpInputEndpointInner {
                             })
                             .unwrap()
                         },
-                        hasher,
+                        hasher.map(|h| h.finish()),
                     );
                     details.consumer.extended(num_records, Some(resume));
                 }

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -342,13 +342,12 @@ impl Parser for DummyParser {
         Box::new(DummyStagedBuffers {
             data: buffers
                 .into_iter()
-                .map(|buffer| {
+                .filter_map(|buffer| {
                     (buffer as Box<dyn Any>)
                         .downcast::<DummyInputBuffer>()
                         .unwrap()
                         .data
                 })
-                .flatten()
                 .collect(),
             handle: self.0.clone(),
         })

--- a/crates/adapters/src/transport/nexmark.rs
+++ b/crates/adapters/src/transport/nexmark.rs
@@ -381,7 +381,7 @@ fn worker_thread(
                         event_ids: events.unwrap_or_else(|| next_event_id..next_event_id),
                     })
                     .unwrap(),
-                    hasher,
+                    hasher.map(|h| h.finish()),
                 );
                 consumers[NexmarkTable::Bid].extended(total, Some(resume));
             }

--- a/crates/adapters/src/transport/s3/mod.rs
+++ b/crates/adapters/src/transport/s3/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, VecDeque},
+    hash::Hasher,
     sync::Arc,
     thread,
 };
@@ -696,7 +697,7 @@ impl S3InputReader {
                                 partially_processed_keys: partially_processed_keys.by_index().await,
                             })
                             .unwrap(),
-                            hasher,
+                            hasher.map(|h| h.finish()),
                         )),
                     );
                 }

--- a/crates/adapters/src/transport/url.rs
+++ b/crates/adapters/src/transport/url.rs
@@ -395,7 +395,7 @@ impl UrlInputReader {
                                         ofs..ofs
                                     }),
                             }).unwrap();
-                            consumer.extended(total, Some(Resume::new_metadata_only(seek, hasher)));
+                            consumer.extended(total, Some(Resume::new_metadata_only(seek, hasher.map(|h| h.finish()))));
                         }
                         InputReaderCommand::Disconnect => return Ok(()),
                     }

--- a/crates/datagen/src/lib.rs
+++ b/crates/datagen/src/lib.rs
@@ -660,8 +660,10 @@ impl InputGenerator {
                         seed,
                     }
                     .into();
-                    let resume =
-                        Resume::new_metadata_only(serde_json::to_value(metadata).unwrap(), hasher);
+                    let resume = Resume::new_metadata_only(
+                        serde_json::to_value(metadata).unwrap(),
+                        hasher.map(|h| h.finish()),
+                    );
                     consumer.extended(total, Some(resume));
                 }
                 Some(InputReaderCommand::Disconnect) => break,

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -65,7 +65,9 @@ pub use generator::{Generator, GeneratorNested};
 // // //pub use index::Index;
 pub use group::CmpFunc;
 use input::Mailbox;
-pub use input::{IndexedZSetHandle, Input, InputHandle, MapHandle, SetHandle, Update, ZSetHandle};
+pub use input::{
+    IndexedZSetHandle, Input, InputHandle, MapHandle, SetHandle, StagedBuffers, Update, ZSetHandle,
+};
 pub use inspect::Inspect;
 
 pub use dynamic::join_range::StreamJoinRange;


### PR DESCRIPTION
In my testing with one particular test case, with the file input adapter, this made the overall pipeline run about 25% faster.

Please read commit messages for the individual commits.

This shouldn't be any kind of breaking change.