### PR TITLE
[SQL] Support `ORDER BY` in `ARRAY_AGG`

### DIFF
--- a/crates/sqllib/src/array.rs
+++ b/crates/sqllib/src/array.rs
@@ -1,6 +1,7 @@
 // Array operations
 
 use crate::{some_function2, ConcatSemigroup, Semigroup, Weight};
+use dbsp::CmpFunc;
 use itertools::Itertools;
 use std::{collections::HashSet, fmt::Debug, hash::Hash, sync::Arc};
 
@@ -14,6 +15,25 @@ pub fn to_array<T>(data: Vec<T>) -> Array<T> {
 #[doc(hidden)]
 pub fn to_arrayN<T>(data: Option<Vec<T>>) -> Option<Array<T>> {
     data.map(|data| to_array(data))
+}
+
+#[doc(hidden)]
+pub fn sort_to_array<F, G, T, D>(mut data: Vec<T>, _cmp: F, proj: G) -> Array<D>
+where
+    F: CmpFunc<T>,
+    G: FnMut(T) -> D,
+{
+    data.sort_unstable_by(|a, b| F::cmp(a, b));
+    Arc::new(data.into_iter().map(proj).collect::<Vec<D>>())
+}
+
+#[doc(hidden)]
+pub fn sort_to_arrayN<F, G, T, D>(data: Option<Vec<T>>, cmp: F, proj: G) -> Option<Array<D>>
+where
+    F: CmpFunc<T>,
+    G: FnMut(T) -> D,
+{
+    data.map(|data| sort_to_array(data, cmp, proj))
 }
 
 /// Convert a SQL array to a Rust Vec

--- a/docs.feldera.com/docs/sql/aggregates.md
+++ b/docs.feldera.com/docs/sql/aggregates.md
@@ -38,8 +38,8 @@ DECIMAL(10, 4))` if you expect 10-digit results to be possible.
     <th>Description</th>
   </tr>
   <tr>
-     <td><a id="array_agg"></a><code>ARRAY_AGG([ ALL | DISTINCT ] value [ RESPECT NULLS | IGNORE NULLS ] )</code></td>
-     <td>Gathers all values in an array.  The order of the values in the array is unspecified (but it is deterministic).</td>
+     <td><a id="array_agg"></a><code>ARRAY_AGG([ ALL | DISTINCT ] value [ RESPECT NULLS | IGNORE NULLS ] [ORDER BY orderItem [, orderItem]*] )</code></td>
+     <td>Gathers all values in an array.  If `ORDER BY` is not present, the order of the values in the array is unspecified (but it is deterministic).</td>
   </tr>
   <tr>
      <td><a id="avg"></a><code>AVG( [ ALL | DISTINCT ] numeric)</code></td>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPNoComparatorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPNoComparatorExpression.java
@@ -38,6 +38,9 @@ import org.dbsp.util.IIndentStream;
 public final class DBSPNoComparatorExpression extends DBSPComparatorExpression {
     public final DBSPType tupleType;
 
+    /** Create a comparator that compares no fields
+     * @param tupleType Type of the data that is being compared.
+     */
     public DBSPNoComparatorExpression(CalciteObject node, DBSPType tupleType) {
         super(node, DBSPComparatorType.generateType(tupleType));
         this.tupleType = tupleType;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -60,6 +60,22 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void issue4447() {
+        var ccs = this.getCCS("""
+            CREATE TABLE TT(id INT, pid INT);
+            CREATE VIEW V AS SELECT ARRAY_AGG(id ORDER BY pid) FROM TT;""");
+        ccs.step("INSERT INTO TT VALUES(10, 10);", """
+                 array  | weight
+                ----------------
+                 { 10 } | 1""");
+        ccs.step("INSERT INTO TT VALUES(5, 5);", """
+                 array  | weight
+                ----------------
+                 { 10 } | -1
+                 { 5, 10 } | 1""");
+    }
+
+    @Test
     public void internalIssue143() {
         this.compileRustTestCase("""
                 CREATE TABLE T(x INT);


### PR DESCRIPTION
Fixes #4777

To support ORDER BY in `ARRAY_AGG` we build the accumulator with all fields that one needs in the output OR in the sort order, and in the postprocessing function we sort the accumulator. This is very expensive, but the asymptotic cost is the same as the standard `ARRAY_AGG`. It's conceivable that this could be improved on by relying on Z-sets to keep the input collection sorted on the correct fields.