### PR TITLE
[SQL] Support for ORDER BY with OFFSET

### DIFF
--- a/docs.feldera.com/docs/sql/grammar.md
+++ b/docs.feldera.com/docs/sql/grammar.md
@@ -283,7 +283,9 @@ query
       |   query INTERSECT [ ALL | DISTINCT ] query
       }
       [ ORDER BY orderItem [, orderItem ]* ]
-      [ LIMIT { count | ALL } ]
+      [ LIMIT [ start, ] { count | ALL } ]
+      [ OFFSET start [ { ROW | ROWS } ] ]
+      [ FETCH { FIRST | NEXT } [ count ] { ROW | ROWS } ONLY ]
 
 
 withItem

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -344,12 +344,6 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 // we don't use sort_unstable_by because it is
                 // non-deterministic
                 .append("v.sort_by(comp);").newline();
-        if (expression.limit != null) {
-            this.builder.append("let mut v = (**array).clone();").newline();
-            this.builder.append("v.truncate(");
-            expression.limit.accept(this);
-            this.builder.append(");").newline();
-        }
         this.builder.append("v.into()");
         this.builder.newline()
                 .decrease()

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -404,9 +404,8 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> {
     @Override
     public void postorder(DBSPSortExpression node) {
         DBSPExpression comparator = this.getE(node.comparator);
-        DBSPExpression limit = this.getEN(node.limit);
         this.map(node, new DBSPSortExpression(node.getNode(), node.elementType,
-                comparator.to(DBSPComparatorExpression.class), limit));
+                comparator.to(DBSPComparatorExpression.class)));
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -1189,9 +1189,9 @@ public abstract class InnerRewriteVisitor
         this.push(expression);
         DBSPExpression comparator = this.transform(expression.comparator);
         DBSPType elementType = this.transform(expression.elementType);
-        @Nullable DBSPExpression limit = this.transformN(expression.limit);
         this.pop(expression);
-        DBSPExpression result = new DBSPSortExpression(expression.getNode(), elementType, comparator, limit);
+        DBSPExpression result = new DBSPSortExpression(
+                expression.getNode(), elementType, comparator);
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPSortExpression.java
@@ -51,12 +51,9 @@ public final class DBSPSortExpression extends DBSPExpression {
     // Usually a DBSPComparatorExpression, but can be a PathExpression too.
     public final DBSPExpression comparator;
     public final DBSPType elementType;
-    @Nullable
-    public final DBSPExpression limit;
 
     public DBSPSortExpression(
-            CalciteObject node, DBSPType elementType,
-            DBSPExpression comparator, @Nullable DBSPExpression limit) {
+            CalciteObject node, DBSPType elementType, DBSPExpression comparator) {
         super(node, new DBSPTypeFunction(
                 // Return type
                 new DBSPTypeArray(elementType, false),
@@ -66,7 +63,6 @@ public final class DBSPSortExpression extends DBSPExpression {
                         new DBSPTypeArray(elementType, false).ref())));
         this.comparator = comparator;
         this.elementType = elementType;
-        this.limit = limit;
     }
 
     @Override
@@ -76,10 +72,6 @@ public final class DBSPSortExpression extends DBSPExpression {
         visitor.push(this);
         visitor.property("comparator");
         this.comparator.accept(visitor);
-        if (this.limit != null) {
-            visitor.property("limit");
-            this.limit.accept(visitor);
-        }
         visitor.property("elementType");
         this.elementType.accept(visitor);
         visitor.pop(this);
@@ -93,8 +85,7 @@ public final class DBSPSortExpression extends DBSPExpression {
         if (o == null)
             return false;
         return this.comparator == o.comparator &&
-                this.elementType == o.elementType &&
-                this.limit == o.limit;
+                this.elementType == o.elementType;
     }
 
     @Override
@@ -107,7 +98,7 @@ public final class DBSPSortExpression extends DBSPExpression {
     @Override
     public DBSPExpression deepCopy() {
         return new DBSPSortExpression(this.getNode(), this.elementType,
-                this.comparator.deepCopy().to(DBSPComparatorExpression.class), this.limit);
+                this.comparator.deepCopy().to(DBSPComparatorExpression.class));
     }
 
     @Override
@@ -115,8 +106,7 @@ public final class DBSPSortExpression extends DBSPExpression {
         DBSPSortExpression otherExpression = other.as(DBSPSortExpression.class);
         if (otherExpression == null)
             return false;
-        return this.comparator.equivalent(context, otherExpression.comparator) &&
-                EquivalenceContext.equiv(this.limit, otherExpression.limit);
+        return this.comparator.equivalent(context, otherExpression.comparator);
     }
 
 
@@ -124,9 +114,6 @@ public final class DBSPSortExpression extends DBSPExpression {
     public static DBSPSortExpression fromJson(JsonNode node, JsonDecoder decoder) {
         DBSPExpression comparator = fromJsonInner(node, "comparator", decoder, DBSPExpression.class);
         DBSPType elementType = fromJsonInner(node, "elementType", decoder, DBSPType.class);
-        DBSPExpression limit = null;
-        if (node.has("limit"))
-            limit = fromJsonInner(node, "limit", decoder, DBSPExpression.class);
-        return new DBSPSortExpression(CalciteObject.EMPTY, elementType, comparator, limit);
+        return new DBSPSortExpression(CalciteObject.EMPTY, elementType, comparator);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/FoodmartBaseTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/FoodmartBaseTests.java
@@ -49,7 +49,68 @@ public class FoodmartBaseTests extends SqlIoTest {
                 INSERT INTO EMP VALUES(7876,'ADAMS','CLERK',35,7788,'1987-05-23',1100,NULL,20,'adams@calcite',NULL,'23:11:06','2017-08-18 23:11:06');
                 INSERT INTO EMP VALUES(7900,'JAMES','CLERK',40,7698,'1981-12-03',950,NULL,30,'james@calcite','2020-01-02 12:19:00','12:19:00','2020-01-02 12:19:00');
                 INSERT INTO EMP VALUES(7902,'FORD','ANALYST',28,7566,'1981-12-03',3000,NULL,20,'ford@calcite','2019-05-29 00:00:00',NULL,'2019-05-29 00:00:00');
-                INSERT INTO EMP VALUES(7934,'MILLER','CLERK',32,7782,'1982-01-23',1300,NULL,10,NULL,'2016-09-02 23:15:01','23:15:01','2016-09-02 23:15:01')
+                INSERT INTO EMP VALUES(7934,'MILLER','CLERK',32,7782,'1982-01-23',1300,NULL,10,NULL,'2016-09-02 23:15:01','23:15:01','2016-09-02 23:15:01');
+                
+                CREATE TABLE DAYS(DAY INTEGER, WEEK_DAY VARCHAR);
+                INSERT INTO DAYS VALUES(1,'Sunday');
+                INSERT INTO DAYS VALUES(2,'Monday');
+                INSERT INTO DAYS VALUES(5,'Thursday');
+                INSERT INTO DAYS VALUES(4,'Wednesday');
+                INSERT INTO DAYS VALUES(3,'Tuesday');
+                INSERT INTO DAYS VALUES(6,'Friday');
+                INSERT INTO DAYS VALUES(7,'Saturday');
+                
+                CREATE TABLE STORE(
+                    STORE_ID INT,
+                    STORE_TYPE VARCHAR,
+                    REGION_ID INT,
+                    STORE_NAME VARCHAR,
+                    STORE_NUMBER INT,
+                    store_street_address VARCHAR,
+                    store_city VARCHAR,
+                    store_state CHAR(2),
+                    store_postal_code INT,
+                    store_country VARCHAR,
+                    store_manager VARCHAR,
+                    store_phone VARCHAR,
+                    store_fax VARCHAR,
+                    first_opened_date TIMESTAMP,
+                    last_remodel_date TIMESTAMP,
+                    store_sqft INT,
+                    grocery_sqft INT,
+                    frozen_sqft INT,
+                    meat_sqft INT,
+                    coffee_bar BOOLEAN,
+                    video_store BOOLEAN,
+                    salad_bar BOOLEAN,
+                    prepared_food BOOLEAN,
+                    florist BOOLEAN
+                );
+                INSERT INTO STORE VALUES(0,'HeadQuarters',0,'HQ',0,'1 Alameda Way','Alameda','CA',55555,'USA',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,false,false,false,false,false);
+                INSERT INTO STORE VALUES(1,'Supermarket',28,'Store 1',1,'2853 Bailey Rd','Acapulco','Guerrero',55555,'Mexico','Jones','262-555-5124','262-555-5121','1982-01-09 00:00:00.0','1990-12-05 00:00:00.0',23593,17475,3671,2447,false,false,false,false,false);
+                INSERT INTO STORE VALUES(2,'Small Grocery',78,'Store 2',2,'5203 Catanzaro Way','Bellingham','WA',55555,'USA','Smith','605-555-8203','605-555-8201','1970-04-02 00:00:00.0','1973-06-04 00:00:00.0',28206,22271,3561,2374,true,false,false,false,false);
+                INSERT INTO STORE VALUES(3,'Supermarket',76,'Store 3',3,'1501 Ramsey Circle','Bremerton','WA',55555,'USA','Davis','509-555-1596','509-555-1591','1959-06-14 00:00:00.0','1967-11-19 00:00:00.0',39696,24390,9184,6122,false,false,true,true,false);
+                INSERT INTO STORE VALUES(4,'Gourmet Supermarket',27,'Store 4',4,'433 St George Dr','Camacho','Zacatecas',55555,'Mexico','Johnson','304-555-1474','304-555-1471','1994-09-27 00:00:00.0','1995-12-01 00:00:00.0',23759,16844,4149,2766,true,false,true,true,true);
+                INSERT INTO STORE VALUES(5,'Small Grocery',4,'Store 5',5,'1250 Coggins Drive','Guadalajara','Jalisco',55555,'Mexico','Green','801-555-4324','801-555-4321','1978-09-18 00:00:00.0','1991-06-29 00:00:00.0',24597,15012,5751,3834,true,false,false,false,false);
+                INSERT INTO STORE VALUES(6,'Gourmet Supermarket',47,'Store 6',6,'5495 Mitchell Canyon Road','Beverly Hills','CA',55555,'USA','Maris','958-555-5002','958-555-5001','1981-01-03 00:00:00.0','1991-03-13 00:00:00.0',23688,15337,5011,3340,true,true,true,true,true);
+                INSERT INTO STORE VALUES(7,'Supermarket',3,'Store 7',7,'1077 Wharf Drive','Los Angeles','CA',55555,'USA','White','477-555-7967','477-555-7961','1971-05-21 00:00:00.0','1981-10-20 00:00:00.0',23598,14210,5633,3755,false,false,false,false,true);
+                INSERT INTO STORE VALUES(8,'Deluxe Supermarket',26,'Store 8',8,'3173 Buena Vista Ave','Merida','Yucatan',55555,'Mexico','Williams','797-555-3417','797-555-3411','1958-09-23 00:00:00.0','1967-11-18 00:00:00.0',30797,20141,6393,4262,true,true,true,true,true);
+                INSERT INTO STORE VALUES(9,'Mid-Size Grocery',2,'Store 9',9,'1872 El Pintado Road','Mexico City','DF',55555,'Mexico','Stuber','439-555-3524','439-555-3521','1955-03-18 00:00:00.0','1959-06-07 00:00:00.0',36509,22450,8435,5624,false,false,false,false,false);
+                INSERT INTO STORE VALUES(10,'Supermarket',24,'Store 10',10,'7894 Rotherham Dr','Orizaba','Veracruz',55555,'Mexico','Merz','212-555-4774','212-555-4771','1979-04-13 00:00:00.0','1982-01-30 00:00:00.0',34791,26354,5062,3375,false,false,true,true,false);
+                INSERT INTO STORE VALUES(11,'Supermarket',22,'Store 11',11,'5371 Holland Circle','Portland','OR',55555,'USA','Erickson','685-555-8995','685-555-8991','1976-09-17 00:00:00.0','1982-05-15 00:00:00.0',20319,16232,2452,1635,false,false,false,false,false);
+                INSERT INTO STORE VALUES(12,'Deluxe Supermarket',25,'Store 12',12,'1120 Westchester Pl','Hidalgo','Zacatecas',55555,'Mexico','Kalman','151-555-1702','151-555-1701','1968-03-25 00:00:00.0','1993-12-18 00:00:00.0',30584,21938,5188,3458,true,true,true,true,true);
+                INSERT INTO STORE VALUES(13,'Deluxe Supermarket',23,'Store 13',13,'5179 Valley Ave','Salem','OR',55555,'USA','Inmon','977-555-2724','977-555-2721','1957-04-13 00:00:00.0','1997-11-10 00:00:00.0',27694,18670,5415,3610,true,true,true,true,true);
+                INSERT INTO STORE VALUES(14,'Small Grocery',1,'Store 14',14,'4365 Indigo Ct','San Francisco','CA',55555,'USA','Strehlo','135-555-4888','135-555-4881','1957-11-24 00:00:00.0','1958-01-07 00:00:00.0',22478,15321,4294,2863,true,false,false,false,false);
+                INSERT INTO STORE VALUES(15,'Supermarket',18,'Store 15',15,'5006 Highland Drive','Seattle','WA',55555,'USA','Ollom','893-555-1024','893-555-1021','1969-07-24 00:00:00.0','1973-10-19 00:00:00.0',21215,13305,4746,3164,true,false,false,false,false);
+                INSERT INTO STORE VALUES(16,'Supermarket',87,'Store 16',16,'5922 La Salle Ct','Spokane','WA',55555,'USA','Mantle','643-555-3645','643-555-3641','1974-08-23 00:00:00.0','1977-07-13 00:00:00.0',30268,22063,4923,3282,false,false,false,false,false);
+                INSERT INTO STORE VALUES(17,'Deluxe Supermarket',84,'Store 17',17,'490 Risdon Road','Tacoma','WA',55555,'USA','Mays','855-555-5581','855-555-5581','1970-05-30 00:00:00.0','1976-06-23 00:00:00.0',33858,22123,7041,4694,true,false,true,true,true);
+                INSERT INTO STORE VALUES(18,'Mid-Size Grocery',25,'Store 18',18,'6764 Glen Road','Hidalgo','Zacatecas',55555,'Mexico','Brown','528-555-8317','528-555-8311','1969-06-28 00:00:00.0','1975-08-30 00:00:00.0',38382,30351,4819,3213,false,false,false,false,false);
+                INSERT INTO STORE VALUES(19,'Deluxe Supermarket',5,'Store 19',19,'6644 Sudance Drive','Vancouver','BC',55555,'Canada','Ruth','862-555-7395','862-555-7391','1977-03-27 00:00:00.0','1990-10-25 00:00:00.0',23112,16418,4016,2678,true,true,true,true,true);
+                INSERT INTO STORE VALUES(20,'Mid-Size Grocery',6,'Store 20',20,'3706 Marvelle Ln','Victoria','BC',55555,'Canada','Cobb','897-555-1931','897-555-1931','1980-02-06 00:00:00.0','1987-04-09 00:00:00.0',34452,27463,4193,2795,true,false,false,false,true);
+                INSERT INTO STORE VALUES(21,'Deluxe Supermarket',106,'Store 21',21,'4093 Steven Circle','San Andres','DF',55555,'Mexico','Jones','493-555-4781','493-555-4781','1986-02-07 00:00:00.0','1990-04-16 00:00:00.0',NULL,NULL,NULL,NULL,true,false,true,true,true);
+                INSERT INTO STORE VALUES(22,'Small Grocery',88,'Store 22',22,'9606 Julpum Loop','Walla Walla','WA',55555,'USA','Byrg','881-555-5117','881-555-5111','1951-01-24 00:00:00.0','1969-10-17 00:00:00.0',NULL,NULL,NULL,NULL,false,false,false,false,false);
+                INSERT INTO STORE VALUES(23,'Mid-Size Grocery',89,'Store 23',23,'3920 Noah Court','Yakima','WA',55555,'USA','Johnson','170-555-8424','170-555-8421','1977-07-16 00:00:00.0','1987-07-24 00:00:00.0',NULL,NULL,NULL,NULL,false,false,false,false,false);
+                INSERT INTO STORE VALUES(24,'Supermarket',7,'Store 24',24,'2342 Waltham St.','San Diego','CA',55555,'USA','Byrd','111-555-0303','111-555-0304','1979-05-22 00:00:00.0','1986-04-20 00:00:00.0',NULL,NULL,NULL,NULL,true,false,true,false,true);
                 """);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SortHrTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SortHrTests.java
@@ -1,0 +1,101 @@
+package org.dbsp.sqlCompiler.compiler.sql.quidem;
+
+import org.junit.Test;
+
+/** Tests from sort.iq that use the HR database */
+public class SortHrTests extends HrBaseTests {
+    @Test
+    public void testSort() {
+        this.qs("""
+                select * from "emps" offset 0;
+                +-------+--------+-----------+---------+------------+
+                | empid | deptno | name      | salary  | commission |
+                +-------+--------+-----------+---------+------------+
+                |   100 |     10 | Bill|       10000.0 |       1000 |
+                |   110 |     10 | Theodore|   11500.0 |        250 |
+                |   150 |     10 | Sebastian|   7000.0 |            |
+                |   200 |     20 | Eric|        8000.0 |        500 |
+                +-------+--------+-----------+---------+------------+
+                (4 rows)
+                
+                select distinct "deptno", count(*) as c
+                from "emps"
+                group by "deptno"
+                order by count(*) desc;
+                +--------+---+
+                | deptno | C |
+                +--------+---+
+                |     10 | 3 |
+                |     20 | 1 |
+                +--------+---+
+                (2 rows)
+                
+                select distinct count("empid") as c
+                from "emps"
+                group by "empid"
+                order by 1;
+                +---+
+                | C |
+                +---+
+                | 1 |
+                +---+
+                (1 row)
+
+                with e as (select "empid" as empid from "emps" where "empid" < 120)
+                select * from e as e1, e as e2 order by e1.empid + e2.empid, e1.empid;
+                +-------+--------+
+                | EMPID | EMPID0 |
+                +-------+--------+
+                |   100 |    100 |
+                |   100 |    110 |
+                |   110 |    100 |
+                |   110 |    110 |
+                +-------+--------+
+                (4 rows)
+                
+                with e as (select "empid" as empid from "emps" where "empid" < 200)
+                select * from e where empid > 100 limit 5;
+                +-------+
+                | EMPID |
+                +-------+
+                |   150 |
+                |   110 |
+                +-------+
+                (2 rows)
+                
+                select * from
+                (values
+                (2, array[2, 3]),
+                (3, array[3, 4]),
+                (1, array[1, 2]),
+                (4, array[4, 5])) as t(id, arr)
+                order by arr asc;
+                +----+--------+
+                | ID | ARR    |
+                +----+--------+
+                |  1 | {1, 2} |
+                |  2 | {2, 3} |
+                |  3 | {3, 4} |
+                |  4 | {4, 5} |
+                +----+--------+
+                (4 rows)
+                
+                select * from
+                (values
+                (2, array[2, 3]),
+                (3, array[3, 4]),
+                (1, array[1, 2]),
+                (4, array[4, 5])) as t(id, arr)
+                order by arr desc;
+                +----+--------+
+                | ID | ARR    |
+                +----+--------+
+                |  4 | {4, 5} |
+                |  3 | {3, 4} |
+                |  2 | {2, 3} |
+                |  1 | {1, 2} |
+                +----+--------+
+                (4 rows)
+                """);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SortTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/SortTests.java
@@ -1,0 +1,235 @@
+package org.dbsp.sqlCompiler.compiler.sql.quidem;
+
+import org.junit.Test;
+
+/** Tests from Calcite's sort.iq */
+public class SortTests extends FoodmartBaseTests {
+    @Test public void testSortOffset() {
+        this.qs("""
+                select *
+                from dept
+                order by deptno offset 1;
+                +--------+------------+---------+
+                | DEPTNO | DNAME      | LOC     |
+                +--------+------------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                |     40 | OPERATIONS| BOSTON|
+                +--------+------------+---------+
+                (3 rows)
+                
+                select *
+                from dept
+                order by deptno limit 1, all;
+                +--------+------------+---------+
+                | DEPTNO | DNAME      | LOC     |
+                +--------+------------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                |     40 | OPERATIONS| BOSTON|
+                +--------+------------+---------+
+                (3 rows)""");
+    }
+
+    @Test
+    public void testSort() {
+        this.qs("""
+                select * from "days" order by "day";
+                +-----+----------+
+                | day | week_day |
+                +-----+-------+
+                |   1 | Sunday|
+                |   2 | Monday|
+                |   3 | Tuesday|
+                |   4 | Wednesday|
+                |   5 | Thursday|
+                |   6 | Friday|
+                |   7 | Saturday|
+                +-----+-------+
+                (7 rows)
+                
+                select * from "days" order by "day" limit 2;
+                +-----+----------+
+                | day | week_day |
+                +-----+-------+
+                |   1 | Sunday|
+                |   2 | Monday|
+                +-----+-------+
+                (2 rows)
+                
+                select * from "days" where "day" between 2 and 4 order by "day";
+                +-----+-----------+
+                | day | week_day  |
+                +-----+-----------+
+                |   2 | Monday|
+                |   3 | Tuesday|
+                |   4 | Wednesday|
+                +-----+-----------+
+                (3 rows)
+                
+                select "store_id", "grocery_sqft" from "store"
+                where "store_id" < 3
+                order by 2 DESC;
+                +----------+--------------+
+                | store_id | grocery_sqft |
+                +----------+--------------+
+                |        0 |              |
+                |        2 |        22271 |
+                |        1 |        17475 |
+                +----------+--------------+
+                (3 rows)
+                
+                select "store_id", "grocery_sqft" from "store"
+                where "store_id" < 3
+                order by "florist", 2 DESC;
+                +----------+--------------+
+                | store_id | grocery_sqft |
+                +----------+--------------+
+                |        0 |              |
+                |        2 |        22271 |
+                |        1 |        17475 |
+                +----------+--------------+
+                (3 rows)
+                
+                select "store_id", "grocery_sqft" from "store"
+                where "store_id" < 3
+                order by 2;
+                +----------+--------------+
+                | store_id | grocery_sqft |
+                +----------+--------------+
+                |        1 |        17475 |
+                |        2 |        22271 |
+                |        0 |              |
+                +----------+--------------+
+                (3 rows)
+                
+                select "store_id", "grocery_sqft" from "store"
+                where "store_id" < 3
+                order by "florist", 2;
+                +----------+--------------+
+                | store_id | grocery_sqft |
+                +----------+--------------+
+                |        1 |        17475 |
+                |        2 |        22271 |
+                |        0 |              |
+                +----------+--------------+
+                (3 rows)
+                
+                select *
+                from DEPT
+                order by deptno desc, dname, deptno;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     40 | OPERATIONS| BOSTON|
+                |     30 | SALES| CHICAGO|
+                |     20 | RESEARCH| DALLAS|
+                |     10 | ACCOUNTING| NEW YORK|
+                +--------+------------+----------+
+                (4 rows)
+                
+                select *
+                from dept
+                order by deptno limit 2 offset 1;
+                +--------+----------+---------+
+                | DEPTNO | DNAME    | LOC     |
+                +--------+----------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                +--------+----------+---------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno offset 1 fetch next 2 rows only;
+                +--------+----------+---------+
+                | DEPTNO | DNAME    | LOC     |
+                +--------+----------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                +--------+----------+---------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno limit 2;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     10 | ACCOUNTING| NEW YORK|
+                |     20 | RESEARCH| DALLAS|
+                +--------+------------+----------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno fetch next 2 rows only;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     10 | ACCOUNTING| NEW YORK|
+                |     20 | RESEARCH| DALLAS|
+                +--------+------------+----------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     10 | ACCOUNTING| NEW YORK|
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                |     40 | OPERATIONS| BOSTON|
+                +--------+------------+----------+
+                (4 rows)
+                
+                select *
+                from dept
+                order by deptno offset 1 limit 2;
+                +--------+----------+---------+
+                | DEPTNO | DNAME    | LOC     |
+                +--------+----------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                +--------+----------+---------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno limit 1, 2;
+                +--------+----------+---------+
+                | DEPTNO | DNAME    | LOC     |
+                +--------+----------+---------+
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                +--------+----------+---------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno limit 2;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     10 | ACCOUNTING| NEW YORK|
+                |     20 | RESEARCH| DALLAS|
+                +--------+------------+----------+
+                (2 rows)
+                
+                select *
+                from dept
+                order by deptno limit all;
+                +--------+------------+----------+
+                | DEPTNO | DNAME      | LOC      |
+                +--------+------------+----------+
+                |     10 | ACCOUNTING| NEW YORK|
+                |     20 | RESEARCH| DALLAS|
+                |     30 | SALES| CHICAGO|
+                |     40 | OPERATIONS| BOSTON|
+                +--------+------------+----------+
+                (4 rows)
+                """);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -1573,4 +1573,18 @@ public class Regression1Tests extends SqlIoTest {
                 LAG(intt) OVER ()
                 FROM tbl;""");
     }
+
+    @Test
+    public void limitDuplicate() {
+        var ccs = this.getCCS("""
+                CREATE TABLE T(x INT);
+                CREATE VIEW V AS SELECT * FROM T ORDER BY x LIMIT 1;""");
+        ccs.step("""
+                INSERT INTO T VALUES(1);
+                INSERT INTO T VALUES(1);
+                """, """
+                 x | weight
+                ------------
+                 1 | 1""");
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -60,6 +60,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
         options.languageOptions.incrementalize = false;
         options.languageOptions.unrestrictedIOTypes = true;
         options.ioOptions.verbosity = 2;
+        options.languageOptions.ignoreOrderBy = true;
         return options;
     }
 


### PR DESCRIPTION
Calcite supports a wealth of syntaxes for specifying the OFFSET, and we inherit all of them.

Turns out that OFFSET is not difficult: it's always a TopK operator, whose result is SUBTRACTED from the result that would be produced by the ORDER BY or the ORDER BY LIMIT (where the limit is the original limit plus the offset).