### PR TITLE
[docs] Add --pull always to docker quickstart

### DIFF
--- a/docs.feldera.com/docs/get-started/docker.md
+++ b/docs.feldera.com/docs/get-started/docker.md
@@ -7,7 +7,7 @@ use, check out [Feldera Enterprise](/get-started/enterprise).
 ## Docker Quickstart
 
 ```
-docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
+docker run --pull always -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
 ```
 
 Once you see the Feldera logo on your terminal, go ahead and open the Web Console


### PR DESCRIPTION
Docker quickstart is likely one of the first entry points for users testing Feldera, this ensure they always get last version.

Close #5023 

## Checklist

- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
