### PR TITLE
[py] Don't allow listen() on a stopped pipeline.

### DIFF
--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -15,6 +15,14 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        BACKWARD-INCOMPATIBLE PYTHON SDK CHANGES
+
+        - The `Pipeline.listen` method can now only be called when the pipeline is running or paused. Previously
+          it was possible to call `Pipeline.listen` before starting the pipeline in order to guarantee that all
+          outputs produced by the pipeline are captured by the listener. With the new API, you can achieve the
+          same by starting the pipeline in a paused state using `Pipeline.start_paused` and calling `Pipeline.listen`
+          before unpausing the pipeline using `Pipeline.resume`.
+
         ## 0.148.0
 
         API CHANGES: BACKWARD INCOMPATIBLE

--- a/python/docs/examples.rst
+++ b/python/docs/examples.rst
@@ -201,10 +201,10 @@ Using Pandas DataFrames
     df_students = pd.read_csv('students.csv')
     df_grades = pd.read_csv('grades.csv')
 
+    pipeline.start()
+
     # subscribe to listen to outputs from a view
     out = pipeline.listen("average_scores")
-
-    pipeline.start()
 
     # feed pandas dataframes as input
     pipeline.input_pandas("students", df_students)
@@ -260,11 +260,12 @@ It takes a callback, and calls the callback on each chunk of received data.
 
     pipeline = PipelineBuilder(client, name="notebook", sql=sql).create_or_replace()
 
+    # run the pipeline
+    pipeline.start()
+
     # register the callback for data received from the selected view
     pipeline.foreach_chunk("view_name", callback)
 
-    # run the pipeline
-    pipeline.start()
     pipeline.input_pandas("table_name", df)
 
     # wait for the pipeline to finish and stop
@@ -353,8 +354,11 @@ This example shows creating and running a pipeline with Feldera's internal data 
 
     pipeline = PipelineBuilder(client, name="kafka_example", sql=sql).create_or_replace()
 
+    # Start the pipeline in paused state, attach listener, then unpause the pipeline.
+    # This ensures that the listener gets all the output from the view.
+    pipeline.start_paused()
     out = pipeline.listen("googl_stocks")
-    pipeline.start()
+    pipeline.resume()
 
     # important: `wait_for_completion` will block forever here
     pipeline.wait_for_idle()

--- a/python/docs/pandas.rst
+++ b/python/docs/pandas.rst
@@ -74,11 +74,12 @@ To ensure all data is received start listening before calling
     df_students = pd.read_csv('students.csv')
     df_grades = pd.read_csv('grades.csv')
 
+    pipeline.start()
+
     # listen for the output of the view here in the notebook
     # you do not need to call this if you are forwarding the data to a sink
     out = pipeline.listen("average_scores")
 
-    pipeline.start()
     pipeline.input_pandas("students", df_students)
     pipeline.input_pandas("grades", df_grades)
 

--- a/python/feldera/_callback_runner.py
+++ b/python/feldera/_callback_runner.py
@@ -1,17 +1,10 @@
-from enum import Enum
 from threading import Thread
 from typing import Callable, Optional
-from queue import Queue, Empty
 
 import pandas as pd
 from feldera import FelderaClient
 from feldera._helpers import dataframe_from_response
 from feldera.enums import PipelineFieldSelector
-
-
-class _CallbackRunnerInstruction(Enum):
-    PipelineStarted = 1
-    RanToCompletion = 2
 
 
 class CallbackRunner(Thread):
@@ -21,7 +14,6 @@ class CallbackRunner(Thread):
         pipeline_name: str,
         view_name: str,
         callback: Callable[[pd.DataFrame, int], None],
-        queue: Optional[Queue],
     ):
         super().__init__()
         self.daemon = True
@@ -29,7 +21,6 @@ class CallbackRunner(Thread):
         self.pipeline_name: str = pipeline_name
         self.view_name: str = view_name
         self.callback: Callable[[pd.DataFrame, int], None] = callback
-        self.queue: Optional[Queue] = queue
         self.schema: Optional[dict] = None
 
     def run(self):
@@ -54,70 +45,20 @@ class CallbackRunner(Thread):
                 f"Table or View {self.view_name} not found in the pipeline schema."
             )
 
-        # by default, we assume that the pipeline has been started
-        ack = _CallbackRunnerInstruction.PipelineStarted
+        gen_obj = self.client.listen_to_pipeline(
+            self.pipeline_name,
+            self.view_name,
+            format="json",
+            case_sensitive=self.schema.case_sensitive,
+        )
 
-        # if there is Queue, we wait for the instruction to start the pipeline
-        # this means that we are listening to the pipeline before running it, therefore, all data should be received
-        if self.queue:
-            ack = self.queue.get()
+        iterator = gen_obj()
 
-        match ack:
-            # if the pipeline has actually been started, we start a listener
-            case _CallbackRunnerInstruction.PipelineStarted:
-                # listen to the pipeline
-                gen_obj = self.client.listen_to_pipeline(
-                    self.pipeline_name,
-                    self.view_name,
-                    format="json",
-                    case_sensitive=self.schema.case_sensitive,
+        for chunk in iterator:
+            chunk: dict = chunk
+            data: Optional[list[dict]] = chunk.get("json_data")
+            seq_no: Optional[int] = chunk.get("sequence_number")
+            if data is not None and seq_no is not None:
+                self.callback(
+                    dataframe_from_response([data], self.schema.fields), seq_no
                 )
-
-                # if there is a queue set up, inform the main thread that the listener has been started, and it can
-                # proceed with starting the pipeline
-                if self.queue:
-                    # stop blocking the main thread on `join` for the previous message
-                    self.queue.task_done()
-
-                iterator = gen_obj()
-
-                for chunk in iterator:
-                    chunk: dict = chunk
-                    data: Optional[list[dict]] = chunk.get("json_data")
-                    seq_no: Optional[int] = chunk.get("sequence_number")
-                    if data is not None and seq_no is not None:
-                        self.callback(
-                            dataframe_from_response([data], self.schema.fields), seq_no
-                        )
-
-                    if self.queue:
-                        try:
-                            # if a non-blocking way, check if the queue has received further instructions
-                            # this should be a RanToCompletion instruction, which means that the pipeline has been
-                            # completed
-                            again_ack = self.queue.get_nowait()
-
-                            # if the queue has received a message
-                            if again_ack:
-                                match again_ack:
-                                    case _CallbackRunnerInstruction.RanToCompletion:
-                                        # stop blocking the main thread on `join` and return from this thread
-                                        self.queue.task_done()
-
-                                        return
-
-                                    case _CallbackRunnerInstruction.PipelineStarted:
-                                        # if the pipeline has been started again, which shouldn't happen,
-                                        # ignore it and continue listening, call `task_done` to avoid blocking the main
-                                        # thread on `join`
-                                        self.queue.task_done()
-
-                                        continue
-                        except Empty:
-                            # if the queue is empty, continue listening
-                            continue
-
-            case _CallbackRunnerInstruction.RanToCompletion:
-                if self.queue:
-                    self.queue.task_done()
-                return

--- a/python/feldera/output_handler.py
+++ b/python/feldera/output_handler.py
@@ -1,7 +1,5 @@
 import pandas as pd
-from typing import Optional
 
-from queue import Queue
 from feldera import FelderaClient
 from feldera._callback_runner import CallbackRunner
 
@@ -12,7 +10,6 @@ class OutputHandler:
         client: FelderaClient,
         pipeline_name: str,
         view_name: str,
-        queue: Optional[Queue],
     ):
         """
         Initializes the output handler, but doesn't start it.
@@ -22,7 +19,6 @@ class OutputHandler:
         self.client: FelderaClient = client
         self.pipeline_name: str = pipeline_name
         self.view_name: str = view_name
-        self.queue: Optional[Queue] = queue
         self.buffer: list[pd.DataFrame] = []
 
         # the callback that is passed to the `CallbackRunner`
@@ -32,7 +28,7 @@ class OutputHandler:
 
         # sets up the callback runner
         self.handler = CallbackRunner(
-            self.client, self.pipeline_name, self.view_name, callback, queue
+            self.client, self.pipeline_name, self.view_name, callback
         )
 
     def start(self):

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -68,11 +68,13 @@ class TestPipeline(SharedTestPipeline):
         assert stats.get("outputs") is not None
 
     def test_case_sensitive_views_listen(self):
+        self.pipeline.start_paused()
+
         all_stream = self.pipeline.listen("v0")
         odd_stream = self.pipeline.listen("V0")
         even_stream = self.pipeline.listen("DATE")
 
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl", [{"id": i} for i in range(10)])
         self.pipeline.wait_for_completion()
 
@@ -159,8 +161,9 @@ class TestPipeline(SharedTestPipeline):
         """
         df_students = pd.read_csv("tests/assets/students.csv")
         df_grades = pd.read_csv("tests/assets/grades.csv")
+        self.pipeline.start_paused()
         out = self.pipeline.listen("average_scores")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
         self.pipeline.wait_for_completion(True)
@@ -170,8 +173,9 @@ class TestPipeline(SharedTestPipeline):
     def test_pipeline_get(self):
         df_students = pd.read_csv("tests/assets/students.csv")
         df_grades = pd.read_csv("tests/assets/grades.csv")
+        self.pipeline.start_paused()
         out = self.pipeline.listen("average_scores")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
         self.pipeline.wait_for_completion(True)
@@ -196,8 +200,9 @@ class TestPipeline(SharedTestPipeline):
 
         df_students = pd.read_csv("tests/assets/students.csv")
         df_grades = pd.read_csv("tests/assets/grades.csv")
+        self.pipeline.start_paused()
         self.pipeline.foreach_chunk("average_scores", callback)
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_pandas("students", df_students)
         self.pipeline.input_pandas("grades", df_grades)
         self.pipeline.wait_for_completion(True)
@@ -267,11 +272,12 @@ class TestPipeline(SharedTestPipeline):
             {"json": {"name": "John", "scores": [9, 10]}, "insert_delete": 1},
         ]
         # Set up listeners for all output views
+        self.pipeline.start_paused()
         variant_out = self.pipeline.listen("json_view")
         json_out = self.pipeline.listen("json_string_view")
         average_out = self.pipeline.listen("average_view")
         typed_out = self.pipeline.listen("typed_view")
-        self.pipeline.start()
+        self.pipeline.resume()
 
         # Feed JSON as strings, receive output from `average_view` and `json_view`
         self.pipeline.input_json("json_table", input_strings)
@@ -331,8 +337,9 @@ class TestPipeline(SharedTestPipeline):
 
     def test_input_json0(self):
         data = {"insert": {"id": 1}}
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v0")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl", data, update_format="insert_delete")
         self.pipeline.wait_for_completion(True)
         out_data = out.to_dict()
@@ -341,8 +348,9 @@ class TestPipeline(SharedTestPipeline):
 
     def test_input_json1(self):
         data = [{"id": 1}, {"id": 2}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v0")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl", data)
         self.pipeline.wait_for_completion(True)
         out_data = out.to_dict()
@@ -352,8 +360,9 @@ class TestPipeline(SharedTestPipeline):
     @enterprise_only
     def test_suspend(self):
         data = {"insert": {"id": 1}}
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v0")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl", data, update_format="insert_delete")
         self.pipeline.wait_for_completion(False)
         self.pipeline.stop(force=False)
@@ -382,8 +391,9 @@ class TestPipeline(SharedTestPipeline):
                 ],
             }
         )
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_timestamp")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_pandas("tbl_timestamp", df)
         self.pipeline.wait_for_completion(True)
         df_out = out.to_pandas()
@@ -396,8 +406,9 @@ class TestPipeline(SharedTestPipeline):
         """
         data = [{"c1": [12, 34, 56]}]
         expected_data = [{"c1": [34, 56], "insert_delete": 1}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_binary")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_binary", data=data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -412,8 +423,9 @@ class TestPipeline(SharedTestPipeline):
 
         data = [{"c1": 2.25}]
         expected = [{"c1": Decimal("5.00"), "insert_delete": 1}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_decimal")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_decimal", data=data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -425,8 +437,9 @@ class TestPipeline(SharedTestPipeline):
         CREATE VIEW v_array AS SELECT c1 FROM tbl_array;
         """
         data = [{"c1": [1, 2, 3]}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_array")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_array", data=data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -443,8 +456,9 @@ class TestPipeline(SharedTestPipeline):
         CREATE VIEW v_struct AS SELECT c1 FROM tbl_struct;
         """
         data = [{"c1": {"f1": 1, "f2": "a"}}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_struct")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_struct", data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -467,8 +481,9 @@ class TestPipeline(SharedTestPipeline):
                 "insert_delete": 1,
             }
         ]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_datetime")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_datetime", data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -494,8 +509,9 @@ class TestPipeline(SharedTestPipeline):
                 "c8": "c",
             }
         ]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_simple")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_simple", data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -513,15 +529,17 @@ class TestPipeline(SharedTestPipeline):
         """
         data = [{"c1": {"a": 1, "b": 2}}]
         expected = [{"c1": {"a": 1, "b": 2}, "insert_delete": 1}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_map")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_map", data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
         assert expected == got
         # Second round: single dict
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_map")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_map", {"c1": {"a": 1, "b": 2}})
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -535,8 +553,9 @@ class TestPipeline(SharedTestPipeline):
         import uuid
 
         data = [{"c0": uuid.uuid4()}]
+        self.pipeline.start_paused()
         out = self.pipeline.listen("v_uuid")
-        self.pipeline.start()
+        self.pipeline.resume()
         self.pipeline.input_json("tbl_uuid", data)
         self.pipeline.wait_for_completion(True)
         got = out.to_dict()
@@ -677,10 +696,11 @@ class TestPipeline(SharedTestPipeline):
         ) WITH ('materialized' = 'true');
         """
         # Test egress with URL encoding - listen directly to table with special characters
+        self.pipeline.start_paused()
         out = self.pipeline.listen("t1#a1")
 
         # Test ingress with URL encoding
-        self.pipeline.start()
+        self.pipeline.resume()
         data = [{"c1": "test_value"}]
 
         # Test pushing data to table with special characters in name

--- a/python/tests/runtime/lateness/test_issue4457.py
+++ b/python/tests/runtime/lateness/test_issue4457.py
@@ -21,10 +21,11 @@ class TestIssue_4457(unittest.TestCase):
             TEST_CLIENT, name=unique_pipeline_name("test_issue4457"), sql=sql
         ).create_or_replace()
 
+        pipeline.start_paused()
         # TODO: use .query() instead
         out = pipeline.listen("v")
 
-        pipeline.start()
+        pipeline.resume()
 
         pipeline.input_json(
             "test_events",

--- a/python/tests/runtime/test_udf.py
+++ b/python/tests/runtime/test_udf.py
@@ -236,9 +236,9 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
         ).create_or_replace()
 
         # TODO: use .query() instead
+        pipeline.start_paused()
         out = pipeline.listen("v")
-
-        pipeline.start()
+        pipeline.resume()
 
         pipeline.input_json(
             "t",


### PR DESCRIPTION
The `Pipeline.listen` method can now only be called when the pipeline is running or paused. Previously it was possible to call `Pipeline.listen` before starting the pipeline in order to guarantee that all outputs produced by the pipeline are captured by the listener.  With the new API, you can achieve the same by starting the pipeline in a paused state using `Pipeline.start_paused` and calling `Pipeline.listen` before unpausing the pipeline using `Pipeline.resume`.

This change eliminates some complex code that deal with setting up listeners before starting the pipeline.

The main reason for implementing this simplification now is the upcoming backfill avoidance feature, which would make maintaining the previous API even harder.

Add a brief description of the pull request.

## Checklist

- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [x] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
