### PR TITLE
[adapters] Use a dedicate tokio IO runtime in delta.

### DIFF
--- a/crates/dbsp/src/circuit/tokio.rs
+++ b/crates/dbsp/src/circuit/tokio.rs
@@ -1,4 +1,4 @@
 /// The process running dbsp can share a single Tokio runtime.
 ///
 /// This is `pub` so it can be used in adapters too for IO.
-pub use feldera_storage::tokio::TOKIO;
+pub use feldera_storage::tokio::{TOKIO, TOKIO_DEDICATED_IO};


### PR DESCRIPTION
See commit messages.

Fixes: #4972 