### PR TITLE
[SQL] A few more optimizations for empty inputs

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
@@ -3,7 +3,6 @@ package org.dbsp.sqlCompiler.ir.expression;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.dbsp.sqlCompiler.compiler.IConstructor;
 import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
-import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
@@ -40,7 +39,8 @@ public final class DBSPIndexedZSetExpression extends DBSPExpression
 
     @Override
     public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
-        throw new UnimplementedException();
+        // This is accurate only for empty IndexedZSets, which is the only supported case so far
+        return this.getType().sameType(other.getType());
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPMapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPMapExpression.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 /** Represents a map constructor. */
-public final class DBSPMapExpression extends DBSPExpression implements ISameValue, IConstructor {
+public final class DBSPMapExpression extends DBSPExpression implements ISameValue, IConstructor, IDBSPContainer {
     // Both lists must have the same length
     @Nullable
     public final List<DBSPExpression> keys;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/IDBSPContainer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/IDBSPContainer.java
@@ -25,4 +25,6 @@ package org.dbsp.sqlCompiler.ir.expression;
 
 import org.dbsp.util.ICastable;
 
+/** Base interface for classes representing expressions that have container types,
+ * e.g., Array, Map, ZSet, IndexedZSet. */
 public interface IDBSPContainer extends ICastable  { }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -1,8 +1,11 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
@@ -934,5 +937,20 @@ public class IncrementalRegressionTests extends SqlIoTest {
                  1  | a|    2 | 1
                  1  | b|    4 | 1
                  2  | d|    1 | 1""");
+    }
+
+    @Test
+    public void outerJoin() {
+        var cc = this.getCC("""
+                CREATE TABLE tab0(x int);
+                CREATE TABLE tab2(x int);
+                CREATE VIEW V AS SELECT ALL * FROM tab2 AS cor0 LEFT OUTER JOIN tab0 AS cor1 ON NULL IS NOT NULL;""");
+        // The optimizer should reduce this to just a Map operator
+        cc.visit(new CircuitVisitor(cc.compiler) {
+            @Override
+            public void postorder(DBSPJoinBaseOperator node) {
+                Assert.fail("Should have been removed");
+            }
+        });
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -12,7 +12,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStaticItem;
 import org.dbsp.util.Linq;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;


### PR DESCRIPTION
This was motivated by the SLT test failure overnight.
But by looking the program generated I realized that we were missing some optimizations:
- empty constant followed by map-index
- empty constant followed by antijoin