### PR TITLE
python: refactor README and remove Kafka dev dependency

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,73 +1,139 @@
 # Feldera Python SDK
 
-Feldera Python is the Feldera SDK for Python developers.
+The `feldera` Python package is the Python client for the Feldera HTTP API.
 
-## Installation
+The Python SDK documentation is available at: https://docs.feldera.com/python
+
+## Getting started
+
+### Installation
 
 ```bash
 uv pip install feldera
 ```
 
-### Installing from Github
+### Example usage
 
+The Python client interacts with the API server of the Feldera instance.
+
+```python
+# File: example.py
+from feldera import FelderaClient, PipelineBuilder, Pipeline
+
+# Instantiate client
+client = FelderaClient()  # Default: http://localhost:8080 without authentication
+# client = FelderaClient(url="https://localhost:8080", api_key="apikey:...", requests_verify="/path/to/tls.crt")
+
+# (Re)create pipeline
+name = "example"
+sql = """
+CREATE TABLE t1 (i1 INT) WITH ('materialized' = 'true');
+CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1;
+"""
+print("(Re)creating pipeline...")
+pipeline = PipelineBuilder(client, name, sql).create_or_replace()
+pipeline.start()
+print(f"Pipeline status: {pipeline.status()}")
+pipeline.pause()
+print(f"Pipeline status: {pipeline.status()}")
+pipeline.stop(force=True)
+
+# Find existing pipeline
+pipeline = Pipeline.get(name, client)
+pipeline.start()
+print(f"Pipeline status: {pipeline.status()}")
+pipeline.stop(force=True)
+pipeline.clear_storage()
+```
+
+Run using:
+```bash
+uv run python example.py
+```
+
+### Environment variables
+
+Some default parameter values in the Python SDK can be overridden via environment variables.
+
+**Environment variables for `FelderaClient(...)`**
+
+```bash
+export FELDERA_HOST="https://localhost:8080"  # Overrides default for `url`
+export FELDERA_API_KEY="apikey:..."  # Overrides default for `api_key`
+
+# The following together override default for `requests_verify`
+# export FELDERA_TLS_INSECURE="false"  # If set to "1", "true" or "yes" (all case-insensitive), disables TLS certificate verification
+# export FELDERA_HTTPS_TLS_CERT="/path/to/tls.crt"  # Custom TLS certificate
+```
+
+**Environment variables for `PipelineBuilder(...)`**
+
+```bash
+export FELDERA_RUNTIME_VERSION="..."  # Overrides default for `runtime_version`
+```
+
+## Development
+
+Development assumes you have cloned the Feldera code repository.
+
+### Installation
+
+```bash
+cd python
+# Optional: create and activate virtual environment if you don't have one
+uv venv
+source .venv/bin/activate
+# Install in editable mode
+uv pip install -e .
+```
+
+### Formatting
+
+Formatting requires the `ruff` package: `uv pip install ruff`
+
+```bash
+cd python
+ruff check
+ruff format
+```
+
+### Tests
+
+Running the test requires the `pytest` package: `uv pip install pytest`
+
+```bash
+# All tests
+cd python
+uv run python -m pytest tests/
+
+# Specific tests directory
+uv run python -m pytest tests/platform/
+
+# Specific test file
+uv run python -m pytest tests/platform/test_pipeline_crud.py
+```
+
+For further information about the tests, please see `tests/README.md`.
+
+### Documentation
+
+Building documentation requires the `sphinx` package: `uv pip install sphinx`
+
+```bash
+cd python/docs
+sphinx-apidoc -o . ../feldera
+make html
+make clean  # Cleanup afterwards
+```
+
+### Installation from GitHub
+
+Latest `main` branch:
 ```bash
 uv pip install git+https://github.com/feldera/feldera#subdirectory=python
 ```
 
-Similarly, to install from a specific branch:
-
+Different branch (replace `BRANCH_NAME`):
 ```bash
-uv pip install git+https://github.com/feldera/feldera@{BRANCH_NAME}#subdirectory=python
+uv pip install git+https://github.com/feldera/feldera@BRANCH_NAME#subdirectory=python
 ```
-
-Replace `{BRANCH_NAME}` with the name of the branch you want to install from.
-
-### Installing from Local Directory
-
-If you have cloned the Feldera repo, you can install the python SDK as follows:
-
-```bash
-# the Feldera Python SDK is present inside the python/ directory
-cd python
-# If you don't have a virtual environment, create one
-uv venv
-source .venv/activate
-# Install the SDK in editable mode
-uv pip install .
-```
-
-## Documentation
-
-The Python SDK documentation is available at
-[Feldera Python SDK Docs](https://docs.feldera.com/python).
-
-To build the html documentation run:
-
-Ensure that you have sphinx installed. If not, install it using `uv pip install sphinx`.
-
-Then run the following commands:
-
-```bash
-cd docs
-sphinx-apidoc -o . ../feldera
-make html
-```
-
-To clean the build, run `make clean`.
-
-## Linting and formatting
-
-Use [Ruff] to run the lint checks that will be executed by the
-precommit hook when a PR is submitted:
-
-```bash
-ruff check python/
-```
-
-To reformat the code in the same way as the precommit hook:
-
-```bash
-ruff format
-```
-
-[Ruff]: https://github.com/astral-sh/ruff

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -43,10 +43,6 @@ BASE_URL = (
     or os.environ.get("FELDERA_BASE_URL")
     or "http://localhost:8080"
 )
-KAFKA_SERVER = os.environ.get("FELDERA_KAFKA_SERVER", "localhost:19092")
-PIPELINE_TO_KAFKA_SERVER = os.environ.get(
-    "FELDERA_PIPELINE_TO_KAFKA_SERVER", "redpanda:9092"
-)
 FELDERA_REQUESTS_VERIFY = requests_verify_from_env()
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,6 @@ Issues = "https://github.com/feldera/feldera/issues"
 
 [tool.uv]
 dev-dependencies = [
-    "kafka-python-ng==2.2.2",
     "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.8.0",
     "pytest>=8.3.5",

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -4,8 +4,6 @@ from feldera.testutils import (
     enterprise_only,
     API_KEY,
     BASE_URL,
-    PIPELINE_TO_KAFKA_SERVER,
-    KAFKA_SERVER,
     FELDERA_REQUESTS_VERIFY,
 )
 
@@ -15,7 +13,5 @@ __all__ = [
     "enterprise_only",
     "API_KEY",
     "BASE_URL",
-    "PIPELINE_TO_KAFKA_SERVER",
-    "KAFKA_SERVER",
     "FELDERA_REQUESTS_VERIFY",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -151,7 +151,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "kafka-python-ng" },
     { name = "pytest" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
@@ -173,7 +172,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "kafka-python-ng", specifier = "==2.2.2" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
@@ -219,15 +217,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
-]
-
-[[package]]
-name = "kafka-python-ng"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/19/e4a236b7504ef39ebca780c6a11481a3d2db759f9878cb0a4fbc8b08b243/kafka-python-ng-2.2.2.tar.gz", hash = "sha256:87ad3a766e2c0bec71d9b99bdd9e9c5cda62d96cfda61a8ca16510484d6ad7d4", size = 329740 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/5d/f5c5180e5ec5ca594f81b40948d8d5da7e20b6312cb58416e4b766f06847/kafka_python_ng-2.2.2-py2.py3-none-any.whl", hash = "sha256:3fab1a03133fade1b6fd5367ff726d980e59031c4aaca9bf02c516840a4f8406", size = 232369 },
 ]
 
 [[package]]


### PR DESCRIPTION
README changes:
- Example usage
- Explain environment variables
- General restructuring

Removes the `kafka-python-ng` Python dev dependency along with the Kafka-related test environment variables as they are not used anywhere currently.

**PR information:**
- Documentation updated
- Changelog not updated
- No breaking changes
- No backward incompatible changes