### PR TITLE
[adapters] Delta connector: stage input buffers.

### DIFF
--- a/crates/adapterlib/src/format.rs
+++ b/crates/adapterlib/src/format.rs
@@ -198,6 +198,68 @@ impl InputBuffer for Option<Box<dyn InputBuffer>> {
     }
 }
 
+impl InputBuffer for Box<dyn InputBuffer> {
+    fn len(&self) -> BufferSize {
+        self.as_ref().len()
+    }
+
+    fn hash(&self, hasher: &mut dyn Hasher) {
+        self.as_ref().hash(hasher)
+    }
+
+    fn flush(&mut self) {
+        self.as_mut().flush()
+    }
+
+    fn take_some(&mut self, n: usize) -> Option<Box<dyn InputBuffer>> {
+        self.as_mut().take_some(n)
+    }
+}
+
+/// A wrapper around a [StagedBuffers] that implements the [InputBuffer] trait.
+///
+/// The `StagedBuffers` trait is similar to `InputBuffer` in that it supports flushing
+/// a set of tuples to the circuit. Unlike `InputBuffer`, it doesn't support returning
+/// its size as a `BufferSize`. It also doesn't support hashing and taking a subset of
+/// records.
+///
+/// This wrapper adds the former by storing `BufferSize` collected from `InputBuffer`s
+/// used to create the `StagedBuffers`.
+///
+/// `hash()` and `take_some()` methods are unimplemented. Therefore this wrapper can only be
+/// safely used in contexts where these methods are not needed.
+///
+// FIXME: It would be better to encode the unimplemented functionality in the type system,
+// e.g., as an extension trait.
+pub struct StagedInputBuffer {
+    buffer: Box<dyn StagedBuffers>,
+    size: BufferSize,
+}
+
+impl StagedInputBuffer {
+    pub fn new(buffer: Box<dyn StagedBuffers>, size: BufferSize) -> Self {
+        Self { buffer, size }
+    }
+}
+
+impl InputBuffer for StagedInputBuffer {
+    fn flush(&mut self) {
+        self.buffer.flush()
+    }
+
+    fn len(&self) -> BufferSize {
+        self.size
+    }
+
+    fn hash(&self, _hasher: &mut dyn Hasher) {
+        unimplemented!()
+    }
+
+    fn take_some(&mut self, _n: usize) -> Option<Box<dyn InputBuffer>> {
+        unimplemented!()
+    }
+}
+
 /// Parses raw bytes into database records.
 pub trait Parser: Send + Sync {
     /// Parses `data` into records and returns the records and any parse errors

--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -270,9 +270,9 @@ pub enum NonFtInputReaderCommand {
     Transition(PipelineState),
 }
 
-pub struct InputQueueEntry<A> {
+pub struct InputQueueEntry<A, B> {
     /// Data buffer to push to the circuit.
-    buffer: Option<Box<dyn InputBuffer>>,
+    buffer: Option<B>,
 
     /// Time when data in this buffer was received from the transport endpoint.
     /// It is used to track the processing latency in different stages of the pipeline.
@@ -289,7 +289,7 @@ pub struct InputQueueEntry<A> {
     aux: A,
 }
 
-impl<A> InputQueueEntry<A> {
+impl<A, B> InputQueueEntry<A, B> {
     pub fn new_with_aux(timestamp: DateTime<Utc>, aux: A) -> Self {
         Self {
             buffer: None,
@@ -300,7 +300,7 @@ impl<A> InputQueueEntry<A> {
         }
     }
 
-    pub fn with_buffer(self, buffer: Option<Box<dyn InputBuffer>>) -> Self {
+    pub fn with_buffer(self, buffer: Option<B>) -> Self {
         Self { buffer, ..self }
     }
 
@@ -326,14 +326,14 @@ impl<A> InputQueueEntry<A> {
 ///
 /// Commonly used by `InputReader` implementations for staging buffers from
 /// worker threads.
-pub struct InputQueue<A = ()> {
+pub struct InputQueue<A = (), B = Box<dyn InputBuffer>> {
     #[allow(clippy::type_complexity)]
-    pub queue: Mutex<VecDeque<InputQueueEntry<A>>>,
+    pub queue: Mutex<VecDeque<InputQueueEntry<A, B>>>,
     pub consumer: Box<dyn InputConsumer>,
     pub transaction_in_progress: AtomicBool,
 }
 
-impl<A> InputQueue<A> {
+impl<A, B: InputBuffer> InputQueue<A, B> {
     pub fn new(consumer: Box<dyn InputConsumer>) -> Self {
         Self {
             queue: Mutex::new(VecDeque::new()),
@@ -342,9 +342,12 @@ impl<A> InputQueue<A> {
         }
     }
 
-    pub fn push_entry(&self, entry: InputQueueEntry<A>, errors: Vec<ParseError>) {
+    pub fn push_entry(&self, entry: InputQueueEntry<A, B>, errors: Vec<ParseError>) {
         self.consumer.parse_errors(errors);
-        let len = entry.buffer.len();
+        let len = entry
+            .buffer
+            .as_ref()
+            .map_or(BufferSize::empty(), |buffer| buffer.len());
 
         let mut queue = self.queue.lock().unwrap();
         queue.push_back(entry);
@@ -363,7 +366,7 @@ impl<A> InputQueue<A> {
     /// to the controller that `errors` have occurred during parsing.
     pub fn push_with_aux(
         &self,
-        (buffer, errors): (Option<Box<dyn InputBuffer>>, Vec<ParseError>),
+        (buffer, errors): (Option<B>, Vec<ParseError>),
         timestamp: DateTime<Utc>,
         aux: A,
     ) {
@@ -507,7 +510,7 @@ impl<A> InputQueue<A> {
     }
 }
 
-impl InputQueue<()> {
+impl InputQueue<(), Box<dyn InputBuffer>> {
     /// Appends `buffer`, if nonempty,` to the queue.  Reports to the controller
     /// that `errors` occurred during parsing.
     pub fn push(

--- a/crates/adapters/src/test/mock_dezset.rs
+++ b/crates/adapters/src/test/mock_dezset.rs
@@ -293,7 +293,11 @@ where
     }
 }
 
-impl<T, U> StagedBuffers for MockDeZSetStreamStagedBuffers<T, U> {
+impl<T, U> StagedBuffers for MockDeZSetStreamStagedBuffers<T, U>
+where
+    T: Send + Sync,
+    U: Send + Sync,
+{
     fn flush(&mut self) {
         self.handle
             .0

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -58,7 +58,7 @@ pub type ZSetStream<K> = Stream<RootCircuit, OrdZSet<K>>;
 /// than in [StagedBuffers::flush].  This means that, if the code driving the
 /// circuit can buffer data ahead of the circuit's demand for it, the cost can
 /// be hidden and data processing as a whole runs faster.
-pub trait StagedBuffers {
+pub trait StagedBuffers: Send + Sync {
     /// Flushes the data gathered into this buffer to the circuit.
     fn flush(&mut self);
 }


### PR DESCRIPTION
Use the staging optimization to distribute records received from the delta connector across workers asynchronously.

This seems to reduce the amount of time the controller spends sharding data between steps significantly.