### PR TITLE
[WebConsole] Fix cursor jumps to beginning when pipeline polling is in flight

### DIFF
--- a/web-console/src/lib/components/layout/pipelines/PipelineConfigurationsPopup.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineConfigurationsPopup.svelte
@@ -5,16 +5,13 @@
   import JSONbig from 'true-json-bigint'
   import MultiJSONDialog from '$lib/components/dialogs/MultiJSONDialog.svelte'
   import { useToast } from '$lib/compositions/useToastNotification'
-  import Tooltip from '$lib/components/common/Tooltip.svelte'
+  import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
 
   let {
     pipeline,
     pipelineBusy
   }: {
-    pipeline: {
-      current: ExtendedPipeline
-      patch: (pipeline: Partial<Pipeline>) => Promise<ExtendedPipeline>
-    }
+    pipeline: WritablePipeline
     pipelineBusy: boolean
   } = $props()
 

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -45,17 +45,14 @@
   import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import PipelineCrashBanner from '$lib/components/pipelines/editor/PipelineCrashBanner.svelte'
+  import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
 
   let {
     preloaded,
     pipeline
   }: {
     preloaded: { pipelines: PipelineThumb[] }
-    pipeline: {
-      current: ExtendedPipeline
-      patch: (pipeline: Partial<Pipeline>) => Promise<ExtendedPipeline>
-      optimisticUpdate: (newPipeline: Partial<ExtendedPipeline>) => Promise<void>
-    }
+    pipeline: WritablePipeline
   } = $props()
 
   let editCodeDisabled = $derived(
@@ -102,7 +99,7 @@
             return current.programCode
           },
           set current(programCode: string) {
-            patch({ programCode })
+            patch({ programCode }, true)
           }
         },
         language: 'sql' as const,
@@ -132,7 +129,7 @@
             return current.programUdfRs
           },
           set current(programUdfRs: string) {
-            patch({ programUdfRs })
+            patch({ programUdfRs }, true)
           }
         },
         language: 'rust' as const,
@@ -154,7 +151,7 @@ pub fn my_udf(input: String) -> Result<String, Box<dyn std::error::Error>> {
             return current.programUdfToml
           },
           set current(programUdfToml: string) {
-            patch({ programUdfToml })
+            patch({ programUdfToml }, true)
           }
         },
         language: 'graphql' as const,

--- a/web-console/src/lib/components/layout/pipelines/PipelineToolbarMenuPopup.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineToolbarMenuPopup.svelte
@@ -10,6 +10,7 @@
   import JSONbig from 'true-json-bigint'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
+  import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
 
   let {
     pipelineName,
@@ -20,10 +21,7 @@
     onDeletePipeline
   }: {
     pipelineName: string
-    pipeline: {
-      current: ExtendedPipeline
-      patch: (pipeline: Partial<Pipeline>) => Promise<ExtendedPipeline>
-    }
+    pipeline: WritablePipeline
     saveFile: () => void
     pipelineBusy: boolean
     downstreamChanged: boolean

--- a/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -63,6 +63,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
   import { useIsMobile } from '$lib/compositions/layout/useIsMobile.svelte'
   import { usePipelineAction } from '$lib/compositions/usePipelineAction.svelte'
   import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
 
   let {
     pipeline,
@@ -73,11 +74,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
     saveFile,
     class: _class = ''
   }: {
-    pipeline: {
-      current: ExtendedPipeline
-      patch: (pipeline: Partial<Pipeline>) => Promise<ExtendedPipeline>
-      optimisticUpdate: (newPipeline: Partial<ExtendedPipeline>) => Promise<void>
-    }
+    pipeline: WritablePipeline
     onDeletePipeline?: (pipelineName: string) => void
     editConfigDisabled: boolean
     unsavedChanges: boolean
@@ -234,9 +231,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
         { SqlCompiled: P.any },
         { CompilingRust: P.any },
         (cause) => [
-          Object.values(cause)[0].cause === 'upgrade'
-            ? ('_unschedule' as const)
-            : ('_spacer_long' as const),
+          ...(Object.values(cause)[0].cause === 'upgrade' ? ['_unschedule' as const] : []),
           '_start_pending',
           '_saveFile',
           '_configurations',

--- a/web-console/src/lib/compositions/usePipelineAction.svelte.ts
+++ b/web-console/src/lib/compositions/usePipelineAction.svelte.ts
@@ -82,10 +82,8 @@ export const usePipelineAction = () => {
 
       // Apply optimistic updates
       if (optimisticStatus) {
-        // pipeline.optimisticUpdate({ status: optimisticStatus })
         updatePipeline(pipeline_name, (p) => ({ ...p, status: optimisticStatus }))
       } else if (action === 'clear') {
-        // pipeline.optimisticUpdate({ storageStatus: 'Clearing' })
         updatePipeline(pipeline_name, (p) => ({ ...p, storageStatus: 'Clearing' }))
       }
 

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -231,7 +231,7 @@ const toPipeline = <
   pipeline: P
 ) => ({
   name: pipeline.name,
-  description: pipeline.description,
+  description: pipeline.description ?? '',
   runtimeConfig: pipeline.runtime_config,
   programConfig: pipeline.program_config,
   programCode: pipeline.program_code ?? '',

--- a/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.svelte
+++ b/web-console/src/routes/(system)/(authenticated)/(pipelines)/pipelines/[pipelineName]/+page.svelte
@@ -7,7 +7,7 @@
   } from '$lib/compositions/useWritablePipeline.svelte.js'
   import { goto } from '$app/navigation'
   import { base } from '$app/paths'
-  import type { ExtendedPipeline } from '$lib/services/pipelineManager.js'
+  import type { ExtendedPipeline, PipelineThumb } from '$lib/services/pipelineManager.js'
   import { usePipelineList } from '$lib/compositions/pipelines/usePipelineList.svelte.js'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte.js'
 
@@ -22,17 +22,21 @@
   let set = (pipeline: ExtendedPipeline) => {
     pipelineCache.current = pipeline
   }
+  let update = (pipeline: Partial<ExtendedPipeline>) => {
+    pipelineCache.current = { ...pipelineCache.current, ...pipeline }
+  }
   const api = usePipelineManager()
-  let pipeline = $derived(writablePipeline(api, pipelineCache, set))
+  let pipeline = $derived(writablePipeline({ api, pipeline: pipelineCache, set, update }))
   const pipelineList = usePipelineList(data.preloaded)
 
-  useRefreshPipeline(
-    () => pipelineCache,
+  useRefreshPipeline({
+    getPreloaded: () => data.preloadedPipeline,
+    getPipelines: () => pipelineList.pipelines,
+    getPipeline: () => pipelineCache,
     set,
-    () => data.preloadedPipeline,
-    () => pipelineList.pipelines,
-    () => goto(`${base}/`)
-  )
+    update,
+    onNotFound: () => goto(`${base}/`)
+  })
 </script>
 
 <PipelineEditLayout preloaded={data.preloaded} {pipeline}></PipelineEditLayout>


### PR DESCRIPTION
This is more likely to occur on a slower connection to a Feldera instance

Fix https://github.com/feldera/feldera/issues/4835: The cursor jumps to the beginning of the code

The issue was caused by local code cache not getting updated before patch pipeline request resolves, before which a pipeline polling request could resolve and overwrite the code editor with now-stale cache data. The solution is to optimistically update code state cache