### PR TITLE
python: remove `FELDERA_BASE_URL`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8593,7 +8593,7 @@ pipeline = client.create_pipeline("my_pipeline")
 
 ### Testing Best Practices
 
-- **Environment Setup**: Tests expect Feldera instance at `$FELDERA_BASE_URL` (default: `http://localhost:8080`)
+- **Environment Setup**: Tests expect Feldera instance at `$FELDERA_HOST` (default: `http://localhost:8080`)
 - **Test Organization**: Group related functionality (aggregates, arithmetic, complex types)
 - **DDL Management**: Use docstring DDLs in shared test classes
 - **Enterprise Testing**: Separate OSS and Enterprise test paths

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -31,12 +31,7 @@ class Config:
             takes priority.
         """
 
-        BASE_URL = (
-            url
-            or os.environ.get("FELDERA_HOST")
-            or os.environ.get("FELDERA_BASE_URL")
-            or "http://localhost:8080"
-        )
+        BASE_URL = url or os.environ.get("FELDERA_HOST") or "http://localhost:8080"
         self.url: str = BASE_URL
         self.api_key: Optional[str] = os.environ.get("FELDERA_API_KEY", api_key)
         self.version: str = version or "v0"

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -38,11 +38,7 @@ def _get_effective_api_key():
     return oidc_token if oidc_token else API_KEY
 
 
-BASE_URL = (
-    os.environ.get("FELDERA_HOST")
-    or os.environ.get("FELDERA_BASE_URL")
-    or "http://localhost:8080"
-)
+BASE_URL = os.environ.get("FELDERA_HOST") or "http://localhost:8080"
 FELDERA_REQUESTS_VERIFY = requests_verify_from_env()
 
 


### PR DESCRIPTION
The environment variable is not used anymore, as it is replaced by `FELDERA_HOST`.

**PR information:**
- Documentation is not updated
- Changelog is not updated
- Breaking change for Python SDK: `FELDERA_BASE_URL` no longer works to replace the default for the `url` argument