### PR TITLE
[adapters] Fix pipeline getting stuck due to output connector error.

### DIFF
--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -686,7 +686,9 @@ impl Runtime {
                     }
                     // Nothing to do: do some housekeeping and relinquish the CPU if there's none
                     // left.
-                    Err(TryRecvError::Empty) => parker.park(),
+                    Err(TryRecvError::Empty) => {
+                        parker.park();
+                    }
                     Err(_) => {
                         break;
                     }
@@ -1913,7 +1915,6 @@ pub(crate) mod tests {
             panic!("revert_to_unknown_checkpoint is supposed to fail");
         };
 
-        println!("revert_to_unknown_checkpoint: result: {err:?}");
         assert!(matches!(
             err,
             DbspError::Storage(StorageError::CheckpointNotFound(_))


### PR DESCRIPTION
This fixes the following deadlock:

- Output connector initialization fails.
- Before exiting, the controller Drop's DBSPHandle, which waits for all worker threads and aux threads to exit. Aux threads are used with connectors that have output buffers.
- However since nothing wakes up the aux thread, it remains parked.

The fix is for DBSPHandle::kill to unpark aux thread.

