### PR TITLE
[python] Propagate exceptions in listening threads back to the caller.

### DIFF
--- a/python/feldera/_callback_runner.py
+++ b/python/feldera/_callback_runner.py
@@ -14,7 +14,7 @@ class CallbackRunner(Thread):
         pipeline_name: str,
         view_name: str,
         callback: Callable[[pd.DataFrame, int], None],
-        exception_callback: Callable[[BaseException], None]
+        exception_callback: Callable[[BaseException], None],
     ):
         super().__init__()
         self.daemon = True

--- a/python/feldera/output_handler.py
+++ b/python/feldera/output_handler.py
@@ -34,8 +34,11 @@ class OutputHandler:
 
         # sets up the callback runner
         self.handler = CallbackRunner(
-            self.client, self.pipeline_name, self.view_name, callback,
-            exception_callback
+            self.client,
+            self.pipeline_name,
+            self.view_name,
+            callback,
+            exception_callback,
         )
 
     def start(self):

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -269,7 +269,9 @@ class Pipeline:
         if self.status() not in [PipelineStatus.RUNNING, PipelineStatus.PAUSED]:
             raise RuntimeError("Pipeline must be running or paused to listen to output")
 
-        handler = CallbackRunner(self.client, self.name, view_name, callback, lambda exception: None)
+        handler = CallbackRunner(
+            self.client, self.name, view_name, callback, lambda exception: None
+        )
         handler.start()
 
     def wait_for_completion(


### PR DESCRIPTION
I ran into this while debugging CI last week.