### PR TITLE
[docs] example how to enable json logs with helm

### DIFF
--- a/docs.feldera.com/docs/operations/json-logging.md
+++ b/docs.feldera.com/docs/operations/json-logging.md
@@ -100,6 +100,12 @@ Pipeline log:
 FELDERA_LOG_JSON=1 cargo run --bin=pipeline-manager
 ```
 
+Helm:
+
+```bash
+helm upgrade --install feldera <chart> --namespace feldera --create-namespace --set logJson=true
+```
+
 ## Notes
 
 - Plain-text logging remains the default; JSON is opt-in via `FELDERA_LOG_JSON`.


### PR DESCRIPTION
Add an example in docs how to enable JSON logging in a feldera container

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
