### PR TITLE
Refactor pipeline state transition detection to run callbacks on

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "@fontsource-variable/dm-sans": "5.1.1",
         "@fontsource/dm-mono": "5.1.1",
         "@fortawesome/fontawesome-free": "6.7.2",
+        "@githubnext/tiny-svelte-fsm": "^1.0.0",
         "@hey-api/client-fetch": "0.1.10",
         "@hey-api/openapi-ts": "0.47.2",
         "@monaco-editor/loader": "1.6.1",
@@ -253,6 +254,8 @@
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
     "@gcornut/valibot-json-schema": ["@gcornut/valibot-json-schema@0.31.0", "", { "dependencies": { "valibot": "~0.31.0" }, "optionalDependencies": { "@types/json-schema": ">= 7.0.14", "esbuild": ">= 0.18.20", "esbuild-runner": ">= 2.2.2" }, "bin": { "valibot-json-schema": "bin/index.js" } }, "sha512-3xGptCurm23e7nuPQkdrE5rEs1FeTPHhAUsBuwwqG4/YeZLwJOoYZv+fmsppUEfo5y9lzUwNQrNqLS/q7HMc7g=="],
+
+    "@githubnext/tiny-svelte-fsm": ["@githubnext/tiny-svelte-fsm@1.0.0", "", { "peerDependencies": { "svelte": "^5.0.0-next.1" } }, "sha512-taFbtAsZHSCKgl3pEcRmBE4XsydJnZUTvwUMqb5VPVSAyzmT51tD8opSubbW2M84sA7hN1tfq3zHgcXrF06c+Q=="],
 
     "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 

--- a/js-packages/web-console/package.json
+++ b/js-packages/web-console/package.json
@@ -30,6 +30,7 @@
     "@fontsource-variable/dm-sans": "5.1.1",
     "@fontsource/dm-mono": "5.1.1",
     "@fortawesome/fontawesome-free": "6.7.2",
+    "@githubnext/tiny-svelte-fsm": "^1.0.0",
     "@hey-api/client-fetch": "0.1.10",
     "@hey-api/openapi-ts": "0.47.2",
     "@monaco-editor/loader": "1.6.1",

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -290,11 +290,10 @@ example = "1.0"`
       {changes}
       onCancel={() => (contextDrawer.content = null)}
       onApprove={async () => {
-        const { waitFor } = await pipelineAction.postPipelineAction(
+        await pipelineAction.postPipelineAction(
           pipeline.current.name,
           'approve_changes'
         )
-        await waitFor()
       }}
     >
       {#snippet titleEnd()}

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -290,10 +290,7 @@ example = "1.0"`
       {changes}
       onCancel={() => (contextDrawer.content = null)}
       onApprove={async () => {
-        await pipelineAction.postPipelineAction(
-          pipeline.current.name,
-          'approve_changes'
-        )
+        await pipelineAction.postPipelineAction(pipeline.current.name, 'approve_changes')
       }}
     >
       {#snippet titleEnd()}

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -16,8 +16,6 @@
   import {
     programStatusOf,
     type ExtendedPipeline,
-    type Pipeline,
-    type PipelineAction,
     type PipelineThumb
   } from '$lib/services/pipelineManager'
   import {
@@ -95,17 +93,11 @@
   const pipelineAction = usePipelineAction()
 
   const api = usePipelineManager()
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
-  const handleActionSuccess = async (pipelineName: string, action: PipelineAction) => {
-    const cbs = pipelineActionCallbacks.getAll(pipelineName, action)
-    await Promise.allSettled(cbs.map((x) => x(pipelineName)))
-  }
+  // Initialize the callback system to start reactive monitoring
+  usePipelineActionCallbacks(preloaded)
+
   const handleDeletePipeline = async (pipelineName: string) => {
     updatePipelines((pipelines) => pipelines.filter((p) => p.name !== pipelineName))
-    const cbs = pipelineActionCallbacks
-      .getAll('', 'delete')
-      .concat(pipelineActionCallbacks.getAll(pipelineName, 'delete'))
-    cbs.map((x) => x(pipelineName))
   }
 
   const programErrors = $derived(
@@ -323,7 +315,6 @@ example = "1.0"`
     onDeletePipeline={handleDeletePipeline}
     {editConfigDisabled}
     unsavedChanges={downstreamChanged}
-    onActionSuccess={handleActionSuccess}
     {saveFile}
   ></PipelineActions>
 {/snippet}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/CodeEditor.svelte
@@ -30,7 +30,7 @@
     }
   })
 
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
+  const pipelineActionCallbacks = getPipelineActionCallbacks()
   const dropOpenedFile = async (pipelineName: string) => {
     const files = ['program.sql', 'stubs.rs', 'udf.rs', 'udf.toml'].map(
       (file) => `${pipelineName}/${file}`
@@ -63,7 +63,7 @@
   import { pipelineFileNameRegex } from '$lib/compositions/health/systemErrors'
   import { effectMonacoContentPlaceholder } from '$lib/components/monacoEditor/effectMonacoContentPlaceholder.svelte'
   import { GenericOverlayWidget } from '$lib/components/monacoEditor/GenericOverlayWidget'
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import { getPipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
   import { useCodeEditorSettings } from '$lib/compositions/pipelines/useCodeEditorSettings.svelte'
   import { rgbToHex } from '$lib/functions/common/color'
   import type { $ } from 'bun'

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -80,7 +80,7 @@
   $effect(() => {
     untrack(() => pipelineActionCallbacks.add('', 'delete', forgetCurrentTab))
     return () => {
-      pipelineActionCallbacks.remove('', 'start_paused', forgetCurrentTab)
+      pipelineActionCallbacks.remove('', 'delete', forgetCurrentTab)
     }
   })
 

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
+  const pipelineActionCallbacks = getPipelineActionCallbacks()
 </script>
 
 <script lang="ts">
@@ -13,7 +13,7 @@
   import { tuple } from '$lib/functions/common/tuple'
   import type { ExtendedPipeline } from '$lib/services/pipelineManager'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import { getPipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
   import { count } from '$lib/functions/common/array'
   import { untrack } from 'svelte'
   import ClipboardCopyButton from '$lib/components/other/ClipboardCopyButton.svelte'

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -44,7 +44,7 @@
   let pipelinesRelations = $state<
     Record<string, Record<string, Record<string, ExtraType & { type: 'tables' | 'views' }>>>
   >({})
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
+  const pipelineActionCallbacks = getPipelineActionCallbacks()
   let changeStream: Record<string, Record<string, ChangeStreamData>> = {} // Initialize row array nested by tenant and pipeline
   // Separate getRows as a $state avoids burdening rows array itself with reactivity overhead
   let getChangeStream = $state(() => changeStream)
@@ -220,7 +220,7 @@
 </script>
 
 <script lang="ts">
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import { getPipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
 
   import {
     getCaseIndependentName,

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -14,7 +14,7 @@
     }
   > = {}
   let getStreams = $state(() => streams)
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
+  const pipelineActionCallbacks = getPipelineActionCallbacks()
   const dropLogHistory = async (pipelineName: string) => {
     if ('open' in streams[pipelineName].stream) {
       streams[pipelineName].stream.stop()
@@ -32,7 +32,7 @@
     SplitNewlineTransformStream
   } from '$lib/functions/pipelines/changeStream'
   import { type ExtendedPipeline, type PipelineStatus } from '$lib/services/pipelineManager'
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import { getPipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
   import { untrack } from 'svelte'
   import WarningBanner from '$lib/components/pipelines/editor/WarningBanner.svelte'
   import { useInterval } from '$lib/compositions/common/useInterval.svelte'

--- a/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -62,7 +62,6 @@ groups related actions into multi-action dropdowns when multiple options are ava
   import { slide } from 'svelte/transition'
   import { useIsMobile } from '$lib/compositions/layout/useIsMobile.svelte'
   import { usePipelineAction } from '$lib/compositions/usePipelineAction.svelte'
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
   import type { WritablePipeline } from '$lib/compositions/useWritablePipeline.svelte'
 
   let {
@@ -328,24 +327,13 @@ groups related actions into multi-action dropdowns when multiple options are ava
   const importantBtnColor = 'preset-filled-primary-500'
 
   const { postPipelineAction } = usePipelineAction()
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
 
   const performStartAction = async (action: PipelineAction) => {
-    const callbacks =
-      action === 'start'
-        ? {
-            onPausedReady: async (pipelineName: string) => {
-              const cbs = pipelineActionCallbacks.getAll(pipelineName, 'start_paused')
-              await Promise.allSettled(cbs.map((x) => x(pipelineName)))
-            }
-          }
-        : undefined
-
-    const { waitFor } = await postPipelineAction(pipeline.current.name, action, callbacks)
-    waitFor().then(
-      () => {},
-      toastError
-    )
+    try {
+      await postPipelineAction(pipeline.current.name, action)
+    } catch (error) {
+      toastError(error instanceof Error ? error : new Error(String(error)))
+    }
   }
 
   // Static multi-action dropdown configurations
@@ -411,9 +399,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Pause',
       description: 'Pause the running pipeline',
       onclick: async () => {
-        const pipelineName = pipeline.current.name
-        const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipeline.current.name, 'pause')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       disabled: () => false,
       standaloneButton: _pause
@@ -422,9 +412,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Start in Standby',
       description: 'Put the pipeline in standby mode',
       onclick: async () => {
-        const pipelineName = pipeline.current.name
-        const { waitFor } = await postPipelineAction(pipelineName, 'standby')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipeline.current.name, 'standby')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       disabled: () => false,
       standaloneButton: _standby
@@ -433,9 +425,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Activate',
       description: 'Activate the pipeline to start data ingress and processing',
       onclick: async () => {
-        const pipelineName = pipeline.current.name
-        const { waitFor } = await postPipelineAction(pipelineName, 'activate')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipeline.current.name, 'activate')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       disabled: () => false,
       standaloneButton: _activate
@@ -449,8 +443,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       'Clear',
       (name) => `Clear ${name} pipeline storage?`,
       async (pipelineName: string) => {
-        const { waitFor } = await postPipelineAction(pipelineName, 'clear')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipelineName, 'clear')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       'This will delete all checkpoints.'
     )(pipeline.current.name)}
@@ -477,8 +474,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       'Force stop',
       (name) => `Force stop ${name} pipeline?`,
       async (pipelineName: string) => {
-        const { waitFor } = await postPipelineAction(pipelineName, 'kill')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipelineName, 'kill')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       'The pipeline will stop processing inputs without making a checkpoint, leaving only a previous one, if any.'
     )(pipeline.current.name)}
@@ -492,8 +492,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
       'Stop',
       (name) => `Stop ${name} pipeline?`,
       async (pipelineName: string) => {
-        const { waitFor } = await postPipelineAction(pipelineName, 'stop')
-        waitFor().then(() => {}, toastError)
+        try {
+          await postPipelineAction(pipelineName, 'stop')
+        } catch (error) {
+          toastError(error instanceof Error ? error : new Error(String(error)))
+        }
       },
       'The pipeline will stop processing inputs and make a checkpoint of its state.'
     )(pipeline.current.name)}
@@ -738,9 +741,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
   <button
     class="hidden sm:flex {buttonClass} {longClass} {basicBtnColor}"
     onclick={async () => {
-      const pipelineName = pipeline.current.name
-      const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-      waitFor().then(() => {}, toastError)
+      try {
+        await postPipelineAction(pipeline.current.name, 'pause')
+      } catch (error) {
+        toastError(error instanceof Error ? error : new Error(String(error)))
+      }
     }}
   >
     <span class="fd fd-pause {iconClass}"></span>
@@ -750,9 +755,11 @@ groups related actions into multi-action dropdowns when multiple options are ava
   <button
     class="flex sm:hidden {buttonClass} {shortClass} {basicBtnColor} {iconClass}"
     onclick={async () => {
-      const pipelineName = pipeline.current.name
-      const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-      waitFor().then(() => {}, toastError)
+      try {
+        await postPipelineAction(pipeline.current.name, 'pause')
+      } catch (error) {
+        toastError(error instanceof Error ? error : new Error(String(error)))
+      }
     }}
   >
     <span class="fd fd-pause {iconClass}"></span>

--- a/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -70,7 +70,6 @@ groups related actions into multi-action dropdowns when multiple options are ava
     onDeletePipeline,
     editConfigDisabled,
     unsavedChanges,
-    onActionSuccess,
     saveFile,
     class: _class = ''
   }: {
@@ -78,7 +77,6 @@ groups related actions into multi-action dropdowns when multiple options are ava
     onDeletePipeline?: (pipelineName: string) => void
     editConfigDisabled: boolean
     unsavedChanges: boolean
-    onActionSuccess?: (pipelineName: string, action: PipelineAction) => void
     saveFile: () => void
     class?: string
   } = $props()
@@ -332,11 +330,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
   const { postPipelineAction } = usePipelineAction()
   const pipelineActionCallbacks = usePipelineActionCallbacks()
 
-  const performStartAction = async (
-    action: PipelineAction,
-    pipelineName: string
-    // nextStatus: PipelineStatus
-  ) => {
+  const performStartAction = async (action: PipelineAction) => {
     const callbacks =
       action === 'start'
         ? {
@@ -349,7 +343,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
 
     const { waitFor } = await postPipelineAction(pipeline.current.name, action, callbacks)
     waitFor().then(
-      (shouldContinue) => shouldContinue && onActionSuccess?.(pipelineName, action),
+      () => {},
       toastError
     )
   }
@@ -372,8 +366,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Start',
       description: 'Start the pipeline normally',
       onclick: () => {
-        const pipelineName = pipeline.current.name
-        performStartAction('start', pipelineName)
+        performStartAction('start')
       },
       disabled: () => unsavedChanges,
       disabledText: 'Save First',
@@ -383,8 +376,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Start as Paused',
       description: 'Start the pipeline in a paused state',
       onclick: () => {
-        const pipelineName = pipeline.current.name
-        performStartAction('start_paused', pipelineName)
+        performStartAction('start_paused')
       },
       disabled: () => unsavedChanges,
       disabledText: 'Save First',
@@ -394,8 +386,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       label: 'Resume',
       description: 'Resume the paused pipeline',
       onclick: () => {
-        const pipelineName = pipeline.current.name
-        performStartAction('resume', pipelineName)
+        performStartAction('resume')
       },
       disabled: () => unsavedChanges,
       disabledText: 'Save First',
@@ -422,7 +413,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       onclick: async () => {
         const pipelineName = pipeline.current.name
         const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-        waitFor().then(() => onActionSuccess?.(pipelineName, 'pause'), toastError)
+        waitFor().then(() => {}, toastError)
       },
       disabled: () => false,
       standaloneButton: _pause
@@ -433,7 +424,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       onclick: async () => {
         const pipelineName = pipeline.current.name
         const { waitFor } = await postPipelineAction(pipelineName, 'standby')
-        waitFor().then(() => onActionSuccess?.(pipelineName, 'standby'), toastError)
+        waitFor().then(() => {}, toastError)
       },
       disabled: () => false,
       standaloneButton: _standby
@@ -444,7 +435,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       onclick: async () => {
         const pipelineName = pipeline.current.name
         const { waitFor } = await postPipelineAction(pipelineName, 'activate')
-        waitFor().then(() => onActionSuccess?.(pipelineName, 'activate'), toastError)
+        waitFor().then(() => {}, toastError)
       },
       disabled: () => false,
       standaloneButton: _activate
@@ -487,7 +478,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       (name) => `Force stop ${name} pipeline?`,
       async (pipelineName: string) => {
         const { waitFor } = await postPipelineAction(pipelineName, 'kill')
-        waitFor().then(() => onActionSuccess?.(pipelineName, 'kill'), toastError)
+        waitFor().then(() => {}, toastError)
       },
       'The pipeline will stop processing inputs without making a checkpoint, leaving only a previous one, if any.'
     )(pipeline.current.name)}
@@ -502,7 +493,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
       (name) => `Stop ${name} pipeline?`,
       async (pipelineName: string) => {
         const { waitFor } = await postPipelineAction(pipelineName, 'stop')
-        waitFor().then(() => onActionSuccess?.(pipelineName, 'stop'), toastError)
+        waitFor().then(() => {}, toastError)
       },
       'The pipeline will stop processing inputs and make a checkpoint of its state.'
     )(pipeline.current.name)}
@@ -661,8 +652,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
           return
         }
         const action = getAction(e.ctrlKey || e.shiftKey || e.metaKey)
-        const pipelineName = pipeline.current.name
-        performStartAction(action, pipelineName)
+        performStartAction(action)
       }}
     >
       <span class="fd fd-play {iconClass}"></span>
@@ -750,7 +740,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
     onclick={async () => {
       const pipelineName = pipeline.current.name
       const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-      waitFor().then(() => onActionSuccess?.(pipelineName, 'pause'), toastError)
+      waitFor().then(() => {}, toastError)
     }}
   >
     <span class="fd fd-pause {iconClass}"></span>
@@ -762,7 +752,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
     onclick={async () => {
       const pipelineName = pipeline.current.name
       const { waitFor } = await postPipelineAction(pipelineName, 'pause')
-      waitFor().then(() => onActionSuccess?.(pipelineName, 'pause'), toastError)
+      waitFor().then(() => {}, toastError)
     }}
   >
     <span class="fd fd-pause {iconClass}"></span>

--- a/js-packages/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
@@ -15,7 +15,7 @@
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { usePremiumFeatures } from '$lib/compositions/usePremiumFeatures.svelte'
   import { usePipelineAction } from '$lib/compositions/usePipelineAction.svelte'
-  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import { getPipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
   import type { PipelineAction as Action } from '$lib/services/pipelineManager'
 
   let {
@@ -23,7 +23,7 @@
     selectedPipelines = $bindable()
   }: { pipelines: PipelineThumb[]; selectedPipelines: string[] } = $props()
   const { updatePipelines, updatePipeline } = useUpdatePipelineList()
-  const pipelineActionCallbacks = usePipelineActionCallbacks()
+  const pipelineActionCallbacks = getPipelineActionCallbacks()
   const sortedSelectedPipelines = $derived([...selectedPipelines].sort())
 
   // Helper to wait for a pipeline action to complete

--- a/js-packages/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/table/AvailableActions.svelte
@@ -15,12 +15,27 @@
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { usePremiumFeatures } from '$lib/compositions/usePremiumFeatures.svelte'
   import { usePipelineAction } from '$lib/compositions/usePipelineAction.svelte'
+  import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
+  import type { PipelineAction as Action } from '$lib/services/pipelineManager'
+
   let {
     pipelines,
     selectedPipelines = $bindable()
   }: { pipelines: PipelineThumb[]; selectedPipelines: string[] } = $props()
   const { updatePipelines, updatePipeline } = useUpdatePipelineList()
+  const pipelineActionCallbacks = usePipelineActionCallbacks()
   const sortedSelectedPipelines = $derived([...selectedPipelines].sort())
+
+  // Helper to wait for a pipeline action to complete
+  const waitForAction = (pipelineName: string, action: Action): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      const callback = async () => {
+        pipelineActionCallbacks.remove(pipelineName, action, callback)
+        resolve()
+      }
+      pipelineActionCallbacks.add(pipelineName, action, callback)
+    })
+  }
   const availableActions = [
     'start' as const,
     'resume' as const,
@@ -120,23 +135,25 @@
   const { postPipelineAction } = usePipelineAction()
   let deletePipelines = () => {
     selected.forEach(async (pipeline) => {
-      if (!isPipelineCodeEditable(pipeline.status)) {
-        const { waitFor } = await postPipelineAction(
-          pipeline.name,
-          isPremium.value ? 'stop' : 'kill'
-        )
-        updatePipeline(pipeline.name, (p) => ({
-          ...p,
-          status: isPremium.value ? 'Stopping' : 'Stopping'
-        }))
-        await waitFor().catch(toastError)
+      try {
+        // Step 1: Stop the pipeline if it's running
+        if (!isPipelineCodeEditable(pipeline.status)) {
+          const stopAction = isPremium.value ? 'stop' : 'kill'
+          await postPipelineAction(pipeline.name, stopAction)
+          await waitForAction(pipeline.name, stopAction)
+        }
+
+        // Step 2: Clear storage if in use
+        if (pipeline.storageStatus !== 'Cleared') {
+          await postPipelineAction(pipeline.name, 'clear')
+          await waitForAction(pipeline.name, 'clear')
+        }
+
+        // Step 3: Delete the pipeline
+        await api.deletePipeline(pipeline.name)
+      } catch (error) {
+        toastError(error instanceof Error ? error : new Error(String(error)))
       }
-      if (pipeline.storageStatus !== 'Cleared') {
-        const { waitFor } = await postPipelineAction(pipeline.name, 'clear')
-        updatePipeline(pipeline.name, (p) => ({ ...p, storageStatus: 'Clearing' }))
-        await waitFor().catch(toastError)
-      }
-      return api.deletePipeline(pipeline.name)
     })
     selectedPipelines = []
   }

--- a/js-packages/web-console/src/lib/components/profiler/ProfilerLayout.svelte
+++ b/js-packages/web-console/src/lib/components/profiler/ProfilerLayout.svelte
@@ -107,7 +107,7 @@
 <div class="flex flex-wrap items-center gap-2 pb-2 sm:-mt-2">
   <!-- Toolbar start snippet (Load Profile and Snapshot) -->
   <!-- <div class="toolbar-start"> -->
-    {@render toolbarStart?.()}
+  {@render toolbarStart?.()}
   <!-- </div> -->
 
   <!-- Toolbar end (Metrics, Workers, Search) -->
@@ -235,13 +235,13 @@
                   </tr>
                 {/if}
 
-              <!-- Additional attributes -->
-              {#each Array.from(tooltipData.attributes.entries()) as [key, value]}
-                <tr>
-                  <td class="whitespace-nowrap">{key}</td>
-                  <td colspan={tooltipData.columns.length} class="whitespace-nowrap">{value}</td>
-                </tr>
-              {/each}
+                <!-- Additional attributes -->
+                {#each Array.from(tooltipData.attributes.entries()) as [key, value]}
+                  <tr>
+                    <td class="whitespace-nowrap">{key}</td>
+                    <td colspan={tooltipData.columns.length} class="whitespace-nowrap">{value}</td>
+                  </tr>
+                {/each}
               </tbody>
             </table>
           </div>

--- a/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
@@ -1,10 +1,18 @@
-import type { PipelineAction } from '$lib/services/pipelineManager'
+import type { PipelineAction, PipelineThumb } from '$lib/services/pipelineManager'
+import { usePipelineList } from './usePipelineList.svelte'
 
 type Cb = (pipelineName: string) => Promise<void>
 
 type Action = PipelineAction | 'delete'
 
+type PendingAction = {
+  pipelineName: string
+  action: Action
+  isDesiredState: (pipeline: PipelineThumb) => boolean
+}
+
 const callbacks: Record<string, Partial<Record<Action, Cb[]>>> = $state({})
+const pendingActions: PendingAction[] = $state([])
 
 const pop = (pipelineName: string, action: Action) => {
   callbacks[pipelineName] ??= {}
@@ -12,7 +20,80 @@ const pop = (pipelineName: string, action: Action) => {
   return callbacks[pipelineName][action].pop()
 }
 
-export function usePipelineActionCallbacks() {
+export function usePipelineActionCallbacks(preloaded?: { pipelines: PipelineThumb[] }) {
+  const pipelineList = usePipelineList(preloaded)
+
+  // Track previous pipeline names to detect deletions
+  let previousPipelineNames = $state<Set<string>>(new Set())
+
+  // Reactive effect to monitor pipeline changes and trigger callbacks
+  $effect(() => {
+    const currentPipelines = pipelineList.pipelines
+    const currentPipelineNames = new Set(currentPipelines.map(p => p.name))
+
+    // Check for deleted pipelines
+    const deletedPipelines = Array.from(previousPipelineNames).filter(
+      name => !currentPipelineNames.has(name)
+    )
+
+    // Only process deletions if we had pipelines before (not initial load)
+    if (previousPipelineNames.size > 0) {
+      for (const deletedPipelineName of deletedPipelines) {
+        // Call delete callbacks for specific pipeline
+        const specificCbs = callbacks[deletedPipelineName]?.['delete'] ?? []
+        // Call global delete callbacks
+        const globalCbs = callbacks['']?.['delete'] ?? []
+        const allDeleteCbs = [...specificCbs, ...globalCbs]
+
+        // Execute callbacks
+        Promise.allSettled(allDeleteCbs.map(cb => cb(deletedPipelineName)))
+
+        // Remove pending actions for deleted pipeline
+        const toRemove = pendingActions.filter(pa => pa.pipelineName === deletedPipelineName)
+        toRemove.forEach(pa => {
+          const idx = pendingActions.indexOf(pa)
+          if (idx !== -1) {
+            pendingActions.splice(idx, 1)
+          }
+        })
+      }
+    }
+
+    // Check pending actions for state matches
+    const toRemove: PendingAction[] = []
+    for (const pendingAction of pendingActions) {
+      const pipeline = currentPipelines.find(p => p.name === pendingAction.pipelineName)
+
+      if (!pipeline) {
+        // Pipeline not found, skip for now (might be deleted, handled above)
+        continue
+      }
+
+      // Check if desired state is reached
+      if (pendingAction.isDesiredState(pipeline)) {
+        // Get callbacks for this action
+        const cbs = callbacks[pendingAction.pipelineName]?.[pendingAction.action] ?? []
+
+        // Execute callbacks
+        Promise.allSettled(cbs.map(cb => cb(pendingAction.pipelineName)))
+
+        // Mark for removal
+        toRemove.push(pendingAction)
+      }
+    }
+
+    // Remove completed pending actions
+    toRemove.forEach(pa => {
+      const idx = pendingActions.indexOf(pa)
+      if (idx !== -1) {
+        pendingActions.splice(idx, 1)
+      }
+    })
+
+    // Update previous pipeline names
+    previousPipelineNames = currentPipelineNames
+  })
+
   return {
     add(pipelineName: string, action: Action, callback: Cb) {
       callbacks[pipelineName] ??= {}
@@ -27,6 +108,17 @@ export function usePipelineActionCallbacks() {
         return
       }
       callbacks[pipelineName][action].splice(idx, 1)
+    },
+    registerPendingAction(
+      pipelineName: string,
+      action: Action,
+      isDesiredState: (pipeline: PipelineThumb) => boolean
+    ) {
+      pendingActions.push({
+        pipelineName,
+        action,
+        isDesiredState
+      })
     },
     pop,
     popIterator: (pipelineName: string, action: Action) => ({

--- a/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
@@ -1,4 +1,8 @@
-import type { PipelineAction, PipelineThumb } from '$lib/services/pipelineManager'
+import type {
+  PipelineAction,
+  PipelineStatus,
+  PipelineThumb
+} from '$lib/services/pipelineManager'
 import { untrack } from 'svelte'
 import { usePipelineList } from './usePipelineList.svelte'
 
@@ -8,19 +12,110 @@ type Action = PipelineAction | 'delete'
 
 const callbacks: Record<string, Partial<Record<Action, Cb[]>>> = $state({})
 
-// Map of action types to their desired state predicates
-const isDesiredState: Record<Action, (pipeline: PipelineThumb) => boolean> = {
-  start: (p) => p.status === 'Running',
-  resume: (p) => p.status === 'Running',
-  pause: (p) => p.status === 'Paused',
-  start_paused: (p) => p.status === 'Paused',
-  stop: (p) => p.status === 'Stopped',
-  kill: (p) => p.status === 'Stopped',
-  clear: (p) => p.storageStatus === 'Cleared',
-  standby: (p) => p.status === 'Standby',
-  activate: (p) => p.status === 'Running',
-  approve_changes: (p) => p.status !== 'AwaitingApproval',
-  delete: () => false // Never check for desired state on delete - handled separately
+// Helper to normalize status to string for comparison
+const statusToString = (status: PipelineStatus): string => {
+  return typeof status === 'string' ? status : Object.keys(status)[0]
+}
+
+// Stable states are those where pipelines can remain (not transitional)
+const stableStates = [
+  'Stopped',
+  'Running',
+  'Paused',
+  'Standby',
+  'Suspended',
+  'SqlError',
+  'RustError',
+  'SystemError',
+  'AwaitingApproval',
+  'Unavailable'
+] as const
+
+const isStableState = (status: PipelineStatus): boolean => {
+  const statusStr = statusToString(status)
+  return stableStates.includes(statusStr as any)
+}
+
+/**
+ * Track pipeline state transitions
+ *
+ * This tracker records the "stable" state before a pipeline enters transitional states.
+ * For example: Stopped → Preparing → Provisioning → Initializing → Paused
+ * We record: lastStableState = "Stopped", and when reaching "Paused", we know the
+ * transition is Stopped → Paused (start_paused action), not Running → Paused (pause action).
+ *
+ * Transitional states (ignored): Preparing, Provisioning, Initializing, Pausing, Resuming, Stopping, etc.
+ * Stable states: Stopped, Running, Paused, Standby, Error states, etc.
+ */
+type PipelineTracker = {
+  lastStableState: string | null
+  currentState: PipelineStatus
+  currentStorageStatus: PipelineThumb['storageStatus']
+  lastStorageStatus: PipelineThumb['storageStatus'] | null
+}
+
+const trackers = $state<Record<string, PipelineTracker>>({})
+
+// Define which transitions match which actions
+type TransitionMatcher = (tracker: PipelineTracker, pipeline: PipelineThumb) => boolean
+
+const isStoppedOrError = (status: string) =>
+  ['Stopped', 'SqlError', 'RustError', 'SystemError'].includes(status)
+
+const actionTransitions: Record<Action, TransitionMatcher> = {
+  // start_paused: Stopped/Error → Paused (when starting in paused state)
+  start_paused: (t, p) =>
+    t.lastStableState !== null &&
+    isStoppedOrError(t.lastStableState) &&
+    statusToString(p.status) === 'Paused',
+
+  // start: Stopped/Error → Running (normal start flow)
+  start: (t, p) =>
+    t.lastStableState !== null &&
+    isStoppedOrError(t.lastStableState) &&
+    statusToString(p.status) === 'Running',
+
+  // resume: Paused → Running (resuming from paused state)
+  resume: (t, p) =>
+    t.lastStableState === 'Paused' && statusToString(p.status) === 'Running',
+
+  // pause: Running → Paused (pausing from running state)
+  pause: (t, p) =>
+    t.lastStableState === 'Running' && statusToString(p.status) === 'Paused',
+
+  // stop: Running/Paused → Stopped (graceful stop with checkpoint)
+  stop: (t, p) =>
+    t.lastStableState !== null &&
+    ['Running', 'Paused'].includes(t.lastStableState) &&
+    statusToString(p.status) === 'Stopped',
+
+  // kill: Any non-Stopped → Stopped (force stop)
+  kill: (t, p) =>
+    t.lastStableState !== null &&
+    t.lastStableState !== 'Stopped' &&
+    statusToString(p.status) === 'Stopped',
+
+  // standby: Any → Standby
+  standby: (_t, p) => statusToString(p.status) === 'Standby',
+
+  // activate: Standby → Running
+  activate: (t, p) =>
+    t.lastStableState === 'Standby' && statusToString(p.status) === 'Running',
+
+  // approve_changes: AwaitingApproval → Any other stable state
+  approve_changes: (t, p) =>
+    t.lastStableState === 'AwaitingApproval' &&
+    statusToString(p.status) !== 'AwaitingApproval' &&
+    isStableState(p.status),
+
+  // clear: storageStatus transitions to Cleared
+  clear: (t, p) =>
+    t.lastStorageStatus !== null &&
+    t.lastStorageStatus !== 'Cleared' &&
+    p.storageStatus === 'Cleared',
+
+  // delete: handled separately (pipeline removed from list)
+  delete: () => false
 }
 
 const pop = (pipelineName: string, action: Action) => {
@@ -58,30 +153,74 @@ export function usePipelineActionCallbacks(preloaded?: { pipelines: PipelineThum
           // Execute callbacks
           Promise.allSettled(allDeleteCbs.map((cb) => cb(deletedPipelineName)))
 
-          // Clean up callbacks for deleted pipeline
+          // Clean up callbacks and tracker for deleted pipeline
           delete callbacks[deletedPipelineName]
+          delete trackers[deletedPipelineName]
         }
       }
 
-      // Check all registered callbacks to see if their desired states are reached
-      for (const pipelineName in callbacks) {
-        if (pipelineName === '') continue // Skip global callbacks (only used for delete)
+      // Process each current pipeline to detect state transitions
+      for (const pipeline of currentPipelines) {
+        const pipelineName = pipeline.name
 
-        const pipeline = currentPipelines.find((p) => p.name === pipelineName)
-        if (!pipeline) continue // Pipeline not found
+        // Initialize tracker if not exists
+        if (!trackers[pipelineName]) {
+          trackers[pipelineName] = {
+            lastStableState: isStableState(pipeline.status) ? statusToString(pipeline.status) : null,
+            currentState: pipeline.status,
+            currentStorageStatus: pipeline.storageStatus,
+            lastStorageStatus: pipeline.storageStatus
+          }
+          continue
+        }
 
-        for (const action in callbacks[pipelineName]) {
-          const actionKey = action as Action
-          if (actionKey === 'delete') continue // Delete handled above
+        const tracker = trackers[pipelineName]
+        const statusChanged = JSON.stringify(tracker.currentState) !== JSON.stringify(pipeline.status)
+        const storageChanged = tracker.currentStorageStatus !== pipeline.storageStatus
 
-          const cbs = callbacks[pipelineName][actionKey] ?? []
-          if (cbs.length === 0) continue
+        // Update storage status tracking
+        if (storageChanged) {
+          tracker.lastStorageStatus = tracker.currentStorageStatus
+          tracker.currentStorageStatus = pipeline.storageStatus
+        }
 
-          // Check if desired state is reached
-          if (isDesiredState[actionKey](pipeline)) {
-            // Execute all callbacks for this action
-            // Note: Callbacks are NOT automatically removed - callers must remove them explicitly
-            // callbacks[pipelineName][actionKey] = []
+        // Update status tracking
+        if (statusChanged) {
+          const oldStatusStr = statusToString(tracker.currentState)
+          const newStatusStr = statusToString(pipeline.status)
+
+          // If transitioning from stable to another state, record the stable origin
+          if (isStableState(tracker.currentState) && oldStatusStr !== newStatusStr) {
+            tracker.lastStableState = oldStatusStr
+          }
+
+          // Update current state
+          tracker.currentState = pipeline.status
+
+          // If we reached a new stable state, check for matching action transitions
+          if (isStableState(pipeline.status)) {
+            // Check all registered callbacks for this pipeline
+            for (const action in callbacks[pipelineName]) {
+              const actionKey = action as Action
+              if (actionKey === 'delete') continue
+
+              const cbs = callbacks[pipelineName][actionKey] ?? []
+              if (cbs.length === 0) continue
+
+              // Check if this transition matches the action
+              if (actionTransitions[actionKey](tracker, pipeline)) {
+                // Execute all callbacks for this action
+                // Note: Callbacks are NOT automatically removed - callers must remove them explicitly
+                Promise.allSettled(cbs.map((cb) => cb(pipelineName)))
+              }
+            }
+          }
+        }
+
+        // Also check storage transitions (clear action)
+        if (storageChanged && pipeline.storageStatus === 'Cleared') {
+          const cbs = callbacks[pipelineName]?.['clear'] ?? []
+          if (cbs.length > 0 && actionTransitions['clear'](tracker, pipeline)) {
             Promise.allSettled(cbs.map((cb) => cb(pipelineName)))
           }
         }

--- a/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/pipelines/usePipelineActionCallbacks.svelte.ts
@@ -5,6 +5,7 @@ import type {
 } from '$lib/services/pipelineManager'
 import { untrack } from 'svelte'
 import { usePipelineList } from './usePipelineList.svelte'
+import { fsm } from '@githubnext/tiny-svelte-fsm'
 
 type Cb = (pipelineName: string) => Promise<void>
 
@@ -18,105 +19,151 @@ const statusToString = (status: PipelineStatus): string => {
 }
 
 // Stable states are those where pipelines can remain (not transitional)
-const stableStates = [
-  'Stopped',
-  'Running',
-  'Paused',
-  'Standby',
-  'Suspended',
-  'SqlError',
-  'RustError',
-  'SystemError',
-  'AwaitingApproval',
-  'Unavailable'
-] as const
+// We ignore: Preparing, Provisioning, Initializing, Pausing, Resuming, Stopping, Bootstrapping, Replaying, etc.
+type StableStatus =
+  | 'Stopped'
+  | 'Running'
+  | 'Paused'
+  | 'Standby'
+  | 'Suspended'
+  | 'SqlError'
+  | 'RustError'
+  | 'SystemError'
+  | 'AwaitingApproval'
+  | 'Unavailable'
+
+type StorageStatus = PipelineThumb['storageStatus']
+
+// FSM state is a tuple: "PipelineStatus:StorageStatus"
+type FSMState = `${StableStatus}:${StorageStatus}`
+
+// Event to signal reaching a new stable state
+type FSMEvent = 'transition'
 
 const isStableState = (status: PipelineStatus): boolean => {
   const statusStr = statusToString(status)
-  return stableStates.includes(statusStr as any)
+  const stableStates: StableStatus[] = [
+    'Stopped',
+    'Running',
+    'Paused',
+    'Standby',
+    'Suspended',
+    'SqlError',
+    'RustError',
+    'SystemError',
+    'AwaitingApproval',
+    'Unavailable'
+  ]
+  return stableStates.includes(statusStr as StableStatus)
 }
 
-/**
- * Track pipeline state transitions
- *
- * This tracker records the "stable" state before a pipeline enters transitional states.
- * For example: Stopped → Preparing → Provisioning → Initializing → Paused
- * We record: lastStableState = "Stopped", and when reaching "Paused", we know the
- * transition is Stopped → Paused (start_paused action), not Running → Paused (pause action).
- *
- * Transitional states (ignored): Preparing, Provisioning, Initializing, Pausing, Resuming, Stopping, etc.
- * Stable states: Stopped, Running, Paused, Standby, Error states, etc.
- */
-type PipelineTracker = {
-  lastStableState: string | null
-  currentState: PipelineStatus
-  currentStorageStatus: PipelineThumb['storageStatus']
-  lastStorageStatus: PipelineThumb['storageStatus'] | null
+const makeStateKey = (pipeline: PipelineThumb): FSMState => {
+  return `${statusToString(pipeline.status)}:${pipeline.storageStatus}` as FSMState
 }
 
-const trackers = $state<Record<string, PipelineTracker>>({})
+// Parse state key back to components
+const parseStateKey = (key: FSMState): { status: string; storageStatus: StorageStatus } => {
+  const [status, storageStatus] = key.split(':')
+  return { status, storageStatus: storageStatus as StorageStatus }
+}
 
-// Define which transitions match which actions
-type TransitionMatcher = (tracker: PipelineTracker, pipeline: PipelineThumb) => boolean
-
+// Helper to check if status is Stopped or Error
 const isStoppedOrError = (status: string) =>
   ['Stopped', 'SqlError', 'RustError', 'SystemError'].includes(status)
 
-const actionTransitions: Record<Action, TransitionMatcher> = {
-  // start_paused: Stopped/Error → Paused (when starting in paused state)
-  start_paused: (t, p) =>
-    t.lastStableState !== null &&
-    isStoppedOrError(t.lastStableState) &&
-    statusToString(p.status) === 'Paused',
+// Check which action matches a transition
+const matchActionForTransition = (from: FSMState, to: FSMState): Action[] => {
+  const fromState = parseStateKey(from)
+  const toState = parseStateKey(to)
 
-  // start: Stopped/Error → Running (normal start flow)
-  start: (t, p) =>
-    t.lastStableState !== null &&
-    isStoppedOrError(t.lastStableState) &&
-    statusToString(p.status) === 'Running',
+  const matchedActions: Action[] = []
 
-  // resume: Paused → Running (resuming from paused state)
-  resume: (t, p) =>
-    t.lastStableState === 'Paused' && statusToString(p.status) === 'Running',
+  // Pipeline status transitions
+  if (fromState.status !== toState.status) {
+    // start_paused: Stopped/Error → Paused
+    if (isStoppedOrError(fromState.status) && toState.status === 'Paused') {
+      matchedActions.push('start_paused')
+    }
 
-  // pause: Running → Paused (pausing from running state)
-  pause: (t, p) =>
-    t.lastStableState === 'Running' && statusToString(p.status) === 'Paused',
+    // start: Stopped/Error → Running
+    if (isStoppedOrError(fromState.status) && toState.status === 'Running') {
+      matchedActions.push('start')
+    }
 
-  // stop: Running/Paused → Stopped (graceful stop with checkpoint)
-  stop: (t, p) =>
-    t.lastStableState !== null &&
-    ['Running', 'Paused'].includes(t.lastStableState) &&
-    statusToString(p.status) === 'Stopped',
+    // resume: Paused → Running
+    if (fromState.status === 'Paused' && toState.status === 'Running') {
+      matchedActions.push('resume')
+    }
 
-  // kill: Any non-Stopped → Stopped (force stop)
-  kill: (t, p) =>
-    t.lastStableState !== null &&
-    t.lastStableState !== 'Stopped' &&
-    statusToString(p.status) === 'Stopped',
+    // pause: Running → Paused
+    if (fromState.status === 'Running' && toState.status === 'Paused') {
+      matchedActions.push('pause')
+    }
 
-  // standby: Any → Standby
-  standby: (_t, p) => statusToString(p.status) === 'Standby',
+    // stop: Running/Paused → Stopped
+    if (['Running', 'Paused'].includes(fromState.status) && toState.status === 'Stopped') {
+      matchedActions.push('stop')
+    }
 
-  // activate: Standby → Running
-  activate: (t, p) =>
-    t.lastStableState === 'Standby' && statusToString(p.status) === 'Running',
+    // kill: Any non-Stopped → Stopped
+    if (fromState.status !== 'Stopped' && toState.status === 'Stopped') {
+      matchedActions.push('kill')
+    }
 
-  // approve_changes: AwaitingApproval → Any other stable state
-  approve_changes: (t, p) =>
-    t.lastStableState === 'AwaitingApproval' &&
-    statusToString(p.status) !== 'AwaitingApproval' &&
-    isStableState(p.status),
+    // standby: Any → Standby
+    if (toState.status === 'Standby') {
+      matchedActions.push('standby')
+    }
 
-  // clear: storageStatus transitions to Cleared
-  clear: (t, p) =>
-    t.lastStorageStatus !== null &&
-    t.lastStorageStatus !== 'Cleared' &&
-    p.storageStatus === 'Cleared',
+    // activate: Standby → Running
+    if (fromState.status === 'Standby' && toState.status === 'Running') {
+      matchedActions.push('activate')
+    }
 
-  // delete: handled separately (pipeline removed from list)
-  delete: () => false
+    // approve_changes: AwaitingApproval → Any other
+    if (fromState.status === 'AwaitingApproval' && toState.status !== 'AwaitingApproval') {
+      matchedActions.push('approve_changes')
+    }
+  }
+
+  // Storage status transitions
+  if (fromState.storageStatus !== toState.storageStatus) {
+    // clear: Any → Cleared
+    if (fromState.storageStatus !== 'Cleared' && toState.storageStatus === 'Cleared') {
+      matchedActions.push('clear')
+    }
+  }
+
+  return matchedActions
 }
+
+// Create FSM for tracking pipeline state transitions
+const createPipelineFSM = (initialState: FSMState, pipelineName: string) => {
+  // Use wildcard pattern to allow any state to transition to any other state
+  return fsm<FSMState, FSMEvent>(initialState, {
+    '*': {
+      transition: (newState: FSMState) => newState,
+      _enter: ({ from, to }: { from: FSMState | null; to: FSMState }) => {
+        // Skip initial state entry
+        if (from === null) return
+
+        // Detect which actions this transition represents
+        const actions = matchActionForTransition(from, to)
+
+        // Execute callbacks for matched actions
+        for (const action of actions) {
+          const cbs = callbacks[pipelineName]?.[action] ?? []
+          if (cbs.length > 0) {
+            Promise.allSettled(cbs.map((cb) => cb(pipelineName)))
+          }
+        }
+      }
+    }
+  } as any) // Type assertion needed due to FSM's strict typing with dynamic states
+}
+
+// Track FSM instances per pipeline
+const pipelineFSMs = $state<Record<string, ReturnType<typeof createPipelineFSM>>>({})
 
 const pop = (pipelineName: string, action: Action) => {
   callbacks[pipelineName] ??= {}
@@ -153,77 +200,31 @@ export function usePipelineActionCallbacks(preloaded?: { pipelines: PipelineThum
           // Execute callbacks
           Promise.allSettled(allDeleteCbs.map((cb) => cb(deletedPipelineName)))
 
-          // Clean up callbacks and tracker for deleted pipeline
+          // Clean up callbacks and FSM for deleted pipeline
           delete callbacks[deletedPipelineName]
-          delete trackers[deletedPipelineName]
+          delete pipelineFSMs[deletedPipelineName]
         }
       }
 
-      // Process each current pipeline to detect state transitions
+      // Process each current pipeline
       for (const pipeline of currentPipelines) {
         const pipelineName = pipeline.name
 
-        // Initialize tracker if not exists
-        if (!trackers[pipelineName]) {
-          trackers[pipelineName] = {
-            lastStableState: isStableState(pipeline.status) ? statusToString(pipeline.status) : null,
-            currentState: pipeline.status,
-            currentStorageStatus: pipeline.storageStatus,
-            lastStorageStatus: pipeline.storageStatus
-          }
+        // Skip transitional states - only process stable states
+        if (!isStableState(pipeline.status)) {
           continue
         }
 
-        const tracker = trackers[pipelineName]
-        const statusChanged = JSON.stringify(tracker.currentState) !== JSON.stringify(pipeline.status)
-        const storageChanged = tracker.currentStorageStatus !== pipeline.storageStatus
+        const currentStateKey = makeStateKey(pipeline)
 
-        // Update storage status tracking
-        if (storageChanged) {
-          tracker.lastStorageStatus = tracker.currentStorageStatus
-          tracker.currentStorageStatus = pipeline.storageStatus
+        // Initialize FSM if this is the first time we see this pipeline (in a stable state)
+        if (!pipelineFSMs[pipelineName]) {
+          pipelineFSMs[pipelineName] = createPipelineFSM(currentStateKey, pipelineName)
+          continue
         }
 
-        // Update status tracking
-        if (statusChanged) {
-          const oldStatusStr = statusToString(tracker.currentState)
-          const newStatusStr = statusToString(pipeline.status)
-
-          // If transitioning from stable to another state, record the stable origin
-          if (isStableState(tracker.currentState) && oldStatusStr !== newStatusStr) {
-            tracker.lastStableState = oldStatusStr
-          }
-
-          // Update current state
-          tracker.currentState = pipeline.status
-
-          // If we reached a new stable state, check for matching action transitions
-          if (isStableState(pipeline.status)) {
-            // Check all registered callbacks for this pipeline
-            for (const action in callbacks[pipelineName]) {
-              const actionKey = action as Action
-              if (actionKey === 'delete') continue
-
-              const cbs = callbacks[pipelineName][actionKey] ?? []
-              if (cbs.length === 0) continue
-
-              // Check if this transition matches the action
-              if (actionTransitions[actionKey](tracker, pipeline)) {
-                // Execute all callbacks for this action
-                // Note: Callbacks are NOT automatically removed - callers must remove them explicitly
-                Promise.allSettled(cbs.map((cb) => cb(pipelineName)))
-              }
-            }
-          }
-        }
-
-        // Also check storage transitions (clear action)
-        if (storageChanged && pipeline.storageStatus === 'Cleared') {
-          const cbs = callbacks[pipelineName]?.['clear'] ?? []
-          if (cbs.length > 0 && actionTransitions['clear'](tracker, pipeline)) {
-            Promise.allSettled(cbs.map((cb) => cb(pipelineName)))
-          }
-        }
+        // Send transition event to FSM - it will handle detecting the transition and executing callbacks
+        pipelineFSMs[pipelineName].send('transition', currentStateKey)
       }
 
       // Update previous pipeline names

--- a/js-packages/web-console/src/lib/compositions/usePipelineAction.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/usePipelineAction.svelte.ts
@@ -1,11 +1,7 @@
 // export const usePipelineAction = (api: PipelineManagerApi, pipelines: () => PipelineThumb[]) => {
 
 import type { NamesInUnion } from '$lib/functions/common/union'
-import type {
-  PipelineAction,
-  PipelineStatus,
-  PipelineThumb
-} from '$lib/services/pipelineManager'
+import type { PipelineAction, PipelineStatus, PipelineThumb } from '$lib/services/pipelineManager'
 import { usePipelineList, useUpdatePipelineList } from './pipelines/usePipelineList.svelte'
 import { usePipelineManager } from './usePipelineManager.svelte'
 import { useReactiveWaiter } from './useReactiveWaiter.svelte'
@@ -61,72 +57,72 @@ export const usePipelineAction = () => {
     pipeline_name: string,
     action: PipelineAction | 'resume'
   ): Promise<void> => {
-      // Optimistic status update based on action
-      const optimisticStatus = match(action)
-        .returnType<PipelineThumb['status'] | undefined>()
-        .with('start', () => 'Preparing')
-        .with('resume', () => 'Resuming')
-        .with('start_paused', () => 'Preparing')
-        .with('pause', () => 'Pausing')
-        .with('stop', 'kill', () => 'Stopping')
-        .with('clear', () => undefined) // clear updates storageStatus, not status
-        .with('standby', () => 'Initializing')
-        .with('activate', () => 'Running')
-        .with('approve_changes', () => undefined)
-        .exhaustive()
+    // Optimistic status update based on action
+    const optimisticStatus = match(action)
+      .returnType<PipelineThumb['status'] | undefined>()
+      .with('start', () => 'Preparing')
+      .with('resume', () => 'Resuming')
+      .with('start_paused', () => 'Preparing')
+      .with('pause', () => 'Pausing')
+      .with('stop', 'kill', () => 'Stopping')
+      .with('clear', () => undefined) // clear updates storageStatus, not status
+      .with('standby', () => 'Initializing')
+      .with('activate', () => 'Running')
+      .with('approve_changes', () => undefined)
+      .exhaustive()
 
-      // Apply optimistic updates
-      if (optimisticStatus) {
-        updatePipeline(pipeline_name, (p) => ({ ...p, status: optimisticStatus }))
-      } else if (action === 'clear') {
-        updatePipeline(pipeline_name, (p) => ({ ...p, storageStatus: 'Clearing' }))
-      }
-
-      // Handle 'start' action with hidden paused intermediate state
-      if (action === 'start') {
-        // First start in paused state
-        await api.postPipelineAction(pipeline_name, 'start_paused')
-
-        // Wait for paused state
-        const pausedWaiter = reactiveWaiter.createWaiter({
-          predicate: (ps) => {
-            const p = ps.find((p) => p.name === pipeline_name)
-            if (!p) {
-              throw new Error('Pipeline not found in pipelines list')
-            }
-            if (ignoreStatuses.includes(unionName(p.status))) {
-              return null
-            }
-            if (
-              (['Paused', 'AwaitingApproval'] satisfies PipelineStatus[]).findIndex(
-                (status) => status === p.status
-              ) !== -1
-            ) {
-              return { value: true }
-            }
-            if (p.status === 'Stopped') {
-              return { value: false }
-            }
-            throw new Error(
-              `Unexpected status ${JSON.stringify(p.status)} while waiting for pipeline ${pipeline_name} to reach paused state`
-            )
-          }
-        })
-
-        const shouldContinue = await pausedWaiter.waitFor()
-        if (!shouldContinue) {
-          // Pipeline was stopped before it could be resumed, don't try to resume
-          return
-        }
-
-        updatePipeline(pipeline_name, (p) => ({ ...p, status: 'Initializing' }))
-
-        // Then start normally (resume action will trigger its own callbacks reactively)
-        await api.postPipelineAction(pipeline_name, 'resume')
-      } else {
-        await api.postPipelineAction(pipeline_name, action)
-      }
+    // Apply optimistic updates
+    if (optimisticStatus) {
+      updatePipeline(pipeline_name, (p) => ({ ...p, status: optimisticStatus }))
+    } else if (action === 'clear') {
+      updatePipeline(pipeline_name, (p) => ({ ...p, storageStatus: 'Clearing' }))
     }
+
+    // Handle 'start' action with hidden paused intermediate state
+    if (action === 'start') {
+      // First start in paused state
+      await api.postPipelineAction(pipeline_name, 'start_paused')
+
+      // Wait for paused state
+      const pausedWaiter = reactiveWaiter.createWaiter({
+        predicate: (ps) => {
+          const p = ps.find((p) => p.name === pipeline_name)
+          if (!p) {
+            throw new Error('Pipeline not found in pipelines list')
+          }
+          if (ignoreStatuses.includes(unionName(p.status))) {
+            return null
+          }
+          if (
+            (['Paused', 'AwaitingApproval'] satisfies PipelineStatus[]).findIndex(
+              (status) => status === p.status
+            ) !== -1
+          ) {
+            return { value: true }
+          }
+          if (p.status === 'Stopped') {
+            return { value: false }
+          }
+          throw new Error(
+            `Unexpected status ${JSON.stringify(p.status)} while waiting for pipeline ${pipeline_name} to reach paused state`
+          )
+        }
+      })
+
+      const shouldContinue = await pausedWaiter.waitFor()
+      if (!shouldContinue) {
+        // Pipeline was stopped before it could be resumed, don't try to resume
+        return
+      }
+
+      updatePipeline(pipeline_name, (p) => ({ ...p, status: 'Initializing' }))
+
+      // Then start normally (resume action will trigger its own callbacks reactively)
+      await api.postPipelineAction(pipeline_name, 'resume')
+    } else {
+      await api.postPipelineAction(pipeline_name, action)
+    }
+  }
 
   return {
     postPipelineAction

--- a/js-packages/web-console/src/lib/services/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/services/pipelineManager.ts
@@ -226,6 +226,7 @@ export const programStatusOf = (status: PipelineStatus) =>
 const toPipelineThumb = (
   pipeline: Omit<ExtendedPipelineDescr, 'program_code' | 'program_error' | 'udf_rust' | 'udf_toml'>
 ) => ({
+  id: pipeline.id,
   name: pipeline.name,
   description: pipeline.description,
   storageStatus: pipeline.storage_status,


### PR DESCRIPTION
Previously the registered callbacks on pipeline actions were only executed when these actions were triggered from web-console. For example, you couldn't follow the change stream if a pipeline was started through the API.
Now the occurred pipeline actions are derived from each pipeline's status transitions, received when polling `/v0/pipelines`.
Aside from the functional changes, the new implementation has lower coupling to adjacent code than the previous one.

Fix https://github.com/feldera/feldera/issues/4822: skip the PAUSED state if we don't need to listen for any changes