### PR TITLE
[DBSP] Include circuit graph(s) with JSON profile

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -1184,14 +1184,7 @@ impl Serialize for GlobalNodeId {
     where
         S: Serializer,
     {
-        let mut s = "[".to_string();
-        for n in self.0.iter() {
-            if s.len() > 1 {
-                s.push(',');
-            }
-            s.push_str(&n.0.to_string());
-        }
-        s.push(']');
+        let s = self.node_identifier();
         serializer.serialize_str(&s)
     }
 }
@@ -1243,6 +1236,19 @@ impl GlobalNodeId {
         let mut ids = circuit.global_node_id().path().to_owned();
         ids.push(node_id);
         Self(ids)
+    }
+
+    /// Generate unique name to use as a node label in a visual graph.
+    pub fn node_identifier(&self) -> String {
+        let mut node_ident = "n".to_string();
+
+        for i in 0..self.path().len() {
+            node_ident.push_str(&self.path()[i].to_string());
+            if i < self.path().len() - 1 {
+                node_ident.push('_');
+            }
+        }
+        node_ident
     }
 
     /// Returns local node id of `self` or `None` if `self` is the root node.

--- a/crates/dbsp/src/monitor.rs
+++ b/crates/dbsp/src/monitor.rs
@@ -168,6 +168,12 @@ impl TraceMonitor {
         self.visualize_circuit_annotate(|_| ("".to_string(), 0f64))
     }
 
+    /// This is almost like visualize_circuit, but it does not merge
+    /// the two halves of strict operators.
+    pub fn get_circuit(&self) -> VisGraph {
+        self.0.borrow().circuit.get_graph()
+    }
+
     pub fn visualize_circuit_annotate<F>(&self, annotate: F) -> VisGraph
     where
         F: Fn(&GlobalNodeId) -> (String, f64),

--- a/crates/dbsp/src/monitor/circuit_graph.rs
+++ b/crates/dbsp/src/monitor/circuit_graph.rs
@@ -119,6 +119,27 @@ impl Region {
         )
     }
 
+    /// Output region as a cluster in a visual graph.
+    /// Similar to 'visualize', but does not merge halves of strict operators.
+    fn get_graph(&self, scope: &Node) -> ClusterNode {
+        let mut nodes = Vec::new();
+        for nodeid in self.nodes.iter() {
+            if let Some(vnode) = scope.children().unwrap().get(nodeid).unwrap().get_graph() {
+                nodes.push(vnode)
+            }
+        }
+
+        for child in self.children.iter() {
+            nodes.push(VisNode::Cluster(child.get_graph(scope)));
+        }
+
+        ClusterNode::new(
+            Self::region_identifier(&scope.id, &self.id),
+            label(&self.name, self.location),
+            nodes,
+        )
+    }
+
     fn do_add_region(
         &mut self,
         path: &[usize],
@@ -287,16 +308,8 @@ impl Node {
 
     /// Generate unique name for the node to use as a node label in a visual
     /// graph.
-    fn node_identifier(node_id: &GlobalNodeId) -> String {
-        let mut node_ident = "n".to_string();
-
-        for i in 0..node_id.path().len() {
-            node_ident.push_str(&node_id.path()[i].to_string());
-            if i < node_id.path().len() - 1 {
-                node_ident.push('_');
-            }
-        }
-        node_ident
+    pub(super) fn node_identifier(node_id: &GlobalNodeId) -> String {
+        node_id.node_identifier()
     }
 
     /// Output circuit node as a node in a visual graph.
@@ -330,6 +343,26 @@ impl Node {
                     annotation
                 ),
                 importance,
+            ))),
+            NodeKind::StrictOutput => None,
+        }
+    }
+
+    /// Output circuit node as a node in a visual graph, without merging the two halves of strict operators.
+    fn get_graph(&self) -> Option<VisNode> {
+        match &self.kind {
+            NodeKind::Operator => Some(VisNode::Simple(SimpleNode::new(
+                Self::node_identifier(&self.id),
+                label(&self.name, self.location),
+                0f64,
+            ))),
+
+            NodeKind::Circuit { region, .. } => Some(VisNode::Cluster(region.get_graph(self))),
+
+            NodeKind::StrictInput { .. } => Some(VisNode::Simple(SimpleNode::new(
+                Self::node_identifier(&self.id),
+                label(&self.name, self.location),
+                0f64,
             ))),
             NodeKind::StrictOutput => None,
         }
@@ -409,6 +442,29 @@ impl CircuitGraph {
                         to_node.is_circuit(),
                     ));
                 }
+            }
+        }
+
+        VisGraph::new(cluster, edges)
+    }
+
+    /// Similar to 'visualize' without any annotations, but it does not merge the two halves of strict operators.
+    pub(super) fn get_graph(&self) -> VisGraph {
+        let cluster = self.nodes.get_graph().unwrap().cluster().unwrap();
+
+        let mut edges = Vec::new();
+
+        for (from_id, to) in self.edges.iter() {
+            let from_node = self.node_ref(from_id).unwrap();
+
+            for (to_id, _kind) in to.iter() {
+                let to_node = self.node_ref(to_id).unwrap();
+                edges.push(VisEdge::new(
+                    Node::node_identifier(from_id),
+                    from_node.is_circuit(),
+                    Node::node_identifier(to_id),
+                    to_node.is_circuit(),
+                ));
             }
         }
 

--- a/crates/dbsp/src/profile.rs
+++ b/crates/dbsp/src/profile.rs
@@ -248,14 +248,19 @@ $(foreach format,$(FORMATS),$(eval $(call format_template,$(format))))
 }
 
 /// Runtime profiles collected from all DBSP worker threads.
+/// This also includes the circuit graph.
 #[derive(Debug, Serialize)]
 pub struct DbspProfile {
     pub worker_profiles: Vec<WorkerProfile>,
+    pub graph: Option<Graph>,
 }
 
 impl DbspProfile {
-    pub fn new(worker_profiles: Vec<WorkerProfile>) -> Self {
-        Self { worker_profiles }
+    pub fn new(worker_profiles: Vec<WorkerProfile>, graph: Option<Graph>) -> Self {
+        Self {
+            worker_profiles,
+            graph,
+        }
     }
 
     /// Serialize the profile as a JSON string
@@ -547,6 +552,11 @@ impl Profiler {
         }
 
         WorkerProfile::new(metadata)
+    }
+
+    /// Dump the circuit graph without any processing.
+    pub fn dump_graph(&self) -> Graph {
+        self.monitor.get_circuit()
     }
 
     /// Dump profile in graphviz format.


### PR DESCRIPTION
Recently we have added the capability of retrieving a profile in JSON format.
However, the profile is just a map from node to metadata.
This PR adds to the JSON document an array of graphs, one per worker.
I believe that today all graphs are identical, so maybe this can be simplified.
The node name serialization has been changed to match in the profile and in the graph.