### PR TITLE
Fix egress endpoint does not urlencode relation name

### DIFF
--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -1318,6 +1318,7 @@ async fn create_http_input_endpoint(
 #[post("/ingress/{table_name}")]
 async fn input_endpoint(
     state: WebData<ServerState>,
+    path: web::Path<String>,
     req: HttpRequest,
     args: Query<IngressArgs>,
     payload: Payload,
@@ -1329,14 +1330,7 @@ async fn input_endpoint(
     }
     debug!("{req:?}");
 
-    let table_name = match req.match_info().get("table_name") {
-        None => {
-            return Err(PipelineError::MissingUrlEncodedParam {
-                param: "table_name",
-            });
-        }
-        Some(table_name) => table_name.to_string(),
-    };
+    let table_name = path.into_inner();
 
     // Generate endpoint name.
     let endpoint_name = format!("api-ingress-{table_name}-{}", Uuid::new_v4());
@@ -1446,21 +1440,13 @@ struct EgressArgs {
 #[post("/egress/{table_name}")]
 async fn output_endpoint(
     state: WebData<ServerState>,
+    path: web::Path<String>,
     req: HttpRequest,
     args: Query<EgressArgs>,
 ) -> impl Responder {
     debug!("/egress request:{req:?}");
 
-    let state = state.into_inner();
-
-    let table_name = match req.match_info().get("table_name") {
-        None => {
-            return Err(PipelineError::MissingUrlEncodedParam {
-                param: "table_name",
-            });
-        }
-        Some(table_name) => table_name.to_string(),
-    };
+    let table_name = path.into_inner();
 
     // Generate endpoint name depending on the query and output mode.
     let endpoint_name = format!("api-{}-{table_name}", Uuid::new_v4());

--- a/crates/pipeline-manager/src/api/util.rs
+++ b/crates/pipeline-manager/src/api/util.rs
@@ -13,6 +13,13 @@ pub(crate) fn parse_url_parameter(
         None => Err(ManagerError::from(ApiError::MissingUrlEncodedParam {
             param: param_name,
         })),
-        Some(value) => Ok(value.to_string()),
+        Some(value) => Ok(urlencoding::decode(value)
+            .map_err(|e| {
+                ManagerError::from(ApiError::InvalidNameParam {
+                    value: value.to_string(),
+                    error: format!("Failed to URL-decode parameter '{}': {}", param_name, e),
+                })
+            })?
+            .to_string()),
     }
 }

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -5,6 +5,7 @@ import time
 import json
 from decimal import Decimal
 from typing import Generator, Mapping
+from urllib.parse import quote
 
 from feldera.rest.config import Config
 from feldera.rest.feldera_config import FelderaConfig
@@ -750,7 +751,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             data = bytes(str(data), "utf-8")
 
         resp = self.http.post(
-            path=f"/pipelines/{pipeline_name}/ingress/{table_name}",
+            path=f"/pipelines/{quote(pipeline_name, safe='')}/ingress/{quote(table_name, safe='')}",
             params=params,
             content_type=content_type,
             body=data,
@@ -863,7 +864,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         table_name = f'"{table_name}"' if case_sensitive else table_name
 
         resp = self.http.post(
-            path=f"/pipelines/{pipeline_name}/egress/{table_name}",
+            path=f"/pipelines/{quote(pipeline_name, safe='')}/egress/{quote(table_name, safe='')}",
             params=params,
             stream=True,
         )

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -432,7 +432,7 @@ export const relationEgressStream = async (pipelineName: string, relationName: s
   // const result = await httpOutput({path: {pipeline_name: pipelineName, table_name: relationName}, query: {'format': 'json', 'mode': 'watch', 'array': false, 'query': 'table'}})
   return streamingFetch(
     getAuthenticatedFetch(),
-    `${felderaEndpoint}/v0/pipelines/${pipelineName}/egress/${relationName}?format=json&array=false`,
+    `${felderaEndpoint}/v0/pipelines/${pipelineName}/egress/${encodeURIComponent(relationName)}?format=json&array=false`,
     {
       method: 'POST'
     },


### PR DESCRIPTION
Steps to reproduce:

1. Create a program:
```
CREATE TABLE  "direct__document#parent__document" (
    object_id TEXT NOT NULL
);
```
2. Subscribe to the table's Change Stream in web-console

3. Insert a value via ad-hoc query:
```
INSERT INTO "direct__document#parent__document" (object_id) VALUES ('foo');
```
4. Observe change does not appear