### PR TITLE
[dbsp, adapters] Add some missing region annotations.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
+++ b/crates/dbsp/src/operator/dynamic/aggregate/chain_aggregate.rs
@@ -59,27 +59,32 @@ where
         // ```
 
         let circuit = self.circuit();
-        let stream = self.dyn_shard(input_factories);
 
-        let bounds = TraceBounds::unbounded();
+        circuit
+            .region("chain_aggregate", || {
+                let stream = self.dyn_shard(input_factories);
 
-        let feedback = circuit.add_accumulate_integrate_trace_feedback::<Spine<OZ>>(
-            persistent_id,
-            output_factories,
-            bounds,
-        );
+                let bounds = TraceBounds::unbounded();
 
-        let output = circuit
-            .add_binary_operator(
-                ChainAggregate::new(output_factories, finit, fupdate),
-                &stream.dyn_accumulate(input_factories),
-                &feedback.delayed_trace,
-            )
-            .mark_sharded();
+                let feedback = circuit.add_accumulate_integrate_trace_feedback::<Spine<OZ>>(
+                    persistent_id,
+                    output_factories,
+                    bounds,
+                );
 
-        feedback.connect(&output, output_factories);
+                let output = circuit
+                    .add_binary_operator(
+                        ChainAggregate::new(output_factories, finit, fupdate),
+                        &stream.dyn_accumulate(input_factories),
+                        &feedback.delayed_trace,
+                    )
+                    .mark_sharded();
 
-        output
+                feedback.connect(&output, output_factories);
+
+                output
+            })
+            .clone()
     }
 }
 


### PR DESCRIPTION
Create regions for chain_aggregate circuits and for output circuits created by register_output_XXX functions.

@mihaibudiu , @Karakatiza666 , region names for output collections contain table/view names, which can be arbitrary unicode garbage. Can you check that the profile accepts that?