### PR TITLE
py: fix license and dependency-group warnings

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "feldera"
 readme = "README.md"
 description = "The feldera python client"
 version = "0.204.0"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 authors = [
     { "name" = "Feldera Team", "email" = "dev@feldera.com" },
@@ -17,7 +17,6 @@ keywords = [
     "python",
 ]
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.10",
     "Operating System :: OS Independent",
 ]
@@ -36,8 +35,8 @@ Documentation = "https://docs.feldera.com/python"
 Repository = "https://github.com/feldera/feldera"
 Issues = "https://github.com/feldera/feldera/issues"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.8.0",
     "pytest>=8.3.5",


### PR DESCRIPTION
The `project.license` field in `pyproject.toml` no longer accepts a table, so use plain text. Use MIT license.

Also fix the `dev-dependency` warning.

Fixes: #5066 