### PR TITLE
pipeline-manager: support multiple compiler workers for parallel compilation

### DIFF
--- a/crates/pipeline-manager/src/compiler/main.rs
+++ b/crates/pipeline-manager/src/compiler/main.rs
@@ -17,13 +17,13 @@ use crate::db::types::tenant::TenantId;
 use crate::db::types::version::Version;
 use crate::error::ManagerError;
 use actix_files::NamedFile;
-use actix_web::{get, web, HttpRequest, HttpServer, Responder};
-use futures_util::join;
+use actix_web::{get, post, web, HttpRequest, HttpResponse, HttpServer, Responder};
+use futures_util::{join, StreamExt};
 use log::{error, info};
 use std::net::TcpListener;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::{fs, spawn, sync::Mutex};
+use tokio::{fs, io::AsyncWriteExt, spawn, sync::Mutex};
 use uuid::Uuid;
 
 /// Decodes the URL encoded parameter value as a string.
@@ -97,6 +97,149 @@ async fn get_binary(
 
     // Read and return file as response
     Ok(NamedFile::open_async(binary_file_path).await)
+}
+
+/// Uploads a compiled binary using streaming.
+/// Metadata is passed via path parameters and the binary is streamed directly to disk.
+#[post("/binary/{pipeline_id}/{program_version}/{source_checksum}/{integrity_checksum}")]
+async fn upload_binary(
+    config: web::Data<CompilerConfig>,
+    req: HttpRequest,
+    mut payload: web::Payload,
+) -> Result<impl Responder, ManagerError> {
+    // Retrieve URL encoded parameters
+    let path_parameters = req.match_info();
+    let pipeline_id =
+        decode_url_encoded_parameter("pipeline_id", path_parameters.get("pipeline_id"))?;
+    let program_version =
+        decode_url_encoded_parameter("program_version", path_parameters.get("program_version"))?;
+    let source_checksum =
+        decode_url_encoded_parameter("source_checksum", path_parameters.get("source_checksum"))?;
+    let expected_integrity_checksum = decode_url_encoded_parameter(
+        "integrity_checksum",
+        path_parameters.get("integrity_checksum"),
+    )?;
+
+    // Validate parameters
+    let pipeline_id_uuid =
+        Uuid::from_str(&pipeline_id).map_err(|e| ApiError::InvalidUuidParam {
+            value: pipeline_id.clone(),
+            error: e.to_string(),
+        })?;
+    let pipeline_id = PipelineId(pipeline_id_uuid);
+
+    let program_version =
+        Version(
+            i64::from_str(&program_version).map_err(|e| ApiError::InvalidVersionParam {
+                value: program_version.clone(),
+                error: e.to_string(),
+            })?,
+        );
+
+    validate_is_sha256_checksum(&source_checksum).map_err(|e| {
+        ManagerError::from(ApiError::InvalidChecksumParam {
+            value: source_checksum.to_string(),
+            error: e,
+        })
+    })?;
+
+    validate_is_sha256_checksum(&expected_integrity_checksum).map_err(|e| {
+        ManagerError::from(ApiError::InvalidChecksumParam {
+            value: expected_integrity_checksum.to_string(),
+            error: e,
+        })
+    })?;
+
+    // Create pipeline-binaries directory if it doesn't exist
+    let pipeline_binaries_dir = config
+        .working_dir()
+        .join("rust-compilation")
+        .join("pipeline-binaries");
+
+    fs::create_dir_all(&pipeline_binaries_dir)
+        .await
+        .map_err(|e| {
+            ManagerError::from(CommonError::io_error(
+                format!("creating directory '{}'", pipeline_binaries_dir.display()),
+                e,
+            ))
+        })?;
+
+    // Form the target file path
+    let target_file_path = pipeline_binaries_dir.join(format!(
+        "pipeline_{}_v{}_sc_{}_ic_{}",
+        pipeline_id, program_version, source_checksum, expected_integrity_checksum
+    ));
+
+    // Stream the binary directly to disk with integrity checksum validation
+    let mut file = fs::File::create(&target_file_path).await.map_err(|e| {
+        ManagerError::from(CommonError::io_error(
+            format!("creating file '{}'", target_file_path.display()),
+            e,
+        ))
+    })?;
+
+    let mut hasher = openssl::sha::Sha256::new();
+    let mut total_size = 0usize;
+
+    while let Some(chunk) = payload.next().await {
+        let chunk = chunk.map_err(|e| {
+            ManagerError::from(CommonError::io_error(
+                "reading payload chunk".to_string(),
+                std::io::Error::other(format!("Payload error: {e}")),
+            ))
+        })?;
+
+        // Update checksum
+        hasher.update(&chunk);
+        total_size += chunk.len();
+
+        // Write chunk to file
+        file.write_all(&chunk).await.map_err(|e| {
+            ManagerError::from(CommonError::io_error(
+                format!("writing to file '{}'", target_file_path.display()),
+                e,
+            ))
+        })?;
+    }
+
+    // Flush and close file
+    file.flush().await.map_err(|e| {
+        ManagerError::from(CommonError::io_error(
+            format!("flushing file '{}'", target_file_path.display()),
+            e,
+        ))
+    })?;
+    drop(file);
+
+    // Validate integrity checksum
+    let actual_integrity_checksum = hex::encode(hasher.finish());
+    if actual_integrity_checksum != expected_integrity_checksum {
+        // Remove the invalid file
+        let _ = fs::remove_file(&target_file_path).await;
+        return Err(ManagerError::from(ApiError::InvalidChecksumParam {
+            value: format!(
+                "Expected integrity checksum '{}', but calculated '{}'",
+                expected_integrity_checksum, actual_integrity_checksum
+            ),
+            error: "Integrity checksum mismatch".to_string(),
+        }));
+    }
+
+    info!(
+        "Successfully received binary for pipeline {} (program version: {}) ({} bytes)",
+        pipeline_id, program_version, total_size
+    );
+
+    // Return success response
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "message": "Binary uploaded successfully",
+        "pipeline_id": pipeline_id.to_string(),
+        "program_version": program_version.0,
+        "source_checksum": source_checksum,
+        "integrity_checksum": expected_integrity_checksum,
+        "file_size": total_size
+    })))
 }
 
 /// Health check which returns success if it is able to reach the database.
@@ -217,6 +360,9 @@ pub async fn compiler_precompile(
             error: compilation_info.to_string(),
         },
         RustCompilationError::SystemError(error) => CompilerError::PrecompilationError { error },
+        RustCompilationError::BinaryUploadError(error) => {
+            CompilerError::PrecompilationError { error }
+        }
     })?;
 
     // Success
@@ -240,6 +386,8 @@ pub async fn compiler_main(
     common_config: CommonConfig,
     config: CompilerConfig,
     db: Arc<Mutex<StoragePostgres>>,
+    worker_id: usize,
+    total_workers: usize,
 ) -> Result<(), ManagerError> {
     // All threads will operate in the same working directory.
     // This must be created in advance such that there is no
@@ -248,11 +396,15 @@ pub async fn compiler_main(
 
     // Spawn compilation threads
     let sql_task = spawn(sql_compiler_task(
+        worker_id,
+        total_workers,
         common_config.clone(),
         config.clone(),
         db.clone(),
     ));
     let rust_task = spawn(rust_compiler_task(
+        worker_id,
+        total_workers,
         common_config.clone(),
         config.clone(),
         db.clone(),
@@ -266,6 +418,7 @@ pub async fn compiler_main(
             .app_data(config.clone())
             .app_data(probe.clone())
             .service(get_binary)
+            .service(upload_binary)
             .service(healthz)
     })
     .workers(common_config.http_workers)
@@ -314,12 +467,15 @@ pub async fn compiler_main(
 mod test {
     use crate::api::error::ApiError;
     use crate::compiler::main::{
-        create_working_directory_if_not_exists, decode_url_encoded_parameter,
+        create_working_directory_if_not_exists, decode_url_encoded_parameter, upload_binary,
     };
     use crate::config::CompilerConfig;
     use crate::db::types::program::CompilationProfile;
     use crate::error::ManagerError;
+    use actix_web::{test as actix_test, web, App};
+    use openssl::sha::sha256;
     use tokio::fs;
+    use uuid::Uuid;
 
     #[test]
     fn decoding_url_encoded_parameter() {
@@ -360,6 +516,10 @@ mod test {
             sql_compiler_cache_url: "".to_string(),
             compilation_cargo_lock_path: "".to_string(),
             dbsp_override_path: "".to_string(),
+            binary_upload_endpoint: None,
+            binary_upload_timeout_secs: 600,
+            binary_upload_max_retries: 3,
+            binary_upload_retry_delay_ms: 1000,
             precompile: false,
         })
         .await
@@ -376,10 +536,286 @@ mod test {
             sql_compiler_cache_url: "".to_string(),
             compilation_cargo_lock_path: "".to_string(),
             dbsp_override_path: "".to_string(),
+            binary_upload_endpoint: None,
+            binary_upload_timeout_secs: 600,
+            binary_upload_max_retries: 3,
+            binary_upload_retry_delay_ms: 1000,
             precompile: false,
         })
         .await
         .unwrap();
         assert!(non_existing_path.is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_streaming_binary_upload_success() {
+        let (_tempdir, config) = create_test_config("success");
+        let app = create_test_app(config.clone()).await;
+
+        // Test cases with different data sizes
+        let test_cases = vec![
+            UploadTestCase::new("small", SMALL_TEST_DATA.to_vec()),
+            UploadTestCase::new("medium", create_test_data(64 * 1024)), // 64KB
+            UploadTestCase::new("large", create_test_data(1024 * 1024)), // 1MB
+        ];
+
+        for test_case in test_cases {
+            // Send upload request
+            let req = actix_test::TestRequest::post()
+                .uri(&test_case.url())
+                .set_payload(test_case.data.clone())
+                .to_request();
+
+            let resp = actix_test::call_service(&app, req).await;
+
+            // Verify successful response
+            assert!(
+                resp.status().is_success(),
+                "Upload should succeed for test case: {}",
+                test_case.name
+            );
+
+            // Verify response body structure
+            let body: serde_json::Value = actix_test::read_body_json(resp).await;
+            assert_eq!(body["message"], "Binary uploaded successfully");
+            assert_eq!(body["pipeline_id"], test_case.pipeline_id.to_string());
+            assert_eq!(body["program_version"], test_case.program_version);
+            assert_eq!(body["source_checksum"], test_case.source_checksum);
+            assert_eq!(body["integrity_checksum"], test_case.integrity_checksum);
+            assert_eq!(body["file_size"], test_case.data.len());
+
+            // Verify file was written correctly
+            let expected_path = get_expected_binary_path(
+                &std::path::PathBuf::from(&config.compiler_working_directory),
+                &test_case.pipeline_id,
+                test_case.program_version,
+                &test_case.source_checksum,
+                &test_case.integrity_checksum,
+            );
+
+            assert!(
+                expected_path.exists(),
+                "Binary file should exist for test case: {}",
+                test_case.name
+            );
+
+            // Verify file contents match original data
+            let written_data = fs::read(&expected_path).await.unwrap();
+            assert_eq!(
+                written_data, test_case.data,
+                "Written data should match original for test case: {}",
+                test_case.name
+            );
+
+            // Verify integrity checksum
+            let actual_checksum = hex::encode(sha256(&written_data));
+            assert_eq!(
+                actual_checksum, test_case.integrity_checksum,
+                "Checksum should match for test case: {}",
+                test_case.name
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_streaming_binary_upload_checksum_mismatch() {
+        let (_tempdir, config) = create_test_config("checksum_fail");
+        let app = create_test_app(config.clone()).await;
+
+        let test_data = SMALL_TEST_DATA;
+        let pipeline_id = Uuid::now_v7();
+        let source_checksum = hex::encode(sha256(b"test_source"));
+        let wrong_integrity_checksum = hex::encode(sha256(b"wrong_data")); // Intentionally wrong
+
+        let url = build_upload_url(&pipeline_id, 1, &source_checksum, &wrong_integrity_checksum);
+
+        // Send request with mismatched checksum
+        let req = actix_test::TestRequest::post()
+            .uri(&url)
+            .set_payload(test_data.to_vec())
+            .to_request();
+
+        let resp = actix_test::call_service(&app, req).await;
+
+        // Should return 400 Bad Request
+        assert_eq!(
+            resp.status(),
+            400,
+            "Upload should fail with checksum mismatch"
+        );
+
+        // Verify file was NOT created (should be cleaned up)
+        let expected_path = get_expected_binary_path(
+            &std::path::PathBuf::from(&config.compiler_working_directory),
+            &pipeline_id,
+            1,
+            &source_checksum,
+            &wrong_integrity_checksum,
+        );
+
+        assert!(
+            !expected_path.exists(),
+            "Binary file should not exist after checksum failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_binary_upload_invalid_parameters() {
+        let (_tempdir, config) = create_test_config("invalid_params");
+        let app = create_test_app(config).await;
+
+        let test_data = SMALL_TEST_DATA;
+        let valid_pipeline_id = Uuid::now_v7();
+
+        // Test cases for parameter validation
+        let invalid_cases = vec![
+            (
+                "invalid UUID",
+                "/binary/not-a-uuid/1/".to_string() + VALID_SHA256 + "/" + VALID_SHA256,
+            ),
+            (
+                "invalid version",
+                format!(
+                    "/binary/{}/not-a-number/{}/{}",
+                    valid_pipeline_id, VALID_SHA256, VALID_SHA256
+                ),
+            ),
+            (
+                "invalid source checksum",
+                format!("/binary/{}/1/short/{}", valid_pipeline_id, VALID_SHA256),
+            ),
+            (
+                "invalid integrity checksum",
+                format!("/binary/{}/1/{}/short", valid_pipeline_id, VALID_SHA256),
+            ),
+        ];
+
+        for (test_name, url) in invalid_cases {
+            let req = actix_test::TestRequest::post()
+                .uri(&url)
+                .set_payload(test_data.to_vec())
+                .to_request();
+
+            let resp = actix_test::call_service(&app, req).await;
+
+            assert_eq!(
+                resp.status(),
+                400,
+                "Should return 400 Bad Request for test case: {}",
+                test_name
+            );
+        }
+    }
+
+    // Test helper functions and constants
+    const SMALL_TEST_DATA: &[u8] = b"Hello, World! This is test binary data.";
+    const VALID_SHA256: &str = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
+
+    /// Creates a test CompilerConfig with a temporary directory
+    fn create_test_config(test_name: &str) -> (tempfile::TempDir, CompilerConfig) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let working_dir = tempdir.path().join(test_name);
+
+        let config = CompilerConfig {
+            compiler_working_directory: working_dir.to_string_lossy().to_string(),
+            compilation_profile: CompilationProfile::Optimized,
+            sql_compiler_path: String::new(),
+            sql_compiler_cache_url: String::new(),
+            compilation_cargo_lock_path: String::new(),
+            dbsp_override_path: String::new(),
+            binary_upload_endpoint: None,
+            binary_upload_timeout_secs: 600,
+            binary_upload_max_retries: 3,
+            binary_upload_retry_delay_ms: 1000,
+            precompile: false,
+        };
+
+        (tempdir, config)
+    }
+
+    /// Creates a test app with the upload_binary service
+    async fn create_test_app(
+        config: CompilerConfig,
+    ) -> impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    > {
+        actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(config))
+                .service(upload_binary),
+        )
+        .await
+    }
+
+    /// Creates test binary data of specified size with predictable pattern
+    fn create_test_data(size: usize) -> Vec<u8> {
+        (0..size).map(|i| (i % 256) as u8).collect()
+    }
+
+    /// Builds upload URL from parameters
+    fn build_upload_url(
+        pipeline_id: &Uuid,
+        program_version: i64,
+        source_checksum: &str,
+        integrity_checksum: &str,
+    ) -> String {
+        format!(
+            "/binary/{}/{}/{}/{}",
+            pipeline_id, program_version, source_checksum, integrity_checksum
+        )
+    }
+
+    /// Creates expected file path for a binary
+    fn get_expected_binary_path(
+        working_dir: &std::path::Path,
+        pipeline_id: &Uuid,
+        program_version: i64,
+        source_checksum: &str,
+        integrity_checksum: &str,
+    ) -> std::path::PathBuf {
+        working_dir
+            .join("rust-compilation")
+            .join("pipeline-binaries")
+            .join(format!(
+                "pipeline_{}_v{}_sc_{}_ic_{}",
+                pipeline_id, program_version, source_checksum, integrity_checksum
+            ))
+    }
+
+    /// Test data structure for parameterized tests
+    struct UploadTestCase {
+        name: &'static str,
+        data: Vec<u8>,
+        pipeline_id: Uuid,
+        program_version: i64,
+        source_checksum: String,
+        integrity_checksum: String,
+    }
+
+    impl UploadTestCase {
+        fn new(name: &'static str, data: Vec<u8>) -> Self {
+            let source_checksum = hex::encode(sha256(b"test_source"));
+            let integrity_checksum = hex::encode(sha256(&data));
+
+            Self {
+                name,
+                data,
+                pipeline_id: Uuid::now_v7(),
+                program_version: 1,
+                source_checksum,
+                integrity_checksum,
+            }
+        }
+
+        fn url(&self) -> String {
+            build_upload_url(
+                &self.pipeline_id,
+                self.program_version,
+                &self.source_checksum,
+                &self.integrity_checksum,
+            )
+        }
     }
 }

--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -14,8 +14,10 @@ use crate::db::types::program::{CompilationProfile, RuntimeSelector, RustCompila
 use crate::db::types::tenant::TenantId;
 use crate::db::types::utils::{validate_program_config, validate_program_info};
 use crate::db::types::version::Version;
+use crate::error::source_error;
 use crate::has_unstable_feature;
 use chrono::{DateTime, Utc};
+use futures_util::stream;
 use indoc::formatdoc;
 use log::{debug, error, info, trace, warn};
 use openssl::sha;
@@ -26,6 +28,7 @@ use std::time::{Instant, SystemTime};
 use std::{process::Stdio, sync::Arc};
 use tokio::{
     fs,
+    io::AsyncReadExt,
     process::Command,
     sync::Mutex,
     time::{sleep, Duration},
@@ -59,11 +62,16 @@ const CLEANUP_INTERVAL: Duration = Duration::from_secs(120);
 /// a significant amount of time.
 const CLEANUP_RETENTION: Duration = Duration::from_secs(3600);
 
+/// Maximum chunk size for uploading binary to HTTP endpoint.
+/// This balances memory usage and upload performance.
+const MAX_CHUNK_SIZE_FOR_UPLOAD_BINARY: usize = 10 * 1024 * 1024; // 10MB
+
 /// Rust compilation task that wakes up periodically.
 /// Sleeps inbetween ticks which affects the response time of Rust compilation.
-/// Note that the logic in this task assumes only one is run at a time.
 /// This task cannot fail, and any internal errors are caught and written to log if need-be.
 pub async fn rust_compiler_task(
+    worker_id: usize,
+    total_workers: usize,
     common_config: CommonConfig,
     config: CompilerConfig,
     db: Arc<Mutex<StoragePostgres>>,
@@ -77,10 +85,10 @@ pub async fn rust_compiler_task(
             if let Err(e) = cleanup_rust_compilation(&config, db.clone()).await {
                 match e {
                     RustCompilationCleanupError::Database(e) => {
-                        error!("Rust compilation cleanup failed: database error occurred: {e}");
+                        error!("Rust worker {worker_id}: compilation cleanup failed: database error occurred: {e}");
                     }
                     RustCompilationCleanupError::Utility(e) => {
-                        error!("Rust compilation cleanup failed: utility error occurred: {e}");
+                        error!("Rust worker {worker_id}: compilation cleanup failed: utility error occurred: {e}");
                     }
                 }
                 unexpected_error = true;
@@ -89,21 +97,28 @@ pub async fn rust_compiler_task(
         }
 
         // Compile
-        let result = attempt_end_to_end_rust_compilation(&common_config, &config, db.clone()).await;
+        let result = attempt_end_to_end_rust_compilation(
+            worker_id,
+            total_workers,
+            &common_config,
+            &config,
+            db.clone(),
+        )
+        .await;
         if let Err(e) = &result {
             match e {
                 DBError::UnknownPipeline { pipeline_id } => {
-                    debug!("Rust compilation canceled: pipeline {pipeline_id} no longer exists");
+                    debug!("Rust worker {worker_id}: compilation canceled: pipeline {pipeline_id} no longer exists");
                 }
                 DBError::OutdatedProgramVersion {
                     outdated_version,
                     latest_version,
                 } => {
-                    debug!("Rust compilation canceled: pipeline program version ({outdated_version}) is outdated by latest ({latest_version})");
+                    debug!("Rust worker {worker_id}: compilation canceled: pipeline program version ({outdated_version}) is outdated by latest ({latest_version})");
                 }
                 e => {
                     unexpected_error = true;
-                    error!("Rust compilation canceled: unexpected database error occurred: {e}");
+                    error!("Rust worker {worker_id}: compilation canceled: unexpected database error occurred: {e}");
                 }
             }
         }
@@ -147,23 +162,32 @@ pub async fn rust_compiler_task(
 /// - The pipeline program is detected to be updated (it became outdated)
 /// - The database cannot be reached
 async fn attempt_end_to_end_rust_compilation(
+    worker_id: usize,
+    total_workers: usize,
     common_config: &CommonConfig,
     config: &CompilerConfig,
     db: Arc<Mutex<StoragePostgres>>,
 ) -> Result<bool, DBError> {
-    trace!("Performing Rust compilation...");
+    trace!("Rust worker {worker_id}: Performing Rust compilation...");
 
     // (1) Reset any pipeline which is `CompilingRust` back to `SqlCompiled`
+    // Only the owner worker (by modulo) resets stuck CompilingRust pipelines to SqlCompiled
+    // This ensures that only the assigned worker for a pipeline can reset its status
     db.lock()
         .await
-        .clear_ongoing_rust_compilation(&common_config.platform_version)
+        .clear_ongoing_rust_compilation_for_worker(
+            &common_config.platform_version,
+            worker_id,
+            total_workers,
+        )
         .await?;
 
     // (2) Find pipeline which needs Rust compilation
+    // Atomically claim the next pipeline for Rust compilation using modulo sharding
     let Some((tenant_id, pipeline)) = db
         .lock()
         .await
-        .get_next_rust_compilation(&common_config.platform_version)
+        .get_next_rust_compilation(&common_config.platform_version, worker_id, total_workers)
         .await?
     else {
         trace!("No pipeline found which needs Rust compilation");
@@ -270,6 +294,18 @@ async fn attempt_end_to_end_rust_compilation(
                     .await?;
                 error!("Rust compilation failed: pipeline {} (program version: {}) due to system error:\n{}", pipeline.id, pipeline.program_version, internal_system_error);
             }
+            RustCompilationError::BinaryUploadError(upload_error) => {
+                db.lock()
+                    .await
+                    .transit_program_status_to_system_error(
+                        tenant_id,
+                        pipeline.id,
+                        pipeline.program_version,
+                        &upload_error,
+                    )
+                    .await?;
+                error!("Rust compilation failed: pipeline {} (program version: {}) due to binary upload error:\n{}", pipeline.id, pipeline.program_version, upload_error);
+            }
         },
     }
     Ok(true)
@@ -312,6 +348,54 @@ fn calculate_source_checksum(
     hex::encode(hasher.finish())
 }
 
+/// Metadata for a compiled binary
+#[derive(Debug, Clone)]
+struct BinaryMetadata {
+    pipeline_id: PipelineId,
+    program_version: Version,
+    source_checksum: String,
+    integrity_checksum: String,
+}
+
+impl BinaryMetadata {
+    /// Generate filename for the binary
+    fn filename(&self) -> String {
+        format!(
+            "pipeline_{}_v{}_sc_{}_ic_{}",
+            self.pipeline_id, self.program_version, self.source_checksum, self.integrity_checksum
+        )
+    }
+}
+
+/// Binary delivery mode for compiled pipeline binaries.
+#[derive(Debug, Clone)]
+pub enum BinaryDeliveryMode {
+    /// Copy binary to local filesystem destination
+    LocalCopy,
+    /// Upload binary to HTTP endpoint
+    HttpUpload {
+        endpoint: String,
+        timeout_secs: u64,
+        max_retries: u32,
+        retry_delay_ms: u64,
+    },
+}
+
+impl BinaryDeliveryMode {
+    /// Create binary delivery mode from configuration
+    pub fn from_config(config: &CompilerConfig) -> Self {
+        match &config.binary_upload_endpoint {
+            Some(endpoint) => Self::HttpUpload {
+                endpoint: endpoint.clone(),
+                timeout_secs: config.binary_upload_timeout_secs,
+                max_retries: config.binary_upload_max_retries,
+                retry_delay_ms: config.binary_upload_retry_delay_ms,
+            },
+            None => Self::LocalCopy,
+        }
+    }
+}
+
 /// Rust compilation possible error outcomes.
 #[derive(Debug)]
 pub enum RustCompilationError {
@@ -338,6 +422,8 @@ pub enum RustCompilationError {
     RustError(RustCompilationInfo),
     /// General system problem occurred (e.g., I/O error)
     SystemError(String),
+    /// Binary upload to HTTP endpoint failed
+    BinaryUploadError(String),
 }
 
 /// Utility errors are system errors during Rust compilation.
@@ -345,6 +431,207 @@ impl From<UtilError> for RustCompilationError {
     fn from(value: UtilError) -> Self {
         RustCompilationError::SystemError(value.to_string())
     }
+}
+
+/// Delivers the compiled binary according to the configured delivery mode.
+///
+/// For local copy mode, the binary is copied to the pipeline-binaries directory.
+/// For HTTP upload mode, the binary is uploaded to the configured endpoint as multipart/form-data.
+///
+/// Returns the final binary location/identifier.
+async fn deliver_binary(
+    common_config: &CommonConfig,
+    delivery_mode: &BinaryDeliveryMode,
+    source_file_path: &Path,
+    metadata: &BinaryMetadata,
+    pipeline_binaries_dir: &Path,
+) -> Result<String, RustCompilationError> {
+    match delivery_mode {
+        BinaryDeliveryMode::LocalCopy => {
+            // Original behavior: copy to local directory
+            let target_file_path = pipeline_binaries_dir.join(metadata.filename());
+
+            // Copy binary from Cargo target profile directory to the pipeline-binaries directory
+            copy_file(source_file_path, &target_file_path).await?;
+
+            Ok(target_file_path.to_string_lossy().to_string())
+        }
+        BinaryDeliveryMode::HttpUpload { .. } => {
+            // New behavior: upload to HTTP endpoint with retries
+            upload_binary_to_endpoint_with_retries(
+                common_config,
+                delivery_mode,
+                source_file_path,
+                metadata,
+            )
+            .await
+        }
+    }
+}
+
+/// Uploads the compiled binary to an HTTP endpoint with retry logic.
+async fn upload_binary_to_endpoint_with_retries(
+    common_config: &CommonConfig,
+    delivery_mode: &BinaryDeliveryMode,
+    binary_path: &Path,
+    metadata: &BinaryMetadata,
+) -> Result<String, RustCompilationError> {
+    let mut attempts = 0;
+
+    let (endpoint, timeout_secs, max_retries, mut retry_delay_ms) = match delivery_mode {
+        BinaryDeliveryMode::HttpUpload {
+            endpoint,
+            timeout_secs,
+            max_retries,
+            retry_delay_ms,
+        } => (endpoint, *timeout_secs, *max_retries, *retry_delay_ms),
+        _ => {
+            return Err(RustCompilationError::SystemError(
+                "Invalid delivery mode for HTTP upload".to_string(),
+            ))
+        }
+    };
+
+    loop {
+        attempts += 1;
+
+        match upload_binary_to_endpoint(
+            common_config,
+            endpoint,
+            timeout_secs,
+            binary_path,
+            metadata,
+        )
+        .await
+        {
+            Ok(result) => {
+                if attempts > 1 {
+                    info!(
+                        "Binary upload succeeded on attempt {} for pipeline {} (program version: {})",
+                        attempts, metadata.pipeline_id, metadata.program_version
+                    );
+                }
+                return Ok(result);
+            }
+            Err(e) => {
+                if attempts > max_retries {
+                    error!(
+                        "Binary upload failed after {} attempts for pipeline {} (program version: {}): {:?}",
+                        attempts, metadata.pipeline_id, metadata.program_version, e
+                    );
+                    return Err(e);
+                }
+
+                warn!(
+                    "Binary upload attempt {} failed for pipeline {} (program version: {}): {:?}. Retrying in {}ms...",
+                    attempts, metadata.pipeline_id, metadata.program_version, e, retry_delay_ms
+                );
+
+                // Wait before retrying with exponential backoff
+                sleep(Duration::from_millis(retry_delay_ms)).await;
+                retry_delay_ms *= 2; // Double the delay for next attempt
+            }
+        }
+    }
+}
+
+/// Uploads the compiled binary to an HTTP endpoint (single attempt) using streaming.
+async fn upload_binary_to_endpoint(
+    common_config: &CommonConfig,
+    endpoint: &str,
+    timeout_secs: u64,
+    binary_path: &Path,
+    metadata: &BinaryMetadata,
+) -> Result<String, RustCompilationError> {
+    // Open binary file for streaming
+    let file = fs::File::open(binary_path).await.map_err(|e| {
+        RustCompilationError::BinaryUploadError(format!(
+            "Failed to open binary file '{}': {}",
+            binary_path.display(),
+            e
+        ))
+    })?;
+
+    // Get file size for Content-Length header
+    let file_metadata = file.metadata().await.map_err(|e| {
+        RustCompilationError::BinaryUploadError(format!(
+            "Failed to get file metadata '{}': {}",
+            binary_path.display(),
+            e
+        ))
+    })?;
+    let file_size = file_metadata.len();
+
+    let stream = stream::try_unfold(file, |mut file| async move {
+        let mut buffer = vec![0u8; MAX_CHUNK_SIZE_FOR_UPLOAD_BINARY];
+        match file.read(&mut buffer).await {
+            Ok(0) => Ok(None), // EOF
+            Ok(n) => {
+                buffer.truncate(n);
+                Ok(Some((buffer, file)))
+            }
+            Err(e) => Err(e),
+        }
+    });
+
+    let body = reqwest::Body::wrap_stream(stream);
+
+    // Build URL with path parameters
+    let url = format!(
+        "{}/binary/{}/{}/{}/{}",
+        endpoint.trim_end_matches('/'),
+        metadata.pipeline_id,
+        metadata.program_version,
+        metadata.source_checksum,
+        metadata.integrity_checksum
+    );
+
+    // Use the properly configured HTTP client from common_config
+    let client = common_config.reqwest_client().await;
+
+    // Send request with timeout
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/octet-stream")
+        .header("Content-Length", file_size.to_string())
+        .body(body)
+        .timeout(Duration::from_secs(timeout_secs))
+        .send()
+        .await
+        .map_err(|e| {
+            RustCompilationError::BinaryUploadError(format!(
+                "Failed to upload binary to '{}': {} ({})",
+                url,
+                &e,
+                source_error(&e)
+            ))
+        })?;
+
+    // Check response status
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(RustCompilationError::BinaryUploadError(format!(
+            "Binary upload failed with status {}: {}",
+            status, error_text
+        )));
+    }
+
+    // Get response body for any location information
+    let response_text = response
+        .text()
+        .await
+        .unwrap_or_else(|_| endpoint.to_string());
+
+    debug!(
+        "Successfully uploaded binary for pipeline {} (program version: {}) to {}",
+        metadata.pipeline_id, metadata.program_version, endpoint
+    );
+
+    Ok(response_text)
 }
 
 pub(super) struct RustCompilationResult {
@@ -465,6 +752,7 @@ pub async fn perform_rust_compilation(
 
     // Perform the compilation in the workspace
     let (compilation_info, integrity_checksum, binary_size) = call_compiler(
+        common_config,
         db,
         tenant_id,
         pipeline_id,
@@ -1011,6 +1299,7 @@ extern crate sync_checkpoint;"#,
 /// Calls the compiler on the project with the provided source checksum and using the compilation profile.
 #[allow(clippy::too_many_arguments)]
 async fn call_compiler(
+    common_config: &CommonConfig,
     db: Option<Arc<Mutex<StoragePostgres>>>,
     tenant_id: TenantId,
     pipeline_id: PipelineId,
@@ -1072,6 +1361,12 @@ async fn call_compiler(
 
     // Formulate command
     let mut command = Command::new("cargo");
+
+    // get env vars that start with SCCACHE
+    let preserved_env_vars: Vec<(String, String)> = std::env::vars()
+        .filter(|(key, _)| key.starts_with("SCCACHE"))
+        .collect();
+
     command.env_clear();
     command.env("PATH", env_path);
     if !runtime_selector.is_platform() {
@@ -1080,6 +1375,28 @@ async fn call_compiler(
     if let Some(env_rustflags) = optional_env_rustflags {
         command.env("RUSTFLAGS", env_rustflags);
     }
+
+    if let Some(rustc_wrapper) = std::env::var_os("RUSTC_WRAPPER") {
+        command.env("RUSTC_WRAPPER", rustc_wrapper);
+    }
+
+    // Preserve CARGO_INCREMENTAL if set, to allow sccache to work properly.
+    if let Some(cargo_incremental) = std::env::var_os("CARGO_INCREMENTAL") {
+        command.env("CARGO_INCREMENTAL", cargo_incremental);
+    }
+
+    // Preserve AWS_PROFILE if set, to allow sccache to use
+    // credentials from there.
+    // we avoid passing all AWS_* env vars to prevent leaking
+    // credentials from the malicious build scripts.
+    if let Some(aws_profile) = std::env::var_os("AWS_PROFILE") {
+        command.env("AWS_PROFILE", aws_profile);
+    }
+
+    for (key, value) in preserved_env_vars {
+        command.env(key, value);
+    }
+
     command
         // Set compiler stack size to 20MB (10x the default) to prevent
         // SIGSEGV when the compiler runs out of stack on large programs.
@@ -1185,13 +1502,27 @@ async fn call_compiler(
 
         // Integrity checksum of the source file
         let (file_size, integrity_checksum) = checksum_file(&source_file_path).await?;
-        // Destination file
-        let target_file_path = pipeline_binaries_dir.join(format!(
-            "pipeline_{pipeline_id}_v{program_version}_sc_{source_checksum}_ic_{integrity_checksum}"
-        ));
 
-        // Copy binary from Cargo target profile directory to the pipeline-binaries directory
-        copy_file(&source_file_path, &target_file_path).await?;
+        // Create binary metadata
+        let metadata = BinaryMetadata {
+            pipeline_id,
+            program_version,
+            source_checksum: source_checksum.to_string(),
+            integrity_checksum: integrity_checksum.clone(),
+        };
+
+        // Determine binary delivery mode from configuration
+        let delivery_mode = BinaryDeliveryMode::from_config(config);
+
+        // Deliver binary according to the configured mode
+        let _binary_location = deliver_binary(
+            common_config,
+            &delivery_mode,
+            &source_file_path,
+            &metadata,
+            &pipeline_binaries_dir,
+        )
+        .await?;
 
         // Success
         Ok((compilation_info, integrity_checksum, file_size))
@@ -1744,6 +2075,57 @@ mod test {
             .await
             .unwrap()
             .contains(&format!("members = [ \"crates/{main_crate_name}\" ]")));
+    }
+
+    /// Tests the binary delivery mode configuration.
+    #[tokio::test]
+    async fn binary_delivery_mode_from_config() {
+        use crate::compiler::rust_compiler::BinaryDeliveryMode;
+        use crate::config::CompilerConfig;
+        use crate::db::types::program::CompilationProfile;
+
+        // Test local copy mode (default)
+        let config = CompilerConfig {
+            compiler_working_directory: "/tmp".to_string(),
+            compilation_profile: CompilationProfile::Dev,
+            sql_compiler_path: "test.jar".to_string(),
+            sql_compiler_cache_url: "http://test.com".to_string(),
+            compilation_cargo_lock_path: "Cargo.lock".to_string(),
+            dbsp_override_path: ".".to_string(),
+            binary_upload_endpoint: None,
+            binary_upload_timeout_secs: 300,
+            binary_upload_max_retries: 3,
+            binary_upload_retry_delay_ms: 1000,
+            precompile: false,
+        };
+
+        let delivery_mode = BinaryDeliveryMode::from_config(&config);
+        assert!(matches!(delivery_mode, BinaryDeliveryMode::LocalCopy));
+
+        // Test HTTP upload mode
+        let config = CompilerConfig {
+            binary_upload_endpoint: Some("https://example.com".to_string()),
+            binary_upload_timeout_secs: 600,
+            binary_upload_max_retries: 5,
+            binary_upload_retry_delay_ms: 2000,
+            ..config
+        };
+
+        let delivery_mode = BinaryDeliveryMode::from_config(&config);
+        match delivery_mode {
+            BinaryDeliveryMode::HttpUpload {
+                endpoint,
+                timeout_secs,
+                max_retries,
+                retry_delay_ms,
+            } => {
+                assert_eq!(endpoint, "https://example.com");
+                assert_eq!(timeout_secs, 600);
+                assert_eq!(max_retries, 5);
+                assert_eq!(retry_delay_ms, 2000);
+            }
+            _ => panic!("Expected HttpUpload mode"),
+        }
     }
 
     /// Tests the cleanup decision helper function.

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -62,9 +62,10 @@ const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 
 /// SQL compilation task that wakes up periodically.
 /// Sleeps inbetween ticks which affects the response time of SQL compilation.
-/// Note that the logic in this task assumes only one is run at a time.
 /// This task cannot fail, and any internal errors are caught and written to log if need-be.
 pub async fn sql_compiler_task(
+    worker_id: usize,
+    total_workers: usize,
     common_config: CommonConfig,
     config: CompilerConfig,
     db: Arc<Mutex<StoragePostgres>>,
@@ -79,10 +80,10 @@ pub async fn sql_compiler_task(
             if let Err(e) = cleanup_sql_compilation(&config, db.clone()).await {
                 match e {
                     SqlCompilationCleanupError::Database(e) => {
-                        error!("SQL compilation cleanup failed: database error occurred: {e}");
+                        error!("SQL worker {worker_id}: compilation cleanup failed: database error occurred: {e}");
                     }
                     SqlCompilationCleanupError::Utility(e) => {
-                        error!("SQL compilation cleanup failed: filesystem operation error occurred: {e}");
+                        error!("SQL worker {worker_id}: compilation cleanup failed: filesystem operation error occurred: {e}");
                     }
                 }
                 unexpected_error = true;
@@ -91,21 +92,28 @@ pub async fn sql_compiler_task(
         }
 
         // Compile
-        let result = attempt_end_to_end_sql_compilation(&common_config, &config, db.clone()).await;
+        let result = attempt_end_to_end_sql_compilation(
+            worker_id,
+            total_workers,
+            &common_config,
+            &config,
+            db.clone(),
+        )
+        .await;
         if let Err(e) = &result {
             match e {
                 DBError::UnknownPipeline { pipeline_id } => {
-                    debug!("SQL compilation canceled: pipeline {pipeline_id} no longer exists");
+                    debug!("SQL worker {worker_id}: compilation canceled: pipeline {pipeline_id} no longer exists");
                 }
                 DBError::OutdatedProgramVersion {
                     outdated_version,
                     latest_version,
                 } => {
-                    debug!("SQL compilation canceled: pipeline program version ({outdated_version}) is outdated by latest ({latest_version})");
+                    debug!("SQL worker {worker_id}: compilation canceled: pipeline program version ({outdated_version}) is outdated by latest ({latest_version})");
                 }
                 e => {
                     unexpected_error = true;
-                    error!("SQL compilation canceled: unexpected database error occurred: {e}");
+                    error!("SQL worker {worker_id}: compilation canceled: unexpected database error occurred: {e}");
                 }
             }
         }
@@ -150,23 +158,29 @@ pub async fn sql_compiler_task(
 /// - The pipeline program is detected to be updated (it became outdated)
 /// - The database cannot be reached
 pub(crate) async fn attempt_end_to_end_sql_compilation(
+    worker_id: usize,
+    total_workers: usize,
     common_config: &CommonConfig,
     config: &CompilerConfig,
     db: Arc<Mutex<StoragePostgres>>,
 ) -> Result<bool, DBError> {
-    trace!("Performing SQL compilation...");
+    trace!("SQL worker {worker_id}: Performing SQL compilation...");
 
     // (1) Reset any pipeline which is `CompilingSql` back to `Pending`
     db.lock()
         .await
-        .clear_ongoing_sql_compilation(&common_config.platform_version)
+        .clear_ongoing_sql_compilation_for_worker(
+            &common_config.platform_version,
+            worker_id,
+            total_workers,
+        )
         .await?;
 
     // (2) Find pipeline which needs SQL compilation
     let Some((tenant_id, pipeline)) = db
         .lock()
         .await
-        .get_next_sql_compilation(&common_config.platform_version)
+        .get_next_sql_compilation(&common_config.platform_version, worker_id, total_workers)
         .await?
     else {
         trace!("No pipeline found which needs SQL compilation");

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -57,6 +57,10 @@ impl CompilerTest {
             compilation_profile: CompilationProfile::Optimized,
             precompile: false,
             compiler_working_directory: workdir.to_owned(),
+            binary_upload_endpoint: None,
+            binary_upload_timeout_secs: 600,
+            binary_upload_max_retries: 3,
+            binary_upload_retry_delay_ms: 1000,
         };
 
         // Test in-memory database
@@ -177,6 +181,8 @@ impl CompilerTest {
             .await
             .unwrap();
         attempt_end_to_end_sql_compilation(
+            0, // Use worker 0 for tests
+            1,
             &self.common_config,
             &self.compiler_config,
             self.db.clone(),

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -816,6 +816,38 @@ pub struct CompilerConfig {
     #[arg(long, default_value_t = default_dbsp_override_path())]
     pub dbsp_override_path: String,
 
+    /// HTTP endpoint URL for uploading compiled binaries.
+    /// If set, compiled binaries will be uploaded to this endpoint instead of being copied locally.
+    /// The binary will be uploaded as raw binary data using POST with Content-Type: application/octet-stream.
+    /// Metadata is included in the URL path as follows:
+    /// {endpoint}/binary/{pipeline_id}/{program_version}/{source_checksum}/{integrity_checksum}
+    /// Where:
+    /// - pipeline_id: The UUID of the pipeline
+    /// - program_version: The version number of the program
+    /// - source_checksum: SHA256 checksum of the source code
+    /// - integrity_checksum: SHA256 checksum of the compiled binary
+    ///
+    /// Example: --binary-upload-endpoint http://127.0.0.1:8085
+    ///          --binary-upload-endpoint https://compiler-server-0:8085
+    #[arg(long)]
+    pub binary_upload_endpoint: Option<String>,
+
+    /// Timeout in seconds for binary upload requests.
+    /// Default is 600 seconds (10 minutes).
+    #[arg(long, default_value_t = 600)]
+    pub binary_upload_timeout_secs: u64,
+
+    /// Maximum number of retry attempts for binary upload requests.
+    /// Default is 3 retries.
+    #[arg(long, default_value_t = 3)]
+    pub binary_upload_max_retries: u32,
+
+    /// Initial delay in milliseconds between retry attempts for binary upload requests.
+    /// The delay doubles after each retry (exponential backoff).
+    /// Default is 1000 milliseconds (1 second).
+    #[arg(long, default_value_t = 1000)]
+    pub binary_upload_retry_delay_ms: u64,
+
     /// Precompile Rust dependencies in the working directory.
     ///
     /// Instructs the manager to download and compile all crates needed by

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -1519,7 +1519,12 @@ pub(crate) async fn list_pipelines_across_all_tenants_for_monitoring(
 pub(crate) async fn get_next_sql_compilation(
     txn: &Transaction<'_>,
     platform_version: &str,
+    worker_id: usize,
+    total_workers: usize,
 ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+    // The expression `abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3`
+    // converts the first 8 bytes of the UUID to a bigint, takes its absolute value,
+    // and computes the modulo with the total number of workers.
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT {RETRIEVE_PIPELINE_COLUMNS}
@@ -1527,6 +1532,7 @@ pub(crate) async fn get_next_sql_compilation(
              WHERE p.deployment_resources_status = 'stopped'
                    AND p.program_status = 'pending'
                    AND p.platform_version = $1
+                   AND (abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3
              ORDER BY p.program_status_since ASC, p.id ASC
              LIMIT 1
             "
@@ -1537,6 +1543,8 @@ pub(crate) async fn get_next_sql_compilation(
             &stmt,
             &[
                 &platform_version.to_string(), // $1: platform_version
+                &(total_workers as i64),       // $2: total_workers
+                &(worker_id as i64),           // $3: worker_id
             ],
         )
         .await?;
@@ -1554,7 +1562,12 @@ pub(crate) async fn get_next_sql_compilation(
 pub(crate) async fn get_next_rust_compilation(
     txn: &Transaction<'_>,
     platform_version: &str,
+    worker_id: usize,
+    total_workers: usize,
 ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+    // The expression `abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3`
+    // converts the first 8 bytes of the UUID to a bigint, takes its absolute value,
+    // and computes the modulo with the total number of workers.
     let stmt = txn
         .prepare_cached(&format!(
             "SELECT {RETRIEVE_PIPELINE_COLUMNS}
@@ -1562,6 +1575,7 @@ pub(crate) async fn get_next_rust_compilation(
              WHERE p.deployment_resources_status = 'stopped'
                    AND p.program_status = 'sql_compiled'
                    AND p.platform_version = $1
+                   AND (abs(('x' || substr(replace(p.id::text, '-', ''), 1, 16))::bit(64)::bigint) % $2) = $3
              ORDER BY p.program_status_since ASC, p.id ASC
              LIMIT 1
             "
@@ -1572,6 +1586,8 @@ pub(crate) async fn get_next_rust_compilation(
             &stmt,
             &[
                 &platform_version.to_string(), // $1: platform_version
+                &(total_workers as i64),       // $2: total_workers
+                &(worker_id as i64),           // $3: worker_id
             ],
         )
         .await?;

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -402,13 +402,22 @@ pub(crate) trait Storage {
     /// If the platform version is not the current one, its `platform_version` will be updated and
     /// the `program_status` will be set back to `Pending` (if not already) such that the SQL
     /// compiler can pick it up again.
-    async fn clear_ongoing_sql_compilation(&self, platform_version: &str) -> Result<(), DBError>;
+    /// Only the owner worker (by modulo) resets `CompilingSql` pipelines to `Pending`
+    /// This ensures that only the assigned worker for a pipeline can reset its status.
+    async fn clear_ongoing_sql_compilation_for_worker(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<(), DBError>;
 
     /// Retrieves the pipeline which is stopped, whose program status has been Pending
     /// for the longest, and is of the current platform version. Returns `None` if none is found.
     async fn get_next_sql_compilation(
         &self,
         platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
     ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError>;
 
     /// Determines what to do with pipelines that are `SqlCompiled` and `CompilingRust`.
@@ -419,13 +428,22 @@ pub(crate) trait Storage {
     /// If the platform version is not the current one, its `platform_version` will be updated and
     /// the `program_status` will be set back to `Pending` such that the Rust compiler can pick it
     /// up again.
-    async fn clear_ongoing_rust_compilation(&self, platform_version: &str) -> Result<(), DBError>;
+    /// Only the owner worker (by modulo) resets stuck `CompilingRust` pipelines to `SqlCompiled`.
+    /// This ensures that only the assigned worker for a pipeline can reset its status.
+    async fn clear_ongoing_rust_compilation_for_worker(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<(), DBError>;
 
     /// Retrieves the pipeline which is stopped, whose program status has been SqlCompiled
     /// for the longest, and is of the current platform version. Returns `None` if none is found.
     async fn get_next_rust_compilation(
         &self,
         platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
     ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError>;
 
     /// Retrieves the list of fully compiled pipeline programs (pipeline identifier, program version,

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -2,7 +2,7 @@ use crate::api::support_data_collector::SupportBundleData;
 use crate::auth::{generate_api_key, TenantRecord};
 use crate::db::error::DBError;
 use crate::db::storage::{ExtendedPipelineDescrRunner, Storage};
-use crate::db::storage_postgres::StoragePostgres;
+use crate::db::storage_postgres::{is_pipeline_assigned_to_worker, StoragePostgres};
 use crate::db::types::api_key::{ApiKeyDescr, ApiKeyId, ApiPermission};
 use crate::db::types::pipeline::{
     ExtendedPipelineDescr, ExtendedPipelineDescrMonitoring, PipelineDescr, PipelineId,
@@ -1230,13 +1230,24 @@ async fn pipeline_program_compilation() {
     let handle = test_setup().await;
     let tenant_id = TenantRecord::default().id;
 
+    let worker_id = 0;
+    let total_workers = 1;
+
     // There is no program to compile
     assert_eq!(
-        handle.db.get_next_sql_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_sql_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         None
     );
     assert_eq!(
-        handle.db.get_next_rust_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_rust_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         None
     );
 
@@ -1280,7 +1291,11 @@ async fn pipeline_program_compilation() {
 
     // Initially, the next program to compile is the one with program status being pending the longest
     assert_eq!(
-        handle.db.get_next_sql_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_sql_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         Some((tenant_id, pipeline1.clone()))
     );
 
@@ -1318,7 +1333,7 @@ async fn pipeline_program_compilation() {
     assert_eq!(
         handle
             .db
-            .get_next_rust_compilation("v0")
+            .get_next_rust_compilation("v0", worker_id, total_workers)
             .await
             .unwrap()
             .unwrap()
@@ -1350,7 +1365,11 @@ async fn pipeline_program_compilation() {
 
     // Next up, it should be pipeline2
     assert_eq!(
-        handle.db.get_next_sql_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_sql_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         Some((tenant_id, pipeline2.clone()))
     );
 
@@ -1377,11 +1396,19 @@ async fn pipeline_program_compilation() {
 
     // There should be nothing left to compile
     assert_eq!(
-        handle.db.get_next_sql_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_sql_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         None
     );
     assert_eq!(
-        handle.db.get_next_rust_compilation("v0").await.unwrap(),
+        handle
+            .db
+            .get_next_rust_compilation("v0", worker_id, total_workers)
+            .await
+            .unwrap(),
         None
     );
 }
@@ -2574,23 +2601,23 @@ fn db_impl_behaves_like_model() {
                                 check_response_pipelines_for_monitoring_with_tenant_id(i, model_response, impl_response);
                             }
                             StorageAction::ClearOngoingSqlCompilation(platform_version) => {
-                                let model_response = model.clear_ongoing_sql_compilation(&platform_version).await;
-                                let impl_response = handle.db.clear_ongoing_sql_compilation(&platform_version).await;
+                                let model_response = model.clear_ongoing_sql_compilation_for_worker(&platform_version, 0, 1).await;
+                                let impl_response = handle.db.clear_ongoing_sql_compilation_for_worker(&platform_version, 0, 1).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::GetNextSqlCompilation(platform_version) => {
-                                let model_response = model.get_next_sql_compilation(&platform_version).await;
-                                let impl_response = handle.db.get_next_sql_compilation(&platform_version).await;
+                                let model_response = model.get_next_sql_compilation(&platform_version, 0, 1).await;
+                                let impl_response = handle.db.get_next_sql_compilation(&platform_version, 0, 1).await;
                                 check_response_optional_pipeline_with_tenant_id(i, model_response, impl_response);
                             }
                             StorageAction::ClearOngoingRustCompilation(platform_version) => {
-                                let model_response = model.clear_ongoing_rust_compilation(&platform_version).await;
-                                let impl_response = handle.db.clear_ongoing_rust_compilation(&platform_version).await;
+                                let model_response = model.clear_ongoing_rust_compilation_for_worker(&platform_version, 0, 1).await;
+                                let impl_response = handle.db.clear_ongoing_rust_compilation_for_worker(&platform_version, 0, 1).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::GetNextRustCompilation(platform_version) => {
-                                let model_response = model.get_next_rust_compilation(&platform_version).await;
-                                let impl_response = handle.db.get_next_rust_compilation(&platform_version).await;
+                                let model_response = model.get_next_rust_compilation(&platform_version, 0, 1).await;
+                                let impl_response = handle.db.get_next_rust_compilation(&platform_version, 0, 1).await;
                                 check_response_optional_pipeline_with_tenant_id(i, model_response, impl_response);
                             }
                             StorageAction::ListPipelineProgramsAcrossAllTenants => {
@@ -3968,11 +3995,21 @@ impl Storage for Mutex<DbModel> {
         Ok(result)
     }
 
-    async fn clear_ongoing_sql_compilation(&self, platform_version: &str) -> Result<(), DBError> {
+    async fn clear_ongoing_sql_compilation_for_worker(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<(), DBError> {
         let pipelines = self
             .list_pipelines_across_all_tenants_for_monitoring()
             .await?;
         for (tid, pipeline) in pipelines {
+            // Skip pipelines not assigned to this worker
+            if !is_pipeline_assigned_to_worker(pipeline.id, worker_id as u64, total_workers as u64)
+            {
+                continue;
+            }
             if pipeline.deployment_resources_status == ResourcesStatus::Stopped {
                 if pipeline.platform_version == platform_version {
                     if pipeline.program_status == ProgramStatus::CompilingSql {
@@ -4007,47 +4044,33 @@ impl Storage for Mutex<DbModel> {
         Ok(())
     }
 
-    async fn get_next_sql_compilation(
+    async fn clear_ongoing_rust_compilation_for_worker(
         &self,
         platform_version: &str,
-    ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
-        let mut pipelines: Vec<(TenantId, ExtendedPipelineDescr)> = self
-            .lock()
-            .await
-            .pipelines
-            .iter()
-            .filter(|(_, p)| {
-                p.deployment_resources_status == ResourcesStatus::Stopped
-                    && p.program_status == ProgramStatus::Pending
-                    && p.platform_version == platform_version
-            })
-            .map(|((tid, _), pipeline)| (*tid, pipeline.clone()))
-            .collect();
-        if pipelines.is_empty() {
-            return Ok(None);
-        }
-        pipelines.sort_by(|(_, p1), (_, p2)| {
-            (p1.program_status_since, p1.id).cmp(&(p2.program_status_since, p2.id))
-        });
-        let chosen = pipelines.first().unwrap().clone(); // Already checked for empty
-        Ok(Some((chosen.0, chosen.1)))
-    }
-
-    async fn clear_ongoing_rust_compilation(&self, platform_version: &str) -> Result<(), DBError> {
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<(), DBError> {
         let pipelines = self
             .list_pipelines_across_all_tenants_for_monitoring()
             .await?;
         for (tid, pipeline) in pipelines {
+            // Skip pipelines not assigned to this worker
+            if !is_pipeline_assigned_to_worker(pipeline.id, worker_id as u64, total_workers as u64)
+            {
+                continue;
+            }
             if pipeline.deployment_resources_status == ResourcesStatus::Stopped {
                 if pipeline.platform_version == platform_version {
                     if pipeline.program_status == ProgramStatus::CompilingRust {
-                        let pipeline_complete = self.get_pipeline_by_id(tid, pipeline.id).await?;
                         self.transit_program_status_to_sql_compiled(
                             tid,
                             pipeline.id,
                             pipeline.program_version,
-                            &pipeline_complete.program_error.sql_compilation.unwrap(),
-                            &pipeline_complete.program_info.unwrap(),
+                            &SqlCompilationInfo {
+                                exit_code: 0,
+                                messages: vec![],
+                            },
+                            &serde_json::json!({}),
                         )
                         .await?;
                     }
@@ -4075,9 +4098,40 @@ impl Storage for Mutex<DbModel> {
         Ok(())
     }
 
+    async fn get_next_sql_compilation(
+        &self,
+        platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
+    ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
+        let mut pipelines: Vec<(TenantId, ExtendedPipelineDescr)> = self
+            .lock()
+            .await
+            .pipelines
+            .iter()
+            .filter(|(_, p)| {
+                p.deployment_resources_status == ResourcesStatus::Stopped
+                    && p.program_status == ProgramStatus::Pending
+                    && p.platform_version == platform_version
+                    && is_pipeline_assigned_to_worker(p.id, worker_id as u64, total_workers as u64)
+            })
+            .map(|((tid, _), pipeline)| (*tid, pipeline.clone()))
+            .collect();
+        if pipelines.is_empty() {
+            return Ok(None);
+        }
+        pipelines.sort_by(|(_, p1), (_, p2)| {
+            (p1.program_status_since, p1.id).cmp(&(p2.program_status_since, p2.id))
+        });
+        let chosen = pipelines.first().unwrap().clone(); // Already checked for empty
+        Ok(Some((chosen.0, chosen.1)))
+    }
+
     async fn get_next_rust_compilation(
         &self,
         platform_version: &str,
+        worker_id: usize,
+        total_workers: usize,
     ) -> Result<Option<(TenantId, ExtendedPipelineDescr)>, DBError> {
         let mut pipelines: Vec<(TenantId, ExtendedPipelineDescr)> = self
             .lock()
@@ -4088,6 +4142,7 @@ impl Storage for Mutex<DbModel> {
                 p.deployment_resources_status == ResourcesStatus::Stopped
                     && p.program_status == ProgramStatus::SqlCompiled
                     && p.platform_version == platform_version
+                    && is_pipeline_assigned_to_worker(p.id, worker_id as u64, total_workers as u64)
             })
             .map(|((tid, _), pipeline)| (*tid, pipeline.clone()))
             .collect();


### PR DESCRIPTION
This is the foundational work to enable running multiple compiler server instances to scale compilation.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

current functionality is same so shouldn't be a breaking change
