### PR TITLE
py: ensure aggtst_base returns an empty list for tables/views without input

### DIFF
--- a/python/tests/runtime_aggtest/aggtst_base.py
+++ b/python/tests/runtime_aggtest/aggtst_base.py
@@ -235,9 +235,10 @@ class TstAccumulator:
             pipeline.start()
 
             for table in self.tables:
-                pipeline.input_json(
-                    table.name, table.get_data(), update_format="insert_delete"
-                )
+                if table.get_data() != []:
+                    pipeline.input_json(
+                        table.name, table.get_data(), update_format="insert_delete"
+                    )
 
                 pipeline.wait_for_completion(force_stop=False, timeout_s=320)
 

--- a/python/tests/runtime_aggtest/lateness_tests/main.py
+++ b/python/tests/runtime_aggtest/lateness_tests/main.py
@@ -1,0 +1,13 @@
+## Add here import statements for all files with tests
+
+from tests.runtime_aggtest.aggtst_base import *  # noqa: F403
+from tests.runtime_aggtest.atest_run import run  # noqa: F403
+from test_lateness_check import *  # noqa: F403
+
+
+def main():
+    run("lateness_tests", "lateness_")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/runtime_aggtest/lateness_tests/test_lateness_check.py
+++ b/python/tests/runtime_aggtest/lateness_tests/test_lateness_check.py
@@ -1,0 +1,28 @@
+from tests.runtime_aggtest.aggtst_base import TstView, TstTable
+
+
+# The following LATENESS test verifies that the feature works as expected,
+# And also that the tables/views with no data provided do not produce JSON NULL errors.
+class lateness_lateness_tbl(TstTable):
+    """Define the table used by the lateness tests"""
+
+    def __init__(self):
+        self.sql = """CREATE TABLE purchase (
+                        ts TIMESTAMP NOT NULL LATENESS INTERVAL 1 HOUR,
+                        amount BIGINT
+                    ) WITH (
+                        'append_only' = 'true'
+                    )"""
+        self.data = []
+
+
+class lateness_lateness_check(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW daily_total_final
+                    WITH ('emit_final' = 'd')
+                    AS
+                    SELECT
+                        TIMESTAMP_TRUNC(ts, DAY) AS d,
+                        SUM(amount) AS total
+                    FROM purchase
+                    GROUP BY TIMESTAMP_TRUNC(ts, DAY)"""


### PR DESCRIPTION
**Problem:** When running tests with no input data provided to tables, Feldera API raises a parse error because it receives a NULL input:

```
feldera.rest.errors.FelderaAPIError:
Error Code: ParseErrors
Message: Errors parsing input data (1 errors):
Parse error: error deserializing string as a JSON array of updates: invalid type: null, expected a sequence at line 1 column 4
Invalid fragment: 'null'
Example valid JSON: '[{{"insert": {{...}} }}, {{"delete": {{...}} }}]'
Response Status: 400
```
This change ensures that `pipeline.input_json` is only called if the table actually has data, thus skipping tables with no input and avoiding invalid JSON errors.