### PR TITLE
Parquet test + S3 error handling

### DIFF
--- a/crates/adapterlib/src/format.rs
+++ b/crates/adapterlib/src/format.rs
@@ -405,6 +405,19 @@ impl ParseError {
             suggestion,
         )))
     }
+
+    /// Returns a new `ParseError` with the description modified by `f`.
+    ///
+    /// Can be used, e.g., to prepend context to the description.
+    pub fn map_description<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&str) -> String,
+    {
+        let mut inner = self.0;
+        let description = f(&inner.description);
+        inner.description = description;
+        Self(inner)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]

--- a/crates/adapters/src/transport/s3.rs
+++ b/crates/adapters/src/transport/s3.rs
@@ -588,6 +588,17 @@ impl S3InputReader {
                                         break;
                                     };
                                     let (buffer, errors) = parser.parse(chunk);
+                                    let errors = errors
+                                        .into_iter()
+                                        .map(|e| {
+                                            e.map_description(|desc| {
+                                                format!(
+                                                    "error parsing object '{}': {desc}",
+                                                    &partially_processed_key.key
+                                                )
+                                            })
+                                        })
+                                        .collect::<Vec<_>>();
                                     consumer.buffered(buffer.len());
                                     let end_offset = splitter.position();
 


### PR DESCRIPTION
An additional parquet parser test + better error reporting in the s3 connector.

See individual commits for details.