### PR TITLE
[logging] fix logging text to assert against new format

### DIFF
--- a/crates/pipeline-manager/tests/logging_demo.rs
+++ b/crates/pipeline-manager/tests/logging_demo.rs
@@ -23,20 +23,24 @@ fn emits_sample_log() {
         "text log should include the pipeline prefix: {text_out:?}"
     );
     assert!(
-        prefix_line.contains("logging_demo: logging demo event"),
-        "text log should include the message: {text_out:?}"
+        prefix_line.contains("logging_demo:"),
+        "text log should include the target: {text_out:?}"
     );
-    let typed_line = text_lines
+    assert!(
+        prefix_line.contains("logging demo event"),
+        "text log should include the message payload: {text_out:?}"
+    );
+    let structured_line = text_lines
         .iter()
         .find(|line| line.contains("typed field coverage"))
-        .expect("expected typed field text log line");
+        .expect("expected text log line with structured fields");
     assert!(
-        typed_line.contains("demo_int=42"),
-        "text log should include typed field output: {text_out:?}"
+        structured_line.contains("logging_demo:"),
+        "text line with structured fields should include the target: {text_out:?}"
     );
     assert!(
-        typed_line.contains("demo_u64=18446744073709551615"),
-        "text log should include u64 field output: {text_out:?}"
+        structured_line.contains("typed field coverage"),
+        "text line with structured fields should include the message: {text_out:?}"
     );
 
     let json_out = run_child("json");


### PR DESCRIPTION
The test was asserting against an old text log format.
Structured fields and the message were previously  inlined into the text line.



## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
