### PR TITLE
[SQL] Better explicit representation for arithmetic on time values

### DIFF
--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     operators::{eq, gt, gte, lt, lte, neq},
-    polymorphic_return_function2, some_existing_operator, some_operator,
-    some_polymorphic_function1, some_polymorphic_function2,
-    timestamp::{extract_epoch_Date, extract_quarter_Date, plus_Date_LongInterval_Date},
+    some_existing_operator, some_function2, some_operator, some_polymorphic_function1,
+    some_polymorphic_function2,
+    timestamp::{extract_epoch_Date, extract_quarter_Date, plus_Date_Date_LongInterval__},
     Date, SqlDecimal,
 };
 use dbsp::{algebra::F64, num_entries_scalar};
@@ -371,36 +371,30 @@ pub fn div_ShortInterval_i64(left: ShortInterval, right: i64) -> ShortInterval {
 some_polymorphic_function2!(div, ShortInterval, ShortInterval, i64, i64, ShortInterval);
 
 #[doc(hidden)]
-pub fn plus_ShortInterval_ShortInterval_ShortInterval(
+pub fn plus_ShortInterval_ShortInterval_ShortInterval__(
     left: ShortInterval,
     right: ShortInterval,
 ) -> ShortInterval {
     left + right
 }
 
-polymorphic_return_function2!(
-    plus,
-    ShortInterval,
-    ShortInterval,
-    ShortInterval,
+some_function2!(
+    plus_ShortInterval_ShortInterval_ShortInterval,
     ShortInterval,
     ShortInterval,
     ShortInterval
 );
 
 #[doc(hidden)]
-pub fn minus_ShortInterval_ShortInterval_ShortInterval(
+pub fn minus_ShortInterval_ShortInterval_ShortInterval__(
     left: ShortInterval,
     right: ShortInterval,
 ) -> ShortInterval {
     left - right
 }
 
-polymorphic_return_function2!(
-    minus,
-    ShortInterval,
-    ShortInterval,
-    ShortInterval,
+some_function2!(
+    minus_ShortInterval_ShortInterval_ShortInterval,
     ShortInterval,
     ShortInterval,
     ShortInterval
@@ -705,36 +699,30 @@ some_polymorphic_function2!(
 );
 
 #[doc(hidden)]
-pub fn plus_LongInterval_LongInterval_LongInterval(
+pub fn plus_LongInterval_LongInterval_LongInterval__(
     left: LongInterval,
     right: LongInterval,
 ) -> LongInterval {
     left + right
 }
 
-polymorphic_return_function2!(
-    plus,
-    LongInterval,
-    LongInterval,
-    LongInterval,
+some_function2!(
+    plus_LongInterval_LongInterval_LongInterval,
     LongInterval,
     LongInterval,
     LongInterval
 );
 
 #[doc(hidden)]
-pub fn minus_LongInterval_LongInterval_LongInterval(
+pub fn minus_LongInterval_LongInterval_LongInterval__(
     left: LongInterval,
     right: LongInterval,
 ) -> LongInterval {
     left - right
 }
 
-polymorphic_return_function2!(
-    minus,
-    LongInterval,
-    LongInterval,
-    LongInterval,
+some_function2!(
+    minus_LongInterval_LongInterval_LongInterval,
     LongInterval,
     LongInterval,
     LongInterval
@@ -753,7 +741,7 @@ pub fn extract_month_LongInterval(value: LongInterval) -> i64 {
 #[doc(hidden)]
 pub fn extract_quarter_LongInterval(value: LongInterval) -> i64 {
     let dt = Date::from(0);
-    let dt = plus_Date_LongInterval_Date(dt, value);
+    let dt = plus_Date_Date_LongInterval__(dt, value);
     extract_quarter_Date(dt)
 }
 
@@ -783,7 +771,7 @@ pub fn extract_day_LongInterval(_value: LongInterval) -> i64 {
 #[doc(hidden)]
 pub fn extract_epoch_LongInterval(value: LongInterval) -> i64 {
     let dt = Date::from(0);
-    let dt = plus_Date_LongInterval_Date(dt, value);
+    let dt = plus_Date_Date_LongInterval__(dt, value);
     // I think this is right and Postgres is wrong
     extract_epoch_Date(dt)
 }

--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -171,29 +171,6 @@ macro_rules! some_polymorphic_function1 {
 
 pub(crate) use some_polymorphic_function1;
 
-// Macro to create variants of a polymorphic function with 1 argument that is
-// also polymorphic in the return type.
-// If there exists a function is f_type_result(x: T) -> S, this creates a
-// function
-// f_typeN_resultN(x: Option<T>) -> Option<S>
-// { let x = x?; Some(f_type(x)) }.
-#[allow(unused_macros)]
-macro_rules! polymorphic_return_function1 {
-    ($func_name:ident, $type_name: ident, $arg_type:ty, $ret_name: ident, $ret_type:ty) => {
-        ::paste::paste! {
-            #[doc(hidden)]
-            pub fn [<$func_name _ $type_name N _ $ret_name N>]( arg: Option<$arg_type> ) -> Option<$ret_type> {
-                let arg = arg?;
-                Some([<$func_name _ $type_name >](arg))
-            }
-        }
-    };
-}
-
-// Maybe we will need this someday
-#[allow(unused_imports)]
-pub(crate) use polymorphic_return_function1;
-
 // Macro to create variants of a function with 2 arguments
 // If there exists a function is f__(x: T, y: S) -> U, this creates
 // three functions:
@@ -227,41 +204,6 @@ macro_rules! some_function2 {
 }
 
 pub(crate) use some_function2;
-
-// Macro to create variants of a polymorphic function with 2 arguments
-// that is also polymorphic in the return type
-// If there exists a function is f_type1_type2_result(x: T, y: S) -> U, this
-// creates three functions:
-// - f_type1_type2N_resultN(x: T, y: Option<S>) -> Option<U>
-// - f_type1N_type2_resultN(x: Option<T>, y: S) -> Option<U>
-// - f_type1N_type2N_resultN(x: Option<T>, y: Option<S>) -> Option<U>
-// The resulting functions return Some only if all arguments are 'Some'.
-macro_rules! polymorphic_return_function2 {
-    ($func_name:ident, $type_name0: ident, $arg_type0:ty, $type_name1: ident, $arg_type1:ty, $ret_name: ident, $ret_type:ty) => {
-        ::paste::paste! {
-            #[doc(hidden)]
-            pub fn [<$func_name _$type_name0 _ $type_name1 N _ $ret_name N>]( arg0: $arg_type0, arg1: Option<$arg_type1> ) -> Option<$ret_type> {
-                let arg1 = arg1?;
-                Some([<$func_name _ $type_name0 _ $type_name1 _ $ret_name>](arg0, arg1))
-            }
-
-            #[doc(hidden)]
-            pub fn [<$func_name _ $type_name0 N _ $type_name1 _ $ret_name N>]( arg0: Option<$arg_type0>, arg1: $arg_type1 ) -> Option<$ret_type> {
-                let arg0 = arg0?;
-                Some([<$func_name _ $type_name0 _ $type_name1 _ $ret_name>](arg0, arg1))
-            }
-
-            #[doc(hidden)]
-            pub fn [<$func_name _ $type_name0 N _ $type_name1 N _ $ret_name N>]( arg0: Option<$arg_type0>, arg1: Option<$arg_type1> ) -> Option<$ret_type> {
-                let arg0 = arg0?;
-                let arg1 = arg1?;
-                Some([<$func_name _ $type_name0 _ $type_name1 _ $ret_name>](arg0, arg1))
-            }
-        }
-    }
-}
-
-pub(crate) use polymorphic_return_function2;
 
 // Macro to create variants of a polymorphic function with 2 arguments
 // If there exists a function is f_type1_type2(x: T, y: S) -> U, this

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -29,8 +29,8 @@ use std::{
 
 use crate::{
     operators::{eq, gt, gte, lt, lte, neq},
-    polymorphic_return_function2, some_existing_operator, some_function2, some_operator,
-    some_polymorphic_function1, some_polymorphic_function2, some_polymorphic_function3,
+    some_existing_operator, some_function2, some_operator, some_polymorphic_function1,
+    some_polymorphic_function2, some_polymorphic_function3,
 };
 
 /// Represents a date and a time without timezone information.
@@ -310,22 +310,22 @@ impl Add<i64> for Timestamp {
 }
 
 #[doc(hidden)]
-pub fn plus_Timestamp_ShortInterval_Timestamp(left: Timestamp, right: ShortInterval) -> Timestamp {
+pub fn plus_Timestamp_Timestamp_ShortInterval__(
+    left: Timestamp,
+    right: ShortInterval,
+) -> Timestamp {
     left.add(right.milliseconds())
 }
 
-polymorphic_return_function2!(
-    plus,
-    Timestamp,
+some_function2!(
+    plus_Timestamp_Timestamp_ShortInterval,
     Timestamp,
     ShortInterval,
-    ShortInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn plus_Timestamp_LongInterval_Timestamp(left: Timestamp, right: LongInterval) -> Timestamp {
+pub fn plus_Timestamp_Timestamp_LongInterval__(left: Timestamp, right: LongInterval) -> Timestamp {
     let dt = left.to_naiveDateTime();
     let months = right.months();
     let ndt = if months < 0 {
@@ -336,18 +336,15 @@ pub fn plus_Timestamp_LongInterval_Timestamp(left: Timestamp, right: LongInterva
     Timestamp::from_naiveDateTime(ndt.unwrap())
 }
 
-polymorphic_return_function2!(
-    plus,
-    Timestamp,
+some_function2!(
+    plus_Timestamp_Timestamp_LongInterval,
     Timestamp,
     LongInterval,
-    LongInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn minus_Timestamp_LongInterval_Timestamp(left: Timestamp, right: LongInterval) -> Timestamp {
+pub fn minus_Timestamp_Timestamp_LongInterval__(left: Timestamp, right: LongInterval) -> Timestamp {
     let dt = left.to_naiveDateTime();
     let months = right.months();
     let ndt = if months < 0 {
@@ -358,103 +355,94 @@ pub fn minus_Timestamp_LongInterval_Timestamp(left: Timestamp, right: LongInterv
     Timestamp::from_naiveDateTime(ndt.unwrap())
 }
 
-polymorphic_return_function2!(
-    minus,
-    Timestamp,
+some_function2!(
+    minus_Timestamp_Timestamp_LongInterval,
     Timestamp,
     LongInterval,
-    LongInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn plus_Date_ShortInterval_Timestamp(left: Date, right: ShortInterval) -> Timestamp {
-    plus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left).unwrap(), right)
+pub fn plus_Timestamp_Date_ShortInterval__(left: Date, right: ShortInterval) -> Timestamp {
+    plus_Timestamp_Timestamp_ShortInterval__(cast_to_Timestamp_Date(left).unwrap(), right)
 }
 
-polymorphic_return_function2!(
-    plus,
-    Date,
+some_function2!(
+    plus_Timestamp_Date_ShortInterval,
     Date,
     ShortInterval,
-    ShortInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn minus_Timestamp_Timestamp_ShortInterval(left: Timestamp, right: Timestamp) -> ShortInterval {
+pub fn minus_ShortInterval_Timestamp_Timestamp__(
+    left: Timestamp,
+    right: Timestamp,
+) -> ShortInterval {
     ShortInterval::from(left.milliseconds() - right.milliseconds())
 }
 
-polymorphic_return_function2!(
-    minus,
+some_function2!(
+    minus_ShortInterval_Timestamp_Timestamp,
     Timestamp,
     Timestamp,
-    Timestamp,
-    Timestamp,
-    ShortInterval,
     ShortInterval
 );
 
 #[doc(hidden)]
-pub fn minus_Time_Time_ShortInterval(left: Time, right: Time) -> ShortInterval {
+pub fn minus_ShortInterval_Time_Time__(left: Time, right: Time) -> ShortInterval {
     ShortInterval::from((left.nanoseconds() as i64 - right.nanoseconds() as i64) / 1000000)
 }
 
-polymorphic_return_function2!(minus, Time, Time, Time, Time, ShortInterval, ShortInterval);
+some_function2!(minus_ShortInterval_Time_Time, Time, Time, ShortInterval);
 
 #[doc(hidden)]
-pub fn minus_Timestamp_ShortInterval_Timestamp(left: Timestamp, right: ShortInterval) -> Timestamp {
+pub fn minus_Timestamp_Timestamp_ShortInterval__(
+    left: Timestamp,
+    right: ShortInterval,
+) -> Timestamp {
     Timestamp::new(left.milliseconds() - right.milliseconds())
 }
 
-polymorphic_return_function2!(
-    minus,
-    Timestamp,
+some_function2!(
+    minus_Timestamp_Timestamp_ShortInterval,
     Timestamp,
     ShortInterval,
-    ShortInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn minus_Date_ShortInterval_Timestamp(left: Date, right: ShortInterval) -> Timestamp {
-    minus_Timestamp_ShortInterval_Timestamp(cast_to_Timestamp_Date(left).unwrap(), right)
+pub fn minus_Timestamp_Date_ShortInterval__(left: Date, right: ShortInterval) -> Timestamp {
+    minus_Timestamp_Timestamp_ShortInterval__(cast_to_Timestamp_Date(left).unwrap(), right)
 }
 
-polymorphic_return_function2!(
-    minus,
-    Date,
+some_function2!(
+    minus_Timestamp_Date_ShortInterval,
     Date,
     ShortInterval,
-    ShortInterval,
-    Timestamp,
     Timestamp
 );
 
 #[doc(hidden)]
-pub fn plus_Date_ShortInterval_Date(left: Date, right: ShortInterval) -> Date {
+pub fn plus_Date_Date_ShortInterval__(left: Date, right: ShortInterval) -> Date {
     let days = (right.milliseconds() / (86400 * 1000)) as i32;
     let diff = left.days() + days;
     Date::new(diff)
 }
 
-polymorphic_return_function2!(plus, Date, Date, ShortInterval, ShortInterval, Date, Date);
+some_function2!(plus_Date_Date_ShortInterval, Date, ShortInterval, Date);
 
 #[doc(hidden)]
-pub fn minus_Date_ShortInterval_Date(left: Date, right: ShortInterval) -> Date {
+pub fn minus_Date_Date_ShortInterval__(left: Date, right: ShortInterval) -> Date {
     let days = (right.milliseconds() / (86400 * 1000)) as i32;
     let diff = left.days() - days;
     Date::new(diff)
 }
 
-polymorphic_return_function2!(minus, Date, Date, ShortInterval, ShortInterval, Date, Date);
+some_function2!(minus_Date_Date_ShortInterval, Date, ShortInterval, Date);
 
 #[doc(hidden)]
-pub fn plus_Date_LongInterval_Date(left: Date, right: LongInterval) -> Date {
+pub fn plus_Date_Date_LongInterval__(left: Date, right: LongInterval) -> Date {
     let date = left.to_date();
     if right.months() < 0 {
         let result = date
@@ -469,10 +457,10 @@ pub fn plus_Date_LongInterval_Date(left: Date, right: LongInterval) -> Date {
     }
 }
 
-polymorphic_return_function2!(plus, Date, Date, LongInterval, LongInterval, Date, Date);
+some_function2!(plus_Date_Date_LongInterval, Date, LongInterval, Date);
 
 #[doc(hidden)]
-pub fn minus_Date_LongInterval_Date(left: Date, right: LongInterval) -> Date {
+pub fn minus_Date_Date_LongInterval__(left: Date, right: LongInterval) -> Date {
     let date = left.to_date();
     if right.months() < 0 {
         let result = date
@@ -497,10 +485,10 @@ pub fn minus_Date_LongInterval_Date(left: Date, right: LongInterval) -> Date {
     }
 }
 
-polymorphic_return_function2!(minus, Date, Date, LongInterval, LongInterval, Date, Date);
+some_function2!(minus_Date_Date_LongInterval, Date, LongInterval, Date);
 
 #[doc(hidden)]
-pub fn minus_Timestamp_Timestamp_LongInterval(left: Timestamp, right: Timestamp) -> LongInterval {
+pub fn minus_LongInterval_Timestamp_Timestamp__(left: Timestamp, right: Timestamp) -> LongInterval {
     let swap = left < right;
     let ldate;
     let rdate;
@@ -528,13 +516,10 @@ pub fn minus_Timestamp_Timestamp_LongInterval(left: Timestamp, right: Timestamp)
     LongInterval::from(if swap { -months } else { months })
 }
 
-polymorphic_return_function2!(
-    minus,
+some_function2!(
+    minus_LongInterval_Timestamp_Timestamp,
     Timestamp,
     Timestamp,
-    Timestamp,
-    Timestamp,
-    LongInterval,
     LongInterval
 );
 
@@ -737,7 +722,7 @@ pub fn floor_week_Timestamp(value: Timestamp) -> Timestamp {
     let wd = extract_dow_Timestamp(value) - Date::first_day_of_week();
     let notimeTs = floor_day_Timestamp(value);
     let interval = ShortInterval::from_seconds(wd * 86400);
-    minus_Timestamp_ShortInterval_Timestamp(notimeTs, interval)
+    minus_Timestamp_Timestamp_ShortInterval__(notimeTs, interval)
 }
 
 some_polymorphic_function1!(floor_week, Timestamp, Timestamp, Timestamp);
@@ -911,7 +896,7 @@ pub fn ceil_week_Timestamp(value: Timestamp) -> Timestamp {
     }
     let notimeTs = floor_day_Timestamp(value);
     let interval = ShortInterval::from_seconds((7 - wd) * 86400);
-    plus_Timestamp_ShortInterval_Timestamp(notimeTs, interval)
+    plus_Timestamp_Timestamp_ShortInterval__(notimeTs, interval)
 }
 
 some_polymorphic_function1!(ceil_week, Timestamp, Timestamp, Timestamp);
@@ -924,7 +909,7 @@ pub fn ceil_day_Timestamp(value: Timestamp) -> Timestamp {
     }
     let notimeTs = floor_day_Timestamp(value);
     let day = ShortInterval::from_seconds(86400);
-    plus_Timestamp_ShortInterval_Timestamp(notimeTs, day)
+    plus_Timestamp_Timestamp_ShortInterval__(notimeTs, day)
 }
 
 some_polymorphic_function1!(ceil_day, Timestamp, Timestamp, Timestamp);
@@ -937,7 +922,7 @@ pub fn ceil_hour_Timestamp(value: Timestamp) -> Timestamp {
     }
     let floored = floor_hour_Timestamp(value);
     let hour = ShortInterval::from_seconds(3600);
-    plus_Timestamp_ShortInterval_Timestamp(floored, hour)
+    plus_Timestamp_Timestamp_ShortInterval__(floored, hour)
 }
 
 some_polymorphic_function1!(ceil_hour, Timestamp, Timestamp, Timestamp);
@@ -950,7 +935,7 @@ pub fn ceil_minute_Timestamp(value: Timestamp) -> Timestamp {
     }
     let floored = floor_minute_Timestamp(value);
     let minute = ShortInterval::from_seconds(60);
-    plus_Timestamp_ShortInterval_Timestamp(floored, minute)
+    plus_Timestamp_Timestamp_ShortInterval__(floored, minute)
 }
 
 some_polymorphic_function1!(ceil_minute, Timestamp, Timestamp, Timestamp);
@@ -963,7 +948,7 @@ pub fn ceil_second_Timestamp(value: Timestamp) -> Timestamp {
     }
     let floored = floor_second_Timestamp(value);
     let second = ShortInterval::from_seconds(1);
-    plus_Timestamp_ShortInterval_Timestamp(floored, second)
+    plus_Timestamp_Timestamp_ShortInterval__(floored, second)
 }
 
 some_polymorphic_function1!(ceil_second, Timestamp, Timestamp, Timestamp);
@@ -1400,7 +1385,7 @@ some_polymorphic_function1!(floor_month, Date, Date, Date);
 pub fn floor_week_Date(value: Date) -> Date {
     let wd = extract_dow_Date(value) - Date::first_day_of_week();
     let interval = ShortInterval::from_seconds(wd * 86400);
-    minus_Date_ShortInterval_Date(value, interval)
+    minus_Date_Date_ShortInterval__(value, interval)
 }
 
 some_polymorphic_function1!(floor_week, Date, Date, Date);
@@ -1551,7 +1536,7 @@ pub fn ceil_week_Date(value: Date) -> Date {
         return value;
     }
     let interval = ShortInterval::from_seconds((7 - wd) * 86400);
-    plus_Date_ShortInterval_Date(value, interval)
+    plus_Date_Date_ShortInterval__(value, interval)
 }
 
 some_polymorphic_function1!(ceil_week, Date, Date, Date);
@@ -1607,7 +1592,7 @@ some_polymorphic_function1!(ceil_nanosecond, Date, Date, Date);
 
 // right - left
 #[doc(hidden)]
-pub fn minus_Date_Date_LongInterval(left: Date, right: Date) -> LongInterval {
+pub fn minus_LongInterval_Date_Date__(left: Date, right: Date) -> LongInterval {
     // Logic adapted from https://github.com/mysql/mysql-server/blob/ea1efa9822d81044b726aab20c857d5e1b7e046a/sql/item_timefunc.cc
     let ld = left.to_dateTime();
     let rd = right.to_dateTime();
@@ -1641,16 +1626,16 @@ pub fn minus_Date_Date_LongInterval(left: Date, right: Date) -> LongInterval {
     LongInterval::from(months * neg)
 }
 
-polymorphic_return_function2!(minus, Date, Date, Date, Date, LongInterval, LongInterval);
+some_function2!(minus_LongInterval_Date_Date, Date, Date, LongInterval);
 
 #[doc(hidden)]
-pub fn minus_Date_Date_ShortInterval(left: Date, right: Date) -> ShortInterval {
+pub fn minus_ShortInterval_Date_Date__(left: Date, right: Date) -> ShortInterval {
     let ld = left.days() as i64;
     let rd = right.days() as i64;
     ShortInterval::from_seconds((ld - rd) * 86400)
 }
 
-polymorphic_return_function2!(minus, Date, Date, Date, Date, ShortInterval, ShortInterval);
+some_function2!(minus_ShortInterval_Date_Date, Date, Date, ShortInterval);
 
 #[doc(hidden)]
 pub fn extract_year_Date(value: Date) -> i64 {
@@ -2783,32 +2768,32 @@ some_polymorphic_function1!(time_trunc_nanosecond, Time, Time, Time);
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn plus_Time_ShortInterval_Time(left: Time, right: ShortInterval) -> Time {
+pub fn plus_Time_Time_ShortInterval__(left: Time, right: ShortInterval) -> Time {
     left + right
 }
 
-polymorphic_return_function2!(plus, Time, Time, ShortInterval, ShortInterval, Time, Time);
+some_function2!(plus_Time_Time_ShortInterval, Time, ShortInterval, Time);
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn minus_Time_ShortInterval_Time(left: Time, right: ShortInterval) -> Time {
+pub fn minus_Time_Time_ShortInterval__(left: Time, right: ShortInterval) -> Time {
     left - right
 }
 
-polymorphic_return_function2!(minus, Time, Time, ShortInterval, ShortInterval, Time, Time);
+some_function2!(minus_Time_Time_ShortInterval, Time, ShortInterval, Time);
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn plus_Time_LongInterval_Time(left: Time, _: LongInterval) -> Time {
+pub fn plus_Time_Time_LongInterval__(left: Time, _: LongInterval) -> Time {
     left
 }
 
-polymorphic_return_function2!(plus, Time, Time, LongInterval, LongInterval, Time, Time);
+some_function2!(plus_Time_Time_LongInterval, Time, LongInterval, Time);
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn minus_Time_LongInterval_Time(left: Time, _: LongInterval) -> Time {
+pub fn minus_Time_Time_LongInterval__(left: Time, _: LongInterval) -> Time {
     left
 }
 
-polymorphic_return_function2!(minus, Time, Time, LongInterval, LongInterval, Time, Time);
+some_function2!(minus_Time_Time_LongInterval, Time, LongInterval, Time);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -610,6 +610,21 @@ public class ToJsonInnerVisitor extends InnerVisitor {
     }
 
     @Override
+    public void postorder(DBSPTimeAddSub node) {
+        this.property("opcode");
+        this.stream.append(node.opcode.name());
+        if (node.longUnits != null) {
+            this.property("longUnits");
+            this.stream.append(node.longUnits.name());
+        }
+        if (node.shortUnits != null) {
+            this.property("shortUnits");
+            this.stream.append(node.shortUnits.name());
+        }
+        super.postorder(node);
+    }
+
+    @Override
     public void postorder(DBSPUnsignedUnwrapExpression node) {
         this.property("nullsLast");
         this.stream.append(node.nullsLast);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -23,14 +23,12 @@
 
 package org.dbsp.sqlCompiler.compiler.backend.rust;
 
-import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.*;
 import org.dbsp.sqlCompiler.ir.type.*;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeRawTuple;
-import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
 import org.dbsp.sqlCompiler.ir.type.primitive.*;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.util.Utilities;
@@ -43,78 +41,74 @@ import java.util.function.Function;
  * runtime library: support functions that implement the SQL semantics. */
 @SuppressWarnings({"SpellCheckingInspection"})
 public class RustSqlRuntimeLibrary {
-    private final LinkedHashMap<String, DBSPOpcode> universalFunctions = new LinkedHashMap<>();
-    private final LinkedHashMap<String, DBSPOpcode> arithmeticFunctions = new LinkedHashMap<>();
-    private final LinkedHashMap<String, DBSPOpcode> dateFunctions = new LinkedHashMap<>();
-    private final LinkedHashMap<String, DBSPOpcode> stringFunctions = new LinkedHashMap<>();
-    private final LinkedHashMap<String, DBSPOpcode> booleanFunctions = new LinkedHashMap<>();
-    private final LinkedHashMap<String, DBSPOpcode> otherFunctions = new LinkedHashMap<>();
+    private final HashMap<DBSPOpcode, String> universalFunctions = new HashMap<>();
+    private final HashMap<DBSPOpcode, String > arithmeticFunctions = new HashMap<>();
+    private final HashMap<DBSPOpcode, String> dateFunctions = new HashMap<>();
+    private final HashMap<DBSPOpcode, String> stringFunctions = new HashMap<>();
+    private final HashMap<DBSPOpcode, String> booleanFunctions = new HashMap<>();
+    private final HashMap<DBSPOpcode, String> otherFunctions = new HashMap<>();
 
     public static final RustSqlRuntimeLibrary INSTANCE = new RustSqlRuntimeLibrary();
 
     protected RustSqlRuntimeLibrary() {
-        this.universalFunctions.put("eq", DBSPOpcode.EQ);
-        this.universalFunctions.put("neq", DBSPOpcode.NEQ);
-        this.universalFunctions.put("lt", DBSPOpcode.LT);
-        this.universalFunctions.put("gt", DBSPOpcode.GT);
-        this.universalFunctions.put("lte", DBSPOpcode.LTE);
-        this.universalFunctions.put("gte", DBSPOpcode.GTE);
-        this.universalFunctions.put(DBSPOpcode.IS_DISTINCT.toString(), DBSPOpcode.IS_DISTINCT);
-        this.universalFunctions.put(DBSPOpcode.MIN.toString(), DBSPOpcode.MIN);
-        this.universalFunctions.put(DBSPOpcode.MAX.toString(), DBSPOpcode.MAX);
-        this.universalFunctions.put(DBSPOpcode.MIN_IGNORE_NULLS.toString(), DBSPOpcode.MIN_IGNORE_NULLS);
-        this.universalFunctions.put(DBSPOpcode.MAX_IGNORE_NULLS.toString(), DBSPOpcode.MAX_IGNORE_NULLS);
-        this.universalFunctions.put(DBSPOpcode.AGG_LTE.toString(), DBSPOpcode.AGG_LTE);
-        this.universalFunctions.put(DBSPOpcode.AGG_GTE.toString(), DBSPOpcode.AGG_GTE);
-        this.universalFunctions.put(DBSPOpcode.AGG_MIN.toString(), DBSPOpcode.AGG_MIN);
-        this.universalFunctions.put(DBSPOpcode.AGG_MAX.toString(), DBSPOpcode.AGG_MAX);
-        this.universalFunctions.put(DBSPOpcode.AGG_MIN1.toString(), DBSPOpcode.AGG_MIN1);
-        this.universalFunctions.put(DBSPOpcode.AGG_MAX1.toString(), DBSPOpcode.AGG_MAX1);
+        this.universalFunctions.put(DBSPOpcode.EQ,  "eq");
+        this.universalFunctions.put(DBSPOpcode.NEQ, "neq");
+        this.universalFunctions.put(DBSPOpcode.LT,  "lt");
+        this.universalFunctions.put(DBSPOpcode.GT,  "gt");
+        this.universalFunctions.put(DBSPOpcode.LTE, "lte");
+        this.universalFunctions.put(DBSPOpcode.GTE, "gte");
+        this.universalFunctions.put(DBSPOpcode.IS_DISTINCT, DBSPOpcode.IS_DISTINCT.toString());
+        this.universalFunctions.put(DBSPOpcode.MIN, DBSPOpcode.MIN.toString());
+        this.universalFunctions.put(DBSPOpcode.MAX, DBSPOpcode.MAX.toString());
+        this.universalFunctions.put(DBSPOpcode.MIN_IGNORE_NULLS, DBSPOpcode.MIN_IGNORE_NULLS.toString());
+        this.universalFunctions.put(DBSPOpcode.MAX_IGNORE_NULLS, DBSPOpcode.MAX_IGNORE_NULLS.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_LTE, DBSPOpcode.AGG_LTE.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_GTE, DBSPOpcode.AGG_GTE.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_MIN, DBSPOpcode.AGG_MIN.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_MAX, DBSPOpcode.AGG_MAX.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_MIN1, DBSPOpcode.AGG_MIN1.toString());
+        this.universalFunctions.put(DBSPOpcode.AGG_MAX1, DBSPOpcode.AGG_MAX1.toString());
 
-        this.arithmeticFunctions.put("plus", DBSPOpcode.ADD);
-        this.arithmeticFunctions.put("minus", DBSPOpcode.SUB);
-        this.arithmeticFunctions.put("modulo", DBSPOpcode.MOD);
-        this.arithmeticFunctions.put("times", DBSPOpcode.MUL);
-        this.arithmeticFunctions.put("div", DBSPOpcode.DIV);
-        this.arithmeticFunctions.put(DBSPOpcode.DIV_NULL.toString(), DBSPOpcode.DIV_NULL);
-        this.arithmeticFunctions.put("band", DBSPOpcode.BW_AND);
-        this.arithmeticFunctions.put("bor", DBSPOpcode.BW_OR);
-        this.arithmeticFunctions.put("bxor", DBSPOpcode.XOR);
-        this.arithmeticFunctions.put("mul_by_ref", DBSPOpcode.MUL_WEIGHT);
-        this.arithmeticFunctions.put(DBSPOpcode.AGG_ADD.toString(), DBSPOpcode.AGG_ADD);
-        this.arithmeticFunctions.put(DBSPOpcode.AGG_ADD_NON_NULL.toString(), DBSPOpcode.AGG_ADD_NON_NULL);
-        this.arithmeticFunctions.put(DBSPOpcode.AGG_AND.toString(), DBSPOpcode.AGG_AND);
-        this.arithmeticFunctions.put(DBSPOpcode.AGG_OR.toString(), DBSPOpcode.AGG_OR);
-        this.arithmeticFunctions.put(DBSPOpcode.AGG_XOR.toString(), DBSPOpcode.AGG_XOR);
-        this.arithmeticFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
-                DBSPOpcode.CONTROLLED_FILTER_GTE);
+        this.arithmeticFunctions.put(DBSPOpcode.ADD, "plus");
+        this.arithmeticFunctions.put(DBSPOpcode.SUB, "minus");
+        this.arithmeticFunctions.put(DBSPOpcode.MOD, "modulo");
+        this.arithmeticFunctions.put(DBSPOpcode.MUL, "times");
+        this.arithmeticFunctions.put(DBSPOpcode.DIV, "div");
+        this.arithmeticFunctions.put(DBSPOpcode.BW_AND, "band");
+        this.arithmeticFunctions.put(DBSPOpcode.BW_OR, "bor");
+        this.arithmeticFunctions.put(DBSPOpcode.XOR, "bxor");
+        this.arithmeticFunctions.put(DBSPOpcode.MUL_WEIGHT, "mul_by_ref");
+        this.arithmeticFunctions.put(DBSPOpcode.DIV_NULL, DBSPOpcode.DIV_NULL.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.AGG_ADD, DBSPOpcode.AGG_ADD.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.AGG_ADD_NON_NULL, DBSPOpcode.AGG_ADD_NON_NULL.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.AGG_AND, DBSPOpcode.AGG_AND.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.AGG_OR, DBSPOpcode.AGG_OR.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.AGG_XOR, DBSPOpcode.AGG_XOR.toString());
+        this.arithmeticFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE, DBSPOpcode.CONTROLLED_FILTER_GTE.toString());
 
-        this.dateFunctions.put("plus", DBSPOpcode.TS_ADD);
-        this.dateFunctions.put("minus", DBSPOpcode.TS_SUB);
-        this.dateFunctions.put("times", DBSPOpcode.INTERVAL_MUL);
-        this.dateFunctions.put("div", DBSPOpcode.INTERVAL_DIV);
-        this.dateFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(), DBSPOpcode.CONTROLLED_FILTER_GTE);
+        this.dateFunctions.put(DBSPOpcode.INTERVAL_MUL, "times");
+        this.dateFunctions.put(DBSPOpcode.INTERVAL_DIV, "div");
+        this.dateFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE, DBSPOpcode.CONTROLLED_FILTER_GTE.toString());
 
-        this.stringFunctions.put("concat", DBSPOpcode.CONCAT);
-        this.stringFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
-                DBSPOpcode.CONTROLLED_FILTER_GTE);
+        this.stringFunctions.put(DBSPOpcode.CONCAT, "concat");
+        this.stringFunctions.put(
+                DBSPOpcode.CONTROLLED_FILTER_GTE,
+                DBSPOpcode.CONTROLLED_FILTER_GTE.toString());
 
-        this.booleanFunctions.put("and", DBSPOpcode.AND);
-        this.booleanFunctions.put("or", DBSPOpcode.OR);
-        this.booleanFunctions.put(DBSPOpcode.IS_FALSE.toString(), DBSPOpcode.IS_FALSE);
-        this.booleanFunctions.put(DBSPOpcode.IS_NOT_TRUE.toString(), DBSPOpcode.IS_NOT_TRUE);
-        this.booleanFunctions.put(DBSPOpcode.IS_TRUE.toString(), DBSPOpcode.IS_TRUE);
-        this.booleanFunctions.put(DBSPOpcode.IS_NOT_FALSE.toString(), DBSPOpcode.IS_NOT_FALSE);
-        this.booleanFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
-                DBSPOpcode.CONTROLLED_FILTER_GTE);
+        this.booleanFunctions.put(DBSPOpcode.AND, "and");
+        this.booleanFunctions.put(DBSPOpcode.OR, "or");
+        this.booleanFunctions.put(DBSPOpcode.IS_FALSE, DBSPOpcode.IS_FALSE.toString());
+        this.booleanFunctions.put(DBSPOpcode.IS_NOT_TRUE, DBSPOpcode.IS_NOT_TRUE.toString());
+        this.booleanFunctions.put(DBSPOpcode.IS_TRUE, DBSPOpcode.IS_TRUE.toString());
+        this.booleanFunctions.put(DBSPOpcode.IS_NOT_FALSE, DBSPOpcode.IS_NOT_FALSE.toString());
+        this.booleanFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE, DBSPOpcode.CONTROLLED_FILTER_GTE.toString());
 
         // These are defined for VARBIT types
-        this.otherFunctions.put(DBSPOpcode.AGG_AND.toString(), DBSPOpcode.AGG_AND);
-        this.otherFunctions.put(DBSPOpcode.AGG_OR.toString(), DBSPOpcode.AGG_OR);
-        this.otherFunctions.put(DBSPOpcode.AGG_XOR.toString(), DBSPOpcode.AGG_XOR);
-        this.otherFunctions.put("concat", DBSPOpcode.CONCAT);
-        this.otherFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE.toString(),
-                DBSPOpcode.CONTROLLED_FILTER_GTE);
+        this.otherFunctions.put(DBSPOpcode.CONCAT, "concat");
+        this.otherFunctions.put(DBSPOpcode.AGG_AND, DBSPOpcode.AGG_AND.toString());
+        this.otherFunctions.put(DBSPOpcode.AGG_OR, DBSPOpcode.AGG_OR.toString());
+        this.otherFunctions.put(DBSPOpcode.AGG_XOR, DBSPOpcode.AGG_XOR.toString());
+        this.otherFunctions.put(DBSPOpcode.CONTROLLED_FILTER_GTE, DBSPOpcode.CONTROLLED_FILTER_GTE.toString());
     }
 
     public static class FunctionDescription {
@@ -157,22 +151,23 @@ public class RustSqlRuntimeLibrary {
                 unsignedType.baseTypeWithSuffix(), unsignedType);
     }
 
-    /** The name of the Rust function in the sqllib which implements a specific operation
-     * @param node                Calcite node.
-     * @param opcode              Operation opcode.
-     * @param expectedReturnType  Return type of the function.
-     * @param ltype               Type of first argument.
-     * @param rtype               Type of second argument; null if function takes only one argument.
-     * @return                    The function name.
+    /**
+     * The name of the Rust function in the sqllib which implements a specific operation
+     *
+     * @param node   Calcite node.
+     * @param opcode Operation opcode.
+     * @param ltype  Type of first argument.
+     * @param rtype  Type of second argument; null if function takes only one argument.
+     * @return The function name.
      */
     public String getFunctionName(CalciteObject node,
-                                  DBSPOpcode opcode, DBSPType expectedReturnType,
+                                  DBSPOpcode opcode,
                                   DBSPType ltype, @Nullable DBSPType rtype) {
         if (ltype.is(DBSPTypeAny.class) || (rtype != null && rtype.is(DBSPTypeAny.class)))
             throw new InternalCompilerError("Unexpected type _ for operand of " + opcode, ltype);
-        HashMap<String, DBSPOpcode> map = null;
-        String suffixReturn = "";  // suffix based on the return type
+        HashMap<DBSPOpcode, String> map = null;
 
+        String separator = "_";
         if (opcode.isComparison() ||
             opcode == DBSPOpcode.MAX || opcode == DBSPOpcode.MIN ||
             opcode == DBSPOpcode.MAX_IGNORE_NULLS || opcode == DBSPOpcode.MIN_IGNORE_NULLS ||
@@ -185,16 +180,6 @@ public class RustSqlRuntimeLibrary {
             map = this.booleanFunctions;
         } else if (ltype.is(IsTimeRelatedType.class)) {
             map = this.dateFunctions;
-            if (opcode == DBSPOpcode.TS_SUB || opcode == DBSPOpcode.TS_ADD) {
-                if (ltype.is(IsTimeRelatedType.class)) {
-                    Utilities.enforce(rtype != null);
-                    suffixReturn = "_" + expectedReturnType.to(DBSPTypeBaseType.class).shortName()
-                            + expectedReturnType.nullableSuffix();
-                    if (rtype.is(IsNumericType.class))
-                        throw new CompilationError("Cannot apply operation " + Utilities.singleQuote(opcode.toString()) +
-                                " to arguments of type " + ltype.asSqlString() + " and " + rtype.asSqlString(), node);
-                }
-            }
         } else if (ltype.is(IsNumericType.class)) {
             map = this.arithmeticFunctions;
         } else if (ltype.is(DBSPTypeString.class)) {
@@ -237,13 +222,10 @@ public class RustSqlRuntimeLibrary {
         if (map == null)
             throw new UnimplementedException("Rust implementation for " +
                     Utilities.singleQuote(opcode.toString()) + " not found", node);
-        for (String k: map.keySet()) {
-            DBSPOpcode inMap = map.get(k);
-            if (opcode.equals(inMap)) {
-                return k + "_" + tsuffixl + suffixl + "_" + tsuffixr + suffixr + suffixReturn;
-            }
-        }
+        String k = map.get(opcode);
+        if (k != null)
+            return k + separator + tsuffixl + suffixl + separator + tsuffixr + suffixr;
         throw new UnimplementedException("Rust implementation for " +
-                Utilities.singleQuote(opcode.toString()) + "/" + ltype + " not found", node);
+                opcode.name() + "/" + ltype + " not found", node);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -124,6 +124,17 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
     }
 
     @Override
+    public void postorder(DBSPTimeAddSub node) {
+        DBSPExpression left = this.getE(node.left);
+        DBSPExpression right = this.getE(node.right);
+        this.map(node, new DBSPTimeAddSub(node.getNode(),
+                node.getType(),
+                node.opcode,
+                left,
+                right));
+    }
+
+    @Override
     public void postorder(DBSPBlockExpression node) {
         List<DBSPStatement> statements =
                 Linq.map(node.contents, c -> this.get(c).to(DBSPStatement.class));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -870,6 +870,19 @@ public abstract class InnerRewriteVisitor
     }
 
     @Override
+    public VisitDecision preorder(DBSPTimeAddSub expression) {
+        this.push(expression);
+        DBSPExpression left = this.transform(expression.left);
+        DBSPExpression right = this.transform(expression.right);
+        DBSPType type = this.transform(expression.getType());
+        this.pop(expression);
+        DBSPExpression result = new DBSPTimeAddSub(expression.getNode(), type,
+                expression.opcode, left, right);
+        this.map(expression, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
     public VisitDecision preorder(DBSPBlockExpression expression) {
         this.push(expression);
         List<DBSPStatement> body = Linq.map(expression.contents, this::transform);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -610,6 +610,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPExpression) node);
     }
 
+    public VisitDecision preorder(DBSPTimeAddSub node) {
+        return this.preorder((DBSPExpression) node);
+    }
+
     public VisitDecision preorder(DBSPEnumValue node) {
         return this.preorder((DBSPExpression) node);
     }
@@ -1241,6 +1245,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public void postorder(DBSPBinaryExpression node) {
+        this.postorder((DBSPExpression) node);
+    }
+
+    public void postorder(DBSPTimeAddSub node) {
         this.postorder((DBSPExpression) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -648,7 +648,7 @@ public class Simplify extends ExpressionTranslator {
                         }
                     }
                 }
-            } else if (opcode == DBSPOpcode.ADD || opcode == DBSPOpcode.TS_ADD) {
+            } else if (opcode == DBSPOpcode.ADD) {
                 if (left.is(DBSPLiteral.class)) {
                     DBSPLiteral leftLit = left.to(DBSPLiteral.class);
                     IHasZero iLeftType = leftType.as(IHasZero.class);
@@ -676,7 +676,7 @@ public class Simplify extends ExpressionTranslator {
                         }
                     }
                 }
-            } else if (opcode == DBSPOpcode.SUB || opcode == DBSPOpcode.TS_SUB) {
+            } else if (opcode == DBSPOpcode.SUB) {
                 if (left.is(DBSPLiteral.class)) {
                     DBSPLiteral leftLit = left.to(DBSPLiteral.class);
                     if (leftLit.isNull()) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
@@ -38,6 +38,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPMapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPSomeExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPStaticExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTimeAddSub;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedUnwrapExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnsignedWrapExpression;
@@ -230,6 +231,12 @@ public class FindUnusedFields extends SymbolicInterpreter<FieldUseMap> {
 
     @Override
     public void postorder(DBSPBinaryExpression expression) {
+        this.used(expression.left);
+        this.used(expression.right);
+    }
+
+    @Override
+    public void postorder(DBSPTimeAddSub expression) {
         this.used(expression.left);
         this.used(expression.right);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPBinaryExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPBinaryExpression.java
@@ -31,6 +31,11 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
@@ -45,6 +50,15 @@ public final class DBSPBinaryExpression extends DBSPExpression {
         this.opcode = opcode;
         this.left = left;
         this.right = right;
+        if (opcode == DBSPOpcode.ADD || opcode == DBSPOpcode.SUB) {
+            // These should use DBSPTimeAddSub
+            Utilities.enforce(!type.is(DBSPTypeMillisInterval.class));
+            Utilities.enforce(!type.is(DBSPTypeMonthsInterval.class));
+            Utilities.enforce(!type.is(DBSPTypeTime.class));
+            Utilities.enforce(!type.is(DBSPTypeDate.class));
+            Utilities.enforce(!type.is(DBSPTypeTimestamp.class));
+        }
+
     }
 
     public DBSPBinaryExpression replaceSources(DBSPExpression left, DBSPExpression right) {
@@ -102,9 +116,6 @@ public final class DBSPBinaryExpression extends DBSPExpression {
     public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
         DBSPBinaryExpression otherExpression = other.as(DBSPBinaryExpression.class);
         if (otherExpression == null)
-            return false;
-        if (this.opcode == DBSPOpcode.TS_SUB || this.opcode == DBSPOpcode.TS_ADD &&
-            !this.hasSameType(other))
             return false;
         return this.opcode == otherExpression.opcode &&
                 context.equivalent(this.left, otherExpression.left) &&

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -55,9 +55,6 @@ public enum DBSPOpcode {
     DECIMAL_TO_INTEGER("decimal_to_integer", false),
     INTEGER_TO_DECIMAL("integer_to_decimal", false),
 
-    // Timestamp-based operations
-    TS_ADD("+", false),
-    TS_SUB("-", false),
     // Interval-based operations
     INTERVAL_MUL("*", false),
     INTERVAL_DIV("/", false),
@@ -120,7 +117,7 @@ public enum DBSPOpcode {
             case WRAP_BOOL, MAP_CONVERT, ARRAY_CONVERT, CONTROLLED_FILTER_GTE, AGG_LTE, AGG_GTE, AGG_ADD, AGG_MIN,
                  AGG_MAX, AGG_XOR, AGG_OR, AGG_AND, IS_DISTINCT, CONCAT, MIN, MAX, OR, AND, IS_NOT_FALSE, IS_NOT_TRUE,
                  AGG_MAX1, AGG_MIN1, INDICATOR -> false;
-            case NEG, INTERVAL_DIV, INTERVAL_MUL, TS_SUB, TS_ADD, DECIMAL_TO_INTEGER, INTEGER_TO_DECIMAL,
+            case NEG, INTERVAL_DIV, INTERVAL_MUL, DECIMAL_TO_INTEGER, INTEGER_TO_DECIMAL,
                  RUST_INDEX, VARIANT_INDEX, MAP_INDEX,
                  SQL_INDEX, XOR, BW_OR, MUL_WEIGHT, BW_AND, GTE, LTE, GT, LT, NEQ, EQ, MOD, DIV_NULL, DIV, MUL, SUB,
                  ADD, TYPEDBOX, IS_TRUE, IS_FALSE, NOT, UNARY_PLUS -> true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTimeAddSub.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPTimeAddSub.java
@@ -1,0 +1,122 @@
+package org.dbsp.sqlCompiler.ir.expression;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMonthsInterval;
+import org.dbsp.util.IIndentStream;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.Nullable;
+
+/** Represents a wide class of addition or subtraction operations on time-related values.
+ * Time-related values can have one of 5 main types
+ * - DATE
+ * - TIME
+ * - TIMESTAMP
+ * - SHORT INTERVAL
+ * - LONG INTERVAL
+ * Operation can be addition or subtraction. */
+public class DBSPTimeAddSub extends DBSPExpression {
+    public final DBSPOpcode opcode;
+    public final DBSPExpression left;
+    public final DBSPExpression right;
+    // The following two fields are redundant with the result type information, and can be derived from it.
+    // However, by keeping them here explicitly we ensure that equivalence checks do not forget to check the result type.
+    // The result type for all other operations is a deterministic function of the input types and the operation fields.
+    // By using these fields, we ensure that this operation follows the same pattern.
+    @Nullable
+    public final DBSPTypeMillisInterval.Units shortUnits;
+    @Nullable
+    public final DBSPTypeMonthsInterval.Units longUnits;
+
+    public DBSPTimeAddSub(CalciteObject node, DBSPType type, DBSPOpcode opcode, DBSPExpression left, DBSPExpression right) {
+        super(node, type);
+        this.opcode = opcode;
+        Utilities.enforce(opcode == DBSPOpcode.ADD || opcode == DBSPOpcode.SUB);
+        this.left = left;
+        this.right = right;
+        if (this.type.is(DBSPTypeMillisInterval.class)) {
+            this.shortUnits = this.type.to(DBSPTypeMillisInterval.class).units;
+            this.longUnits = null;
+        } else if (this.type.is(DBSPTypeMonthsInterval.class)) {
+            this.longUnits = this.type.to(DBSPTypeMonthsInterval.class).units;
+            this.shortUnits = null;
+        } else {
+            this.shortUnits = null;
+            this.longUnits = null;
+        }
+    }
+
+    @Override
+    public DBSPExpression deepCopy() {
+        return new DBSPTimeAddSub(this.node, this.type, this.opcode, left.deepCopy(), right.deepCopy());
+    }
+
+    @Override
+    public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
+        DBSPTimeAddSub otherExpression = other.as(DBSPTimeAddSub.class);
+        if (otherExpression == null)
+            return false;
+        return this.opcode == otherExpression.opcode &&
+                this.shortUnits == otherExpression.shortUnits &&
+                this.longUnits == otherExpression.longUnits &&
+                context.equivalent(this.left, otherExpression.left) &&
+                context.equivalent(this.right, otherExpression.right);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        visitor.property("type");
+        this.type.accept(visitor);
+        visitor.property("left");
+        this.left.accept(visitor);
+        visitor.property("right");
+        this.right.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean sameFields(IDBSPInnerNode other) {
+        DBSPTimeAddSub o = other.as(DBSPTimeAddSub.class);
+        if (o == null)
+            return false;
+        return this.left == o.left &&
+                this.right == o.right &&
+                this.opcode == o.opcode &&
+                this.longUnits == o.longUnits &&
+                this.shortUnits == o.shortUnits;
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        return builder.append("(")
+                .append(this.left)
+                .append(" ")
+                .append(this.left.type.mayBeNull ? "?" : "")
+                .append(this.opcode.toString())
+                .append(this.right.type.mayBeNull ? "?" : "")
+                .append(" ")
+                .append(this.right)
+                .append(")");
+    }
+
+    @SuppressWarnings("unused")
+    public static DBSPTimeAddSub fromJson(JsonNode node, JsonDecoder decoder) {
+        DBSPType type = getJsonType(node, decoder);
+        DBSPExpression left = fromJsonInner(node, "left", decoder, DBSPExpression.class);
+        DBSPExpression right = fromJsonInner(node, "right", decoder, DBSPExpression.class);
+        DBSPOpcode opcode = DBSPOpcode.fromJson(node);
+        return new DBSPTimeAddSub(CalciteObject.EMPTY, type, opcode, left, right);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampDiffTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampDiffTests.java
@@ -3,7 +3,7 @@ package org.dbsp.sqlCompiler.compiler.sql.mysql;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.junit.Test;
 
-public class TimestampdiffTests extends SqlIoTest {
+public class TimestampDiffTests extends SqlIoTest {
     @Test
     public void issue3021() {
         this.compileRustTestCase("""


### PR DESCRIPTION
Fixes #5103

Before this PR all arithmetic on 5 types of values (TIME, DATE, TIMETSTAMP, short intervals, and long intervals) was using just two opcodes TS_ADD and TS_SUB. The types of the arguments and result were used to discriminate the operation. This led to some subtle bugs in the past. The PR introduces non-polymorphic operations for representing explicitly all allowed combinations: e.g., TS_ADD_SHORT_TS. This is how the code in sqllib looks anyway.