### PR TITLE
pg: print the entire error context

### DIFF
--- a/crates/adapters/src/integrated/postgres/output.rs
+++ b/crates/adapters/src/integrated/postgres/output.rs
@@ -45,7 +45,7 @@ impl BackoffError {
         match self {
             BackoffError::Permanent(error) | BackoffError::Temporary(error) => {
                 // include the context info
-                anyhow!(error.to_string())
+                anyhow!("{error:?}")
             }
         }
     }


### PR DESCRIPTION
Fixes: #4680

This is what new errors will look like:

```txt
FATAL error on output endpoint 'v1.unnamed-0':
while executing insert statement: [{"id":1}]

Caused by:
    postgres error: permanent: SqlState: Some(SqlState(E23505)): db error:
    ERROR: duplicate key value violates unique constraint "feldera_out_pkey"
    DETAIL: Key (id)=(1) already exists.
```


