### PR TITLE
[SQL] Fix incorrect compilation for some expressions involving `NOW`

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -198,7 +198,7 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
         // The pipeline manager uses --nowstream
         @Parameter(names = "--nowstream",
                 description = "Implement NOW as a stream (true) or as an internal operator (false)")
-        public boolean nowStream = false;
+        public boolean nowStream = true;
         @Parameter(names = "--sqlnames", hidden = true,
                 description = "Use the table names as identifiers in the generated code")
         public boolean sqlNames = false;
@@ -258,6 +258,7 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
                     ",\n\tverbosity=" + this.verbosity +
                     ",\n\tquiet=" + this.quiet +
                     ",\n\tnoRust=" + this.noRust +
+                    ",\n\tnowStream=" + this.nowStream +
                     '}';
         }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -929,7 +929,7 @@ public class MetadataTests extends BaseSQLTests {
                       Default: false
                     --nowstream
                       Implement NOW as a stream (true) or as an internal operator (false)
-                      Default: false
+                      Default: true
                     --outputsAreSets
                       Ensure that outputs never contain duplicates
                       Default: false

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/InternalNowTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/InternalNowTests.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.sql.streaming;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
+import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.sql.StreamingTestBase;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuit;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
@@ -11,6 +12,13 @@ import org.junit.Test;
 
 /** Tests that exercise the internal implementation of NOW as a source operator */
 public class InternalNowTests extends StreamingTestBase {
+    @Override
+    public CompilerOptions testOptions() {
+        CompilerOptions options = super.testOptions();
+        options.ioOptions.nowStream = false;
+        return options;
+    }
+
     @Test
     public void testNow() {
         String sql = """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -359,6 +359,7 @@ public class BaseSQLTests {
         options.languageOptions.incrementalize = false;
         options.languageOptions.unrestrictedIOTypes = true;
         options.languageOptions.optimizationLevel = 2;
+        options.ioOptions.nowStream = true;
         return options;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -60,6 +60,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         options.languageOptions.incrementalize = false;
         options.languageOptions.unrestrictedIOTypes = true;
         options.ioOptions.verbosity = 2;
+        options.ioOptions.nowStream = true;
         return options;
     }
 

--- a/sql-to-dbsp-compiler/using.md
+++ b/sql-to-dbsp-compiler/using.md
@@ -89,7 +89,7 @@ Usage: sql-to-dbsp [options] Input file to compile
       Default: false
     --nowstream
       Implement NOW as a stream (true) or as an internal operator (false)
-      Default: false
+      Default: true
     --outputsAreSets
       Ensure that outputs never contain duplicates
       Default: false


### PR DESCRIPTION
Fixes #4904 

I also made the --nowStream flag default to true for all Java tests, since this is the value it has in the pipeline manager.