### PR TITLE
[manager] Switch from awc to reqwest.

### DIFF
--- a/crates/pipeline-manager/src/api/endpoints/config.rs
+++ b/crates/pipeline-manager/src/api/endpoints/config.rs
@@ -146,7 +146,7 @@ impl Configuration {
 #[get("/config")]
 pub(crate) async fn get_config(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     _tenant_id: ReqData<TenantId>,
 ) -> Result<HttpResponse, ManagerError> {
     let config = Configuration::gather(&state).await;

--- a/crates/pipeline-manager/src/api/endpoints/metrics.rs
+++ b/crates/pipeline-manager/src/api/endpoints/metrics.rs
@@ -29,7 +29,7 @@ use feldera_types::runtime_status::RuntimeStatus;
 #[get("/metrics")]
 pub(crate) async fn get_metrics(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
 ) -> Result<HttpResponse, ManagerError> {
     let pipelines = state

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -89,7 +89,7 @@ pub mod support_bundle;
 #[post("/pipelines/{pipeline_name}/ingress/{table_name}")]
 pub(crate) async fn http_input(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String)>,
     req: HttpRequest,
@@ -170,7 +170,7 @@ pub(crate) async fn http_input(
 #[post("/pipelines/{pipeline_name}/egress/{table_name}")]
 pub(crate) async fn http_output(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String)>,
     req: HttpRequest,
@@ -256,7 +256,7 @@ pub(crate) async fn http_output(
 #[post("/pipelines/{pipeline_name}/tables/{table_name}/connectors/{connector_name}/{action}")]
 pub(crate) async fn post_pipeline_input_connector_action(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String, String, String)>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -343,7 +343,7 @@ pub(crate) async fn post_pipeline_input_connector_action(
 #[get("/pipelines/{pipeline_name}/tables/{table_name}/connectors/{connector_name}/stats")]
 pub(crate) async fn get_pipeline_input_connector_status(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String, String)>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -414,7 +414,7 @@ pub(crate) async fn get_pipeline_input_connector_status(
 #[get("/pipelines/{pipeline_name}/views/{view_name}/connectors/{connector_name}/stats")]
 pub(crate) async fn get_pipeline_output_connector_status(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String, String)>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -479,7 +479,7 @@ pub(crate) async fn get_pipeline_output_connector_status(
 #[get("/pipelines/{pipeline_name}/stats")]
 pub(crate) async fn get_pipeline_stats(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -531,7 +531,7 @@ pub(crate) async fn get_pipeline_stats(
 #[get("/pipelines/{pipeline_name}/metrics")]
 pub(crate) async fn get_pipeline_metrics(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     _query: web::Query<MetricsParameters>,
@@ -583,7 +583,7 @@ pub(crate) async fn get_pipeline_metrics(
 #[get("/pipelines/{pipeline_name}/time_series")]
 pub(crate) async fn get_pipeline_time_series(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -640,7 +640,7 @@ pub(crate) async fn get_pipeline_time_series(
 #[get("/pipelines/{pipeline_name}/time_series_stream")]
 pub(crate) async fn get_pipeline_time_series_stream(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -693,7 +693,7 @@ pub(crate) async fn get_pipeline_time_series_stream(
 #[get("/pipelines/{pipeline_name}/circuit_profile")]
 pub(crate) async fn get_pipeline_circuit_profile(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -745,7 +745,7 @@ pub(crate) async fn get_pipeline_circuit_profile(
 #[get("/pipelines/{pipeline_name}/circuit_json_profile")]
 pub(crate) async fn get_pipeline_circuit_json_profile(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -796,7 +796,7 @@ pub(crate) async fn get_pipeline_circuit_json_profile(
 #[post("/pipelines/{pipeline_name}/checkpoint/sync")]
 pub(crate) async fn sync_checkpoint(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -862,7 +862,7 @@ pub(crate) async fn sync_checkpoint(
 #[post("/pipelines/{pipeline_name}/checkpoint")]
 pub(crate) async fn checkpoint_pipeline(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -926,7 +926,7 @@ pub(crate) async fn checkpoint_pipeline(
 #[get("/pipelines/{pipeline_name}/checkpoint_status")]
 pub(crate) async fn get_checkpoint_status(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -978,7 +978,7 @@ pub(crate) async fn get_checkpoint_status(
 #[get("/pipelines/{pipeline_name}/checkpoint/sync_status")]
 pub(crate) async fn get_checkpoint_sync_status(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1033,7 +1033,7 @@ pub(crate) async fn get_checkpoint_sync_status(
 #[get("/pipelines/{pipeline_name}/heap_profile")]
 pub(crate) async fn get_pipeline_heap_profile(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1080,7 +1080,7 @@ pub(crate) async fn get_pipeline_heap_profile(
 #[post("/pipelines/{pipeline_name}/pause")]
 pub(crate) async fn post_pipeline_pause(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -1140,7 +1140,7 @@ pub(crate) async fn post_pipeline_pause(
 #[post("/pipelines/{pipeline_name}/resume")]
 pub(crate) async fn post_pipeline_resume(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -1211,7 +1211,7 @@ pub(crate) async fn post_pipeline_resume(
 #[post("/pipelines/{pipeline_name}/activate")]
 pub(crate) async fn post_pipeline_activate(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     _query: web::Query<ActivateParams>,
@@ -1295,7 +1295,7 @@ pub(crate) async fn post_pipeline_activate(
 #[post("/pipelines/{pipeline_name}/approve")]
 pub(crate) async fn post_pipeline_approve(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1384,7 +1384,8 @@ fn request_is_websocket(request: &HttpRequest) -> bool {
 #[get("/pipelines/{pipeline_name}/query")]
 pub(crate) async fn pipeline_adhoc_sql(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    reqwest_client: WebData<reqwest::Client>,
+    awc_client: WebData<awc::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1395,7 +1396,7 @@ pub(crate) async fn pipeline_adhoc_sql(
         state
             .runner
             .forward_websocket_request_to_pipeline_by_name(
-                client.as_ref(),
+                awc_client.as_ref(),
                 *tenant_id,
                 &pipeline_name,
                 "query",
@@ -1407,7 +1408,7 @@ pub(crate) async fn pipeline_adhoc_sql(
         state
             .runner
             .forward_streaming_http_request_to_pipeline_by_name(
-                client.as_ref(),
+                reqwest_client.as_ref(),
                 *tenant_id,
                 &pipeline_name,
                 "query",
@@ -1460,7 +1461,7 @@ pub(crate) async fn pipeline_adhoc_sql(
 )]
 pub(crate) async fn completion_token(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<(String, String, String)>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -1534,7 +1535,7 @@ pub(crate) async fn completion_token(
 #[get("/pipelines/{pipeline_name}/completion_status")]
 pub(crate) async fn completion_status(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1589,7 +1590,7 @@ pub(crate) async fn completion_status(
 #[post("/pipelines/{pipeline_name}/start_transaction")]
 pub(crate) async fn start_transaction(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,
@@ -1643,7 +1644,7 @@ pub(crate) async fn start_transaction(
 #[post("/pipelines/{pipeline_name}/commit_transaction")]
 pub(crate) async fn commit_transaction(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     request: HttpRequest,

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction/support_bundle.rs
@@ -152,7 +152,7 @@ impl SupportBundleZip {
 #[get("/pipelines/{pipeline_name}/support_bundle")]
 pub(crate) async fn get_pipeline_support_bundle(
     state: WebData<ServerState>,
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     query: web::Query<SupportBundleParameters>,

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -1226,7 +1226,7 @@ pub(crate) async fn post_pipeline_start(
 #[post("/pipelines/{pipeline_name}/stop")]
 pub(crate) async fn post_pipeline_stop(
     state: WebData<ServerState>,
-    _client: WebData<awc::Client>,
+    _client: WebData<reqwest::Client>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,
     query: web::Query<PostStopPipelineParameters>,
@@ -1395,7 +1395,7 @@ pub(crate) async fn post_pipeline_clear(
 )]
 #[get("/pipelines/{pipeline_name}/logs")]
 pub(crate) async fn get_pipeline_logs(
-    client: WebData<awc::Client>,
+    client: WebData<reqwest::Client>,
     state: WebData<ServerState>,
     tenant_id: ReqData<TenantId>,
     path: web::Path<String>,

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -396,11 +396,19 @@ impl CommonConfig {
             reqwest::ClientBuilder::new()
                 .https_only(true) // Only connect to HTTPS
                 .add_root_certificate(root_cert) // Add our own TLS certificate which is used
-                .tls_built_in_root_certs(false) // Other TLS certificates are not used
+                .tls_built_in_root_certs(false) // Other
+                // Disable connection caching. Normally, the HTTP client would cache HTTP connections
+                // to pipelines, but when the pipeline pod gets evicted and restarts on a different
+                // host or just stops and restarts, this connection is no longer valid, causing
+                // HTTP errors. This setting disables connection caching.
+                .pool_max_idle_per_host(0)
                 .build()
                 .expect("HTTPS client should be built")
         } else {
-            reqwest::Client::new()
+            reqwest::ClientBuilder::new()
+                .pool_max_idle_per_host(0)
+                .build()
+                .expect("HTTP client should be built")
         }
     }
 


### PR DESCRIPTION
This patch replaces `awc` with `reqwest` as the HTTP client for talking to the pipeline. The main reason for this are various hard-to-explain HTTP errors we've observed in CI. On top of this, awc doesn't support a clean way to disable connection caching. It can only be achieved by setting the `connection: Close` header, which we suspect confuses the server. In contrast, reqwest supports setting connection pool size to 0.

This commit was mostly generated by cursor.

There are a couple of subtle points here (which cursor missed)

- In awc, ClientRequest::timeout() controls timeout from request start till HTTP response header is returned. reqwest doesn't have a similar method, so we use tokio::timeout instead.

- reqwest seems to handle disconnects differently from awc: in awc when the pipeline drops its end of a streaming response, the byte stream simply ends (without an error); in reqwest, the stream contains an error, which gets propagated to the API client. This may be the right thing to do, but currently the Python SDK doesn't expect that. We simulate the old behavior to avoid a breaking change.