### PR TITLE
[py] Fix race in negative tests.

### DIFF
--- a/python/tests/runtime_aggtest/aggtst_base.py
+++ b/python/tests/runtime_aggtest/aggtst_base.py
@@ -145,6 +145,7 @@ class View(SqlObject):
                 data, expected, f"\nASSERTION ERROR: failed view: {self.name}"
             )
 
+
 class DeploymentErrorException(Exception):
     """Adds deployment error information to an exception.
 
@@ -176,6 +177,7 @@ class DeploymentErrorException(Exception):
             f"{str(self.original_exception)}\n"
             f"Pipeline deployment error: {self.deployment_error}"
         )
+
 
 class TstAccumulator:
     """Base class which accumulates multiple DBSP tests to run and executes them"""


### PR DESCRIPTION
This fix attempts to address the following race:

- Pipeline panics during a negative test (as expected)
- The client keeps polling the pipeline, e.g., with /completion_status.
- Before the client request hits the pipeline, the runner detects the panic and starts stopping the pipeline.
- At this point, instead of an error indicating that the pipeline failed with a panic, the client will get back a different error - that the manager cannot interact with the pipeline in the stopping state. The problem with this is that the test expects the exception to contain a specific substring, and will fail if the string is not found.

Note that the error description is still available in the deployment_error field of the pipeline descriptor.

The fix attempts to address this by enriching the exception thrown by the pipeline with the text in the deployment_error field of the pipeline.

This issue is not easy to reproduce deterministically, so I wasn't able to test the fix.
