### PR TITLE
[adapters] Latency measurement framework.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,6 +4736,7 @@ dependencies = [
  "apache-avro 0.18.0",
  "arrow",
  "bytemuck",
+ "chrono",
  "datafusion",
  "dbsp",
  "dyn-clone",

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -36,6 +36,7 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 datafusion = { workspace = true }
 thiserror = { workspace = true }
 serde_json_path_to_error = { workspace = true }
+chrono = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["num-traits"]

--- a/crates/adapters/src/controller/checkpoint.rs
+++ b/crates/adapters/src/controller/checkpoint.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::{
     collections::HashMap,
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Mutex,
+    },
 };
 
 use crate::{
@@ -100,6 +103,12 @@ impl From<&CheckpointInputEndpointMetrics> for InputEndpointMetrics {
             num_transport_errors: AtomicU64::new(value.num_transport_errors),
             num_parse_errors: AtomicU64::new(value.num_parse_errors),
             end_of_input: AtomicBool::new(false),
+            processing_latency_micros_histogram: Mutex::new(
+                InputEndpointMetrics::processing_latency_histogram(),
+            ),
+            completion_latency_micros_histogram: Mutex::new(
+                InputEndpointMetrics::completion_latency_histogram(),
+            ),
         }
     }
 }

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -4,7 +4,7 @@ use crate::{controller::FormatConfig, InputConsumer, ParseError, Parser};
 use anyhow::{anyhow, Error as AnyError};
 use dbsp::operator::StagedBuffers;
 use feldera_adapterlib::format::BufferSize;
-use feldera_adapterlib::transport::Resume;
+use feldera_adapterlib::transport::{Resume, Watermark};
 use feldera_types::config::FtModel;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -113,7 +113,7 @@ impl InputConsumer for MockInputConsumer {
 
     fn request_step(&self) {}
 
-    fn extended(&self, _amt: BufferSize, _resume: Option<Resume>) {
+    fn extended(&self, _amt: BufferSize, _resume: Option<Resume>, _watermark: Vec<Watermark>) {
         self.state().n_extended += 1;
     }
 }

--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -15,12 +15,13 @@
 //! The connector supports exactly-once FT.
 
 use anyhow::{anyhow, Result as AnyResult};
+use chrono::Utc;
 use dbsp::circuit::tokio::TOKIO;
 use feldera_adapterlib::{
     format::{BufferSize, Parser},
     transport::{
         InputConsumer, InputEndpoint, InputReader, InputReaderCommand, Resume,
-        TransportInputEndpoint,
+        TransportInputEndpoint, Watermark,
     },
     PipelineState,
 };
@@ -222,7 +223,7 @@ impl ClockReader {
                              seek: serde_json::Value::Null,
                              replay: RmpValue::from(now),
                              hash: 0
-                        }));
+                        }), vec![Watermark::new(Utc::now(), None)]);
 
                         // Schedule next tick.
                         next_tick = Some(Self::next_tick_time(&config, &now));

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -19,7 +19,7 @@ use crossbeam::sync::{Parker, Unparker};
 use csv::ReaderBuilder as CsvReaderBuilder;
 use dbsp::operator::StagedBuffers;
 use feldera_adapterlib::format::BufferSize;
-use feldera_adapterlib::transport::Resume;
+use feldera_adapterlib::transport::{Resume, Watermark};
 use feldera_types::config::{
     default_max_batch_size, default_max_queued_records, ConnectorConfig, FormatConfig, FtModel,
     InputEndpointConfig, OutputBufferConfig, TransportConfig,
@@ -555,7 +555,7 @@ impl InputConsumer for DummyInputConsumer {
         });
     }
 
-    fn extended(&self, amt: BufferSize, resume: Option<Resume>) {
+    fn extended(&self, amt: BufferSize, resume: Option<Resume>, _watermark: Vec<Watermark>) {
         self.called(ConsumerCall::Extended {
             num_records: amt.records,
             metadata: resume

--- a/docs.feldera.com/docs/operations/metrics.md
+++ b/docs.feldera.com/docs/operations/metrics.md
@@ -138,6 +138,8 @@ invisible to users unless a pause or checkpoint happens mid-batch.
 | `input_connector_errors_parse_total` |counter | Total number of errors encountered parsing records received by the input connector. |
 | `input_connector_errors_transport_total` |counter | Total number of errors encountered by the input connector at the transport layer. |
 | `input_connector_records_total` |counter | Total number of records received by an input connector. |
+| `input_connector_processing_latency_seconds` | histogram | Time elapsed (seconds) between when the connector receives new data and when the pipeline processes this data and computes output updates. The histogram is maintained over at most the last 600 seconds or at most 10,000 samples. This latency includes: (1) parsing the input data, (2) buffering delay while data waits in the connector queue, and (3) processing time in the query engine to evaluate changes and compute outputs. |
+| `input_connector_completion_latency_seconds` | histogram | Time elapsed (seconds) between the connector receives new data and when the pipeline processes this data, computes output updates, and sends these updates to all output connectors. The histogram is maintained over at most the last 600 seconds or at most 10,000 samples. This latency includes `input_connector_processing_latency_seconds` plus the time required for all output connectors to write output updates to their data sinks. |
 
 ## Output Connectors
 


### PR DESCRIPTION
Fixes: #4637.

A minimal implementation of RFC #4637.

**Defitions: Processing latency and completion latency**

*Processing latency* is the time it takes the pipeline to process a batch of records from when they are ingested from the wire to when the circuit completes processing these records. This includes: parsing, queuing, and processing by the circuit.

*Completion latency* includes processing latency plus the time it takes the pipeline to push outputs to all output endpoints (this includes output buffering delay if output buffers are enabled for some endpoints).

**API**

This commit introduces two extensions to the Feldera API:

1. We add two new histograms per input connector in the set of metrics produced by the `/metrics` endpoint: processing latency and completion latency, both for a bounded time window.

2. We add a new `watermark` field to input connector stats returned by the `/stats` endpoint. This field is only set for connectors that support watermark metadata, currently only Kafka and DeltaLake. It has the following format:

   ```json
    {
       "metadata":{"eoi":true,"version":10},
       "ingested_at":"2025-09-18T22:04:10.899899+00:00",
       "processed_at":"2025-09-18T22:05:09.648376+00:00",
       "completed_at":"2025-09-18T22:05:09.648378+00:00"
    }
    ```

   where:
   * `metadata` - transport-specific metadata that identifies the last offset in the input stream fully processed by the pipeline.
   * `ingested_at` - timestamp when the pipeline started ingesting data corresponding to this offset.
   * `processed_at` - time when the pipeline finished computing output updates for this input.
   * `completed_at` - time when the pipeline finished sending all output updates to all output connectors.

**Watermarks**

Internally, we use watermarks for latency tracking.

A watermark is a marker associated with a batch of records ingested by the endpoint. It consists of the timestamp when the connector started receiving data from the wire and optional transport-specific metadata that identifies the position in the input data stream, e.g., Kafka offset.

**The algorithm**

Latency tracking starts when a connector starts ingesting a new input batch from its associated data sink. It associates the timestamp when it startes reading the batch and, optionally, metadata with the batch and keeps track of these attributes as it parses and buffers the batch internally.

When finally the connector pushes the batch to the circuit before the circuit performs a step, it notifies the circuit about the number of ingested records via `extended()` call, and provides a list of watermarks, which indicate what input data will be processed when the step completes, e.g.,:
* 100 records ingested at time t1, that corresponds to Kafka offsets 12000
* 100 records ingested at time t2, that corresponds to Kafka offsets 12100
* ...

When the step completes, the controller marks all watermarks processed during this step as processed and adds the processed_at timestamp to them.

Later, when the outputs produced by this step have been pushed to all output endpoints, the controller marks these watermarks as completed and updates two histograms: processing latency and completion latency.

In addition, the controller keeps track of the latest watermark whose metadata is not `None` and reports it via the `/status` API. This allows clients to track how far their input data has been processed by the pipeline.

**Limitations**

* We currently only track metadata for DeltaLake and Kafka connectors. For other connectors, we maintain the latency histograms, but not the watermark in `/stats`.

* We do not checkpoint the state of the watermark tracker, so latency metrics get reset on failover.

Add a brief description of the pull request.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated