### PR TITLE
[adapters] Pin pydantic version.

### DIFF
--- a/crates/iceberg/src/test/requirements.ci.txt
+++ b/crates/iceberg/src/test/requirements.ci.txt
@@ -3,3 +3,5 @@ numpy==2.2.0
 pandas==2.2.3
 pyarrow==17.0.0
 pyiceberg[sql-sqlite]==0.8.1
+# Transitive dependency via pyiceberg.
+pydantic==2.11.10

--- a/crates/iceberg/src/test/requirements.txt
+++ b/crates/iceberg/src/test/requirements.txt
@@ -2,3 +2,5 @@ numpy==2.2.0
 pandas==2.2.3
 pyarrow==17.0.0
 pyiceberg[s3fs,glue,sql-sqlite]==0.8.1
+# Transitive dependency via pyiceberg.
+pydantic==2.11.10


### PR DESCRIPTION
We have a transitive dependency on pydantic in iceberg tests. It looks like a recent release (3 hours ago at the time of writing) broke pyiceberg. I pinned the pydantic version as a workaround.
