### PR TITLE
[SQL] Improve CSE pass for operators

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
@@ -144,6 +144,12 @@ public class DBSPChainOperator extends DBSPUnaryOperator {
         /** Return a function that is equivalent to the composition of the functions in the chain.
          * If the chain contains any filters the result will have an Option type result. */
         public DBSPClosureExpression collapse(DBSPCompiler compiler) {
+            if (this.computations.size() == 1) {
+                Computation comp = this.computations.get(0);
+                if (comp.kind != ComputationKind.Filter)
+                    return comp.closure;
+            }
+
             DBSPVariablePath inputVar;
             DBSPExpression currentArg;
             if (this.inputType.is(DBSPTypeZSet.class)) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNowOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNowOperator.java
@@ -13,14 +13,19 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeZSet;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-/** Operator that generates the NOW() timestamp */
+/** Operator that generates the NOW() timestamp.
+ * There is no equivalent DBSP operator, this is only used during compilation to
+ * represent an input which is connected to a special stream.
+ * (The compiler flag --nowstream controls whether this happens, or
+ * this operator is implemented as a Rust Generator). */
 public final class DBSPNowOperator extends DBSPSimpleOperator {
-    // zset!(Tup1::new(now()))
     static DBSPExpression createFunction(CalciteObject node) {
         return new DBSPZSetExpression(
                 new DBSPTupleExpression(new DBSPApplyExpression(
@@ -29,7 +34,7 @@ public final class DBSPNowOperator extends DBSPSimpleOperator {
 
     public DBSPNowOperator(CalciteRelNode node) {
         super(node, "now", createFunction(node),
-                createFunction(node).getType(),
+                new DBSPTypeZSet(new DBSPTypeTuple(DBSPTypeTimestamp.create(node, false))),
                 false, false);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.backend.dot;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperatorBase;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPChainOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
@@ -160,6 +161,8 @@ public class ToDotNodesVisitor extends CircuitVisitor {
             if (aggregate.aggregateList != null) {
                 return aggregate.aggregateList.toString();
             }
+        } else if (node.is(DBSPChainOperator.class)) {
+            return node.to(DBSPChainOperator.class).chain.toString();
         }
         if (expression == null)
             return "";

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Maybe.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Maybe.java
@@ -4,5 +4,13 @@ package org.dbsp.util;
 public enum Maybe {
     NO,
     MAYBE,
-    YES
+    YES;
+
+    public boolean toBool() {
+        return switch (this) {
+            case NO -> false;
+            case MAYBE -> throw new RuntimeException("Cannot convert MAYBE to BOOLEAN");
+            case YES -> true;
+        };
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -108,10 +108,8 @@
             "partial": 3
           }]
       },
-      "positions": [
-        {"start_line_number":1,"start_column":1,"end_line_number":1,"end_column":56}
-      ],
-      "persistent_id": "7684c3b73a6314cdb2e4342c658d4749799627e5ccdb1174d848823bbd68bba3"
+      "positions": [],
+      "persistent_id": "20e32f4b3b66b72a630fe9dfde075dbf6f5685dc5a61574bd7a2ee844174b882"
     }, "s4": {
       "operation": "differentiate",
       "inputs": [
@@ -121,7 +119,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "01faa7580b0056d187ace3cd6d84378af92e4b695805e5446059ba5495eb41af"
+      "persistent_id": "cc69beadd24044b7aaabbdc61c90ee37b09b25f8d0112c6dd86b082103ea83e0"
     }, "s5": {
       "operation": "aggregate_linear_postprocess",
       "inputs": [
@@ -133,7 +131,7 @@
       "positions": [
         {"start_line_number":2,"start_column":25,"end_line_number":2,"end_column":33}
       ],
-      "persistent_id": "972329ef8724635f60da98480c55fb2d0e6f5e86fe2762e01b6d193c3ab4a0e6"
+      "persistent_id": "32f329161cff377eccfee10bce1ac87eb5543b421883668f7d5da95995f0b4ad"
     }, "s6": {
       "operation": "map",
       "inputs": [
@@ -143,7 +141,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "fa2c5d61862919e46280473305fc6c572d2f253b16291ddcf1d1c0b02811cdbb"
+      "persistent_id": "c367b4224f98769888a42e13d239aa6651d5a56b8b333ebae3334fd819fe9afb"
     }, "s7": {
       "operation": "map",
       "inputs": [
@@ -153,7 +151,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "29b5cad4cdd9c7ebd8bdfae248cc0ca934bef75a9c74c3fad4346a1c7eade068"
+      "persistent_id": "a79ebbec91d4f6bcbc6cb045c645a6449baab41fdd5cdb62eb0d5b6b1ec01d01"
     }, "s8": {
       "operation": "neg",
       "inputs": [
@@ -163,7 +161,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "7fa2c27e4e0ca396a5798029520d203ff87bf9f3d13ed39090570838d9ad1cc3"
+      "persistent_id": "0d007812638dc383a380e3e803478904ebf71f5fee333bdbca7447e081c9b195"
     }, "s9": {
       "operation": "integrate",
       "inputs": [
@@ -173,7 +171,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "52165e29b7cdee78296cc216b13ebc1a3640837302d057059fa1abb86d06e83e"
+      "persistent_id": "366e6d7bdf3c407fc239f3b97384083bec0ad9a1fb2b2bfaab6b018ea7527117"
     }, "s10": {
       "operation": "integrate",
       "inputs": [
@@ -183,7 +181,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "5c034254b63c337f3a465639aaed1950999ec8e82d1625454fcbd4f02a6ee3a9"
+      "persistent_id": "c7ea6b2781f1cd89eec8a5ad1fe10b4b954ff2cd1dcf1aeba4ea81ee36512283"
     }, "s11": {
       "operation": "sum",
       "inputs": [
@@ -195,7 +193,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "7868dec0d654c687104911b9aa76e751983577c13a237431d65c32452bcc61c2"
+      "persistent_id": "12e5a0c136961c04c66a174a2e3ef2b3beb7f7fa5a554c06e648bd2cb36dd173"
     }, "s12": {
       "operation": "inspect",
       "inputs": [
@@ -205,7 +203,7 @@
         "final": 3
       },
       "positions": [],
-      "persistent_id": "ef960de2d6c71c5f017a139ae64cf5d64e0d83de5e75957f0f442e7208c32750"
+      "persistent_id": "2677029b7c370ea231dc55c2fdb210c7b851d8b65a1da4e7ef835daa912c6db5"
     }, "s13": {
       "operation": "inspect",
       "inputs": [


### PR DESCRIPTION
The CSE pass would not detect identical constant operators, preventing it from CSE-ing all their successors.
This had an impact on programs that used global aggregates, where there is always a constant input holding the result for an empty collection.
This compiler was sound, though.