### PR TITLE
docs: removed CONVERT function from the index of functions

### DIFF
--- a/docs.feldera.com/docs/sql/function-index.md
+++ b/docs.feldera.com/docs/sql/function-index.md
@@ -72,7 +72,6 @@
 * `CONCAT`: [string](string.md#concat)
 * `CONCAT_WS`: [string](string.md#concat_ws)
 * `CONNECTOR_METADATA`: [grammar](grammar.md#connector_metadata)
-* `CONVERT`: [casts](casts.md#casts-and-data-type-conversions)
 * `COS`: [float](float.md#cos)
 * `COSH`: [float](float.md#cosh)
 * `COT`: [float](float.md#cot)


### PR DESCRIPTION
Updated the documentation to remove the  function `CONVERT` from the [Index Of Functions](https://docs.feldera.com/sql/function-index/) page since it is not currently supported. 