### PR TITLE
[docs] add JSON logging howto and specs to the documentation

### DIFF
--- a/crates/feldera-observability/src/json_logging.rs
+++ b/crates/feldera-observability/src/json_logging.rs
@@ -15,6 +15,8 @@ pub enum ServiceName {
     Runner,
     CompilerServer,
     ControlPlane,
+    KubernetesRunner,
+    Pipeline,
 }
 
 impl ServiceName {
@@ -24,6 +26,8 @@ impl ServiceName {
             ServiceName::Runner => "runner",
             ServiceName::CompilerServer => "compiler-server",
             ServiceName::ControlPlane => "control-plane",
+            ServiceName::KubernetesRunner => "kubernetes-runner",
+            ServiceName::Pipeline => "pipeline",
         }
     }
 }
@@ -86,7 +90,7 @@ where
             LogIdentity::Service { service_name } => {
                 service_name.map(|service| service.as_str().to_string())
             }
-            LogIdentity::Pipeline { .. } => None,
+            LogIdentity::Pipeline { .. } => Some(ServiceName::Pipeline.as_str().to_string()),
         };
 
         // Allow structured fields to override the defaults.
@@ -114,6 +118,12 @@ where
             && feldera_service.as_deref() != Some("compiler-server")
         {
             feldera_service = Some("compiler-server".to_string());
+        } else if metadata
+            .target()
+            .starts_with("cluster_control_plane::kubernetes_runner")
+            && feldera_service.as_deref() != Some("kubernetes-runner")
+        {
+            feldera_service = Some("kubernetes-runner".to_string());
         }
         let mut obj = Map::new();
         obj.insert("timestamp".to_string(), Value::String(now_timestamp()));

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -971,7 +971,6 @@ pub(crate) async fn post_pipeline(
     info!(
         pipeline = %returned_pipeline.name,
         pipeline_id = %returned_pipeline.id,
-        tenant_id = %tenant_id.0,
         "Created pipeline {name:?} ({}) (tenant: {})",
         returned_pipeline.id,
         *tenant_id
@@ -1045,7 +1044,6 @@ pub(crate) async fn put_pipeline(
         info!(
             pipeline = %returned_pipeline.name,
             pipeline_id = %returned_pipeline.id,
-            tenant_id = %tenant_id.0,
             "Created pipeline {pipeline_name:?} ({}) (tenant: {})",
             returned_pipeline.id,
             *tenant_id
@@ -1057,7 +1055,6 @@ pub(crate) async fn put_pipeline(
         info!(
             pipeline = %returned_pipeline.name,
             pipeline_id = %returned_pipeline.id,
-            tenant_id = %tenant_id.0,
             "Fully updated pipeline {pipeline_name:?} ({}) to version {} (tenant: {})",
             returned_pipeline.id,
             returned_pipeline.version,
@@ -1268,7 +1265,6 @@ pub(crate) async fn delete_pipeline(
     info!(
         pipeline = %pipeline_name,
         pipeline_id = %pipeline_id,
-        tenant_id = %tenant_id.0,
         "Deleted pipeline {pipeline_name:?} ({}) (tenant: {})",
         pipeline_id,
         *tenant_id

--- a/crates/pipeline-manager/src/compiler/rust_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/rust_compiler.rs
@@ -895,7 +895,7 @@ pub async fn perform_rust_compilation(
     })?;
     let runtime_selector = program_config.runtime_version();
     assert!(has_unstable_feature("runtime_version") || runtime_selector.is_platform());
-    let pipeline_name_for_log = pipeline_name.clone().unwrap_or_default();
+    let pipeline_name_for_log = pipeline_name.clone().unwrap_or_else(|| "N/A".to_string());
     info!(
         pipeline_id = %pipeline_id,
         pipeline = pipeline_name_for_log.as_str(),
@@ -1550,7 +1550,7 @@ async fn call_compiler(
     // Create pipeline-binaries directory if it does not yet exist
     let pipeline_binaries_dir = workspace_dir.join("pipeline-binaries");
     create_dir_if_not_exists(&pipeline_binaries_dir).await?;
-    let pipeline_name_for_log = pipeline_name.unwrap_or_default();
+    let pipeline_name_for_log = pipeline_name.unwrap_or_else(|| "N/A".to_string());
 
     // Create file where stdout will be written to
     let stdout_file_path = pipeline_main_crate_dir.join("stdout.log");

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -503,10 +503,10 @@ pub(crate) async fn perform_sql_compilation(
 
     let runtime_selector = program_config.runtime_version();
     assert!(has_unstable_feature("runtime_version") || runtime_selector.is_platform());
-    let pipeline_name = pipeline_name.as_deref();
+    let pipeline_name = pipeline_name.as_deref().unwrap_or("N/A");
     info!(
         pipeline_id = %pipeline_id,
-        pipeline = pipeline_name.unwrap_or(""),
+        pipeline = pipeline_name,
         "SQL compilation started: pipeline {} (program version: {}{})",
         pipeline_id,
         program_version,
@@ -637,7 +637,7 @@ pub(crate) async fn perform_sql_compilation(
                             Err(e) => {
                                 error!(
                                     pipeline_id = %pipeline_id,
-                                    pipeline = pipeline_name.unwrap_or(""),
+                                    pipeline = pipeline_name,
                                     "SQL compilation outdated check failed due to database error: {e}"
                                 )
                                 // As preemption check failing is not fatal, compilation will continue
@@ -697,7 +697,7 @@ pub(crate) async fn perform_sql_compilation(
                 } else {
                     error!(
                         pipeline_id = %pipeline_id,
-                        pipeline = pipeline_name.unwrap_or(""),
+                        pipeline = pipeline_name,
                         "Unable to parse SQL compiler response after successful compilation, warnings were not passed to client: {}",
                         stderr_str
                     );

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -219,7 +219,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
     pub async fn run(mut self) {
         let pipeline_id = self.pipeline_id;
         debug!(
-            pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+            pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
             pipeline_id = %pipeline_id,
             "Automaton started: pipeline {pipeline_id}"
         );
@@ -252,7 +252,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                         // Pipeline deletions should not lead to errors in the logs.
                         DBError::UnknownPipeline { pipeline_id } => {
                             info!(
-                                pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                                pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                                 pipeline_id = %pipeline_id,
                                 "Automaton ended: pipeline {pipeline_id}"
                             );
@@ -452,7 +452,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                                 // and as such will cause a database error to bubble up if it does not.
                                 info!(
                                     pipeline_id = %self.pipeline_id,
-                                    pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                                    pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                                     "Pipeline automaton {}: version initially intended to be started ({}) is outdated by latest ({})",
                                     self.pipeline_id,
                                     outdated_version,
@@ -462,7 +462,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                                 {
                                     error!(
                                         pipeline_id = %self.pipeline_id,
-                                        pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                                        pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                                         "Outdated pipeline version occurred when transitioning from {} to Provisioning (not Stopped)",
                                         pipeline.deployment_resources_status
                                     );
@@ -1276,7 +1276,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                                 _ => {
                                     warn!(
                                         pipeline_id = %pipeline_id,
-                                        pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                                        pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                                         "Pipeline {pipeline_id} status is unavailable because the endpoint responded with 503 Service Unavailable:\n{error_response:?}"
                                     );
                                     Ok(ExtendedRuntimeStatus {
@@ -1304,7 +1304,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     });
                     error!(
                         pipeline_id = %pipeline_id,
-                        pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                        pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                         "Pipeline {pipeline_id} has fatal runtime error and will be stopped. Error:\n{error_response:?}"
                     );
                     Err(error_response)
@@ -1323,7 +1323,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 } else {
                     warn!(
                         pipeline_id = %pipeline_id,
-                        pipeline = self.pipeline_name.as_deref().unwrap_or(""),
+                        pipeline = self.pipeline_name.as_deref().unwrap_or("N/A"),
                         "Pipeline {pipeline_id} status is unavailable because the endpoint could not be reached due to: {e}"
                     );
                     Ok(ExtendedRuntimeStatus {

--- a/docs.feldera.com/docs/operations/json-logging.md
+++ b/docs.feldera.com/docs/operations/json-logging.md
@@ -1,0 +1,106 @@
+---
+title: JSON logging
+sidebar_position: 25
+---
+
+# Logging (JSON)
+
+This page documents the structured JSON log format emitted when the `FELDERA_LOG_JSON` environment variable is set (for example, `FELDERA_LOG_JSON=1`). The default pretty text logs are unchanged. Logs come from two sources:
+
+- Control plane components (manager, runner, compiler-server, kubernetes-runner, control-plane): these carry `feldera-service` set to the component name.
+- Pipelines (the dataflow processes): these carry `feldera-service: "pipeline"` and `pipeline-name`/`pipeline-id`. Control plane logs that are about a specific pipeline also include the pipeline identifiers.
+
+## Identity fields
+
+These identity fields are lifted alongside the standard top-level metadata (`timestamp`, `level`, `target`):
+
+| Field              | Meaning                                                                          |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `feldera-service`  | Source: `manager` \| `runner` \| `compiler-server` \| `kubernetes-runner` \| `control-plane` \| `pipeline` (auto-tagged by module path). This identifies which Feldera component produced the log. |
+| `pipeline-name`    | Human-friendly pipeline name when available; if it is not immediately available it is set to `N/A`. Present for pipeline events. Control plane events tied to a specific pipeline also include this name. |
+| `pipeline-id`      | Pipeline UUID when the event relates to a specific pipeline. Present for pipeline events. Control plane events tied to a specific pipeline also include this ID. |
+
+## JSON object members (spec)
+
+Each log entry is a JSON object whose members are:
+
+- `timestamp` (required): string value, UTC with microsecond precision (e.g. `2025-12-06T02:08:14.902292Z`).
+- `level` (required): string value, one of `TRACE` \| `DEBUG` \| `INFO` \| `WARN` \| `ERROR`.
+- `target` (required): string value, Rust module path of the log source.
+- `fields` (required): object value containing the event payload (one of `message` or `line`).
+- `feldera-service` (optional): string value, present for control plane events and for pipelines (as `pipeline`).
+- `pipeline-name` (optional): string value, present when the event is tied to a pipeline.
+- `pipeline-id` (optional): string value, present when the event is tied to a pipeline.
+
+> Practical rule: every log line has `timestamp`, `level`, `target`, and `fields`. Control plane logs add `feldera-service`; pipeline-related logs add `feldera-service: "pipeline"` plus `pipeline-name` and `pipeline-id`.
+
+## Examples
+
+Manager pipeline lifecycle:
+
+```json
+{
+  "timestamp": "2025-12-05T18:54:07.231095Z",
+  "level": "INFO",
+  "target": "pipeline_manager::api::endpoints::pipeline_management",
+  "feldera-service": "manager",
+  "pipeline-name": "MyPipeline",
+  "pipeline-id": "019af011-5282-7751-98c2-f61478d0df63",
+  "fields": {
+    "message": "Created pipeline \"MyPipeline\" (019af011-5282-7751-98c2-f61478d0df63) (tenant: 00000000-0000-0000-0000-000000000000)"
+  }
+}
+```
+
+Runner log stream starting up:
+
+```json
+{
+  "timestamp": "2025-12-06T02:08:14.902292Z",
+  "level": "INFO",
+  "target": "pipeline_manager::runner::pipeline_logs",
+  "feldera-service": "runner",
+  "pipeline-name": "N/A",
+  "pipeline-id": "019af16a-ba26-7933-a6e5-65d9d717cb7a",
+  "fields": { "line": "Fresh start of pipeline logs" }
+}
+```
+
+Compiler server log:
+
+```json
+{
+  "timestamp": "2025-12-05T18:01:22.996459Z",
+  "level": "INFO",
+  "target": "pipeline_manager::compiler::sql_compiler",
+  "feldera-service": "compiler-server",
+  "pipeline-name": "MyPipeline",
+  "pipeline-id": "019aefac-fc78-75b0-9089-0f7496f8ac1f",
+  "fields": { "message": "SQL compilation started: pipeline 019aefac-fc78-75b0-9089-0f7496f8ac1f (program version: 1)" }
+}
+```
+
+Pipeline log:
+
+```json
+{
+  "timestamp": "2025-12-09T21:26:17.362514Z",
+  "level": "INFO",
+  "target": "dbsp_adapters::server",
+  "feldera-service": "pipeline",
+  "pipeline-name": "MyPipeline",
+  "pipeline-id": "019af16a-ba26-7933-a6e5-65d9d717cb7a",
+  "fields": { "message": "Pipeline initialization complete" }
+}
+```
+
+## Example: enabling JSON
+
+```bash
+FELDERA_LOG_JSON=1 cargo run --bin=pipeline-manager
+```
+
+## Notes
+
+- Plain-text logging remains the default; JSON is opt-in via `FELDERA_LOG_JSON`.
+- The event payload lives under `fields` (`message` or `line`); identity fields (`feldera-service`, `pipeline-name`, `pipeline-id`) are at the top level.

--- a/docs.feldera.com/docs/sidebars.js
+++ b/docs.feldera.com/docs/sidebars.js
@@ -459,6 +459,7 @@ const operations = {
         'operations/guide',
         'operations/memory',
         'operations/metrics',
+        'operations/json-logging',
     ]
 };
 


### PR DESCRIPTION
[docs] add JSON logging howto and specs to the documentation
Fix json formatting and update the docs accordingly
## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
