### PR TITLE
s3_input: retry on intermittent connection failure

### DIFF
--- a/crates/feldera-types/src/transport/s3.rs
+++ b/crates/feldera-types/src/transport/s3.rs
@@ -6,7 +6,7 @@ fn default_max_concurrent_fetches() -> u32 {
 }
 
 fn default_max_retries() -> u32 {
-    3
+    5
 }
 
 /// Configuration for reading data from AWS S3.
@@ -47,9 +47,9 @@ pub struct S3InputConfig {
     #[serde(default = "default_max_concurrent_fetches")]
     pub max_concurrent_fetches: u32,
 
-    /// Maximum number of retries for failed requests.
-    /// This is used for both, the AWS SDK and by Feldera to handle transient connection errors.
-    /// Recommended range: 2-5. Default: 3.
+    /// Retry `max_retries` times with exponential backoff.
+    /// If the object changes during a retry attempt, the remaining part of the object will not be processed.
+    /// Recommended range: 3-10. Default: 5.
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
 }

--- a/docs.feldera.com/docs/connectors/sources/s3.md
+++ b/docs.feldera.com/docs/connectors/sources/s3.md
@@ -32,6 +32,7 @@ The S3 input connector supports [fault tolerance](/pipelines/fault-tolerance).
 | `bucket_name`[^2]             | string |            | S3 bucket name. |
 | `endpoint_url`                | string |            | The endpoint URL used to communicate with this service. Explicitly set it to connect to non-AWS services. For example, use `https://storage.googleapis.com` to interact with Google Cloud Storage. |
 | `max_concurrent_fetches`      | integer| 8          | <p>Controls the number of S3 objects fetched in parallel.</p><p>Increasing this value can improve throughput by enabling greater concurrency. However, higher concurrency may lead to timeouts or increased memory usage due to in-memory buffering.</p><p>Recommended range: 1–10. Default: 8.</p> |
+| `max_retries`                 | integer| 5          | Retry `max_retries` times with exponential backoff. <p>If the object changes during a retry attempt, the remaining part of the object will not be processed.</p> |
 
 :::tip
 When `prefix` is used, Feldera reads objects in alphabetical order,

--- a/openapi.json
+++ b/openapi.json
@@ -10085,7 +10085,7 @@
           "max_retries": {
             "type": "integer",
             "format": "int32",
-            "description": "Maximum number of retries for failed requests.\nThis is used for both, the AWS SDK and by Feldera to handle transient connection errors.\nRecommended range: 2-5. Default: 3.",
+            "description": "Retry `max_retries` times with exponential backoff.\nIf the object changes during a retry attempt, the remaining part of the object will not be processed.\nRecommended range: 3-10. Default: 5.",
             "minimum": 0
           },
           "no_sign_request": {


### PR DESCRIPTION
Adds a `max_retries` config to `S3InputConfig`. Default: 3. 

Introduces a retry mechanism at a couple points:
- Introduces a `retry_fetching_object` function that retries to fetch an object with exponential backoff, with a base delay of 100 seconds until `max_retries` is reached.
- On failures midway when reading an object (`object.body.next()` fails) drop this connection to refetch this object and try again for `max_retries` attempts. Failures will only be reported as transport connection issue if they persist after the retries.

To ensure that the object has not changed between reconnections, and we are reading from the correct offset, we keep around the last chunk and compare it to the first chunk we get after reconnection. We then skip all the bytes that were already processed.

Fixes a prior bug where we would get a random chunk of bytes when trying to start from a specified offset. To start reading from an offset, we must set: `bytes={start}-`. This final `-` was missing previously.

