### PR TITLE
[adapters] Warn when the pipeline stalls due to output buffers filling.

### DIFF
--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -708,6 +708,10 @@ impl LongOperationWarning {
             self.warn_threshold *= 2;
         }
     }
+
+    pub fn next_warning(&self) -> Instant {
+        self.start + self.warn_threshold
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I tested this manually.  It seems like a lot of work to test it automatically.
