### PR TITLE
storage: better checkpoint GC during S3 sync

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -6547,9 +6547,13 @@ impl RunningCheckpoint {
         checkpoint: Checkpoint,
         circuit: &mut CircuitThread,
     ) -> Result<Checkpoint, ControllerError> {
-        if circuit.sync_checkpoint_requests.is_empty()
-            && let Err(error) = circuit.circuit.gc_checkpoint()
-        {
+        if let Err(error) = circuit.circuit.gc_checkpoint(
+            circuit
+                .sync_checkpoint_requests
+                .iter()
+                .map(|c| c.uuid())
+                .collect::<HashSet<_>>(),
+        ) {
             warn!("error removing old checkpoints: {error}");
         }
 

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -27,6 +27,8 @@ def storage_cfg(
     standby: bool = False,
     pull_interval: int = 2,
     push_interval: Optional[int] = None,
+    retention_min_count: int = 1,
+    retention_min_age: int = 0,
 ) -> dict:
     return {
         "backend": {
@@ -43,6 +45,8 @@ def storage_cfg(
                     "standby": standby,
                     "pull_interval": pull_interval,
                     "push_interval": push_interval,
+                    "retention_min_count": retention_min_age,
+                    "retention_min_age": retention_min_count,
                 }
             },
         }
@@ -70,7 +74,10 @@ class TestCheckpointSync(SharedTestPipeline):
         """
 
         storage_config = storage_cfg(
-            self.pipeline.name, push_interval=automated_sync_interval
+            self.pipeline.name,
+            push_interval=automated_sync_interval,
+            retention_min_count=1,
+            retention_min_age=5 if from_uuid else 0,
         )
         ft = FaultToleranceModel.AtLeastOnce
 
@@ -119,7 +126,7 @@ class TestCheckpointSync(SharedTestPipeline):
 
         if automated_sync_interval is not None:
             time.sleep(automated_sync_interval + 1)
-            timeout = time.monotonic() + 5
+            timeout = time.monotonic() + 15
             success = None
             while time.monotonic() < timeout and success is None:
                 try:


### PR DESCRIPTION
Previously:
- During S3 sync, we would prevent the GC of existing local checkpoints.
- Only one checkpoint would be GCed at a time.

This commit updates the `gc_checkpoint` method such that it such that, we can GC all *old* checkpoints (ie, checkpoints older than the retention threshold, currently 2 of the most recent) are GCed, except for any checkpoint in the `except` list or newer.
This except list is populated from currently active requests for checkpoint syncs.

