### PR TITLE
[SQL] Generate all default values for tables with key

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -759,9 +759,9 @@ public class ToRustVisitor extends CircuitVisitor {
         }
 
         if (!this.useHandles) {
-            this.generateNestedStructs(new DBSPStructItem(type, null), false);
+            this.generateNestedStructs(new DBSPStructItem(type, operator.getMetadata()), false);
             this.generateNestedStructs(new DBSPStructItem(keyStructType, null), false);
-            this.generateNestedStructs(new DBSPStructItem(upsertStruct, null), false);
+            this.generateNestedStructs(new DBSPStructItem(upsertStruct, operator.getMetadata()), false);
 
             IHasSchema tableDescription = this.metadata.getTableDescription(operator.getTableName());
             JsonNode j = tableDescription.asJson(true);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -785,6 +785,37 @@ public class CatalogTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue5351() {
+        this.getCCS("""
+                CREATE TABLE test_data (
+                    username VARCHAR NOT NULL PRIMARY KEY,
+                    kafka_timestamp VARIANT DEFAULT CONNECTOR_METADATA()
+                ) WITH ('connectors' = '[
+                    {
+                        "format":{
+                            "name":"avro",
+                            "config": {
+                                "update_format":"raw",
+                                "registry_urls": ["http://localhost:18081"]
+                            }
+                        },
+                        "transport":{
+                            "name":"kafka_input",
+                            "config": {
+                                "topic":"test_topic",
+                                "start_from":"latest",
+                                "bootstrap.servers":"localhost:19092",
+                                "include_timestamp": true
+                            }
+                        }
+                    }
+                    ]',
+                    'append_only'='false',
+                    'materialized' = 'true'
+                );""");
+    }
+
+    @Test
     public void primaryKeyTest2() {
         String sql = """
                 create table t1(


### PR DESCRIPTION
Fixes #5351 

Here is the generated code:

```rust
        deserialize_table_record!(struct_59e068ad60738049["test_data", Variant, 2] {
            (field0, "username", false, SqlString, |_| None),
            (field1, "kafka_timestamp", false, Option<Variant>, |connector_metadata: &Option<Variant>| Some((*connector_metadata).clone().into()))
        });
        serialize_table_record!(struct_59e068ad60738049[2]{
            field0["username"]: SqlString,
            field1["kafka_timestamp"]: Option<Variant>
        });

        deserialize_table_record!(struct_878344184b6f1c0e["struct_59e068ad60738049_key", Variant, 1] {
            (field0, "username", false, SqlString, |_| None)
        });
        serialize_table_record!(struct_878344184b6f1c0e[1]{
            field0["username"]: SqlString
        });

        deserialize_table_record!(struct_a3040038fa4d9455["struct_59e068ad60738049_upsert", Variant, 2] {
            (field0, "username", false, SqlString, |_| None),
            (field1, "kafka_timestamp", false, Option<Option<Variant>>, |connector_metadata: &Option<Variant>| Some((*connector_metadata).clone().into()), |x| if x.is_none() { Some(None) } else {x})
        });
        serialize_table_record!(struct_a3040038fa4d9455[2]{
            field0["username"]: SqlString,
            field1["kafka_timestamp"]: Option<Option<Variant>>
        });
```