### PR TITLE
[readme] update required version of nodejs 20 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ To run Feldera from sources, ensure at least 6 GB of free space in the sources d
 - Java Development Kit (JDK), version 19 or newer (21 is recommended)
 - maven
 - [Bun](https://bun.sh/docs/installation)
+- [nodejs v20](https://github.com/nodesource/distributions/blob/master/DEV_README.md)
 
 After that, the first step is to build the SQL compiler:
 


### PR DESCRIPTION
nodejs v20 is needed for the styleText in the webconsole, we use version 20 in our build Docker image

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

Add a few sentences describing the incompatible changes if any.
