### PR TITLE
[fda] Fix: command  alias  is duplicated

### DIFF
--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -670,7 +670,6 @@ pub enum PipelineAction {
         no_wait: bool,
     },
     /// Initiate rebalancing.
-    #[clap(aliases = &["rebalance"])]
     Rebalance {
         /// The name of the pipeline.
         #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]


### PR DESCRIPTION
Fixes:
```
thread 'main' (2019) panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.39/src/builder/debug_asserts.rs:347:13:
Command fda: command `rebalance` alias `rebalance` is duplicated
```