### PR TITLE
Fix pinned 'top nodes' tooltip not updated when choosing another metric

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -570,7 +570,7 @@
 
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 
-    "@sveltejs/kit": ["@sveltejs/kit@2.49.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA=="],
+    "@sveltejs/kit": ["@sveltejs/kit@2.49.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-vByReCTTdlNM80vva8alAQC80HcOiHLkd8XAxIiKghKSHcqeNfyhp3VsYAV8VSiPKu4Jc8wWCfsZNAIvd1uCqA=="],
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.1", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ=="],
 
@@ -1048,7 +1048,7 @@
 
     "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
 
-    "esrap": ["esrap@2.2.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-WBmtxe7R9C5mvL4n2le8nMUe4mD5V9oiK2vJpQ9I3y20ENPUomPcphBXE8D1x/Bm84oN1V+lOfgXxtqmxTp3Xg=="],
+    "esrap": ["esrap@2.2.1", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
@@ -1648,7 +1648,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.45.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.5.0", "esm-env": "^1.2.1", "esrap": "^2.2.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-ngKXNhNvwPzF43QqEhDOue7TQTrG09em1sd4HBxVF0Wr2gopAmdEWan+rgbdgK4fhBtSOTJO8bYU4chUG7VXZQ=="],
+    "svelte": ["svelte@5.45.5", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.5.0", "esm-env": "^1.2.1", "esrap": "^2.2.1", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2074U+vObO5Zs8/qhxtBwdi6ZXNIhEBTzNmUFjiZexLxTdt9vq96D/0pnQELl6YcpLMD7pZ2dhXKByfGS8SAdg=="],
 
     "svelte-attr": ["svelte-attr@0.0.2", "", { "dependencies": { "node-html-parser": "^6.1.5" }, "peerDependencies": { "svelte": "^3.44.0" } }, "sha512-/C7pAz98vv6OGwfIweWaGerwojlw3lTfrqSA61/FfEzyFn/eElGtdAPiKthuFy4Nw8igI3aygaKHrSoqOf9huw=="],
 
@@ -1946,10 +1946,6 @@
 
     "varstream/readable-stream": ["readable-stream@1.1.14", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.1", "isarray": "0.0.1", "string_decoder": "~0.10.x" } }, "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ=="],
 
-    "web-console/@sveltejs/kit": ["@sveltejs/kit@2.49.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-vByReCTTdlNM80vva8alAQC80HcOiHLkd8XAxIiKghKSHcqeNfyhp3VsYAV8VSiPKu4Jc8wWCfsZNAIvd1uCqA=="],
-
-    "web-console/svelte": ["svelte@5.45.5", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.5.0", "esm-env": "^1.2.1", "esrap": "^2.2.1", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2074U+vObO5Zs8/qhxtBwdi6ZXNIhEBTzNmUFjiZexLxTdt9vq96D/0pnQELl6YcpLMD7pZ2dhXKByfGS8SAdg=="],
-
     "web-console/vite": ["vite@7.2.6", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1999,8 +1995,6 @@
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "varstream/readable-stream/string_decoder": ["string_decoder@0.10.31", "", {}, "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="],
-
-    "web-console/svelte/esrap": ["esrap@2.2.1", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg=="],
 
     "web-console/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/js-packages/profiler-app/src/fileLoader.ts
+++ b/js-packages/profiler-app/src/fileLoader.ts
@@ -70,7 +70,7 @@ export class ProfileLoader {
     }
 
     /** Display the top nodes for a specified metric */
-    showTopNodes(metric: string, isSticky?: boolean | undefined): void {
-        this.visualizer.showTopNodes(metric, isSticky);
+    showTopNodes(isSticky?: boolean | undefined): void {
+        this.visualizer.showTopNodes(isSticky);
     }
 }

--- a/js-packages/profiler-app/src/index.ts
+++ b/js-packages/profiler-app/src/index.ts
@@ -225,9 +225,9 @@ async function main() {
         }
     });
 
-    metricButton?.addEventListener('mouseover', () => loader.showTopNodes(metricSelector.value, false));
+    metricButton?.addEventListener('mouseover', () => loader.showTopNodes(false));
     metricButton?.addEventListener('mouseout', () => loader.hideNodeAttributes());
-    metricButton?.addEventListener('click', () => loader.showTopNodes(metricSelector.value, true));
+    metricButton?.addEventListener('click', () => loader.showTopNodes(true));
 
     // Show welcome message
     messageContainer.innerHTML = `

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -517,7 +517,8 @@ export class CytographRendering {
         readonly selection: CircuitSelection,
         private metadataSelection: MetadataSelection,
         private message: (msg: string) => void,
-        private clearMessage: () => void) {
+        private clearMessage: () => void,
+        private onTooltipContextChanged: () => void) {
         cytoscape.use(elk);
         cytoscape.use(dblclick);
 
@@ -972,6 +973,7 @@ export class CytographRendering {
 
         // Track the current tooltip node for refreshing on metadata changes
         this.currentTooltipNode = nodeId;
+        this.onTooltipContextChanged()
 
         // highlight edges
         let reachable = this.reachableFrom(nodeId, true);
@@ -1057,6 +1059,7 @@ export class CytographRendering {
 
     hideNodeInformation() {
         this.currentTooltipNode = null;
+        this.onTooltipContextChanged()
         this.callbacks.displayNodeAttributes(Option.none(), false);
         let reachable = this.cy.edges();
         reachable.removeClass('highlight-forward');

--- a/js-packages/profiler-lib/src/metadataSelection.ts
+++ b/js-packages/profiler-lib/src/metadataSelection.ts
@@ -48,14 +48,17 @@ export class MetadataSelector {
      */
     initialize(): void {
         // Notify about available metrics
+        this.notifyMetricsChanged();
+        // Notify about available workers
+        this.notifyWorkersChanged();
+    }
+
+    notifyMetricsChanged() {
         const metrics: MetricOption[] = Array.from(this.allMetrics).sort().map(metric => ({
             id: metric,
             label: metric
         }));
         this.callbacks.onMetricsChanged(metrics, this.selectedMetric);
-
-        // Notify about available workers
-        this.notifyWorkersChanged();
     }
 
     /**

--- a/js-packages/web-console/src/lib/components/profiler/ProfilerDiagram.svelte
+++ b/js-packages/web-console/src/lib/components/profiler/ProfilerDiagram.svelte
@@ -105,8 +105,8 @@
     instance?.visualizer.hideNodeAttributes(hideSticky)
   }
 
-  export function showTopNodes(metric: string, isSticky?: boolean) {
-    return instance?.visualizer.showTopNodes(metric, isSticky)
+  export function showTopNodes(isSticky?: boolean) {
+    return instance?.visualizer.showTopNodes(isSticky)
   }
 
   // Cleanup on component destruction

--- a/js-packages/web-console/src/lib/components/profiler/ProfilerLayout.svelte
+++ b/js-packages/web-console/src/lib/components/profiler/ProfilerLayout.svelte
@@ -87,11 +87,9 @@
   }
 
   // Handle metric selection change
-  function handleMetricChange(event: Event) {
-    const target = event.target as HTMLSelectElement
-    selectedMetricId = target.value
-    profilerDiagram?.selectMetric(target.value)
-  }
+  $effect(() => {
+    profilerDiagram?.selectMetric(selectedMetricId)
+  })
 
   // Handle worker checkbox change
   function handleWorkerChange(workerId: string) {
@@ -178,7 +176,7 @@
     <!-- Metric Selector -->
     <label class="flex items-center gap-2 text-sm">
       <span class="text-surface-600-400">Metric:</span>
-      <select value={selectedMetricId} onchange={handleMetricChange} class="select text-sm">
+      <select bind:value={selectedMetricId} class="select text-sm">
         {#each metrics as metric (metric.id)}
           <option value={metric.id}>{metric.label}</option>
         {/each}
@@ -194,13 +192,13 @@
 
     {@render pseudoNode({
       onmouseenter: () => {
-        profilerDiagram?.showTopNodes(selectedMetricId)
+        profilerDiagram?.showTopNodes()
       },
       onmouseleave: () => {
         profilerDiagram?.hideNodeAttributes()
       },
       onclick: () => {
-        profilerDiagram?.showTopNodes(selectedMetricId, true)
+        profilerDiagram?.showTopNodes(true)
       },
       text: 'top nodes'
     })}

--- a/js-packages/web-console/src/lib/components/profiler/ProfilerTooltip.svelte
+++ b/js-packages/web-console/src/lib/components/profiler/ProfilerTooltip.svelte
@@ -160,7 +160,7 @@
     z-index: 2;
     border-radius: 8px;
     max-height: calc(100% - 1rem);
-    max-width: calc(100% + 1rem);
+    max-width: calc(100% - 1rem);
     overflow-y: auto;
     overflow-x: auto;
   }


### PR DESCRIPTION
Please decide with @ryzhyk if we want this change; I believe it is clearly a better UX, and makes the behavior more intuitive.

Also: showTopNodes() method in profiler-lib no longer takes the selected metric as an argument because it is selected with a separate function call beforehand.