### PR TITLE
[tracing] Use JSON logging helpers and document usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4949,8 +4949,13 @@ version = "0.198.0"
 dependencies = [
  "actix-http",
  "awc",
+ "chrono",
+ "colored",
  "reqwest 0.12.20",
  "sentry",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -11786,6 +11791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11795,12 +11810,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata 0.4.9",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -157,7 +157,7 @@ governor = { workspace = true }
 nonzero_ext = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 comfy-table = { workspace = true }
 tokio-postgres = { workspace = true, features = [
     "with-serde_json-1",

--- a/crates/feldera-observability/Cargo.toml
+++ b/crates/feldera-observability/Cargo.toml
@@ -15,3 +15,8 @@ awc = { workspace = true }
 actix-http = { workspace = true }
 reqwest = { workspace = true }
 sentry = { workspace = true }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+colored = { workspace = true }

--- a/crates/feldera-observability/src/json_logging.rs
+++ b/crates/feldera-observability/src/json_logging.rs
@@ -1,0 +1,194 @@
+use chrono::Utc;
+use colored::{ColoredString, Colorize};
+use serde_json::{Map, Value};
+use tracing::Subscriber;
+use tracing_subscriber::fmt::format::{Format, Writer};
+use tracing_subscriber::fmt::{FormatEvent, FormatFields};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::EnvFilter;
+
+/// Shared JSON formatter that injects pipeline/service name and structured fields.
+pub struct JsonPipelineFormat {
+    pipeline: String,
+}
+
+impl JsonPipelineFormat {
+    pub fn new(pipeline: String) -> Self {
+        Self { pipeline }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for JsonPipelineFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let mut visitor = SerdeVisitor::default();
+        event.record(&mut visitor);
+
+        let metadata = event.metadata();
+        let mut obj = Map::new();
+        obj.insert("timestamp".to_string(), Value::String(now_timestamp()));
+        obj.insert(
+            "level".to_string(),
+            Value::String(metadata.level().as_str().to_string()),
+        );
+        obj.insert(
+            "target".to_string(),
+            Value::String(metadata.target().to_string()),
+        );
+        obj.insert("pipeline".to_string(), Value::String(self.pipeline.clone()));
+        obj.insert("fields".to_string(), Value::Object(visitor.fields));
+
+        if let Some(span) = ctx.lookup_current() {
+            obj.insert("span".to_string(), Value::String(span.name().to_string()));
+        }
+
+        let json = Value::Object(obj);
+        writeln!(writer, "{}", json)
+    }
+}
+
+#[derive(Default)]
+pub struct SerdeVisitor {
+    pub fields: Map<String, Value>,
+}
+
+impl tracing::field::Visit for SerdeVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.insert(
+            field.name().to_string(),
+            Value::String(format!("{value:?}")),
+        );
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        let as_number = serde_json::Number::from_f64(value);
+        let val = as_number
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_i128(&mut self, field: &tracing::field::Field, value: i128) {
+        let val = i64::try_from(value)
+            .map(|v| Value::Number(v.into()))
+            .unwrap_or_else(|_| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_u128(&mut self, field: &tracing::field::Field, value: u128) {
+        let val = u64::try_from(value)
+            .map(|v| Value::Number(v.into()))
+            .unwrap_or_else(|_| Value::String(value.to_string()));
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), Value::String(value.to_string()));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), Value::Number(value.into()));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), Value::Bool(value));
+    }
+}
+
+fn now_timestamp() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
+}
+
+/// True when structured JSON logging is requested via `FELDERA_LOG_JSON`.
+pub fn use_json_log_format() -> bool {
+    matches!(
+        std::env::var("FELDERA_LOG_JSON")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Remove surrounding `[]` often used in pretty log prefixes.
+pub fn sanitize_pipeline_name(name: impl AsRef<str>) -> String {
+    name.as_ref()
+        .trim_matches(|c| c == '[' || c == ']')
+        .to_string()
+}
+
+/// Initialize logging with either the JSON or text pipeline format.
+pub fn init_pipeline_logging(
+    pipeline_name: ColoredString,
+    env_filter: EnvFilter,
+) -> Result<(), tracing_subscriber::util::TryInitError> {
+    if use_json_log_format() {
+        let pipeline_name_json = sanitize_pipeline_name(pipeline_name.clone().clear().to_string());
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(JsonPipelineFormat::new(pipeline_name_json))
+                    .with_ansi(false),
+            )
+            .with(env_filter)
+            .with(sentry::integrations::tracing::layer())
+            .try_init()
+    } else {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer().event_format(FormatWithPrefix::new(pipeline_name)),
+            )
+            .with(env_filter)
+            .with(sentry::integrations::tracing::layer())
+            .try_init()
+    }
+}
+
+/// Text formatter that prepends the pipeline name to each event.
+pub struct FormatWithPrefix {
+    pipeline_name: ColoredString,
+    inner: Format,
+}
+
+impl FormatWithPrefix {
+    pub fn new(pipeline_name: ColoredString) -> Self {
+        Self {
+            pipeline_name,
+            inner: Format::default(),
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for FormatWithPrefix
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        write!(writer, "{} ", self.pipeline_name)?;
+        self.inner.format_event(ctx, writer, event)
+    }
+}

--- a/crates/feldera-observability/src/lib.rs
+++ b/crates/feldera-observability/src/lib.rs
@@ -67,6 +67,8 @@ pub fn actix_middleware() -> sentry::integrations::actix::Sentry {
         .finish()
 }
 
+pub mod json_logging;
+
 fn trace_header_value() -> Option<String> {
     if !sentry_enabled() {
         return None;

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -30,7 +30,7 @@ rustls = { workspace = true }
 
 # Logging
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 colored = { workspace = true }
 sentry = { workspace = true }
 feldera-observability = { workspace = true }

--- a/crates/pipeline-manager/src/logging.rs
+++ b/crates/pipeline-manager/src/logging.rs
@@ -1,57 +1,18 @@
 use colored::ColoredString;
+use feldera_observability::json_logging::init_pipeline_logging;
 use tracing::warn;
-use tracing::Subscriber;
-use tracing_subscriber::fmt::format::Format;
-use tracing_subscriber::fmt::{FormatEvent, FormatFields};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 /// Initializes the logger by setting its filter and template.
 /// By default, the logging level is set to `INFO`.
 /// This can be overridden by setting the `RUST_LOG` environment variable.
+/// Set `FELDERA_LOG_JSON=1` to emit structured JSON logs instead of pretty text.
 pub fn init_logging(name: ColoredString) {
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))
         .expect("valid default filter");
 
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().event_format(ManagerFormat::new(name)))
-        .with(env_filter)
-        .with(sentry::integrations::tracing::layer())
-        .try_init()
-        .unwrap_or_else(|e| {
-            warn!("Unable to initialize logging -- has it already been initialized? ({e})")
-        });
-}
-
-struct ManagerFormat {
-    name: ColoredString,
-    inner: Format,
-}
-
-impl ManagerFormat {
-    fn new(name: ColoredString) -> Self {
-        Self {
-            name,
-            inner: Format::default(),
-        }
-    }
-}
-
-impl<S, N> FormatEvent<S, N> for ManagerFormat
-where
-    S: Subscriber + for<'a> LookupSpan<'a>,
-    N: for<'a> FormatFields<'a> + 'static,
-{
-    fn format_event(
-        &self,
-        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
-        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
-        event: &tracing::Event<'_>,
-    ) -> std::fmt::Result {
-        write!(writer, "{} ", self.name)?;
-        self.inner.format_event(ctx, writer, event)
-    }
+    init_pipeline_logging(name, env_filter).unwrap_or_else(|e| {
+        warn!("Unable to initialize logging -- has it already been initialized? ({e})")
+    });
 }

--- a/crates/pipeline-manager/tests/logging_demo.rs
+++ b/crates/pipeline-manager/tests/logging_demo.rs
@@ -1,0 +1,102 @@
+use colored::Colorize;
+use pipeline_manager::logging::init_logging;
+use serde_json::Value;
+use std::process::Command;
+use tracing::info;
+
+#[test]
+fn emits_sample_log() {
+    // When invoked as a subprocess, just emit the logs and exit so the parent can assert on output.
+    if let Ok(mode) = std::env::var("LOGGING_DEMO_CHILD") {
+        emit_logs(mode == "json");
+        return;
+    }
+
+    let text_out = run_child("text");
+    let text_lines: Vec<_> = text_out.lines().collect();
+    let prefix_line = text_lines
+        .iter()
+        .find(|line| line.contains("logging demo event"))
+        .expect("expected text log line with demo event");
+    assert!(
+        prefix_line.starts_with("[logging-demo] "),
+        "text log should include the pipeline prefix: {text_out:?}"
+    );
+    assert!(
+        prefix_line.contains("logging_demo: logging demo event"),
+        "text log should include the message: {text_out:?}"
+    );
+    let typed_line = text_lines
+        .iter()
+        .find(|line| line.contains("typed field coverage"))
+        .expect("expected typed field text log line");
+    assert!(
+        typed_line.contains("demo_int=42"),
+        "text log should include typed field output: {text_out:?}"
+    );
+    assert!(
+        typed_line.contains("demo_u64=18446744073709551615"),
+        "text log should include u64 field output: {text_out:?}"
+    );
+
+    let json_out = run_child("json");
+    let json_lines: Vec<_> = json_out.lines().collect();
+    let json_line = json_lines
+        .iter()
+        .rev()
+        .find(|line| line.trim_start().starts_with('{'))
+        .expect("expected JSON log lines from subprocess");
+    let parsed: Value = serde_json::from_str(json_line)
+        .unwrap_or_else(|e| panic!("failed to parse JSON log: {e}: {json_line}"));
+
+    assert_eq!(parsed["pipeline"], "logging-demo");
+    assert_eq!(parsed["fields"]["demo_int"], 42);
+    assert_eq!(parsed["fields"]["demo_u64"], Value::from(u64::MAX));
+    assert_eq!(parsed["fields"]["demo_float"], 3.1415);
+    assert_eq!(parsed["fields"]["demo_neg_float"], -2.5);
+    assert_eq!(parsed["fields"]["demo_text"], "sample");
+}
+
+fn run_child(mode: &str) -> String {
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = Command::new(exe)
+        .env("LOGGING_DEMO_CHILD", mode)
+        .env("RUST_LOG", "info")
+        .env("FELDERA_LOG_JSON", if mode == "json" { "1" } else { "0" })
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn child: {e}"));
+
+    assert!(
+        output.status.success(),
+        "child process exited with {:?}\nstderr: {}\nstdout: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    String::from_utf8(output.stdout).expect("child stdout to be utf-8")
+}
+
+fn emit_logs(json: bool) {
+    if json {
+        std::env::set_var("FELDERA_LOG_JSON", "1");
+    } else {
+        std::env::remove_var("FELDERA_LOG_JSON");
+    }
+    // Force INFO output for the demo regardless of upstream defaults.
+    std::env::set_var("RUST_LOG", "info");
+    std::env::set_var("NO_COLOR", "1");
+    init_logging("[logging-demo]".cyan());
+    info!("logging demo event");
+    info!(
+        demo_int = 42i64,
+        demo_u64 = u64::MAX,
+        demo_float = 3.1415f64,
+        demo_neg_float = -2.5f64,
+        demo_text = "sample",
+        "typed field coverage"
+    );
+    // Ensure stdout is flushed before the child exits so the parent sees the logs.
+    std::io::Write::flush(&mut std::io::stdout()).expect("flush stdout");
+}


### PR DESCRIPTION
Issue # 4586 : Write logs in JSON format

Set RUST_LOG_JSON to enable structured logging: any of 1, true, yes, or on
switches tracing output to JSON with timestamp, level, target, pipeline, fields.
Unset or any other value keeps the default text formatter.

Centralizes JSON logging helpers (use_json_log_format, sanitize_pipeline_name, JsonPipelineFormat)
in feldera-observability crate and updates pipeline manager to use them.

Extends JSON logging to preserve floats and large integers with a typed visitor.

Add logging demo test to emit typed fields for comparing default text vs JSON output.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
