### PR TITLE
[SQL] Better error reporting for calls to unwrap

### DIFF
--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -3941,6 +3941,14 @@ pub fn cast_to_Uuid_bytes(value: ByteArray) -> SqlResult<Uuid> {
 
 cast_function!(Uuid, Uuid, bytes, ByteArray);
 
+#[doc(hidden)]
+pub fn unwrap_value<T>(value: Option<T>, message: &'static str) -> SqlResult<T> {
+    match value {
+        None => Err(SqlRuntimeError::from_strng(message)),
+        Some(value) => Ok(value),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use arcstr::ArcStr;

--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -1005,13 +1005,18 @@ pub fn md5_s(source: SqlString) -> SqlString {
 
 some_polymorphic_function1!(md5, s, SqlString, SqlString);
 
+#[doc(hidden)]
 pub fn intern(s: Option<SqlString>) -> Option<InternedString> {
     s.map(|s| intern_string(&s))
 }
 
+#[doc(hidden)]
 pub fn unintern(id: Option<InternedString>) -> Option<SqlString> {
     match id {
         None => None,
-        Some(id) => unintern_string(&id),
+        Some(id) => match unintern_string(&id) {
+            Some(s) => Some(s),
+            None => panic!("Interning library has not returned a string for id='{id}'"),
+        },
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -625,6 +625,13 @@ public class ToJsonInnerVisitor extends InnerVisitor {
     }
 
     @Override
+    public void postorder(DBSPUnwrapExpression node) {
+        this.property("message");
+        this.stream.append(node.message);
+        super.postorder(node);
+    }
+
+    @Override
     public void postorder(DBSPUnsignedUnwrapExpression node) {
         this.property("nullsLast");
         this.stream.append(node.nullsLast);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -2125,10 +2125,11 @@ public class ToRustInnerVisitor extends InnerVisitor {
     public VisitDecision preorder(DBSPUnwrapExpression expression) {
         this.push(expression);
         this.builder.append("(");
+        this.builder.append("unwrap_value(");
         expression.expression.accept(this);
-        if (expression.expression.getType().is(DBSPTypeTupleBase.class))
-            this.builder.append(".as_ref()");
-        this.builder.append(".unwrap()");
+        this.builder.append(", ")
+                .append(Utilities.doubleQuote(expression.message, false))
+                .append(")");
         this.builder.append(")");
         this.pop(expression);
         return VisitDecision.STOP;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -589,7 +589,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
                     "TIMESTAMP used for TUMBLE function is nullable; this can cause runtime crashes.\n" +
                             "We recommend filtering out null values before applying the TUMBLE function");
         }
-        args[0] = row.deref().field(timestampIndex).unwrapIfNullable();
+        args[0] = row.deref().field(timestampIndex).unwrapIfNullable("TUMBLE timestamp should never be NULL");
         args[1] = interval;
         if (start != null)
             args[2] = start;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -194,7 +194,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             case TUPLE, RAW_TUPLE -> {
                 DBSPTypeTupleBase tuple = destinationType.to(DBSPTypeTupleBase.class);
                 DBSPExpression[] fields = new DBSPExpression[tuple.size()];
-                DBSPExpression safeSource = source.unwrapIfNullable();
+                DBSPExpression safeSource = source.unwrapIfNullable("Cast to non-nullable type applied to NULL value");
                 for (int i = 0; i < tuple.size(); i++) {
                     if (source.is(DBSPBaseTupleExpression.class) &&
                             source.to(DBSPBaseTupleExpression.class).fields == null) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/AggregateCompiler.java
@@ -965,7 +965,8 @@ public class AggregateCompiler implements ICompilerComponent {
             DBSPExpression isNull = this.getAggregatedValue().is_null();
             DBSPPath path = new DBSPPath(LinearAggregate.userDefinedAccumulatorTypeName(function.getName()), "zero");
             DBSPExpression accumulatorZero = new DBSPApplyExpression(new DBSPPathExpression(DBSPTypeAny.getDefault(), path), innerAccumType);
-            DBSPExpression unwrappedAggregated = this.getAggregatedValue().unwrapIfNullable();
+            DBSPExpression unwrappedAggregated = this.getAggregatedValue()
+                    .unwrapIfNullable("Aggregated value should not be NULL");
             DBSPExpression callMap =
                     new DBSPTupleExpression(
                             new DBSPIfExpression(this.node, isNull, accumulatorZero,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/LeadLagAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/LeadLagAggregates.java
@@ -102,7 +102,7 @@ public class LeadLagAggregates extends WindowAggregates {
         List<DBSPExpression> lagColumnExpressions = new ArrayList<>();
         for (int i = 0; i < lagColumns.size(); i++) {
             int field = lagColumns.get(i);
-            DBSPExpression expression = var.unwrap()
+            DBSPExpression expression = var.unwrap("LAG value should never be NULL")
                     .deref()
                     .field(field)
                     // cast the results to whatever Calcite says they will be.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpandCasts.java
@@ -251,7 +251,8 @@ public class ExpandCasts extends InnerRewriteVisitor {
             } else {
                 result = new DBSPIfExpression(node, source.is_null(),
                         // Causes a runtime panic
-                        type.withMayBeNull(true).nullValue().unwrap(), result);
+                        type.withMayBeNull(true).nullValue()
+                                .unwrap("Cast to non-nullable value applied to NULL"), result);
             }
         }
         return result;
@@ -367,7 +368,7 @@ public class ExpandCasts extends InnerRewriteVisitor {
             } else if (sourceType.mayBeNull && !type.is(DBSPTypeVariant.class)) {
                 // Cast from Option<T> to T
                 // Only VARIANT has a different implementation
-                result = expression.source.unwrap().applyCloneIfNeeded();
+                result = expression.source.unwrap("NULL value should be impossible here").applyCloneIfNeeded();
             }
         } else if (type.is(DBSPTypeVariant.class)) {
             result = convertToVariant(node, source, type.mayBeNull);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -192,7 +192,10 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
 
     @Override
     public void postorder(DBSPMinMax aggregator) {
-        this.map(aggregator, aggregator);
+        DBSPExpression post = this.getEN(aggregator.postProcessing);
+        @Nullable DBSPClosureExpression postClosure = post != null ? post.to(DBSPClosureExpression.class) : null;
+        DBSPMinMax result = new DBSPMinMax(aggregator.getNode(), aggregator.getType(), postClosure, aggregator.aggregation);
+        this.map(aggregator, result);
     }
 
     @Override
@@ -455,7 +458,7 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
     @Override
     public void postorder(DBSPUnwrapExpression node) {
         DBSPExpression expression = this.getE(node.expression);
-        this.map(node, new DBSPUnwrapExpression(expression));
+        this.map(node, new DBSPUnwrapExpression(node.message, expression));
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -1061,7 +1061,7 @@ public abstract class InnerRewriteVisitor
         this.push(expression);
         DBSPExpression source = this.transform(expression.expression);
         this.pop(expression);
-        DBSPExpression result = new DBSPUnwrapExpression(source);
+        DBSPExpression result = new DBSPUnwrapExpression(expression.message, source);
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -152,7 +152,7 @@ public class Simplify extends ExpressionTranslator {
         if (source.is(DBSPSomeExpression.class)) {
             result = source.to(DBSPSomeExpression.class).expression;
         } else {
-            result = source.unwrapIfNullable();
+            result = source.unwrapIfNullable(expression.message);
         }
         this.map(expression, result);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
@@ -505,7 +505,7 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
         DBSPExpression reduced = null;
 
         if (source.mayBeMonotone()) {
-            reduced = new DBSPUnwrapExpression(source.getReducedExpression());
+            reduced = new DBSPUnwrapExpression(expression.message, source.getReducedExpression());
         }
         if (this.positiveExpressions.contains(expression.expression))
             this.positiveExpressions.add(expression);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LowerCircuitVisitor.java
@@ -185,7 +185,8 @@ public class LowerCircuitVisitor extends CircuitCloneVisitor {
                 throw new InternalCompilerError("Unexpected collection type in flatmap " + flatmap.collectionKind);
             }
 
-            DBSPExpression contents = statement.getVarReference().unwrap().deref().applyClone();
+            DBSPExpression contents = statement.getVarReference().unwrap("Collection UNNESTed should not be NULL")
+                    .deref().applyClone();
             collectionExpression = new DBSPIfExpression(flatmap.getNode(), condition, empty, contents);
         } else {
             collectionExpression = statement.getVarReference().deref().applyClone();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/InternInner.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/InternInner.java
@@ -267,7 +267,7 @@ public class InternInner extends ExpressionTranslator {
                 Utilities.enforce(internedType.code == originalType.code);
                 DBSPTypeTupleBase tuple = originalType.to(DBSPTypeTupleBase.class);
                 DBSPExpression[] fields = new DBSPExpression[tuple.size()];
-                DBSPExpression safeSource = interned.unwrapIfNullable();
+                DBSPExpression safeSource = interned.unwrapIfNullable("Tuple should not be NULL");
                 for (int i = 0; i < tuple.size(); i++) {
                     DBSPExpression simplified = Simplify.simplify(this.compiler, safeSource.field(i));
                     fields[i] = callUninternRecursive(simplified, tuple.getFieldType(i));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/RemoveUnusedFields.java
@@ -80,7 +80,7 @@ public class RemoveUnusedFields extends CircuitCloneVisitor {
         DBSPExpression field1 = var.field(1).deref();
         boolean nullable = field1.getType().mayBeNull;
         List<DBSPExpression> resultFields = Linq.map(fieldMap.deref().getUsedFields(),
-                f -> field1.deepCopy().unwrapIfNullable().field(f).applyCloneIfNeeded());
+                f -> field1.deepCopy().unwrapIfNullable("Field should not be NULL").field(f).applyCloneIfNeeded());
         DBSPExpression rightSide = new DBSPTupleExpression(resultFields, nullable);
         if (nullable)
             rightSide = new DBSPIfExpression(node, field1.is_null(), rightSide.getType().none(), rightSide);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPExpression.java
@@ -122,13 +122,14 @@ public abstract class DBSPExpression
     }
 
     /** Unwrap an expression with a nullable type */
-    public DBSPExpression unwrap() {
+    public DBSPExpression unwrap(String message) {
         Utilities.enforce(this.type.mayBeNull, () -> "Unwrapping non-nullable type");
-        return new DBSPUnwrapExpression(this);
+        return new DBSPUnwrapExpression(message, this);
     }
 
-    /** Unwrap an expression if the type is nullable */
-    public DBSPExpression unwrapIfNullable() {
+    /** Unwrap an expression if the type is nullable
+     * @param message Message to report if the unwrap fails. */
+    public DBSPExpression unwrapIfNullable(String message) {
         if (!this.type.mayBeNull)
             return this;
         DBSPBaseTupleExpression tuple = this.as(DBSPBaseTupleExpression.class);
@@ -141,7 +142,7 @@ public abstract class DBSPExpression
                 default: break;
             }
         }
-        return this.unwrap();
+        return this.unwrap(message);
     }
 
     public DBSPExpressionStatement toStatement() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPHandleErrorExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPHandleErrorExpression.java
@@ -13,7 +13,6 @@ import org.dbsp.util.Utilities;
 /**
  * This expression is inserted very late in the circuit transformation
  * to handle (some) expressions that can lead to runtime panics.
- * Today it is only used for casts, but we hope to expand its uses.
  *
  * <p>The actual Rust representation has slightly different types
  * than this instruction; the argument type in particular will always

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnwrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnwrapExpression.java
@@ -15,10 +15,12 @@ import org.dbsp.util.Utilities;
  * Note that there is a different resultUnwrap, which is meant
  * to be applied to Result values */
 public final class DBSPUnwrapExpression extends DBSPExpression {
+    public final String message;
     public final DBSPExpression expression;
 
-    public DBSPUnwrapExpression(DBSPExpression expression) {
+    public DBSPUnwrapExpression(String message, DBSPExpression expression) {
         super(expression.getNode(), expression.getType().withMayBeNull(false));
+        this.message = message;
         this.expression = expression;
         Utilities.enforce(expression.getType().mayBeNull);
     }
@@ -41,18 +43,24 @@ public final class DBSPUnwrapExpression extends DBSPExpression {
         DBSPUnwrapExpression o = other.as(DBSPUnwrapExpression.class);
         if (o == null)
             return false;
-        return this.expression == o.expression;
+        return this.message.equals(o.message) && this.expression == o.expression;
     }
 
     @Override
     public DBSPExpression deepCopy() {
-        return new DBSPUnwrapExpression(this.expression.deepCopy());
+        return new DBSPUnwrapExpression(this.message, this.expression.deepCopy());
     }
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append(this.expression)
+        if (this.message.isEmpty())
+            return builder.append(this.expression)
                 .append(".unwrap()");
+        else
+            return builder.append(this.expression)
+                    .append(".expect(")
+                    .append(Utilities.doubleQuote(this.message, false))
+                    .append(")");
     }
 
     @Override
@@ -67,6 +75,7 @@ public final class DBSPUnwrapExpression extends DBSPExpression {
     public static DBSPUnwrapExpression fromJson(JsonNode node, JsonDecoder decoder) {
         getJsonType(node, decoder);
         DBSPExpression expression = fromJsonInner(node, "expression", decoder, DBSPExpression.class);
-        return new DBSPUnwrapExpression(expression);
+        String message = Utilities.getStringProperty(node, "message");
+        return new DBSPUnwrapExpression(message, expression);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/InternTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/InternTests.java
@@ -122,7 +122,8 @@ public class InternTests extends SqlIoTest {
         DBSPExpression expr0 = ExpressionCompiler.expandTupleCast(CalciteObject.EMPTY, var, tuple);
         Assert.assertEquals("Tup2::new((t.0), (t.1), )", expr0.toString());
         DBSPExpression expr1 = ExpressionCompiler.expandTupleCast(CalciteObject.EMPTY, nVar, tuple);
-        Assert.assertEquals("Tup2::new((n.unwrap().0), (n.unwrap().1), )", expr1.toString());
+        Assert.assertEquals("Tup2::new((n.expect(\"Cast to non-nullable type applied to NULL value\").0), " +
+                "(n.expect(\"Cast to non-nullable type applied to NULL value\").1), )", expr1.toString());
         DBSPExpression expr2 = ExpressionCompiler.expandTupleCast(CalciteObject.EMPTY, var, nTuple);
         Assert.assertEquals("Some(Tup2::new((t.0), (t.1), ))", expr2.toString());
         DBSPExpression expr3 = ExpressionCompiler.expandTupleCast(CalciteObject.EMPTY, nVar, nTuple);
@@ -130,7 +131,7 @@ public class InternTests extends SqlIoTest {
                 if n.is_none() {
                     None
                 } else {
-                    Some(Tup2::new((n.unwrap().0), (n.unwrap().1), ))
+                    Some(Tup2::new((n.expect("Cast to non-nullable type applied to NULL value").0), (n.expect("Cast to non-nullable type applied to NULL value").1), ))
                 }""", expr3.toString());
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -74,7 +74,7 @@ public class ProfilingTests extends StreamingTestBase {
                     append_to_collection_handle,
                     append_to_map_handle,
                     read_output_spine,
-                    casts::{cast_to_Timestamp_s,handle_error},
+                    casts::{cast_to_Timestamp_s,handle_error,unwrap_value},
                     string::SqlString,
                 };
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
@@ -414,7 +414,7 @@
           {"start_line_number":19,"start_column":8,"end_line_number":19,"end_column":26},
           {"start_line_number":20,"start_column":27,"end_line_number":20,"end_column":37}
         ],
-        "persistent_id": "c4a85bf710dd3401e8c109627ff19a982d7ac56502679cd4ccc751868d929416"
+        "persistent_id": "8dab10904e879fd2b4f461f3281c7457c6174c8564b4947de60c8eca065bd95e"
       },
       "s5": {
         "operation": "flat_map_index",
@@ -435,7 +435,7 @@
           {"start_line_number":19,"start_column":17,"end_line_number":19,"end_column":26},
           {"start_line_number":20,"start_column":11,"end_line_number":20,"end_column":21}
         ],
-        "persistent_id": "04ab9bc2922e5e848f6cb7939658e97c4e2c150331bd0654ed8d98cd85427191"
+        "persistent_id": "958477ed0fb64636fab2e45cd593974f814228cbdae788f5cb8b7fcf118b888d"
       },
       "s6": {
         "operation": "delta0",
@@ -475,7 +475,7 @@
           {"start_line_number":16,"start_column":9,"end_line_number":16,"end_column":33},
           {"start_line_number":19,"start_column":8,"end_line_number":19,"end_column":26}
         ],
-        "persistent_id": "181d7b128313b90121fa9cff13307d45ac1537762a0e02b5b8a12a9f916432a5"
+        "persistent_id": "47cb54e0e3400032561f07d695462ef691b9c1d6ba68ee27c35d2033ad44a3e9"
       },
       "s9": {
         "operation": "sum",
@@ -487,7 +487,7 @@
           "final": 10
         },
         "positions": [],
-        "persistent_id": "2802674a2b09d121d723e7df8195958a3d2bdda1a8214e853dfe38b1b85ceae7"
+        "persistent_id": "087132e3fddfdf1940662f137e42e2f354ad9a623e09f22861af0001a167d40c"
       }
     }, "s10": {
       "operation": "inspect",
@@ -502,7 +502,7 @@
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1},
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1}
       ],
-      "persistent_id": "451ae0acedceb2cceda4533904ef0fe3464c05508e468d588061c1957d064537"
+      "persistent_id": "12ac9e4cba406528432e234f7ebe6efad19866b1e837686f0986125c577920dd"
     }, "s11": {
       "operation": "inspect",
       "inputs": [


### PR DESCRIPTION
This PR adds additional description to various `unwrap()` calls generated by the compiler.
If source position information is available, it will be reported as well.
These errors should make it a little bit easier to diagnose panics related to unwrap calls.
This is motivated by an error report from a user who triggered an unwrap call in the string uninterning path.