### PR TITLE
[SQL] Make enforce lazy in its second argument

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -141,7 +141,7 @@ public final class DBSPCircuit extends DBSPNode
     public DBSPType getSingleOutputType() {
         List<DBSPSinkOperator> sinks = Linq.where(
                 Linq.list(this.sinkOperators.values()), o -> !o.metadata.system);
-        Utilities.enforce(sinks.size() == 1, "Expected a single output, got " + sinks.size());
+        Utilities.enforce(sinks.size() == 1, () -> "Expected a single output, got " + sinks.size());
         return sinks.get(0).getType();
     }
 
@@ -166,7 +166,7 @@ public final class DBSPCircuit extends DBSPNode
                 .appendSupplier(operator::toString)
                 .newline();
         Utilities.enforce(!this.operators.contains(operator),
-                "Operator " + operator + " already inserted");
+                () -> "Operator " + operator.getId() + " already inserted");
         this.operators.add(operator);
         IInputOperator source = operator.as(IInputOperator.class);
         if (source != null)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/Annotation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/annotation/Annotation.java
@@ -30,7 +30,7 @@ public abstract class Annotation implements ICastable {
         ObjectNode object = (ObjectNode) node;
         JsonNode cls = object.get("class");
         Utilities.enforce(cls != null,
-                "Node does not have 'class' field: " + Utilities.toDepth(node, 1));
+                () -> "Node does not have 'class' field: " + Utilities.toDepth(node, 1));
         try {
             Class<?> clazz = Class.forName("org.dbsp.sqlCompiler.circuit.annotation." + cls.asText());
             Method method = clazz.getMethod("fromJson", JsonNode.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAntiJoinOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAntiJoinOperator.java
@@ -26,7 +26,7 @@ public final class DBSPAntiJoinOperator extends DBSPBinaryOperator {
                 .keyType
                 .sameType(right.getOutputIndexedZSetType()
                         .keyType),
-                "Anti join key types to not match\n" +
+                () -> "Anti join key types to not match\n" +
                         left.getOutputIndexedZSetType().keyType + " and\n" +
                         right.getOutputIndexedZSetType().keyType);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApply2Operator.java
@@ -24,13 +24,13 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
                               OutputPort left, OutputPort right) {
         super(node, "apply2", function, function.getResultType(), false, left, right, false);
         Utilities.enforce(function.parameters.length == 2,
-                "Expected 2 parameters for function " + function);
+                () -> "Expected 2 parameters for function " + function);
         DBSPType param0Type = function.parameters[0].getType().deref();
         Utilities.enforce(left.outputType().sameType(param0Type),
-                "Parameter type " + param0Type + " does not match input type " + left.outputType());
+                () -> "Parameter type " + param0Type + " does not match input type " + left.outputType());
         DBSPType param1Type = function.parameters[1].getType().deref();
         Utilities.enforce(right.outputType().sameType(param1Type),
-                "Parameter type " + param1Type + " does not match input type " + right.outputType());
+                () -> "Parameter type " + param1Type + " does not match input type " + right.outputType());
         DBSPApplyOperator.noZsets(left.outputType());
         DBSPApplyOperator.noZsets(right.outputType());
         DBSPApplyOperator.noZsets(this.outputType());
@@ -41,7 +41,7 @@ public final class DBSPApply2Operator extends DBSPBinaryOperator {
             @Nullable DBSPExpression function, DBSPType outputType,
            List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs " + newInputs);
+            Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs " + newInputs);
             return new DBSPApply2Operator(
                     this.getRelNode(), toClosure(function),
                     newInputs.get(0), newInputs.get(1))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPApplyOperator.java
@@ -36,14 +36,15 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
     public DBSPApplyOperator(CalciteRelNode node, DBSPClosureExpression function,
                              DBSPType outputType, OutputPort input, @Nullable String comment) {
         super(node, "apply", function, outputType, false, input, comment, false);
-        Utilities.enforce(function.parameters.length == 1, "Expected 1 parameter for function " + function);
+        Utilities.enforce(function.parameters.length == 1,
+                () -> "Expected 1 parameter for function " + function);
         DBSPType paramType = function.parameters[0].getType().deref();
         Utilities.enforce(input.outputType().sameType(paramType),
-                "Parameter type " + paramType + " does not match input type " + input.outputType());
+                () -> "Parameter type " + paramType + " does not match input type " + input.outputType());
         noZsets(input.outputType());
         noZsets(this.outputType());
         Utilities.enforce(function.getResultType().sameType(outputType),
-                "Function return type " + function.getResultType() + " does not match output type " + outputType);
+                () -> "Function return type " + function.getResultType() + " does not match output type " + outputType);
     }
 
     public DBSPApplyOperator(CalciteRelNode node, DBSPClosureExpression function,
@@ -56,7 +57,7 @@ public final class DBSPApplyOperator extends DBSPUnaryOperator {
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 1, "Expected 1 input " + newInputs);
+            Utilities.enforce(newInputs.size() == 1, () -> "Expected 1 input " + newInputs);
             return new DBSPApplyOperator(
                     this.getRelNode(), toClosure(function),
                     newInputs.get(0), this.comment)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPControlledKeyFilterOperator.java
@@ -72,7 +72,7 @@ public final class DBSPControlledKeyFilterOperator extends DBSPOperatorWithError
             DBSPType rightType = right.getType();
             Utilities.enforce(leftType.withMayBeNull(true)
                     .sameType(rightType.withMayBeNull(true)),
-                    "Types differ: " + leftType + " vs " + rightType);
+                    () -> "Types differ: " + leftType + " vs " + rightType);
             // Notice the comparison using AGG_GTE, which never returns NULL
             DBSPExpression comparison = new DBSPBinaryExpression(CalciteEmptyRel.INSTANCE,
                     DBSPTypeBool.create(false), opcode, left, right);
@@ -108,7 +108,7 @@ public final class DBSPControlledKeyFilterOperator extends DBSPOperatorWithError
 
     @Override
     public DBSPOperator withInputs(List<OutputPort> newInputs, boolean force) {
-        Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs, got " + newInputs.size());
+        Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
         if (force || this.inputsDiffer(newInputs))
             return new DBSPControlledKeyFilterOperator(
                     this.getRelNode(), this.function, this.error,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainKeysOperator.java
@@ -39,12 +39,12 @@ public final class DBSPIntegrateTraceRetainKeysOperator
     public static DBSPIntegrateTraceRetainKeysOperator create(
             CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control) {
         DBSPType controlType = control.outputType();
-        Utilities.enforce(controlType.is(DBSPTypeTupleBase.class), "Control type is not a tuple: " + controlType);
+        Utilities.enforce(controlType.is(DBSPTypeTupleBase.class), () -> "Control type is not a tuple: " + controlType);
         DBSPTypeTupleBase controlTuple = controlType.to(DBSPTypeTupleBase.class);
         Utilities.enforce(controlTuple.size() == 2);
         DBSPType leftSliceType = Objects.requireNonNull(dataProjection.getProjectedType());
         Utilities.enforce(leftSliceType.sameType(controlTuple.getFieldType(1)),
-                "Projection type does not match control type " + leftSliceType + "/" + controlType);
+                () -> "Projection type does not match control type " + leftSliceType + "/" + controlType);
 
         DBSPParameter param;
         DBSPExpression compare;
@@ -86,7 +86,7 @@ public final class DBSPIntegrateTraceRetainKeysOperator
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs, got " + newInputs.size());
+            Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
             return new DBSPIntegrateTraceRetainKeysOperator(
                     this.getRelNode(), toClosure(function),
                     newInputs.get(0), newInputs.get(1)).copyAnnotations(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPIntegrateTraceRetainValuesOperator.java
@@ -41,13 +41,13 @@ public final class DBSPIntegrateTraceRetainValuesOperator
             CalciteRelNode node, OutputPort data, IMaybeMonotoneType dataProjection, OutputPort control, boolean accumulate) {
         DBSPType controlType = control.outputType();
         Utilities.enforce(controlType.is(DBSPTypeTupleBase.class),
-                "Control type is not a tuple: " + controlType);
+                () -> "Control type is not a tuple: " + controlType);
         DBSPTypeTupleBase controlTuple = controlType.to(DBSPTypeTupleBase.class);
         Utilities.enforce(controlTuple.size() == 2);
 
         DBSPVariablePath controlArg = controlType.ref().var();
         Utilities.enforce(data.outputType().is(DBSPTypeIndexedZSet.class),
-                "Data is not indexed: " + data.outputType());
+                () -> "Data is not indexed: " + data.outputType());
         DBSPType valueType = data.getOutputIndexedZSetType().elementType;
         DBSPVariablePath dataArg = valueType.ref().var();
         DBSPParameter param = new DBSPParameter(dataArg.variable, dataArg.getType());
@@ -74,7 +74,7 @@ public final class DBSPIntegrateTraceRetainValuesOperator
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs, got " + newInputs.size());
+            Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
             return new DBSPIntegrateTraceRetainValuesOperator(
                     this.getRelNode(), Objects.requireNonNull(function),
                     newInputs.get(0), newInputs.get(1), this.accumulate);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinBaseOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPJoinBaseOperator.java
@@ -22,17 +22,17 @@ public abstract class DBSPJoinBaseOperator extends DBSPBinaryOperator {
         DBSPTypeIndexedZSet leftType = left.getOutputIndexedZSetType();
         DBSPTypeIndexedZSet rightType = right.getOutputIndexedZSetType();
         Utilities.enforce(closure.parameters[1].getType().deref().sameType(leftType.elementType),
-                "Type of parameter 1 of join function " + closure.parameters[1].getType() + 
+                () -> "Type of parameter 1 of join function " + closure.parameters[1].getType() +
                         " does not match left input element type " + leftType.elementType);
         Utilities.enforce(this.is(DBSPAsofJoinOperator.class) || // Not always true
                 closure.parameters[2].getType().deref().sameType(rightType.elementType),
-                "Type of parameter 2 of join function " + closure.parameters[2].getType() +
+                () -> "Type of parameter 2 of join function " + closure.parameters[2].getType() +
                         " does not match right input element type " + rightType.elementType);
         Utilities.enforce(closure.parameters[0].getType().deref().sameType(leftType.keyType),
-                "Type of parameter 0 of join function " + closure.parameters[0].getType() +
+                () -> "Type of parameter 0 of join function " + closure.parameters[0].getType() +
                         " does not match left input key type " + leftType.keyType);
         Utilities.enforce(closure.parameters[0].getType().deref().sameType(rightType.keyType),
-                "Type of parameter 0 of join function " + closure.parameters[0].getType() +
+                () -> "Type of parameter 0 of join function " + closure.parameters[0].getType() +
                         " does not match right input element type " + rightType.keyType);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPLagOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPLagOperator.java
@@ -50,7 +50,7 @@ public final class DBSPLagOperator extends DBSPUnaryOperator {
             Utilities.enforce(comparator.to(DBSPComparatorExpression.class)
                     .comparedValueType()
                     .sameType(source.getOutputIndexedZSetType().elementType),
-                    "Comparator type " + comparator + "\ndoes not match element type for LAG\n" +
+                    () -> "Comparator type " + comparator + "\ndoes not match element type for LAG\n" +
                     source.getOutputIndexedZSetType().elementType);
         }
         this.comparator = comparator;
@@ -75,7 +75,7 @@ public final class DBSPLagOperator extends DBSPUnaryOperator {
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 1, "Expected 1 input " + newInputs);
+            Utilities.enforce(newInputs.size() == 1, () -> "Expected 1 input " + newInputs);
             return new DBSPLagOperator(this.getRelNode(), this.offset,
                     this.projection, toClosure(function), this.comparator,
                     outputType.to(DBSPTypeIndexedZSet.class), newInputs.get(0))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPrimitiveAggregateOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPPrimitiveAggregateOperator.java
@@ -30,7 +30,7 @@ public final class DBSPPrimitiveAggregateOperator extends DBSPBinaryOperator {
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs");
+            Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs");
             if (force || this.inputsDiffer(newInputs))
                 return new DBSPPrimitiveAggregateOperator(this.getRelNode(), function,
                         outputType, newInputs.get(0), newInputs.get(1)).copyAnnotations(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAntiJoinOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPStreamAntiJoinOperator.java
@@ -20,7 +20,8 @@ public final class DBSPStreamAntiJoinOperator extends DBSPBinaryOperator {
         super(node, "stream_antijoin", null, left.outputType(), left.isMultiset(), left, right, false);
         left.getOutputIndexedZSetType();
         right.getOutputIndexedZSetType();
-        Utilities.enforce(left.getOutputIndexedZSetType().keyType.sameType(right.getOutputIndexedZSetType().keyType), "Anti join key types to not match\n" +
+        Utilities.enforce(left.getOutputIndexedZSetType().keyType.sameType(right.getOutputIndexedZSetType().keyType),
+                () -> "Anti join key types to not match\n" +
                 left.getOutputIndexedZSetType().keyType + " and\n" +
                 right.getOutputIndexedZSetType().keyType);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPWindowOperator.java
@@ -41,7 +41,7 @@ public final class DBSPWindowOperator extends DBSPBinaryOperator {
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            Utilities.enforce(newInputs.size() == 2, "Expected 2 inputs, got " + newInputs.size());
+            Utilities.enforce(newInputs.size() == 2, () -> "Expected 2 inputs, got " + newInputs.size());
             if (force || this.inputsDiffer(newInputs))
                 return new DBSPWindowOperator(
                         this.getRelNode(), this.lowerInclusive, this.upperInclusive,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/JsonDecoder.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/JsonDecoder.java
@@ -95,7 +95,8 @@ public class JsonDecoder {
         }
         Long originalId = Utilities.getLongProperty(node, "id");
         JsonNode cls = object.get("class");
-        Utilities.enforce(cls != null, "Node does not have 'class' field: " + Utilities.toDepth(node, 1));
+        Utilities.enforce(cls != null,
+                () -> "Node does not have 'class' field: " + Utilities.toDepth(node, 1));
         Class<?> clazz = getClass(cls.asText(), outer);
         try {
             Method method = clazz.getMethod("fromJson", JsonNode.class, JsonDecoder.class);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotEdgesVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotEdgesVisitor.java
@@ -21,6 +21,9 @@ import java.util.Set;
 
 /** This visitor dumps the edges circuit to a dot file. */
 public class ToDotEdgesVisitor extends CircuitVisitor implements IWritesLogs {
+    // Above this level of details show types
+    static final int TYPE_DETAILS = 4;
+
     protected final IndentStream stream;
     // A higher value -> more details
     protected final int details;
@@ -60,7 +63,7 @@ public class ToDotEdgesVisitor extends CircuitVisitor implements IWritesLogs {
             this.stream.append(this.getPortName(i))
                     .append(" -> ")
                     .append(node.getNodeName(false));
-            if (this.details >= 2 && !this.edgesLabeled.contains(i)) {
+            if (this.details >= TYPE_DETAILS && !this.edgesLabeled.contains(i)) {
                 String label = this.getEdgeLabel(i);
                 this.stream.append(" [xlabel=")
                         .append(Utilities.doubleQuote(label, false))
@@ -80,7 +83,7 @@ public class ToDotEdgesVisitor extends CircuitVisitor implements IWritesLogs {
             this.stream.append(this.getPortName(i))
                     .append(" -> ")
                     .append(node.getOutputName());
-            if (this.details >= 2 && !this.edgesLabeled.contains(i)) {
+            if (this.details >= TYPE_DETAILS && !this.edgesLabeled.contains(i)) {
                 String label = this.getEdgeLabel(i);
                 this.stream.append(" [xlabel=")
                         .append(Utilities.doubleQuote(label, false))

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -472,7 +472,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
 
         DBSPTypeFunction functionType = new DBSPTypeFunction(type, leftElementType.ref());
         Utilities.enforce(flatmap.getType().sameType(functionType),
-                "Expected type to be\n" + functionType + "\nbut it is\n" + flatmap.getType());
+                () -> "Expected type to be\n" + functionType + "\nbut it is\n" + flatmap.getType());
         DBSPSimpleOperator result = new DBSPFlatMapOperator(
                 new LastRel(correlate, SourcePositionRange.INVALID),
                 flatmap, TypeCompiler.makeZSet(type), left.outputPort());
@@ -2588,7 +2588,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         if (!lastOperator.getOutputZSetElementType().sameType(resultType)) {
             Utilities.enforce(
                     lastOperator.getOutputZSetElementType().to(DBSPTypeTuple.class).size() == tuple.size(),
-                    "Window aggregate type size does not match expected size");
+                    () -> "Window aggregate type size does not match expected size");
             DBSPVariablePath var = lastOperator.getOutputZSetElementType().ref().var();
             List<DBSPExpression> fields = new ArrayList<>();
             for (int i = 0; i < tuple.size(); i++) {
@@ -2754,7 +2754,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         // First process children
         super.visit(node, ordinal, parent);
         RelNode last = Utilities.removeLast(this.ancestors);
-        Utilities.enforce(last == node, "Corrupted stack: got " + last + " expected " + node);
+        Utilities.enforce(last == node, () -> "Corrupted stack: got " + last + " expected " + node);
 
         // Synthesize current node
         boolean success =

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -346,7 +346,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
     // Like makeBinaryExpression, but accepts multiple operands.
     static DBSPExpression makeBinaryExpressions(
             CalciteObject node, DBSPType type, DBSPOpcode opcode, List<DBSPExpression> operands) {
-        Utilities.enforce(operands.size() >= 2, "Expected at least two operands for binary expression " + opcode);
+        Utilities.enforce(operands.size() >= 2,
+                () -> "Expected at least two operands for binary expression " + opcode);
         DBSPExpression accumulator = operands.get(0);
         for (int i = 1; i < operands.size(); i++)
             accumulator = makeBinaryExpression(node, type, opcode, accumulator, operands.get(i));
@@ -374,7 +375,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             throw new InternalCompilerError("Expected 2 operands, got " + operands.size(), node);
         DBSPExpression left = operands.get(0);
         DBSPExpression right = operands.get(1);
-        Utilities.enforce(left != null && right != null, "Null operand for binary expression " + opcode + ": " + left + ", " + right);
+        Utilities.enforce(left != null && right != null,
+                () -> "Null operand for binary expression " + opcode + ": " + left + ", " + right);
         return makeBinaryExpression(node, type, opcode, left, right);
     }
 
@@ -434,7 +436,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         boolean anyNull = leftType.mayBeNull || rightType.mayBeNull;
         DBSPType typeWithNull = type.withMayBeNull(anyNull);
 
-        Utilities.enforce(opcode != DBSPOpcode.DIV_NULL || type.mayBeNull, "DIV_NULL should produce a nullable result");
+        Utilities.enforce(opcode != DBSPOpcode.DIV_NULL || type.mayBeNull,
+                () -> "DIV_NULL should produce a nullable result");
         // Type produced by this operation; if different from 'type', a cast may be needed.
         DBSPType expressionResultType;
         if (needCommonType(opcode, type, leftType, rightType)) {
@@ -1352,7 +1355,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                             this.ensureInteger(node, ops, i);
                         return compileFunction(call, node, type, ops, 2);
                     case "blackbox":
-                        Utilities.enforce(ops.size() == 1, "expected one argument for blackbox function");
+                        Utilities.enforce(ops.size() == 1,
+                                () -> "expected one argument for blackbox function");
                         return new DBSPApplyExpression(node, "blackbox", ops.get(0).type, ops.toArray(new DBSPExpression[0]));
                     case "regexp_replace": {
                         validateArgCount(node, operationName, ops.size(), 2, 3);
@@ -1830,7 +1834,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             case ROW: {
                 // The Calcite optimizer does not always preserve the types of the operands of the constructor
                 DBSPTypeTuple tuple = type.to(DBSPTypeTuple.class);
-                Utilities.enforce(tuple.size() == ops.size(), "Incorrect number of operands for ROW");
+                Utilities.enforce(tuple.size() == ops.size(), () -> "Incorrect number of operands for ROW");
                 List<DBSPExpression> converted = new ArrayList<>();
                 for (int i = 0; i < tuple.size(); i++) {
                     converted.add(ops.get(i).cast(node, tuple.getFieldType(i), false));
@@ -1979,7 +1983,9 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         if (isConstructor) {
             DBSPTypeStruct struct = this.compiler.getStructByName(function);
             DBSPType structTuple = Objects.requireNonNull(struct).toTupleDeep();
-            Utilities.enforce(structTuple.sameType(type), "Expected the same type " + structTuple + " and " + type);
+            DBSPType finalType = type;
+            Utilities.enforce(structTuple.sameType(type),
+                    () -> "Expected the same type " + structTuple + " and " + finalType);
             DBSPTypeTupleBase tuple = type.to(DBSPTypeTupleBase.class);
             for (int i = 0; i < ops.size(); i++) {
                 DBSPExpression opi = ops.get(i);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/JoinConditionAnalyzer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/JoinConditionAnalyzer.java
@@ -204,7 +204,7 @@ public class JoinConditionAnalyzer implements IWritesLogs {
 
         /** Analyze an equality comparison.  Return 'true' if this is suitable for an equijoin */
         public boolean analyzeEquals(RexCall call) {
-            Utilities.enforce(call.operands.size() == 2, "Expected 2 operands for equality checking");
+            Utilities.enforce(call.operands.size() == 2, () -> "Expected 2 operands for equality checking");
             CalciteObject node = CalciteObject.create(this.join, call);
             RexNode left = call.operands.get(0);
             RexNode right = call.operands.get(1);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/AggregateCompiler.java
@@ -498,7 +498,8 @@ public class AggregateCompiler implements ICompilerComponent {
         }
 
         DBSPTupleExpression tuple = this.getAggregatedValue().to(DBSPTupleExpression.class);
-        Utilities.enforce(tuple.fields != null && tuple.fields.length == 2, "Expected 2 arguments for " + kind);
+        Utilities.enforce(tuple.fields != null && tuple.fields.length == 2,
+                () -> "Expected 2 arguments for " + kind);
         NonLinearAggregate aggregate;
         // Must compare first on second field
         DBSPTypeTuple dataType = tuple.getTypeAsTuple();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -715,7 +715,7 @@ public class SqlToRelCompiler implements IWritesLogs {
             SqlCall newCall = Objects.requireNonNull((SqlCall) super.visit(call));
             if (newCall.getOperator().kind == SqlKind.PLUS_PREFIX) {
                 Utilities.enforce(newCall.getOperandList().size() == 1,
-                        "Expected unary plus to have exactly 1 operand");
+                        () -> "Expected unary plus to have exactly 1 operand");
                 return newCall.getOperandList().get(0);
             } else if (newCall.getOperator().kind == SqlKind.CREATE_VIEW) {
                 // The shuttle does not correctly create a view by replacing operands.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
@@ -432,7 +432,8 @@ public abstract class ReduceExpressionsRule<C extends org.apache.calcite.rel.rul
                     final List<RexNode> expList = new ArrayList<>(aggCall.getOperands());
                     if (reduceExpressions(window, expList, predicates)) {
                         aggCall =
-                                new Window.RexWinAggCall((SqlAggFunction) aggCall.getOperator(),
+                                new Window.RexWinAggCall(aggCall.getParserPosition(),
+                                        (SqlAggFunction) aggCall.getOperator(),
                                         aggCall.type, expList,
                                         aggCall.ordinal, aggCall.distinct, aggCall.ignoreNulls);
                         reduced = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/EliminateDump.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/EliminateDump.java
@@ -43,7 +43,7 @@ public class EliminateDump extends InnerRewriteVisitor {
                 //                          writelog("%%,", tuple[n]);
                 //                          print(")\n");
                 //                          tuple.clone()) }
-                Utilities.enforce(arguments.length == 2, "Expected 2 arguments for dump function");
+                Utilities.enforce(arguments.length == 2, () -> "Expected 2 arguments for dump function");
                 Function<DBSPExpression, DBSPExpressionStatement> makePrint = stringArgument ->
                         new DBSPApplyExpression(
                                 expression.getNode(), "print", DBSPTypeVoid.INSTANCE, stringArgument)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionsCSE.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionsCSE.java
@@ -248,7 +248,7 @@ public class ExpressionsCSE extends ExpressionTranslator {
 
     @Override
     public void endVisit() {
-        Utilities.enforce(this.assignments.isEmpty(), "Unused CSE expressions");
+        Utilities.enforce(this.assignments.isEmpty(), () -> "Unused CSE expressions");
         super.endVisit();
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -122,7 +122,7 @@ public abstract class InnerRewriteVisitor
      * any of its fields differs. */
     protected void map(IDBSPInnerNode old, IDBSPInnerNode newOp) {
         // noinspection ConstantValue
-        Utilities.enforce(newOp != null, "No replacement computed for " + old);
+        Utilities.enforce(newOp != null, () -> "No replacement computed for " + old);
         if ((old == newOp) || (!this.force && old.sameFields(newOp))) {
             // Ignore new op.
             this.lastResult = old;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
@@ -358,9 +358,11 @@ public class Projection extends InnerVisitor {
                 Utilities.enforce(bodyType.tupFields.length == 2);
                 int totalSize = bodyType.tupFields[0].to(DBSPTypeTupleBase.class).size() +
                         bodyType.tupFields[1].to(DBSPTypeTupleBase.class).size();
-                Utilities.enforce(iomapSize == totalSize, "IOMap has " + iomapSize + " fields, but expected " + totalSize);
+                Utilities.enforce(iomapSize == totalSize,
+                        () -> "IOMap has " + iomapSize + " fields, but expected " + totalSize);
             } else {
-                Utilities.enforce(iomapSize == bodyType.size(), "IOMap has " + iomapSize + " fields, but expected " + bodyType.size());
+                Utilities.enforce(iomapSize == bodyType.size(),
+                        () -> "IOMap has " + iomapSize + " fields, but expected " + bodyType.size());
             }
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneExpression.java
@@ -28,7 +28,8 @@ public class MonotoneExpression {
         this.id = crtId++;
         DBSPType expressionType = expression.getType();
         DBSPType monotoneType = type.getType();
-        Utilities.enforce(expressionType.sameType(monotoneType), "Types differ\n" + expressionType + " and\n" + monotoneType);
+        Utilities.enforce(expressionType.sameType(monotoneType),
+                () -> "Types differ\n" + expressionType + " and\n" + monotoneType);
     }
 
     public DBSPExpression getReducedExpression() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
@@ -191,7 +191,7 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
         DBSPExpression tuple = new DBSPTupleExpression(outputFields, false);
         DBSPType resultType = expression.getType().to(DBSPTypeFunction.class).resultType;
         Utilities.enforce(tuple.getType().sameType(resultType),
-                "Flatmap result type " + resultType + " does not match computed type " + tuple.getType());
+                () -> "Flatmap result type " + resultType + " does not match computed type " + tuple.getType());
         DBSPClosureExpression closure = tuple.closure(param);
         // This is the same as this.apply(closure)
         this.resolver.apply(closure);
@@ -355,7 +355,7 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
         if (value == null)
             return;
         Utilities.enforce(value.expression.getType().sameType(var.getType()),
-                "Variable " + var.variable + "(" + var.getId() + ") type " + var.getType() +
+                () -> "Variable " + var.variable + "(" + var.getId() + ") type " + var.getType() +
                 " does not match expected type in expression " + value.expression +
                 "(" + value.expression.getId() + ")" +
                 " with type " + value.expression.getType());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/ScalarMonotoneType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/ScalarMonotoneType.java
@@ -12,7 +12,7 @@ public abstract class ScalarMonotoneType
 
     protected ScalarMonotoneType(DBSPType type) {
         super();
-        Utilities.enforce(!type.is(DBSPTypeTupleBase.class), "Type should have been scalar " + type);
+        Utilities.enforce(!type.is(DBSPTypeTupleBase.class), () -> "Type should have been scalar " + type);
         this.type = type;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -90,7 +90,7 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
         if (!oldPort.equals(newPort)) {
             if (this.preservesTypes && oldPort.exists() && newPort.exists()) {
                 Utilities.enforce(oldPort.outputType().sameType(newPort.outputType()),
-                        "Replacing operator with type\n" + oldPort.outputType() +
+                        () -> "Replacing operator with type\n" + oldPort.outputType() +
                                 " with new type\n" + newPort.outputType());
             }
             Logger.INSTANCE.belowLevel(this, 1)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CompactNames.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CompactNames.java
@@ -16,13 +16,13 @@ public class CompactNames extends CircuitCloneVisitor {
 
     @Override
     public VisitDecision preorder(DBSPOperator operator) {
-        operator.addAnnotation(new CompactName("s" + id++), DBSPOperator.class);
+        operator.addAnnotation(new CompactName("s" + this.id++), DBSPOperator.class);
         return super.preorder(operator);
     }
 
     @Override
     public VisitDecision preorder(DBSPNestedOperator operator) {
-        operator.addAnnotation(new CompactName("s" + id++), DBSPOperator.class);
+        operator.addAnnotation(new CompactName("s" + this.id++), DBSPOperator.class);
         return super.preorder(operator);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/InternInner.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/InternInner.java
@@ -216,7 +216,7 @@ public class InternInner extends ExpressionTranslator {
             resolveReferences.apply(expression);
             this.refMap = resolveReferences.reference;
             Utilities.enforce(expression.parameters.length == this.parameterTypes.length,
-                    "Parameter count " + this.parameterTypes.length +
+                    () -> "Parameter count " + this.parameterTypes.length +
                             " does not match closure parameter count " + expression.parameters.length);
             for (int i = 0; i < expression.parameters.length; i++) {
                 DBSPType type = this.parameterTypes[i];

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
@@ -178,7 +178,7 @@ public class RewriteInternedFields extends CircuitCloneVisitor {
         }
         if (!HasInternedTypes.check(this.compiler, outputType))
             Utilities.enforce(outputType.sameType(operator.outputType),
-                    "Output type not preserved for " + operator + " during interning:\n" +
+                    () -> "Output type not preserved for " + operator + " during interning:\n" +
             outputType + ", expected\n" + operator.outputType);
         DBSPSimpleOperator replacement = operator.with(
                 function, outputType, Linq.list(input), false)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -661,7 +661,8 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         // Compute the waterline for the new rolling aggregate operator
         DBSPTypeTupleBase varType = projection.getType().to(DBSPTypeTupleBase.class);
-        Utilities.enforce(varType.size() == 2, "Expected a pair, got " + varType);
+        DBSPTypeTupleBase finalVarType = varType;
+        Utilities.enforce(varType.size() == 2, () -> "Expected a pair, got " + finalVarType);
         varType = new DBSPTypeRawTuple(varType.tupFields[0].ref(), varType.tupFields[1].ref());
         final DBSPVariablePath var = varType.var();
         DBSPExpression body = var.field(0).deref();
@@ -1496,7 +1497,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         DBSPType leftSliceType = Objects.requireNonNull(monotoneType.getProjectedType());
         Utilities.enforce(leftSliceType.sameType(controlType),
-                "Projection type does not match control type " + leftSliceType + "/" + controlType);
+                () -> "Projection type does not match control type " + leftSliceType + "/" + controlType);
 
         DBSPType rowType = data.getOutputRowType();
         DBSPVariablePath dataVar = rowType.ref().var();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -182,7 +182,8 @@ public class Monotonicity extends CircuitVisitor {
         MonotoneTransferFunctions.ArgumentKind argumentType;
         if (pairOfReferences) {
             DBSPTypeTupleBase tpl = varType.to(DBSPTypeTupleBase.class);
-            Utilities.enforce(tpl.size() == 2, "Expected a pair, got " + varType);
+            DBSPType finalVarType = varType;
+            Utilities.enforce(tpl.size() == 2, () -> "Expected a pair, got " + finalVarType);
             varType = tpl.makeRelatedTupleType(Linq.list(tpl.tupFields[0].ref(), tpl.tupFields[1].ref()));
             var = varType.var();
             body = tpl.makeTuple(var.field(0).deref(), var.deepCopy().field(1).deref());
@@ -803,9 +804,10 @@ public class Monotonicity extends CircuitVisitor {
         DBSPTypeTupleBase outputValueType = ix.getKVType();
 
         Utilities.enforce(tuple0.getType().sameType(outputValueType.tupFields[0]),
-                "Types differ " + tuple0.getType() + " and " + outputValueType.tupFields[0]);
+                () -> "Types differ " + tuple0.getType() + " and " + outputValueType.tupFields[0]);
         DBSPTypeTupleBase varType = projection.getType().to(DBSPTypeTupleBase.class);
-        Utilities.enforce(varType.size() == 2, "Expected a pair, got " + varType);
+        DBSPTypeTupleBase finalVarType = varType;
+        Utilities.enforce(varType.size() == 2, () -> "Expected a pair, got " + finalVarType);
         varType = new DBSPTypeRawTuple(varType.tupFields[0].ref(), varType.tupFields[1].ref());
         DBSPVariablePath var = varType.var();
         // Drop field 1 of the value projection.
@@ -872,9 +874,11 @@ public class Monotonicity extends CircuitVisitor {
         DBSPTypeIndexedZSet ix = node.getOutputIndexedZSetType();
         DBSPTypeTupleBase outputValueType = ix.elementType.to(DBSPTypeTupleBase.class);
 
-        Utilities.enforce(timestamp.getType().sameType(outputValueType.tupFields[0]), "Types differ " + timestampType + " and " + outputValueType.tupFields[0]);
+        Utilities.enforce(timestamp.getType().sameType(outputValueType.tupFields[0]),
+                () -> "Types differ " + timestampType + " and " + outputValueType.tupFields[0]);
         DBSPTypeTupleBase varType = inputProjection.getType().to(DBSPTypeTupleBase.class);
-        Utilities.enforce(varType.size() == 2, "Expected a pair, got " + varType);
+        DBSPTypeTupleBase finalVarType = varType;
+        Utilities.enforce(varType.size() == 2, () -> "Expected a pair, got " + finalVarType);
         varType = new DBSPTypeRawTuple(varType.tupFields[0].ref(), varType.tupFields[1].ref());
         DBSPVariablePath var = varType.var();
         DBSPExpression lowerBound = ExpressionCompiler.makeBinaryExpression(node.getNode(),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPNode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPNode.java
@@ -187,7 +187,7 @@ public abstract class DBSPNode
 
     public static <T extends IDBSPInnerNode> List<T> fromJsonInnerList(
             JsonNode node, JsonDecoder decoder, Class<T> clazz) {
-        Utilities.enforce(node.isArray(), "Node is not an array " + Utilities.toDepth(node, 1));
+        Utilities.enforce(node.isArray(), () -> "Node is not an array " + Utilities.toDepth(node, 1));
         return Linq.list(Linq.map(
                 node.elements(), e -> decoder.decodeInner(e, clazz)));
     }
@@ -200,7 +200,7 @@ public abstract class DBSPNode
 
     public static <T extends IDBSPOuterNode> List<T> fromJsonOuterList(
             JsonNode node, JsonDecoder decoder, Class<T> clazz) {
-        Utilities.enforce(node.isArray(), "Node is not an array " + Utilities.toDepth(node, 1));
+        Utilities.enforce(node.isArray(), () -> "Node is not an array " + Utilities.toDepth(node, 1));
         return Linq.list(Linq.map(
                 node.elements(), e -> decoder.decodeOuter(e, clazz)));
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPAggregateList.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/aggregate/DBSPAggregateList.java
@@ -44,9 +44,9 @@ public final class DBSPAggregateList extends DBSPNode
             List<DBSPParameter> params = b.getRowVariableReferences();
             for (DBSPParameter p: params) {
                 Utilities.enforce(this.rowVar.getType().sameType(p.getType()),
-                        "Row var type does not match: " + this.rowVar.getType() + " vs " + p.getType());
+                        () -> "Row var type does not match: " + this.rowVar.getType() + " vs " + p.getType());
                 Utilities.enforce(this.rowVar.variable.equals(p.name),
-                        "Row var name does not match: " + this.rowVar.variable + " vs " + p.name);
+                        () -> "Row var name does not match: " + this.rowVar.variable + " vs " + p.name);
             }
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPApplyBaseExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPApplyBaseExpression.java
@@ -20,7 +20,7 @@ public abstract class DBSPApplyBaseExpression extends DBSPExpression {
         if (this.function.getType().is(DBSPTypeFunction.class)) {
             DBSPTypeFunction funcType = this.function.getType().to(DBSPTypeFunction.class);
             Utilities.enforce(funcType.parameterTypes.length == this.arguments.length,
-                    "Has " + funcType.parameterTypes.length + " parameters, but " +
+                    () -> "Has " + funcType.parameterTypes.length + " parameters, but " +
                             this.arguments.length + " arguments");
             parameterTypes = funcType.parameterTypes;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -51,9 +51,9 @@ public final class DBSPCastExpression extends DBSPExpression {
         this.safe = safe;
         Utilities.enforce(source.getType().is(DBSPTypeTupleBase.class) == to.is(DBSPTypeTupleBase.class)
                 || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class),
-                "Cast to/from tuple from/to non-tuple " + source.getType() + " to " + to);
-        Utilities.enforce(to.code != DBSPTypeCode.INTERNED_STRING, "Cast to INTERNED");
-        Utilities.enforce(source.getType().code != DBSPTypeCode.INTERNED_STRING, "Cast from INTERNED");
+                () -> "Cast to/from tuple from/to non-tuple " + source.getType() + " to " + to);
+        Utilities.enforce(to.code != DBSPTypeCode.INTERNED_STRING, () -> "Cast to INTERNED");
+        Utilities.enforce(source.getType().code != DBSPTypeCode.INTERNED_STRING, () -> "Cast from INTERNED");
         Utilities.enforce(!safe || to.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -77,7 +77,7 @@ public abstract class DBSPExpression
 
     /** Generates an expression that calls clone() on this. */
     public DBSPExpression applyClone() {
-        Utilities.enforce(!this.type.is(DBSPTypeRef.class), "Cloning a reference " + this);
+        Utilities.enforce(!this.type.is(DBSPTypeRef.class), () -> "Cloning a reference " + this);
         if (this.is(DBSPCloneExpression.class))
             return this;
         return new DBSPCloneExpression(this.getNode(), this);
@@ -121,7 +121,7 @@ public abstract class DBSPExpression
 
     /** Unwrap an expression with a nullable type */
     public DBSPExpression unwrap() {
-        Utilities.enforce(this.type.mayBeNull, "Unwrapping non-nullable type");
+        Utilities.enforce(this.type.mayBeNull, () -> "Unwrapping non-nullable type");
         return new DBSPUnwrapExpression(this);
     }
 
@@ -243,7 +243,7 @@ public abstract class DBSPExpression
     public DBSPExpression nullabilityCast(DBSPType to, boolean safe) {
         DBSPType sourceType = this.getType();
         Utilities.enforce(sourceType.sameTypeIgnoringNullability(to),
-                "Cast from " + sourceType + " to " + to + " is not a nullability cast.");
+                () -> "Cast from " + sourceType + " to " + to + " is not a nullability cast.");
         return this.cast(this.getNode(), to, safe);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFieldExpression.java
@@ -45,7 +45,7 @@ public final class DBSPFieldExpression extends DBSPExpression {
         super(node, type);
         this.expression = expression;
         this.fieldNo = fieldNo;
-        Utilities.enforce(fieldNo >= 0, "Negative field index " + fieldNo);
+        Utilities.enforce(fieldNo >= 0, () -> "Negative field index " + fieldNo);
         Utilities.enforce(!expression.getType().mayBeNull || type.mayBeNull);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFlatmap.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFlatmap.java
@@ -101,7 +101,7 @@ public final class DBSPFlatmap extends DBSPExpression {
         }
         Utilities.enforce(collectionExpression.parameters.length == 1);
         Utilities.enforce(collectionExpression.parameters[0].type.sameType(this.inputRowType.ref()),
-                "Collection expression expects " + collectionExpression.parameters[0].type
+                () -> "Collection expression expects " + collectionExpression.parameters[0].type
                 + " but input element type is " + this.inputRowType.ref());
         DBSPTypeFunction flatmapFunctionType = this.type.to(DBSPTypeFunction.class);
         Utilities.enforce(flatmapFunctionType.resultType.is(DBSPTypeTuple.class));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPLetExpression.java
@@ -22,7 +22,8 @@ public class DBSPLetExpression extends DBSPExpression implements IDBSPDeclaratio
 
     public DBSPLetExpression(DBSPVariablePath var, DBSPExpression initializer, DBSPExpression consumer) {
         super(initializer.getNode(), consumer.getType());
-        Utilities.enforce(var.getType().sameType(initializer.getType()), "Variable has type " + var.getType() + " and initializer has type " + initializer.getType());
+        Utilities.enforce(var.getType().sameType(initializer.getType()),
+                () -> "Variable has type " + var.getType() + " and initializer has type " + initializer.getType());
         this.variable = var;
         this.initializer = initializer;
         this.consumer = consumer;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTupleExpression.java
@@ -47,12 +47,14 @@ import java.util.Objects;
 public final class DBSPTupleExpression extends DBSPBaseTupleExpression {
     public DBSPTupleExpression(CalciteObject object, DBSPTypeTuple type, DBSPExpression... expressions) {
         super(object, type, expressions);
-        Utilities.enforce(type.size() == expressions.length, "Tuple expression has size " + expressions.length +
+        Utilities.enforce(type.size() == expressions.length,
+                () -> "Tuple expression has size " + expressions.length +
                 " but the declared type is " + type);
         for (int i = 0; i < type.size(); i++) {
+            int finalI = i;
             Utilities.enforce(type.tupFields[i].sameType(expressions[i].getType()),
-                    "Tuple field " + expressions[i] + " has type " + expressions[i].getType() +
-                    " that does not match the declared field type " + type.tupFields[i]);
+                    () -> "Tuple field " + expressions[finalI] + " has type " + expressions[finalI].getType() +
+                    " that does not match the declared field type " + type.tupFields[finalI]);
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPVariablePath.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPVariablePath.java
@@ -98,9 +98,11 @@ public final class DBSPVariablePath extends DBSPExpression {
         if (otherExpression == null)
             return false;
         IDBSPDeclaration leftDeclaration = context.leftDeclaration.get(this.variable);
-        Utilities.enforce(leftDeclaration != null, "Declaration for variable " + Utilities.singleQuote(this.variable) + " not found");
+        Utilities.enforce(leftDeclaration != null,
+                () -> "Declaration for variable " + Utilities.singleQuote(this.variable) + " not found");
         IDBSPDeclaration rightDeclaration = context.rightDeclaration.get(otherExpression.variable);
-        Utilities.enforce(rightDeclaration != null, "Declaration for variable " + Utilities.singleQuote(otherExpression.variable) + " not found");
+        Utilities.enforce(rightDeclaration != null,
+                () -> "Declaration for variable " + Utilities.singleQuote(otherExpression.variable) + " not found");
         IDBSPDeclaration subst = context.leftToRight.get(leftDeclaration);
         return subst.equals(rightDeclaration);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeRef.java
@@ -44,7 +44,7 @@ public class DBSPTypeRef extends DBSPType {
 
     public DBSPTypeRef(DBSPType type, boolean mutable, boolean mayBeNull) {
         super(type.getNode(), REF, mayBeNull);
-        Utilities.enforce(!type.is(DBSPTypeRef.class), "Reference of reference not supported");
+        Utilities.enforce(!type.is(DBSPTypeRef.class), () -> "Reference of reference not supported");
         this.type = type;
         this.mutable = mutable;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ExplicitShuffle.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ExplicitShuffle.java
@@ -64,8 +64,8 @@ public class ExplicitShuffle implements Shuffle {
         List<Integer> shuffle = new ArrayList<>();
         for (T in : input) {
             int index = output.indexOf(in);
-            Utilities.enforce(index >= 0, "Input " + in + " not found in output");
-            Utilities.enforce(!shuffle.contains(index), "Input " + in + " appears twice");
+            Utilities.enforce(index >= 0, () -> "Input " + in + " not found in output");
+            Utilities.enforce(!shuffle.contains(index), () -> "Input " + in + " appears twice");
             shuffle.add(index);
         }
         return new ExplicitShuffle(input.size(), shuffle);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IdShuffle.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/IdShuffle.java
@@ -19,7 +19,8 @@ public class IdShuffle implements Shuffle {
 
     @Override
     public <T> List<T> shuffle(List<T> data) {
-        Utilities.enforce(data.size() <= this.inputLength, "Shuffling " + data.size() + " more than expected " + this.inputLength);
+        Utilities.enforce(data.size() <= this.inputLength,
+                () -> "Shuffling " + data.size() + " more than expected " + this.inputLength);
         return data;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -109,9 +110,9 @@ public class Utilities {
      * @param expression  When this expression is false, this function throws.
      * @param message     Message for exception when expression is false */
     @Contract("false, _ -> fail")
-    public static void enforce(boolean expression, String message) {
+    public static void enforce(boolean expression, Supplier<String> message) {
         if (!expression)
-            throw new InternalCompilerError(message + System.lineSeparator() + getCurrentStackTrace());
+            throw new InternalCompilerError(message.get() + System.lineSeparator() + getCurrentStackTrace());
     }
 
     public static TimestampString roundMillis(TimestampString ts) {
@@ -161,7 +162,7 @@ public class Utilities {
             return;
         boolean success = file.delete();
         if (enforce)
-            Utilities.enforce(success, "Could not delete file " + file.getName());
+            Utilities.enforce(success, () -> "Could not delete file " + file.getName());
     }
 
     public static String getBaseName(String filePath) {
@@ -339,7 +340,7 @@ public class Utilities {
     public static <T> void removeLast(List<T> data, T expected) {
         T removed = removeLast(data);
         Utilities.enforce(removed.equals(expected),
-                "Unexpected node popped " + removed + " expected " + expected);
+                () -> "Unexpected node popped " + removed + " expected " + expected);
     }
 
     public static <T> T[] arraySlice(T[] data, int start, int endExclusive) {
@@ -538,7 +539,7 @@ public class Utilities {
     public static JsonNode getProperty(JsonNode node, String property) {
         JsonNode prop = node.get(property);
         Utilities.enforce(prop != null,
-                "Node does not have property " + Utilities.singleQuote(property) +
+                () -> "Node does not have property " + Utilities.singleQuote(property) +
                 Utilities.toDepth(node, 1));
         return prop;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -799,6 +799,7 @@ public class IncrementalRegressionTests extends SqlIoTest {
     // Tests that are not in the repository; run manually
     @Test @Ignore
     public void extraTests() throws IOException {
+        this.showFinalVerbose(3);
         String dir = "../extra";
         File file = new File(dir);
         if (file.exists()) {
@@ -807,7 +808,7 @@ public class IncrementalRegressionTests extends SqlIoTest {
                 return;
             Arrays.sort(toCompile);
             for (File c: toCompile) {
-                if (!c.getName().contains("no-min.sql")) continue;
+                if (!c.getName().contains("temp-program.sql")) continue;
                 if (c.getName().contains("sql")) {
                     System.out.println("Compiling " + c);
                     String sql = Utilities.readFile(c.getPath());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChangeStream.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/InputOutputChangeStream.java
@@ -31,9 +31,12 @@ public class InputOutputChangeStream {
     }
 
     public InputOutputChangeStream addChange(InputOutputChange change) {
-        Utilities.enforce(this.changes.isEmpty() || this.changes.get(0).compatible(change), "Incompatible change");
-        Utilities.enforce(this.inputTables.isEmpty() || change.inputs.getSetCount() == this.inputTables.size(), "Change does not have the same number of input tables as specified");
-        Utilities.enforce(this.outputTables.isEmpty() || change.outputs.getSetCount() == this.outputTables.size(), "Change does not have the same number of output tables as specified");
+        Utilities.enforce(this.changes.isEmpty() || this.changes.get(0).compatible(change),
+                () -> "Incompatible change");
+        Utilities.enforce(this.inputTables.isEmpty() || change.inputs.getSetCount() == this.inputTables.size(),
+                () -> "Change does not have the same number of input tables as specified");
+        Utilities.enforce(this.outputTables.isEmpty() || change.outputs.getSetCount() == this.outputTables.size(),
+                () -> "Change does not have the same number of output tables as specified");
         this.changes.add(change);
         return this;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -381,7 +381,8 @@ public class TableParser {
                         Utilities.enforce(!trimmed.isEmpty());
 
                         String[] parts = trimmed.split(",");
-                        Utilities.enforce(parts.length == tuple.size(), "Expected " + tuple.size() + " fields for tuple, got " + parts.length);
+                        Utilities.enforce(parts.length == tuple.size(),
+                                () -> "Expected " + tuple.size() + " fields for tuple, got " + parts.length);
                         List<DBSPExpression> fields = new ArrayList<>(tuple.size());
                         int index = 0;
                         for (DBSPType ft : tuple.tupFields)


### PR DESCRIPTION
 this avoids a lot of needless work in formatting error messages never output

At some point in the past I have realized that assert in Java does not work in release mode, so I replaced it with my own function "enforce". However, assert is lazy in its second argument, while enforce is not. This means that all assertion checks are actually producing the formatted error messages which are never displayed. Some of these messages require complex traversals of large objects, so they can be very expensive.

As a side-effect this change should make compilation significantly faster for large programs.