### PR TITLE
[pipeline-manager] Support additional private CA for pipeline connections

### DIFF
--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -1002,6 +1002,7 @@ mod test {
             enable_https: false,
             https_tls_cert_path: None,
             https_tls_key_path: None,
+            private_ca_cert_path: None,
         };
 
         let manager_config = ApiServerConfig {

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -47,6 +47,7 @@ impl CompilerTest {
             enable_https: false,
             https_tls_cert_path: None,
             https_tls_key_path: None,
+            private_ca_cert_path: None,
         };
         let compiler_config = CompilerConfig {
             sql_compiler_path:

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -2001,6 +2001,7 @@ mod test {
                 enable_https: false,
                 https_tls_cert_path: None,
                 https_tls_key_path: None,
+                private_ca_cert_path: None,
             },
             pipeline_id,
             Some("test-pipeline".to_string()),


### PR DESCRIPTION
This will enable the coordinator to generate certificates for connections to pipelines in multihost environments.