### PR TITLE
[dbsp] GC for asof join postfix.

### DIFF
--- a/crates/dbsp/src/operator/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/accumulate_trace.rs
@@ -1,7 +1,7 @@
 use crate::{
     Circuit, DBData, DBWeight, Stream,
     circuit::metadata::MetaItem,
-    dynamic::{DowncastTrait, DynData, Erase, WithFactory},
+    dynamic::{DowncastTrait, DynData, Erase},
     operator::TraceBound,
     trace::{BatchReaderFactories, Filter},
     typed_batch::{Batch, DynBatch, DynBatchReader, Spine, TypedBatch, TypedBox},
@@ -266,7 +266,6 @@ where
     {
         self.inner()
             .dyn_accumulate_integrate_trace_retain_values_last_n(
-                WithFactory::<B::Val>::FACTORY,
                 &bounds_stream.inner_data(),
                 Box::new(move |ts: &DynData| {
                     let metadata = MetaItem::String(format!("{ts:?}"));

--- a/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
@@ -1,7 +1,7 @@
 use crate::Runtime;
 use crate::circuit::circuit_builder::{StreamId, register_replay_stream};
 use crate::circuit::metadata::{NUM_ALLOCATIONS_LABEL, NUM_INPUTS_LABEL};
-use crate::dynamic::{Factory, Weight, WeightTrait};
+use crate::dynamic::{Weight, WeightTrait};
 use crate::operator::dynamic::trace::{DelayedTraceId, TraceBounds};
 use crate::operator::{TraceBound, require_persistent_id};
 use crate::trace::spine_async::WithSnapshot;
@@ -166,7 +166,6 @@ where
     #[track_caller]
     pub fn dyn_accumulate_integrate_trace_retain_values_last_n<TS>(
         &self,
-        val_factory: &'static dyn Factory<B::Val>,
         bounds_stream: &Stream<C, Box<TS>>,
         retain_val_func: Box<dyn Fn(&TS) -> Filter<B::Val>>,
         n: usize,
@@ -179,7 +178,7 @@ where
         bounds.set_unique_val_bound_name(bounds_stream.get_persistent_id().as_deref());
 
         bounds_stream.inspect(move |ts| {
-            let filter = GroupFilter::LastN(n, retain_val_func(ts.as_ref()), val_factory);
+            let filter = GroupFilter::LastN(n, retain_val_func(ts.as_ref()));
             bounds.set_val_filter(filter);
         });
     }

--- a/crates/dbsp/src/operator/dynamic/asof_join.rs
+++ b/crates/dbsp/src/operator/dynamic/asof_join.rs
@@ -1301,7 +1301,6 @@ mod test {
                     hresult_integral.concat().consolidate(),
                     asof_join_reference2(&htransactions_output_handle, &husers_output_handle)
                 );
-
             }
 
             for (mut transactions, mut users) in deletions {
@@ -1313,7 +1312,6 @@ mod test {
                     hresult_integral.concat().consolidate(),
                     asof_join_reference2(&htransactions_output_handle, &husers_output_handle)
                 );
-
             }
         }
     }
@@ -1334,7 +1332,6 @@ mod test {
                     hresult_integral.concat().consolidate(),
                     asof_join_reference2(&htransactions_output_handle, &husers_output_handle)
                 );
-
             }
         }
     }

--- a/crates/dbsp/src/operator/trace.rs
+++ b/crates/dbsp/src/operator/trace.rs
@@ -1,7 +1,7 @@
 use crate::{
     Circuit, DBData, DBWeight, Stream,
     circuit::metadata::MetaItem,
-    dynamic::{DowncastTrait, DynData, Erase, WithFactory},
+    dynamic::{DowncastTrait, DynData, Erase},
     operator::TraceBound,
     trace::{BatchReaderFactories, Filter},
     typed_batch::{Batch, DynBatch, DynBatchReader, Spine, TypedBatch, TypedBox},
@@ -233,7 +233,6 @@ where
         RV: Fn(&B::Val, &TS) -> bool + Clone + Send + Sync + 'static,
     {
         self.inner().dyn_integrate_trace_retain_values_last_n(
-            WithFactory::<B::Val>::FACTORY,
             &bounds_stream.inner_data(),
             Box::new(move |ts: &DynData| {
                 let metadata = MetaItem::String(format!("{ts:?}"));

--- a/crates/dbsp/src/trace/cursor.rs
+++ b/crates/dbsp/src/trace/cursor.rs
@@ -799,6 +799,10 @@ where
     }
 }
 
+/// A cursor that filters keys and values based on a key filter and a value filter.
+///
+/// This cursor only support simple value filters. Use `FilteredMergeCursorWithSnapshot`
+/// to evaluate more complex filters, such as `GroupFilter::LastN`.
 pub struct FilteredMergeCursor<K, V, T, R, C>
 where
     K: ?Sized,
@@ -808,106 +812,8 @@ where
 {
     cursor: C,
     key_filter: Option<Filter<K>>,
-    value_filter: Option<GroupFilterCursor<V>>,
+    value_filter: Option<Filter<V>>,
     phantom: PhantomData<(T, Box<R>)>,
-}
-
-/// State maintained by a `GroupFilter` for a cursor.
-enum GroupFilterCursor<V: ?Sized> {
-    Simple {
-        filter: Filter<V>,
-    },
-    LastN {
-        n: usize,
-        filter: Filter<V>,
-        val: Box<V>,
-    },
-}
-
-impl<V: DataTrait + ?Sized> GroupFilter<V> {
-    fn new_cursor(&self) -> GroupFilterCursor<V> {
-        match self {
-            Self::Simple(filter) => GroupFilterCursor::Simple {
-                filter: filter.clone(),
-            },
-            Self::LastN(n, filter, val_factory) => GroupFilterCursor::LastN {
-                n: *n,
-                filter: filter.clone(),
-                val: val_factory.default_box(),
-            },
-        }
-    }
-}
-
-impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
-    /// Called after the cursor has advanced to a new key.
-    ///
-    /// Skip over values that don't satisfy the filter.
-    /// Return true if the cursor points to the valid values, false otherwise.
-    fn on_step_key<K: ?Sized, T, R: ?Sized>(
-        &mut self,
-        cursor: &mut dyn Cursor<K, V, T, R>,
-    ) -> bool {
-        match self {
-            Self::Simple { filter } => {
-                while let Some(val) = cursor.get_val() {
-                    if (filter.filter_func())(val) {
-                        return true;
-                    }
-                    cursor.step_val();
-                }
-                false
-            }
-            Self::LastN { n, filter, val } => {
-                // Find the last value below the waterline.
-                cursor.fast_forward_vals();
-                cursor.seek_val_with_reverse(&|val| !(filter.filter_func())(val));
-
-                // Find n'th value below the waterline.
-                let mut count = 1;
-                while count < *n && cursor.val_valid() {
-                    cursor.step_val_reverse();
-                    count += 1;
-                }
-
-                if cursor.val_valid() {
-                    // We need to discard everything below the current value.
-                    // Since cursors can't change direction, we need to remember
-                    // the value and rewind the cursor to the beginning.
-                    cursor.val().clone_to(val);
-                    cursor.rewind_vals();
-                    // Skip over values we discard.
-                    while cursor.val_valid() && cursor.val() != &**val {
-                        // println!("skipping: {:?}", cursor.val());
-                        cursor.step_val();
-                    }
-                    debug_assert_eq!(cursor.val(), &**val);
-                    true
-                } else {
-                    // Nothing to discard, rewind the cursor.
-                    cursor.rewind_vals();
-                    cursor.val_valid()
-                }
-            }
-        }
-    }
-
-    /// Called after the cursor has advanced to a new value.
-    ///
-    /// Skip over values that don't satisfy the filter.
-    fn on_step_val<K: ?Sized, T, R: ?Sized>(&mut self, cursor: &mut dyn Cursor<K, V, T, R>) {
-        match self {
-            Self::Simple { filter } => {
-                while let Some(val) = cursor.get_val() {
-                    if (filter.filter_func())(val) {
-                        return;
-                    }
-                    cursor.step_val();
-                }
-            }
-            Self::LastN { .. } => {}
-        }
-    }
 }
 
 impl<K, V, T, R, C> FilteredMergeCursor<K, V, T, R, C>
@@ -921,10 +827,9 @@ where
     pub fn new(
         mut cursor: C,
         key_filter: Option<Filter<K>>,
-        value_filter: Option<GroupFilter<V>>,
+        value_filter: Option<Filter<V>>,
     ) -> Self {
-        let mut value_filter = value_filter.map(|filter| filter.new_cursor());
-        Self::skip_filtered_keys(&mut cursor, &key_filter, &mut value_filter);
+        Self::skip_filtered_keys(&mut cursor, &key_filter, &value_filter);
         Self {
             cursor,
             key_filter,
@@ -936,14 +841,10 @@ where
     fn skip_filtered_keys(
         cursor: &mut C,
         key_filter: &Option<Filter<K>>,
-        value_filter: &mut Option<GroupFilterCursor<V>>,
+        value_filter: &Option<Filter<V>>,
     ) {
         while let Some(key) = cursor.get_key() {
-            if Filter::include(key_filter, key)
-                && value_filter
-                    .as_mut()
-                    .map(|filter| filter.on_step_key(cursor))
-                    .unwrap_or(true)
+            if Filter::include(key_filter, key) && Self::skip_filtered_values(cursor, value_filter)
             {
                 return;
             } else {
@@ -952,10 +853,14 @@ where
         }
     }
 
-    fn skip_filtered_values(cursor: &mut C, value_filter: &mut Option<GroupFilterCursor<V>>) {
-        if let Some(filter) = value_filter.as_mut() {
-            filter.on_step_val(cursor)
+    fn skip_filtered_values(cursor: &mut C, value_filter: &Option<Filter<V>>) -> bool {
+        while let Some(val) = cursor.get_val() {
+            if Filter::include(value_filter, val) {
+                return true;
+            }
+            cursor.step_val();
         }
+        false
     }
 }
 
@@ -981,11 +886,11 @@ where
     }
     fn step_key(&mut self) {
         self.cursor.step_key();
-        Self::skip_filtered_keys(&mut self.cursor, &self.key_filter, &mut self.value_filter);
+        Self::skip_filtered_keys(&mut self.cursor, &self.key_filter, &self.value_filter);
     }
     fn step_val(&mut self) {
         self.cursor.step_val();
-        Self::skip_filtered_values(&mut self.cursor, &mut self.value_filter);
+        Self::skip_filtered_values(&mut self.cursor, &self.value_filter);
     }
     fn map_times(&mut self, logic: &mut dyn FnMut(&T, &R)) {
         self.cursor.map_times(logic);
@@ -995,6 +900,207 @@ where
         T: PartialEq<()>,
     {
         self.cursor.weight()
+    }
+}
+
+/// A cursor that filters keys and values based on a key filter and a value filter.
+///
+/// Uses a trace of the spine to evaluate `GroupFilter::LastN` filters.
+pub struct FilteredMergeCursorWithSnapshot<'a, K, V, T, R, C>
+where
+    K: ?Sized,
+    V: ?Sized + 'static,
+    R: ?Sized,
+    C: Cursor<K, V, T, R>,
+{
+    cursor: C,
+    trace_cursor: Box<dyn Cursor<K, V, T, R> + Send + 'a>,
+    key_filter: Option<Filter<K>>,
+    value_filter: GroupFilterCursor<V>,
+    phantom: PhantomData<(T, Box<R>)>,
+}
+
+impl<'a, K, V, T, R, C> FilteredMergeCursorWithSnapshot<'a, K, V, T, R, C>
+where
+    K: ?Sized + 'static,
+    V: DataTrait + ?Sized,
+    R: ?Sized + 'static,
+    C: Cursor<K, V, T, R>,
+    T: 'static,
+{
+    /// The `snapshot` argument must be the snapshot of the entire spine that the cursor is being created for.
+    pub fn new<S>(
+        cursor: C,
+        key_filter: Option<Filter<K>>,
+        value_filter: GroupFilter<V>,
+        snapshot: &'a S,
+    ) -> Self
+    where
+        S: BatchReader<Key = K, Val = V, Time = T, R = R>,
+    {
+        let trace_cursor = Box::new(snapshot.cursor());
+        let value_filter = value_filter.new_cursor();
+        let mut result = Self {
+            cursor,
+            trace_cursor,
+            key_filter,
+            value_filter,
+            phantom: PhantomData,
+        };
+        result.skip_filtered_keys();
+
+        result
+    }
+
+    fn skip_filtered_keys(&mut self) {
+        while let Some(key) = self.cursor.get_key() {
+            if Filter::include(&self.key_filter, key)
+                && self
+                    .value_filter
+                    .on_step_key(&mut self.cursor, &mut self.trace_cursor)
+            {
+                return;
+            } else {
+                self.cursor.step_key();
+            }
+        }
+    }
+
+    fn skip_filtered_values(&mut self) {
+        self.value_filter
+            .on_step_val(&mut self.cursor, &mut self.trace_cursor);
+    }
+}
+
+impl<'a, K, V, T, R, C> MergeCursor<K, V, T, R>
+    for FilteredMergeCursorWithSnapshot<'a, K, V, T, R, C>
+where
+    K: ?Sized + 'static,
+    V: DataTrait + ?Sized,
+    R: ?Sized + 'static,
+    T: 'static,
+    C: Cursor<K, V, T, R>,
+{
+    fn key_valid(&self) -> bool {
+        self.cursor.key_valid()
+    }
+    fn val_valid(&self) -> bool {
+        self.cursor.val_valid()
+    }
+    fn key(&self) -> &K {
+        self.cursor.key()
+    }
+    fn val(&self) -> &V {
+        self.cursor.val()
+    }
+    fn step_key(&mut self) {
+        self.cursor.step_key();
+        self.skip_filtered_keys();
+    }
+    fn step_val(&mut self) {
+        self.cursor.step_val();
+        self.skip_filtered_values();
+    }
+    fn map_times(&mut self, logic: &mut dyn FnMut(&T, &R)) {
+        self.cursor.map_times(logic);
+    }
+    fn weight(&mut self) -> &R
+    where
+        T: PartialEq<()>,
+    {
+        self.cursor.weight()
+    }
+}
+
+/// State maintained by a `GroupFilter` for a cursor.
+enum GroupFilterCursor<V: ?Sized> {
+    Simple { filter: Filter<V> },
+    LastN { n: usize, filter: Filter<V> },
+}
+
+impl<V: DataTrait + ?Sized> GroupFilter<V> {
+    fn new_cursor(&self) -> GroupFilterCursor<V> {
+        match self {
+            Self::Simple(filter) => GroupFilterCursor::Simple {
+                filter: filter.clone(),
+            },
+            Self::LastN(n, filter) => GroupFilterCursor::LastN {
+                n: *n,
+                filter: filter.clone(),
+            },
+        }
+    }
+}
+
+impl<V: DataTrait + ?Sized> GroupFilterCursor<V> {
+    /// Called after the cursor has advanced to a new key.
+    ///
+    /// Skip over values that don't satisfy the filter.
+    /// Return true if the cursor points to the valid values, false otherwise.
+    fn on_step_key<K: ?Sized, T, R: ?Sized>(
+        &mut self,
+        cursor: &mut dyn Cursor<K, V, T, R>,
+        trace_cursor: &mut dyn Cursor<K, V, T, R>,
+    ) -> bool {
+        if !trace_cursor.seek_key_exact(cursor.key(), None) {
+            return false;
+        }
+
+        match self {
+            Self::Simple { filter } => {
+                while let Some(val) = cursor.get_val() {
+                    if (filter.filter_func())(val) {
+                        return true;
+                    }
+                    cursor.step_val();
+                }
+                false
+            }
+            Self::LastN { n, filter } => {
+                // Find the last value below the waterline.
+                trace_cursor.fast_forward_vals();
+                trace_cursor.seek_val_with_reverse(&|val| !(filter.filter_func())(val));
+
+                // Find n'th value below the waterline.
+                let mut count = 1;
+                while count < *n && trace_cursor.val_valid() {
+                    trace_cursor.step_val_reverse();
+                    count += 1;
+                }
+
+                if trace_cursor.val_valid() {
+                    // `trace_cursor` points to the first value below the waterline.
+                    // Skip values up to this value.
+                    while cursor.val_valid() && cursor.val() < trace_cursor.val() {
+                        // println!("skipping: {:?}", cursor.val());
+                        cursor.step_val();
+                    }
+                }
+
+                cursor.val_valid()
+            }
+        }
+    }
+
+    /// Called after the cursor has advanced to a new value.
+    ///
+    /// Skip over values that don't satisfy the filter.
+    fn on_step_val<K: ?Sized, T, R: ?Sized>(
+        &mut self,
+        cursor: &mut dyn Cursor<K, V, T, R>,
+        _trace_cursor: &mut dyn Cursor<K, V, T, R>,
+    ) {
+        match self {
+            Self::Simple { filter } => {
+                while let Some(val) = cursor.get_val() {
+                    if (filter.filter_func())(val) {
+                        return;
+                    }
+                    cursor.step_val();
+                }
+            }
+            Self::LastN { .. } => {}
+        }
     }
 }
 

--- a/crates/dbsp/src/trace/filter.rs
+++ b/crates/dbsp/src/trace/filter.rs
@@ -5,7 +5,7 @@
 
 use dyn_clone::DynClone;
 
-use crate::{circuit::metadata::MetaItem, dynamic::Factory};
+use crate::circuit::metadata::MetaItem;
 
 pub trait FilterFunc<V: ?Sized>: Fn(&V) -> bool + DynClone + Send + Sync {}
 
@@ -65,16 +65,34 @@ impl<V: ?Sized> Clone for Filter<V> {
 ///   it is also satisfied for all subsequent values for the same key.
 ///   Also assumed that the values are ordered in some way, so that the last N
 ///   values under the cursor ate the ones that need to be preserved.
+///
+/// Note that the `LastN` filter can not be evaluated against an individual batch and
+/// requires access to the complete spine that the batch belongs to.  The reason is that
+/// some of the last N values in the batch may not be present in the trace because
+/// there may exist retractions for them in other batches within the spine.
+///
+/// Therefore, the `LastN` filter is only evaluated as part of a background merge.
+/// See `BatchReader::merge_batches_with_snapshot` for more details.
 pub enum GroupFilter<V: ?Sized + 'static> {
     Simple(Filter<V>),
-    LastN(usize, Filter<V>, &'static dyn Factory<V>),
+    LastN(usize, Filter<V>),
+}
+impl<V: ?Sized + 'static> GroupFilter<V> {
+    /// Returns true if the filter cannot be evaluated against an individual batch and requires
+    /// access to the complete spine that the batch belongs to.
+    pub fn requires_snapshot(&self) -> bool {
+        match self {
+            Self::Simple(..) => false,
+            Self::LastN(..) => true,
+        }
+    }
 }
 
 impl<V: ?Sized> Clone for GroupFilter<V> {
     fn clone(&self) -> Self {
         match self {
             Self::Simple(filter) => Self::Simple(filter.clone()),
-            Self::LastN(n, filter, val_factory) => Self::LastN(*n, filter.clone(), *val_factory),
+            Self::LastN(n, filter) => Self::LastN(*n, filter.clone()),
         }
     }
 }
@@ -83,7 +101,7 @@ impl<V: ?Sized> GroupFilter<V> {
     pub fn metadata(&self) -> MetaItem {
         match self {
             Self::Simple(filter) => filter.metadata().clone(),
-            Self::LastN(_n, filter, _val_factory) => filter.metadata().clone(),
+            Self::LastN(_n, filter) => filter.metadata().clone(),
         }
     }
 }

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -178,7 +178,7 @@ pub fn filter<K: DataTrait + ?Sized, V: DataTrait + ?Sized, T, R: WeightTrait + 
                 tuples.retain(|((_k, v, _t), _r)| (filter.filter_func())(v.as_ref()));
                 return tuples;
             }
-            GroupFilter::LastN(n, filter, _val_factory) => {
+            GroupFilter::LastN(n, filter) => {
                 let mut tuples_by_key = BTreeMap::new();
                 for ((k, v, t), w) in tuples.into_iter() {
                     tuples_by_key


### PR DESCRIPTION
Fix a logical bug in the implementation of the LastN value filter.  The original thinking was that a conservative estimate for keeping the last N values was to keep the last n values in each merged batch. This is actually unsound because the last value under the waterline in a given batch may not be present in the trace due to a matching retraction in another batch. In this case we may need to keep additional values in the output of the cursor. The number of additional values is generally unbounded.

A reliable way to establish the bound is to compute the last n values in the complete trace and discard everything below that. This commit implements this behavior. The main complication here is that we need to pass a spine snapshot to the merge cursor, which required extending the merge cursor API.

Add a brief description of the pull request.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
