### PR TITLE
[storage] Account for deletions when overwriting in the POSIX backend.

### DIFF
--- a/crates/dbsp/src/storage/backend/posixio_impl.rs
+++ b/crates/dbsp/src/storage/backend/posixio_impl.rs
@@ -271,6 +271,12 @@ impl FileWriter for PosixWriter {
 
             // Remove the .mut extension from the file.
             let finalized_path = self.drop.path.with_extension("");
+            self.drop.usage.fetch_sub(
+                finalized_path
+                    .metadata()
+                    .map_or(0, |metadata| metadata.size() as i64),
+                Ordering::Relaxed,
+            );
             fs::rename(&self.drop.path, &finalized_path)
                 .map_err(|e| StorageError::stdio(e.kind(), "rename", self.drop.path.display()))?;
 


### PR DESCRIPTION
The POSIX storage backend accounted for writing and deleting files in its storage usage tracking, but it didn't track file overwrites.  This fixes the problem.

Fixes: https://github.com/feldera/feldera/issues/5095
