### PR TITLE
[adapters] Fixup clock test.

### DIFF
--- a/crates/adapters/src/transport/clock.rs
+++ b/crates/adapters/src/transport/clock.rs
@@ -446,7 +446,8 @@ inputs:
 
         let ticks = test_stats.ticks();
         println!("{ticks} ticks replayed after restart");
-        assert_eq!(ticks, ticks_after_checkpoint);
+        // Allow at most one extra tick after pause.
+        assert!(ticks >= ticks_after_checkpoint && ticks <= ticks_after_checkpoint + 1);
 
         controller.stop().unwrap();
         println!("Clock test is finished");


### PR DESCRIPTION
The test assumed that the connector cannot produce new inputs after `pause`, however pause is an async operation, which can return before the connector performs an extra clock tick.