### PR TITLE
standby: pull once more after activation

### DIFF
--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -56,6 +56,8 @@ class HttpRequests:
         """
         self.headers["Content-Type"] = content_type
 
+        prev_resp: Optional[requests.Response] = None
+
         try:
             conn_timeout = self.config.connection_timeout
             timeout = self.config.timeout
@@ -102,6 +104,8 @@ class HttpRequests:
                         verify=self.requests_verify,
                     )
 
+                prev_resp = request
+
                 try:
                     resp = self.__validate(request, stream=stream)
                     logging.debug("got response: %s", str(resp))
@@ -133,6 +137,10 @@ class HttpRequests:
 
         except requests.exceptions.ConnectionError as err:
             raise FelderaCommunicationError(str(err)) from err
+
+        raise FelderaAPIError(
+            "Max retries exceeded, couldn't successfully connect to Feldera", prev_resp
+        )
 
     def get(
         self,

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -185,7 +185,7 @@ class FelderaClient:
                 elapsed = time.monotonic() - start_time
                 if elapsed > timeout_s:
                     raise TimeoutError(
-                        f"Timed out waiting for pipeline {pipeline_name} to"
+                        f"Timed out waiting for pipeline {pipeline_name} to "
                         f"transition to '{state}' state"
                     )
 

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -150,8 +150,7 @@ class TestCheckpointSync(SharedTestPipeline):
 
             if standby:
                 assert self.pipeline.status() == PipelineStatus.STANDBY
-
-                self.pipeline.activate(timeout_s=10)
+                self.pipeline.activate()
 
         got_after = list(self.pipeline.query("SELECT * FROM v0"))
 


### PR DESCRIPTION
Once we receive an activation request, pull once more to be up to date with the latest checkpoint in S3. If there is no newer checkpoint, the download should not take too long.

