### PR TITLE
[sbom] add SBOM workflows and release artifacts

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,6 +22,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
+      actions: read
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -31,6 +32,9 @@ jobs:
           private-key: ${{ secrets.CI_ACCESS_APP_PKEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: write
+          permission-actions: read
+          permission-workflows: write
+          permission-metadata: read
 
       - name: Set SHA_TO_RELEASE and CURRENT_VERSION
         if: github.event_name == 'repository_dispatch'
@@ -66,10 +70,11 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
           commit: ${{ env.SHA_TO_RELEASE }}
-          name: feldera-sql-compiler-*|feldera-binaries-*|feldera-docs
+          name: feldera-sql-compiler-*|feldera-binaries-*|feldera-docs|feldera-sbom
           name_is_regexp: true
           skip_unpack: true
           if_no_artifact_found: fail
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Attach version to binaries
         run: |
@@ -78,6 +83,12 @@ jobs:
           unzip -jo feldera-sql-compiler.zip 'sql2dbsp-jar-with-dependencies.jar' -d .
           mv sql2dbsp-jar-with-dependencies.jar sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
           mv feldera-docs.zip feldera-docs-v${{ env.CURRENT_VERSION }}.zip
+
+      - name: Prepare SBOM files
+        run: |
+          unzip feldera-sbom.zip
+          mv feldera-sbom-source-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-source-v${{ env.CURRENT_VERSION }}.spdx.json
+          mv feldera-sbom-image-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-image-v${{ env.CURRENT_VERSION }}.spdx.json
 
       - name: Generate Release token
         id: release-token
@@ -102,6 +113,8 @@ jobs:
             feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
             feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
             sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
+            feldera-sbom-source-v${{ env.CURRENT_VERSION }}.spdx.json
+            feldera-sbom-image-v${{ env.CURRENT_VERSION }}.spdx.json
           # A custom token is necessary so the ci-post-release.yml workflow is triggered
           # see also https://github.com/softprops/action-gh-release/issues/59
           token: ${{ steps.release-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     secrets: inherit
 
+  invoke-generate-sbom:
+    name: Generate SBOMs
+    needs: [invoke-build-docker]
+    uses: ./.github/workflows/generate-sbom.yml
+    secrets: inherit
+
   invoke-tests-integration-platform:
     name: Integration Tests
     needs: [invoke-build-docker]
@@ -77,6 +83,7 @@ jobs:
       - invoke-tests-unit
       - invoke-tests-adapter
       - invoke-build-docker
+      - invoke-generate-sbom
       - invoke-tests-integration-platform
       - invoke-tests-integration-runtime
       - invoke-tests-java

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,42 @@
+name: Generate SBOMs
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  generate-sbom:
+    if: ${{ vars.CI_DRY_RUN != 'true' }}
+    runs-on: ubuntu-latest-amd64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Syft
+        uses: anchore/sbom-action/download-syft@v0.17.4
+
+      - name: Create source SBOM
+        run: syft dir:. --output spdx-json=feldera-sbom-source-${GITHUB_SHA}.spdx.json
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create image SBOM
+        run: |
+          IMAGE_REF=${{ vars.FELDERA_IMAGE_NAME }}:sha-${GITHUB_SHA}
+          syft "$IMAGE_REF" --output spdx-json=feldera-sbom-image-${GITHUB_SHA}.spdx.json
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: feldera-sbom
+          path: |
+            feldera-sbom-source-${{ github.sha }}.spdx.json
+            feldera-sbom-image-${{ github.sha }}.spdx.json
+          retention-days: 7


### PR DESCRIPTION
Generate SBOM files for binaries and image in SPDX-JSON format and add SBOM artifacts to release generation

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
