### PR TITLE
[SQL] Generate correct code for LAG operators, using the comparator type

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -1313,7 +1313,7 @@ public class ToRustVisitor extends CircuitVisitor {
                 .append(operator.operation);
         this.builder.append("_persistent");
         this.builder.append("::<_, _, _, ");
-        operator.comparator.accept(this.innerVisitor);
+        this.builder.append(operator.comparator.to(DBSPComparatorExpression.class).getComparatorStructName());
         this.builder.append(", _>")
                 .append("(hash, ")
                 .increase();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -1564,4 +1564,13 @@ public class Regression1Tests extends SqlIoTest {
                 CREATE LOCAL VIEW V AS
                 SELECT NULL::LEVEL_0 AS null_col""");
     }
+
+    @Test
+    public void issue5311() {
+        this.getCCS("""
+                CREATE TABLE tbl(intt INT);
+                CREATE MATERIALIZED VIEW v AS SELECT
+                LAG(intt) OVER ()
+                FROM tbl;""");
+    }
 }

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -10,15 +10,15 @@ default = []
 [dependencies]
 arcstr = { version = "1.2.0" }
 paste = { version = "1.0.12" }
-derive_more = { version = "0.99.17", features = ["add", "not", "from"] }
+derive_more = { version = "2.0.1", features = ["add", "not", "from"] }
 dbsp = { path = "../../crates/dbsp", features = ["backend-mode"] }
 dbsp_adapters = { path = "../../crates/adapters", default-features = false }
 feldera-types = { path = "../../crates/feldera-types" }
 feldera-sqllib = { path = "../../crates/sqllib" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.213", features = ["derive"] }
 compare = { version = "0.1.0" }
-size-of = { version = "0.1.5", package = "feldera-size-of" }
-serde_json = { version = "1.0.127", features = ["arbitrary_precision"] }
+size-of = { version = "0.1.7", package = "feldera-size-of" }
+serde_json = { version = "1.0.132", features = ["arbitrary_precision"] }
 rkyv = { version = "0.7.45", default-features = false, features = ["std", "size_64"] }
 erased-serde = "0.3.31"
 
@@ -28,7 +28,7 @@ tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_ma
 [dev-dependencies]
 hashing = { path = "../lib/hashing" }
 readers = { path = "../lib/readers" }
-uuid = { version = "1.6.1" }
+uuid = { version = "1.17.0" }
 # Used only in some unit tests
 metrics = { version = "0.23.0" }
 metrics-util = { version = "0.17.0" }
@@ -37,7 +37,3 @@ sltsqlvalue = { path = "../lib/sltsqlvalue" }
 [lib]
 path = "src/lib.rs"
 doctest = false
-
-# Incremental builds sometimes crash the Rust compiler
-#[profile.test]
-#incremental = false


### PR DESCRIPTION
Fixes #5311

Also updates temp/Cargo.toml to match the versions of the crates used in the root Cargo.toml file