### PR TITLE
[SQL] Produce correct result nullability for window aggregates

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/NoChain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/NoChain.java
@@ -1,0 +1,7 @@
+package org.dbsp.sqlCompiler.circuit.annotation;
+
+/** Do not use this operator in a ChainOperator.
+ * Used for example by the operator following a {@link
+ * org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator} - only
+ * {@link org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator} works there. */
+public class NoChain extends Annotation {}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPMapOperator.java
@@ -41,10 +41,10 @@ import java.util.Objects;
 
 public final class DBSPMapOperator extends DBSPUnaryOperator {
     public DBSPMapOperator(CalciteRelNode node, DBSPExpression function,
-                           DBSPTypeZSet outputType, OutputPort input) {
+                           DBSPTypeZSet outputType, boolean isMultiset, OutputPort input) {
+        super(node, "map", function, outputType, isMultiset, input);
         // Currently the output type can only be a ZSet, but the input
         // type may be a ZSet or an IndexedZSet.
-        super(node, "map", function, outputType, true, input);
         DBSPType elementType = this.getOutputZSetElementType();
         if (function.is(DBSPClosureExpression.class)) {
             // Could also be a SortExpression
@@ -52,6 +52,11 @@ public final class DBSPMapOperator extends DBSPUnaryOperator {
         }
         this.checkResultType(function, elementType);
         checkArgumentFunctionType(function, input);
+    }
+
+    public DBSPMapOperator(CalciteRelNode node, DBSPExpression function,
+                           DBSPTypeZSet outputType, OutputPort input) {
+        this(node, function, outputType, true, input);
     }
 
     public DBSPMapOperator(CalciteRelNode node, DBSPClosureExpression function, OutputPort input) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPOperator.java
@@ -114,6 +114,10 @@ public abstract class DBSPOperator extends DBSPNode implements IDBSPOuterNode {
         return this.annotations.contains(test);
     }
 
+    public <T extends Annotation> boolean hasAnnotation(Class<T> clazz) {
+        return this.hasAnnotation(clazz::isInstance);
+    }
+
     /**
      * Return true if any of the inputs in `newInputs` is different from one of the inputs
      * of this operator.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -77,6 +77,7 @@ import org.apache.calcite.sql.ddl.SqlCreateType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.circuit.annotation.NoChain;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
@@ -3172,7 +3173,8 @@ public class CalciteToDBSPCompiler extends RelVisitor
                 DBSPExpression body = new DBSPRawTupleExpression(
                         new DBSPTupleExpression(keyFields, false),
                         new DBSPApplyMethodExpression(this.node, "unwrap_or_default", aggResultType, agg));
-                index = new DBSPMapIndexOperator(this.node, body.closure(var), windowAgg.outputPort());
+                index = new DBSPMapIndexOperator(this.node, body.closure(var), windowAgg.outputPort())
+                        .addAnnotation(new NoChain(), DBSPMapIndexOperator.class);
                 this.compiler.getCircuit().addOperator(index);
             }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -345,7 +345,7 @@ public class SqlToRelCompiler implements IWritesLogs {
 
         @Override
         public int getMaxPrecision(SqlTypeName typeName) {
-            if (typeName.equals(SqlTypeName.TIME))
+            if (typeName == SqlTypeName.TIME)
                 return 9;
             return super.getMaxPrecision(typeName);
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ChainVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ChainVisitor.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.annotation.NoChain;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
@@ -40,6 +41,8 @@ public class ChainVisitor extends CircuitCloneWithGraphsVisitor {
     DBSPChainOperator chain(DBSPUnaryOperator operator) {
         if (this.getGraph().getFanout(operator.input().node()) != 1)
             return null;
+        if (operator.hasAnnotation(NoChain.class))
+            return null;
         DBSPChainOperator.Computation computation = getComputation(operator);
         if (computation == null)
             return null;
@@ -50,7 +53,7 @@ public class ChainVisitor extends CircuitCloneWithGraphsVisitor {
             return new DBSPChainOperator(operator.getRelNode().after(in.node().getRelNode()),
                     chain.add(computation), operator.isMultiset, chainOp.input());
         } else {
-            if (!in.node().is(DBSPSimpleOperator.class))
+            if (!in.node().is(DBSPSimpleOperator.class) || in.node().hasAnnotation(NoChain.class))
                 return null;
             DBSPSimpleOperator inSimple = in.simpleNode();
             DBSPChainOperator.Computation inComputation = getComputation(inSimple);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeMaps.java
@@ -96,7 +96,8 @@ public class OptimizeMaps extends CircuitCloneWithGraphsVisitor {
                     .applyAfter(this.compiler(), expression, Maybe.MAYBE);
             CalciteRelNode node = operator.getRelNode().after(source.node().getRelNode());
             DBSPSimpleOperator result = new DBSPMapIndexOperator(
-                    node, newFunction, operator.getOutputIndexedZSetType(), source.node().inputs.get(0));
+                    node, newFunction, operator.getOutputIndexedZSetType(), source.node().inputs.get(0))
+                    .copyAnnotations(operator).copyAnnotations(source.simpleNode());
             this.map(operator, result);
             return;
         } else if (source.node().is(DBSPMapIndexOperator.class) && this.canMergeSource(source, size)) {
@@ -113,7 +114,8 @@ public class OptimizeMaps extends CircuitCloneWithGraphsVisitor {
                     .reduce(this.compiler()).to(DBSPClosureExpression.class);
             CalciteRelNode node = operator.getRelNode().after(source.node().getRelNode());
             DBSPSimpleOperator result = new DBSPMapIndexOperator(
-                    node, newFunction, operator.getOutputIndexedZSetType(), source.node().inputs.get(0));
+                    node, newFunction, operator.getOutputIndexedZSetType(), source.node().inputs.get(0))
+                    .copyAnnotations(operator).copyAnnotations(source.simpleNode());
             this.map(operator, result);
             return;
         } else if ((source.node().is(DBSPIntegrateOperator.class)) ||
@@ -126,6 +128,7 @@ public class OptimizeMaps extends CircuitCloneWithGraphsVisitor {
             for (OutputPort sourceSource: source.node().inputs) {
                 DBSPSimpleOperator newProjection = operator
                         .withInputs(Linq.list(sourceSource), true)
+                        .copyAnnotations(operator)
                         .to(DBSPSimpleOperator.class);
                 newSources.add(newProjection.outputPort());
                 this.addOperator(newProjection);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
@@ -426,6 +426,7 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
             DBSPClosureExpression compressed = rw.rewriteClosure(closure);
             OutputPort source = this.mapped(operator.input());
             DBSPSimpleOperator adjust = new DBSPMapIndexOperator(operator.getRelNode(), projection, source)
+                    .copyAnnotations(operator)
                     .addAnnotation(new IsProjection(size), DBSPSimpleOperator.class);
             this.addOperator(adjust);
             DBSPSimpleOperator result = new DBSPMapIndexOperator(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
@@ -29,8 +29,8 @@ public class MinMaxAggregate extends NonLinearAggregate {
     /** A closure with signature |row| -> { compared value }, where 'row'
      * has the same type as the row variable (second parameter of the increment).
      * For min and max this is the argument value; for arg_min and arg_max this
-     * contains both arguments.  This is currently only used for optimizing Min and Max
-     * aggregate implementations. */
+     * contains both arguments.  This is currently only used for optimizing Min, Max,
+     * ArgMin and ArgMAx aggregate implementations. */
     public final DBSPClosureExpression comparedValue;
 
     public MinMaxAggregate(CalciteObject origin, DBSPExpression zero, DBSPClosureExpression increment,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/MinMaxAggregate.java
@@ -30,7 +30,7 @@ public class MinMaxAggregate extends NonLinearAggregate {
      * has the same type as the row variable (second parameter of the increment).
      * For min and max this is the argument value; for arg_min and arg_max this
      * contains both arguments.  This is currently only used for optimizing Min, Max,
-     * ArgMin and ArgMAx aggregate implementations. */
+     * ArgMin and ArgMax aggregate implementations. */
     public final DBSPClosureExpression comparedValue;
 
     public MinMaxAggregate(CalciteObject origin, DBSPExpression zero, DBSPClosureExpression increment,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -814,4 +814,18 @@ public class IncrementalRegressionTests extends SqlIoTest {
                     FROM T
                 ) WHERE rn = 1;""");
     }
+
+    @Test
+    public void issue4660() {
+        var ccs = this.getCCS("""
+                CREATE TABLE T(x BIGINT NOT NULL);
+                CREATE VIEW V AS SELECT MAX(x) OVER () FROM T;""");
+        ccs.step("", """
+                 max | weight
+                --------------""");
+        ccs.step("INSERT INTO T VALUES(1), (2), (-1);", """
+                 max | weight
+                --------------
+                   2 | 3""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/RegressionTests.java
@@ -1648,8 +1648,8 @@ public class RegressionTests extends SqlIoTest {
 
             @Override
             public void endVisit() {
-                // We expect 5 MapIndex operators instead of 11 if CSE works
-                Assert.assertEquals(5, this.mapIndex);
+                // We expect 7 MapIndex operators instead of 11 if CSE works
+                Assert.assertEquals(7, this.mapIndex);
             }
         };
         visitor.apply(circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -1596,7 +1596,7 @@ public class StreamingTests extends StreamingTestBase {
 
             @Override
             public void endVisit() {
-                Assert.assertEquals(4, fmi);
+                Assert.assertEquals(2, fmi);
             }
         };
         ccs.visit(visitor);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -96,7 +96,7 @@
       "positions": [],
       "persistent_id": "5e6c4775639ef50da58436d192195ae13fa8cd9681af464d09f0927ebbd24bbf"
     }, "s3": {
-      "operation": "flat_map_index",
+      "operation": "map_index",
       "inputs": [
         { "node": "s2", "output": 0 }
       ],
@@ -111,7 +111,7 @@
       "positions": [
         {"start_line_number":1,"start_column":1,"end_line_number":1,"end_column":56}
       ],
-      "persistent_id": "818c7468fa4db4704d39762d9a674575e6e67c76d9c99264abc9813294dd6feb"
+      "persistent_id": "7684c3b73a6314cdb2e4342c658d4749799627e5ccdb1174d848823bbd68bba3"
     }, "s4": {
       "operation": "differentiate",
       "inputs": [
@@ -121,7 +121,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "6facae8579db99aae3877089a35d46490e1c9c0eafd864388065616a487f41c8"
+      "persistent_id": "01faa7580b0056d187ace3cd6d84378af92e4b695805e5446059ba5495eb41af"
     }, "s5": {
       "operation": "aggregate_linear_postprocess",
       "inputs": [
@@ -133,7 +133,7 @@
       "positions": [
         {"start_line_number":2,"start_column":25,"end_line_number":2,"end_column":33}
       ],
-      "persistent_id": "5831bd22095859ae6d17404d40f72561f0c0c36761b5907d8d9fa5c6e001596a"
+      "persistent_id": "972329ef8724635f60da98480c55fb2d0e6f5e86fe2762e01b6d193c3ab4a0e6"
     }, "s6": {
       "operation": "map",
       "inputs": [
@@ -143,7 +143,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "c8fd9fc09b83cf238328247c1b6faed3e265f1a6a0683f789156ce860ad4ba6c"
+      "persistent_id": "fa2c5d61862919e46280473305fc6c572d2f253b16291ddcf1d1c0b02811cdbb"
     }, "s7": {
       "operation": "map",
       "inputs": [
@@ -153,7 +153,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "8d256cf38ddf1bf079a872f36daed47a9de84e5816412f2e5a1385f718cc25f0"
+      "persistent_id": "29b5cad4cdd9c7ebd8bdfae248cc0ca934bef75a9c74c3fad4346a1c7eade068"
     }, "s8": {
       "operation": "neg",
       "inputs": [
@@ -163,7 +163,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "12e5a0e02a224730afc31fbce47476d7d434b0bf265e04e4c6b5a832125617d7"
+      "persistent_id": "7fa2c27e4e0ca396a5798029520d203ff87bf9f3d13ed39090570838d9ad1cc3"
     }, "s9": {
       "operation": "integrate",
       "inputs": [
@@ -173,7 +173,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "a3fb62354d350e8aa3aeab9ca9b19d0c1582eed8b8dc4c0f095695a8b0e61fd0"
+      "persistent_id": "52165e29b7cdee78296cc216b13ebc1a3640837302d057059fa1abb86d06e83e"
     }, "s10": {
       "operation": "integrate",
       "inputs": [
@@ -183,7 +183,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "fcdebbc3936a0e34809778d6707cbe190c30a01b996a1a496caa506a9890b86e"
+      "persistent_id": "5c034254b63c337f3a465639aaed1950999ec8e82d1625454fcbd4f02a6ee3a9"
     }, "s11": {
       "operation": "sum",
       "inputs": [
@@ -195,7 +195,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "c2f4d0f93c2e5ec31d2c1c695329b56b488197dd7f9b553ed4086d1be7fc12a2"
+      "persistent_id": "7868dec0d654c687104911b9aa76e751983577c13a237431d65c32452bcc61c2"
     }, "s12": {
       "operation": "inspect",
       "inputs": [
@@ -205,7 +205,7 @@
         "final": 3
       },
       "positions": [],
-      "persistent_id": "4f1413d7a616964084a0afe72a3765e5182b0b32c20f70929a1ee950090adfd3"
+      "persistent_id": "ef960de2d6c71c5f017a139ae64cf5d64e0d83de5e75957f0f442e7208c32750"
     }, "s13": {
       "operation": "inspect",
       "inputs": [


### PR DESCRIPTION
Fixes #4660 

Contains 3 commits fixing independent problems:

- Some aggregates, such as Max, always return Nullable results, because they have no choice over an empty collection.
However, a window aggregate never runs over an empty collection, so the result can be non-nullable when the field aggregated is not nullable. This requires "correcting" the result using a cast (unwrap) which can never fail.

- The stream produced by a `partitioned_rolling_aggregate` does not support operations such as flat_map, so the `map_index` operator following the rolling aggregate should not be combined with other operators.

- If a chain operator does not contain any filters, produce a Map/MapIndex instead of a FlatMap/FlatMapIndex
