### PR TITLE
[SQL] Add missing visitor method

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPInputMapWithWaterlineOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPInputMapWithWaterlineOperator.java
@@ -152,6 +152,18 @@ public class DBSPInputMapWithWaterlineOperator
     public void accept(InnerVisitor visitor) {
         visitor.property("originalRowType");
         this.originalRowType.accept(visitor);
+        visitor.property("outputType");
+        this.outputType.accept(visitor);
+        visitor.property("initializer");
+        this.initializer.accept(visitor);
+        visitor.property("timestamp");
+        this.timestamp.accept(visitor);
+        visitor.property("lub");
+        this.lub.accept(visitor);
+        visitor.property("filter");
+        this.filter.accept(visitor);
+        visitor.property("error");
+        this.error.accept(visitor);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -912,4 +912,9 @@ public class Regression1Tests extends SqlIoTest {
                  true | 1
                  false | 1""");
     }
+
+    @Test
+    public void issue4729() {
+        this.getCCS("CREATE TABLE t (ts BIGINT NOT NULL PRIMARY KEY LATENESS 5);");
+    }
 }


### PR DESCRIPTION
Fixes #4729 

The missing visitor method caused some passes to skip rewriting the `input_map_with_waterline` operator.
