### PR TITLE
[SQL] Perform Calcite join optimizations both before and after decorrelation

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -196,11 +196,11 @@ def validate_view(pipeline: Pipeline, view: ViewSpec):
 
             if extra_rows:
                 log("Extra rows in Feldera output, but not in the ad hoc query output")
-                log(json.dumps(extra_rows))
+                log(json.dumps(extra_rows, default=str))
 
             if missing_rows:
                 log("Extra rows in the ad hoc query output, but not in Feldera output")
-                log(json.dumps(missing_rows))
+                log(json.dumps(missing_rows, default=str))
         except Exception as e:
             log(f"Error querying view '{view.name}': {e}")
             log(f"Ad-hoc Query: {view_query}")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FilterCorrelateRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FilterCorrelateRule.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A modified version of {@link org.apache.calcite.rel.rules.FilterCorrelateRule}
+ * which does not push predicates that contain other correlated variables.
+ *
+ * <p>Planner rule that pushes a {@link Filter} above a {@link Correlate} into the
+ * inputs of the Correlate.
+ *
+ * @see CoreRules#FILTER_CORRELATE
+ */
+public class FilterCorrelateRule
+        extends RelRule<org.apache.calcite.rel.rules.FilterCorrelateRule.Config>
+        implements TransformationRule {
+
+    /** Creates a FilterCorrelateRule. */
+    protected FilterCorrelateRule(org.apache.calcite.rel.rules.FilterCorrelateRule.Config config) {
+        super(config);
+    }
+
+    //~ Methods ----------------------------------------------------------------
+
+    static class CorrelVariableFinder extends RexShuttle {
+        boolean found = false;
+
+        @Override
+        public RexNode visitCorrelVariable(RexCorrelVariable correlVariable) {
+            found = true;
+            return correlVariable;
+        }
+
+        static boolean has(RexNode root) {
+            CorrelVariableFinder finder = new CorrelVariableFinder();
+            root.accept(finder);
+            return finder.found;
+        }
+    }
+
+
+    @Override public void onMatch(RelOptRuleCall call) {
+        final Filter filter = call.rel(0);
+        final Correlate corr = call.rel(1);
+
+        List<RexNode> aboveFilters =
+                RelOptUtil.conjunctions(filter.getCondition());
+
+        List<RexNode> leftFilters = new ArrayList<>();
+        List<RexNode> rightFilters = new ArrayList<>();
+
+	    List<RexNode> ineligible = new ArrayList<>();
+	    List<RexNode> eligible = new ArrayList<>();
+        for (RexNode f: aboveFilters) {
+            if (CorrelVariableFinder.has(f)) {
+                ineligible.add(f);
+            } else {
+                eligible.add(f);
+            }
+        }
+
+        aboveFilters = eligible;
+        // Try to push down above filters. These are typically where clause
+        // filters. They can be pushed down if they are not on the NULL
+        // generating side.
+        RelOptUtil.classifyFilters(
+                corr,
+                aboveFilters,
+                false,
+                true,
+                corr.getJoinType().canPushRightFromAbove(),
+                aboveFilters,
+                leftFilters,
+                rightFilters);
+
+        if (leftFilters.isEmpty() && rightFilters.isEmpty()) {
+            // no filters got pushed
+            return;
+        }
+
+	    aboveFilters.addAll(ineligible);
+
+        // Create Filters on top of the children if any filters were
+        // pushed to them.
+        final RexBuilder rexBuilder = corr.getCluster().getRexBuilder();
+        final RelBuilder relBuilder = call.builder();
+        final RelNode leftRel =
+                relBuilder.push(corr.getLeft()).filter(leftFilters).build();
+        final RelNode rightRel =
+                relBuilder.push(corr.getRight()).filter(rightFilters).build();
+
+        // Create the new Correlate
+        RelNode newCorrRel =
+                corr.copy(corr.getTraitSet(), ImmutableList.of(leftRel, rightRel));
+
+        call.getPlanner().onCopy(corr, newCorrRel);
+
+        if (!leftFilters.isEmpty()) {
+            call.getPlanner().onCopy(filter, leftRel);
+        }
+        if (!rightFilters.isEmpty()) {
+            call.getPlanner().onCopy(filter, rightRel);
+        }
+
+        // Create a Filter on top of the join if needed
+        relBuilder.push(newCorrRel);
+        relBuilder.filter(
+                RexUtil.fixUp(rexBuilder, aboveFilters,
+                        RelOptUtil.getFieldTypeList(relBuilder.peek().getRowType())));
+
+        call.transformTo(relBuilder.build());
+    }
+
+    public static final FilterCorrelateRule FILTER_CORRELATE =
+            new FilterCorrelateRule(org.apache.calcite.rel.rules.FilterCorrelateRule.Config.DEFAULT);
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ReferenceMap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ReferenceMap.java
@@ -21,8 +21,8 @@ public class ReferenceMap {
         if (this.declarations.containsKey(var)) {
             IDBSPDeclaration decl = this.declarations.get(var);
             if (decl != declaration)
-                throw new InternalCompilerError("Changing declaration of " + var + " from " +
-                        decl + " to " + declaration, var);
+                throw new InternalCompilerError("Changing declaration of " + var + " from\n" +
+                        decl + " to\n" + declaration, var);
             return;
         }
         Utilities.putNew(this.declarations, var, declaration);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -31,7 +31,6 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.MerkleOuter;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
-import org.dbsp.sqlCompiler.compiler.visitors.inner.BetaReduction;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.CanonicalForm;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EliminateDump;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpandCasts;
@@ -140,8 +139,6 @@ public class CircuitOptimizer extends Passes {
         this.add(new ImplementChains(compiler));
         // Lowering may surface additional casts that need to be expanded
         this.add(new Repeat(compiler, new ExpandCasts(compiler).circuitRewriter(true)));
-        // Beta reduction after implementing aggregates.
-        this.add(new BetaReduction(compiler).getCircuitRewriter(false));
         this.add(new CSE(compiler));
         this.add(new ExpandJoins(compiler));
         this.add(new RemoveViewOperators(compiler, true));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpchTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/TpchTest.java
@@ -1,6 +1,8 @@
 package org.dbsp.sqlCompiler.compiler.sql.suites;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinFilterMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
@@ -90,6 +92,60 @@ public class TpchTest extends BaseSQLTests {
             @Override
             public void postorder(DBSPJoinFilterMapOperator join) {
                 Assert.fail();
+            }
+        });
+    }
+
+    @Test
+    public void compilerTpch21() throws IOException {
+        var cc = this.compileQuery(21);
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            void someKey(DBSPJoinBaseOperator operator) {
+                // Check that the keys are not Tup0<>
+                Assert.assertNotEquals(0, operator.left().getOutputIndexedZSetType()
+                        .keyType.to(DBSPTypeTupleBase.class).size());
+            }
+
+            @Override
+            public void postorder(DBSPJoinOperator operator) {
+                this.someKey(operator);
+            }
+
+            @Override
+            public void postorder(DBSPJoinIndexOperator operator) {
+                this.someKey(operator);
+            }
+
+            @Override
+            public void postorder(DBSPJoinFilterMapOperator operator) {
+                this.someKey(operator);
+            }
+        });
+    }
+
+    @Test
+    public void compilerTpch2() throws IOException {
+        var cc = this.compileQuery(2);
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            void someKey(DBSPJoinBaseOperator operator) {
+                // Check that the keys are not Tup0<>
+                Assert.assertNotEquals(0, operator.left().getOutputIndexedZSetType()
+                        .keyType.to(DBSPTypeTupleBase.class).size());
+            }
+
+            @Override
+            public void postorder(DBSPJoinOperator operator) {
+                this.someKey(operator);
+            }
+
+            @Override
+            public void postorder(DBSPJoinIndexOperator operator) {
+                this.someKey(operator);
+            }
+
+            @Override
+            public void postorder(DBSPJoinFilterMapOperator operator) {
+                this.someKey(operator);
             }
         });
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
@@ -77,6 +77,33 @@
         },
         {
           "id": 3,
+          "relOp": "LogicalFilter",
+          "condition": {
+            "op": {
+              "name": "<",
+              "kind": "LESS_THAN",
+              "syntax": "BINARY"
+            },
+            "operands": [
+              {
+                "input": 0,
+                "name": "$0"
+              },
+              {
+                "literal": 10,
+                "type": {
+                  "type": "INTEGER",
+                  "nullable": false
+                }
+              }
+            ]
+          },
+          "inputs": [
+            2
+          ]
+        },
+        {
+          "id": 4,
           "relOp": "LogicalProject",
           "fields": [
             "n",
@@ -118,33 +145,6 @@
           ]
         },
         {
-          "id": 4,
-          "relOp": "LogicalFilter",
-          "condition": {
-            "op": {
-              "name": "<",
-              "kind": "LESS_THAN",
-              "syntax": "BINARY"
-            },
-            "operands": [
-              {
-                "input": 0,
-                "name": "$0"
-              },
-              {
-                "literal": 10,
-                "type": {
-                  "type": "INTEGER",
-                  "nullable": false
-                }
-              }
-            ]
-          },
-          "inputs": [
-            3
-          ]
-        },
-        {
           "id": 5,
           "relOp": "LogicalFilter",
           "condition": {
@@ -168,7 +168,7 @@
             ]
           },
           "inputs": [
-            2
+            4
           ]
         },
         {
@@ -182,18 +182,18 @@
             },
             "operands": [
               {
-                "input": 3,
-                "name": "$3"
+                "input": 0,
+                "name": "$0"
               },
               {
-                "input": 2,
-                "name": "$2"
+                "input": 4,
+                "name": "$4"
               }
             ]
           },
           "joinType": "inner",
           "inputs": [
-            4,
+            3,
             5
           ]
         },
@@ -213,8 +213,8 @@
               },
               "operands": [
                 {
-                  "input": 3,
-                  "name": "$3"
+                  "input": 0,
+                  "name": "$0"
                 },
                 {
                   "literal": 1,
@@ -233,12 +233,12 @@
               },
               "operands": [
                 {
-                  "input": 4,
-                  "name": "$4"
-                },
-                {
                   "input": 1,
                   "name": "$1"
+                },
+                {
+                  "input": 3,
+                  "name": "$3"
                 }
               ]
             }
@@ -299,7 +299,7 @@
         "calcite": {
           "seq": [
             {
-              "final": 5
+              "final": 3
             },{
               "partial": 6
             }]
@@ -318,9 +318,9 @@
         "calcite": {
           "seq": [
             {
-              "final": 3
-            },{
               "final": 4
+            },{
+              "final": 5
             },{
               "partial": 6
             }]
@@ -359,8 +359,8 @@
       "s8": {
         "operation": "join",
         "inputs": [
-          { "node": "s5", "output": 0 },
-          { "node": "s4", "output": 0 }
+          { "node": "s4", "output": 0 },
+          { "node": "s5", "output": 0 }
         ],
         "calcite": {
           "partial": 6
@@ -369,7 +369,7 @@
           {"start_line_number":16,"start_column":9,"end_line_number":16,"end_column":33},
           {"start_line_number":15,"start_column":9,"end_line_number":15,"end_column":18}
         ],
-        "persistent_id": "de9ef9705dbd23ecebb057d78c4b03b40f821a9da8d20ddfdaaf494b95d67ce3"
+        "persistent_id": "f7e48fa774d50b1ed15f1300a2882b4f16567808cde35fd137a46ef153cfdbc5"
       },
       "s9": {
         "operation": "sum",
@@ -381,7 +381,7 @@
           "final": 8
         },
         "positions": [],
-        "persistent_id": "1b929a147eeb312635f5be31d04291cc0886f049bc29eb5f49c400efe4bd9d42"
+        "persistent_id": "18fd13ca7df0f4021055a5baaf5e6cb74d137212787dca80d40e149e3582933f"
       }
     }, "s10": {
       "operation": "inspect",
@@ -392,7 +392,7 @@
         "final": 8
       },
       "positions": [],
-      "persistent_id": "839bb28c34d9c6fe44d2e4afc688c43ea063ac477911baf81218c30d721ca8e4"
+      "persistent_id": "bf8f6c7cffaadfddd8c7fe702709e02e786220624bccf9d3296c7997186a9242"
     }, "s11": {
       "operation": "inspect",
       "inputs": [

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/tpch.sql
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/tpch.sql
@@ -1,11 +1,13 @@
 CREATE TABLE NATION  ( N_NATIONKEY  INTEGER NOT NULL,
                             N_NAME       CHAR(25) NOT NULL,
                             N_REGIONKEY  INTEGER NOT NULL,
-                            N_COMMENT    VARCHAR(152));
+                            N_COMMENT    VARCHAR(152))
+with ('expected_size' = '25');
 
 CREATE TABLE REGION  ( R_REGIONKEY  INTEGER NOT NULL,
                             R_NAME       CHAR(25) NOT NULL,
-                            R_COMMENT    VARCHAR(152));
+                            R_COMMENT    VARCHAR(152))
+with ('expected_size' = '5');
 
 CREATE TABLE PART  ( P_PARTKEY     INTEGER NOT NULL,
                           P_NAME        VARCHAR(55) NOT NULL,
@@ -15,7 +17,8 @@ CREATE TABLE PART  ( P_PARTKEY     INTEGER NOT NULL,
                           P_SIZE        INTEGER NOT NULL,
                           P_CONTAINER   CHAR(10) NOT NULL,
                           P_RETAILPRICE DECIMAL(15,2) NOT NULL,
-                          P_COMMENT     VARCHAR(23) NOT NULL );
+                          P_COMMENT     VARCHAR(23) NOT NULL )
+with ('expected_size' = '200000');
 
 CREATE TABLE SUPPLIER ( S_SUPPKEY     INTEGER NOT NULL,
                              S_NAME        CHAR(25) NOT NULL,
@@ -23,13 +26,15 @@ CREATE TABLE SUPPLIER ( S_SUPPKEY     INTEGER NOT NULL,
                              S_NATIONKEY   INTEGER NOT NULL,
                              S_PHONE       CHAR(15) NOT NULL,
                              S_ACCTBAL     DECIMAL(15,2) NOT NULL,
-                             S_COMMENT     VARCHAR(101) NOT NULL);
+                             S_COMMENT     VARCHAR(101) NOT NULL)
+with ('expected_size' = '10000');
 
 CREATE TABLE PARTSUPP ( PS_PARTKEY     INTEGER NOT NULL,
                              PS_SUPPKEY     INTEGER NOT NULL,
                              PS_AVAILQTY    INTEGER NOT NULL,
                              PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
-                             PS_COMMENT     VARCHAR(199) NOT NULL );
+                             PS_COMMENT     VARCHAR(199) NOT NULL )
+with ('expected_size' = '800000');
 
 CREATE TABLE CUSTOMER ( C_CUSTKEY     INTEGER NOT NULL,
                              C_NAME        VARCHAR(25) NOT NULL,
@@ -38,7 +43,8 @@ CREATE TABLE CUSTOMER ( C_CUSTKEY     INTEGER NOT NULL,
                              C_PHONE       CHAR(15) NOT NULL,
                              C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
                              C_MKTSEGMENT  CHAR(10) NOT NULL,
-                             C_COMMENT     VARCHAR(117) NOT NULL);
+                             C_COMMENT     VARCHAR(117) NOT NULL)
+ with ('expected_size' = '150000');
 
 CREATE TABLE ORDERS  ( O_ORDERKEY       INTEGER NOT NULL,
                            O_CUSTKEY        INTEGER NOT NULL,
@@ -48,7 +54,8 @@ CREATE TABLE ORDERS  ( O_ORDERKEY       INTEGER NOT NULL,
                            O_ORDERPRIORITY  CHAR(15) NOT NULL,
                            O_CLERK          CHAR(15) NOT NULL,
                            O_SHIPPRIORITY   INTEGER NOT NULL,
-                           O_COMMENT        VARCHAR(79) NOT NULL);
+                           O_COMMENT        VARCHAR(79) NOT NULL)
+with ('expected_size' = '1500000');
 
 CREATE TABLE LINEITEM ( L_ORDERKEY    INTEGER NOT NULL,
                              L_PARTKEY     INTEGER NOT NULL,
@@ -65,7 +72,8 @@ CREATE TABLE LINEITEM ( L_ORDERKEY    INTEGER NOT NULL,
                              L_RECEIPTDATE DATE NOT NULL,
                              L_SHIPINSTRUCT CHAR(25) NOT NULL,
                              L_SHIPMODE     CHAR(10) NOT NULL,
-                             L_COMMENT      VARCHAR(44) NOT NULL);
+                             L_COMMENT      VARCHAR(44) NOT NULL)
+with ('expected_size' = '6000000');
 
 // query source:
 // https://github.com/2ndQuadrant/pg-tpch/blob/master/queries


### PR DESCRIPTION
This should improve the plans for many TPC-H queries.

We always had an attribute for tables `expected_size` which can be used to pass a cost for the table to the Calcite optimizer. With some small fixes in this PR, now the optimizer has access to the cost. I have not verified that the costs themselves do improve the plans, but there is no harm having them. I have also annotated the TPC-H tables in our test with their expected sizes.