### PR TITLE
[adapters] Deserialize Avro enums.

### DIFF
--- a/crates/adapters/src/format/avro/schema.rs
+++ b/crates/adapters/src/format/avro/schema.rs
@@ -300,9 +300,12 @@ fn validate_uuid_schema(avro_schema: &AvroSchema) -> Result<(), String> {
 }
 
 fn validate_string_schema(avro_schema: &AvroSchema) -> Result<(), String> {
-    if !matches!(avro_schema, AvroSchema::String | AvroSchema::Uuid) {
+    if !matches!(
+        avro_schema,
+        AvroSchema::String | AvroSchema::Uuid | AvroSchema::Enum(_)
+    ) {
         return Err(format!(
-            "invalid Avro schema for a column of type 'STRING': expected 'string' or '{{\"type\": \"string\",\"logicalType\": \"uuid\"}}', but found {}",
+            "invalid Avro schema for a column of type 'STRING': expected 'string', 'enum', or '{{\"type\": \"string\",\"logicalType\": \"uuid\"}}', but found {}",
             schema_json(avro_schema)
         ));
     }

--- a/docs.feldera.com/docs/formats/avro.md
+++ b/docs.feldera.com/docs/formats/avro.md
@@ -85,7 +85,7 @@ A SQL column and a field in the Avro schema are compatible if the following cond
 | `REAL`                        | `float`        |                                                                     |
 | `DOUBLE`                      | `double`       |                                                                     |
 | `DECIMAL(precision,scale)`    | `decimal`      | Precision and scale of the Avro decimal type must precisely match the SQL type.  |
-| `CHAR`, `VARCHAR`             | `string`       | SQL string type can be deserialized from Avro strings, including strings whose logical type is set to `uuid`. |
+| `CHAR`, `VARCHAR`             | `string`, `enum` | SQL string type can be deserialized from Avro strings, including strings whose logical type is set to `uuid`. Avro enums are also deserialized into SQL strings. |
 | `UUID`                        | `string`       | The Avro logical type can be _optionally_ set to `uuid`.            |
 | `BINARY`, `VARBINARY`         | `bytes`        |                                                                     |
 | `DATE`                        | `int`          |                                                                     |


### PR DESCRIPTION
Fixes #5137.

We don't have an enum type in SQL, so we deserialize Avro enum into SQL strings.

## Checklist

- [x] Documentation updated
- [ ] Changelog updated