### PR TITLE
[SQL] Simplify linear aggregates for users

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -15,6 +15,17 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        Simplified the way user-defined aggregates are defined -- the
+        compiler now automates the handling of NULL values.
+
+        The following change doesn't affect the external Feldera API, only the
+        pipeline's API available from a sidecar container. The `/status`
+        endpoint no longer returns HTTP status 503 (SERVICE_UNAVAILABLE) while
+        the pipeline is initializing. Instead it returns status OK with message
+        body containing the "Initializing" string.
+
+        ## 0.138.0
+
         [Transaction (also known as huge-step) support](/pipelines/transactions).
 
         TIMESTAMP is now the same as TIMESTAMP(3); TIME is now the same as
@@ -23,11 +34,7 @@ import TabItem from '@theme/TabItem';
         that differ from the default ones are ignored (and the compiler
         gives a warning).
 
-        The following change doesn't affect the external Feldera API, only the
-        pipeline's API available from a sidecar container. The `/status`
-        endpoint no longer returns HTTP status 503 (SERVICE_UNAVAILABLE) while
-        the pipeline is initializing. Instead it returns status OK with message
-        body containing the "Initializing" string.
+        ## 0.136.0
 
         ### Changes to Python SDK `feldera`:
         - `Pipeline.sync_checkpoint` will now raise a runtime error if `wait`

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -3108,9 +3108,10 @@ public class CalciteToDBSPCompiler extends RelVisitor
         String name = uda.description.name.getSimple();
         if (uda.isLinear()) {
             // Add two functions that the user needs to define to the circuit declarations.
-            DBSPTypeUser accumulatorType = LinearAggregate.accumulatorType(node, name);
+            DBSPType accumulatorType = LinearAggregate.userAccumulatorType(node, name);
             List<DBSPParameter> parameters = Linq.map(uda.description.parameterList,
-                    p -> new DBSPParameter(p.getName(), this.convertType(node.getPositionRange(), p.getType(), false)));
+                    p -> new DBSPParameter(p.getName(),
+                            this.convertType(node.getPositionRange(), p.getType(), false).withMayBeNull(false)));
             DBSPFunction mapFunction = new DBSPFunction(
                     node, LinearAggregate.userDefinedMapFunctionName(name), parameters, accumulatorType, null, Linq.list());
             this.getCircuit().addDeclaration(new DBSPDeclaration(new DBSPFunctionItem(mapFunction)));
@@ -3118,7 +3119,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
             DBSPType resultType = this.convertType(node.getPositionRange(), uda.description.returnType, false);
             DBSPFunction postFunction = new DBSPFunction(
                     node, LinearAggregate.userDefinedPostFunctionName(name),
-                    Linq.list(new DBSPParameter("accumulator", accumulatorType)), resultType, null, Linq.list());
+                    Linq.list(new DBSPParameter("accumulator", accumulatorType)), resultType.withMayBeNull(false), null, Linq.list());
             this.getCircuit().addDeclaration(new DBSPDeclaration(new DBSPFunctionItem(postFunction)));
         } else {
             throw new UnimplementedException("Non-linear user-defined aggregation functions");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/JoinConditionAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/JoinConditionAnalyzer.java
@@ -220,9 +220,9 @@ public class JoinConditionAnalyzer implements IWritesLogs {
                 return false;
             }
             DBSPType leftType = JoinConditionAnalyzer.this.typeCompiler.convertType(
-                    left.getType(), true);
+                    node.getPositionRange(), left.getType(), true);
             DBSPType rightType = JoinConditionAnalyzer.this.typeCompiler.convertType(
-                    right.getType(), true);
+                    node.getPositionRange(), right.getType(), true);
             boolean mayBeNull = false;
             if (call.op.kind == SqlKind.IS_NOT_DISTINCT_FROM) {
                 // Only used if any of the operands is not nullable

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/FirstLastAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/FirstLastAggregate.java
@@ -94,7 +94,7 @@ public class FirstLastAggregate extends WindowAggregates {
         IntermediateRel node = CalciteObject.create(this.window);
         DBSPSimpleOperator index = this.compiler.indexWindow(this.window, this.group);
         RelNode input = this.window.getInput();
-        DBSPType inputRowType = this.compiler.convertType(input.getRowType(), false);
+        DBSPType inputRowType = this.compiler.convertType(this.node.getPositionRange(), input.getRowType(), false);
 
         // Generate comparison function for sorting the vector
         boolean reverse = this.getKind() == SqlKind.LAST_VALUE;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
@@ -201,7 +201,8 @@ public class RangeAggregates extends WindowAggregates {
             DBSPWindowBoundExpression ub = this.compileWindowBound(group.upperBound, sortType, unsignedSortType, eComp);
 
             List<DBSPType> types = Linq.map(
-                    this.aggregateCalls, c -> this.compiler.convertType(c.type, false));
+                    this.aggregateCalls,
+                    c -> this.compiler.convertType(this.node.getPositionRange(), c.type, false));
             DBSPTypeTuple tuple = new DBSPTypeTuple(types);
             DBSPAggregateList list = this.compiler.createAggregates(this.compiler.compiler(),
                     this.window, this.aggregateCalls, this.window.constants, tuple, this.inputRowType, 0,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/WindowAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/WindowAggregates.java
@@ -54,9 +54,9 @@ public abstract class WindowAggregates {
         this.group = group;
         this.aggregateCalls = new ArrayList<>();
         this.windowFieldIndex = windowFieldIndex;
-        this.windowResultType = this.compiler.convertType(
+        this.windowResultType = this.compiler.convertType(node.getPositionRange(),
                 window.getRowType(), false).to(DBSPTypeTuple.class);
-        this.inputRowType = this.compiler.convertType(
+        this.inputRowType = this.compiler.convertType(node.getPositionRange(),
                 window.getInput().getRowType(), false).to(DBSPTypeTuple.class);
         this.partitionKeys = this.group.keys.toList();
         this.inputRowRefVar = this.inputRowType.ref().var();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ExternalFunction.java
@@ -120,7 +120,7 @@ public class ExternalFunction extends SqlFunction {
      * I.e., may be a struct. */
     public DBSPType getFunctionReturnType(TypeCompiler compiler) {
         if (this.structReturnType == null)
-            this.structReturnType = compiler.convertType(this.returnType, true);
+            this.structReturnType = compiler.convertType(this.position, this.returnType, true);
         return this.structReturnType;
     }
 
@@ -149,11 +149,11 @@ public class ExternalFunction extends SqlFunction {
     public DBSPFunction getDeclaration(TypeCompiler typeCompiler) {
         List<DBSPParameter> parameters = new ArrayList<>();
         for (RelDataTypeField param: this.parameterList) {
-            DBSPType type = typeCompiler.convertType(param.getType(), false);
+            DBSPType type = typeCompiler.convertType(this.position, param.getType(), false);
             DBSPParameter p = new DBSPParameter(param.getName(), type);
             parameters.add(p);
         }
-        DBSPType returnType = typeCompiler.convertType(this.returnType, false);
+        DBSPType returnType = typeCompiler.convertType(SourcePositionRange.INVALID, this.returnType, false);
         // Must wrap the return type in a Result
         returnType = new DBSPTypeResult(returnType);
         return new DBSPFunction(this.node, this.getName(), parameters, returnType, null, Linq.list());
@@ -164,12 +164,12 @@ public class ExternalFunction extends SqlFunction {
         if (this.body != null) {
             List<DBSPParameter> parameters = new ArrayList<>();
             for (RelDataTypeField param: this.parameterList) {
-                DBSPType type = typeCompiler.convertType(param.getType(), false);
+                DBSPType type = typeCompiler.convertType(this.position, param.getType(), false);
                 DBSPParameter p = new DBSPParameter(param.getName(), type);
                 parameters.add(p);
             }
             FunctionBodyGenerator generator = new FunctionBodyGenerator(compiler, parameters);
-            DBSPType returnType = typeCompiler.convertType(this.returnType, false);
+            DBSPType returnType = typeCompiler.convertType(this.position, this.returnType, false);
             DBSPExpression functionBody = generator.compile(this.body);
 
             DBSPType functionType = functionBody.getType();
@@ -198,7 +198,7 @@ public class ExternalFunction extends SqlFunction {
                 strct.map(move |x: _, | -> _ { x.into() })
             }
              */
-            DBSPType returnType = typeCompiler.convertType(this.returnType, false);
+            DBSPType returnType = typeCompiler.convertType(this.position, this.returnType, false);
             DBSPType structType = this.getFunctionReturnType(typeCompiler);
             if (this.parameterList.size() != 1) {
                 compiler.reportError(this.position, "Incorrect signature",
@@ -206,7 +206,7 @@ public class ExternalFunction extends SqlFunction {
                                 " must have a single parameter");
                 return null;
             }
-            DBSPType parameterType = typeCompiler.convertType(this.parameterList.get(0).getType(), false);
+            DBSPType parameterType = typeCompiler.convertType(this.position, this.parameterList.get(0).getType(), false);
             DBSPParameter param = new DBSPParameter("s", parameterType);
             List<DBSPStatement> statements = new ArrayList<>();
             if (parameterType.mayBeNull)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/LinearAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/LinearAggregate.java
@@ -199,10 +199,15 @@ public class LinearAggregate extends IAggregate {
         return false;
     }
 
-    /** The accumulator type generated for a linear user-defined aggregate function */
-    public static DBSPTypeUser accumulatorType(CalciteObject node, String aggregateFunctionName) {
-        String accumulatorTypeName = aggregateFunctionName + "_accumulator_type";
+    /** The user-defined accumulator type for a linear user-defined aggregate function */
+    public static DBSPType userAccumulatorType(CalciteObject node, String aggregateFunctionName) {
+        String accumulatorTypeName = userDefinedAccumulatorTypeName(aggregateFunctionName);
         return new DBSPTypeUser(node, USER, accumulatorTypeName, false);
+    }
+
+    /** Name of the user-defined accumulator type */
+    public static String userDefinedAccumulatorTypeName(String aggregateFunctionName) {
+        return aggregateFunctionName + "_accumulator_type";
     }
 
     /** The name of the map function generated for a linear user-defined aggregate function */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
@@ -54,6 +54,7 @@ public class MultiCrateTests extends BaseSQLTests {
         compileToMultiCrate(file, check, true);
     }
 
+
     static void compileProgramToMultiCrate(String sql, boolean check) throws IOException, SQLException, InterruptedException {
         File file = createInputScript(sql);
         compileToMultiCrate(file.getAbsolutePath(), check);
@@ -339,15 +340,12 @@ public class MultiCrateTests extends BaseSQLTests {
                 
                 pub type i8_avg_accumulator_type = Tup2<i32, i32>;
                 
-                pub fn i8_avg_map(val: Option<i8>) -> Tup2<i32, i32> {
-                    match (val) {
-                        None => Tup2::new(0, 1),
-                        Some(x) => Tup2::new(x as i32, 1),
-                    }
+                pub fn i8_avg_map(val: i8) -> Tup2<i32, i32> {
+                    Tup2::new(val as i32, 1)
                 }
                 
-                pub fn i8_avg_post(val: Tup2<i32, i32>) -> Option<i8> {
-                    Some((val.0 / val.1).try_into().unwrap())
+                pub fn i8_avg_post(val: i8_avg_accumulator_type) -> i8 {
+                    (val.0 / val.1).try_into().unwrap()
                 }
                 """);
         compileToMultiCrate(file.getAbsolutePath(), true, false);


### PR DESCRIPTION
There are two commits.

First one improves a little error reporting in some cases.
Second one makes it easier to implement linear aggregates, by moving the task of handling `NULL` values in the compiler, and letting users only worry about the non-null case. This way users are also less likely to get it wrong.

## Checklist

- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

- [x] Feldera SQL (Syntax, Semantics)
