### PR TITLE
[py] Take advantage of pipeline field selector.

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -469,7 +469,6 @@ pub enum PipelineFieldSelector {
     /// - `program_version`
     /// - `program_status`
     /// - `program_status_since`
-    /// - `program_error`
     /// - `deployment_error`
     /// - `refresh_version`
     /// - `storage_status`

--- a/python/feldera/_callback_runner.py
+++ b/python/feldera/_callback_runner.py
@@ -6,6 +6,7 @@ from queue import Queue, Empty
 import pandas as pd
 from feldera import FelderaClient
 from feldera._helpers import dataframe_from_response
+from feldera.enums import PipelineFieldSelector
 
 
 class _CallbackRunnerInstruction(Enum):
@@ -38,7 +39,7 @@ class CallbackRunner(Thread):
         :meta private:
         """
 
-        pipeline = self.client.get_pipeline(self.pipeline_name)
+        pipeline = self.client.get_pipeline(self.pipeline_name, PipelineFieldSelector.ALL)
 
         schemas = pipeline.tables + pipeline.views
         for schema in schemas:

--- a/python/feldera/_callback_runner.py
+++ b/python/feldera/_callback_runner.py
@@ -39,7 +39,9 @@ class CallbackRunner(Thread):
         :meta private:
         """
 
-        pipeline = self.client.get_pipeline(self.pipeline_name, PipelineFieldSelector.ALL)
+        pipeline = self.client.get_pipeline(
+            self.pipeline_name, PipelineFieldSelector.ALL
+        )
 
         schemas = pipeline.tables + pipeline.views
         for schema in schemas:

--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Optional
 
-
 class CompilationProfile(Enum):
     """
     The compilation profile to use when compiling the program.
@@ -336,3 +335,10 @@ class FaultToleranceModel(Enum):
         raise ValueError(
             f"Unknown value '{value}' for enum {FaultToleranceModel.__name__}"
         )
+
+class PipelineFieldSelector(Enum):
+    ALL = "all"
+    """Select all fields of a pipeline."""
+
+    STATUS = "status"
+    """Select only the fields required to know the status of a pipeline."""

--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Optional
 
+
 class CompilationProfile(Enum):
     """
     The compilation profile to use when compiling the program.
@@ -335,6 +336,7 @@ class FaultToleranceModel(Enum):
         raise ValueError(
             f"Unknown value '{value}' for enum {FaultToleranceModel.__name__}"
         )
+
 
 class PipelineFieldSelector(Enum):
     ALL = "all"

--- a/python/feldera/pipeline_builder.py
+++ b/python/feldera/pipeline_builder.py
@@ -60,7 +60,10 @@ class PipelineBuilder:
             raise ValueError("Name and SQL are required to create a pipeline")
 
         try:
-            if self.client.get_pipeline(self.name, PipelineFieldSelector.STATUS) is not None:
+            if (
+                self.client.get_pipeline(self.name, PipelineFieldSelector.STATUS)
+                is not None
+            ):
                 raise RuntimeError(f"Pipeline with name {self.name} already exists")
         except FelderaAPIError as err:
             if err.error_code != "UnknownPipelineName":

--- a/python/feldera/pipeline_builder.py
+++ b/python/feldera/pipeline_builder.py
@@ -4,7 +4,7 @@ from typing import Optional
 from feldera.rest.feldera_client import FelderaClient
 from feldera.rest.pipeline import Pipeline as InnerPipeline
 from feldera.pipeline import Pipeline
-from feldera.enums import CompilationProfile
+from feldera.enums import CompilationProfile, PipelineFieldSelector
 from feldera.runtime_config import RuntimeConfig
 from feldera.rest.errors import FelderaAPIError
 
@@ -60,7 +60,7 @@ class PipelineBuilder:
             raise ValueError("Name and SQL are required to create a pipeline")
 
         try:
-            if self.client.get_pipeline(self.name) is not None:
+            if self.client.get_pipeline(self.name, PipelineFieldSelector.STATUS) is not None:
                 raise RuntimeError(f"Pipeline with name {self.name} already exists")
         except FelderaAPIError as err:
             if err.error_code != "UnknownPipelineName":

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -94,7 +94,9 @@ class FelderaClient:
 
         return FelderaClient(f"http://127.0.0.1:{port}")
 
-    def get_pipeline(self, pipeline_name: str, field_selector: PipelineFieldSelector) -> Pipeline:
+    def get_pipeline(
+        self, pipeline_name: str, field_selector: PipelineFieldSelector
+    ) -> Pipeline:
         """
         Get a pipeline by name
 
@@ -102,7 +104,9 @@ class FelderaClient:
         :param field_selector: Choose what pipeline information to refresh; see PipelineFieldSelector enum definition.
         """
 
-        resp = self.http.get(f"/pipelines/{pipeline_name}?selector={field_selector.value}")
+        resp = self.http.get(
+            f"/pipelines/{pipeline_name}?selector={field_selector.value}"
+        )
 
         return Pipeline.from_dict(resp)
 
@@ -506,7 +510,9 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         start = time.monotonic()
 
         while time.monotonic() - start < timeout_s:
-            status = self.get_pipeline(pipeline_name, PipelineFieldSelector.STATUS).deployment_status
+            status = self.get_pipeline(
+                pipeline_name, PipelineFieldSelector.STATUS
+            ).deployment_status
 
             if status == "Stopped":
                 return
@@ -540,7 +546,9 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         start = time.monotonic()
 
         while time.monotonic() - start < timeout_s:
-            status = self.get_pipeline(pipeline_name, PipelineFieldSelector.STATUS).storage_status
+            status = self.get_pipeline(
+                pipeline_name, PipelineFieldSelector.STATUS
+            ).storage_status
 
             if status == "Cleared":
                 return

--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -63,8 +63,8 @@ def get(path: str, **kw) -> requests.Response:
     return http_request("GET", path, **kw)
 
 
-def get_pipeline(name: str):
-    return get(f"{API_PREFIX}/pipelines/{name}")
+def get_pipeline(name: str, selector: str) -> requests.Response:
+    return get(f"{API_PREFIX}/pipelines/{name}?selector={selector}")
 
 
 def post_no_body(path: str, **kw):
@@ -91,7 +91,7 @@ def wait_for_deployment_status(name: str, desired: str, timeout_s: float = 60.0)
     deadline = time.time() + timeout_s
     last = None
     while time.time() < deadline:
-        r = get_pipeline(name)
+        r = get_pipeline(name, "status")
         if r.status_code != HTTPStatus.OK:
             time.sleep(0.25)
             continue
@@ -160,7 +160,7 @@ def wait_for_cleared_storage(name: str, timeout_s: float = 60.0):
     deadline = time.time() + timeout_s
     last = None
     while time.time() < deadline:
-        r = get_pipeline(name)
+        r = get_pipeline(name, "status")
         if r.status_code != HTTPStatus.OK:
             time.sleep(0.25)
             continue
@@ -182,7 +182,7 @@ def clear_pipeline(name: str, wait: bool = True):
 
 
 def reset_pipeline(name: str):
-    if get_pipeline(name).status_code != HTTPStatus.OK:
+    if get_pipeline(name, "status").status_code != HTTPStatus.OK:
         return
     stop_pipeline(name, force=True)
     clear_pipeline(name)

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -319,7 +319,9 @@ def test_pipeline_clear(pipeline_name):
     assert first.status_code == HTTPStatus.ACCEPTED
     second = clear_pipeline(pipeline_name, wait=True)
     assert second.status_code == HTTPStatus.ACCEPTED
-    assert get_pipeline(pipeline_name, "status").json().get("storage_status") == "Cleared"
+    assert (
+        get_pipeline(pipeline_name, "status").json().get("storage_status") == "Cleared"
+    )
 
 
 @gen_pipeline_name

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -586,7 +586,9 @@ class TestPipeline(SharedTestPipeline):
         resources = Resources(config)
         self.pipeline.set_runtime_config(RuntimeConfig(resources=resources))
         self.pipeline.start()
-        got = TEST_CLIENT.get_pipeline(self.pipeline.name, PipelineFieldSelector.ALL).runtime_config["resources"]
+        got = TEST_CLIENT.get_pipeline(
+            self.pipeline.name, PipelineFieldSelector.ALL
+        ).runtime_config["resources"]
         assert got == config
 
     def test_support_bundle(self):

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -9,7 +9,7 @@ import zipfile
 
 from tests.shared_test_pipeline import SharedTestPipeline
 from tests import TEST_CLIENT, enterprise_only
-from feldera.enums import PipelineStatus
+from feldera.enums import PipelineFieldSelector, PipelineStatus
 
 
 class TestPipeline(SharedTestPipeline):
@@ -52,7 +52,7 @@ class TestPipeline(SharedTestPipeline):
         assert self.pipeline.name in [p.name for p in pipelines]
 
     def test_get_pipeline(self):
-        p = TEST_CLIENT.get_pipeline(self.pipeline.name)
+        p = TEST_CLIENT.get_pipeline(self.pipeline.name, PipelineFieldSelector.ALL)
         assert self.pipeline.name == p.name
 
     def test_get_pipeline_config(self):
@@ -586,7 +586,7 @@ class TestPipeline(SharedTestPipeline):
         resources = Resources(config)
         self.pipeline.set_runtime_config(RuntimeConfig(resources=resources))
         self.pipeline.start()
-        got = TEST_CLIENT.get_pipeline(self.pipeline.name).runtime_config["resources"]
+        got = TEST_CLIENT.get_pipeline(self.pipeline.name, PipelineFieldSelector.ALL).runtime_config["resources"]
         assert got == config
 
     def test_support_bundle(self):


### PR DESCRIPTION
Python SDK called the GET /pipeline/<name> endpoint without using the
selector argument. This meant that even when polling the manager waiting
for pipeline compilation to complete or for a specific pipeline status,
it retrieved the entire source code, schema, and the list of compiler
errors and warnings every time. This could cause a lot of unnecessary
load on the manager.

This commit changes the SDK to instead use the "status" selector where
possible to only retrieve fields needed for runtime monitoring of the
pipeline. This approach may still be a bit crude, and we may want an
even more fine grained API, but it should improve things significantly.