### PR TITLE
[fda] Fix assertion failure at runtime.

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -428,7 +428,6 @@ pub enum PipelineAction {
     },
     /// Recompile a pipeline with the Feldera runtime version included in the
     /// currently installed Feldera platform.
-    #[clap(aliases = &["update-runtime"])]
     UpdateRuntime {
         /// The name of the pipeline.
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]


### PR DESCRIPTION
This fixes the runtime error:

```
Command fda: command `update-runtime` alias `update-runtime` is duplicated
```
