### PR TITLE
[profile-vis] Fix support bundle files not discovered when located in subdirectories of the archive

### DIFF
--- a/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
+++ b/js-packages/profiler-layout/src/lib/functions/processZipBundle.ts
@@ -33,8 +33,9 @@ export function getSuitableProfiles(zipData: Uint8Array): [Date, ZipItem[]][] {
   const profileTimestamps = groupBy(
     profileFiles,
     // group by file timestamp; all files in a bundle are named with names like TIMESTAMP_FILENAME
-    // where TIMESTAMP is a string encoding a timestamp
-    (file) => file.filename.match(/^(.*?)_/)?.[1] ?? ''
+    // where TIMESTAMP is an ISO 8601 timestamp
+    // Examples: "2026-01-19T12:55:54.152834443+00:00_logs.txt", "some/path/2026-01-19T12:55:54.152834443+00:00_logs.txt"
+    (file) => file.filename.match(/(?:^|\/)(\d{4}-\d{2}-\d{2}T[^/_]+)_/)?.[1] ?? ''
   ).filter(
     (group) => group[0] && group[1].some((file) => circuitProfileRegex.test(file.filename))
     // Pipeline config and dataflow graph are not required

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabProfileVisualizer.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabProfileVisualizer.svelte
@@ -58,6 +58,11 @@
       loadedPipelineName = sourceName
       getProfileFiles = () => suitableProfiles
       selectedProfile = suitableProfiles.at(-1)![0] // Select most recent
+      if (!selectedProfile || isNaN(selectedProfile.getTime())) { // Hopefully a redundant check for an obscure case where we did not pick a valid bundle
+        errorMessage = `Unexpected error: unable to pick the latest profile in a support bundle. Inspect the bundle archive for integrity.`
+        selectedProfile = null
+        return false
+      }
       return true
     } catch (error) {
       if (error instanceof Error) {


### PR DESCRIPTION
All the files in the archive are easily discoverable - their parent directories are just prepended in the full path, so I only needed to revise the regex to properly extract the profile timetamp for both shallow and deep file paths