### PR TITLE
py: remove default timeouts

### DIFF
--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -300,7 +300,7 @@ class Pipeline:
         handler.start()
 
     def wait_for_completion(
-        self, force_stop: bool = False, timeout_s: Optional[float] = None
+        self, force_stop: bool = False, timeout_s: float | None = None
     ):
         """
         Block until the pipeline has completed processing all input records.
@@ -376,7 +376,7 @@ class Pipeline:
     def wait_for_idle(
         self,
         idle_interval_s: float = 5.0,
-        timeout_s: float = 600.0,
+        timeout_s: float | None = None,
         poll_interval_s: float = 0.2,
     ):
         """
@@ -396,12 +396,12 @@ class Pipeline:
         :raises RuntimeError: If the metrics are missing or the timeout was
             reached.
         """
-        if idle_interval_s > timeout_s:
+        if timeout_s is not None and idle_interval_s > timeout_s:
             raise ValueError(
                 f"idle interval ({idle_interval_s}s) cannot be larger than"
                 f" timeout ({timeout_s}s)"
             )
-        if poll_interval_s > timeout_s:
+        if timeout_s is not None and poll_interval_s > timeout_s:
             raise ValueError(
                 f"poll interval ({poll_interval_s}s) cannot be larger than"
                 f" timeout ({timeout_s}s)"
@@ -447,7 +447,7 @@ metrics"""
                 return
 
             # Timeout
-            if now_s - start_time_s >= timeout_s:
+            if timeout_s is not None and now_s - start_time_s >= timeout_s:
                 raise RuntimeError(f"waiting for idle reached timeout ({timeout_s}s)")
             time.sleep(poll_interval_s)
 
@@ -696,7 +696,7 @@ metrics"""
                 err.message = f"Pipeline with name {name} not found"
                 raise err
 
-    def checkpoint(self, wait: bool = False, timeout_s=300) -> int:
+    def checkpoint(self, wait: bool = False, timeout_s: Optional[float] = None) -> int:
         """
         Checkpoints this pipeline.
 
@@ -718,7 +718,7 @@ metrics"""
 
         while True:
             elapsed = time.monotonic() - start
-            if elapsed > timeout_s:
+            if timeout_s is not None and elapsed > timeout_s:
                 raise TimeoutError(
                     f"""timeout ({timeout_s}s) reached while waiting for \
 pipeline '{self.name}' to make checkpoint '{seq}'"""
@@ -754,7 +754,9 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
         if seq < success:
             return CheckpointStatus.Unknown
 
-    def sync_checkpoint(self, wait: bool = False, timeout_s=300) -> str:
+    def sync_checkpoint(
+        self, wait: bool = False, timeout_s: Optional[float] = None
+    ) -> str:
         """
         Syncs this checkpoint to object store.
 
@@ -776,7 +778,7 @@ pipeline '{self.name}' to make checkpoint '{seq}'"""
 
         while True:
             elapsed = time.monotonic() - start
-            if elapsed > timeout_s:
+            if timeout_s is not None and elapsed > timeout_s:
                 raise TimeoutError(
                     f"""timeout ({timeout_s}s) reached while waiting for \
 pipeline '{self.name}' to sync checkpoint '{uuid}'"""

--- a/python/feldera/rest/_helpers.py
+++ b/python/feldera/rest/_helpers.py
@@ -20,20 +20,20 @@ def requests_verify_from_env() -> str | bool:
     if env_feldera_tls_insecure is not None and FELDERA_HTTPS_TLS_CERT is not None:
         logging.warning(
             "environment variables FELDERA_HTTPS_TLS_CERT and "
-            "FELDERA_TLS_INSECURE both are set."
-            "\nFELDERA_HTTPS_TLS_CERT takes priority."
+            + "FELDERA_TLS_INSECURE both are set."
+            + "\nFELDERA_HTTPS_TLS_CERT takes priority."
         )
 
     if env_feldera_tls_insecure is None:
-        FELDERA_TLS_INSECURE = False
+        feldera_tls_insecure = False
     else:
-        FELDERA_TLS_INSECURE = env_feldera_tls_insecure.strip().lower() in (
+        feldera_tls_insecure = env_feldera_tls_insecure.strip().lower() in (
             "1",
             "true",
             "yes",
         )
 
-    requests_verify = not FELDERA_TLS_INSECURE
+    requests_verify = not feldera_tls_insecure
     if FELDERA_HTTPS_TLS_CERT is not None:
         requests_verify = FELDERA_HTTPS_TLS_CERT
 

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -56,7 +56,7 @@ class HttpRequests:
         """
         self.headers["Content-Type"] = content_type
 
-        prev_resp: Optional[requests.Response] = None
+        prev_resp: requests.Response | None = None
 
         try:
             conn_timeout = self.config.connection_timeout
@@ -156,7 +156,7 @@ class HttpRequests:
         body: Optional[
             Union[Mapping[str, Any], Sequence[Mapping[str, Any]], List[str], str]
         ] = None,
-        content_type: Optional[str] = "application/json",
+        content_type: str = "application/json",
         params: Optional[Mapping[str, Any]] = None,
         stream: bool = False,
         serialize: bool = True,
@@ -177,7 +177,7 @@ class HttpRequests:
         body: Optional[
             Union[Mapping[str, Any], Sequence[Mapping[str, Any]], List[str], str]
         ] = None,
-        content_type: Optional[str] = "application/json",
+        content_type: str = "application/json",
         params: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         return self.send_request(requests.patch, path, body, content_type, params)
@@ -188,7 +188,7 @@ class HttpRequests:
         body: Optional[
             Union[Mapping[str, Any], Sequence[Mapping[str, Any]], List[str], str]
         ] = None,
-        content_type: Optional[str] = "application/json",
+        content_type: str = "application/json",
         params: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         return self.send_request(requests.put, path, body, content_type, params)

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -39,7 +39,7 @@ class Config:
         )
         self.url: str = BASE_URL
         self.api_key: Optional[str] = os.environ.get("FELDERA_API_KEY", api_key)
-        self.version: Optional[str] = version or "v0"
+        self.version: str = version or "v0"
         self.timeout: Optional[float] = timeout
         self.connection_timeout: Optional[float] = connection_timeout
         env_verify = requests_verify_from_env()


### PR DESCRIPTION
Remove timeouts from the python SDK. ~Leaves the timeout intact for `wait_for_idle`, I think as you are deliberately waiting for the pipeline to become idle, it should timeout if it doesn't idle in a reasonable time.~

## Breaking Changes?

None
