### PR TITLE
python: improve constructor documentation

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -28,7 +28,9 @@ extensions = [
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-
+autodoc_default_options = {
+    "special-members": "__init__",
+}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/python/feldera/__init__.py
+++ b/python/feldera/__init__.py
@@ -1,9 +1,9 @@
 from feldera.rest.feldera_client import FelderaClient as FelderaClient
 from feldera.pipeline import Pipeline as Pipeline
 from feldera.pipeline_builder import PipelineBuilder as PipelineBuilder
-from feldera.rest._helpers import client_version
+from feldera.rest._helpers import determine_client_version
 
-__version__ = client_version()
+__version__ = determine_client_version()
 
 import pretty_errors
 

--- a/python/feldera/rest/_helpers.py
+++ b/python/feldera/rest/_helpers.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 
-def client_version() -> str:
+def determine_client_version() -> str:
     from importlib.metadata import version, PackageNotFoundError
 
     try:

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -6,7 +6,8 @@ import logging
 
 class Config:
     """
-    :class:`.FelderaClient`'s credentials and configuration parameters
+    :class:`.FelderaClient` configuration, which includes authentication information
+    and the address of the Feldera API the client will interact with.
     """
 
     def __init__(
@@ -19,20 +20,12 @@ class Config:
         requests_verify: Optional[bool | str] = None,
     ) -> None:
         """
-        :param url: The url to the Feldera API (ex: https://try.feldera.com)
-        :param api_key: The optional API key to access Feldera
-        :param version: The version of the API to use
-        :param timeout: The timeout for the HTTP requests
-        :param connection_timeout: The connection timeout for the HTTP requests
-        :param requests_verify: The `verify` parameter passed to the requests
-            library. `True` by default. Can also be set using environment
-            variables `FELDERA_TLS_INSECURE` to disable TLS and
-            `FELDERA_HTTPS_TLS_CERT` to set the certificate path. The latter
-            takes priority.
-        """
+        See documentation of the `FelderaClient` constructor for the other arguments.
 
-        BASE_URL = url or os.environ.get("FELDERA_HOST") or "http://localhost:8080"
-        self.url: str = BASE_URL
+        :param version: (Optional) Version of the API to use.
+            Default: `v0`.
+        """
+        self.url: str = url or os.environ.get("FELDERA_HOST") or "http://localhost:8080"
         self.api_key: Optional[str] = api_key or os.environ.get("FELDERA_API_KEY")
         self.version: str = version or "v0"
         self.timeout: Optional[float] = timeout
@@ -43,4 +36,4 @@ class Config:
         )
 
         if self.requests_verify is False:
-            logging.warning("TLS verification is disabled.")
+            logging.warning("Feldera client: TLS verification is disabled!")

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -9,7 +9,7 @@ from urllib.parse import quote
 import requests
 
 from feldera.enums import BootstrapPolicy, PipelineFieldSelector, PipelineStatus
-from feldera.rest._helpers import client_version
+from feldera.rest._helpers import determine_client_version
 from feldera.rest._httprequests import HttpRequests
 from feldera.rest.config import Config
 from feldera.rest.errors import FelderaAPIError, FelderaTimeoutError
@@ -38,10 +38,13 @@ def _prepare_boolean_input(value: bool) -> str:
 
 class FelderaClient:
     """
-    A client for the Feldera HTTP API
+    A client for the Feldera HTTP API.
 
-    A client instance is needed for every Feldera API method to know the
-    location of Feldera and its permissions.
+    The client is initialized with the configuration needed for interacting with the
+    Feldera HTTP API, which it uses in its calls. Its methods are implemented
+    by issuing one or more HTTP requests to the API, and as such can provide higher
+    level operations (e.g., support waiting for the success of asynchronous HTTP API
+    functionality).
     """
 
     def __init__(
@@ -53,22 +56,33 @@ class FelderaClient:
         requests_verify: Optional[bool | str] = None,
     ) -> None:
         """
-        :param url: The url to Feldera API (ex: https://try.feldera.com). If
-            not set, attempts to read from the environment variable
-            `FELDERA_HOST`. Default: `http://localhost:8080`
-        :param api_key: The optional API key for Feldera
-        :param timeout: (optional) The amount of time in seconds that the
-            client will wait for a response before timing out.
-        :param connection_timeout: (optional) The amount of time in seconds
-            that the client will wait to establish connection before timing out
-        :param requests_verify: The `verify` parameter passed to the requests
-            library. `True` by default. To use a self signed certificate, set
-            it to the path to the certificate.
+        Constructs a Feldera client.
+
+        :param url: (Optional) URL to the Feldera API.
+            The default is read from the `FELDERA_HOST` environment variable;
+            if the variable is not set, the default is `"http://localhost:8080"`.
+        :param api_key: (Optional) API key to access Feldera (format: `"apikey:..."`).
+            The default is read from the `FELDERA_API_KEY` environment variable;
+            if the variable is not set, the default is `None` (no API key is provided).
+        :param timeout: (Optional) Duration in seconds that the client will wait to receive
+            a response of an HTTP request, after which it times out.
+            The default is `None` (wait indefinitely; no timeout is enforced).
+        :param connection_timeout: (Optional) Duration in seconds that the client will wait
+            to establish the connection of an HTTP request, after which it times out.
+            The default is `None` (wait indefinitely; no timeout is enforced).
+        :param requests_verify: (Optional) The `verify` parameter passed to the `requests` library,
+            which is used internally to perform HTTP requests.
+            See also: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification .
+            The default is based on the `FELDERA_HTTPS_TLS_CERT` or the `FELDERA_TLS_INSECURE` environment variable.
+            By setting `FELDERA_HTTPS_TLS_CERT` to a path, the default becomes the CA bundle it points to.
+            By setting `FELDERA_TLS_INSECURE` to `"1"`, `"true"` or `"yes"` (all case-insensitive), the default becomes
+            `False` which means to disable TLS verification by default. If both variables are set, the former takes
+            priority over the latter. If neither variable is set, the default is `True`.
         """
 
         self.config = Config(
-            url,
-            api_key,
+            url=url,
+            api_key=api_key,
             timeout=timeout,
             connection_timeout=connection_timeout,
             requests_verify=requests_verify,
@@ -76,12 +90,12 @@ class FelderaClient:
         self.http = HttpRequests(self.config)
 
         try:
-            config = self.get_config()
-            version = client_version()
-            if config.version != version:
+            client_version = determine_client_version()
+            server_config = self.get_config()
+            if client_version != server_config.version:
                 logging.warning(
-                    f"Client is on version {version} while server is at "
-                    f"{config.version}. There could be incompatibilities."
+                    f"Feldera client is on version {client_version} while server is at "
+                    f"{server_config.version}. There could be incompatibilities."
                 )
         except Exception as e:
             logging.error(f"Failed to connect to Feldera API: {e}")
@@ -1184,7 +1198,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 
     def get_config(self) -> FelderaConfig:
         """
-        Get general feldera configuration.
+        Retrieves the general Feldera server configuration.
         """
 
         resp = self.http.get(path="/config")


### PR DESCRIPTION
Specifically mention the default values and the environment variables.

Additionally make a couple of small changes in function and variable naming for clarity.

In the warnings it now expressly prints "Feldera client" such that their origin is clear.

**PR information**
- Inline documentation updated
- Changelog not updated
- No breaking changes