### PR TITLE
Enable FIPS in CI but not by default in the build.

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   CARGO_FLAGS: "--release --locked --all-targets"
-  CARGO_FEATURES_BASE: "pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue"
+  CARGO_FEATURES_BASE: "fips,pubsub-emulator-test,iceberg-tests-fs,iceberg-tests-glue"
   FELDERA_PLATFORM_VERSION_SUFFIX: ${{ github.sha }}
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: ${{ vars.SCCACHE_CACHE_SIZE }}

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -50,6 +50,7 @@ feldera-enterprise = []
 iceberg-tests-fs = []
 iceberg-tests-glue = []
 iceberg-tests-rest = []
+fips = ["rustls/fips"]
 
 [dependencies]
 feldera-types = { workspace = true }
@@ -186,6 +187,7 @@ inventory = { workspace = true }
 backtrace = { workspace = true }
 itertools = { workspace = true }
 metrics-process = { version = "2.4.0", default-features = false }
+rustls = { workspace = true }
 serde_json_path_to_error = { workspace = true }
 smallstr = { workspace = true }
 dashmap = { workspace = true }
@@ -201,10 +203,6 @@ ignored = ["num-traits"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = { workspace = true, features = ["symbolize"] }
-rustls = { workspace = true, features = ["fips"] }
-
-[target.'cfg(not(target_os = "linux"))'.dependencies]
-rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/pipeline-manager/Cargo.toml
+++ b/crates/pipeline-manager/Cargo.toml
@@ -92,6 +92,7 @@ awc = { workspace = true, features = ["rustls-0_23", "rustls-0_23-native-roots"]
 reqwest = { workspace = true, features = ["json", "rustls-tls-native-roots"] }
 cached = { workspace = true }
 crossbeam = { workspace = true }
+rustls = { workspace = true }
 
 # System interaction
 dirs = { workspace = true }  # For: discovering home directory
@@ -105,15 +106,6 @@ tempfile = { workspace = true }
 compare = { workspace = true }
 sha2 = { workspace = true }
 
-# Cryptography provider (FIPS enabled by default)
-# Make sure this is the same rustls version used by other crates in the dependency tree.
-# See the `ensure_default_crypto_provider` function at the root of this crate.
-[target.'cfg(target_os = "linux")'.dependencies]
-rustls = { workspace = true, features = ["fips"] }
-
-[target.'cfg(not(target_os = "linux"))'.dependencies]
-rustls = { workspace = true, features = ["aws-lc-rs"] }
-
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true, features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
@@ -121,6 +113,7 @@ tikv-jemallocator = { workspace = true, features = ["profiling", "unprefixed_mal
 default = ["postgresql_embedded"]
 feldera-enterprise = []
 runtime-version = []
+fips = ["rustls/fips"]
 
 [build-dependencies]
 change-detection = { workspace = true }


### PR DESCRIPTION
FIPS doesn't build with GCC >= 14, which means that the build is broken on any recent Fedora release (which only has GCC 14 and 15).