### PR TITLE
Add a button to copy the result of ad-hoc queries

### DIFF
--- a/js-packages/web-console/.prettierignore
+++ b/js-packages/web-console/.prettierignore
@@ -2,6 +2,9 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+# Svelte
+.svelte-kit/
+/build/
 # Other files
 src/assets
 tmp/

--- a/js-packages/web-console/README.md
+++ b/js-packages/web-console/README.md
@@ -61,6 +61,7 @@ bun run check
 ### Build issues
 
 If you experience unexpected build issues, run `bun run clean` from the repository root and make sure you have the supported Node.js (v20) and Bun.js (1.3.3) versions installed:
+
 ```bash
 bun run clean
 node --version && bun --version

--- a/js-packages/web-console/src/lib/components/other/ClipboardCopyButton.svelte
+++ b/js-packages/web-console/src/lib/components/other/ClipboardCopyButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { clipboard } from '@svelte-bin/clipboard'
+  import { clipboard, type Parameter } from '@svelte-bin/clipboard'
   import { clickedClass } from '$lib/compositions/actions/clickedClass'
   import type { Snippet } from '$lib/types/svelte'
 
@@ -7,11 +7,11 @@
     value,
     class: _class,
     children
-  }: { value: string; class?: string; children?: Snippet } = $props()
+  }: { value: Parameter; class?: string; children?: Snippet } = $props()
 </script>
 
 <button
-  class="btn flex h-9 flex-none before:w-4 before:transition-transform {_class}"
+  class="btn-icon flex h-9 flex-none before:w-4 before:transition-transform {_class}"
   use:clipboard={value}
   use:clickedClass={{
     base: 'fd fd-copy',

--- a/js-packages/web-console/src/lib/components/other/SQLValueTooltip.svelte
+++ b/js-packages/web-console/src/lib/components/other/SQLValueTooltip.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { useToast } from '$lib/compositions/useToastNotification'
+  import { displaySQLValue, serializeSQLValue } from '$lib/functions/sql'
+  import type { SQLValueJS } from '$lib/types/sql'
+  import ClipboardCopyButton from './ClipboardCopyButton.svelte'
+
+  let {
+    popupRef = $bindable(),
+    tooltipData
+  }: {
+    popupRef?: HTMLElement
+    tooltipData?: { x: number; y: number; targetWidth: number; value: SQLValueJS }
+  } = $props()
+
+  const toast = useToast()
+</script>
+
+<div
+  class="bg-white-dark absolute m-0 w-max max-w-lg -translate-x-[4.5px] -translate-y-[2.5px] border border-surface-500 px-2 py-1 break-words whitespace-break-spaces text-surface-950-50"
+  popover="manual"
+  bind:this={popupRef}
+  style={tooltipData
+    ? `left: ${tooltipData.x}px; top: ${tooltipData.y}px; min-width: ${tooltipData.targetWidth + 8}px`
+    : ''}
+>
+  <div class="flex flex-nowrap justify-between gap-2">
+    <span class="flex-1">
+      {(tooltipData && toast.catchError(displaySQLValue)(tooltipData.value)) || ''}
+    </span>
+    {#if tooltipData}
+      <ClipboardCopyButton
+        class="flex-none p-0"
+        value={() => toast.catchError(serializeSQLValue)(tooltipData.value) ?? ''}
+      ></ClipboardCopyButton>
+    {/if}
+  </div>
+</div>

--- a/js-packages/web-console/src/lib/components/other/ScrollDownFab.svelte
+++ b/js-packages/web-console/src/lib/components/other/ScrollDownFab.svelte
@@ -2,19 +2,21 @@
   import { scale } from 'svelte/transition'
 
   const {
-    reverseScroll
+    reverseScroll,
+    class: className = ''
   }: {
     reverseScroll: {
       scrollToBottom: (lastOffset?: number) => void
       stickToBottom: boolean
     }
+    class?: string
   } = $props()
 </script>
 
 {#if !reverseScroll.stickToBottom}
   <button
     transition:scale={{ duration: 200 }}
-    class="fd fd-arrow-down absolute right-4 bottom-4 z-20 rounded-full preset-filled-primary-500 p-2 text-[20px]"
+    class="fd fd-arrow-down absolute right-4 bottom-4 z-20 rounded-full preset-filled-primary-500 p-2 text-[20px] {className}"
     onclick={() => {
       reverseScroll.stickToBottom = true
       reverseScroll.scrollToBottom()

--- a/js-packages/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/ChangeStream.svelte
@@ -23,6 +23,8 @@
   import { usePopoverTooltip } from '$lib/compositions/common/usePopoverTooltip.svelte'
   import { useReverseScrollContainer } from '$lib/compositions/common/useReverseScrollContainer.svelte'
   import ScrollDownFab from '$lib/components/other/ScrollDownFab.svelte'
+  import SQLValueTooltip from '$lib/components/other/SQLValueTooltip.svelte'
+  import type { SQLValueJS } from '$lib/types/sql'
 
   let {
     changeStream
@@ -31,25 +33,14 @@
   } = $props()
 
   let popupRef: HTMLElement | undefined = $state()
-  let tooltip = usePopoverTooltip(() => popupRef)
+  let tooltip = usePopoverTooltip<SQLValueJS>(() => popupRef)
 
   const reverseScroll = useReverseScrollContainer({
     observeContentSize: () => changeStream.rows.length
   })
 </script>
 
-<div
-  class="bg-white-dark absolute m-0 scrollbar max-h-[90%] w-max max-w-lg -translate-x-[4.5px] -translate-y-[2.5px] overflow-auto border border-surface-500 px-2 py-2"
-  popover="manual"
-  bind:this={popupRef}
-  style={tooltip.data
-    ? `left: ${tooltip.data.x}px; top: ${tooltip.data.y}px; min-width: ${tooltip.data.targetWidth + 8}px`
-    : ''}
->
-  <div class="break-words whitespace-break-spaces text-surface-950-50">
-    {tooltip.data?.text}
-  </div>
-</div>
+<SQLValueTooltip bind:popupRef tooltipData={tooltip.data}></SQLValueTooltip>
 
 <div class="bg-white-dark relative flex w-full flex-1 flex-col rounded">
   {#if changeStream.totalSkippedBytes}
@@ -118,10 +109,10 @@
             <SQLValue
               {value}
               class="cursor-pointer"
-              props={(format) => ({
-                onclick: tooltip.showTooltip(format(value)),
+              props={{
+                onclick: tooltip.showTooltip(value),
                 onmouseleave: tooltip.onmouseleave
-              })}
+              }}
             ></SQLValue>
           {/each}
         </tr>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -139,7 +139,10 @@
   {#snippet tabBarEnd()}
     {#if currentTab.value !== 'Errors'}
       <div class="ml-auto flex">
-        <ClipboardCopyButton value={pipeline.current.id} class="h-8 w-auto preset-tonal-surface">
+        <ClipboardCopyButton
+          value={pipeline.current.id}
+          class="h-8 w-auto! gap-2 preset-tonal-surface px-4"
+        >
           <span class="text-base font-normal text-surface-950-50"> Pipeline ID </span>
         </ClipboardCopyButton>
         <Tooltip placement="top">

--- a/js-packages/web-console/src/lib/components/relationData/SQLValue.svelte
+++ b/js-packages/web-console/src/lib/components/relationData/SQLValue.svelte
@@ -37,22 +37,13 @@
     class: _class,
     ...rest
   }: { value: SQLValueJS } & {
-    props?: (formatter: (value: SQLValueJS) => string) => HTMLTdAttributes
+    props?: HTMLTdAttributes
   } & HTMLTdAttributes = $props()
   const thumb = $derived(value === null ? 'NULL' : trim(stringifyUntilLength(value, 50)))
-  const displayValue = (value: SQLValueJS) => {
-    return value === null
-      ? 'NULL'
-      : typeof value === 'string'
-        ? value
-        : BigNumber.isBigNumber(value)
-          ? value.toFixed()
-          : JSONbig.stringify(value, undefined, 1)
-  }
 </script>
 
 <td
-  {...props?.(displayValue)}
+  {...props}
   class:italic={value === null}
   class="px-3 {typeof value === 'number' || BigNumber.isBigNumber(value)
     ? 'text-right'

--- a/js-packages/web-console/src/lib/compositions/common/usePopoverTooltip.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/common/usePopoverTooltip.svelte.ts
@@ -1,8 +1,8 @@
 import { untrack } from 'svelte'
 
-export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined) => {
-  let tooltipDetails: { element: HTMLElement; value: any } | undefined = $state()
-  let popupData: { x: number; y: number; targetWidth: number; text: string } | undefined = $state()
+export const usePopoverTooltip = <T = any>(popoverElement: () => HTMLElement | undefined) => {
+  let tooltipDetails: { element: HTMLElement; value: T } | undefined = $state()
+  let popupData: { x: number; y: number; targetWidth: number; value: T } | undefined = $state()
   let hoverCount = $state(0)
   $effect(() => {
     if (hoverCount > 3) {
@@ -57,13 +57,13 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
       el.hidePopover()
       return
     }
-    const text = tooltipDetails.value
+    const value = tooltipDetails.value
     const rect = tooltipDetails.element.getBoundingClientRect()
     popupData = {
       x: 0,
       y: 0,
       targetWidth: 0,
-      text
+      value
     }
     el.showPopover()
     requestAnimationFrame(() => {
@@ -72,18 +72,18 @@ export const usePopoverTooltip = (popoverElement: () => HTMLElement | undefined)
         x: Math.min(Math.max(0, rect.left), window.innerWidth - rect2.width),
         y: Math.min(rect.top, window.innerHeight - rect2.height),
         targetWidth: tooltipDetails!.element.clientWidth,
-        text
+        value
       }
     })
   })
   type CustomMouseEvent = MouseEvent & {
     currentTarget: EventTarget & HTMLTableCellElement
   }
-  const showTooltipWith = (e: CustomMouseEvent, value: any) => {
+  const showTooltipWith = (e: CustomMouseEvent, value: T) => {
     tooltipDetails = { element: e.currentTarget, value }
     ++hoverCount
   }
-  const showTooltipCb = (value: any) => (e: CustomMouseEvent) => showTooltipWith(e, value)
+  const showTooltipCb = (value: T) => (e: CustomMouseEvent) => showTooltipWith(e, value)
   const onmouseleave = (e: CustomMouseEvent) => {
     requestAnimationFrame(() => {
       hoverCount -= hoverCount > 0 ? 1 : 0

--- a/js-packages/web-console/src/lib/compositions/useToastNotification.ts
+++ b/js-packages/web-console/src/lib/compositions/useToastNotification.ts
@@ -1,12 +1,32 @@
 import { toast } from 'svelte-french-toast'
 
 export const useToast = () => {
-  return {
-    toastError(e: Error, durationMs?: number) {
-      toast.error(e.message, {
+  const toastError = (error: Error, durationMs?: number) => {
+    try {
+      toast.error(error.message, {
         className: 'text-lg !max-w-[500px]',
         duration: durationMs
       })
+    } catch (e) {
+      console.log('Unable to push toast error:', e)
+      console.log('Original error: ', error)
+    }
+  }
+  return {
+    toastError,
+    catchError<Args extends any[], R>(f: (...args: Args) => R, durationMs?: number) {
+      return (...args: Args) => {
+        try {
+          return f(...args)
+        } catch (e) {
+          if (e instanceof Error) {
+            requestAnimationFrame(() => {
+              toastError(e, durationMs)
+            })
+          }
+          return undefined
+        }
+      }
     },
     toastMain(message: string) {
       toast.error(message, {

--- a/js-packages/web-console/src/lib/functions/sql.ts
+++ b/js-packages/web-console/src/lib/functions/sql.ts
@@ -1,5 +1,10 @@
+import { BigNumber } from 'bignumber.js'
+import { Dayjs, isDayjs } from 'dayjs'
+import JSONbig from 'true-json-bigint'
+import type { QueryResult } from '$lib/components/adhoc/Query.svelte'
 import { nonNull } from '$lib/functions/common/function'
 import type { ColumnType } from '$lib/services/manager'
+import type { SQLValueJS } from '$lib/types/sql'
 
 const displaySQLType = (columntype: ColumnType): string =>
   (columntype.component ? displaySQLType(columntype.component) + ' ' : '') +
@@ -11,3 +16,82 @@ const displaySQLType = (columntype: ColumnType): string =>
 
 export const displaySQLColumnType = ({ columntype }: { columntype: ColumnType }) =>
   columntype.type ? displaySQLType(columntype) + (columntype.nullable ? '' : ' NOT NULL') : ''
+
+export const displaySQLValue = (value: SQLValueJS) => {
+  return value === null
+    ? 'NULL'
+    : typeof value === 'string'
+      ? value
+      : BigNumber.isBigNumber(value)
+        ? value.toFixed()
+        : JSONbig.stringify(value, undefined, 1)
+}
+
+/**
+ * Convert SQLValueJS to a JSON-serializable value
+ * Handles recursive structures including Maps and nested arrays
+ */
+const toJSONValue = (value: SQLValueJS): unknown => {
+  if (value === null) {
+    return null
+  }
+  if (isDayjs(value)) {
+    return value.toISOString()
+  }
+  if (value instanceof Map) {
+    // Convert Map to plain object, recursively converting values
+    const obj: Record<string, unknown> = {}
+    for (const [key, val] of value) {
+      obj[key] = toJSONValue(val)
+    }
+    return obj
+  }
+  if (Array.isArray(value)) {
+    // Recursively convert array elements
+    return value.map(toJSONValue)
+  }
+  // For primitives (string, number, boolean) and BigNumber, return as-is
+  // JSONbig.stringify will handle BigNumber correctly
+  return value
+}
+
+/**
+ * Serialize SQLValueJS to a JSON string representation suitable for CSV export
+ */
+export const serializeSQLValue = (value: SQLValueJS): string => {
+  return JSONbig.stringify(toJSONValue(value))
+}
+
+/**
+ * Convert QueryResult to CSJV (Comma-Separated JSON Values) format
+ *
+ * CSJV is like CSV, but each cell is serialized as a JSON value.
+ * The first row contains column names as JSON strings.
+ * Subsequent rows contain data cells as JSON values.
+ *
+ * @param result - The query result to serialize
+ * @returns CSJV-formatted string
+ */
+export const tableToCSJV = (result: QueryResult): string => {
+  const rows = result.rows()
+  const columns = result.columns
+
+  // Pre-allocate array for worst case (header + all rows)
+  const lines = new Array<string>(rows.length + 1)
+
+  // Build the header row with column names as JSON strings
+  lines[0] = columns.map((col) => JSONbig.stringify(col.name)).join(',')
+
+  // Build data rows in a single pass: data rows have a `cells` property,
+  // while error/warning rows use `error` or `warning`. Only data rows are exported.
+  let lineIndex = 0
+  for (const row of rows) {
+    if ('cells' in row) {
+      lines[++lineIndex] = row.cells.map(serializeSQLValue).join(',')
+    }
+  }
+
+  // Truncate array to actual size (in case some rows were errors/warnings)
+  lines.length = lineIndex + 1
+  return lines.join('\n')
+}


### PR DESCRIPTION
The implementation correctly handles nested collection types.

<img width="1103" height="775" alt="image" src="https://github.com/user-attachments/assets/964f077a-e7df-48b6-896b-f5a6d232c07f" />

The result:

```bash

"cc_num","name","lat","long"
100000000000002,"Elwin Becker",38.675322903215616,-95.24527236636264
100000000000003,"Dillon Turner",31.299302184625372,-90.2092812664037
100000000000004,"Jose Christiansen",40.54722284074282,-95.0805152553869
100000000000013,"Frederic Oberbrunner",47.42061505582383,-83.07470872217422
100000000000017,"Davon Kerluke",41.41167950963154,-93.10512208724244
...

```

Also, Fix https://github.com/feldera/feldera/issues/4294: Cannot copy/paste value from adhoc-query output 
<img width="1103" height="775" alt="image" src="https://github.com/user-attachments/assets/1ae37506-eea7-4029-b0d1-92455ed4c38b" />



Fixed adhoc query result flickering in Firefox