### PR TITLE
[WebConsole] Prevent selecting more than 4 change streams under HTTP

### DIFF
--- a/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -103,10 +103,14 @@
     }
     $effect.root(() => {
       if (cancelStream) {
+        // Avoid redundant cleanup on first start
         endMetricsStream()
       }
       setTimeout(() => startMetricsStream(api, pipelineName), 100)
     })
+    return () => {
+      endMetricsStream()
+    }
   })
 </script>
 

--- a/web-console/src/lib/compositions/useProtocol.ts
+++ b/web-console/src/lib/compositions/useProtocol.ts
@@ -1,0 +1,34 @@
+/**
+ * Composition hook to determine whether the app is served over HTTP or HTTPS
+ */
+
+export type Protocol = 'http' | 'https'
+
+/**
+ * Returns the protocol (http or https) used to serve the application
+ * @returns The current protocol as 'http' or 'https'
+ */
+export const useProtocol = (): Protocol => {
+  if (typeof window === 'undefined') {
+    // SSR context - default to https
+    return 'https'
+  }
+
+  return window.location.protocol === 'https:' ? 'https' : 'http'
+}
+
+/**
+ * Returns whether the app is served over HTTPS
+ * @returns true if served over HTTPS, false otherwise
+ */
+export const isSecure = (): boolean => {
+  return useProtocol() === 'https'
+}
+
+/**
+ * Returns whether the app is served over HTTP (not HTTPS)
+ * @returns true if served over HTTP, false otherwise
+ */
+export const isInsecure = (): boolean => {
+  return useProtocol() === 'http'
+}

--- a/web-console/src/lib/functions/common/array.ts
+++ b/web-console/src/lib/functions/common/array.ts
@@ -195,10 +195,13 @@ export function chunkIndices(min: number, max: number, size: number): number[] {
   return result
 }
 
-export function count<T>(arr: T[], pred: (v: T) => boolean | null | undefined) {
+export function count<T>(arr: T[], pred: (v: T) => boolean | number | null | undefined) {
   let count = 0
   for (const e of arr) {
-    if (pred(e)) {
+    const result = pred(e)
+    if (typeof result === 'number') {
+      count += result
+    } else if (result) {
       ++count
     }
   }


### PR DESCRIPTION
Also, fix stream in performance tab not cleaning up.


<img width="1336" height="362" alt="image" src="https://github.com/user-attachments/assets/272ecf68-a6b8-4234-ade3-4f7fa21b88fa" />
In another pipeline at the same time:
<img width="1336" height="362" alt="image" src="https://github.com/user-attachments/assets/6769f487-7294-4d01-a227-7598c1671188" />

