### PR TITLE
[fips] enable fips by default

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -69,10 +69,6 @@ jobs:
       - name: Build Rust binaries
         run: |
           FEATURES="${{ env.CARGO_FEATURES_BASE }}"
-          case "${{ matrix.target }}" in
-            *musl*) ;; # OpenSSL’s FIPS mode is implemented as a dynamically loaded provider (fips.so)
-            *) FEATURES="$FEATURES,fips" ;;
-          esac
           cargo build ${{ env.CARGO_FLAGS }} --features "$FEATURES" --target=${{ matrix.target }}
 
       - name: Print sccache stats
@@ -84,10 +80,6 @@ jobs:
         id: collect
         run: |
           FEATURES="${{ env.CARGO_FEATURES_BASE }}"
-          case "${{ matrix.target }}" in
-            *musl*) ;; # OpenSSL’s FIPS mode is implemented as a dynamically loaded provider (fips.so)
-            *) FEATURES="$FEATURES,fips" ;;
-          esac
           # Run again with --message-format=json to list out executables
           # (No real recompile since nothing has changed).
           # Then transform newlines to spaces for the artifact step.

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -25,7 +25,6 @@ default = [
     "with-redis",
     "with-nats",
 ]
-fips = ["rustls/fips"]
 with-kafka = ["rdkafka"]
 with-deltalake = ["deltalake", "deltalake-catalog-unity"]
 with-iceberg = ["feldera-iceberg"]
@@ -110,7 +109,7 @@ utoipa = { workspace = true }
 chrono = { workspace = true, features = ["rkyv-64", "serde"] }
 colored = { workspace = true }
 uuid = { workspace = true, features = ["v4", "std"] }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["fips"] }
 rkyv = { workspace = true, features = ["std", "size_64"] }
 csv-core = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -23,10 +23,10 @@ feldera-types = { workspace = true }
 feldera-cloud1-client = { workspace = true }
 feldera-ir = { workspace = true }
 
-# Cryptography provider
+# Cryptography provider (FIPS enabled by default)
 # Make sure this is the same rustls version used by other crates in the dependency tree.
 # See the `ensure_default_crypto_provider` function at the root of this crate.
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["fips"] }
 
 # Logging
 tracing = { workspace = true }
@@ -117,7 +117,6 @@ tikv-jemallocator = { workspace = true, features = ["profiling", "unprefixed_mal
 default = ["postgresql_embedded"]
 feldera-enterprise = []
 runtime-version = []
-fips = ["rustls/fips"]
 
 [build-dependencies]
 change-detection = { workspace = true }


### PR DESCRIPTION
Build rustls with fips  enabled by default. 
Remove check for musl target as we don't have it.
no changes to rust_compiler.rs

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
