### PR TITLE
[logging] Add pipeline UUID to JSON logs

### DIFF
--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -123,6 +123,7 @@ impl LocalRunner {
                                 logs_sender.send(LogMessage::new_from_control_plane(
                                     module_path!(),
                                     "control-plane",
+                                    pipeline_id.to_string(),
                                     Level::ERROR,
                                     &line,
                                 )).await;
@@ -151,6 +152,7 @@ impl LocalRunner {
                                 logs_sender.send(LogMessage::new_from_control_plane(
                                     module_path!(),
                                     "control-plane",
+                                    pipeline_id.to_string(),
                                     Level::ERROR,
                                     &line,
                                 )).await;
@@ -336,6 +338,7 @@ impl LocalRunner {
                 .send(LogMessage::new_from_control_plane(
                     module_path!(),
                     "control-plane",
+                    self.pipeline_id.to_string(),
                     Level::ERROR,
                     &format!("Resources error: {error}"),
                 ))

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -183,8 +183,11 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
         logs_receiver: mpsc::Receiver<LogMessage>,
     ) -> Self {
         // Start the thread which composes the pipeline logs and serves them
-        let logs_thread_terminate_sender_and_join_handle =
-            start_thread_pipeline_logs(follow_request_receiver, logs_receiver);
+        let logs_thread_terminate_sender_and_join_handle = start_thread_pipeline_logs(
+            pipeline_id.to_string(),
+            follow_request_receiver,
+            logs_receiver,
+        );
 
         Self {
             platform_version: common_config.platform_version.clone(),
@@ -540,6 +543,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     .send(LogMessage::new_from_control_plane(
                         module_path!(),
                         pipeline.name.clone(),
+                        pipeline.id.to_string(),
                         Level::INFO,
                         "Storage has been cleared",
                     ))
@@ -557,6 +561,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                         .send(LogMessage::new_from_control_plane(
                             module_path!(),
                             pipeline.name.clone(),
+                            pipeline.id.to_string(),
                             Level::INFO,
                             &message,
                         ))
@@ -583,6 +588,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                         .send(LogMessage::new_from_control_plane(
                             module_path!(),
                             pipeline.name.clone(),
+                            pipeline.id.to_string(),
                             Level::INFO,
                             &message,
                         ))


### PR DESCRIPTION
  - LogMessage control-plane entries carry pipeline-id and emit it in JSON
  - Tracing JSON formatter adds pipeline-id field alongside pipeline name

Having pipeline UUID in the json metadata allows customers and developers (when debugging, for example) to differentiate logs from different pipelines using pipeline UUID.

Currently the only option is to use a pipeline name. Multiple components can emit logs with the same pipeline name. For example control plane generates logs with pipeline name "manager", and also user can create a pipeline with the name "manager". Using UUID solves this ambiguity.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
