### PR TITLE
[web-console] Add Scarf Pixel to track OSS usage

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -7,6 +7,7 @@ env:
   CARGO_FLAGS: "--release --locked --all-targets"
   CARGO_FEATURES_BASE: "fips,pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue"
   FELDERA_PLATFORM_VERSION_SUFFIX: ${{ github.sha }}
+  FELDERA_BUILD_ORIGIN: ci
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: ${{ vars.SCCACHE_CACHE_SIZE }}
   SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}

--- a/crates/pipeline-manager/build.rs
+++ b/crates/pipeline-manager/build.rs
@@ -100,6 +100,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=FELDERA_PLATFORM_VERSION_SUFFIX");
     println!("cargo:rustc-env=FELDERA_PLATFORM_VERSION_SUFFIX={platform_version_suffix}");
 
+    // Capture build source (ci vs source)
+    let build_source = env::var("FELDERA_BUILD_ORIGIN").unwrap_or("source".to_string());
+    println!("cargo:rerun-if-env-changed=FELDERA_BUILD_ORIGIN");
+    println!("cargo:rustc-env=FELDERA_BUILD_ORIGIN={build_source}");
+
     let build = BuildBuilder::default().build_timestamp(true).build()?;
     let cargo = CargoBuilder::all_cargo()?;
     let gitcl = GitclBuilder::default().sha(false).dirty(false).build()?;

--- a/crates/pipeline-manager/src/api/endpoints/config.rs
+++ b/crates/pipeline-manager/src/api/endpoints/config.rs
@@ -89,6 +89,8 @@ pub(crate) struct Configuration {
     pub update_info: Option<UpdateInformation>,
     /// Information about the build environment
     pub build_info: BuildInformation,
+    /// Build source: "ci" for GitHub Actions builds, "source" for local builds
+    pub build_source: String,
 }
 
 impl Configuration {
@@ -124,6 +126,7 @@ impl Configuration {
             license_validity: license_check.map(|v| v.check_outcome),
             update_info: None,
             build_info: BuildInformation::from_env(),
+            build_source: env!("FELDERA_BUILD_ORIGIN").to_string(),
         }
     }
 }

--- a/js-packages/web-console/src/lib/services/manager/sdk.gen.ts
+++ b/js-packages/web-console/src/lib/services/manager/sdk.gen.ts
@@ -133,6 +133,9 @@ import type {
   PostPipelinePauseData,
   PostPipelinePauseErrors,
   PostPipelinePauseResponses,
+  PostPipelineRebalanceData,
+  PostPipelineRebalanceErrors,
+  PostPipelineRebalanceResponses,
   PostPipelineResponses,
   PostPipelineResumeData,
   PostPipelineResumeErrors,
@@ -853,6 +856,28 @@ export const pipelineAdhocSql = <ThrowOnError extends boolean = false>(
   (options.client ?? client).get<PipelineAdhocSqlResponses, PipelineAdhocSqlErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],
     url: '/v0/pipelines/{pipeline_name}/query',
+    ...options
+  })
+
+/**
+ * Initiate rebalancing.
+ *
+ * Initiate immediate rebalancing of the pipeline. Normally rebalancing is initiated automatically
+ * when the drift in the size of joined relations exceeds a threshold. This endpoint forces the balancer
+ * to reevaluate and apply an optimal partitioning policy regardless of the threshold.
+ *
+ * This operation is a no-op unless the `adaptive_joins` feature is enabled in `dev_tweaks`.
+ */
+export const postPipelineRebalance = <ThrowOnError extends boolean = false>(
+  options: Options<PostPipelineRebalanceData, ThrowOnError>
+) =>
+  (options.client ?? client).post<
+    PostPipelineRebalanceResponses,
+    PostPipelineRebalanceErrors,
+    ThrowOnError
+  >({
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/v0/pipelines/{pipeline_name}/rebalance',
     ...options
   })
 

--- a/js-packages/web-console/src/routes/+layout.svelte
+++ b/js-packages/web-console/src/routes/+layout.svelte
@@ -26,6 +26,18 @@
     afterNavigate(() => posthog.capture('$pageview'))
   }
 
+  // Scarf.sh tracking for OSS deployments
+  // Only track Open source edition (excludes Enterprise builds)
+  const shouldTrack = $derived(
+    browser && page.data.feldera?.config?.edition === 'Open source'
+  )
+  const scarfPixelId = 'c5e8a21a-5f5a-424d-81c4-5ded97174900'
+  const scarfTrackingUrl = $derived(
+    shouldTrack
+      ? `https://static.scarf.sh/a.png?x-pxid=${scarfPixelId}&version=${encodeURIComponent(page.data.feldera!.config!.version)}&build_source=${encodeURIComponent(page.data.feldera!.config!.build_source)}`
+      : ''
+  )
+
   const { upsert } = useSystemMessages()
   useInterval(() => {
     if (!page.data.feldera) {
@@ -43,6 +55,10 @@
 
 <Toaster position={'bottom-right'} toastOptions={{}}></Toaster>
 {@render children?.()}
+
+{#if shouldTrack}
+  <img src={scarfTrackingUrl} alt="" aria-hidden="true" style="display: none;" />
+{/if}
 
 <style lang="scss" global>
   .toast-error {

--- a/openapi.json
+++ b/openapi.json
@@ -6873,11 +6873,16 @@
           "revision",
           "runtime_revision",
           "changelog_url",
-          "build_info"
+          "build_info",
+          "build_source"
         ],
         "properties": {
           "build_info": {
             "$ref": "#/components/schemas/BuildInformation"
+          },
+          "build_source": {
+            "type": "string",
+            "description": "Build source: \"ci\" for GitHub Actions builds, \"source\" for local builds"
           },
           "changelog_url": {
             "type": "string",


### PR DESCRIPTION
**Add Scarf.sh Tracking for OSS Deployments**                                                                                             
                                                                                                                                        
  This PR adds lightweight usage tracking to help us understand how Feldera OSS is being deployed in the wild.                          
                                                                                                                                        
  What Gets Tracked by Scarf                                                                                                                  
                                                                                                                                        
  When users access the web-console in an Open Source deployment, a tracking pixel loads with two metadata fields:                      
  - Version: The Feldera version number (e.g., 0.227.0)                                                                                 
  - Build source: Whether the deployment came from:                                                                                     
    - ci - Official GitHub release Docker images                                                                                        
    - source - Built locally from source code                                                                                           
    - Geographic location: Country/region derived from IP address                                                                         
    - Timestamp: When the deployment was accessed                                                                                         
                                                                                                                                        
  What Doesn't Get Tracked                                                                                                              
                                                                                                                                        
  - ❌ Enterprise deployments - Automatically excluded via edition check                                                                
  - ❌ Personal identifiers - No user IDs, emails, or account information                                                               
  - ❌ Usage patterns - No behavioral tracking or feature usage monitoring
  - ❌ Session data - No tracking across pages or time

  Why This Matters

  This helps us answer important questions about the OSS community:                                                                     
  - How many users deploy from official releases vs building from source?
  - Which versions are most widely deployed?
  - Where in the world is Feldera being used?
  - When should we sunset old versions?
                                                                                                                                        
  Privacy

  The tracking pixel is visible in browser network requests and can be blocked by browser extensions or network policies. Geographic  data is aggregated at the country/region level. We only see deployment patterns, not individual users or detailed usage behavior.