### PR TITLE
[manager] Only keep relations with lateness in the schema.

### DIFF
--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -174,7 +174,7 @@ impl ProgramSchema {
         self.inputs
             .iter()
             .chain(self.outputs.iter())
-            .filter(|rel| rel.fields.iter().any(|f| f.lateness.is_some()))
+            .filter(|rel| rel.has_lateness())
             .map(|rel| rel.name.clone())
             .collect()
     }
@@ -233,6 +233,10 @@ impl Relation {
     pub fn field(&self, name: &str) -> Option<&Field> {
         let name = canonical_identifier(name);
         self.fields.iter().find(|f| f.name == name)
+    }
+
+    pub fn has_lateness(&self) -> bool {
+        self.fields.iter().any(|f| f.lateness.is_some())
     }
 }
 


### PR DESCRIPTION
We include program IR and schema in pipeline config. The config is passed to the pipeline via ConfigMap, which has a size limit of 1MB. A large program can easily exceed this limit. Previously we reduced IR size by only keeping source and sink nodes. A program with a very large number of relations can still exceed the limit. Since this information is currently only used as part of backfill avoidance, which only cares about relations with lateness, we prune all relations without lateness to further reduce pipeline config size.

