### PR TITLE
[SQL] Two more optimizations related to unused fields

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -85,6 +85,7 @@ public class CircuitOptimizer extends Passes {
         this.add(new UnusedFields(compiler));
         this.add(new Intern(compiler));
         this.add(new CSE(compiler));
+        this.add(new OptimizeWithGraph(compiler, g -> new CloneOperatorsWithFanout(compiler, g)));
         this.add(new ExpandAggregates(compiler, compiler.weightVar));
         this.add(new ExpandAggregateZero(compiler));
         this.add(new DeadCode(compiler, true));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CloneOperatorsWithFanout.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CloneOperatorsWithFanout.java
@@ -1,0 +1,56 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPUnaryOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.util.Linq;
+
+/** We do something very simple: if an operator has a fanout greater than 1,
+ * and if any of its successors can be merged with it, we just make a clone of the operator. */
+public class CloneOperatorsWithFanout extends CircuitCloneWithGraphsVisitor {
+    public CloneOperatorsWithFanout(DBSPCompiler compiler, CircuitGraphs graphs) {
+        super(compiler, graphs, false);
+    }
+
+    boolean shouldCloneInput(DBSPUnaryOperator operator) {
+        DBSPOperator input = operator.input().node();
+        int inputFanout = this.getGraph().getFanout(input);
+        if (inputFanout == 1)
+            return false;
+        return input.is(DBSPMapOperator.class) ||
+                input.is(DBSPMapIndexOperator.class) ||
+                input.is(DBSPFilterOperator.class);
+    }
+
+    void cloneInput(DBSPUnaryOperator operator) {
+        if (this.shouldCloneInput(operator)) {
+            DBSPUnaryOperator input = operator.input().node().to(DBSPUnaryOperator.class);
+            OutputPort inputInput = this.mapped(input.input());
+            DBSPOperator inputClone = input.withInputs(Linq.list(inputInput), true);
+            this.addOperator(inputClone);
+            DBSPOperator replace = operator.withInputs(Linq.list(inputClone.getOutput(0)), true);
+            this.map(operator.getOutput(0), replace.getOutput(0));
+        } else {
+            super.postorder(operator);
+        }
+    }
+
+    @Override
+    public void postorder(DBSPMapOperator operator) {
+        this.cloneInput(operator);
+    }
+
+    @Override
+    public void postorder(DBSPMapIndexOperator operator) {
+        this.cloneInput(operator);
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator operator) {
+        this.cloneInput(operator);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/ReplaceCommonProjections.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/ReplaceCommonProjections.java
@@ -8,6 +8,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteEmptyRel;
@@ -55,6 +56,12 @@ public class ReplaceCommonProjections extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPStreamJoinOperator operator) {
+        if (!this.process(operator))
+            super.postorder(operator);
+    }
+
+    @Override
+    public void postorder(DBSPStreamJoinIndexOperator operator) {
         if (!this.process(operator))
             super.postorder(operator);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -914,6 +914,424 @@ public class IncrementalRegressionTests extends SqlIoTest {
     }
 
     @Test
+    public void testHashes2() {
+        String common = """
+                CREATE TABLE LINEITEM (
+                        L_ORDERKEY    INTEGER NOT NULL,
+                        L_PARTKEY     INTEGER NOT NULL,
+                        L_SUPPKEY     INTEGER NOT NULL,
+                        L_LINENUMBER  INTEGER NOT NULL,
+                        L_QUANTITY    DECIMAL(15,2) NOT NULL,
+                        L_EXTENDEDPRICE  DECIMAL(15,2) NOT NULL,
+                        L_DISCOUNT    DECIMAL(15,2) NOT NULL,
+                        L_TAX         DECIMAL(15,2) NOT NULL,
+                        L_RETURNFLAG  CHAR(1) NOT NULL,
+                        L_LINESTATUS  CHAR(1) NOT NULL,
+                        L_SHIPDATE    DATE NOT NULL,
+                        L_COMMITDATE  DATE NOT NULL,
+                        L_RECEIPTDATE DATE NOT NULL,
+                        L_SHIPINSTRUCT CHAR(25) NOT NULL,
+                        L_SHIPMODE     CHAR(10) NOT NULL,
+                        L_COMMENT      VARCHAR(44) NOT NULL
+                );
+                
+                -- Orders
+                CREATE TABLE ORDERS  (
+                        O_ORDERKEY       INTEGER NOT NULL,
+                        O_CUSTKEY        INTEGER NOT NULL,
+                        O_ORDERSTATUS    CHAR(1) NOT NULL,
+                        O_TOTALPRICE     DECIMAL(15,2) NOT NULL,
+                        O_ORDERDATE      DATE NOT NULL,
+                        O_ORDERPRIORITY  CHAR(15) NOT NULL,
+                        O_CLERK          CHAR(15) NOT NULL,
+                        O_SHIPPRIORITY   INTEGER NOT NULL,
+                        O_COMMENT        VARCHAR(79) NOT NULL
+                );
+                
+                -- Part
+                CREATE TABLE PART (
+                        P_PARTKEY     INTEGER NOT NULL,
+                        P_NAME        VARCHAR(55) NOT NULL,
+                        P_MFGR        CHAR(25) NOT NULL,
+                        P_BRAND       CHAR(10) NOT NULL,
+                        P_TYPE        VARCHAR(25) NOT NULL,
+                        P_SIZE        INTEGER NOT NULL,
+                        P_CONTAINER   CHAR(10) NOT NULL,
+                        P_RETAILPRICE DECIMAL(15,2) NOT NULL,
+                        P_COMMENT     VARCHAR(23) NOT NULL
+                );
+                
+                -- Customer
+                CREATE TABLE CUSTOMER (
+                        C_CUSTKEY     INTEGER NOT NULL,
+                        C_NAME        VARCHAR(25) NOT NULL,
+                        C_ADDRESS     VARCHAR(40) NOT NULL,
+                        C_NATIONKEY   INTEGER NOT NULL,
+                        C_PHONE       CHAR(15) NOT NULL,
+                        C_ACCTBAL     DECIMAL(15,2)   NOT NULL,
+                        C_MKTSEGMENT  CHAR(10) NOT NULL,
+                        C_COMMENT     VARCHAR(117) NOT NULL
+                );
+                
+                -- Supplier
+                CREATE TABLE SUPPLIER (
+                        S_SUPPKEY     INTEGER NOT NULL,
+                        S_NAME        CHAR(25) NOT NULL,
+                        S_ADDRESS     VARCHAR(40) NOT NULL,
+                        S_NATIONKEY   INTEGER NOT NULL,
+                        S_PHONE       CHAR(15) NOT NULL,
+                        S_ACCTBAL     DECIMAL(15,2) NOT NULL,
+                        S_COMMENT     VARCHAR(101) NOT NULL
+                );
+                
+                -- Part supplies
+                CREATE TABLE PARTSUPP (
+                        PS_PARTKEY     INTEGER NOT NULL,
+                        PS_SUPPKEY     INTEGER NOT NULL,
+                        PS_AVAILQTY    INTEGER NOT NULL,
+                        PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,
+                        PS_COMMENT     VARCHAR(199) NOT NULL
+                );
+                
+                -- Nation
+                CREATE TABLE NATION  (
+                        N_NATIONKEY  INTEGER NOT NULL,
+                        N_NAME       CHAR(25) NOT NULL,
+                        N_REGIONKEY  INTEGER NOT NULL,
+                        N_COMMENT    VARCHAR(152)
+                );
+                
+                -- Region
+                CREATE TABLE REGION  (
+                        R_REGIONKEY  INTEGER NOT NULL,
+                        R_NAME       CHAR(25) NOT NULL,
+                        R_COMMENT    VARCHAR(152)
+                );
+                
+                -- Pricing Summary Report
+                create materialized view q1
+                as select
+                        l_returnflag,
+                        l_linestatus,
+                        sum(l_quantity) as sum_qty,
+                        sum(l_extendedprice) as sum_base_price,
+                        sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+                        sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+                        avg(l_quantity) as avg_qty,
+                        avg(l_extendedprice) as avg_price,
+                        avg(l_discount) as avg_disc,
+                        count(*) as count_order
+                from
+                        lineitem
+                where
+                        l_shipdate <= date '1998-12-01' - interval '90' day
+                group by
+                        l_returnflag,
+                        l_linestatus
+                order by
+                        l_returnflag,
+                        l_linestatus;
+                
+                -- Minimum Cost Supplier
+                create materialized view q2
+                as select
+                        s_acctbal,
+                        s_name,
+                        n_name,
+                        p_partkey,
+                        p_mfgr,
+                        s_address,
+                        s_phone,
+                        s_comment
+                from
+                        part,
+                        supplier,
+                        partsupp,
+                        nation,
+                        region
+                where
+                        p_partkey = ps_partkey
+                        and s_suppkey = ps_suppkey
+                        and p_size = 15
+                        and p_type like '%BRASS'
+                        and s_nationkey = n_nationkey
+                        and n_regionkey = r_regionkey
+                        and r_name = 'EUROPE'
+                        and ps_supplycost = (
+                                select
+                                        min(ps_supplycost)
+                                from
+                                        partsupp,
+                                        supplier,
+                                        nation,
+                                        region
+                                where
+                                        p_partkey = ps_partkey
+                                        and s_suppkey = ps_suppkey
+                                        and s_nationkey = n_nationkey
+                                        and n_regionkey = r_regionkey
+                                        and r_name = 'EUROPE'
+                        )
+                order by
+                        s_acctbal desc,
+                        n_name,
+                        s_name,
+                        p_partkey
+                limit 100;
+                
+                -- Shipping Priority
+                create materialized view q3
+                as select
+                        l_orderkey,
+                        sum(l_extendedprice * (1 - l_discount)) as revenue,
+                        o_orderdate,
+                        o_shippriority
+                from
+                        customer,
+                        orders,
+                        lineitem
+                where
+                        c_mktsegment = 'BUILDING'
+                        and c_custkey = o_custkey
+                        and l_orderkey = o_orderkey
+                        and o_orderdate < date '1995-03-15'
+                        and l_shipdate > date '1995-03-15'
+                group by
+                        l_orderkey,
+                        o_orderdate,
+                        o_shippriority
+                order by
+                        revenue desc,
+                        o_orderdate
+                limit 10;
+                
+                -- Order Priority Checking
+                create materialized view q4
+                as select
+                        o_orderpriority,
+                        count(*) as order_count
+                from
+                        orders
+                where
+                        o_orderdate >= date '1993-07-01'
+                        and o_orderdate < date '1993-07-01' + interval '3' month
+                        and exists (
+                                select
+                                        *
+                                from
+                                        lineitem
+                                where
+                                        l_orderkey = o_orderkey
+                                        and l_commitdate < l_receiptdate
+                        )
+                group by
+                        o_orderpriority
+                order by
+                        o_orderpriority;
+                
+                create materialized view q5
+                as select
+                        n_name,
+                        sum(l_extendedprice * (1 - l_discount)) as revenue
+                from
+                        customer,
+                        orders,
+                        lineitem,
+                        supplier,
+                        nation,
+                        region
+                where
+                        c_custkey = o_custkey
+                        and l_orderkey = o_orderkey
+                        and l_suppkey = s_suppkey
+                        and c_nationkey = s_nationkey
+                        and s_nationkey = n_nationkey
+                        and n_regionkey = r_regionkey
+                        and r_name = 'ASIA'
+                        and o_orderdate >= date '1994-01-01'
+                        and o_orderdate < date '1994-01-01' + interval '1' year
+                group by
+                        n_name
+                order by
+                        revenue desc;
+                
+                -- Forecasting Revenue Change
+                create materialized view q6
+                as select
+                        sum(l_extendedprice * l_discount) as revenue
+                from
+                        lineitem
+                where
+                        l_shipdate >= date '1994-01-01'
+                        and l_shipdate < date '1994-01-01' + interval '1' year
+                        and l_discount between .06 - 0.01 and .06 + 0.01
+                        and l_quantity < 24;
+                
+                -- Volume Shipping
+                create materialized view q7
+                as select
+                        supp_nation,
+                        cust_nation,
+                        l_year,
+                        sum(volume) as revenue
+                from
+                        (
+                                select
+                                        n1.n_name as supp_nation,
+                                        n2.n_name as cust_nation,
+                                        year(l_shipdate) as l_year,
+                                        l_extendedprice * (1 - l_discount) as volume
+                                from
+                                        supplier,
+                                        lineitem,
+                                        orders,
+                                        customer,
+                                        nation n1,
+                                        nation n2
+                                where
+                                        s_suppkey = l_suppkey
+                                        and o_orderkey = l_orderkey
+                                        and c_custkey = o_custkey
+                                        and s_nationkey = n1.n_nationkey
+                                        and c_nationkey = n2.n_nationkey
+                                        and (
+                                                (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+                                                or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+                                        )
+                                        and l_shipdate between date '1995-01-01' and date '1996-12-31'
+                        ) as shipping
+                group by
+                        supp_nation,
+                        cust_nation,
+                        l_year
+                order by
+                        supp_nation,
+                        cust_nation,
+                        l_year;
+                
+                -- Unfortunately this does not work for q8: there is a
+                -- shared join (followed by 2 projections) between q8 and q10 which causes
+                -- the plans for q8 to differ when compiled with and without q10
+                --
+                ---- National Market Share
+                --create materialized view q8
+                --as select
+                --        o_year,
+                --        sum(case
+                --                when nation = 'BRAZIL' then volume
+                --                else 0
+                --        end) / sum(volume) as mkt_share
+                --from
+                --        (
+                --                select
+                --                        year(o_orderdate) as o_year,
+                --                        l_extendedprice * (1 - l_discount) as volume,
+                --                        n2.n_name as nation
+                --                from
+                --                        part,
+                --                        supplier,
+                --                        lineitem,
+                --                        orders,
+                --                        customer,
+                --                        nation n1,
+                --                        nation n2,
+                --                        region
+                --                where
+                --                        p_partkey = l_partkey
+                --                        and s_suppkey = l_suppkey
+                --                        and l_orderkey = o_orderkey
+                --                        and o_custkey = c_custkey
+                --                        and c_nationkey = n1.n_nationkey
+                --                        and n1.n_regionkey = r_regionkey
+                --                        and r_name = 'AMERICA'
+                --                        and s_nationkey = n2.n_nationkey
+                --                        and o_orderdate between date '1995-01-01' and date '1996-12-31'
+                --                        and p_type = 'ECONOMY ANODIZED STEEL'
+                --        ) as all_nations
+                --group by
+                --        o_year
+                --order by
+                --        o_year;
+                
+                -- Product Type Profit Measure
+                create materialized view q9
+                as select
+                        nation,
+                        o_year,
+                        sum(amount) as sum_profit
+                from
+                        (
+                                select
+                                        n_name as nation,
+                                        year(o_orderdate) as o_year,
+                                        l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+                                from
+                                        part,
+                                        supplier,
+                                        lineitem,
+                                        partsupp,
+                                        orders,
+                                        nation
+                                where
+                                        s_suppkey = l_suppkey
+                                        and ps_suppkey = l_suppkey
+                                        and ps_partkey = l_partkey
+                                        and p_partkey = l_partkey
+                                        and o_orderkey = l_orderkey
+                                        and s_nationkey = n_nationkey
+                                        and p_name like '%green%'
+                        ) as profit
+                group by
+                        nation,
+                        o_year
+                order by
+                        nation,
+                        o_year desc;
+                """;
+        String extra = """
+                create materialized view q10
+                as select
+                      c_custkey,
+                      c_name,
+                      sum(l_extendedprice * (1 - l_discount)) as revenue,
+                      c_acctbal,
+                      n_name,
+                      c_address,
+                      c_phone,
+                      c_comment
+                from
+                      customer,
+                      orders,
+                      lineitem,
+                      nation
+                where
+                      c_custkey = o_custkey
+                      and l_orderkey = o_orderkey
+                      and o_orderdate >= date '1993-10-01'
+                      and o_orderdate < date '1993-10-01' + interval '3' month
+                      and l_returnflag = 'R'
+                      and c_nationkey = n_nationkey
+                group by
+                      c_custkey,
+                      c_name,
+                      c_acctbal,
+                      c_phone,
+                      n_name,
+                      c_address,
+                      c_comment
+                order by
+                      revenue desc
+                limit 20;
+                """;
+
+        var cc0 = this.getCC(common);
+        var cc1 = this.getCC(common + extra);
+        Set<String> hash0 = this.collectHashes(cc0);
+        Set<String> hash1 = this.collectHashes(cc1);
+        Assert.assertTrue(hash1.containsAll(hash0));
+    }
+
+    @Test
     public void issue4799() {
         var ccs = this.getCCS("""
                 CREATE TABLE T(id INT, s VARCHAR);


### PR DESCRIPTION
The first optimization regards joinIndex operators followed by multiple projections: we enable the "widest" projection that comprises both to be propagated up through the joinIndex. (We used to do it for other kinds of joins, not handling this one was an omission).

The second optimization regards Map/MapIndex/Filter operators with a fanout > 1. We now expand these into multiple copies if they are followed by an operator that can be merged into a single one with its source. A side-effect of this optimization is that plans will contain fewer shared operators between unrelated views, enabling more state reuse when modifying the program.

There is a test where adding a view used to change the hash for 4 views, but after this optimization only 1 hash is changed.