### PR TITLE
dbsp: tracking bloom filter

### DIFF
--- a/crates/dbsp/src/storage.rs
+++ b/crates/dbsp/src/storage.rs
@@ -7,6 +7,7 @@ pub mod backend;
 pub mod buffer_cache;
 pub mod dirlock;
 pub mod file;
+pub mod tracking_bloom_filter;
 
 use fdlimit::{Outcome::LimitRaised, raise_fd_limit};
 use tracing::warn;

--- a/crates/dbsp/src/storage/tracking_bloom_filter.rs
+++ b/crates/dbsp/src/storage/tracking_bloom_filter.rs
@@ -1,0 +1,172 @@
+use fastbloom::BloomFilter;
+use std::iter::Sum;
+use std::ops::{Add, AddAssign};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Bloom filter which tracks the number of hits and misses when lookups are performed.
+/// It implements the subset of [`BloomFilter`] functions that are used by Feldera storage.
+#[derive(Debug)]
+pub struct TrackingBloomFilter {
+    /// Underlying Bloom filter.
+    bloom_filter: BloomFilter,
+    /// Number of hits.
+    hits: AtomicUsize,
+    /// Number of misses.
+    misses: AtomicUsize,
+}
+
+/// Statistics about the Bloom filter.
+///
+/// The statistics implement addition such that they can be summed (e.g., when you have a spine
+/// consisting out of multiple batches, each with their own Bloom filter). However, their addition
+/// will lose information about individual sizes, hits, misses and by extension, hit rates.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BloomFilterStats {
+    /// Bloom filter size in bytes.
+    pub size_byte: usize,
+    /// Number of hits.
+    pub hits: usize,
+    /// Number of misses.
+    pub misses: usize,
+}
+
+impl Add for BloomFilterStats {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        self.add_assign(rhs);
+        self
+    }
+}
+
+impl AddAssign for BloomFilterStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.size_byte += rhs.size_byte;
+        self.hits += rhs.hits;
+        self.misses += rhs.misses;
+    }
+}
+
+impl Sum for BloomFilterStats {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::default(), Add::add)
+    }
+}
+
+impl TrackingBloomFilter {
+    /// Constructs a tracking Bloom filter which wraps a regular Bloom filter instance.
+    /// It is assumed the underlying Bloom filter has not yet been used.
+    pub fn new(bloom_filter: BloomFilter) -> Self {
+        Self {
+            bloom_filter,
+            hits: AtomicUsize::new(0),
+            misses: AtomicUsize::new(0),
+        }
+    }
+
+    /// Retrieves statistics.
+    pub fn stats(&self) -> BloomFilterStats {
+        BloomFilterStats {
+            size_byte: size_of_val(&self.bloom_filter) + self.bloom_filter.num_bits() / 8,
+            hits: self.hits.load(Ordering::Acquire),
+            misses: self.misses.load(Ordering::Acquire),
+        }
+    }
+
+    /// See [`BloomFilter::num_hashes`].
+    pub fn num_hashes(&self) -> u32 {
+        self.bloom_filter.num_hashes()
+    }
+
+    /// See [`BloomFilter::insert_hash`].
+    pub fn insert_hash(&mut self, hash: u64) -> bool {
+        self.bloom_filter.insert_hash(hash)
+    }
+
+    /// See [`BloomFilter::as_slice`].
+    pub fn as_slice(&self) -> &[u64] {
+        self.bloom_filter.as_slice()
+    }
+
+    /// See [`BloomFilter::contains_hash`].
+    /// It additionally counts the hits or misses, before returning.
+    pub fn contains_hash(&self, hash: u64) -> bool {
+        let is_hit = self.bloom_filter.contains_hash(hash);
+        if is_hit {
+            self.hits.fetch_add(1, Ordering::Release);
+        } else {
+            self.misses.fetch_add(1, Ordering::Release);
+        }
+        is_hit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BloomFilterStats, TrackingBloomFilter};
+    use fastbloom::BloomFilter;
+
+    #[test]
+    fn tracking_bloom_filter_stats() {
+        let mut filter =
+            TrackingBloomFilter::new(BloomFilter::with_num_bits(8192).expected_items(100));
+        assert_eq!(filter.as_slice(), &[0; 8192 / 64]);
+        assert!(filter.num_hashes() >= 1);
+        assert_eq!(
+            filter.stats(),
+            BloomFilterStats {
+                size_byte: 96 + 8192 / 8,
+                hits: 0,
+                misses: 0,
+            }
+        );
+        filter.insert_hash(123);
+        assert!(filter.contains_hash(123));
+        assert!(!filter.contains_hash(456));
+        assert!(!filter.contains_hash(789));
+        assert_eq!(
+            filter.stats(),
+            BloomFilterStats {
+                size_byte: 96 + 8192 / 8,
+                hits: 1,
+                misses: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn tracking_bloom_filter_stats_default() {
+        assert_eq!(
+            BloomFilterStats::default(),
+            BloomFilterStats {
+                size_byte: 0,
+                hits: 0,
+                misses: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn tracking_bloom_filter_stats_addition() {
+        let stats1 = BloomFilterStats {
+            size_byte: 123,
+            hits: 456,
+            misses: 789,
+        };
+        let stats2 = BloomFilterStats {
+            size_byte: 100,
+            hits: 200,
+            misses: 300,
+        };
+        let stats3 = BloomFilterStats {
+            size_byte: 223,
+            hits: 656,
+            misses: 1089,
+        };
+        assert_eq!(stats1 + stats2, stats3);
+        assert_eq!(
+            vec![stats1, stats2].into_iter().sum::<BloomFilterStats>(),
+            stats3
+        );
+    }
+}

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -1,3 +1,5 @@
+use super::utils::{copy_to_builder, pick_merge_destination};
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBWeight, Error, NumEntries,
     algebra::{AddAssignByRef, AddByRef, NegByRef, ZRingValue},
@@ -27,8 +29,6 @@ use std::{
     fmt::{self, Debug},
     sync::Arc,
 };
-
-use super::utils::{copy_to_builder, pick_merge_destination};
 
 pub type FallbackIndexedWSetFactories<K, V, R> = FileIndexedWSetFactories<K, V, R>;
 
@@ -275,10 +275,10 @@ where
     }
 
     #[inline]
-    fn filter_size(&self) -> usize {
+    fn filter_stats(&self) -> BloomFilterStats {
         match &self.inner {
-            Inner::File(file) => file.filter_size(),
-            Inner::Vec(vec) => vec.filter_size(),
+            Inner::File(file) => file.filter_stats(),
+            Inner::Vec(vec) => vec.filter_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/key_batch.rs
@@ -1,3 +1,5 @@
+use super::utils::{copy_to_builder, pick_merge_destination};
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBData, DBWeight, NumEntries, Timestamp,
     dynamic::{
@@ -24,8 +26,6 @@ use std::{
     fmt::{self, Debug},
     sync::Arc,
 };
-
-use super::utils::{copy_to_builder, pick_merge_destination};
 
 pub struct FallbackKeyBatchFactories<K, T, R>
 where
@@ -267,10 +267,10 @@ where
     }
 
     #[inline]
-    fn filter_size(&self) -> usize {
+    fn filter_stats(&self) -> BloomFilterStats {
         match &self.inner {
-            Inner::File(file) => file.filter_size(),
-            Inner::Vec(vec) => vec.filter_size(),
+            Inner::File(file) => file.filter_stats(),
+            Inner::Vec(vec) => vec.filter_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/fallback/val_batch.rs
@@ -1,7 +1,9 @@
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use super::utils::{copy_to_builder, pick_merge_destination};
 use crate::storage::buffer_cache::CacheStats;
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::trace::cursor::{DelegatingCursor, PushCursor};
 use crate::trace::ord::file::val_batch::FileValBuilder;
 use crate::trace::ord::vec::val_batch::VecValBuilder;
@@ -23,8 +25,6 @@ use feldera_storage::{FileReader, StoragePath};
 use rand::Rng;
 use rkyv::{Archive, Archived, Deserialize, Fallible, Serialize, ser::Serializer};
 use size_of::SizeOf;
-
-use super::utils::{copy_to_builder, pick_merge_destination};
 
 pub struct FallbackValBatchFactories<K, V, T, R>
 where
@@ -274,10 +274,10 @@ where
     }
 
     #[inline]
-    fn filter_size(&self) -> usize {
+    fn filter_stats(&self) -> BloomFilterStats {
         match &self.inner {
-            Inner::File(file) => file.filter_size(),
-            Inner::Vec(vec) => vec.filter_size(),
+            Inner::File(file) => file.filter_stats(),
+            Inner::Vec(vec) => vec.filter_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/fallback/wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/wset.rs
@@ -1,3 +1,5 @@
+use super::utils::{copy_to_builder, pick_merge_destination};
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBWeight, NumEntries,
     algebra::{AddAssignByRef, AddByRef, NegByRef, ZRingValue},
@@ -27,8 +29,6 @@ use std::{
     fmt::{self, Debug},
     sync::Arc,
 };
-
-use super::utils::{copy_to_builder, pick_merge_destination};
 
 pub type FallbackWSetFactories<K, R> = FileWSetFactories<K, R>;
 
@@ -274,10 +274,10 @@ where
     }
 
     #[inline]
-    fn filter_size(&self) -> usize {
+    fn filter_stats(&self) -> BloomFilterStats {
         match &self.inner {
-            Inner::File(file) => file.filter_size(),
-            Inner::Vec(vec) => vec.filter_size(),
+            Inner::File(file) => file.filter_stats(),
+            Inner::Vec(vec) => vec.filter_stats(),
         }
     }
 

--- a/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/indexed_wset_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBData, DBWeight, NumEntries, Runtime,
     algebra::{AddAssignByRef, AddByRef, NegByRef},
@@ -356,8 +357,8 @@ where
         self.file.byte_size().unwrap_storage() as usize
     }
 
-    fn filter_size(&self) -> usize {
-        self.file.filter_size()
+    fn filter_stats(&self) -> BloomFilterStats {
+        self.file.filter_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/key_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::trace::cursor::Position;
 use crate::{
     DBData, DBWeight, NumEntries, Runtime, Timestamp,
@@ -269,8 +270,8 @@ where
         self.file.byte_size().unwrap_storage() as usize
     }
 
-    fn filter_size(&self) -> usize {
-        self.file.filter_size()
+    fn filter_stats(&self) -> BloomFilterStats {
+        self.file.filter_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/val_batch.rs
@@ -1,4 +1,5 @@
 use crate::storage::buffer_cache::CacheStats;
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::trace::BatchLocation;
 use crate::trace::cursor::Position;
 use crate::trace::ord::file::UnwrapStorage;
@@ -294,8 +295,8 @@ where
         self.file.byte_size().unwrap_storage() as usize
     }
 
-    fn filter_size(&self) -> usize {
-        self.file.filter_size()
+    fn filter_stats(&self) -> BloomFilterStats {
+        self.file.filter_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/file/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/file/wset_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBData, DBWeight, NumEntries, Runtime,
     algebra::{AddAssignByRef, AddByRef, NegByRef},
@@ -357,8 +358,8 @@ where
         self.file.byte_size().unwrap_storage() as usize
     }
 
-    fn filter_size(&self) -> usize {
-        self.file.filter_size()
+    fn filter_stats(&self) -> BloomFilterStats {
+        self.file.filter_stats()
     }
 
     #[inline]

--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -1,3 +1,5 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
+use crate::trace::ord::merge_batcher::MergeBatcher;
 use crate::{
     DBData, DBWeight, Error, NumEntries,
     algebra::{NegByRef, ZRingValue},
@@ -23,8 +25,6 @@ use rand::Rng;
 use rkyv::{Archive, Deserialize, Serialize};
 use size_of::SizeOf;
 use std::fmt::{self, Debug, Display};
-
-use crate::trace::ord::merge_batcher::MergeBatcher;
 
 pub struct VecIndexedWSetFactories<K, V, R>
 where
@@ -448,8 +448,8 @@ where
         self.layer.approximate_byte_size()
     }
 
-    fn filter_size(&self) -> usize {
-        0
+    fn filter_stats(&self) -> BloomFilterStats {
+        BloomFilterStats::default()
     }
 
     fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, sample: &mut DynVec<Self::Key>)

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -1,3 +1,5 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
+use crate::trace::ord::merge_batcher::MergeBatcher;
 use crate::{
     DBData, DBWeight, NumEntries, Timestamp,
     dynamic::{
@@ -23,8 +25,6 @@ use std::{
     fmt::{self, Debug, Display},
     sync::Arc,
 };
-
-use crate::trace::ord::merge_batcher::MergeBatcher;
 
 pub struct VecKeyBatchFactories<K, T, R>
 where
@@ -315,8 +315,8 @@ where
         self.layer.approximate_byte_size()
     }
 
-    fn filter_size(&self) -> usize {
-        0
+    fn filter_stats(&self) -> BloomFilterStats {
+        BloomFilterStats::default()
     }
 
     fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, sample: &mut DynVec<Self::Key>)

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::trace::cursor::Position;
 use crate::trace::ord::merge_batcher::MergeBatcher;
 use crate::{
@@ -374,8 +375,8 @@ where
         self.layer.approximate_byte_size()
     }
 
-    fn filter_size(&self) -> usize {
-        0
+    fn filter_stats(&self) -> BloomFilterStats {
+        BloomFilterStats::default()
     }
 
     fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, sample: &mut DynVec<Self::Key>)

--- a/crates/dbsp/src/trace/ord/vec/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/wset_batch.rs
@@ -1,3 +1,4 @@
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBData, DBWeight, NumEntries,
     algebra::{NegByRef, ZRingValue},
@@ -358,8 +359,8 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> BatchReader for VecWSet<K, 
         self.layer.approximate_byte_size()
     }
 
-    fn filter_size(&self) -> usize {
-        0
+    fn filter_stats(&self) -> BloomFilterStats {
+        BloomFilterStats::default()
     }
 
     fn sample_keys<RG>(&self, rng: &mut RG, sample_size: usize, sample: &mut DynVec<Self::Key>)

--- a/crates/dbsp/src/trace/spine_async/snapshot.rs
+++ b/crates/dbsp/src/trace/spine_async/snapshot.rs
@@ -13,6 +13,7 @@ use size_of::SizeOf;
 use super::SpineCursor;
 use crate::NumEntries;
 use crate::dynamic::{DynVec, Factory};
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::trace::cursor::{CursorFactory, CursorList};
 use crate::trace::{Batch, BatchReader, BatchReaderFactories, Cursor, Spine, merge_batches};
 
@@ -226,8 +227,8 @@ where
             .fold(0, |acc, batch| acc + batch.approximate_byte_size())
     }
 
-    fn filter_size(&self) -> usize {
-        self.batches.iter().map(|b| b.filter_size()).sum()
+    fn filter_stats(&self) -> BloomFilterStats {
+        self.batches.iter().map(|b| b.filter_stats()).sum()
     }
 
     fn sample_keys<RG>(&self, _rng: &mut RG, _sample_size: usize, _sample: &mut DynVec<Self::Key>)

--- a/crates/dbsp/src/trace/test/test_batch.rs
+++ b/crates/dbsp/src/trace/test/test_batch.rs
@@ -3,6 +3,7 @@
 //! So far, only methods/traits used in tests have been implemented.
 #![allow(clippy::type_complexity)]
 
+use crate::storage::tracking_bloom_filter::BloomFilterStats;
 use crate::{
     DBData, DBWeight, NumEntries, Timestamp,
     dynamic::{
@@ -1254,8 +1255,8 @@ where
         self.size_of().total_bytes()
     }
 
-    fn filter_size(&self) -> usize {
-        0
+    fn filter_stats(&self) -> BloomFilterStats {
+        BloomFilterStats::default()
     }
 
     fn sample_keys<RG>(&self, _rng: &mut RG, _sample_size: usize, _sample: &mut DynVec<Self::Key>)

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -374,7 +374,10 @@ export function measurementCategory(prop: string): MeasurementCategory {
         "batch sizes",
         "bounds",
         "Bloom filter size",
-        "Bloom filter bits/key"]);
+        "Bloom filter bits/key",
+        "Bloom filter hits",
+        "Bloom filter misses",
+        "Bloom filter hit rate"]);
     map.set("cache", [
         "background cache hit",
         "foreground cache hit",
@@ -474,6 +477,7 @@ export class Measurement {
             case "output redundancy":
             case "background cache hit rate":
             case "foreground cache hit rate":
+            case "Bloom filter hit rate":
                 if (Measurement.RANDOM_DATA) {
                     let v = Math.random() * 100;
                     return Option.some(new PercentValue(v, 1));
@@ -481,6 +485,8 @@ export class Measurement {
                 return Option.some(new PercentValue(value[0][0], value[0][1]));
             case "Bloom filter size":
             case "Bloom filter bits/key":
+            case "Bloom filter hits":
+            case "Bloom filter misses":
             case "total size":
             case "invocations":
             case "allocated bytes":


### PR DESCRIPTION
Tracks for each Bloom filter the number of hits and misses. They are included in the statistics that can be retrieved by the spine. The spine sums up over all the Bloom filter statistics it receives from its batches, which loses insight into individual batch statistics. The spine reports three new metadata fields:

- "Bloom filter hits": usize integer
- "Bloom filter misses": usize integer
- "Bloom filter hit rate": percentage

The Web Console profiler is updated to display the new metadata fields.

**PR information:**
- Documentation: not updated
- Changelog: not updated
- Backward incompatible changes: only new metadata fields are added, and the Web Console profiler has been set to display it. I've checked that it is able to load profiles from before the new metadata fields are added.
- Fixes: https://github.com/feldera/feldera/issues/5439