### PR TITLE
python: configure workers and hosts for tests

### DIFF
--- a/python/feldera/runtime_config.py
+++ b/python/feldera/runtime_config.py
@@ -69,6 +69,7 @@ class RuntimeConfig:
     def __init__(
         self,
         workers: Optional[int] = None,
+        hosts: Optional[int] = None,
         storage: Optional[Storage | bool] = None,
         tracing: Optional[bool] = False,
         tracing_endpoint_jaeger: Optional[str] = "",
@@ -84,6 +85,7 @@ class RuntimeConfig:
         logging: Optional[str] = None,
     ):
         self.workers = workers
+        self.hosts = hosts
         self.tracing = tracing
         self.tracing_endpoint_jaeger = tracing_endpoint_jaeger
         self.cpu_profiler = cpu_profiler

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -40,6 +40,8 @@ def _get_effective_api_key():
 
 BASE_URL = os.environ.get("FELDERA_HOST") or "http://localhost:8080"
 FELDERA_REQUESTS_VERIFY = requests_verify_from_env()
+FELDERA_TEST_NUM_WORKERS = int(os.environ.get("FELDERA_TEST_NUM_WORKERS", "8"))
+FELDERA_TEST_NUM_HOSTS = int(os.environ.get("FELDERA_TEST_NUM_HOSTS", "1"))
 
 
 class _LazyClient:
@@ -249,6 +251,8 @@ def build_pipeline(
         runtime_config=RuntimeConfig(
             provisioning_timeout_secs=60,
             resources=resources,
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
         ),
     ).create_or_replace()
 

--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -24,6 +24,7 @@ from urllib.parse import quote, quote_plus
 
 from feldera.testutils_oidc import get_oidc_test_helper
 from tests import FELDERA_REQUESTS_VERIFY, API_KEY, BASE_URL, unique_pipeline_name
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 API_PREFIX = "/v0"
 
@@ -136,7 +137,15 @@ def wait_for_deployment_status(name: str, desired: str, timeout_s: float = 60.0)
 def create_pipeline(name: str, sql: str):
     r = post_json(
         api_url("/pipelines"),
-        {"name": name, "program_code": sql, "runtime_config": {"logging": "debug"}},
+        {
+            "name": name,
+            "program_code": sql,
+            "runtime_config": {
+                "workers": FELDERA_TEST_NUM_WORKERS,
+                "hosts": FELDERA_TEST_NUM_HOSTS,
+                "logging": "debug",
+            },
+        },
     )
     assert r.status_code == HTTPStatus.CREATED, r.text
     wait_for_program_success(name, 1)

--- a/python/tests/platform/negative_test.py
+++ b/python/tests/platform/negative_test.py
@@ -1,7 +1,12 @@
 import unittest
 from feldera import PipelineBuilder, Pipeline
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
+from feldera.runtime_config import RuntimeConfig
 
 
 class NegativeCompilationTests(unittest.TestCase):
@@ -23,7 +28,13 @@ Code snippet:
                                      ^^^^""".strip()
         with self.assertRaises(Exception) as err:
             PipelineBuilder(
-                TEST_CLIENT, name=pipeline_name, sql=sql
+                TEST_CLIENT,
+                name=pipeline_name,
+                sql=sql,
+                runtime_config=RuntimeConfig(
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
+                ),
             ).create_or_replace()
         got_err: str = err.exception.args[0].strip()
         assert expected == got_err
@@ -36,7 +47,14 @@ Code snippet:
 
         with self.assertRaises(Exception) as err:
             PipelineBuilder(
-                TEST_CLIENT, name=pipeline_name, sql=sql, udf_rust="Davy Jones"
+                TEST_CLIENT,
+                name=pipeline_name,
+                sql=sql,
+                udf_rust="Davy Jones",
+                runtime_config=RuntimeConfig(
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
+                ),
             ).create_or_replace()
 
         assert "Davy Jones" in err.exception.args[0].strip()
@@ -45,7 +63,15 @@ Code snippet:
         sql = "create taabl;"
         name = unique_pipeline_name("test_program_error0")
         try:
-            _ = PipelineBuilder(TEST_CLIENT, name, sql).create_or_replace()
+            _ = PipelineBuilder(
+                TEST_CLIENT,
+                name,
+                sql,
+                runtime_config=RuntimeConfig(
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
+                ),
+            ).create_or_replace()
         except Exception:
             pass
         pipeline = Pipeline.get(name, TEST_CLIENT)
@@ -57,7 +83,15 @@ Code snippet:
     def test_program_error1(self):
         sql = ""
         name = unique_pipeline_name("test_program_error1")
-        _ = PipelineBuilder(TEST_CLIENT, name, sql).create_or_replace()
+        _ = PipelineBuilder(
+            TEST_CLIENT,
+            name,
+            sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
+        ).create_or_replace()
         pipeline = Pipeline.get(name, TEST_CLIENT)
         err = pipeline.program_error()
         assert err["sql_compilation"]["exit_code"] == 0
@@ -69,7 +103,15 @@ Code snippet:
         sql = "SELECT invalid"
         name = unique_pipeline_name("test_errors0")
         try:
-            _ = PipelineBuilder(TEST_CLIENT, name, sql).create_or_replace()
+            _ = PipelineBuilder(
+                TEST_CLIENT,
+                name,
+                sql,
+                runtime_config=RuntimeConfig(
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
+                ),
+            ).create_or_replace()
         except Exception:
             pass
         pipeline = Pipeline.get(name, TEST_CLIENT)
@@ -95,7 +137,13 @@ Code snippet:
         );
         """
         pipeline = PipelineBuilder(
-            TEST_CLIENT, name=unique_pipeline_name("test_initialization_error"), sql=sql
+            TEST_CLIENT,
+            name=unique_pipeline_name("test_initialization_error"),
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
         with self.assertRaises(RuntimeError) as err:
             pipeline.start()

--- a/python/tests/platform/test_bootstrapping.py
+++ b/python/tests/platform/test_bootstrapping.py
@@ -5,6 +5,7 @@ from tests import TEST_CLIENT, enterprise_only
 from .helper import (
     gen_pipeline_name,
 )
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 @enterprise_only
@@ -25,6 +26,8 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         pipeline_name,
         sql=sql,
         runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
             fault_tolerance_model=None,  # We will make manual checkpoints in this test.
         ),
     ).create_or_replace()
@@ -277,6 +280,8 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         pipeline_name,
         sql=sql,
         runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
             fault_tolerance_model=None,  # We will make manual checkpoints in this test.
         ),
     ).create_or_replace()
@@ -319,6 +324,8 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         pipeline_name,
         sql=sql,
         runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
             fault_tolerance_model=None,  # We will make manual checkpoints in this test.
         ),
     ).create_or_replace()
@@ -362,6 +369,8 @@ LATENESS v1.c 0;
         pipeline_name,
         sql=sql,
         runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
             fault_tolerance_model=None,  # We will make manual checkpoints in this test.
         ),
     ).create_or_replace()
@@ -411,6 +420,8 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         pipeline_name,
         sql=gen_sql(""),
         runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
             fault_tolerance_model=None,  # We will make manual checkpoints in this test.
         ),
     ).create_or_replace()

--- a/python/tests/platform/test_checkpoint_sync.py
+++ b/python/tests/platform/test_checkpoint_sync.py
@@ -9,6 +9,7 @@ from feldera.enums import FaultToleranceModel, PipelineStatus
 from feldera.runtime_config import RuntimeConfig, Storage
 from tests import enterprise_only
 from tests.shared_test_pipeline import SharedTestPipeline
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 DEFAULT_ENDPOINT = os.environ.get(
     "DEFAULT_MINIO_ENDPOINT", "http://minio.extra.svc.cluster.local:9000"
@@ -83,6 +84,8 @@ class TestCheckpointSync(SharedTestPipeline):
 
         self.pipeline.set_runtime_config(
             RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 fault_tolerance_model=ft,
                 storage=Storage(config=storage_config),
                 checkpoint_interval_secs=ft_interval,
@@ -159,6 +162,8 @@ class TestCheckpointSync(SharedTestPipeline):
         )
         self.pipeline.set_runtime_config(
             RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 fault_tolerance_model=ft,
                 storage=Storage(config=storage_config),
                 checkpoint_interval_secs=ft_interval,
@@ -261,7 +266,10 @@ class TestCheckpointSync(SharedTestPipeline):
         ft = FaultToleranceModel.AtLeastOnce
         self.pipeline.set_runtime_config(
             RuntimeConfig(
-                fault_tolerance_model=ft, storage=Storage(config=storage_config)
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                fault_tolerance_model=ft,
+                storage=Storage(config=storage_config),
             )
         )
         self.pipeline.start()
@@ -285,6 +293,8 @@ class TestCheckpointSync(SharedTestPipeline):
         pull_interval = 1
         standby.set_runtime_config(
             RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 fault_tolerance_model=ft,
                 storage=Storage(
                     config=storage_cfg(

--- a/python/tests/platform/test_nowstream.py
+++ b/python/tests/platform/test_nowstream.py
@@ -3,7 +3,11 @@ import time
 
 from feldera.pipeline_builder import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
 from feldera.enums import PipelineStatus
 
@@ -32,8 +36,10 @@ class TestNowStream(unittest.TestCase):
             pipeline_name,
             sql=sql,
             runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 # 10 times per second
-                clock_resolution_usecs=100000
+                clock_resolution_usecs=100000,
             ),
         ).create_or_replace()
 

--- a/python/tests/platform/test_pipeline_builder.py
+++ b/python/tests/platform/test_pipeline_builder.py
@@ -1,7 +1,12 @@
 import unittest
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
 from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
 
 
 class TestPipelineBuilder(unittest.TestCase):
@@ -26,7 +31,13 @@ class TestPipelineBuilder(unittest.TestCase):
         pipeline_name = unique_pipeline_name("test_connector_orchestration")
 
         pipeline = PipelineBuilder(
-            TEST_CLIENT, pipeline_name, sql=sql
+            TEST_CLIENT,
+            pipeline_name,
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
         pipeline.start()
 

--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -15,6 +15,7 @@ from feldera.rest.errors import FelderaAPIError
 from feldera.runtime_config import RuntimeConfig
 from tests import TEST_CLIENT, enterprise_only
 from tests.shared_test_pipeline import SharedTestPipeline
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 class TestPipeline(SharedTestPipeline):
@@ -637,7 +638,13 @@ class TestPipeline(SharedTestPipeline):
         }
 
         resources = Resources(config)
-        self.pipeline.set_runtime_config(RuntimeConfig(resources=resources))
+        self.pipeline.set_runtime_config(
+            RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                resources=resources,
+            )
+        )
         self.pipeline.start()
         got = TEST_CLIENT.get_pipeline(
             self.pipeline.name, PipelineFieldSelector.ALL

--- a/python/tests/platform/test_update_runtime.py
+++ b/python/tests/platform/test_update_runtime.py
@@ -2,7 +2,11 @@ import unittest
 
 from feldera.pipeline_builder import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
 from feldera.enums import PipelineStatus
 
@@ -28,6 +32,8 @@ CREATE MATERIALIZED VIEW v0 AS SELECT * FROM tbl;
             pipeline_name,
             sql=sql,
             runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 logging="debug",
             ),
         ).create_or_replace()

--- a/python/tests/runtime/lateness/test_issue4457.py
+++ b/python/tests/runtime/lateness/test_issue4457.py
@@ -3,6 +3,8 @@ import unittest
 from pandas import Timestamp
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT, unique_pipeline_name
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 class TestIssue_4457(unittest.TestCase):
@@ -18,7 +20,13 @@ class TestIssue_4457(unittest.TestCase):
 
         # Make sure the pipelines are unique if we have concurrent runs
         pipeline = PipelineBuilder(
-            TEST_CLIENT, name=unique_pipeline_name("test_issue4457"), sql=sql
+            TEST_CLIENT,
+            name=unique_pipeline_name("test_issue4457"),
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
 
         pipeline.start_paused()

--- a/python/tests/runtime/lateness/test_issue4895.py
+++ b/python/tests/runtime/lateness/test_issue4895.py
@@ -1,9 +1,14 @@
 import unittest
 
 from feldera.pipeline_builder import PipelineBuilder
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
 from feldera.enums import PipelineStatus
+from feldera.runtime_config import RuntimeConfig
 
 
 class TestIssue4895(unittest.TestCase):
@@ -20,7 +25,13 @@ class TestIssue4895(unittest.TestCase):
         """
 
         pipeline = PipelineBuilder(
-            TEST_CLIENT, pipeline_name, sql=sql
+            TEST_CLIENT,
+            pipeline_name,
+            sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
 
         pipeline.start()

--- a/python/tests/runtime/test_transactions.py
+++ b/python/tests/runtime/test_transactions.py
@@ -2,6 +2,8 @@ import unittest
 
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT, unique_pipeline_name
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 class TestTransactions(unittest.TestCase):
@@ -18,6 +20,10 @@ class TestTransactions(unittest.TestCase):
             TEST_CLIENT,
             name=unique_pipeline_name("test_dynamic_output_connector"),
             sql=sql,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
 
         pipeline.start()

--- a/python/tests/runtime/test_uda.py
+++ b/python/tests/runtime/test_uda.py
@@ -3,6 +3,8 @@ import unittest
 from feldera import PipelineBuilder
 from tests.platform.helper import gen_pipeline_name
 from tests import TEST_CLIENT
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 @gen_pipeline_name
@@ -145,6 +147,10 @@ ByteArray::new(&val.data.to_be_bytes()[16..])
         sql=sql,
         udf_rust=udfs,
         udf_toml=toml,
+        runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
+        ),
     ).create_or_replace()
 
     pipeline.start()

--- a/python/tests/runtime/test_udf.py
+++ b/python/tests/runtime/test_udf.py
@@ -4,6 +4,8 @@ import unittest
 from pandas import Timedelta, Timestamp
 from feldera import PipelineBuilder
 from tests import TEST_CLIENT, unique_pipeline_name
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 class TestUDF(unittest.TestCase):
@@ -232,7 +234,14 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
         """
 
         pipeline = PipelineBuilder(
-            TEST_CLIENT, name=unique_pipeline_name("test_udfs"), sql=sql, udf_rust=udfs
+            TEST_CLIENT,
+            name=unique_pipeline_name("test_udfs"),
+            sql=sql,
+            udf_rust=udfs,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+            ),
         ).create_or_replace()
 
         # TODO: use .query() instead

--- a/python/tests/runtime_aggtest/aggtst_base.py
+++ b/python/tests/runtime_aggtest/aggtst_base.py
@@ -9,6 +9,7 @@ from feldera import Pipeline, PipelineBuilder
 from feldera.enums import CompilationProfile
 from feldera.rest.errors import FelderaAPIError
 from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 from tests import TEST_CLIENT, unique_pipeline_name
 
 JSON: TypeAlias = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
@@ -236,7 +237,10 @@ class TstAccumulator:
                 sql=sql,
                 compilation_profile=CompilationProfile.UNOPTIMIZED,
                 runtime_config=RuntimeConfig(
-                    provisioning_timeout_secs=180, logging="debug"
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
+                    provisioning_timeout_secs=180,
+                    logging="debug",
                 ),
             ).create_or_replace()
 

--- a/python/tests/shared_test_pipeline.py
+++ b/python/tests/shared_test_pipeline.py
@@ -1,6 +1,10 @@
 import unittest
 from feldera.runtime_config import RuntimeConfig
-from feldera.testutils import unique_pipeline_name
+from feldera.testutils import (
+    unique_pipeline_name,
+    FELDERA_TEST_NUM_WORKERS,
+    FELDERA_TEST_NUM_HOSTS,
+)
 from tests import TEST_CLIENT
 from feldera import PipelineBuilder, Pipeline
 
@@ -47,6 +51,8 @@ class SharedTestPipeline(unittest.TestCase):
                 cls.pipeline_name,
                 cls.ddl,
                 runtime_config=RuntimeConfig(
+                    workers=FELDERA_TEST_NUM_WORKERS,
+                    hosts=FELDERA_TEST_NUM_HOSTS,
                     logging="debug",
                 ),
             ).create_or_replace()
@@ -57,6 +63,8 @@ class SharedTestPipeline(unittest.TestCase):
             unique_pipeline_name(self._testMethodName),
             sql=self.ddl,
             runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 logging="debug",
             ),
         ).create_or_replace()
@@ -76,6 +84,8 @@ class SharedTestPipeline(unittest.TestCase):
             unique_pipeline_name(f"{self._testMethodName}_{suffix}"),
             sql=self.ddl,
             runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
                 logging="debug",
             ),
         ).create_or_replace()


### PR DESCRIPTION
The number of workers and hosts can be set for several Python tests through the environment variables `FELDERA_TEST_NUM_WORKERS` and `FELDERA_TEST_NUM_HOSTS`.

The only difference this PR results in, is that the tests no longer use the default number of workers or hosts that is set by the backend if no workers or hosts are specified. The environment variables are set by default to these current values (8 and 1 respectively), but if these defaults are ever changed, they also need to be updated in the Python tests.

**Commands to try:**
```
cd python
export FELDERA_HOST="https://localhost"  # Point to instance that supports multihost
export FELDERA_HTTPS_TLS_CERT="..."  # Point to any TLS certificate that needs to be used
export FELDERA_TEST_NUM_HOSTS=2
export FELDERA_TEST_NUM_WORKERS=3
uv run python -m pytest tests/platform
uv run python -m pytest tests/runtime
uv run python -m pytest tests/runtime_aggtest
uv run python -m pytest tests/workloads
```