### PR TITLE
docs: sync: DeleteBucket -> DeleteObject

### DIFF
--- a/docs.feldera.com/docs/pipelines/checkpoint-sync.md
+++ b/docs.feldera.com/docs/pipelines/checkpoint-sync.md
@@ -67,7 +67,7 @@ The following minimum permissions are required to be available on the bucket
 being written to:
 
 - `ListBucket`
-- `DeleteBucket`
+- `DeleteObject`
 - `GetObject`
 - `PutObject`
 - `PutObjectACL`


### PR DESCRIPTION
We don't need DeleteBucket permissions only DeleteObject.