### PR TITLE
[SQL] Skip the (incorrect) type inference when casting NULL values

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
@@ -797,14 +797,14 @@ public class ConvertletTable extends ReflectiveConvertletTable {
                     call.getParserPosition(), call, value, validator, rexBuilder, safe);
         }
 
+        if (SqlUtil.isNullLiteral(left, false)) {
+            validator.setValidatedNodeType(left, arg.getType());
+            return arg;
+        }
         final SqlDataTypeSpec dataType = (SqlDataTypeSpec) right;
         RelDataType type =
                 SqlCastFunction.deriveType(cx.getTypeFactory(), arg.getType(),
                         dataType.deriveType(validator), safe);
-        if (SqlUtil.isNullLiteral(left, false)) {
-            validator.setValidatedNodeType(left, type);
-            return cx.convertExpression(left);
-        }
         if (null != dataType.getCollectionsTypeName()) {
             RelDataType argComponentType = arg.getType().getComponentType();
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -33,6 +33,7 @@ import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.DBSPTypeCode;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeNull;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
@@ -49,8 +50,9 @@ public final class DBSPCastExpression extends DBSPExpression {
         super(node, to);
         this.source = source;
         this.safe = safe;
-        Utilities.enforce(source.getType().is(DBSPTypeTupleBase.class) == to.is(DBSPTypeTupleBase.class)
-                || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class),
+        Utilities.enforce(source.getType().is(DBSPTypeNull.class)
+                        || source.getType().is(DBSPTypeTupleBase.class) == to.is(DBSPTypeTupleBase.class)
+                        || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class),
                 () -> "Cast to/from tuple from/to non-tuple " + source.getType() + " to " + to);
         Utilities.enforce(to.code != DBSPTypeCode.INTERNED_STRING, () -> "Cast to INTERNED");
         Utilities.enforce(source.getType().code != DBSPTypeCode.INTERNED_STRING, () -> "Cast from INTERNED");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -1549,4 +1549,19 @@ public class Regression1Tests extends SqlIoTest {
                 SELECT u256_sum(num1), u256_sum(num2), SUM(small), MAX(sno)
                 FROM A""");
     }
+
+    @Test
+    public void issue5307() {
+        this.getCCS("""
+                CREATE TYPE LEVEL_1 AS (
+                  col VARCHAR NOT NULL
+                );
+                
+                CREATE TYPE LEVEL_0 AS (
+                  col LEVEL_1
+                );
+                
+                CREATE LOCAL VIEW V AS
+                SELECT NULL::LEVEL_0 AS null_col""");
+    }
 }


### PR DESCRIPTION
Fixes #5307 

I am pretty sure that this is a bug in Calcite; Calcite has very strange rules for deciding whether a ROW type is null, which differ from our rules. This fix prevents applying the Calcite type inference rules altogether when casting NULL literals, by noticing that the prior analysis already has computed a correct type for the NULL. We can fix this without involving calcite because we have made a clone of the ConvertletTable class in Calcite to avoid other code transformations that we find undesired.