### PR TITLE
[ci] Add cargo publish --dry-run to merge queue tasks

### DIFF
--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -65,6 +65,8 @@ jobs:
   publish-crates:
     name: ""
     uses: ./.github/workflows/publish-crates.yml
+    with:
+      environment: release
     secrets: inherit
 
   adjust-versions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
     uses: ./.github/workflows/test-java.yml
     secrets: inherit
 
+  invoke-publish-crates-dry-run:
+    name: Publish Crates (Dry Run)
+    needs: [invoke-build-rust]
+    uses: ./.github/workflows/publish-crates.yml
+    with:
+      environment: ci
+    secrets: inherit
+
   # This job needs to be called main (the same as the ci-pre-mergequeue.yml workflow)
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   # and https://github.com/orgs/community/discussions/103114
@@ -72,6 +80,7 @@ jobs:
       - invoke-tests-integration-platform
       - invoke-tests-integration-runtime
       - invoke-tests-java
+      - invoke-publish-crates-dry-run
     steps:
       - name: Finalize Workflow
         run: echo "All tasks completed!"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -6,18 +6,29 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      environment:
+        description: "Environment to use (ci or release)"
+        required: false
+        type: string
+        default: "release"
   workflow_dispatch:
     inputs:
       tag:
         description: "Tag to release (WARNING: Only use for emergency fixes, not for regular releases)"
         required: false
         type: string
+      environment:
+        description: "Environment to use (ci or release)"
+        required: false
+        type: string
+        default: "release"
 
 jobs:
   deploy:
     runs-on: [k8s-runners-amd64]
     environment:
-      name: release
+      name: ${{ inputs.environment || 'release' }}
     container:
       image: ghcr.io/feldera/feldera-dev:sha-a6c448f6eaa832d34bd5d2f6b2b4167245a8de36
     steps:
@@ -31,10 +42,13 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - uses: rust-lang/crates-io-auth-action@v1
+        if: ${{ inputs.environment == 'release' }}
         id: auth
 
       - name: Run cargo publish
-        if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
+        # TODO: Once we are on 1.90 rustc we can just use cargo publish workspace
+        # then we can truly test that this works as part of merge queue
+        if: ${{ vars.RELEASE_DRY_RUN == 'false' && inputs.environment == 'release' }}
         run: |
           cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-ir
           cargo publish ${{ vars.CARGO_PUBLISH_FLAGS }} --package feldera-types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ feldera-cloud1-client = "0.1.2"
 feldera-datagen = { path = "crates/datagen" }
 feldera-fxp = { version = "0.192.0", path = "crates/fxp", features = ["dbsp"] }
 feldera-iceberg = { path = "crates/iceberg" }
-feldera-observability = { path = "crates/feldera-observability" }
+feldera-observability = { version = "0.192.0", path = "crates/feldera-observability" }
 feldera-sqllib = { path = "crates/sqllib" }
 feldera-storage = { version = "0.192.0", path = "crates/storage" }
 feldera-types = { version = "0.192.0", path = "crates/feldera-types" }

--- a/crates/adapterlib/Cargo.toml
+++ b/crates/adapterlib/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [features]
 with-avro = ["apache-avro"]

--- a/crates/datagen/Cargo.toml
+++ b/crates/datagen/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [dependencies]
 feldera-types = { workspace = true }

--- a/crates/fda/Cargo.toml
+++ b/crates/fda/Cargo.toml
@@ -3,6 +3,7 @@ name = "fda"
 description = "A CLI tool for interacting with Feldera"
 readme = "README.md"
 include = ["bench_openapi.json", "/src", "build.rs", "COPYRIGHT", "README.md"]
+publish = true
 edition = { workspace = true }
 version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/feldera-observability/Cargo.toml
+++ b/crates/feldera-observability/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feldera-observability"
 description = "Shared observability utilities for Feldera services"
+publish = true
 edition = { workspace = true }
 version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/iceberg/Cargo.toml
+++ b/crates/iceberg/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
 readme = { workspace = true }
+publish = false
 
 [dependencies]
 feldera-types = { workspace = true }


### PR DESCRIPTION
We usually mess this up every time a new crate gets added and it breaks the release process. This ensures it will fail earlier during the merge queue in the future.

Add a brief description of the pull request.

## Breaking Changes?

No