### PR TITLE
docs: link MAX, MIN, SOME, SUM aggregates to their python test files

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
@@ -137,11 +137,37 @@ public class CalciteFunctions implements FunctionDocumentation.FunctionRegistry 
                     runtime_aggtest/aggregate_tests4/test_{array_every,map_every,varchar_every,varcharn_every}.py|
                     runtime_aggtest/aggregate_tests6/test_{interval_mths_every}.py
                     """, true),
-            new Func(SqlStdOperatorTable.MAX, "MAX", SqlLibrary.STANDARD, "aggregates#max,aggregates#window-max", FunctionDocumentation.NO_FILE, true),
-            new Func(SqlStdOperatorTable.MIN, "MIN", SqlLibrary.STANDARD, "aggregates#min,aggregates#window-min", FunctionDocumentation.NO_FILE, true),
+            new Func(SqlStdOperatorTable.MAX, "MAX", SqlLibrary.STANDARD, "aggregates#max,aggregates#window-max",
+                """
+                runtime_aggtest/aggregate_tests/test_{decimal_max,float_max,max,row_max,empty_set}.py|
+                runtime_aggtest/aggregate_tests2/test_{interval_max,date_max,timestamp_max,charn_max,time_max}.py|
+                runtime_aggtest/aggregate_tests3/test_{binary_max,un_int_max,varbinary_max}.py|
+                runtime_aggtest/aggregate_tests4/test_{array_max,map_max,varchar_max,varcharn_max}.py|
+                runtime_aggtest/aggregate_tests6/test_{interval_mths_max}.py
+                """, true),
+            new Func(SqlStdOperatorTable.MIN, "MIN", SqlLibrary.STANDARD, "aggregates#min,aggregates#window-min",
+                """
+                runtime_aggtest/aggregate_tests/test_{decimal_min,float_min,min,row_min,empty_set}.py|
+                runtime_aggtest/aggregate_tests2/test_{charn_min,time_min,date_min,timestamp_min,interval_min}.py|
+                runtime_aggtest/aggregate_tests3/test_{binary_min,un_int_min,varbinary_min}.py|
+                runtime_aggtest/aggregate_tests4/test_{array_min,map_min,varchar_min,varcharn_min}.py|
+                runtime_aggtest/aggregate_tests6/test_interval_mths_min.py
+                """, true),
             new Func(SqlStdOperatorTable.SINGLE_VALUE, "SINGLE", SqlLibrary.STANDARD, "", FunctionDocumentation.NO_FILE, true),
-            new Func(SqlStdOperatorTable.SOME, "SOME", SqlLibrary.STANDARD, "aggregates#some", FunctionDocumentation.NO_FILE, true),
-            new Func(SqlStdOperatorTable.SUM, "SUM", SqlLibrary.STANDARD, "aggregates#sum,aggregates#window-sum", FunctionDocumentation.NO_FILE, true),
+            new Func(SqlStdOperatorTable.SOME, "SOME", SqlLibrary.STANDARD, "aggregates#some",
+                """
+                runtime_aggtest/aggregate_tests/test_{decimal_some,some,row_some,empty_set}.py|
+                runtime_aggtest/aggregate_tests2/test_{charn_some,time_some,date_some,timestamp_some,interval_some}.py|
+                runtime_aggtest/aggregate_tests3/test_{binary_some,un_int_some,varbinary_some,empty_set}.py|
+                runtime_aggtest/aggregate_tests4/test_{array_some,map_some,varchar_some,varcharn_some}.py|
+                runtime_aggtest/aggregate_tests6/test_interval_mths_some.py
+                """, true),
+            new Func(SqlStdOperatorTable.SUM, "SUM", SqlLibrary.STANDARD, "aggregates#sum,aggregates#window-sum",
+                """
+                runtime_aggtest/aggregate_tests/test_{decimal_sum,sum,empty_set}.py|
+                runtime_aggtest/aggregate_tests3/test_un_int_sum.py|
+                runtime_aggtest/negative_tests/test_agg_arithmetic.py
+                """, true),
             new Func(SqlStdOperatorTable.SUM0, "SUM", SqlLibrary.STANDARD, "", FunctionDocumentation.NO_FILE, true),
             new Func(SqlStdOperatorTable.STDDEV, "STDDEV", SqlLibrary.STANDARD, "aggregates#stddev", FunctionDocumentation.NO_FILE, true),
             new Func(SqlStdOperatorTable.STDDEV_POP, "STDDEV_POP", SqlLibrary.STANDARD, "aggregates#stddev_pop", FunctionDocumentation.NO_FILE, true),


### PR DESCRIPTION
Updated function documentation to link the following aggregates to their corresponding Python test files:

1. MAX
2. MIN
3. SOME
4. SUM 