### PR TITLE
compiler-server: increase default binary upload retries

### DIFF
--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -507,7 +507,7 @@ async fn upload_binary_to_endpoint_with_retries(
         .await
         {
             Ok(result) => {
-                if attempts > 1 {
+                if attempts >= 1 {
                     info!(
                         "Binary upload succeeded on attempt {} for pipeline {} (program version: {})",
                         attempts, metadata.pipeline_id, metadata.program_version

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -842,8 +842,8 @@ pub struct CompilerConfig {
     pub binary_upload_timeout_secs: u64,
 
     /// Maximum number of retry attempts for binary upload requests.
-    /// Default is 3 retries.
-    #[arg(long, default_value_t = 3)]
+    /// Default is 10 retries.
+    #[arg(long, default_value_t = 10)]
     pub binary_upload_max_retries: u32,
 
     /// Initial delay in milliseconds between retry attempts for binary upload requests.


### PR DESCRIPTION
increase from 3 -> 10 so it's much sane

and also log every successful upload of binary

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

not breaking change