### PR TITLE
[manager, webconsole] Explicitly manage pipelines' runtime version

### DIFF
--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -174,6 +174,8 @@ jobs:
           AUTH_ISSUER: ${{ vars.OIDC_TEST_ISSUER }}
           RUST_LOG: info
           RUST_BACKTRACE: 1
+          # Needed by test_update_runtime.py
+          FELDERA_UNSTABLE_FEATURES: "testing"
         options: >-
           --health-cmd "curl --fail --request GET --url http://localhost:8080/healthz || exit 1"
           --health-interval 10s

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -426,6 +426,14 @@ pub enum PipelineAction {
         /// The new value for the configuration.
         value: String,
     },
+    /// Recompile a pipeline with the Feldera runtime version included in the
+    /// currently installed Feldera platform.
+    #[clap(aliases = &["update-runtime"])]
+    UpdateRuntime {
+        /// The name of the pipeline.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        name: String,
+    },
     /// Delete a pipeline.
     #[clap(aliases = &["del"])]
     Delete {

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -1292,6 +1292,21 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 }
             }
         }
+        PipelineAction::UpdateRuntime { name } => {
+            let response = client
+                .post_update_runtime()
+                .pipeline_name(name.clone())
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to update pipeline runtime",
+                    1,
+                ))
+                .unwrap();
+            println!("Pipeline runtime updated successfully.");
+            trace!("{:#?}", response);
+        }
         PipelineAction::Program { action } => program(format, action, client).await,
         PipelineAction::Connector {
             name,

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -374,7 +374,7 @@ impl PipelineSelectedInfoInternal {
             program_code: None,
             udf_rust: None,
             udf_toml: None,
-            program_config: None,
+            program_config: Some(extended_pipeline.program_config),
             program_version: extended_pipeline.program_version,
             program_status: extended_pipeline.program_status,
             program_status_since: extended_pipeline.program_status_since,
@@ -466,6 +466,7 @@ pub enum PipelineFieldSelector {
     /// - `created_at`
     /// - `version`
     /// - `platform_version`
+    /// - `program_config`
     /// - `program_version`
     /// - `program_status`
     /// - `program_status_since`

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -177,6 +177,8 @@ It contains the following fields:
         endpoints::pipeline_management::post_pipeline,
         endpoints::pipeline_management::put_pipeline,
         endpoints::pipeline_management::patch_pipeline,
+        endpoints::pipeline_management::post_pipeline_testing,
+        endpoints::pipeline_management::post_update_runtime,
         endpoints::pipeline_management::delete_pipeline,
         endpoints::pipeline_management::post_pipeline_start,
         endpoints::pipeline_management::post_pipeline_stop,
@@ -457,6 +459,8 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_management::post_pipeline)
         .service(endpoints::pipeline_management::put_pipeline)
         .service(endpoints::pipeline_management::patch_pipeline)
+        .service(endpoints::pipeline_management::post_pipeline_testing)
+        .service(endpoints::pipeline_management::post_update_runtime)
         .service(endpoints::pipeline_management::delete_pipeline)
         .service(endpoints::pipeline_management::post_pipeline_start)
         .service(endpoints::pipeline_management::post_pipeline_stop)

--- a/crates/pipeline-manager/src/db/listen_table.rs
+++ b/crates/pipeline-manager/src/db/listen_table.rs
@@ -415,6 +415,7 @@ mod test {
                 &Some("example-renamed".to_string()),
                 &Some("Description of example2".to_string()),
                 "v0",
+                false,
                 &None,
                 &Some("CREATE TABLE example ( col1 VARCHAR );".to_string()),
                 &None,

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -32,6 +32,7 @@ impl ExtendedPipelineDescrRunner {
                 created_at: pipeline.created_at,
                 version: pipeline.version,
                 platform_version: pipeline.platform_version.clone(),
+                program_config: pipeline.program_config.clone(),
                 program_version: pipeline.program_version,
                 program_status: pipeline.program_status,
                 program_status_since: pipeline.program_status_since,

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2845,6 +2845,7 @@ fn convert_descriptor_to_monitoring(
         created_at: pipeline.created_at,
         version: pipeline.version,
         platform_version: pipeline.platform_version.clone(),
+        program_config: pipeline.program_config.clone(),
         program_version: pipeline.program_version,
         program_status: pipeline.program_status,
         program_status_since: pipeline.program_status_since,

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -263,6 +263,7 @@ pub struct ExtendedPipelineDescrMonitoring {
     pub created_at: DateTime<Utc>,
     pub version: Version,
     pub platform_version: String,
+    pub program_config: serde_json::Value,
     pub program_version: Version,
     pub program_status: ProgramStatus,
     pub program_status_since: DateTime<Utc>,

--- a/crates/pipeline-manager/src/lib.rs
+++ b/crates/pipeline-manager/src/lib.rs
@@ -22,7 +22,8 @@ static UNSTABLE_FEATURES: OnceLock<HashSet<&'static str>> = OnceLock::new();
 
 /// Initialization function to set the platform's unstable feature gate.
 pub fn platform_enable_unstable(requested_features: &str) {
-    let all_features: HashSet<&'static str> = HashSet::from_iter(vec!["runtime_version"]);
+    let all_features: HashSet<&'static str> =
+        HashSet::from_iter(vec!["runtime_version", "testing"]);
     let mut enabled = HashSet::new();
     for requested_feature in requested_features.split(',') {
         if let Some(supported_feature) = all_features.get(requested_feature) {
@@ -69,4 +70,11 @@ pub fn init_fd_limit() {
             debug!("Failed to raise fd limit: {}", e);
         }
     }
+}
+
+/// Check if a pipeline compiled for the specificed `runtime_version` is compatible with the current `platform_version`.
+// TODO: this is a placeholder implementation for now.
+// TODO: do we need `platform_version` here at all? This can be implicitly the current running platform version.
+pub fn is_supported_runtime(_platform_version: &str, _runtime_version: &str) -> bool {
+    true
 }

--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -38,7 +38,7 @@ pub enum RunnerError {
     AutomatonFailedToSerializeDeploymentConfig {
         error: String,
     },
-    AutomatonCannotProvisionDifferentPlatformVersion {
+    AutomatonCannotProvisionUnsupportedPlatformVersion {
         pipeline_platform_version: String,
         runner_platform_version: String,
     },
@@ -117,8 +117,8 @@ impl DetailedError for RunnerError {
             RunnerError::AutomatonFailedToSerializeDeploymentConfig { .. } => {
                 Cow::from("AutomatonFailedToSerializeDeploymentConfig")
             }
-            RunnerError::AutomatonCannotProvisionDifferentPlatformVersion { .. } => {
-                Cow::from("AutomatonCannotProvisionDifferentPlatformVersion")
+            RunnerError::AutomatonCannotProvisionUnsupportedPlatformVersion { .. } => {
+                Cow::from("AutomatonCannotProvisionUnsupportedPlatformVersion")
             }
             RunnerError::AutomatonProvisioningTimeout { .. } => {
                 Cow::from("AutomatonProvisioningTimeout")
@@ -224,14 +224,14 @@ impl Display for RunnerError {
                     "Failed to serialize deployment configuration due to: {error}"
                 )
             }
-            Self::AutomatonCannotProvisionDifferentPlatformVersion {
+            Self::AutomatonCannotProvisionUnsupportedPlatformVersion {
                 pipeline_platform_version,
                 runner_platform_version,
             } => {
                 write!(
                     f,
                     "Unable to provision pipeline because the pipeline platform version ({pipeline_platform_version}) \
-                    differs from the runner platform version ({runner_platform_version}) -- stop and restart the pipeline to resolve this"
+                    is not supported by the installed Feldera platform version ({runner_platform_version}) -- recompile the pipeline with the current platform version to resolve this"
                 )
             }
             Self::AutomatonProvisioningTimeout { timeout } => {
@@ -348,7 +348,7 @@ impl ResponseError for RunnerError {
             Self::AutomatonFailedToSerializeDeploymentConfig { .. } => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
-            Self::AutomatonCannotProvisionDifferentPlatformVersion { .. } => {
+            Self::AutomatonCannotProvisionUnsupportedPlatformVersion { .. } => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::AutomatonProvisioningTimeout { .. } => StatusCode::INTERNAL_SERVER_ERROR,

--- a/openapi.json
+++ b/openapi.json
@@ -4583,6 +4583,73 @@
         ]
       }
     },
+    "/v0/pipelines/{pipeline_name}/testing": {
+      "post": {
+        "tags": [
+          "Pipeline management"
+        ],
+        "summary": "This endpoint is used as part of the test harness. Only available if the `testing`",
+        "description": "unstable feature is enabled. Do not use in production.",
+        "operationId": "post_pipeline_testing",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "set_platform_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request successfully processed"
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Endpoint is disabled. Set FELDERA_UNSTABLE_FEATURES=\"testing\" to enable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
     "/v0/pipelines/{pipeline_name}/time_series": {
       "get": {
         "tags": [
@@ -4798,6 +4865,180 @@
                       }
                     }
                   }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
+    "/v0/pipelines/{pipeline_name}/update_runtime": {
+      "post": {
+        "tags": [
+          "Pipeline management"
+        ],
+        "summary": "Recompile a pipeline with the Feldera runtime version included in the",
+        "description": "currently installed Feldera platform.\n\nUse this endpoint after upgrading Feldera to rebuild pipelines that were\ncompiled with older platform versions. In most cases, recompilation is not\nrequired; pipelines compiled with older versions will continue to run on the\nupgraded platform.\n\nSituations where recompilation may be necessary:\n- To benefit from the latest bug fixes and performance optimizations.\n- When backward-incompatible changes are introduced in Feldera. In this case,\nattempting to start a pipeline compiled with an unsupported version will\nresult in an error.\n\nIf the pipeline is already compiled with the current platform version,\nthis operation is a no-op.\n\nNote that recompiling the pipeline with a new platform version may change its\nquery plan. If the modified pipeline is started from an existing checkpoint,\nit may require bootstrapping parts of its state from scratch.  See Feldera\ndocumentation for details on the bootstrapping process.",
+        "operationId": "post_update_runtime",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PipelineInfo"
+                },
+                "example": {
+                  "id": "67e55044-10b1-426f-9247-bb680e5fe0c8",
+                  "name": "example1",
+                  "description": "Description of the pipeline example1",
+                  "created_at": "1970-01-01T00:00:00Z",
+                  "version": 4,
+                  "platform_version": "v0",
+                  "runtime_config": {
+                    "workers": 16,
+                    "storage": {
+                      "backend": {
+                        "name": "default"
+                      },
+                      "min_storage_bytes": null,
+                      "min_step_storage_bytes": null,
+                      "compression": "default",
+                      "cache_mib": null
+                    },
+                    "fault_tolerance": {
+                      "model": "none",
+                      "checkpoint_interval_secs": 60
+                    },
+                    "cpu_profiler": true,
+                    "tracing": false,
+                    "tracing_endpoint_jaeger": "",
+                    "min_batch_size_records": 0,
+                    "max_buffering_delay_usecs": 0,
+                    "resources": {
+                      "cpu_cores_min": null,
+                      "cpu_cores_max": null,
+                      "memory_mb_min": null,
+                      "memory_mb_max": null,
+                      "storage_mb_max": null,
+                      "storage_class": null
+                    },
+                    "clock_resolution_usecs": 1000000,
+                    "pin_cpus": [],
+                    "provisioning_timeout_secs": null,
+                    "max_parallel_connector_init": null,
+                    "init_containers": null,
+                    "checkpoint_during_suspend": true,
+                    "http_workers": null,
+                    "io_workers": null,
+                    "dev_tweaks": {},
+                    "logging": null
+                  },
+                  "program_code": "CREATE TABLE table1 ( col1 INT );",
+                  "udf_rust": "",
+                  "udf_toml": "",
+                  "program_config": {
+                    "profile": "optimized",
+                    "cache": true,
+                    "runtime_version": null
+                  },
+                  "program_version": 2,
+                  "program_status": "Pending",
+                  "program_status_since": "1970-01-01T00:00:00Z",
+                  "program_error": {
+                    "sql_compilation": null,
+                    "rust_compilation": null,
+                    "system_error": null
+                  },
+                  "program_info": null,
+                  "deployment_error": null,
+                  "refresh_version": 4,
+                  "storage_status": "Cleared",
+                  "deployment_id": null,
+                  "deployment_initial": null,
+                  "deployment_status": "Stopped",
+                  "deployment_status_since": "1970-01-01T00:00:00Z",
+                  "deployment_desired_status": "Stopped",
+                  "deployment_desired_status_since": "1970-01-01T00:00:00Z",
+                  "deployment_resources_status": "Stopped",
+                  "deployment_resources_status_since": "1970-01-01T00:00:00Z",
+                  "deployment_resources_desired_status": "Stopped",
+                  "deployment_resources_desired_status_since": "1970-01-01T00:00:00Z",
+                  "deployment_runtime_status": null,
+                  "deployment_runtime_status_since": null,
+                  "deployment_runtime_desired_status": null,
+                  "deployment_runtime_desired_status_since": null
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Cannot update non-stopped pipeline": {
+                    "value": {
+                      "message": "Pipeline can only be updated while stopped. Stop it first by invoking '/stop'.",
+                      "error_code": "UpdateRestrictedToStopped",
+                      "details": null
+                    }
+                  },
+                  "Name does not match pattern": {
+                    "value": {
+                      "message": "Name 'name-with-invalid-char-#' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)",
+                      "error_code": "NameDoesNotMatchPattern",
+                      "details": {
+                        "name": "name-with-invalid-char-#"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -287,6 +287,21 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             },
         )
 
+    def testing_force_update_platform_version(self, name: str, platform_version: str):
+        self.http.post(
+            path=f"/pipelines/{name}/testing",
+            params={"set_platform_version": platform_version},
+        )
+
+    def update_pipeline_runtime(self, name: str):
+        """
+        Recompile a pipeline with the Feldera runtime version included in the currently installed Feldera platform.
+
+        :param name: The name of the pipeline
+        """
+
+        self.http.post(path=f"/pipelines/{name}/update_runtime")
+
     def delete_pipeline(self, name: str):
         """
         Deletes a pipeline by name

--- a/python/feldera/rest/pipeline.py
+++ b/python/feldera/rest/pipeline.py
@@ -57,6 +57,7 @@ class Pipeline:
         )
         self.program_status: Optional[str] = None
         self.program_status_since: Optional[str] = None
+        self.platform_version: Optional[str] = None
         self.program_error: Optional[dict] = None
         self.storage_status: Optional[str] = None
 

--- a/python/tests/platform/test_pipeline_crud.py
+++ b/python/tests/platform/test_pipeline_crud.py
@@ -56,6 +56,7 @@ PIPELINE_FIELD_SELECTOR_STATUS_FIELDS = [
     "created_at",
     "version",
     "platform_version",
+    "program_config",
     "program_version",
     "program_status",
     "program_status_since",

--- a/python/tests/platform/test_update_runtime.py
+++ b/python/tests/platform/test_update_runtime.py
@@ -1,0 +1,78 @@
+import unittest
+
+from feldera.pipeline_builder import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import unique_pipeline_name
+from tests import TEST_CLIENT
+from feldera.enums import PipelineStatus
+
+
+class TestPipeline(unittest.TestCase):
+    def test_update_runtime(self):
+        """
+        Test the /update_runtime API.
+
+        Pipeline's platform version should only be updated to the current version on-demand
+        (by calling /update_runtime) or when updating the pipeline code.
+        """
+
+        pipeline_name = unique_pipeline_name("test_update_runtime")
+
+        sql = """
+        CREATE TABLE tbl(id INT) WITH ('materialized' = 'true');
+CREATE MATERIALIZED VIEW v0 AS SELECT * FROM tbl;
+        """
+
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                dev_tweaks={"backfill_avoidance": True},
+            ),
+        ).create_or_replace()
+
+        # Make sure the pipeline gets compiled, so we can set its platform version
+        # without having it overwriten by the compiler.
+        pipeline.start()
+        assert pipeline.status() == PipelineStatus.RUNNING
+        pipeline.stop(force=True)
+
+        pipeline.testing_force_update_platform_version("0.0.1")
+        assert pipeline.platform_version() == "0.0.1"
+
+        # Run pipeline compiled by a previous version of the platform without triggering recompilation.
+        pipeline.start()
+
+        assert pipeline.status() == PipelineStatus.RUNNING
+        assert pipeline.platform_version() == "0.0.1"
+
+        # update_runtime fails while the pipeline is running
+        with self.assertRaises(Exception):
+            pipeline.update_runtime()
+
+        pipeline.stop(force=True)
+
+        # update_runtime works when the pipeline is stopped
+        pipeline.update_runtime()
+        assert pipeline.platform_version() != "0.0.1"
+
+        pipeline.start()
+        assert pipeline.status() == PipelineStatus.RUNNING
+
+        pipeline.stop(force=True)
+
+        # Modifying program code updates platform version automatically.
+        pipeline.testing_force_update_platform_version("0.0.1")
+        assert pipeline.platform_version() == "0.0.1"
+
+        pipeline.modify(sql=sql + "\nCREATE MATERIALIZED VIEW v1 AS SELECT * FROM tbl;")
+        pipeline.start()
+        assert pipeline.status() == PipelineStatus.RUNNING
+        assert pipeline.platform_version() != "0.0.1"
+
+        pipeline.stop(force=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web-console/src/lib/components/layout/Footer.svelte
+++ b/web-console/src/lib/components/layout/Footer.svelte
@@ -28,7 +28,7 @@
         rel="noreferrer"
         href={page.data.feldera.changelog}
         class="btn justify-start px-4 hover:bg-surface-50-950"
-        >{page.data.feldera.edition} v{page.data.feldera.version} Changelog</a
+        >{page.data.feldera.edition} {page.data.feldera.version} Changelog</a
       >
     {/if}
     <div class="btn justify-start px-4">© Feldera {new Date().getUTCFullYear()}</div>

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -46,6 +46,8 @@
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import PipelineCrashBanner from '$lib/components/pipelines/editor/PipelineCrashBanner.svelte'
   import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
+  import PipelineVersion from '$lib/components/pipelines/editor/PipelineVersion.svelte'
+  import { page } from '$app/state'
 
   let {
     preloaded,
@@ -387,7 +389,16 @@ example = "1.0"`
             </div>
           {/snippet}
           {#snippet statusBarCenter()}
-            <ProgramStatus programStatus={programStatusOf(pipeline.current.status)}></ProgramStatus>
+            {@const programStatus = programStatusOf(pipeline.current.status)}
+            <ProgramStatus {programStatus}></ProgramStatus>
+            <div class="flex items-center gap-2 pl-1">
+              <PipelineVersion
+                runtimeVersion={pipeline.current.platformVersion}
+                baseRuntimeVersion={page.data.feldera!.version}
+                configuredRuntimeVersion={(pipeline.current.runtimeConfig as any).platformVersion}
+                {programStatus}
+              ></PipelineVersion>
+            </div>
           {/snippet}
           {#snippet statusBarEnd()}
             <div class="ml-auto flex flex-nowrap items-center gap-1">

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -395,7 +395,7 @@ example = "1.0"`
               <PipelineVersion
                 runtimeVersion={pipeline.current.platformVersion}
                 baseRuntimeVersion={page.data.feldera!.version}
-                configuredRuntimeVersion={(pipeline.current.runtimeConfig as any).platformVersion}
+                configuredRuntimeVersion={pipeline.current.programConfig?.runtime_version}
                 {programStatus}
               ></PipelineVersion>
             </div>

--- a/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -393,6 +393,7 @@ example = "1.0"`
             <ProgramStatus {programStatus}></ProgramStatus>
             <div class="flex items-center gap-2 pl-1">
               <PipelineVersion
+                pipelineName={pipeline.current.name}
                 runtimeVersion={pipeline.current.platformVersion}
                 baseRuntimeVersion={page.data.feldera!.version}
                 configuredRuntimeVersion={pipeline.current.programConfig?.runtime_version}

--- a/web-console/src/lib/components/other/ClipboardCopyButton.svelte
+++ b/web-console/src/lib/components/other/ClipboardCopyButton.svelte
@@ -11,11 +11,11 @@
 </script>
 
 <button
-  class="btn-icon flex-none before:w-4 {_class}"
+  class="btn-icon flex h-9 flex-none before:w-4 before:transition-transform {_class}"
   use:clipboard={value}
   use:clickedClass={{
     base: 'fd fd-copy',
-    clicked: 'fd fd-check text-success-500 text-[20px] pointer-events-none'
+    clicked: 'fd fd-check text-success-500 text-[20px] pointer-events-none before:-translate-x-0.5'
   }}
   aria-label="Copy to clipboard"
 >

--- a/web-console/src/lib/components/pipelines/Table.svelte
+++ b/web-console/src/lib/components/pipelines/Table.svelte
@@ -179,6 +179,7 @@
           <td class="relative border-surface-100-900 group-hover:bg-surface-50-950">
             <div class="flex w-full flex-nowrap items-center gap-2 text-nowrap">
               <PipelineVersion
+                pipelineName={pipeline.name}
                 runtimeVersion={pipeline.platformVersion}
                 baseRuntimeVersion={page.data.feldera!.version}
                 configuredRuntimeVersion={pipeline.programConfig.runtime_version}

--- a/web-console/src/lib/components/pipelines/Table.svelte
+++ b/web-console/src/lib/components/pipelines/Table.svelte
@@ -12,6 +12,8 @@
   import { match } from 'ts-pattern'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
   import { unionName, type NamesInUnion } from '$lib/functions/common/union'
+  import PipelineVersion from './table/PipelineVersion.svelte'
+  import { page } from '$app/state'
   let {
     pipelines,
     preHeaderEnd,
@@ -105,6 +107,11 @@
         <th class="px-1 py-1 text-left"
           ><span class="text-base font-normal text-surface-950-50">Message</span></th
         >
+        <ThSort {table} class="w-20 px-1 py-1 xl:w-32" field="platformVersion">
+          <span class="text-base font-normal text-surface-950-50">
+            Runtime <span class="hidden xl:!inline">version</span>
+          </span>
+        </ThSort>
         <ThSort {table} class="px-1 py-1" field="lastStatusSince"
           ><span class="text-base font-normal text-surface-950-50">Status changed</span></ThSort
         >
@@ -168,6 +175,14 @@
                 {message.slice(0, ((idx) => (idx > 0 ? idx : undefined))(message.indexOf('\n')))}
               {/if}
             </span>
+          </td>
+          <td class="relative border-surface-100-900 group-hover:bg-surface-50-950">
+            <div class="flex flex-nowrap items-center w-full justify-end gap-2 text-nowrap text-right">
+              <PipelineVersion
+                runtimeVersion={pipeline.platformVersion}
+                baseRuntimeVersion={page.data.feldera!.version}
+              ></PipelineVersion>
+            </div>
           </td>
           <td class="relative w-28 border-surface-100-900 group-hover:bg-surface-50-950">
             <div class="w-32 text-nowrap text-right">

--- a/web-console/src/lib/components/pipelines/Table.svelte
+++ b/web-console/src/lib/components/pipelines/Table.svelte
@@ -177,10 +177,11 @@
             </span>
           </td>
           <td class="relative border-surface-100-900 group-hover:bg-surface-50-950">
-            <div class="flex flex-nowrap items-center w-full justify-end gap-2 text-nowrap text-right">
+            <div class="flex w-full flex-nowrap items-center gap-2 text-nowrap">
               <PipelineVersion
                 runtimeVersion={pipeline.platformVersion}
                 baseRuntimeVersion={page.data.feldera!.version}
+                configuredRuntimeVersion={pipeline.programConfig.runtime_version}
               ></PipelineVersion>
             </div>
           </td>

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
-  import { nonNull } from '$lib/functions/common/function'
+  import {
+    getRuntimeVersionStatus,
+    normalizeRuntimeVersion
+  } from '$lib/functions/pipelines/runtimeVersion'
   import type { ProgramStatus } from '$lib/services/pipelineManager'
 
   let {
@@ -16,16 +19,16 @@
   } = $props()
 
   let versionStatus = $derived(
-    runtimeVersion === baseRuntimeVersion
-      ? ('latest' as const)
-      : nonNull(configuredRuntimeVersion)
-        ? ('custom' as const)
-        : ('update_available' as const)
+    getRuntimeVersionStatus({
+      runtime: runtimeVersion,
+      base: baseRuntimeVersion,
+      configured: configuredRuntimeVersion
+    })
   )
 </script>
 
 {#if programStatus === 'Success'}
-  {runtimeVersion}
+  {normalizeRuntimeVersion(runtimeVersion)}
   {#if versionStatus === 'custom'}
     <span class="chip relative h-5 text-sm text-surface-700-300 preset-outlined-surface-200-800">
       Custom
@@ -36,7 +39,7 @@
       placement="bottom-end"
       activeContent
     >
-      <div>This runtime version is set in compilation configuration.</div>
+      <div>This custom runtime version is set in the compilation configuration.</div>
     </Tooltip>
   {:else if versionStatus === 'update_available'}
     <span class="chip h-5 text-sm text-blue-500 !ring-blue-500 preset-outlined">
@@ -47,7 +50,7 @@
       placement="bottom-end"
       activeContent
     >
-      <div>A newer runtime version {baseRuntimeVersion} is available.</div>
+      <div>A newer runtime version {normalizeRuntimeVersion(baseRuntimeVersion)} is available.</div>
       <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
     </Tooltip>
   {:else}

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import { nonNull } from '$lib/functions/common/function'
+  import type { ProgramStatus } from '$lib/services/pipelineManager'
+
+  let {
+    runtimeVersion,
+    baseRuntimeVersion,
+    configuredRuntimeVersion,
+    programStatus
+  }: {
+    runtimeVersion: string
+    baseRuntimeVersion: string
+    configuredRuntimeVersion: string | null | undefined
+    programStatus: ProgramStatus | undefined
+  } = $props()
+
+  let versionStatus = $derived(
+    runtimeVersion === baseRuntimeVersion
+      ? ('latest' as const)
+      : nonNull(configuredRuntimeVersion)
+        ? ('custom' as const)
+        : ('update_available' as const)
+  )
+</script>
+
+{#if programStatus === 'Success'}
+  {runtimeVersion}
+  {#if versionStatus === 'custom'}
+    <span class="chip relative h-5 text-sm text-surface-700-300 preset-outlined-surface-200-800">
+      Custom
+      <div class="fd fd-info pl-2 text-[14px] text-warning-600-400"></div>
+    </span>
+    <Tooltip
+      class="bg-white-dark z-20 w-96 rounded-container p-4 text-base text-surface-950-50"
+      placement="bottom-end"
+      activeContent
+    >
+      <div>This runtime version is set in compilation configuration.</div>
+    </Tooltip>
+  {:else if versionStatus === 'update_available'}
+    <span class="chip h-5 text-sm text-blue-500 !ring-blue-500 preset-outlined">
+      Update available
+    </span>
+    <Tooltip
+      class="bg-white-dark z-20 w-96 rounded-container p-4 text-base text-surface-950-50"
+      placement="bottom-end"
+      activeContent
+    >
+      <div>A newer runtime version {baseRuntimeVersion} is available.</div>
+      <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
+    </Tooltip>
+  {:else}
+    <span class="chip h-5 text-sm preset-outlined-success-600-400"> Latest </span>
+  {/if}
+{/if}

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import { page } from '$app/state'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
-    getRuntimeVersionStatus,
+    getRuntimeVersion,
     normalizeRuntimeVersion
   } from '$lib/functions/pipelines/runtimeVersion'
   import type { ProgramStatus } from '$lib/services/pipelineManager'
@@ -21,20 +22,23 @@
     programStatus: ProgramStatus | undefined
   } = $props()
 
-  let versionStatus = $derived(
-    getRuntimeVersionStatus({
-      runtime: runtimeVersion,
-      base: baseRuntimeVersion,
-      configured: configuredRuntimeVersion
-    })
+  let { version, status } = $derived(
+    getRuntimeVersion(
+      {
+        runtime: runtimeVersion,
+        base: baseRuntimeVersion,
+        configured: configuredRuntimeVersion
+      },
+      page.data.feldera!.unstableFeatures
+    )
   )
 
   const api = usePipelineManager()
 </script>
 
 {#if programStatus === 'Success'}
-  {normalizeRuntimeVersion(runtimeVersion)}
-  {#if versionStatus === 'custom'}
+  {version}
+  {#if status === 'custom'}
     <span class="chip relative h-5 text-sm text-surface-700-300 preset-outlined-surface-200-800">
       Custom
       <div class="fd fd-info pl-2 text-[14px] text-warning-600-400"></div>
@@ -46,7 +50,7 @@
     >
       <div>This custom runtime version is set in the compilation configuration.</div>
     </Tooltip>
-  {:else if versionStatus === 'update_available'}
+  {:else if status === 'update_available'}
     <span class="chip h-5 text-sm text-blue-500 !ring-blue-500 preset-outlined">
       Update available
     </span>

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -36,7 +36,7 @@
   const api = usePipelineManager()
 </script>
 
-{#if programStatus === 'Success'}
+{#if programStatus === 'Success' || programStatus === 'SystemError' || programStatus === 'SqlError' || programStatus === 'SqlCompiled' || programStatus === 'RustError'}
   {version}
   {#if status === 'custom'}
     <span class="chip relative h-5 text-sm text-surface-700-300 preset-outlined-surface-200-800">

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
     getRuntimeVersionStatus,
     normalizeRuntimeVersion
@@ -7,11 +8,13 @@
   import type { ProgramStatus } from '$lib/services/pipelineManager'
 
   let {
+    pipelineName,
     runtimeVersion,
     baseRuntimeVersion,
     configuredRuntimeVersion,
     programStatus
   }: {
+    pipelineName: string
     runtimeVersion: string
     baseRuntimeVersion: string
     configuredRuntimeVersion: string | null | undefined
@@ -25,6 +28,8 @@
       configured: configuredRuntimeVersion
     })
   )
+
+  const api = usePipelineManager()
 </script>
 
 {#if programStatus === 'Success'}
@@ -51,7 +56,10 @@
       activeContent
     >
       <div>A newer runtime version {normalizeRuntimeVersion(baseRuntimeVersion)} is available.</div>
-      <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
+      <button
+        class="btn mt-2 h-6 preset-filled-primary-500"
+        onclick={() => api.postUpdateRuntime(pipelineName)}>Update</button
+      >
     </Tooltip>
   {:else}
     <span class="chip h-5 text-sm preset-outlined-success-600-400"> Latest </span>

--- a/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/editor/PipelineVersion.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import ClipboardCopyButton from '$lib/components/other/ClipboardCopyButton.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
     getRuntimeVersion,
@@ -37,7 +38,15 @@
 </script>
 
 {#if programStatus === 'Success' || programStatus === 'SystemError' || programStatus === 'SqlError' || programStatus === 'SqlCompiled' || programStatus === 'RustError'}
-  {version}
+  {#if version.length < 11}
+    {version}
+  {:else}
+    <div class="flex flex-nowrap items-center">
+      {version.slice(0, 7)}
+      <span class="select-none">...</span>
+      <ClipboardCopyButton value={version}></ClipboardCopyButton>
+    </div>
+  {/if}
   {#if status === 'custom'}
     <span class="chip relative h-5 text-sm text-surface-700-300 preset-outlined-surface-200-800">
       Custom

--- a/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import ClipboardCopyButton from '$lib/components/other/ClipboardCopyButton.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
     getRuntimeVersion,
@@ -60,4 +61,12 @@
 {:else}
   <div class="w-5"></div>
 {/if}
-<span class="text-sm">{version}</span>
+{#if version.length < 11}
+  <span class="text-sm">{version}</span>
+{:else}
+  <div class="flex flex-nowrap items-center">
+    {version.slice(0, 7)}
+    <span class="select-none text-sm">...</span>
+    <ClipboardCopyButton value={version}></ClipboardCopyButton>
+  </div>
+{/if}

--- a/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
@@ -1,20 +1,29 @@
 <script lang="ts">
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import {
+    getRuntimeVersionStatus,
+    normalizeRuntimeVersion
+  } from '$lib/functions/pipelines/runtimeVersion'
 
   let {
     runtimeVersion,
-    baseRuntimeVersion
+    baseRuntimeVersion,
+    configuredRuntimeVersion
   }: {
     runtimeVersion: string
     baseRuntimeVersion: string
+    configuredRuntimeVersion: string | null | undefined
   } = $props()
 
   let versionStatus = $derived(
-    runtimeVersion === baseRuntimeVersion ? ('latest' as const) : ('update_available' as const)
+    getRuntimeVersionStatus({
+      runtime: runtimeVersion,
+      base: baseRuntimeVersion,
+      configured: configuredRuntimeVersion
+    })
   )
 </script>
 
-{runtimeVersion}
 {#if versionStatus === 'update_available'}
   <div class="fd fd-info pb-0.5 text-[16px] text-blue-500 !ring-blue-500"></div>
   <Tooltip
@@ -23,9 +32,20 @@
     strategy="fixed"
     activeContent
   >
-    <div>A newer runtime version {baseRuntimeVersion} is available.</div>
+    <div>A newer runtime version {normalizeRuntimeVersion(baseRuntimeVersion)} is available.</div>
     <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
+  </Tooltip>
+{:else if versionStatus === 'custom'}
+  <div class="fd fd-info pb-0.5 text-[16px] text-warning-500 !ring-warning-500"></div>
+  <Tooltip
+    class="bg-white-dark z-20 rounded-container p-4 text-base text-surface-950-50"
+    placement="bottom-end"
+    strategy="fixed"
+    activeContent
+  >
+    <div>This custom runtime version is set in the compilation configuration.</div>
   </Tooltip>
 {:else}
   <div class="w-5"></div>
 {/if}
+<span class="text-sm">{normalizeRuntimeVersion(runtimeVersion)}</span>

--- a/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+
+  let {
+    runtimeVersion,
+    baseRuntimeVersion
+  }: {
+    runtimeVersion: string
+    baseRuntimeVersion: string
+  } = $props()
+
+  let versionStatus = $derived(
+    runtimeVersion === baseRuntimeVersion ? ('latest' as const) : ('update_available' as const)
+  )
+</script>
+
+{runtimeVersion}
+{#if versionStatus === 'update_available'}
+  <div class="fd fd-info pb-0.5 text-[16px] text-blue-500 !ring-blue-500"></div>
+  <Tooltip
+    class="bg-white-dark z-20 rounded-container p-4 text-base text-surface-950-50"
+    placement="bottom-end"
+    strategy="fixed"
+    activeContent
+  >
+    <div>A newer runtime version {baseRuntimeVersion} is available.</div>
+    <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
+  </Tooltip>
+{:else}
+  <div class="w-5"></div>
+{/if}

--- a/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
+  import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
     getRuntimeVersionStatus,
     normalizeRuntimeVersion
   } from '$lib/functions/pipelines/runtimeVersion'
 
   let {
+    pipelineName,
     runtimeVersion,
     baseRuntimeVersion,
     configuredRuntimeVersion
   }: {
+    pipelineName: string
     runtimeVersion: string
     baseRuntimeVersion: string
     configuredRuntimeVersion: string | null | undefined
@@ -22,6 +25,8 @@
       configured: configuredRuntimeVersion
     })
   )
+
+  let api = usePipelineManager()
 </script>
 
 {#if versionStatus === 'update_available'}
@@ -33,7 +38,10 @@
     activeContent
   >
     <div>A newer runtime version {normalizeRuntimeVersion(baseRuntimeVersion)} is available.</div>
-    <!-- <button class="btn mt-2 h-6 preset-filled-primary-500">Update</button> -->
+    <button
+      class="btn mt-2 h-6 preset-filled-primary-500"
+      onclick={() => api.postUpdateRuntime(pipelineName)}>Update</button
+    >
   </Tooltip>
 {:else if versionStatus === 'custom'}
   <div class="fd fd-info pb-0.5 text-[16px] text-warning-500 !ring-warning-500"></div>

--- a/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
+++ b/web-console/src/lib/components/pipelines/table/PipelineVersion.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import { page } from '$app/state'
   import { Tooltip } from '$lib/components/common/Tooltip.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import {
-    getRuntimeVersionStatus,
+    getRuntimeVersion,
     normalizeRuntimeVersion
   } from '$lib/functions/pipelines/runtimeVersion'
 
@@ -18,18 +19,21 @@
     configuredRuntimeVersion: string | null | undefined
   } = $props()
 
-  let versionStatus = $derived(
-    getRuntimeVersionStatus({
-      runtime: runtimeVersion,
-      base: baseRuntimeVersion,
-      configured: configuredRuntimeVersion
-    })
+  let { version, status } = $derived(
+    getRuntimeVersion(
+      {
+        runtime: runtimeVersion,
+        base: baseRuntimeVersion,
+        configured: configuredRuntimeVersion
+      },
+      page.data.feldera!.unstableFeatures
+    )
   )
 
   let api = usePipelineManager()
 </script>
 
-{#if versionStatus === 'update_available'}
+{#if status === 'update_available'}
   <div class="fd fd-info pb-0.5 text-[16px] text-blue-500 !ring-blue-500"></div>
   <Tooltip
     class="bg-white-dark z-20 rounded-container p-4 text-base text-surface-950-50"
@@ -43,7 +47,7 @@
       onclick={() => api.postUpdateRuntime(pipelineName)}>Update</button
     >
   </Tooltip>
-{:else if versionStatus === 'custom'}
+{:else if status === 'custom'}
   <div class="fd fd-info pb-0.5 text-[16px] text-warning-500 !ring-warning-500"></div>
   <Tooltip
     class="bg-white-dark z-20 rounded-container p-4 text-base text-surface-950-50"
@@ -56,4 +60,4 @@
 {:else}
   <div class="w-5"></div>
 {/if}
-<span class="text-sm">{normalizeRuntimeVersion(runtimeVersion)}</span>
+<span class="text-sm">{version}</span>

--- a/web-console/src/lib/components/version/VersionDisplay.svelte
+++ b/web-console/src/lib/components/version/VersionDisplay.svelte
@@ -25,6 +25,6 @@
     </Tooltip>
   {/if}
   {#if page.data.feldera?.update?.version}
-    <span>latest: v{page.data.feldera.update.version}</span>
+    <span>latest: {page.data.feldera.update.version}</span>
   {/if}
 </div>

--- a/web-console/src/lib/compositions/usePipelineManager.svelte.ts
+++ b/web-console/src/lib/compositions/usePipelineManager.svelte.ts
@@ -25,7 +25,8 @@ import {
   type PipelineAction,
   type PipelineStatus,
   type PipelineThumb,
-  type SupportBundleOptions
+  type SupportBundleOptions,
+  postUpdateRuntime
 } from '$lib/services/pipelineManager'
 import { useToast } from '$lib/compositions/useToastNotification'
 import type { FunctionType } from '$lib/types/common/function'
@@ -136,6 +137,10 @@ export const usePipelineManager = () => {
     postPipelineAction: reportError(
       postPipelineAction,
       (pipelineName, action) => `Failed to ${action} ${pipelineName} pipeline`
+    ),
+    postUpdateRuntime: reportError(
+      postUpdateRuntime,
+      (pipelineName) => `Failed to update runtime for ${pipelineName} pipeline`
     ),
     getAuthConfig: getAuthConfig,
     getConfig: getConfig,

--- a/web-console/src/lib/functions/pipelines/runtimeVersion.ts
+++ b/web-console/src/lib/functions/pipelines/runtimeVersion.ts
@@ -2,14 +2,24 @@ import { nonNull } from '$lib/functions/common/function'
 
 export const normalizeRuntimeVersion = (version: string) => version.replace(/\+.*/, '')
 
-export const getRuntimeVersionStatus = (version: {
-  runtime: string
-  base: string
-  configured: string | null | undefined
-}) => {
-  return normalizeRuntimeVersion(version.runtime) === normalizeRuntimeVersion(version.base)
-    ? ('latest' as const)
-    : nonNull(version.configured)
-      ? ('custom' as const)
-      : ('update_available' as const)
+export const getRuntimeVersion = (
+  version: {
+    runtime: string
+    base: string
+    configured: string | null | undefined
+  },
+  unstableFeatures: string[]
+) => {
+  return nonNull(version.configured) && unstableFeatures.includes('runtime_version')
+    ? {
+        version: normalizeRuntimeVersion(version.configured),
+        status: 'custom' as const
+      }
+    : {
+        version: normalizeRuntimeVersion(version.runtime),
+        status:
+          normalizeRuntimeVersion(version.runtime) === normalizeRuntimeVersion(version.base)
+            ? ('latest' as const)
+            : ('update_available' as const)
+      }
 }

--- a/web-console/src/lib/functions/pipelines/runtimeVersion.ts
+++ b/web-console/src/lib/functions/pipelines/runtimeVersion.ts
@@ -1,0 +1,15 @@
+import { nonNull } from '$lib/functions/common/function'
+
+export const normalizeRuntimeVersion = (version: string) => version.replace(/\+.*/, '')
+
+export const getRuntimeVersionStatus = (version: {
+  runtime: string
+  base: string
+  configured: string | null | undefined
+}) => {
+  return normalizeRuntimeVersion(version.runtime) === normalizeRuntimeVersion(version.base)
+    ? ('latest' as const)
+    : nonNull(version.configured)
+      ? ('custom' as const)
+      : ('update_available' as const)
+}

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -100,6 +100,11 @@ export const $AuthProvider = {
   ]
 } as const
 
+export const $BootstrapPolicy = {
+  type: 'string',
+  enum: ['allow', 'reject', 'await_approval']
+} as const
+
 export const $BuildInformation = {
   type: 'object',
   description: 'Information about the build of the platform.',
@@ -356,6 +361,7 @@ export const $CombinedStatus = {
     'Provisioning',
     'Unavailable',
     'Standby',
+    'AwaitingApproval',
     'Initializing',
     'Bootstrapping',
     'Replaying',
@@ -1905,6 +1911,19 @@ connector initializes.`,
 The number of offsets must match the number of partitions in the topic.`
         }
       }
+    },
+    {
+      type: 'object',
+      required: ['timestamp'],
+      properties: {
+        timestamp: {
+          type: 'integer',
+          format: 'int64',
+          description: `Start from a particular timestamp in the topic.
+
+Kafka timestamps are in milliseconds since the epoch.`
+        }
+      }
     }
   ],
   description: 'Where to begin reading a Kafka topic.'
@@ -2567,6 +2586,10 @@ used during a step.`,
       type: 'object',
       required: ['inputs'],
       properties: {
+        dataflow: {
+          type: 'string',
+          nullable: true
+        },
         inputs: {
           type: 'object',
           description: 'Input endpoint configuration.',
@@ -2887,6 +2910,10 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
       ],
       nullable: true
     },
+    deployment_runtime_status_details: {
+      type: 'string',
+      nullable: true
+    },
     deployment_runtime_status_since: {
       type: 'string',
       format: 'date-time',
@@ -3070,6 +3097,18 @@ Default: 1 MiB`,
       description: 'The maximum number of records in a single buffer.',
       nullable: true,
       minimum: 0
+    },
+    on_conflict_do_nothing: {
+      type: 'boolean',
+      description: `Specifies how the connector handles conflicts when executing an \`INSERT\`
+into a table with a primary key. By default, an existing row with the same
+key is overwritten. Setting this flag to \`true\` preserves the existing row
+and ignores the new insert.
+
+This setting does not affect \`UPDATE\` statements, which always replace the
+value associated with the key.
+
+Default: \`false\``
     },
     ssl_ca_pem: {
       type: 'string',
@@ -3989,6 +4028,7 @@ determined by the pipeline and taken over by the runner.`,
     'Unavailable',
     'Standby',
     'Initializing',
+    'AwaitingApproval',
     'Bootstrapping',
     'Replaying',
     'Paused',

--- a/web-console/src/lib/services/manager/schemas.gen.ts
+++ b/web-console/src/lib/services/manager/schemas.gen.ts
@@ -100,11 +100,6 @@ export const $AuthProvider = {
   ]
 } as const
 
-export const $BootstrapPolicy = {
-  type: 'string',
-  enum: ['allow', 'reject', 'await_approval']
-} as const
-
 export const $BuildInformation = {
   type: 'object',
   description: 'Information about the build of the platform.',
@@ -361,7 +356,6 @@ export const $CombinedStatus = {
     'Provisioning',
     'Unavailable',
     'Standby',
-    'AwaitingApproval',
     'Initializing',
     'Bootstrapping',
     'Replaying',
@@ -2586,10 +2580,6 @@ used during a step.`,
       type: 'object',
       required: ['inputs'],
       properties: {
-        dataflow: {
-          type: 'string',
-          nullable: true
-        },
         inputs: {
           type: 'object',
           description: 'Input endpoint configuration.',
@@ -2908,10 +2898,6 @@ If an optional field is not selected (i.e., is \`None\`), it will not be seriali
           $ref: '#/components/schemas/RuntimeStatus'
         }
       ],
-      nullable: true
-    },
-    deployment_runtime_status_details: {
-      type: 'string',
       nullable: true
     },
     deployment_runtime_status_since: {
@@ -4028,7 +4014,6 @@ determined by the pipeline and taken over by the runner.`,
     'Unavailable',
     'Standby',
     'Initializing',
-    'AwaitingApproval',
     'Bootstrapping',
     'Replaying',
     'Paused',

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -46,9 +46,6 @@ import type {
   PostPipelineActivateData,
   PostPipelineActivateError,
   PostPipelineActivateResponse,
-  PostPipelineApproveData,
-  PostPipelineApproveError,
-  PostPipelineApproveResponse,
   CheckpointPipelineData,
   CheckpointPipelineError,
   CheckpointPipelineResponse,
@@ -310,16 +307,6 @@ export const postPipelineActivate = (options: Options<PostPipelineActivateData>)
   return (options?.client ?? client).post<PostPipelineActivateResponse, PostPipelineActivateError>({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/activate'
-  })
-}
-
-/**
- * TODO
- */
-export const postPipelineApprove = (options: Options<PostPipelineApproveData>) => {
-  return (options?.client ?? client).post<PostPipelineApproveResponse, PostPipelineApproveError>({
-    ...options,
-    url: '/v0/pipelines/{pipeline_name}/approve'
   })
 }
 

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -118,12 +118,18 @@ import type {
   PostPipelineInputConnectorActionData,
   PostPipelineInputConnectorActionError,
   PostPipelineInputConnectorActionResponse,
+  PostPipelineTestingData,
+  PostPipelineTestingError,
+  PostPipelineTestingResponse,
   GetPipelineTimeSeriesData,
   GetPipelineTimeSeriesError,
   GetPipelineTimeSeriesResponse,
   GetPipelineTimeSeriesStreamData,
   GetPipelineTimeSeriesStreamError,
   GetPipelineTimeSeriesStreamResponse,
+  PostUpdateRuntimeData,
+  PostUpdateRuntimeError,
+  PostUpdateRuntimeResponse,
   GetPipelineOutputConnectorStatusData,
   GetPipelineOutputConnectorStatusError,
   GetPipelineOutputConnectorStatusResponse
@@ -676,6 +682,17 @@ export const postPipelineInputConnectorAction = (
 }
 
 /**
+ * This endpoint is used as part of the test harness. Only available if the `testing`
+ * unstable feature is enabled. Do not use in production.
+ */
+export const postPipelineTesting = (options: Options<PostPipelineTestingData>) => {
+  return (options?.client ?? client).post<PostPipelineTestingResponse, PostPipelineTestingError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/testing'
+  })
+}
+
+/**
  * Retrieve time series for statistics of a running or paused pipeline.
  */
 export const getPipelineTimeSeries = (options: Options<GetPipelineTimeSeriesData>) => {
@@ -701,6 +718,36 @@ export const getPipelineTimeSeriesStream = (options: Options<GetPipelineTimeSeri
   >({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/time_series_stream'
+  })
+}
+
+/**
+ * Recompile a pipeline with the Feldera runtime version included in the
+ * currently installed Feldera platform.
+ *
+ * Use this endpoint after upgrading Feldera to rebuild pipelines that were
+ * compiled with older platform versions. In most cases, recompilation is not
+ * required; pipelines compiled with older versions will continue to run on the
+ * upgraded platform.
+ *
+ * Situations where recompilation may be necessary:
+ * - To benefit from the latest bug fixes and performance optimizations.
+ * - When backward-incompatible changes are introduced in Feldera. In this case,
+ * attempting to start a pipeline compiled with an unsupported version will
+ * result in an error.
+ *
+ * If the pipeline is already compiled with the current platform version,
+ * this operation is a no-op.
+ *
+ * Note that recompiling the pipeline with a new platform version may change its
+ * query plan. If the modified pipeline is started from an existing checkpoint,
+ * it may require bootstrapping parts of its state from scratch.  See Feldera
+ * documentation for details on the bootstrapping process.
+ */
+export const postUpdateRuntime = (options: Options<PostUpdateRuntimeData>) => {
+  return (options?.client ?? client).post<PostUpdateRuntimeResponse, PostUpdateRuntimeError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/update_runtime'
   })
 }
 

--- a/web-console/src/lib/services/manager/services.gen.ts
+++ b/web-console/src/lib/services/manager/services.gen.ts
@@ -46,6 +46,9 @@ import type {
   PostPipelineActivateData,
   PostPipelineActivateError,
   PostPipelineActivateResponse,
+  PostPipelineApproveData,
+  PostPipelineApproveError,
+  PostPipelineApproveResponse,
   CheckpointPipelineData,
   CheckpointPipelineError,
   CheckpointPipelineResponse,
@@ -307,6 +310,16 @@ export const postPipelineActivate = (options: Options<PostPipelineActivateData>)
   return (options?.client ?? client).post<PostPipelineActivateResponse, PostPipelineActivateError>({
     ...options,
     url: '/v0/pipelines/{pipeline_name}/activate'
+  })
+}
+
+/**
+ * TODO
+ */
+export const postPipelineApprove = (options: Options<PostPipelineApproveData>) => {
+  return (options?.client ?? client).post<PostPipelineApproveResponse, PostPipelineApproveError>({
+    ...options,
+    url: '/v0/pipelines/{pipeline_name}/approve'
   })
 }
 

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -66,8 +66,6 @@ export type AuthProvider =
       GenericOidc: ProviderGenericOidc
     }
 
-export type BootstrapPolicy = 'allow' | 'reject' | 'await_approval'
-
 /**
  * Information about the build of the platform.
  */
@@ -243,7 +241,6 @@ export type CombinedStatus =
   | 'Provisioning'
   | 'Unavailable'
   | 'Standby'
-  | 'AwaitingApproval'
   | 'Initializing'
   | 'Bootstrapping'
   | 'Replaying'
@@ -1896,7 +1893,6 @@ export type PipelineConfig = {
    */
   workers?: number
 } & {
-  dataflow?: string | null
   /**
    * Input endpoint configuration.
    */
@@ -1988,7 +1984,6 @@ export type PipelineSelectedInfo = {
   deployment_runtime_desired_status?: RuntimeDesiredStatus | null
   deployment_runtime_desired_status_since?: string | null
   deployment_runtime_status?: RuntimeStatus | null
-  deployment_runtime_status_details?: string | null
   deployment_runtime_status_since?: string | null
   deployment_status: CombinedStatus
   deployment_status_since: string
@@ -2700,7 +2695,6 @@ export type RuntimeStatus =
   | 'Unavailable'
   | 'Standby'
   | 'Initializing'
-  | 'AwaitingApproval'
   | 'Bootstrapping'
   | 'Replaying'
   | 'Paused'
@@ -3460,27 +3454,11 @@ export type PostPipelineActivateData = {
      */
     pipeline_name: string
   }
-  query?: {
-    initial?: string
-  }
 }
 
 export type PostPipelineActivateResponse = CheckpointResponse
 
 export type PostPipelineActivateError = ErrorResponse
-
-export type PostPipelineApproveData = {
-  path: {
-    /**
-     * Unique pipeline name
-     */
-    pipeline_name: string
-  }
-}
-
-export type PostPipelineApproveResponse = CheckpointResponse
-
-export type PostPipelineApproveError = ErrorResponse
 
 export type CheckpointPipelineData = {
   path: {
@@ -3765,7 +3743,6 @@ export type PostPipelineStartData = {
     pipeline_name: string
   }
   query?: {
-    bootstrap_policy?: BootstrapPolicy
     /**
      * The `initial` parameter determines whether to after provisioning the pipeline make it
      * become `standby`, `paused` or `running` (only valid values).
@@ -4219,23 +4196,6 @@ export type $OpenApiTs = {
   '/v0/pipelines/{pipeline_name}/activate': {
     post: {
       req: PostPipelineActivateData
-      res: {
-        /**
-         * Pipeline activation initiated
-         */
-        '202': CheckpointResponse
-        /**
-         * Pipeline with that name does not exist
-         */
-        '404': ErrorResponse
-        '500': ErrorResponse
-        '503': ErrorResponse
-      }
-    }
-  }
-  '/v0/pipelines/{pipeline_name}/approve': {
-    post: {
-      req: PostPipelineApproveData
       res: {
         /**
          * Pipeline activation initiated

--- a/web-console/src/lib/services/manager/types.gen.ts
+++ b/web-console/src/lib/services/manager/types.gen.ts
@@ -3916,6 +3916,22 @@ export type PostPipelineInputConnectorActionResponse = unknown
 
 export type PostPipelineInputConnectorActionError = ErrorResponse
 
+export type PostPipelineTestingData = {
+  path: {
+    /**
+     * Unique pipeline name
+     */
+    pipeline_name: string
+  }
+  query?: {
+    set_platform_version?: string | null
+  }
+}
+
+export type PostPipelineTestingResponse = unknown
+
+export type PostPipelineTestingError = ErrorResponse
+
 export type GetPipelineTimeSeriesData = {
   path: {
     /**
@@ -3941,6 +3957,19 @@ export type GetPipelineTimeSeriesStreamData = {
 export type GetPipelineTimeSeriesStreamResponse = string
 
 export type GetPipelineTimeSeriesStreamError = ErrorResponse
+
+export type PostUpdateRuntimeData = {
+  path: {
+    /**
+     * Unique pipeline name
+     */
+    pipeline_name: string
+  }
+}
+
+export type PostUpdateRuntimeResponse = PipelineInfo
+
+export type PostUpdateRuntimeError = ErrorResponse
 
 export type GetPipelineOutputConnectorStatusData = {
   path: {
@@ -4669,6 +4698,25 @@ export type $OpenApiTs = {
       }
     }
   }
+  '/v0/pipelines/{pipeline_name}/testing': {
+    post: {
+      req: PostPipelineTestingData
+      res: {
+        /**
+         * Request successfully processed
+         */
+        '200': unknown
+        /**
+         * Pipeline with that name does not exist
+         */
+        '404': ErrorResponse
+        /**
+         * Endpoint is disabled. Set FELDERA_UNSTABLE_FEATURES="testing" to enable.
+         */
+        '405': ErrorResponse
+      }
+    }
+  }
   '/v0/pipelines/{pipeline_name}/time_series': {
     get: {
       req: GetPipelineTimeSeriesData
@@ -4700,6 +4748,23 @@ export type $OpenApiTs = {
         '404': ErrorResponse
         '500': ErrorResponse
         '503': ErrorResponse
+      }
+    }
+  }
+  '/v0/pipelines/{pipeline_name}/update_runtime': {
+    post: {
+      req: PostUpdateRuntimeData
+      res: {
+        /**
+         * Pipeline successfully updated
+         */
+        '200': PipelineInfo
+        '400': ErrorResponse
+        /**
+         * Pipeline with that name does not exist
+         */
+        '404': ErrorResponse
+        '500': ErrorResponse
       }
     }
   }

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -223,7 +223,8 @@ const toPipelineThumb = (
   refreshVersion: pipeline.refresh_version,
   platformVersion: pipeline.platform_version,
   deploymentResourcesStatus: pipeline.deployment_resources_status,
-  deploymentResourcesStatusSince: new Date(pipeline.deployment_resources_status_since)
+  deploymentResourcesStatusSince: new Date(pipeline.deployment_resources_status_since),
+  programConfig: pipeline.program_config!
 })
 
 const toPipeline = <

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -221,6 +221,7 @@ const toPipelineThumb = (
   deploymentError: pipeline.deployment_error,
   programStatusSince: pipeline.program_status_since,
   refreshVersion: pipeline.refresh_version,
+  platformVersion: pipeline.platform_version,
   deploymentResourcesStatus: pipeline.deployment_resources_status,
   deploymentResourcesStatusSince: new Date(pipeline.deployment_resources_status_since)
 })
@@ -264,6 +265,7 @@ const toExtendedPipeline = ({
   runtimeConfig: pipeline.runtime_config,
   version: pipeline.version,
   refreshVersion: pipeline.refresh_version,
+  platformVersion: pipeline.platform_version,
   storageStatus: pipeline.storage_status,
   ...consolidatePipelineStatus(
     program_status,

--- a/web-console/src/lib/services/pipelineManager.ts
+++ b/web-console/src/lib/services/pipelineManager.ts
@@ -12,6 +12,7 @@ import {
   postPipelinePause,
   postPipelineStop,
   postPipelineClear,
+  postUpdateRuntime as _postUpdateRuntime,
   type ErrorResponse,
   postPipeline as _postPipeline,
   type PipelineInfo,
@@ -431,6 +432,10 @@ export const postPipelineAction = async (pipeline_name: string, action: Pipeline
     }),
     (v) => v
   )
+}
+
+export const postUpdateRuntime = async (pipeline_name: string) => {
+  return mapResponse(_postUpdateRuntime({ path: { pipeline_name } }), (v) => v)
 }
 
 export const getAuthConfig = () =>

--- a/web-console/src/routes/+layout.ts
+++ b/web-console/src/routes/+layout.ts
@@ -49,6 +49,7 @@ export type LayoutData = {
         }
         tenantId: string
         tenantName: string
+        unstableFeatures: string[]
         config: Configuration
       }
     | undefined
@@ -180,6 +181,7 @@ export const load = async ({ fetch, url }): Promise<LayoutData> => {
       revision: config.revision,
       tenantId: sessionConfig?.tenant_id || '',
       tenantName: sessionConfig?.tenant_name || '',
+      unstableFeatures: config.unstable_features?.split(',').map((f) => f.trim()) || [],
       config
     }
   }


### PR DESCRIPTION
Fixes #4732

- Change the runner to start pipelines compiled with an older platform versiin
- Add an /update_runtime endpoint to manually trigger recompilation with the current platform

- WebConsole
  - Expose the pipeline's version in the UI
  - Indicate if the pipeline was compiled with an older version of Feldera platform, add an "Update" button to trigger recompilation

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

There shouldn't be any.