### PR TITLE
[adapters] Don't spam the log with 503.

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -824,7 +824,10 @@ async fn status(state: WebData<ServerState>) -> impl Responder {
             let status = controller.status().global_metrics.get_state();
             Ok(HttpResponse::Ok().json(status))
         }
-        None => Err(missing_controller_error(&state)),
+        None => match *state.phase.read().unwrap() {
+            PipelinePhase::Initializing => Ok(HttpResponse::Ok().json("Initializing")),
+            _ => Err(missing_controller_error(&state)),
+        },
     }
 }
 

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -19,6 +19,12 @@ import TabItem from '@theme/TabItem';
         TIME(3) (the default precision has been changed from 0 to 3; the
         documentation always claimed that the precision is 3).
 
+        The following change doesn't affect the external Feldera API, only the
+        pipeline's API available from a sidecare container. The `/status`
+        endpoint no longer returns HTTP status 503 (SERVICE_UNAVAILABLE) while
+        the pipeline is initializing. Instead it returns status OK with message
+        body containing the "Initializing" string.
+
         ## 0.129.0
 
         Values that are late in the NOW stream are no longer logged to the


### PR DESCRIPTION
Fixes #3687

The /status endpoint used to return 503 in the initializing state. This caused the error to be logged, polluting logs with many pointless error messages that did not represent actual errors.

In addition this behavior is simply incorrect because Initializing is a perfectly valid status.  This commit changes it to return status OK with 'Initializing' in the body.  This doesn't affect the public API since the pipeline manager already had the code to interpret 503 with 'Initializing' in the body as successfully returning Initializing status.  We were now able to remove this code.

Add a brief description of the pull request.