### PR TITLE
[adapters] Fix incorrect latency measurement.

### DIFF
--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -205,6 +205,7 @@ impl FileInputReader {
                                     ofs..ofs
                                 }),
                             ));
+                            timestamp = None;
                             staged_hasher = consumer.hasher();
                         }
                         let (mut staged_buffers, timestamp, amt, hash, offsets) =

--- a/crates/adapters/src/transport/kafka/ft/input.rs
+++ b/crates/adapters/src/transport/kafka/ft/input.rs
@@ -516,6 +516,7 @@ impl KafkaFtInputReaderInner {
                                 staged_hasher.finish(),
                                 staged_offsets.clone(),
                             ));
+                            timestamp = None;
                             for partition_offsets in &mut staged_offsets {
                                 partition_offsets.start = partition_offsets.end;
                             }


### PR DESCRIPTION
Fixes #4919.

Kafka and file connectors had a similar logical bug where we didn't reset the ingestion timestamp, causing all input records to be labeled with the same timestamp.