### PR TITLE
[adapters] Parse Avro UUID as VARCHAR.

### DIFF
--- a/crates/adapters/src/format/avro/schema.rs
+++ b/crates/adapters/src/format/avro/schema.rs
@@ -299,6 +299,17 @@ fn validate_uuid_schema(avro_schema: &AvroSchema) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_string_schema(avro_schema: &AvroSchema) -> Result<(), String> {
+    if !matches!(avro_schema, AvroSchema::String | AvroSchema::Uuid) {
+        return Err(format!(
+            "invalid Avro schema for a column of type 'STRING': expected 'string' or '{{\"type\": \"string\",\"logicalType\": \"uuid\"}}', but found {}",
+            schema_json(avro_schema)
+        ));
+    }
+
+    Ok(())
+}
+
 /// Check that Avro schema can be deserialized a SQL column with the given
 /// column type.
 pub fn validate_field_schema(
@@ -327,7 +338,7 @@ pub fn validate_field_schema(
         SqlType::Decimal => {
             return validate_decimal_schema(avro_schema, field_schema);
         }
-        SqlType::Char | SqlType::Varchar => AvroSchema::String,
+        SqlType::Char | SqlType::Varchar => return validate_string_schema(avro_schema),
         SqlType::Binary => {
             return validate_binary_schema(avro_schema, field_schema);
         }


### PR DESCRIPTION
Even though we natively support the SQL UUID type, users sometimes want to ingest it into a column of type String. This commit relaxes Avro schema validation to allow this.

Fixes #4837 