### PR TITLE
docs: mark lifecycle guide as a reference

### DIFF
--- a/docs.feldera.com/docs/pipelines/lifecycle.md
+++ b/docs.feldera.com/docs/pipelines/lifecycle.md
@@ -1,4 +1,7 @@
-# Pipeline lifecycle
+# Reference: Pipeline lifecycle
+
+A pipeline's lifecycle goes through several states as the control plane allocates compute and storage resources for it.
+This page is a reference guide that explains the underlying state machines, aimed at Feldera contributors and advanced users.
 
 The status of a pipeline, returned by the [status endpoint](/api/get-pipeline)
 consists of four related yet separate statuses:

--- a/docs.feldera.com/docs/sidebars.js
+++ b/docs.feldera.com/docs/sidebars.js
@@ -400,7 +400,7 @@ const pipelines = {
         formats,
         {
             type: 'doc',
-            label: "Lifecycle",
+            label: "Reference: Pipeline Lifecycle",
             id: "pipelines/lifecycle",
         },
         {


### PR DESCRIPTION
This guide is not relevant to end users the way it is written. It is best placed in the code or in a separate reference section which we don't have now, so I'll just reword it.

Add a brief description of the pull request.

## Checklist

- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
