### PR TITLE
Add multi-tenant authz support and web-console selector

### DIFF
--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -130,12 +130,24 @@ async fn bearer_auth(
                 ));
             }
 
-            // Get tenant name using new resolution logic
-            let tenant_name = match claim.tenant_name(&state.config) {
+            // Get tenant name using resolution logic with headers
+            let tenant_name = match claim.tenant_name(&state.config, req.headers()) {
                 Ok(name) => name,
                 Err(AuthError::NoTenantFound) => {
                     return Err((
                         create_authz_json_error("You are not authorized to access any Feldera tenant. Contact your administrator if you need access to Feldera."),
+                        req,
+                    ));
+                }
+                Err(AuthError::MissingTenantHeader) => {
+                    return Err((
+                        create_authz_json_error("Feldera-Tenant header is required when your access token contains multiple tenants."),
+                        req,
+                    ));
+                }
+                Err(AuthError::UnauthorizedTenant(tenant)) => {
+                    return Err((
+                        create_authz_json_error(&format!("You are not authorized to access tenant '{}'. Check your access token's tenants claim.", tenant)),
                         req,
                     ));
                 }
@@ -256,32 +268,80 @@ enum Claim {
 }
 
 impl Claim {
-    fn tenant_name(&self, config: &crate::config::ApiServerConfig) -> Result<String, AuthError> {
-        // Generalized tenant resolution logic for all OIDC providers
-        // Priority: tenant > issuer-domain > sub
-        let (tenant_claim, issuer, sub) = match self {
-            Claim::AwsCognito(t) => (&t.claims.tenant, &t.claims.iss, &t.claims.sub),
-            Claim::GenericOidc(t) => (&t.claims.tenant, &t.claims.iss, &t.claims.sub),
+    /// Get the list of authorized tenants for this claim.
+    /// Returns None if tenants should be resolved via other means (issuer/sub).
+    fn authorized_tenants(&self) -> Option<Vec<String>> {
+        match self {
+            Claim::AwsCognito(t) => {
+                // Priority: tenants array > single tenant claim
+                if let Some(ref tenants) = t.claims.tenants {
+                    Some(tenants.clone())
+                } else {
+                    t.claims.tenant.as_ref().map(|t| vec![t.clone()])
+                }
+            }
+            Claim::GenericOidc(t) => {
+                // Priority: tenants array > single tenant claim
+                if let Some(ref tenants) = t.claims.tenants {
+                    Some(tenants.clone())
+                } else {
+                    t.claims.tenant.as_ref().map(|t| vec![t.clone()])
+                }
+            }
+        }
+    }
+
+    /// Resolve tenant name based on claim, headers, and configuration.
+    ///
+    /// For multi-tenant claims (tenants array), requires Feldera-Tenant header to select one.
+    /// For single-tenant claims, uses fallback logic: tenant > issuer > sub
+    fn tenant_name(
+        &self,
+        config: &crate::config::ApiServerConfig,
+        headers: &actix_web::http::header::HeaderMap,
+    ) -> Result<String, AuthError> {
+        let (issuer, sub) = match self {
+            Claim::AwsCognito(t) => (&t.claims.iss, &t.claims.sub),
+            Claim::GenericOidc(t) => (&t.claims.iss, &t.claims.sub),
         };
 
-        // 1. Check for explicit tenant claim
-        if let Some(ref tenant) = tenant_claim {
-            return Ok(tenant.clone());
+        // Check if we have explicit tenant authorization in the claim
+        if let Some(authorized) = self.authorized_tenants() {
+            if authorized.len() > 1 {
+                // Multi-tenant: require header selection
+                let selected = headers
+                    .get(TENANT_HEADER)
+                    .and_then(|h| h.to_str().ok())
+                    .ok_or(AuthError::MissingTenantHeader)?;
+
+                // Validate selected tenant is authorized
+                if authorized.contains(&selected.to_string()) {
+                    return Ok(selected.to_string());
+                } else {
+                    return Err(AuthError::UnauthorizedTenant(selected.to_string()));
+                }
+            } else if authorized.len() == 1 {
+                // Single tenant in array or single tenant claim
+                return Ok(authorized[0].clone());
+            }
+            // Empty array falls through to fallback logic
         }
 
-        // 2. Extract tenant from issuer domain if enabled
+        // Fallback logic when no explicit tenant/tenants claims
+        // Priority: issuer-domain > sub (if enabled)
+
         if config.issuer_tenant {
             if let Some(issuer_tenant) = extract_tenant_from_issuer(issuer) {
                 return Ok(issuer_tenant);
             }
         }
 
-        // 3. Use individual user tenant if enabled
         if config.individual_tenant {
+            debug!("Using sub claim for tenant resolution: {}", sub);
             return Ok(sub.clone());
         }
 
-        // No valid tenant found and individual tenants disabled
+        // No valid tenant found
         Err(AuthError::NoTenantFound)
     }
 
@@ -484,8 +544,14 @@ struct OidcClaim {
     /// Email address (if available)
     email: Option<String>,
 
-    /// Tenant identifier for multi-user deployments
+    /// Tenant identifier for single-tenant deployments
     tenant: Option<String>,
+
+    /// Tenant identifiers for multi-tenant access
+    /// Can be either an array of strings or a comma-separated string
+    /// When present, user can access any of these tenants
+    #[serde(deserialize_with = "deserialize_list")]
+    tenants: Option<Vec<String>>,
 
     /// User groups for authorization (Okta only)
     groups: Option<Vec<String>>,
@@ -493,6 +559,29 @@ struct OidcClaim {
     /// Additional claims for provider-specific data
     #[serde(flatten)]
     additional_claims: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Deserialize tenants claim which can be either:
+/// - An array of strings: ["tenant1", "tenant2"]
+/// - A comma-separated string: "tenant1,tenant2"
+fn deserialize_list<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum TenantsValue {
+        Array(Vec<String>),
+        String(String),
+    }
+
+    let value = Option::<TenantsValue>::deserialize(deserializer)?;
+    Ok(value.map(|v| match v {
+        TenantsValue::Array(arr) => arr,
+        TenantsValue::String(s) => s.split(',').map(|t| t.trim().to_string()).collect(),
+    }))
 }
 
 /// The shape of a claim provided to clients by AwsCognito, following
@@ -533,8 +622,14 @@ struct AwsCognitoClaim {
     /// The sub claim is the appropriate identifier for a user.
     username: String,
 
-    /// Tenant identifier for multi-user deployments
+    /// Tenant identifier for single-tenant deployments
     tenant: Option<String>,
+
+    /// Tenant identifiers for multi-tenant access
+    /// Can be either an array of strings or a comma-separated string
+    /// When present, user can access any of these tenants
+    #[serde(deserialize_with = "deserialize_list")]
+    tenants: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -546,6 +641,8 @@ enum AuthError {
     JwkShape(String),
     NoTenantFound,
     InsufficientGroups,
+    MissingTenantHeader,
+    UnauthorizedTenant(String),
 }
 
 impl std::fmt::Display for AuthError {
@@ -558,6 +655,8 @@ impl std::fmt::Display for AuthError {
             AuthError::JwkContentType => f.write_str("Content type error"),
             AuthError::NoTenantFound => f.write_str("You are not authorized to access any Feldera tenant. Contact your administrator if you need access to Feldera."),
             AuthError::InsufficientGroups => f.write_str("User does not belong to required groups for access."),
+            AuthError::MissingTenantHeader => f.write_str("Feldera-Tenant header is required when access token contains multiple tenants."),
+            AuthError::UnauthorizedTenant(tenant) => write!(f, "You are not authorized to access tenant '{}'. Check your access token's tenants claim.", tenant),
         }
     }
 }
@@ -838,6 +937,9 @@ async fn validate_api_keys(
 const API_KEY_LENGTH: usize = 128;
 pub const API_KEY_PREFIX: &str = "apikey:";
 
+/// HTTP header name for tenant selection in multi-tenant deployments
+pub const TENANT_HEADER: &str = "Feldera-Tenant";
+
 /// Generates a random 128 character API key
 pub fn generate_api_key() -> String {
     assert_impl_any!(ThreadRng: rand::CryptoRng);
@@ -925,6 +1027,7 @@ mod test {
             token_use: "access".to_owned(),
             username: "some-user".to_owned(),
             tenant: None,
+            tenants: None,
         }
     }
 

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -742,7 +742,11 @@ impl ApiServerConfig {
                 cors = cors.allow_any_origin();
             }
             cors.allowed_methods(vec!["GET", "POST", "PATCH", "PUT", "DELETE"])
-                .allowed_headers(vec![header::AUTHORIZATION, header::ACCEPT])
+                .allowed_headers(vec![
+                    header::AUTHORIZATION,
+                    header::ACCEPT,
+                    header::HeaderName::from_static(crate::auth::TENANT_HEADER),
+                ])
                 .supports_credentials()
         }
     }

--- a/web-console/src/lib/components/auth/AuthButton.svelte
+++ b/web-console/src/lib/components/auth/AuthButton.svelte
@@ -28,7 +28,7 @@
     {#snippet content(close)}
       <div
         transition:fade={{ duration: 100 }}
-        class="bg-white-dark absolute right-0 z-30 max-h-[400px] w-[calc(100vw-100px)] max-w-[400px] justify-end rounded-container shadow-md scrollbar"
+        class="bg-white-dark absolute right-0 z-30 w-[calc(100vw-100px)] max-w-[400px] justify-end rounded-container shadow-md scrollbar"
       >
         <AuthPopupMenu user={auth.profile} signOut={auth.logout}></AuthPopupMenu>
       </div>

--- a/web-console/src/lib/components/auth/CurrentTenant.svelte
+++ b/web-console/src/lib/components/auth/CurrentTenant.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation'
   import { page } from '$app/state'
+  import { getSelectedTenant, setSelectedTenant } from '$lib/services/auth'
+
+  const authorizedTenants = page.data.feldera!.authorizedTenants ?? [page.data.feldera!.tenantName]
 </script>
 
 {#if page.data.feldera}
-  <div class="text-nowrap text-end">
-    <span class="pr-2">• Tenant</span>
-    <span class="font-mono">{page.data.feldera.tenantName}</span>
-  </div>
+  <label class="label">
+    <span class="text-left">Tenant</span>
+    <select onchange={() => invalidateAll()} bind:value={getSelectedTenant, setSelectedTenant} class="select {authorizedTenants.length > 1 ? '' : 'pointer-events-none'}">
+      {#each authorizedTenants as tenant}
+        <option value={tenant}>{tenant}</option>
+      {/each}
+    </select>
+  </label>
 {/if}

--- a/web-console/src/lib/services/auth.ts
+++ b/web-console/src/lib/services/auth.ts
@@ -1,10 +1,31 @@
 import * as AxaOidc from '@axa-fr/oidc-client'
-const { OidcClient, OidcLocation } = AxaOidc
+const { OidcClient } = AxaOidc
+
+let selectedTenant: string | undefined =
+  ('window' in globalThis ? window.localStorage.getItem('session/selected_tenant') : undefined) ??
+  undefined
+
+export const getSelectedTenant = () => {
+  return selectedTenant
+}
+
+export const setSelectedTenant = (tenant?: string) => {
+  selectedTenant = tenant
+  if (tenant === undefined) {
+    window.localStorage.removeItem('session/selected_tenant')
+    return
+  }
+  window.localStorage.setItem('session/selected_tenant', tenant)
+}
 
 export const authRequestMiddleware = (request: Request) => {
   const oidcClient = OidcClient.get()
   if (oidcClient.tokens?.accessToken) {
     request.headers.set('Authorization', `Bearer ${oidcClient.tokens.accessToken}`)
+    const tenant = getSelectedTenant()
+    if (tenant) {
+      request.headers.set('Feldera-Tenant', tenant)
+    }
   }
   return request
 }

--- a/web-console/src/routes/+layout.ts
+++ b/web-console/src/routes/+layout.ts
@@ -4,7 +4,12 @@ import * as AxaOidc from '@axa-fr/oidc-client'
 import { fromAxaUserInfo, toAxaOidcConfig } from '$lib/compositions/@axa-fr/auth'
 import { client } from '@hey-api/client-fetch'
 import { base } from '$app/paths'
-import { authRequestMiddleware, authResponseMiddleware } from '$lib/services/auth'
+import {
+  authRequestMiddleware,
+  authResponseMiddleware,
+  getSelectedTenant,
+  setSelectedTenant
+} from '$lib/services/auth'
 import type { AuthDetails } from '$lib/types/auth'
 import { goto } from '$app/navigation'
 import posthog from 'posthog-js'
@@ -15,6 +20,7 @@ import duration from 'dayjs/plugin/duration'
 import { initSystemMessages } from '$lib/compositions/initSystemMessages'
 import { newDate, setCurrentTime } from '$lib/compositions/serverTime'
 import { displayScheduleToDismissable, getLicenseMessage } from '$lib/functions/license'
+import { jwtDecode } from 'jwt-decode'
 
 Dayjs.extend(duration)
 
@@ -49,6 +55,10 @@ export type LayoutData = {
         }
         tenantId: string
         tenantName: string
+        /**
+         * Only available if authenticated and using multi-tenant authorization
+         */
+        authorizedTenants?: string[]
         unstableFeatures: string[]
         config: Configuration
       }
@@ -70,7 +80,7 @@ export const load = async ({ fetch, url }): Promise<LayoutData> => {
 
   const auth = authConfig
     ? await axaOidcAuth({
-        oidcConfig: toAxaOidcConfig(authConfig.oidc),
+        oidcConfig: { ...toAxaOidcConfig(authConfig.oidc) },
         logoutExtras: authConfig.logoutExtras,
         onBeforeLogin: () => window.sessionStorage.setItem('redirect_to', window.location.href),
         onAfterLogin: async () => {
@@ -115,16 +125,24 @@ export const load = async ({ fetch, url }): Promise<LayoutData> => {
     return emptyLayoutData
   }
 
-  // Fetch session config for tenant information (only available if authenticated)
-  let sessionConfig = undefined
-  try {
-    sessionConfig = await getConfigSession()
-  } catch (e: any) {
-    // Session config might not be available if not authenticated, which is fine
-    console.warn('Failed to load session configuration:', e)
-  }
+  let authorizedTenants: string[] | undefined = undefined
 
   if (typeof auth === 'object' && 'logout' in auth) {
+    const tenantsString = auth.accessToken
+      ? jwtDecode<{ tenants?: string[] | string }>(auth.accessToken).tenants
+      : undefined
+    authorizedTenants = tenantsString
+      ? Array.isArray(tenantsString)
+        ? tenantsString
+        : tenantsString.split(',').map((t) => t.trim())
+      : undefined
+    if (authorizedTenants) {
+      const savedTenant = getSelectedTenant()
+      if (!savedTenant || !authorizedTenants.includes(savedTenant)) {
+        setSelectedTenant(authorizedTenants[0])
+      }
+    }
+
     initPosthog(config).then(() => {
       if (auth.profile.email) {
         posthog.identify(auth.profile.email, {
@@ -134,6 +152,15 @@ export const load = async ({ fetch, url }): Promise<LayoutData> => {
         })
       }
     })
+  }
+
+  // Fetch session config for tenant information (only available if authenticated)
+  let sessionConfig = undefined
+  try {
+    sessionConfig = await getConfigSession()
+  } catch (e: any) {
+    // Session config might not be available if not authenticated, which is fine
+    console.warn('Failed to load session configuration:', e)
   }
 
   {
@@ -181,6 +208,7 @@ export const load = async ({ fetch, url }): Promise<LayoutData> => {
       revision: config.revision,
       tenantId: sessionConfig?.tenant_id || '',
       tenantName: sessionConfig?.tenant_name || '',
+      authorizedTenants,
       unstableFeatures: config.unstable_features?.split(',').map((f) => f.trim()) || [],
       config
     }
@@ -194,7 +222,10 @@ const axaOidcAuth = async (params: {
   onAfterLogin?: (idTokenPayload: any, userInfo: Promise<AxaOidc.OidcUserInfo>) => void
   onBeforeLogout?: () => void
 }) => {
-  const oidcClient = OidcClient.getOrCreate(() => fetch, new OidcLocation())(params.oidcConfig)
+  const oidcClient = OidcClient.getOrCreate(
+    () => fetch,
+    new OidcLocation()
+  )({ ...params.oidcConfig, extras: { audience: 'feldera-api' } })
   const href = window.location.href
   const result: AuthDetails = await oidcClient.tryKeepExistingSessionAsync().then(async () => {
     if (href.includes(params.oidcConfig.redirect_uri)) {


### PR DESCRIPTION
Before this PR the only way to explicitly set what pipeline-manager tenant user is authorized to access was via the `tenant` OIDC Access Token claim.

This PR adds support for multiple tenants by expecting the new `tenants` claim, and selection of the current tenant via `Feldera-Tenant` HTTP header.

Each API endpoint still expects authorization only as a single tenant, but the new UX allows to quickly switch between authorized tenants.