### PR TITLE
sync: support automatic periodic checkpoint syncs

### DIFF
--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -58,6 +58,9 @@ pub struct CheckpointSyncStatus {
 
     /// Most recently failed checkpoint sync, and the associated error.
     pub failure: Option<CheckpointSyncFailure>,
+
+    /// Most recently successful automated periodic checkpoint sync.
+    pub periodic: Option<Uuid>,
 }
 
 /// Information about a failed checkpoint sync.

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -527,6 +527,12 @@ pub struct SyncConfig {
     #[serde(default = "default_pull_interval")]
     pub pull_interval: u64,
 
+    /// The interval (in seconds) between each push of checkpoints to object store.
+    ///
+    /// Default: disabled (no periodic push).
+    #[serde(default)]
+    pub push_interval: Option<u64>,
+
     /// Extra flags to pass to `rclone`.
     ///
     /// WARNING: Supplying incorrect or conflicting flags can break `rclone`.

--- a/openapi.json
+++ b/openapi.json
@@ -11518,6 +11518,13 @@
             "default": 10,
             "minimum": 0
           },
+          "push_interval": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The interval (in seconds) between each push of checkpoints to object store.\n\nDefault: disabled (no periodic push).",
+            "nullable": true,
+            "minimum": 0
+          },
           "region": {
             "type": "string",
             "description": "The region that this bucket is in.\n\nLeave empty for Minio or the default region (`us-east-1` for AWS).",


### PR DESCRIPTION
Adds a parameter `push_interval` to `SyncConfig` to specify the interval at which to push the latest checkpoint to object storage. Default is None, disabling the periodic push.

Adds a field `periodic` to response of `/checkpoint/sync_status`, that maintains the latest periodic checkpoint that was synced. I chose adding a field instead of setting it to `success` as I think the user should be able to know if the sync was automatic or manual; it also allows us to maintain the current the behavior of the python client downstream.

