### PR TITLE
[json-logging] add "api-server" feldera-service name

### DIFF
--- a/crates/feldera-observability/src/json_logging.rs
+++ b/crates/feldera-observability/src/json_logging.rs
@@ -17,6 +17,7 @@ pub enum ServiceName {
     ControlPlane,
     KubernetesRunner,
     Pipeline,
+    ApiServer,
 }
 
 impl ServiceName {
@@ -28,6 +29,7 @@ impl ServiceName {
             ServiceName::ControlPlane => "control-plane",
             ServiceName::KubernetesRunner => "kubernetes-runner",
             ServiceName::Pipeline => "pipeline",
+            ServiceName::ApiServer => "api-server",
         }
     }
 }

--- a/docs.feldera.com/docs/operations/json-logging.md
+++ b/docs.feldera.com/docs/operations/json-logging.md
@@ -16,7 +16,7 @@ These identity fields are lifted alongside the standard top-level metadata (`tim
 
 | Field              | Meaning                                                                          |
 | ------------------ | -------------------------------------------------------------------------------- |
-| `feldera-service`  | Source: `manager` \| `runner` \| `compiler-server` \| `kubernetes-runner` \| `control-plane` \| `pipeline` (auto-tagged by module path). This identifies which Feldera component produced the log. |
+| `feldera-service`  | Source: `manager` \| `runner` \| `compiler-server` \| `kubernetes-runner` \| `api-server` \| `control-plane` \| `pipeline` (auto-tagged by module path). This identifies which Feldera component produced the log. |
 | `pipeline-name`    | Human-friendly pipeline name when available; if it is not immediately available it is set to `N/A`. Present for pipeline events. Control plane events tied to a specific pipeline also include this name. |
 | `pipeline-id`      | Pipeline UUID when the event relates to a specific pipeline. Present for pipeline events. Control plane events tied to a specific pipeline also include this ID. |
 


### PR DESCRIPTION
 Used by feldera-cloud api server logging.
 Will update feldera-cloud once it get merged

## Checklist

- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
