### PR TITLE
[DOCS][SQL] Fix incorrect documentation for string literals

### DIFF
--- a/docs.feldera.com/docs/sql/string.md
+++ b/docs.feldera.com/docs/sql/string.md
@@ -46,31 +46,28 @@ but:
 SELECT 'foo'      'bar'
 ```
 
-is not valid syntax.
+is not valid syntax.  Newlines are supported within string literals:
 
-## Escaped characters
+```
+SELECT 'a
+b'
+```
 
-We also accept escaped characters within string constants, which are
-an extension to the SQL standard.  Within a quoted string, a
-backslash character (`\`) begins a C-like backslash escape sequence, in
-which the combination of backslash and the following character(s)
-represent a special byte value:
+produces a multi-line string literal.
 
-|Backslash Escape Sequence|Interpretation|
-|-------------------------|--------------|
-|<code>\b</code>          | backspace    |
-|<code>\f</code>          | form feed    |
-|<code>\n</code>          | newline      |
-|<code>\r</code>          | carriage return |
-|<code>\t</code>          | tab          |
-|<code>\o, \oo, \ooo</code> | (o = 0–7) octal byte value |
-|<code>\xh, \xhh (h = 0–9, A–F)</code> | hexadecimal byte value |
-|<code>\uxxxx, \Uxxxxxxxx (x = 0–9, A–F)</code> | 16 or 32-bit hexadecimal Unicode character value |
+## Unicode characters
 
-Any other character following a backslash is taken literally. Thus, to
-include a backslash character, write two backslashes `\\`. Also, a
-single quote can be included in an escape string by writing `\'`, in
-addition to the normal way of `''`.
+A string literal prefixed with the `U&` can contain unicode characters
+described using their numeric code: `U&'hello\0041'` includes the
+unicode character with code U+0041, which is the uppercase letter 'A'.
+A unicode character is described by an escape character followed by
+four hexadecimal digits.
+
+The default escape character is backslash, but it can be changed using
+the following syntax: `U&'hello!0041' UESCAPE '!'`.  The `UESCAPE`
+notation designates the escape character to use in interpreting the
+current literal, which is the exclamation sign in the previous
+example.
 
 ## Operations on string values
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -4,12 +4,15 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOpera
 import org.dbsp.sqlCompiler.circuit.operator.DBSPLagOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAggregateOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.sql.tools.Change;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCloneExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPZSetExpression;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStaticItem;
 import org.dbsp.util.Linq;
 import org.junit.Assert;
@@ -744,6 +747,40 @@ public class Regression1Tests extends SqlIoTest {
                 CREATE MATERIALIZED VIEW row_max AS SELECT
                 MAX(ROW(c1, c2, c3)) AS c1
                 FROM row_tbl;""");
+    }
+
+    @Test
+    public void issue5087() {
+        this.qs("""
+                SELECT '1
+                2' AS r;
+                 r
+                ---
+                 1\\n2
+                (1 row)
+                
+                SELECT U&'hello\\0041';
+                 r
+                ---
+                 helloA
+                (1 row)
+                
+                SELECT U&'hello!0041' UESCAPE '!';
+                 r
+                ---
+                 helloA
+                (1 row)""");
+    }
+
+    @Test
+    public void issue5087a() {
+        var ccs = this.getCCS("""
+                -- C escape sequences do not have any special meaning
+                CREATE VIEW V AS SELECT 'a\\t\\b\\n\\r'""");
+        ccs.addPair(new Change(),
+                new Change("V",
+                new DBSPZSetExpression(new DBSPTupleExpression(
+                        new DBSPStringLiteral("a\\t\\b\\n\\r")))));
     }
 
     @Test


### PR DESCRIPTION
Fixes #5087

I think we copied the incorrect bit from Postgres a long time ago.