### PR TITLE
python: `api_key` argument takes priority over environment variable

### DIFF
--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -33,7 +33,7 @@ class Config:
 
         BASE_URL = url or os.environ.get("FELDERA_HOST") or "http://localhost:8080"
         self.url: str = BASE_URL
-        self.api_key: Optional[str] = os.environ.get("FELDERA_API_KEY", api_key)
+        self.api_key: Optional[str] = api_key or os.environ.get("FELDERA_API_KEY")
         self.version: str = version or "v0"
         self.timeout: Optional[float] = timeout
         self.connection_timeout: Optional[float] = connection_timeout


### PR DESCRIPTION
Currently the `api_key` is used as a default instead of being used if set and the environment variable being the default. This is fixed.

**PR information**
- Documentation not updated
- Changelog not updated
- Not a breaking change but a fix