### PR TITLE
[adapters] Fix accounting of queued batches with transaction.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2823,6 +2823,8 @@ impl CircuitThread {
                         "Output endpoint '{}' was created during the current transaction (seq. number {}) and will not receive any outputs until the next transaction.",
                         endpoint.endpoint_name, endpoint.created_during_transaction_number
                     );
+                    self.controller.status.enqueue_batch(*endpoint_id, 0);
+
                     // We need to propagate processed_records to the connector for progress tracking.
                     endpoint.queue.push((self.step, None, processed_records));
                     endpoint.unparker.unpark();


### PR DESCRIPTION
Fixes #5464 

A recent change introduced a corner case where an empty batch was pushed to the queue, but the queued batch counter was not updated, leading to an underflow when dequeuing the batch.