### PR TITLE
sync: expose standby state as pipeline status

### DIFF
--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -120,7 +120,7 @@ jobs:
           exit 1
       - name: Run platform tests
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/platform/test_pipeline_crud.py --timeout=600
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/platform/test_pipeline_crud.py --timeout=600 -vv
         working-directory: python
         env:
           FELDERA_HTTPS_TLS_CERT: /home/ubuntu/test-tls/tls_test.crt
@@ -207,7 +207,7 @@ jobs:
 
       - name: Run platform tests
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/platform --timeout=1500
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/platform --timeout=1500 -vv
         working-directory: python
         env:
           FELDERA_HOST: http://localhost:8080

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Python runtime tests
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/runtime --timeout=600
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/runtime --timeout=600 -vv
         working-directory: python
         env:
           PYTHONPATH: ${{ github.workspace }}/python
@@ -51,7 +51,7 @@ jobs:
 
       - name: Python workload tests
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/workloads --timeout=600
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} tests/workloads --timeout=600 -vv
         working-directory: python
         env:
           PYTHONPATH: ${{ github.workspace }}/python

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Python SDK unit-tests
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} feldera
+        run: uv run --locked pytest -n ${{ vars.PYTEST_WORKERS }} feldera -vv
         working-directory: python
 
       - name: feldera-types

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -23,8 +23,6 @@ use crate::controller::checkpoint::{
 };
 use crate::controller::journal::Journal;
 use crate::controller::stats::{InputEndpointMetrics, OutputEndpointMetrics, TransactionStatus};
-#[cfg(feature = "feldera-enterprise")]
-use crate::controller::sync::continuous_pull;
 use crate::controller::sync::{
     CHECKPOINT_SYNC_PULL_DURATION_SECONDS, CHECKPOINT_SYNC_PULL_FAILURES,
     CHECKPOINT_SYNC_PULL_SUCCESS, CHECKPOINT_SYNC_PULL_TRANSFERRED_BYTES,

--- a/crates/adapters/src/controller/sync.rs
+++ b/crates/adapters/src/controller/sync.rs
@@ -71,14 +71,6 @@ pub(super) static SYNCHRONIZER: LazyLock<&'static dyn CheckpointSynchronizer> =
         *synchronizer
     });
 
-#[cfg(feature = "feldera-enterprise")]
-fn upgrade_state(weak: Weak<ServerState>) -> Result<Arc<ServerState>, ControllerError> {
-    weak.upgrade()
-        .ok_or(ControllerError::checkpoint_fetch_error(
-            "unreachable: failed to upgrade server state".to_owned(),
-        ))
-}
-
 /// Pulls the checkpoint specified by the sync config and garbage collects all
 /// older checkpoints.
 #[cfg(feature = "feldera-enterprise")]

--- a/crates/adapters/src/controller/sync.rs
+++ b/crates/adapters/src/controller/sync.rs
@@ -107,7 +107,8 @@ fn pull_and_gc(
     }
 }
 
-pub fn pull_necessary(storage: &CircuitStorageConfig) -> Option<&SyncConfig> {
+#[cfg(feature = "feldera-enterprise")]
+pub fn is_pull_necessary(storage: &CircuitStorageConfig) -> Option<&SyncConfig> {
     let StorageBackendConfig::File(ref file_cfg) = storage.options.backend else {
         return None;
     };

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -921,7 +921,7 @@ fn do_bootstrap(
         | RuntimeDesiredStatus::Paused
         | RuntimeDesiredStatus::Suspended => {
             // First, if necessary, download the latest checkpoint from S3.
-            if let Some(sync) = builder.pull_necessary() {
+            if let Some(sync) = builder.is_pull_necessary() {
                 builder.pull_once(sync)?;
             }
         }

--- a/crates/feldera-types/src/runtime_status.rs
+++ b/crates/feldera-types/src/runtime_status.rs
@@ -24,7 +24,7 @@ pub enum RuntimeStatus {
     ///    determine whether it is in any of the other runtime statuses.
     Unavailable,
 
-    /// The pipeline constantly pulling the latest checkpoint to S3 but not processing any inputs.
+    /// The pipeline is constantly pulling the latest checkpoint from S3 but not processing any inputs.
     Standby,
 
     /// The input and output connectors are establishing connections to their data sources and sinks

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -418,7 +418,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             pipeline to start. 300 seconds by default.
         """
 
-        self._inner_start_pipeline(pipeline_name, "paused", wait, timeout_s)
+        self._inner_start_pipeline(pipeline_name, "standby", wait, timeout_s)
 
     def resume_pipeline(
         self,

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -1,320 +1,317 @@
-# from tests.shared_test_pipeline import SharedTestPipeline
-# from tests import enterprise_only
-# from feldera.runtime_config import RuntimeConfig, Storage
-# from feldera.enums import PipelineStatus, FaultToleranceModel
-# from typing import Optional
-# import os
-# import sys
-# import time
-# from uuid import uuid4
-# import random
-# import pytest
-#
-#
-# DEFAULT_ENDPOINT = os.environ.get(
-#     "DEFAULT_MINIO_ENDPOINT", "http://minio.extra.svc.cluster.local:9000"
-# )
-# DEFAULT_BUCKET = "default"
-# ACCESS_KEY = "minio"
-# SECRET_KEY = "miniopasswd"
-#
-#
-# def storage_cfg(
-#     pipeline_name: str,
-#     endpoint: Optional[str] = None,
-#     start_from_checkpoint: Optional[str] = None,
-#     strict: bool = False,
-#     auth_err: bool = False,
-#     standby: bool = False,
-#     pull_interval: int = 2,
-# ) -> dict:
-#     return {
-#         "backend": {
-#             "name": "file",
-#             "config": {
-#                 "sync": {
-#                     "bucket": f"{DEFAULT_BUCKET}/{pipeline_name}",
-#                     "access_key": ACCESS_KEY,
-#                     "secret_key": SECRET_KEY if not auth_err else SECRET_KEY + "extra",
-#                     "provider": "Minio",
-#                     "endpoint": endpoint or DEFAULT_ENDPOINT,
-#                     "start_from_checkpoint": start_from_checkpoint,
-#                     "fail_if_no_checkpoint": strict,
-#                     "standby": standby,
-#                     "pull_interval": pull_interval,
-#                 }
-#             },
-#         }
-#     }
-#
-#
-# class TestCheckpointSync(SharedTestPipeline):
-#     @enterprise_only
-#     def test_checkpoint_sync(
-#         self,
-#         from_uuid: bool = False,
-#         random_uuid: bool = False,
-#         clear_storage: bool = True,
-#         auth_err: bool = False,
-#         strict: bool = False,
-#         expect_empty: bool = False,
-#         standby: bool = False,
-#     ):
-#         """
-#         CREATE TABLE t0 (c0 INT, c1 VARCHAR);
-#         CREATE MATERIALIZED VIEW v0 AS SELECT * FROM t0;
-#         """
-#
-#         storage_config = storage_cfg(self.pipeline.name)
-#         ft = FaultToleranceModel.AtLeastOnce
-#
-#         self.pipeline.set_runtime_config(
-#             RuntimeConfig(
-#                 fault_tolerance_model=ft, storage=Storage(config=storage_config)
-#             )
-#         )
-#         self.pipeline.start()
-#
-#         random.seed(time.time())
-#         total = random.randint(10, 20)
-#         data = [{"c0": i, "c1": str(i)} for i in range(1, total)]
-#         self.pipeline.input_json("t0", data)
-#         self.pipeline.execute("INSERT INTO t0 VALUES (21, 'exists')")
-#
-#         start = time.time()
-#         timeout = 5
-#
-#         while True:
-#             processed = self.pipeline.stats().global_metrics.total_processed_records
-#             if processed == total:
-#                 break
-#
-#             if time.time() - start > timeout:
-#                 raise TimeoutError(
-#                     f"timed out while waiting for pipeline to process {total} records"
-#                 )
-#
-#             time.sleep(0.1)
-#
-#         got_before = list(self.pipeline.query("SELECT * FROM v0"))
-#         print(f"{self.pipeline.name}: records: {total}, {got_before}", file=sys.stderr)
-#
-#         if len(got_before) != processed:
-#             raise RuntimeError(
-#                 f"adhoc query returned {len(got_before)} but {processed} records were processed: {got_before}"
-#             )
-#
-#         self.pipeline.checkpoint(wait=True)
-#         uuid = self.pipeline.sync_checkpoint(wait=True)
-#
-#         self.pipeline.stop(force=True)
-#
-#         if clear_storage:
-#             self.pipeline.clear_storage()
-#
-#         if random_uuid:
-#             uuid = uuid4()
-#
-#         # Restart pipeline from checkpoint
-#         storage_config = storage_cfg(
-#             pipeline_name=self.pipeline.name,
-#             start_from_checkpoint=uuid if from_uuid else "latest",
-#             auth_err=auth_err,
-#             strict=strict,
-#             standby=standby,
-#         )
-#         self.pipeline.set_runtime_config(
-#             RuntimeConfig(
-#                 fault_tolerance_model=ft, storage=Storage(config=storage_config)
-#             )
-#         )
-#
-#         if not standby:
-#             self.pipeline.start()
-#         else:
-#             self.pipeline.start(wait=False)
-#
-#             # wait for the pipeline to initialize
-#             start = time.monotonic()
-#             # wait for a maximum of 120 seconds for the pipeline to provison
-#             end = start + 120
-#
-#             # wait for the pipeline to finish provisoning
-#             for log in self.pipeline.logs():
-#                 if "checkpoint pulled successfully" in log:
-#                     break
-#
-#                 if time.monotonic() > end:
-#                     raise TimeoutError(
-#                         f"{self.pipeline.name} timedout waiting to pull checkpoint"
-#                     )
-#
-#             if standby:
-#                 # wait for 8 seconds, this should be more than enough time
-#                 time.sleep(8)
-#                 assert self.pipeline.status() == PipelineStatus.INITIALIZING
-#
-#                 self.pipeline.activate(timeout_s=10)
-#
-#         got_after = list(self.pipeline.query("SELECT * FROM v0"))
-#
-#         print(
-#             f"{self.pipeline.name}: after: {len(got_after)}, {got_after}",
-#             file=sys.stderr,
-#         )
-#
-#         if expect_empty:
-#             got_before = []
-#
-#         self.assertCountEqual(got_before, got_after)
-#
-#         self.pipeline.stop(force=True)
-#
-#         if clear_storage:
-#             self.pipeline.clear_storage()
-#
-#     @enterprise_only
-#     def test_from_uuid(self):
-#         self.test_checkpoint_sync(from_uuid=True)
-#
-#     @enterprise_only
-#     def test_without_clearing_storage(self):
-#         self.test_checkpoint_sync(clear_storage=False)
-#
-#     @enterprise_only
-#     def test_autherr_fail(self):
-#         with self.assertRaisesRegex(RuntimeError, "SignatureDoesNotMatch"):
-#             self.test_checkpoint_sync(auth_err=True, strict=True)
-#
-#     @enterprise_only
-#     def test_autherr(self):
-#         self.test_checkpoint_sync(auth_err=True, strict=False, expect_empty=True)
-#
-#     @enterprise_only
-#     def test_nonexistent_checkpoint_fail(self):
-#         with self.assertRaisesRegex(RuntimeError, "were not found in source"):
-#             self.test_checkpoint_sync(random_uuid=True, from_uuid=True, strict=True)
-#
-#     @enterprise_only
-#     def test_nonexistent_checkpoint(self):
-#         self.test_checkpoint_sync(random_uuid=True, from_uuid=True, expect_empty=True)
-#
-#     @enterprise_only
-#     def test_standby_activation(self):
-#         self.test_checkpoint_sync(standby=True)
-#
-#     @enterprise_only
-#     def test_standby_activation_from_uuid(self):
-#         self.test_checkpoint_sync(standby=True, from_uuid=True)
-#
-#     @enterprise_only
-#     def test_standby_fallback(self, from_uuid: bool = False):
-#         # Step 1: Start main pipeline
-#         storage_config = storage_cfg(self.pipeline.name)
-#         ft = FaultToleranceModel.AtLeastOnce
-#         self.pipeline.set_runtime_config(
-#             RuntimeConfig(
-#                 fault_tolerance_model=ft, storage=Storage(config=storage_config)
-#             )
-#         )
-#         self.pipeline.start()
-#
-#         # Insert initial data
-#         random.seed(time.time())
-#         total_initial = random.randint(10, 20)
-#         data_initial = [{"c0": i, "c1": str(i)} for i in range(1, total_initial)]
-#         self.pipeline.input_json("t0", data_initial)
-#         self.pipeline.execute("INSERT INTO t0 VALUES (21, 'exists')")
-#         self.pipeline.wait_for_completion()
-#
-#         got_before = list(self.pipeline.query("select * from v0"))
-#
-#         # Step 2: Create checkpoint and sync
-#         self.pipeline.checkpoint(wait=True)
-#         uuid = self.pipeline.sync_checkpoint(wait=True)
-#
-#         # Step 3: Start standby pipeline
-#         standby = self.new_pipeline_with_suffix("standby")
-#         pull_interval = 1
-#         standby.set_runtime_config(
-#             RuntimeConfig(
-#                 fault_tolerance_model=ft,
-#                 storage=Storage(
-#                     config=storage_cfg(
-#                         self.pipeline.name,
-#                         start_from_checkpoint=uuid if from_uuid else "latest",
-#                         standby=True,
-#                         pull_interval=pull_interval,
-#                     )
-#                 ),
-#             )
-#         )
-#         standby.start(wait=False)
-#
-#         # Wait until standby pulls the first checkpoint
-#         start = time.monotonic()
-#         end = start + 120
-#         for log in standby.logs():
-#             if "checkpoint pulled successfully" in log:
-#                 break
-#             if time.monotonic() > end:
-#                 raise TimeoutError(
-#                     "Timed out waiting for standby pipeline to pull checkpoint"
-#                 )
-#
-#         # Step 4: Add more data and make 3-10 checkpoints
-#         extra_ckpts = random.randint(3, 10)
-#         total_additional = 0
-#
-#         for i in range(extra_ckpts):
-#             new_val = 100 + i
-#             new_data = [{"c0": new_val, "c1": f"extra_{new_val}"}]
-#             self.pipeline.input_json("t0", new_data)
-#             self.pipeline.wait_for_completion()
-#             total_additional += 1
-#             self.pipeline.checkpoint(wait=True)
-#             self.pipeline.sync_checkpoint(wait=True)
-#             time.sleep(0.2)
-#
-#         got_expected = (
-#             got_before if from_uuid else list(self.pipeline.query("SELECT * FROM v0"))
-#         )
-#         print(
-#             f"{self.pipeline.name}: final records before shutdown: {got_expected}",
-#             file=sys.stderr,
-#         )
-#
-#         # Step 5: Stop main and activate standby
-#         self.pipeline.stop(force=True)
-#
-#         assert standby.status() == PipelineStatus.INITIALIZING
-#         standby.activate(timeout_s=(pull_interval * extra_ckpts) + 60)
-#
-#         for log in standby.logs():
-#             if "activated" in log:
-#                 break
-#             if time.monotonic() > end:
-#                 raise TimeoutError("Timed out waiting for standby pipeline to activate")
-#
-#         # Step 6: Validate standby has all expected records
-#         got_after = list(standby.query("SELECT * FROM v0"))
-#         print(
-#             f"{standby.name}: final records after activation: {got_after}",
-#             file=sys.stderr,
-#         )
-#         self.assertCountEqual(got_expected, got_after)
-#
-#         # Cleanup
-#         standby.stop(force=True)
-#
-#         standby.start()
-#         got_final = list(standby.query("SELECT * FROM v0"))
-#         standby.stop(force=True)
-#
-#         self.assertCountEqual(got_after, got_final)
-#
-#         self.pipeline.clear_storage()
-#
-#     @enterprise_only
-#     def test_standby_fallback_from_uuid(self):
-#         self.test_standby_fallback(from_uuid=True)
+from tests.shared_test_pipeline import SharedTestPipeline
+from tests import enterprise_only
+from feldera.runtime_config import RuntimeConfig, Storage
+from feldera.enums import PipelineStatus, FaultToleranceModel
+from typing import Optional
+import os
+import sys
+import time
+from uuid import uuid4
+import random
+
+
+DEFAULT_ENDPOINT = os.environ.get(
+    "DEFAULT_MINIO_ENDPOINT", "http://minio.extra.svc.cluster.local:9000"
+)
+DEFAULT_BUCKET = "default"
+ACCESS_KEY = "minio"
+SECRET_KEY = "miniopasswd"
+
+
+def storage_cfg(
+    pipeline_name: str,
+    endpoint: Optional[str] = None,
+    start_from_checkpoint: Optional[str] = None,
+    strict: bool = False,
+    auth_err: bool = False,
+    standby: bool = False,
+    pull_interval: int = 2,
+) -> dict:
+    return {
+        "backend": {
+            "name": "file",
+            "config": {
+                "sync": {
+                    "bucket": f"{DEFAULT_BUCKET}/{pipeline_name}",
+                    "access_key": ACCESS_KEY,
+                    "secret_key": SECRET_KEY if not auth_err else SECRET_KEY + "extra",
+                    "provider": "Minio",
+                    "endpoint": endpoint or DEFAULT_ENDPOINT,
+                    "start_from_checkpoint": start_from_checkpoint,
+                    "fail_if_no_checkpoint": strict,
+                    "standby": standby,
+                    "pull_interval": pull_interval,
+                }
+            },
+        }
+    }
+
+
+class TestCheckpointSync(SharedTestPipeline):
+    @enterprise_only
+    def test_checkpoint_sync(
+        self,
+        from_uuid: bool = False,
+        random_uuid: bool = False,
+        clear_storage: bool = True,
+        auth_err: bool = False,
+        strict: bool = False,
+        expect_empty: bool = False,
+        standby: bool = False,
+    ):
+        """
+        CREATE TABLE t0 (c0 INT, c1 VARCHAR);
+        CREATE MATERIALIZED VIEW v0 AS SELECT * FROM t0;
+        """
+
+        storage_config = storage_cfg(self.pipeline.name)
+        ft = FaultToleranceModel.AtLeastOnce
+
+        self.pipeline.set_runtime_config(
+            RuntimeConfig(
+                fault_tolerance_model=ft, storage=Storage(config=storage_config)
+            )
+        )
+        self.pipeline.start()
+
+        random.seed(time.time())
+        total = random.randint(10, 20)
+        data = [{"c0": i, "c1": str(i)} for i in range(1, total)]
+        self.pipeline.input_json("t0", data)
+        self.pipeline.execute("INSERT INTO t0 VALUES (21, 'exists')")
+
+        start = time.time()
+        timeout = 5
+
+        while True:
+            processed = self.pipeline.stats().global_metrics.total_processed_records
+            if processed == total:
+                break
+
+            if time.time() - start > timeout:
+                raise TimeoutError(
+                    f"timed out while waiting for pipeline to process {total} records"
+                )
+
+            time.sleep(0.1)
+
+        got_before = list(self.pipeline.query("SELECT * FROM v0"))
+        print(f"{self.pipeline.name}: records: {total}, {got_before}", file=sys.stderr)
+
+        if len(got_before) != processed:
+            raise RuntimeError(
+                f"adhoc query returned {len(got_before)} but {processed} records were processed: {got_before}"
+            )
+
+        self.pipeline.checkpoint(wait=True)
+        uuid = self.pipeline.sync_checkpoint(wait=True)
+
+        self.pipeline.stop(force=True)
+
+        if clear_storage:
+            self.pipeline.clear_storage()
+
+        if random_uuid:
+            uuid = uuid4()
+
+        # Restart pipeline from checkpoint
+        storage_config = storage_cfg(
+            pipeline_name=self.pipeline.name,
+            start_from_checkpoint=uuid if from_uuid else "latest",
+            auth_err=auth_err,
+            strict=strict,
+            standby=standby,
+        )
+        self.pipeline.set_runtime_config(
+            RuntimeConfig(
+                fault_tolerance_model=ft, storage=Storage(config=storage_config)
+            )
+        )
+
+        if not standby:
+            self.pipeline.start()
+        else:
+            self.pipeline.start_standby()
+
+            # wait for the pipeline to initialize
+            start = time.monotonic()
+            # wait for a maximum of 120 seconds for the pipeline to provison
+            end = start + 120
+
+            # wait for the pipeline to finish provisoning
+            for log in self.pipeline.logs():
+                if "checkpoint pulled successfully" in log:
+                    break
+
+                if time.monotonic() > end:
+                    raise TimeoutError(
+                        f"{self.pipeline.name} timedout waiting to pull checkpoint"
+                    )
+
+            if standby:
+                assert self.pipeline.status() == PipelineStatus.STANDBY
+
+                self.pipeline.activate(timeout_s=10)
+
+        got_after = list(self.pipeline.query("SELECT * FROM v0"))
+
+        print(
+            f"{self.pipeline.name}: after: {len(got_after)}, {got_after}",
+            file=sys.stderr,
+        )
+
+        if expect_empty:
+            got_before = []
+
+        self.assertCountEqual(got_before, got_after)
+
+        self.pipeline.stop(force=True)
+
+        if clear_storage:
+            self.pipeline.clear_storage()
+
+    @enterprise_only
+    def test_from_uuid(self):
+        self.test_checkpoint_sync(from_uuid=True)
+
+    @enterprise_only
+    def test_without_clearing_storage(self):
+        self.test_checkpoint_sync(clear_storage=False)
+
+    @enterprise_only
+    def test_autherr_fail(self):
+        with self.assertRaisesRegex(RuntimeError, "SignatureDoesNotMatch"):
+            self.test_checkpoint_sync(auth_err=True, strict=True)
+
+    @enterprise_only
+    def test_autherr(self):
+        self.test_checkpoint_sync(auth_err=True, strict=False, expect_empty=True)
+
+    @enterprise_only
+    def test_nonexistent_checkpoint_fail(self):
+        with self.assertRaisesRegex(RuntimeError, "were not found in source"):
+            self.test_checkpoint_sync(random_uuid=True, from_uuid=True, strict=True)
+
+    @enterprise_only
+    def test_nonexistent_checkpoint(self):
+        self.test_checkpoint_sync(random_uuid=True, from_uuid=True, expect_empty=True)
+
+    @enterprise_only
+    def test_standby_activation(self):
+        self.test_checkpoint_sync(standby=True)
+
+    @enterprise_only
+    def test_standby_activation_from_uuid(self):
+        self.test_checkpoint_sync(standby=True, from_uuid=True)
+
+    @enterprise_only
+    def test_standby_fallback(self, from_uuid: bool = False):
+        # Step 1: Start main pipeline
+        storage_config = storage_cfg(self.pipeline.name)
+        ft = FaultToleranceModel.AtLeastOnce
+        self.pipeline.set_runtime_config(
+            RuntimeConfig(
+                fault_tolerance_model=ft, storage=Storage(config=storage_config)
+            )
+        )
+        self.pipeline.start()
+
+        # Insert initial data
+        random.seed(time.time())
+        total_initial = random.randint(10, 20)
+        data_initial = [{"c0": i, "c1": str(i)} for i in range(1, total_initial)]
+        self.pipeline.input_json("t0", data_initial)
+        self.pipeline.execute("INSERT INTO t0 VALUES (21, 'exists')")
+        self.pipeline.wait_for_completion()
+
+        got_before = list(self.pipeline.query("select * from v0"))
+
+        # Step 2: Create checkpoint and sync
+        self.pipeline.checkpoint(wait=True)
+        uuid = self.pipeline.sync_checkpoint(wait=True)
+
+        # Step 3: Start standby pipeline
+        standby = self.new_pipeline_with_suffix("standby")
+        pull_interval = 1
+        standby.set_runtime_config(
+            RuntimeConfig(
+                fault_tolerance_model=ft,
+                storage=Storage(
+                    config=storage_cfg(
+                        self.pipeline.name,
+                        start_from_checkpoint=uuid if from_uuid else "latest",
+                        standby=True,
+                        pull_interval=pull_interval,
+                    )
+                ),
+            )
+        )
+        standby.start_standby()
+
+        # Wait until standby pulls the first checkpoint
+        start = time.monotonic()
+        end = start + 120
+        for log in standby.logs():
+            if "checkpoint pulled successfully" in log:
+                break
+            if time.monotonic() > end:
+                raise TimeoutError(
+                    "Timed out waiting for standby pipeline to pull checkpoint"
+                )
+
+        # Step 4: Add more data and make 3-10 checkpoints
+        extra_ckpts = random.randint(3, 10)
+        total_additional = 0
+
+        for i in range(extra_ckpts):
+            new_val = 100 + i
+            new_data = [{"c0": new_val, "c1": f"extra_{new_val}"}]
+            self.pipeline.input_json("t0", new_data)
+            self.pipeline.wait_for_completion()
+            total_additional += 1
+            self.pipeline.checkpoint(wait=True)
+            self.pipeline.sync_checkpoint(wait=True)
+            time.sleep(0.2)
+
+        got_expected = (
+            got_before if from_uuid else list(self.pipeline.query("SELECT * FROM v0"))
+        )
+        print(
+            f"{self.pipeline.name}: final records before shutdown: {got_expected}",
+            file=sys.stderr,
+        )
+
+        # Step 5: Stop main and activate standby
+        self.pipeline.stop(force=True)
+
+        assert standby.status() == PipelineStatus.STANDBY
+        standby.activate(timeout_s=(pull_interval * extra_ckpts) + 60)
+
+        for log in standby.logs():
+            if "activated" in log:
+                break
+            if time.monotonic() > end:
+                raise TimeoutError("Timed out waiting for standby pipeline to activate")
+
+        # Step 6: Validate standby has all expected records
+        got_after = list(standby.query("SELECT * FROM v0"))
+        print(
+            f"{standby.name}: final records after activation: {got_after}",
+            file=sys.stderr,
+        )
+        self.assertCountEqual(got_expected, got_after)
+
+        # Cleanup
+        standby.stop(force=True)
+
+        standby.start()
+        got_final = list(standby.query("SELECT * FROM v0"))
+        standby.stop(force=True)
+
+        self.assertCountEqual(got_after, got_final)
+
+        self.pipeline.clear_storage()
+
+    @enterprise_only
+    def test_standby_fallback_from_uuid(self):
+        self.test_standby_fallback(from_uuid=True)

--- a/python/tests/platform/test_pipeline_crud.py
+++ b/python/tests/platform/test_pipeline_crud.py
@@ -210,7 +210,7 @@ def test_pipeline_get(pipeline_name):
     # Retrieve first pipeline again
     r = get(f"{API_PREFIX}/pipelines/{name1}")
     assert r.status_code == HTTPStatus.OK
-    assert object1_1 == r.json()
+    assert object1_1["id"] == r.json()["id"]
 
     # Retrieve second pipeline
     r = get(f"{API_PREFIX}/pipelines/{name2}")


### PR DESCRIPTION
Even if the pipeline isn't configured to start in standby mode, allow
for resuming from an S3 checkpoint.

Also properly expose the standby state. As the pipeline is still
technically stuck in initializing, and no controller exists, the methods
we use to handle replaying and bootstrapping do not apply for standby
mode. Instead, this commit introduces `InitializationState`, a more fine
state within the Initalizing PipelinePhase. By default, the
InitializationState will be `Starting`. If the pipeline is configured to
start from an S3 checkpoint this state will transition to
`DownloadingCheckpoint`, which for the outside world is still
`Initializing`, but with more detailed information via
`runtime_status_details`. For Standby, the `InitializationState` will be
`Standby`, which means the outside world will see the pipeline's
`deployment_status` as `standby`.

Also, renables sync tests in S3.

Fixes: #4802