### PR TITLE
rust: upgrade to latest stable `1.91.1`

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
     tty: true
     environment:
-      - RUST_VERSION=1.87.0
+      - RUST_VERSION=1.91.1
       - RUST_BACKTRACE=1
       - REDPANDA_BROKERS=redpanda:9092
     volumes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@
 - **Primary Languages**: Rust (core engine), Java (SQL compiler), TypeScript/Svelte (web console), Python (SDK)
 - **Size**: Large multi-language repository with 14 Rust crates, Java compiler, web console, Python SDK
 - **License**: MIT OR Apache-2.0
-- **MSRV**: Rust 1.87.0
+- **MSRV**: Rust 1.91.1
 
 ### Key Components
 - **DBSP Engine**: Core incremental computation engine (Rust)
@@ -28,9 +28,9 @@ Always install ALL dependencies before building:
 sudo apt-get update
 sudo apt-get install -y cmake libssl-dev libsasl2-dev
 
-# Rust toolchain (required version 1.87.0)
+# Rust toolchain (required version 1.91.1)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup default 1.87.0
+rustup default 1.91.1
 
 # Java (JDK 19 or newer required)
 # Install OpenJDK 21 or newer

--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -23,7 +23,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -72,7 +72,7 @@ jobs:
   adjust-versions:
     runs-on: [k8s-runners-amd64]
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -18,7 +18,7 @@ jobs:
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   main:
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     runs-on: [k8s-runners-amd64]
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,7 +14,7 @@ jobs:
   copilot-setup-steps:
     # This doesn't work as usual with new github things
     #container:
-    #  image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+    #  image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     runs-on: ubuntu-latest-amd64
     permissions:
       contents: read
@@ -25,7 +25,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.91.1
       - name: Install uv
         uses: astral-sh/setup-uv@v2
         with:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,7 +30,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'release' }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -23,7 +23,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -167,7 +167,7 @@ jobs:
       OIDC_TEST_PASSWORD: ${{ secrets.OIDC_TEST_PASSWORD }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     services:
       pipeline-manager:
         image: ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ github.sha }}

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -28,7 +28,7 @@ jobs:
       FELDERA_API_KEY: ${{ secrets[matrix.feldera_api_key] }}
       FELDERA_RUNTIME_VERSION: ${{ github.sha }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
+      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
 
     steps:
       - name: Checkout repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  rust: 1.87.0
+  rust: 1.91.1
 repos:
   - repo: local
     hooks:

--- a/crates/dbsp/src/dynamic.rs
+++ b/crates/dbsp/src/dynamic.rs
@@ -139,7 +139,7 @@ pub use data::{Data, DataTrait, DataTraitTyped, DynBool, DynData, DynDataTyped, 
 pub use downcast::{AsAny, DowncastTrait};
 pub use erase::Erase;
 pub use factory::{Factory, WithFactory};
-pub use lean_vec::{LeanVec, RawIter};
+pub use lean_vec::{LeanVec, RawIter, RawVec};
 pub use option::{DynOpt, Opt};
 pub use pair::{DynPair, Pair};
 pub use pairs::{DynPairs, Pairs, PairsTrait};

--- a/crates/dbsp/src/dynamic/lean_vec.rs
+++ b/crates/dbsp/src/dynamic/lean_vec.rs
@@ -106,7 +106,7 @@ impl RawVec {
     /// - `new_len` must be less than or equal to [`self.capacity()`].
     /// - The elements at `old_len..new_len` must be initialized.
     ///
-    /// [`self.capacity()`]: RawVec ::capacity
+    /// [`self.capacity()`]: RawVec::capacity
     pub unsafe fn set_len(&mut self, new_len: usize) {
         debug_assert!(new_len <= self.capacity());
         self.length = new_len;
@@ -1174,6 +1174,8 @@ impl<T> LeanVec<T> {
     ///
     /// - `new_len` must be less than or equal to `self.capacity()`.
     /// - The elements at `old_len..new_len` must be initialized.
+    ///
+    /// [`self.capacity()`]: RawVec::capacity
     pub unsafe fn set_len(&mut self, new_len: usize) {
         self.vec.set_len(new_len)
     }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -65,7 +65,7 @@ RUN mkdir -p feldera/demo/packaged/sql
 COPY --chown=ubuntu demo/packaged/sql feldera/demo/packaged/sql
 
 # Install cargo and rust for this non-root user
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.87.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.91.1
 # The download URL for mold uses x86_64/aarch64 whereas dpkg --print-architecture says amd64/arm64
 RUN arch=`dpkg --print-architecture | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"`; \
   curl -LO https://github.com/rui314/mold/releases/download/v2.40.1/mold-2.40.1-$arch-linux.tar.gz \

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -115,7 +115,7 @@ ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.bun/bin:/home/ubuntu/.cargo/bin:
 # Install rust
 ENV RUSTUP_HOME=/home/ubuntu/.rustup
 ENV CARGO_HOME=/home/ubuntu/.cargo
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile default --default-toolchain 1.87.0
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile default --default-toolchain 1.91.1
 RUN cargo install --locked cargo-machete@0.7.0 cargo-edit@0.13.1 just@1.40.0
 
 # Install uv


### PR DESCRIPTION
Prior version is `1.87.0`.

**PR information**
- Documentation not updated: Rust version should be an internal detail
- Changelog not updated: Rust version should be an internal detail
- Should not yield a breaking change as Rust version should be only internal facing