### PR TITLE
pipeline-manager: support HTTPS TLS certificate chain

### DIFF
--- a/docs.feldera.com/docs/get-started/enterprise/https.md
+++ b/docs.feldera.com/docs/get-started/enterprise/https.md
@@ -57,6 +57,14 @@ be using `kubectl` port forwarding.
 
 3. This will create the `tls.key` and `tls.crt` files.
 
+### Not self-signed
+
+If the certificate is not self-signed, but instead is signed by a root CA or an intermediate CA,
+the `tls.crt` should contain the complete bundle of the entire chain up until the root certificate
+authority. As such, it should contain multiple  `-----BEGIN CERTIFICATE----- (...) -----END CERTIFICATE-----`
+sections, starting with the leaf certificate and ending with the root certificate. The `tls.key`
+should only contain the single private key of the leaf certificate.
+
 ## Configure Kubernetes
 
 1. Create the Kubernetes TLS Secret (e.g., in namespace `feldera`, and named `feldera-https-config`)


### PR DESCRIPTION
When the PEM file where `https_tls_cert_path` referred to contained the entire certificate chain rather than only a single certificate, the `reqwest` client only read in the first certificate. This caused it to not be able to connect to Feldera HTTPS servers because it didn't trust the certificates further up the chain (in particular, the root certificate).

Both the `awc` and `reqwest` clients now add the last certificate provided in the bundle as their only root certificate.

Added instructions to the documentation for not self-signed certificates.

**PR information**
- Documentation updated
- Changelog is not updated
- No breaking changes