### PR TITLE
[adapters] Skip replay if pipeline has changed.

### DIFF
--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -1271,6 +1271,19 @@ pub struct ConnectorConfig {
     pub start_after: Option<Vec<String>>,
 }
 
+impl ConnectorConfig {
+    /// Compare two configs modulo the `paused` field.
+    ///
+    /// Used to compare checkpointed and current connector configs.
+    pub fn equal_modulo_paused(&self, other: &Self) -> bool {
+        let mut a = self.clone();
+        let mut b = other.clone();
+        a.paused = false;
+        b.paused = false;
+        a == b
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(default)]
 pub struct OutputBufferConfig {
@@ -1416,6 +1429,18 @@ impl TransportConfig {
             TransportConfig::RedisOutput(_) => "redis_output".to_string(),
             TransportConfig::ClockInput(_) => "clock".to_string(),
         }
+    }
+
+    /// Returns true if the connector is transient, i.e., is created and destroyed
+    /// at runtime on demand, rather than being configured as part of the pipeline.
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            TransportConfig::AdHocInput(_)
+                | TransportConfig::HttpInput(_)
+                | TransportConfig::HttpOutput
+                | TransportConfig::ClockInput(_)
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #4727.

When starting a modified pipeline from a checkpoint, the controller still sometimes replaced the connector configuration specified by the user with the list of connectors from the checkpoint.  The reason for this is that in the exactly-once FT mode the pipeline must replay journaled inputs from all connectors, including transient connectors such as HTTP that are not present in the user-provided config. This could go wrong in multiple ways, including connectors failing to initialize (issue #4727) or, worse, the pipeline running with the wrong configuration. We fix this by comparing old and new connector lists modulo transient connectors and abandoning journal replay if the lists do not match, i.e., the pipeline was modified by the user after a failure.

Add a brief description of the pull request.