### PR TITLE
[adapters] Support ingesting raw data with metadata.

### DIFF
--- a/crates/adapterlib/src/catalog.rs
+++ b/crates/adapterlib/src/catalog.rs
@@ -42,7 +42,7 @@ pub enum RecordFormat {
     Parquet(SqlSerdeConfig),
     #[cfg(feature = "with-avro")]
     Avro,
-    Raw,
+    Raw(String),
 }
 
 /// An input handle that deserializes and buffers records.

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -541,7 +541,7 @@ impl JsonSplitter {
 mod test {
     use crate::{
         format::{InputBuffer, Parser},
-        test::{init_test_logger, kafka::TestStructMetadata, mock_parser_pipeline, MockUpdate},
+        test::{data::TestStructMetadata, init_test_logger, mock_parser_pipeline, MockUpdate},
         transport::InputConsumer,
         FormatConfig, ParseError,
     };

--- a/crates/adapters/src/format/raw.rs
+++ b/crates/adapters/src/format/raw.rs
@@ -12,7 +12,10 @@ use feldera_types::{
     format::raw::{RawParserConfig, RawParserMode},
     serde_with_context::{serde_config::BinaryFormat, SqlSerdeConfig},
 };
-use serde::{de::Error as _, de::SeqAccess, forward_to_deserialize_any, Deserialize, Deserializer};
+use serde::{
+    de::{value::StrDeserializer, Error as _, MapAccess},
+    forward_to_deserialize_any, Deserialize, Deserializer,
+};
 use serde_json::json;
 use serde_urlencoded::Deserializer as UrlDeserializer;
 use std::{borrow::Cow, fmt::Display};
@@ -67,25 +70,46 @@ impl InputFormat for RawInputFormat {
 
         let num_columns = input_stream.schema.fields.len();
 
-        if num_columns != 1 {
-            return Err(ControllerError::invalid_parser_configuration(
-                endpoint_name,
-                &format!("'raw' input format can only be used with tables that have a single column of type 'VARCHAR' or 'VARBINARY', but table '{}' has {num_columns} columns", input_stream.schema.name),
-            ));
-        }
+        let field = if let Some(column_name) = &config.column_name {
+            input_stream
+                .schema
+                .field(column_name)
+                .ok_or_else(|| {
+                    ControllerError::invalid_parser_configuration(
+                        endpoint_name,
+                        &format!(
+                            "column '{}' not found in table '{}'",
+                            column_name, input_stream.schema.name
+                        ),
+                    )
+                })?
+                .clone()
+        } else {
+            if num_columns != 1 {
+                return Err(ControllerError::invalid_parser_configuration(
+                    endpoint_name,
+                    &format!(
+                        "The 'raw' input format is used with table '{}', which has {num_columns} columns. Use the 'column_name' configuration option to specify which column should store the raw input data.",
+                        input_stream.schema.name
+                    ),
+                ));
+            }
 
-        let typ = input_stream.schema.fields[0].columntype.typ;
+            input_stream.schema.fields[0].clone()
+        };
+
+        let typ = field.columntype.typ;
 
         if !typ.is_varchar() && !typ.is_varbinary() {
             return Err(ControllerError::invalid_parser_configuration(
                 endpoint_name,
-                &format!("'raw' input format can only be used with tables that have a single column of type 'VARCHAR' or 'VARBINARY', but table '{}' has a column of type {typ}", input_stream.schema.name),
+                &format!("'raw' input format can only be used with a column of type 'VARCHAR' or 'VARBINARY', but column {} has type {typ}", field.name),
             ));
         }
 
         let input_stream = input_stream
             .handle
-            .configure_deserializer(RecordFormat::Raw)?;
+            .configure_deserializer(RecordFormat::Raw(field.name.to_string()))?;
         Ok(Box::new(RawParser::new(input_stream, config)) as Box<dyn Parser>)
     }
 }
@@ -170,24 +194,30 @@ impl Parser for RawParser {
 /// Deserializer implementation that deserializes a byte slice as a struct with one column that contains
 /// these bytes.
 pub(crate) struct RawDeserializer<'de> {
+    column_name: &'de str,
     bytes: &'de [u8],
 }
 
 impl<'de> RawDeserializer<'de> {
-    pub(crate) fn new(bytes: &'de [u8]) -> Self {
-        Self { bytes }
+    pub(crate) fn new(column_name: &'de str, bytes: &'de [u8]) -> Self {
+        Self { column_name, bytes }
     }
 }
 
 #[derive(Clone)]
-struct RawSeqDeserializer<'de> {
+struct RawMapDeserializer<'de> {
+    column_name: &'de str,
     bytes: &'de [u8],
     done: bool,
 }
 
-impl<'de> RawSeqDeserializer<'de> {
-    fn new(bytes: &'de [u8]) -> Self {
-        Self { bytes, done: false }
+impl<'de> RawMapDeserializer<'de> {
+    fn new(column_name: &'de str, bytes: &'de [u8]) -> Self {
+        Self {
+            column_name,
+            bytes,
+            done: false,
+        }
     }
 }
 
@@ -215,23 +245,31 @@ impl serde::de::Error for RawDeserializeError {
     }
 }
 
-impl<'de> SeqAccess<'de> for RawSeqDeserializer<'de> {
+impl<'de> MapAccess<'de> for RawMapDeserializer<'de> {
     type Error = RawDeserializeError;
 
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
     where
-        T: serde::de::DeserializeSeed<'de>,
+        K: serde::de::DeserializeSeed<'de>,
     {
         if self.done {
             Ok(None)
         } else {
             self.done = true;
-            Ok(Some(seed.deserialize(self.clone())?))
+            seed.deserialize(StrDeserializer::new(self.column_name))
+                .map(Some)
         }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.clone())
     }
 }
 
-impl<'de> Deserializer<'de> for RawSeqDeserializer<'de> {
+impl<'de> Deserializer<'de> for RawMapDeserializer<'de> {
     type Error = RawDeserializeError;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -286,7 +324,7 @@ impl<'de> Deserializer<'de> for RawDeserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_seq(RawSeqDeserializer::new(self.bytes))
+        visitor.visit_map(RawMapDeserializer::new(self.column_name, self.bytes))
     }
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
@@ -310,6 +348,7 @@ mod test {
         program_schema::{ColumnType, Field, Relation, SqlIdentifier},
         serde_with_context::{DeserializeWithContext, SqlSerdeConfig},
     };
+    use std::sync::Arc;
     use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, hash::Hash};
 
     #[derive(Eq, PartialEq, Debug, Hash, Clone)]
@@ -355,6 +394,64 @@ mod test {
     });
 
     #[derive(Eq, PartialEq, Debug, Hash, Clone)]
+    struct OptBinaryWithMetadata {
+        data: Option<ByteArray>,
+        kafka_topic: Option<SqlString>,
+    }
+
+    fn opt_binary_with_metadata_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("opt_binary", false),
+            vec![
+                Field::new(
+                    SqlIdentifier::new("data", false),
+                    ColumnType::varbinary(true),
+                ),
+                Field::new(
+                    SqlIdentifier::new("kafka_topic", false),
+                    ColumnType::varchar(true),
+                ),
+            ],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    deserialize_table_record!(OptBinaryWithMetadata["OptBinaryWithMetadata", Variant, 2] {
+        (data, "data", false, Option<ByteArray>, |_| Some(None)),
+        (kafka_topic, "kafka_topic", false, Option<SqlString>, |metadata: &Option<Variant>| metadata.as_ref().map(|m| SqlString::try_from(m.index_string("kafka_topic")).ok()))
+    });
+
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
+    struct OptBinaryWithNulls {
+        data: Option<ByteArray>,
+        kafka_topic: Option<SqlString>,
+    }
+
+    fn opt_binary_with_nulls_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("opt_binary_with_nulls", false),
+            vec![
+                Field::new(
+                    SqlIdentifier::new("data", false),
+                    ColumnType::varbinary(true),
+                ),
+                Field::new(
+                    SqlIdentifier::new("kafka_topic", false),
+                    ColumnType::varchar(true),
+                ),
+            ],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    deserialize_table_record!(OptBinaryWithNulls["OptBinaryWithNulls", Variant, 2] {
+        (data, "data", false, Option<ByteArray>, |_| Some(None)),
+        (kafka_topic, "kafka_topic", false, Option<SqlString>, |_| Some(None))
+    });
+
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
     struct Varchar {
         data: SqlString,
     }
@@ -370,6 +467,35 @@ mod test {
                 SqlIdentifier::new("data", false),
                 ColumnType::varchar(false),
             )],
+            false,
+            BTreeMap::new(),
+        )
+    }
+
+    #[derive(Eq, PartialEq, Debug, Hash, Clone)]
+    struct VarcharWithMetadata {
+        data: SqlString,
+        kafka_topic: Option<SqlString>,
+    }
+
+    deserialize_table_record!(VarcharWithMetadata["VarcharWithMetadata", Variant, 2] {
+        (data, "data", false, SqlString, |_| None),
+        (kafka_topic, "kafka_topic", false, Option<SqlString>, |metadata: &Option<Variant>| metadata.as_ref().map(|m| SqlString::try_from(m.index_string("kafka_topic")).ok()))
+    });
+
+    fn varchar_with_metadata_schema() -> Relation {
+        Relation::new(
+            SqlIdentifier::new("string_table", false),
+            vec![
+                Field::new(
+                    SqlIdentifier::new("data", false),
+                    ColumnType::varchar(false),
+                ),
+                Field::new(
+                    SqlIdentifier::new("kafka_topic", false),
+                    ColumnType::varchar(true),
+                ),
+            ],
             false,
             BTreeMap::new(),
         )
@@ -404,6 +530,7 @@ mod test {
         /// Expected contents at the end of the test.
         expected_output: Vec<MockUpdate<T, ()>>,
         schema: Relation,
+        metadata: Option<Variant>,
     }
 
     impl<T> TestCase<T> {
@@ -413,12 +540,14 @@ mod test {
             input_batches: Vec<(Vec<u8>, Vec<ParseError>)>,
             expected_output: Vec<MockUpdate<T, ()>>,
             schema: Relation,
+            metadata: Option<Variant>,
         ) -> Self {
             Self {
                 config,
                 input_batches,
                 expected_output,
                 schema,
+                metadata,
             }
         }
     }
@@ -447,7 +576,7 @@ mod test {
             consumer.on_error(Some(Box::new(|_, _| {})));
             parser.on_error(Some(Box::new(|_, _| {})));
             for (data, expected_errors) in test.input_batches {
-                let (mut buffer, errors) = parser.parse(&data, &None);
+                let (mut buffer, errors) = parser.parse(&data, &test.metadata);
                 assert_eq!(&errors, &expected_errors);
                 buffer.flush();
             }
@@ -461,6 +590,7 @@ mod test {
         let test1 = TestCase::new(
             RawParserConfig {
                 mode: RawParserMode::Lines,
+                column_name: None,
             },
             vec![(b"foo\nbar".to_vec(), vec![])],
             vec![
@@ -468,6 +598,42 @@ mod test {
                 MockUpdate::with_polarity(Varchar { data: "bar".into() }, true),
             ],
             varchar_schema(),
+            None,
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_varchar_with_metadata() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Lines,
+                column_name: Some("data".to_string()),
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![
+                MockUpdate::with_polarity(
+                    VarcharWithMetadata {
+                        data: "foo".into(),
+                        kafka_topic: Some("my_topic".into()),
+                    },
+                    true,
+                ),
+                MockUpdate::with_polarity(
+                    VarcharWithMetadata {
+                        data: "bar".into(),
+                        kafka_topic: Some("my_topic".into()),
+                    },
+                    true,
+                ),
+            ],
+            varchar_with_metadata_schema(),
+            Some(Variant::Map(Arc::new(BTreeMap::from([(
+                Variant::String(SqlString::from("kafka_topic")),
+                Variant::String(SqlString::from("my_topic")),
+            )])))),
         );
 
         let test_cases = vec![test1];
@@ -479,6 +645,7 @@ mod test {
         let test1 = TestCase::new(
             RawParserConfig {
                 mode: RawParserMode::Blob,
+                column_name: None,
             },
             vec![(b"foo\nbar".to_vec(), vec![])],
             vec![MockUpdate::with_polarity(
@@ -488,6 +655,7 @@ mod test {
                 true,
             )],
             opt_varchar_schema(),
+            None,
         );
 
         let test_cases = vec![test1];
@@ -499,6 +667,7 @@ mod test {
         let test1 = TestCase::new(
             RawParserConfig {
                 mode: RawParserMode::Lines,
+                column_name: None,
             },
             vec![(b"foo\nbar".to_vec(), vec![])],
             vec![
@@ -516,6 +685,7 @@ mod test {
                 ),
             ],
             binary_schema(),
+            None,
         );
 
         let test_cases = vec![test1];
@@ -527,6 +697,7 @@ mod test {
         let test1 = TestCase::new(
             RawParserConfig {
                 mode: RawParserMode::Blob,
+                column_name: None,
             },
             vec![(b"foo\nbar".to_vec(), vec![])],
             vec![MockUpdate::with_polarity(
@@ -536,6 +707,56 @@ mod test {
                 true,
             )],
             opt_binary_schema(),
+            None,
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_opt_varbinary_with_metadata() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Blob,
+                column_name: Some("data".to_string()),
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![MockUpdate::with_polarity(
+                OptBinaryWithMetadata {
+                    data: Some(b"foo\nbar".as_slice().into()),
+                    kafka_topic: Some("my_topic".into()),
+                },
+                true,
+            )],
+            opt_binary_with_metadata_schema(),
+            Some(Variant::Map(Arc::new(BTreeMap::from([(
+                Variant::String(SqlString::from("kafka_topic")),
+                Variant::String(SqlString::from("my_topic")),
+            )])))),
+        );
+
+        let test_cases = vec![test1];
+        run_test_cases(test_cases);
+    }
+
+    #[test]
+    fn test_raw_opt_varbinary_with_nulls() {
+        let test1 = TestCase::new(
+            RawParserConfig {
+                mode: RawParserMode::Blob,
+                column_name: Some("data".to_string()),
+            },
+            vec![(b"foo\nbar".to_vec(), vec![])],
+            vec![MockUpdate::with_polarity(
+                OptBinaryWithNulls {
+                    data: Some(b"foo\nbar".as_slice().into()),
+                    kafka_topic: None,
+                },
+                true,
+            )],
+            opt_binary_with_nulls_schema(),
+            None,
         );
 
         let test_cases = vec![test1];

--- a/crates/adapters/src/static_compile/seroutput.rs
+++ b/crates/adapters/src/static_compile/seroutput.rs
@@ -435,7 +435,7 @@ where
                 avro_ser_config(),
                 AvroSerializer::create(),
             )),
-            RecordFormat::Raw => todo!(),
+            RecordFormat::Raw(_) => todo!(),
         })
     }
 

--- a/crates/adapters/src/test/data.rs
+++ b/crates/adapters/src/test/data.rs
@@ -256,14 +256,31 @@ pub fn generate_test_batches_with_weights(
     })
 }
 
-#[derive(PartialEq, Debug, Eq, Hash, Clone)]
+/// Used to test passing of record metadata from Kafka connector to deserializer.
+#[derive(
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+#[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
 pub struct TestStructMetadata {
-    i: i32,
-    kafka_headers: Variant,
-    kafka_topic: SqlString,
-    kafka_timestamp: Timestamp,
-    kafka_partition: i32,
-    kafka_offset: i64,
+    pub i: i32,
+    pub kafka_headers: Variant,
+    pub kafka_topic: SqlString,
+    pub kafka_timestamp: Timestamp,
+    pub kafka_partition: i32,
+    pub kafka_offset: i64,
 }
 
 deserialize_table_record!(TestStructMetadata["TestStructMetadata", Variant, 6] {

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -174,13 +174,14 @@ where
             RecordFormat::Avro => {
                 todo!()
             }
-            RecordFormat::Raw => Ok(Box::new(MockDeZSetStream::<
+            RecordFormat::Raw(column_name) => Ok(Box::new(MockDeZSetStream::<
                 RawDeserializerFromBytes,
                 T,
                 U,
                 _,
             >::new(
-                self.clone(), raw_serde_config()
+                self.clone(),
+                (raw_serde_config(), column_name.clone()),
             ))),
         }
     }

--- a/crates/feldera-types/src/format/raw.rs
+++ b/crates/feldera-types/src/format/raw.rs
@@ -16,5 +16,16 @@ pub enum RawParserMode {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema)]
 #[serde(default)]
 pub struct RawParserConfig {
+    /// Ingestion mode.
+    ///
+    /// * `blob` (default) - ingest the entire data chunk received from the transport connector as a single SQL row.
+    ///   For message-oriented transports, such as Kafka or Pub/Sub, an input chunk corresponds to a message.
+    ///   For file-based transports, e.g., the URL connector or the S3 connector, a chunk represents an entire file or object.
+    /// * `lines` - split the input byte stream on the new line character (`\n`) and ingest each line as a separate SQL row.
     pub mode: RawParserMode,
+
+    /// Table column that will store the raw value.
+    ///
+    /// This setting is required if the table has more than 1 column.
+    pub column_name: Option<String>,
 }


### PR DESCRIPTION
Fixes #5184

With this fix it's now possible to ingest raw data into a table with multiple columns as long as all other columns are nullable or have default values. The other columns can be used to store connector metadata.

Add a brief description of the pull request.

## Checklist

- [x] Documentation updated
- [ ] Changelog updated
