### PR TITLE
[web-console] Upgrade to Bun 1.3.3, prepare to use the new Bun.js Security Scanner API

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,7 +69,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
 ## Install Bun.js
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.22"
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
 ENV PATH="$HOME/.bun/bin:$PATH"
 RUN $HOME/.bun/bin/bun install --global @hey-api/openapi-ts @anthropic-ai/claude-code
 

--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -23,7 +23,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ jobs:
             docker_platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -11,7 +11,7 @@ jobs:
       id-token: write
       contents: read
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -72,7 +72,7 @@ jobs:
   adjust-versions:
     runs-on: [k8s-runners-amd64]
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -18,7 +18,7 @@ jobs:
   # because of how merge queues work: https://stackoverflow.com/a/78030618
   main:
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     runs-on: [k8s-runners-amd64]
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,7 +14,7 @@ jobs:
   copilot-setup-steps:
     # This doesn't work as usual with new github things
     #container:
-    #  image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+    #  image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     runs-on: ubuntu-latest-amd64
     permissions:
       contents: read
@@ -47,5 +47,5 @@ jobs:
           node-version: 20
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version: 1.3.3
       - uses: taiki-e/install-action@just

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -30,7 +30,7 @@ jobs:
     environment:
       name: ${{ inputs.environment || 'release' }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -23,7 +23,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -167,7 +167,7 @@ jobs:
       OIDC_TEST_PASSWORD: ${{ secrets.OIDC_TEST_PASSWORD }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     services:
       pipeline-manager:
         image: ${{ vars.FELDERA_IMAGE_NAME }}:sha-${{ github.sha }}

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -28,7 +28,7 @@ jobs:
       FELDERA_API_KEY: ${{ secrets[matrix.feldera_api_key] }}
       FELDERA_RUNTIME_VERSION: ${{ github.sha }}
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
     steps:
       - name: Show Kubernetes node
         if: always()

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/feldera/feldera-dev:sha-a20fef16d212c8c3314c25c0fb16d8c680f95124
+      image: ghcr.io/feldera/feldera-dev:sha-5f0abc505a66168f9f41c38220f9c1ce0abc09db
 
     steps:
       - name: Checkout repository

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[install.security]
+# scanner = "@bun-security-scanner/npm"
+
+[install]
+# Only install package versions published at least 14 days ago
+minimumReleaseAge = 1209600

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -124,7 +124,7 @@ RUN uv python install 3.10
 RUN uv tool install pre-commit --with pre-commit-uv --force-reinstall
 
 # Install Bun.js
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.22"
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
 
 # Install gradle, the version needs to match the version that calcite uses which avoid reinstalling this every time we run build.sh
 RUN cd /home/ubuntu \

--- a/js-packages/web-console/README.md
+++ b/js-packages/web-console/README.md
@@ -19,7 +19,7 @@ sudo apt-get install nodejs -y
 # Install Bun
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg unzip
-sudo curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.22"
+sudo curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
 
 # Install OpenAPI typings generator
 sudo bun install --global @hey-api/openapi-ts

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "feldera-js",
+  "dependencies": {
+    "@sveltejs/kit": "^2.48.4",
+    "svelte": "^5.43.6"
+  },
   "private": true,
-  "workspaces": ["js-packages/*"],
   "scripts": {
     "split-claude": "bun scripts/claude.js split",
     "merge-claude": "bun scripts/claude.js merge"
   },
-  "dependencies": {
-    "@sveltejs/kit": "^2.48.4",
-    "svelte": "^5.43.6"
-  }
+  "workspaces": ["js-packages/*"]
 }


### PR DESCRIPTION
Security Scanner feature (Introduced in Bun 1.3.0) is not enabled yet because the candidate implementation is pending a bugfix: https://github.com/bun-security-scanner/npm/issues/1