### PR TITLE
[fips] use fips aws-lc-fips-sys crypto module only on Linux

### DIFF
--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -109,7 +109,6 @@ utoipa = { workspace = true }
 chrono = { workspace = true, features = ["rkyv-64", "serde"] }
 colored = { workspace = true }
 uuid = { workspace = true, features = ["v4", "std"] }
-rustls = { workspace = true, features = ["fips"] }
 rkyv = { workspace = true, features = ["std", "size_64"] }
 csv-core = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
@@ -202,6 +201,10 @@ ignored = ["num-traits"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = { workspace = true, features = ["symbolize"] }
+rustls = { workspace = true, features = ["fips"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -23,11 +23,6 @@ feldera-types = { workspace = true }
 feldera-cloud1-client = { workspace = true }
 feldera-ir = { workspace = true }
 
-# Cryptography provider (FIPS enabled by default)
-# Make sure this is the same rustls version used by other crates in the dependency tree.
-# See the `ensure_default_crypto_provider` function at the root of this crate.
-rustls = { workspace = true, features = ["fips"] }
-
 # Logging
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
@@ -109,6 +104,15 @@ tempfile = { workspace = true }
 # Keep in-sync with `src/compiler/rust_compiler.rs`.
 compare = { workspace = true }
 sha2 = { workspace = true }
+
+# Cryptography provider (FIPS enabled by default)
+# Make sure this is the same rustls version used by other crates in the dependency tree.
+# See the `ensure_default_crypto_provider` function at the root of this crate.
+[target.'cfg(target_os = "linux")'.dependencies]
+rustls = { workspace = true, features = ["fips"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true, features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }


### PR DESCRIPTION
On non-linux target use aws-lc-rs backend with non-fips aws-lc-sys crypto module because we compile statically and aws-lc-fips-sys can be statically compiled only on linux target.



## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
