### PR TITLE
[tracing] Use JSON logging helpers and document usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4949,8 +4949,12 @@ version = "0.198.0"
 dependencies = [
  "actix-http",
  "awc",
+ "chrono",
  "reqwest 0.12.20",
  "sentry",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -11786,6 +11790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11795,12 +11809,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata 0.4.9",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -157,7 +157,7 @@ governor = { workspace = true }
 nonzero_ext = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 comfy-table = { workspace = true }
 tokio-postgres = { workspace = true, features = [
     "with-serde_json-1",

--- a/crates/feldera-observability/Cargo.toml
+++ b/crates/feldera-observability/Cargo.toml
@@ -15,3 +15,7 @@ awc = { workspace = true }
 actix-http = { workspace = true }
 reqwest = { workspace = true }
 sentry = { workspace = true }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/crates/feldera-observability/README.md
+++ b/crates/feldera-observability/README.md
@@ -1,0 +1,40 @@
+# feldera-observability
+
+Shared observability helpers used across Feldera services (logging formats, middleware, utilities).
+
+## JSON logging
+
+The `json_logging` module provides a structured formatter and helpers so services can emit JSON logs when requested:
+- `JsonPipelineFormat`: tracing formatter that injects `timestamp`, `level`, `target`, `pipeline`, `fields`, and optional `span`.
+- `use_json_log_format()`: checks `RUST_LOG_JSON` (`1/true/yes/on`) to decide between text and JSON.
+- `sanitize_pipeline_name()`: strips surrounding `[]` often used in colored/text prefixes.
+
+Example usage inside a tracing setup:
+
+```rust
+use feldera_observability::json_logging::{
+    JsonPipelineFormat, sanitize_pipeline_name, use_json_log_format,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+if use_json_log_format() {
+    let pipeline = sanitize_pipeline_name("[my-pipeline]");
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().event_format(JsonPipelineFormat::new(pipeline)))
+        .with(env_filter)
+        .try_init()
+        .expect("init tracing");
+} else {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer()) // your text formatter here
+        .with(env_filter)
+        .try_init()
+        .expect("init tracing");
+}
+```
+
+To enable JSON logs at runtime, set `RUST_LOG_JSON=1` (or `true/yes/on`).
+Timestamps are RFC3339 UTC with microsecond precision to match the text formatter.
+Numerics, booleans, strings, and spans are preserved as structured JSON fields.

--- a/crates/feldera-observability/src/json_logging.rs
+++ b/crates/feldera-observability/src/json_logging.rs
@@ -1,0 +1,132 @@
+use chrono::Utc;
+use serde_json::{Map, Value};
+use tracing::Subscriber;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Shared JSON formatter that injects pipeline/service name and structured fields.
+pub struct JsonPipelineFormat {
+    pipeline: String,
+}
+
+impl JsonPipelineFormat {
+    pub fn new(pipeline: String) -> Self {
+        Self { pipeline }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for JsonPipelineFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let mut visitor = SerdeVisitor::default();
+        event.record(&mut visitor);
+
+        let metadata = event.metadata();
+        let mut obj = Map::new();
+        obj.insert("timestamp".to_string(), Value::String(now_timestamp()));
+        obj.insert(
+            "level".to_string(),
+            Value::String(metadata.level().as_str().to_string()),
+        );
+        obj.insert(
+            "target".to_string(),
+            Value::String(metadata.target().to_string()),
+        );
+        obj.insert("pipeline".to_string(), Value::String(self.pipeline.clone()));
+        obj.insert("fields".to_string(), Value::Object(visitor.fields));
+
+        if let Some(span) = ctx.lookup_current() {
+            obj.insert("span".to_string(), Value::String(span.name().to_string()));
+        }
+
+        let json = Value::Object(obj);
+        writeln!(writer, "{}", json)
+    }
+}
+
+#[derive(Default)]
+pub struct SerdeVisitor {
+    pub fields: Map<String, Value>,
+}
+
+impl tracing::field::Visit for SerdeVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.insert(
+            field.name().to_string(),
+            Value::String(format!("{value:?}")),
+        );
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        let as_number = serde_json::Number::from_f64(value);
+        let val = as_number
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_i128(&mut self, field: &tracing::field::Field, value: i128) {
+        let val = i64::try_from(value)
+            .map(|v| Value::Number(v.into()))
+            .unwrap_or_else(|_| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_u128(&mut self, field: &tracing::field::Field, value: u128) {
+        let val = u64::try_from(value)
+            .map(|v| Value::Number(v.into()))
+            .unwrap_or_else(|_| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), Value::String(value.to_string()));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), Value::Bool(value));
+    }
+}
+
+fn now_timestamp() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
+}
+
+/// True when structured JSON logging is requested via `RUST_LOG_JSON`.
+pub fn use_json_log_format() -> bool {
+    matches!(
+        std::env::var("RUST_LOG_JSON")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Remove surrounding `[]` often used in pretty log prefixes.
+pub fn sanitize_pipeline_name(name: impl AsRef<str>) -> String {
+    name.as_ref()
+        .trim_matches(|c| c == '[' || c == ']')
+        .to_string()
+}

--- a/crates/feldera-observability/src/lib.rs
+++ b/crates/feldera-observability/src/lib.rs
@@ -67,6 +67,8 @@ pub fn actix_middleware() -> sentry::integrations::actix::Sentry {
         .finish()
 }
 
+pub mod json_logging;
+
 fn trace_header_value() -> Option<String> {
     if !sentry_enabled() {
         return None;

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -30,7 +30,7 @@ rustls = { workspace = true }
 
 # Logging
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 colored = { workspace = true }
 sentry = { workspace = true }
 feldera-observability = { workspace = true }

--- a/crates/pipeline-manager/src/logging.rs
+++ b/crates/pipeline-manager/src/logging.rs
@@ -1,4 +1,7 @@
-use colored::ColoredString;
+use colored::{ColoredString, Colorize};
+use feldera_observability::json_logging::{
+    sanitize_pipeline_name, use_json_log_format, JsonPipelineFormat,
+};
 use tracing::warn;
 use tracing::Subscriber;
 use tracing_subscriber::fmt::format::Format;
@@ -11,19 +14,33 @@ use tracing_subscriber::EnvFilter;
 /// Initializes the logger by setting its filter and template.
 /// By default, the logging level is set to `INFO`.
 /// This can be overridden by setting the `RUST_LOG` environment variable.
+/// Set `RUST_LOG_JSON=1` to emit structured JSON logs instead of pretty text.
 pub fn init_logging(name: ColoredString) {
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .expect("valid default filter");
 
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().event_format(ManagerFormat::new(name)))
-        .with(env_filter)
-        .with(sentry::integrations::tracing::layer())
-        .try_init()
-        .unwrap_or_else(|e| {
-            warn!("Unable to initialize logging -- has it already been initialized? ({e})")
-        });
+    if use_json_log_format() {
+        let pipeline_name_json = sanitize_pipeline_name(name.clone().clear().to_string());
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(JsonPipelineFormat::new(pipeline_name_json))
+                    .with_ansi(false),
+            )
+            .with(env_filter)
+            .with(sentry::integrations::tracing::layer())
+            .try_init()
+    } else {
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().event_format(ManagerFormat::new(name)))
+            .with(env_filter)
+            .with(sentry::integrations::tracing::layer())
+            .try_init()
+    }
+    .unwrap_or_else(|e| {
+        warn!("Unable to initialize logging -- has it already been initialized? ({e})")
+    });
 }
 
 struct ManagerFormat {

--- a/crates/pipeline-manager/tests/logging_demo.rs
+++ b/crates/pipeline-manager/tests/logging_demo.rs
@@ -1,0 +1,20 @@
+use colored::Colorize;
+use pipeline_manager::logging::init_logging;
+use tracing::info;
+
+#[test]
+fn emits_sample_log() {
+    // Force INFO output for the demo regardless of upstream defaults.
+    std::env::set_var("RUST_LOG", "info");
+
+    init_logging("[logging-demo]".cyan());
+    info!("logging demo event");
+    info!(
+        demo_int = 42i64,
+        demo_u64 = u64::MAX,
+        demo_float = 3.1415f64,
+        demo_neg_float = -2.5f64,
+        demo_text = "sample",
+        "typed field coverage"
+    );
+}


### PR DESCRIPTION
Issue # 4586 : Write logs in JSON format

Set RUST_LOG_JSON to enable structured logging: any of 1, true, yes, or on
switches tracing output to JSON with timestamp, level, target, pipeline, fields.
Unset or any other value keeps the default text formatter.

Centralizes JSON logging helpers (use_json_log_format, sanitize_pipeline_name, JsonPipelineFormat)
in feldera-observability crate and updates pipeline manager to use them.

Extends JSON logging to preserve floats and large integers with a typed visitor.

Adds a README for feldera-observability covering the JSON logging module,
how to switch formats with RUST_LOG_JSON, and example usage.

Add logging demo test to emit typed fields for comparing default text vs JSON output.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
