### PR TITLE
[manager] Prevent awc from caching connections.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,8 @@
         "./python"
     ],
     "prettier.configPath": "web-console/.prettierrc",
-    "svg.preview.background": "transparent"
+    "svg.preview.background": "transparent",
+    "cursorpyright.analysis.extraPaths": [
+        "./python"
+    ]
 }

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -223,7 +223,7 @@ impl RunnerInteraction {
             query_string,
         );
         let timeout = timeout.unwrap_or(Self::PIPELINE_HTTP_REQUEST_TIMEOUT);
-        let request = client.request(method, &url).timeout(timeout);
+        let request = client.request(method, &url).timeout(timeout).force_close();
         let request_str = Self::format_request(&request);
 
         let mut original_response = request.send().await.map_err(|e| match e {
@@ -484,7 +484,8 @@ impl RunnerInteraction {
         let timeout = timeout.unwrap_or(Self::PIPELINE_HTTP_REQUEST_TIMEOUT);
         let mut new_request = client
             .request(request.method().clone(), &url)
-            .timeout(timeout);
+            .timeout(timeout)
+            .force_close();
 
         // Add headers of the original request
         for header in request


### PR DESCRIPTION
We see random CI failures where the pipeline manager gets a timeout sending an HTTP request to the pipeline. This seems to happen for random requests, both streaming and non-streaming. This tends to happen the first time the manager contacts the pipeline after the pipeline restarts after being stopped.

One possible explanation for this behavior is that awc caches TCP connections based on host name. This cache doesn't get invalidated when the pipeline is instantiated on a different host since its host name doesn't change.

This commit is meant as a temporary solution that should eliminate this problem if this is indeed what's going on by making sure that connections don't get cached (by calling force_close). However this means that every HTTP request to the pipeline will require a DNS lookup
+ establishing a new TCP connection, which can affect the performance when processing many small HTTP requests.

A better solution may involve maintaining a per-pipeline awc client and re-creating it every time the pipeline is restarted.

Note that the problem is unlikely specific to awc. reqwest connection cache likely behaves similarly.