### PR TITLE
py: add a fix to aggregate tests

### DIFF
--- a/python/tests/runtime_aggtest/aggregate_tests5/main.py
+++ b/python/tests/runtime_aggtest/aggregate_tests5/main.py
@@ -4,7 +4,7 @@ import tests.runtime_aggtest.aggtst_base as base  # noqa: F403
 from tests.runtime_aggtest.aggtst_base import *  # noqa: F403
 from tests.runtime_aggtest.atest_run import run  # noqa: F403
 
-from table import *  # noqa: F403
+from test_table import *  # noqa: F403
 from test_atbl_varcharn_append import *  # noqa: F403
 from test_atbl_charn_append import *  # noqa: F403
 from test_arg_max_append import *  # noqa: F403

--- a/python/tests/runtime_aggtest/aggregate_tests5/table.py
+++ b/python/tests/runtime_aggtest/aggregate_tests5/table.py
@@ -1,8 +1,0 @@
-from aggregate_tests.test_int_table import *  # noqa: F403
-from aggregate_tests.test_int_table import *  # noqa: F403
-from aggregate_tests.test_decimal_table import *  # noqa: F403
-from aggregate_tests2.test_date_tbl import *  # noqa: F403
-from aggregate_tests2.test_time_tbl import *  # noqa: F403
-from aggregate_tests2.test_timestamp_tbl import *  # noqa: F403
-from aggregate_tests2.test_timestamp_tbl import *  # noqa: F403
-from aggregate_tests2.test_varchar_table import *  # noqa: F403

--- a/python/tests/runtime_aggtest/aggregate_tests5/test_table.py
+++ b/python/tests/runtime_aggtest/aggregate_tests5/test_table.py
@@ -1,0 +1,6 @@
+from tests.runtime_aggtest.aggregate_tests.test_int_table import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests.test_decimal_table import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests2.test_date_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests2.test_time_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests2.test_timestamp_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests2.test_varchar_table import *  # noqa: F403

--- a/python/tests/runtime_aggtest/aggregate_tests6/main.py
+++ b/python/tests/runtime_aggtest/aggregate_tests6/main.py
@@ -4,7 +4,7 @@ import tests.runtime_aggtest.aggtst_base as base  # noqa: F403
 from tests.runtime_aggtest.aggtst_base import *  # noqa: F403
 from tests.runtime_aggtest.atest_run import run  # noqa: F403
 
-from table import *  # noqa: F403
+from test_table import *  # noqa: F403
 from test_array_arg_max_append import *  # noqa: F403
 from test_array_arg_min_append import *  # noqa: F403
 from test_array_max_append import *  # noqa: F403

--- a/python/tests/runtime_aggtest/aggregate_tests6/table.py
+++ b/python/tests/runtime_aggtest/aggregate_tests6/table.py
@@ -1,7 +1,0 @@
-from aggregate_tests2.test_atbl_interval import *  # noqa: F403
-from aggregate_tests4.test_array_tbl import *  # noqa: F403
-from aggregate_tests3.test_binary_tbl import *  # noqa: F403
-from aggregate_tests4.test_map_tbl import *  # noqa: F403
-from aggregate_tests.test_row_tbl import *  # noqa: F403
-from aggregate_tests3.test_unsigned_int_tbl import *  # noqa: F403
-from aggregate_tests3.test_varbinary_tbl import *  # noqa: F403

--- a/python/tests/runtime_aggtest/aggregate_tests6/test_table.py
+++ b/python/tests/runtime_aggtest/aggregate_tests6/test_table.py
@@ -1,0 +1,7 @@
+from tests.runtime_aggtest.aggregate_tests2.test_atbl_interval import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests4.test_array_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests3.test_binary_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests4.test_map_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests.test_row_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests3.test_unsigned_int_tbl import *  # noqa: F403
+from tests.runtime_aggtest.aggregate_tests3.test_varbinary_tbl import *  # noqa: F403

--- a/python/tests/runtime_aggtest/run.sh
+++ b/python/tests/runtime_aggtest/run.sh
@@ -10,6 +10,8 @@ runtest aggregate_tests/main.py
 runtest aggregate_tests2/main.py
 runtest aggregate_tests3/main.py
 runtest aggregate_tests4/main.py
+runtest aggregate_tests5/main.py
+runtest aggregate_tests6/main.py
 runtest arithmetic_tests/main.py
 runtest complex_type_tests/main.py
 runtest orderby_tests/main.py


### PR DESCRIPTION
1. Updated `python/tests/runtime_aggtest/run.sh` to include: `aggregate_tests5/main.py`, `aggregate_tests6/main.py`
2. Fixed broken imports in `python/tests/runtime_aggtest/aggregate_tests5/test_table.py` and `python/tests/runtime_aggtest/aggregate_tests6/test_table.py`