### PR TITLE
[manager] ship json profile together with dot circuit profiles

### DIFF
--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -653,6 +653,7 @@ class TestPipeline(SharedTestPipeline):
             with zipfile.ZipFile(io.BytesIO(support_bundle_bytes), "r") as zip_file:
                 # Check that the ZIP file contains some files
                 file_list = zip_file.namelist()
+                assert any("json_circuit_profile.zip" in item for item in file_list)
                 assert len(file_list) > 0
         except zipfile.BadZipFile:
             self.fail("Support bundle is not a valid ZIP file")


### PR DESCRIPTION
This is a step towards making a html-based profiler browser.
The browser will also need the dataflow graph information; we will add that in a subsequent PR.
