### PR TITLE
[manager] More detailed pipeline HTTP errors.

### DIFF
--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -396,6 +396,7 @@ pub(crate) fn error_illegal_pipeline_storage_action() -> ErrorResponse {
 
 pub(crate) fn error_pipeline_interaction_not_deployed() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&RunnerError::PipelineInteractionNotDeployed {
+        pipeline_name: "my_pipeline".to_string(),
         status: ResourcesStatus::Stopped,
         desired_status: ResourcesDesiredStatus::Provisioned,
     })
@@ -403,18 +404,24 @@ pub(crate) fn error_pipeline_interaction_not_deployed() -> ErrorResponse {
 
 pub(crate) fn error_pipeline_interaction_currently_unavailable() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&RunnerError::PipelineInteractionUnreachable {
+        pipeline_name: "my_pipeline".to_string(),
+        request: "/pause".to_string(),
         error: "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again".to_string()
     })
 }
 
 pub(crate) fn error_pipeline_interaction_disconnected() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&RunnerError::PipelineInteractionUnreachable {
+        pipeline_name: "my_pipeline".to_string(),
+        request: "/pause".to_string(),
         error: format_disconnected_error_message("".to_string()),
     })
 }
 
 pub(crate) fn error_pipeline_interaction_timeout() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&RunnerError::PipelineInteractionUnreachable {
+        pipeline_name: "my_pipeline".to_string(),
+        request: "/pause".to_string(),
         error: format_timeout_error_message(
             RunnerInteraction::PIPELINE_HTTP_REQUEST_TIMEOUT,
             "Timeout while waiting for response".to_string(),

--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -77,13 +77,28 @@ pub enum RunnerError {
 
     // Interaction with the pipeline
     PipelineInteractionNotDeployed {
+        /// Pipeline name or UUID if name is not available.
+        pipeline_name: String,
         status: ResourcesStatus,
         desired_status: ResourcesDesiredStatus,
     },
+    PipelineUnavailable {
+        /// Pipeline name or UUID if name is not available.
+        pipeline_name: String,
+    },
+    PipelineMissingDeploymentLocation {
+        /// Pipeline name or UUID if name is not available.
+        pipeline_name: String,
+    },
     PipelineInteractionUnreachable {
+        /// Pipeline name or UUID if name is not available.
+        pipeline_name: String,
+        request: String,
         error: String,
     },
     PipelineInteractionInvalidResponse {
+        /// Pipeline name or UUID if name is not available.
+        pipeline_name: String,
         error: String,
     },
 }
@@ -147,6 +162,10 @@ impl DetailedError for RunnerError {
             }
             RunnerError::PipelineInteractionNotDeployed { .. } => {
                 Cow::from("PipelineInteractionNotDeployed")
+            }
+            RunnerError::PipelineUnavailable { .. } => Cow::from("PipelineUnavailable"),
+            RunnerError::PipelineMissingDeploymentLocation { .. } => {
+                Cow::from("PipelineMissingDeploymentLocation")
             }
             RunnerError::PipelineInteractionUnreachable { .. } => {
                 Cow::from("PipelineInteractionUnreachable")
@@ -301,22 +320,45 @@ impl Display for RunnerError {
                 write!(f, "Log follow request channel is closed -- this indicates that the runner crashed unexpectedly")
             }
             Self::PipelineInteractionNotDeployed {
+                pipeline_name,
                 status,
                 desired_status: _,
             } => {
                 write!(
                     f,
-                    "Unable to interact with pipeline because the deployment status ({status}) \
+                    "Unable to interact with pipeline '{pipeline_name}' because the deployment status ({status}) \
                     indicates it is not (yet) fully provisioned"
                 )
             }
-            Self::PipelineInteractionUnreachable { error } => {
-                write!(f, "Unable to reach pipeline to interact due to: {error}")
-            }
-            Self::PipelineInteractionInvalidResponse { error } => {
+            Self::PipelineUnavailable { pipeline_name } => {
                 write!(
                     f,
-                    "During pipeline interaction an unexpected invalid response was encountered: {error}"
+                    "Unable to interact with pipeline '{pipeline_name}' because its status is currently 'unavailable'"
+                )
+            }
+            Self::PipelineMissingDeploymentLocation { pipeline_name } => {
+                write!(
+                    f,
+                    "Unable to interact with pipeline '{pipeline_name}' because its deployment location is missing despite it being fully provisioned"
+                )
+            }
+            Self::PipelineInteractionUnreachable {
+                pipeline_name,
+                request,
+                error,
+            } => {
+                write!(
+                    f,
+                    "Error sending HTTP request to pipeline '{pipeline_name}': {error}\nFailed request: {request}"
+                )
+            }
+            Self::PipelineInteractionInvalidResponse {
+                pipeline_name,
+                error,
+            } => {
+                write!(
+                    f,
+                    "Encountered an unexpected invalid response when interacting with pipeline '{pipeline_name}': {error}"
                 )
             }
         }
@@ -367,6 +409,8 @@ impl ResponseError for RunnerError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::PipelineInteractionNotDeployed { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            Self::PipelineUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
+            Self::PipelineMissingDeploymentLocation { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::PipelineInteractionUnreachable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::PipelineInteractionInvalidResponse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -1104,6 +1104,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                                 runtime_desired_status: RuntimeDesiredStatus::Paused,
                             }),
                             "Terminated" => Err(ErrorResponse::from(&RunnerError::PipelineInteractionInvalidResponse {
+                                pipeline_name: self.pipeline_id.to_string(),
                                 error: "Pipeline responded that it is Terminated".to_string(),
                             })),
                             _ => Ok(ExtendedRuntimeStatus {
@@ -1167,6 +1168,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     // running, but the circuit has failed
                     let error_response = serde_json::from_value(body.clone()).unwrap_or_else(|e| {
                         ErrorResponse::from(&RunnerError::PipelineInteractionInvalidResponse {
+                            pipeline_name: self.pipeline_id.to_string(),
                             error: format!("Error response cannot be deserialized due to: {e}. Response was:\n{body:#}"),
                         })
                     });

--- a/openapi.json
+++ b/openapi.json
@@ -1669,27 +1669,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -1697,9 +1702,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -1783,27 +1790,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -1811,9 +1823,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -1896,27 +1910,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -1924,9 +1943,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2009,27 +2030,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2037,9 +2063,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2122,27 +2150,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2150,9 +2183,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2235,27 +2270,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2263,9 +2303,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2414,27 +2456,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2442,9 +2489,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2567,27 +2616,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2595,9 +2649,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2733,27 +2789,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2761,9 +2822,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -2857,27 +2920,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -2885,9 +2953,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -3047,27 +3117,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -3075,9 +3150,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -3256,27 +3333,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -3284,9 +3366,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -3477,27 +3561,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -3505,9 +3594,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -3748,27 +3839,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -3776,9 +3872,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -3861,27 +3959,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -3889,9 +3992,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4168,18 +4273,22 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4281,27 +4390,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -4309,9 +4423,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4416,27 +4532,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -4444,9 +4565,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4554,27 +4677,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -4582,9 +4710,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4734,27 +4864,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -4762,9 +4897,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -4848,27 +4985,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -4876,9 +5018,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }
@@ -5159,27 +5303,32 @@
                 "examples": {
                   "Disconnected during response": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs.\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
                       }
                     }
                   },
                   "Pipeline is currently unavailable": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
                       }
                     }
                   },
                   "Pipeline is not deployed": {
                     "value": {
-                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned",
+                      "message": "Unable to interact with pipeline 'my_pipeline' because the deployment status (stopped) indicates it is not (yet) fully provisioned",
                       "error_code": "PipelineInteractionNotDeployed",
                       "details": {
+                        "pipeline_name": "my_pipeline",
                         "status": "Stopped",
                         "desired_status": "Provisioned"
                       }
@@ -5187,9 +5336,11 @@
                   },
                   "Response timeout": {
                     "value": {
-                      "message": "Unable to reach pipeline to interact due to: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)",
+                      "message": "Error sending HTTP request to pipeline 'my_pipeline': timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)\nFailed request: /pause",
                       "error_code": "PipelineInteractionUnreachable",
                       "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
                         "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
                       }
                     }


### PR DESCRIPTION
Add pipeline name and HTTP request details when reporting a failed request to a pipeline, e.g.:

```
2025-10-10 18:33:06 INFO [manager] [HTTP error] 503 Service Unavailable PipelineInteractionUnreachable: Error sending HTTP request to pipeline 'accelerating-batch-analytics': unable to send request due to: Failed to connect to host: Connection refused (os error 61)
Failed request: HTTP/1.1 GET http://127.0.0.1:62321/stats?
```

There are more errors that would benefit from additional context like pipeline name, but I focused on our immediate needs here.