### PR TITLE
[SQL] Several improvements to the Rust code generation

### DIFF
--- a/crates/sqllib/src/operators.rs
+++ b/crates/sqllib/src/operators.rs
@@ -545,6 +545,46 @@ where
     }
 }
 
+#[inline(always)]
+#[doc(hidden)]
+pub fn max_null_wins__<T>(left: T, right: T) -> T
+where
+    T: Ord,
+{
+    left.max(right)
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub fn max_null_wins_N_<T>(left: Option<T>, right: T) -> Option<T>
+where
+    T: Ord,
+{
+    left.map(|left| left.max(right))
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub fn max_null_wins__N<T>(left: T, right: Option<T>) -> Option<T>
+where
+    T: Ord,
+{
+    right.map(|right| left.max(right))
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub fn max_null_wins_N_N<T>(left: Option<T>, right: Option<T>) -> Option<T>
+where
+    T: Ord,
+{
+    match (&left, &right) {
+        (&None, _) => None,
+        (_, &None) => None,
+        (_, _) => left.max(right),
+    }
+}
+
 #[doc(hidden)]
 pub fn blackbox<T>(value: T) -> T {
     value

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPChainOperator.java
@@ -11,6 +11,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.Simplify;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
@@ -185,10 +186,13 @@ public class DBSPChainOperator extends DBSPUnaryOperator {
                     }
                     case Filter: {
                         foundFilter = true;
-                        stat = new DBSPExpressionStatement(
-                                new DBSPIfExpression(node, this.call(compiler, comp.closure, currentArg).not(),
-                                        new DBSPReturnExpression(node, none),
-                                        null));
+                        DBSPExpression condition = this.call(compiler, comp.closure, currentArg).not();
+                        Simplify simplify = new Simplify(compiler);
+                        condition = simplify.apply(condition).to(DBSPExpression.class);
+                        DBSPExpression cond = new DBSPIfExpression(node, condition,
+                                new DBSPReturnExpression(node, none),
+                                null).simplify();
+                        stat = new DBSPExpressionStatement(cond);
                         break;
                     }
                     default: {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IConstructor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/IConstructor.java
@@ -4,4 +4,6 @@ package org.dbsp.sqlCompiler.compiler;
 public interface IConstructor {
     /** True when the constructed expression has all arguments constant */
     boolean isConstant();
+    /** True when the constructed expression is NULL */
+    boolean isNull();
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/ToJsonInnerVisitor.java
@@ -631,6 +631,13 @@ public class ToJsonInnerVisitor extends InnerVisitor {
     }
 
     @Override
+    public void postorder(DBSPFailExpression node) {
+        this.property("message");
+        this.stream.append(node.message);
+        super.postorder(node);
+    }
+
+    @Override
     public void postorder(DBSPUnwrapExpression node) {
         this.property("message");
         this.stream.append(node.message);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/dot/ToDotNodesVisitor.java
@@ -67,7 +67,7 @@ public class ToDotNodesVisitor extends CircuitVisitor {
 
     @Override
     public VisitDecision preorder(DBSPSourceBaseOperator node) {
-        String name = node.operation + " " + node.tableName;
+        String name = node.tableName + " " + node.operation;
         this.stream.append(node.getNodeName(false))
                 .append(" [ shape=box style=filled fillcolor=lightgrey label=\"")
                 .append(node.getIdString())

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -62,6 +62,7 @@ public class RustSqlRuntimeLibrary {
         this.universalFunctions.put(DBSPOpcode.MAX, DBSPOpcode.MAX.toString());
         this.universalFunctions.put(DBSPOpcode.MIN_IGNORE_NULLS, DBSPOpcode.MIN_IGNORE_NULLS.toString());
         this.universalFunctions.put(DBSPOpcode.MAX_IGNORE_NULLS, DBSPOpcode.MAX_IGNORE_NULLS.toString());
+        this.universalFunctions.put(DBSPOpcode.MAX_NULL_WINS, DBSPOpcode.MAX_NULL_WINS.toString());
         this.universalFunctions.put(DBSPOpcode.AGG_LTE, DBSPOpcode.AGG_LTE.toString());
         this.universalFunctions.put(DBSPOpcode.AGG_GTE, DBSPOpcode.AGG_GTE.toString());
         this.universalFunctions.put(DBSPOpcode.AGG_MIN, DBSPOpcode.AGG_MIN.toString());
@@ -171,6 +172,7 @@ public class RustSqlRuntimeLibrary {
         if (opcode.isComparison() ||
             opcode == DBSPOpcode.MAX || opcode == DBSPOpcode.MIN ||
             opcode == DBSPOpcode.MAX_IGNORE_NULLS || opcode == DBSPOpcode.MIN_IGNORE_NULLS ||
+            opcode == DBSPOpcode.MAX_NULL_WINS ||
             opcode == DBSPOpcode.AGG_GTE || opcode == DBSPOpcode.AGG_LTE ||
             opcode == DBSPOpcode.AGG_MIN || opcode == DBSPOpcode.AGG_MAX ||
             opcode == DBSPOpcode.AGG_MIN1 || opcode == DBSPOpcode.AGG_MAX1 ||

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -651,7 +651,7 @@ public class ToRustVisitor extends CircuitVisitor {
             type.toTupleDeep().accept(this.innerVisitor);
             this.builder.append(", changes: &");
             upsertStruct.toTupleDeep().accept(this.innerVisitor);
-            this.builder.append("| {");
+            this.builder.append("| {").increase();
             int index = 0;
             for (DBSPTypeStruct.Field field: upsertStruct.fields.values()) {
                 String name = field.getSanitizedName();
@@ -670,7 +670,7 @@ public class ToRustVisitor extends CircuitVisitor {
                 }
                 index++;
             }
-            this.builder.append("})");
+            this.builder.decrease().append("})");
         }
         this.builder.decrease().append(");").newline();
         this.tagStream(operator.asOperator());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -1061,7 +1061,8 @@ public class CalciteToDBSPCompiler extends RelVisitor
                     // Calcite's optimizations do not preserve types!
                     exp = ExpressionCompiler.expandTupleCast(exp.getNode(), exp, expectedType);
                 } else {
-                    exp = exp.applyCloneIfNeeded();
+                    if (!exp.is(DBSPApplyExpression.class))
+                        exp = exp.applyCloneIfNeeded();
                 }
                 resultColumns[index] = exp;
                 index++;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
@@ -205,10 +205,11 @@ public class ConvertletTable extends ReflectiveConvertletTable {
         registerOp(SqlLibraryOperators.RTRIM,
                 new ConvertletTable.TrimConvertlet(SqlTrimFunction.Flag.TRAILING));
 
-        registerOp(SqlLibraryOperators.GREATEST, new ConvertletTable.GreatestConvertlet());
-        registerOp(SqlLibraryOperators.GREATEST_PG, new ConvertletTable.GreatestPgConvertlet());
-        registerOp(SqlLibraryOperators.LEAST, new ConvertletTable.GreatestConvertlet());
-        registerOp(SqlLibraryOperators.LEAST_PG, new ConvertletTable.GreatestPgConvertlet());
+        // Removed GREATEST and LEAST - they are inefficient for many arguments
+        // registerOp(SqlLibraryOperators.GREATEST, new ConvertletTable.GreatestConvertlet());
+        // registerOp(SqlLibraryOperators.GREATEST_PG, new ConvertletTable.GreatestPgConvertlet());
+        // registerOp(SqlLibraryOperators.LEAST, new ConvertletTable.GreatestConvertlet());
+        // registerOp(SqlLibraryOperators.LEAST_PG, new ConvertletTable.GreatestPgConvertlet());
         registerOp(SqlLibraryOperators.SUBSTR_BIG_QUERY,
                 new ConvertletTable.SubstrConvertlet(SqlLibrary.BIG_QUERY));
         registerOp(SqlLibraryOperators.SUBSTR_MYSQL,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/CalciteOptimizer.java
@@ -253,7 +253,9 @@ public class CalciteOptimizer implements IWritesLogs {
                         CoreRules.JOIN_CONDITION_PUSH,
                         CoreRules.JOIN_PUSH_EXPRESSIONS,
                         // CoreRules.JOIN_PUSH_TRANSITIVE_PREDICATES,
-                        CoreRules.FILTER_INTO_JOIN
+                        CoreRules.FILTER_INTO_JOIN,
+                        // Sometimes this sequence generates extra filters which can be merged
+                        CoreRules.FILTER_MERGE
                 );
                 OuterJoinFinder finder = new OuterJoinFinder();
                 finder.run(node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CreateRuntimeErrorWrappers.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/CreateRuntimeErrorWrappers.java
@@ -97,6 +97,10 @@ public class CreateRuntimeErrorWrappers extends ExpressionTranslator {
             return;
         DBSPExpression source = this.getE(expression.expression);
         DBSPExpression unwrap = new DBSPUnwrapExpression(expression.message, source.applyCloneIfNeeded());
+        if (expression.neverFails()) {
+            this.map(expression, unwrap);
+            return;
+        }
         final DBSPHandleErrorExpression.RuntimeBehavior behavior;
         final boolean hasSourcePosition = this.operatorContext != null;
         if (source.getSourcePosition().isValid() && hasSourcePosition) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/ExpressionTranslator.java
@@ -464,6 +464,11 @@ public class ExpressionTranslator extends TranslateVisitor<IDBSPInnerNode> imple
     }
 
     @Override
+    public void postorder(DBSPFailExpression node) {
+        this.map(node, node);
+    }
+
+    @Override
     public void postorder(DBSPVariablePath node) {
         this.map(node, node);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -1088,6 +1088,15 @@ public abstract class InnerRewriteVisitor
     }
 
     @Override
+    public VisitDecision preorder(DBSPFailExpression expression) {
+        this.push(expression);
+        this.pop(expression);
+        DBSPExpression result = new DBSPFailExpression(expression.getNode(), expression.type, expression.message);
+        this.map(expression, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
     public VisitDecision preorder(DBSPEnumValue expression) {
         this.map(expression, expression);
         return VisitDecision.STOP;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -643,6 +643,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
         return this.preorder((DBSPExpression) node);
     }
 
+    public VisitDecision preorder(DBSPFailExpression node) {
+        return this.preorder((DBSPExpression) node);
+    }
+
     public VisitDecision preorder(DBSPPathExpression node) {
         return this.preorder((DBSPExpression) node);
     }
@@ -1286,6 +1290,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public void postorder(DBSPUnwrapExpression node) {
+        this.postorder((DBSPExpression) node);
+    }
+
+    public void postorder(DBSPFailExpression node) {
         this.postorder((DBSPExpression) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Projection.java
@@ -356,17 +356,19 @@ public class Projection extends InnerVisitor {
     @Override
     public void endVisit() {
         if (this.ioMap != null && this.expression != null) {
-            DBSPTypeTupleBase bodyType = this.expression.body.getType().to(DBSPTypeTupleBase.class);
-            int iomapSize = this.ioMap.fields().size();
-            if (bodyType.is(DBSPTypeRawTuple.class)) {
-                Utilities.enforce(bodyType.tupFields.length == 2);
-                int totalSize = bodyType.tupFields[0].to(DBSPTypeTupleBase.class).size() +
-                        bodyType.tupFields[1].to(DBSPTypeTupleBase.class).size();
-                Utilities.enforce(iomapSize == totalSize,
-                        () -> "IOMap has " + iomapSize + " fields, but expected " + totalSize);
-            } else {
-                Utilities.enforce(iomapSize == bodyType.size(),
-                        () -> "IOMap has " + iomapSize + " fields, but expected " + bodyType.size());
+            DBSPTypeTupleBase bodyType = this.expression.body.getType().as(DBSPTypeTupleBase.class);
+            if (bodyType != null) {
+                int iomapSize = this.ioMap.fields().size();
+                if (bodyType.is(DBSPTypeRawTuple.class)) {
+                    Utilities.enforce(bodyType.tupFields.length == 2);
+                    int totalSize = bodyType.tupFields[0].to(DBSPTypeTupleBase.class).size() +
+                            bodyType.tupFields[1].to(DBSPTypeTupleBase.class).size();
+                    Utilities.enforce(iomapSize == totalSize,
+                            () -> "IOMap has " + iomapSize + " fields, but expected " + totalSize);
+                } else {
+                    Utilities.enforce(iomapSize == bodyType.size(),
+                            () -> "IOMap has " + iomapSize + " fields, but expected " + bodyType.size());
+                }
             }
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitOptimizer.java
@@ -147,9 +147,10 @@ public class CircuitOptimizer extends Passes {
         this.add(new ImplementChains(compiler));
         this.add(new ExpandCasts(compiler));
         this.add(new Simplify(compiler).getCircuitRewriter(true));
-        this.add(new CSE(compiler));
         this.add(new ExpandJoins(compiler));
         this.add(new RemoveViewOperators(compiler, true));
+        this.add(new OptimizeWithGraph(compiler, g -> new PushDifferentialsUp(compiler, g)));
+        this.add(new CSE(compiler));
         this.add(new CircuitRewriter(compiler, new InnerCSE(compiler), true, InnerCSE::process));
         this.add(new CreateRuntimeErrorWrappers(compiler).getCircuitRewriter(true));
         this.add(new OptimizeWithGraph(compiler, g -> new StrayGC(compiler, g)));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementChains.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ImplementChains.java
@@ -26,7 +26,7 @@ public class ImplementChains extends CircuitCloneVisitor {
 
     /** Compose pairs of maps that can be efficiently composed, taking into advantage
      * the fact that function composition is associative. */
-    DBSPChainOperator.ComputationChain shrink(DBSPChainOperator.ComputationChain chain) {
+    DBSPChainOperator.ComputationChain shrinkMaps(DBSPChainOperator.ComputationChain chain) {
         List<DBSPChainOperator.Computation> result = new ArrayList<>();
         for (DBSPChainOperator.Computation comp: chain.computations()) {
             if (result.isEmpty() || comp.kind() == DBSPChainOperator.ComputationKind.Filter) {
@@ -67,9 +67,57 @@ public class ImplementChains extends CircuitCloneVisitor {
         return new DBSPChainOperator.ComputationChain(chain.inputType(), result);
     }
 
+    /** Convert Map(m1) -> Filter(f) -> Map(m2) into Filter(f \circ m1) -> Map(m2 \circ m1) if m1 is simple */
+    DBSPChainOperator.ComputationChain shrinkMapFilterMap(DBSPChainOperator.ComputationChain chain) {
+        List<DBSPChainOperator.Computation> result = new ArrayList<>();
+        if (chain.size() < 3) {
+            return chain;
+        }
+
+        // Find a sequence Map -> Filter -> Map/MapIndex
+        int startIndex = -1;
+        for (int i = 0; i < chain.size() - 2; i++) {
+            if (chain.computations().get(i).kind() == DBSPChainOperator.ComputationKind.Map &&
+                    chain.computations().get(i+1).kind() == DBSPChainOperator.ComputationKind.Filter &&
+                    chain.computations().get(i+2).kind() != DBSPChainOperator.ComputationKind.Filter) {
+                DBSPClosureExpression map = chain.computations().get(i).closure();
+                if (chain.computations().get(i+1).closure().shouldInlineComposition(this.compiler, map) &&
+                        chain.computations().get(i+2).closure().shouldInlineComposition(this.compiler, map)) {
+                    startIndex = i;
+                    break;
+                }
+            }
+            result.add(chain.computations().get(i));
+        }
+
+        if (startIndex < 0)
+            return chain;
+
+        DBSPChainOperator.Computation first = chain.computations().get(startIndex);
+        DBSPChainOperator.Computation filter = chain.computations().get(startIndex + 1);
+        DBSPChainOperator.Computation third = chain.computations().get(startIndex + 2);
+
+        DBSPClosureExpression filterMap = filter.closure().applyAfter(compiler, first.closure(), Maybe.MAYBE);
+        DBSPClosureExpression mapMap = third.closure().applyAfter(compiler, first.closure(), Maybe.MAYBE);
+        result.add(new DBSPChainOperator.Computation(DBSPChainOperator.ComputationKind.Filter, filterMap));
+        result.add(new DBSPChainOperator.Computation(third.kind(), mapMap));
+        // Keep the subsequent unchanged
+        for (int i = startIndex + 3; i < chain.size(); i++) {
+            result.add(chain.computations().get(i));
+        }
+
+        return new DBSPChainOperator.ComputationChain(chain.inputType(), result);
+    }
+
     @Override
     public void postorder(DBSPChainOperator node) {
-        DBSPChainOperator.ComputationChain chain = this.shrink(node.chain);
+        DBSPChainOperator.ComputationChain chain = this.shrinkMaps(node.chain);
+        while (true) {
+            var newChain = this.shrinkMapFilterMap(chain);
+            if (newChain == chain)
+                break;
+            chain = newChain;
+        }
         DBSPClosureExpression function = chain.collapse(this.compiler);
         boolean containsFilter = chain.containsFilter();
         DBSPSimpleOperator result;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PushDifferentialsUp.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PushDifferentialsUp.java
@@ -1,0 +1,39 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+
+import java.util.List;
+
+/** Applied late during compilation, moves Differential operators before their sources if possible
+ * This is mostly useful when they get moved after Constants */
+public class PushDifferentialsUp extends CircuitCloneWithGraphsVisitor {
+    public PushDifferentialsUp(DBSPCompiler compiler, CircuitGraphs graphs) {
+        super(compiler, graphs, false);
+    }
+
+    @Override
+    public void postorder(DBSPDifferentiateOperator operator) {
+        OutputPort source = this.mapped(operator.input());
+        int inputFanout = this.getGraph().getFanout(operator.input().node());
+        if (inputFanout != 1) {
+            super.postorder(operator);
+            return;
+        }
+        if (source.node().is(DBSPMapIndexOperator.class) ||
+            source.node().is(DBSPMapOperator.class)) {
+            DBSPDifferentiateOperator diff = new DBSPDifferentiateOperator(
+                    operator.getRelNode(), source.node().inputs.get(0));
+            this.addOperator(diff);
+            DBSPSimpleOperator sourceClone = source.node().withInputs(List.of(diff.outputPort()), false)
+                    .to(DBSPSimpleOperator.class);
+            this.map(operator, sourceClone);
+        } else {
+            super.postorder(operator);
+        }
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandUnsafeCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandUnsafeCasts.java
@@ -12,6 +12,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPFailExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
@@ -157,12 +158,11 @@ public class ExpandUnsafeCasts extends ExpressionTranslator {
         DBSPExpression result = new DBSPTupleExpression(source.getNode(), type, fields);
         if (source.getType().mayBeNull) {
             if (type.mayBeNull) {
-                result = new DBSPIfExpression(node, source.is_null(), type.nullValue(), result);
+                result = new DBSPIfExpression(node, source.is_null(), type.none(), result);
             } else {
                 result = new DBSPIfExpression(node, source.is_null(),
-                        // Causes a runtime panic
-                        type.withMayBeNull(true).nullValue()
-                                .unwrap("Cast to non-nullable value applied to NULL"), result);
+                        new DBSPFailExpression(source.getNode(), type, "Cast to non-nullable value applied to NULL"),
+                        result);
             }
         }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
@@ -534,7 +534,7 @@ public class RewriteInternedFields extends CircuitCloneVisitor {
         DBSPExpression right = DBSPTupleExpression.flatten(var.field(1).deref());
         if (sourceType.elementType.mayBeNull) {
             right = new DBSPIfExpression(right.getNode(), var.field(1).is_null(),
-                    sourceType.elementType.nullValue(),
+                    sourceType.elementType.none(),
                     new DBSPTupleExpression(right.allFields(), true));
         }
         DBSPClosureExpression converter = new DBSPRawTupleExpression(

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/unusedFields/FindUnusedFields.java
@@ -29,6 +29,7 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPConstructorExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCustomOrdField;
 import org.dbsp.sqlCompiler.ir.expression.DBSPDerefExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPFailExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPFieldExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPGeoPointConstructor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
@@ -170,6 +171,11 @@ public class FindUnusedFields extends SymbolicInterpreter<FieldUseMap> {
     @Override
     public void postorder(DBSPUnwrapExpression expression) {
         this.used(expression.expression);
+    }
+
+    @Override
+    public void postorder(DBSPFailExpression expression) {
+        this.used(expression);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPArrayExpression.java
@@ -204,6 +204,10 @@ public final class DBSPArrayExpression extends DBSPExpression
         return context.equivalent(this.data, otherExpression.data);
     }
 
+    public boolean isNull() {
+        return this.data == null;
+    }
+
     public String toSqlString() {
         if (this.data == null)
             return DBSPNullLiteral.NULL;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFailExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPFailExpression.java
@@ -1,0 +1,66 @@
+package org.dbsp.sqlCompiler.ir.expression;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.util.IIndentStream;
+import org.dbsp.util.Utilities;
+
+/** A Fail expression is the equivalent of panic(); it can return any type. */
+public class DBSPFailExpression extends DBSPExpression {
+    public final String message;
+
+    public DBSPFailExpression(CalciteObject node, DBSPType type, String message) {
+        super(node, type);
+        this.message = message;
+    }
+
+    @Override
+    public DBSPExpression deepCopy() {
+        return new DBSPFailExpression(this.node, this.type, this.message);
+    }
+
+    @Override
+    public boolean equivalent(EquivalenceContext context, DBSPExpression other) {
+        DBSPFailExpression o = other.as(DBSPFailExpression.class);
+        return o != null;
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        VisitDecision decision = visitor.preorder(this);
+        if (decision.stop()) return;
+        visitor.push(this);
+        visitor.property("type");
+        this.type.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean sameFields(IDBSPInnerNode other) {
+        DBSPFailExpression o = other.as(DBSPFailExpression.class);
+        if (o == null)
+            return false;
+        return this.message.equals(o.message);
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        return builder.append("panic!(")
+                .append(Utilities.doubleQuote(this.message, false))
+                .append(")");
+    }
+
+    @SuppressWarnings("unused")
+    public static DBSPFailExpression fromJson(JsonNode node, JsonDecoder decoder) {
+        DBSPType type = getJsonType(node, decoder);
+        String message = Utilities.getStringProperty(node, "message");
+        return new DBSPFailExpression(CalciteObject.EMPTY, type, message);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIfExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIfExpression.java
@@ -33,6 +33,7 @@ import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
 import org.dbsp.util.IIndentStream;
 
 import javax.annotation.Nullable;
@@ -94,7 +95,9 @@ public final class DBSPIfExpression extends DBSPExpression {
         if (this.condition.is(DBSPBoolLiteral.class)) {
             Boolean cond = this.condition.to(DBSPBoolLiteral.class).value;
             if (cond == null || !cond) {
-                return Objects.requireNonNull(this.negative);
+                if (this.negative == null)
+                    return DBSPTypeVoid.INSTANCE.defaultValue();
+                return this.negative;
             }
             return this.positive;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIndexedZSetExpression.java
@@ -33,6 +33,11 @@ public final class DBSPIndexedZSetExpression extends DBSPExpression
     }
 
     @Override
+    public boolean isNull() {
+        return false;
+    }
+
+    @Override
     public DBSPExpression deepCopy() {
         return new DBSPIndexedZSetExpression(this.getNode(), this.type);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIsNullExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPIsNullExpression.java
@@ -24,6 +24,7 @@
 package org.dbsp.sqlCompiler.ir.expression;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.IConstructor;
 import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
 import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
@@ -63,8 +64,10 @@ public final class DBSPIsNullExpression extends DBSPExpression {
             return new DBSPBoolLiteral(false);
         if (this.expression.is(DBSPCloneExpression.class))
             return this.expression.to(DBSPCloneExpression.class).expression.is_null();
-        if (this.expression.is(DBSPBaseTupleExpression.class) &&
-            this.expression.to(DBSPBaseTupleExpression.class).fields != null)
+        if (this.expression.isNone())
+            return new DBSPBoolLiteral(true);
+        if (this.expression.is(IConstructor.class))
+            // Non-null tuple
             return new DBSPBoolLiteral(false);
         return this;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -44,6 +44,7 @@ public enum DBSPOpcode {
     MIN("min", false),
     MAX_IGNORE_NULLS("max_ignore_nulls", false),
     MIN_IGNORE_NULLS("min_ignore_nulls", false),
+    MAX_NULL_WINS("max_null_wins", false),
     CONCAT("||", false),
     IS_DISTINCT("is_distinct", false),
     SQL_INDEX("index", false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnwrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnwrapExpression.java
@@ -9,12 +9,19 @@ import org.dbsp.sqlCompiler.ir.IDBSPInnerNode;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
+import java.util.Objects;
+
 /** Represents an unwrap() method call in Rust, as applied to
  * an expression with a nullable type.
  * This is created by calling 'Expression.unwrap'.
  * Note that there is a different resultUnwrap, which is meant
- * to be applied to Result values */
+ * to be applied to Result values.
+ * An unwrap "neverFails" if the context promises that it can never fail.
+ * E.g., if (!x.is_none()) x.unwrap();
+ * Such unwraps have different optimization rules from "standard" unwraps.
+ * The unwrap operations cannot be removed -- they still convert Option[T] to T, and generate the same code.*/
 public final class DBSPUnwrapExpression extends DBSPExpression {
+    /** An empty message indicates an unwrap which never fails -- we expect this message can never be displayed. */
     public final String message;
     public final DBSPExpression expression;
 
@@ -23,6 +30,11 @@ public final class DBSPUnwrapExpression extends DBSPExpression {
         this.message = message;
         this.expression = expression;
         Utilities.enforce(expression.getType().mayBeNull);
+    }
+
+    /** Guaranteed by construction to never fail */
+    public boolean neverFails() {
+        return this.message.isEmpty();
     }
 
     @Override
@@ -43,7 +55,7 @@ public final class DBSPUnwrapExpression extends DBSPExpression {
         DBSPUnwrapExpression o = other.as(DBSPUnwrapExpression.class);
         if (o == null)
             return false;
-        return this.message.equals(o.message) && this.expression == o.expression;
+        return Objects.equals(this.message, o.message) && this.expression == o.expression;
     }
 
     @Override
@@ -61,6 +73,34 @@ public final class DBSPUnwrapExpression extends DBSPExpression {
                     .append(".expect(")
                     .append(Utilities.doubleQuote(this.message, false))
                     .append(")");
+    }
+
+    public DBSPExpression simplify() {
+        if (this.expression.is(DBSPSomeExpression.class)) {
+            return this.expression.to(DBSPSomeExpression.class).expression;
+        }
+        if (this.expression.isNone()) {
+            return new DBSPFailExpression(this.getNode(), this.type, this.message);
+        }
+        if (this.expression.is(DBSPFailExpression.class)) {
+            return new DBSPFailExpression(this.getNode(), this.type, this.message);
+        }
+        DBSPBaseTupleExpression tuple = this.expression.as(DBSPBaseTupleExpression.class);
+        if (tuple != null) {
+            // null case handled by isNone above
+            Utilities.enforce(tuple.fields != null);
+            // Convert to non-nullable tuple constructor
+            switch (tuple.getType().code) {
+                case RAW_TUPLE:
+                    return new DBSPRawTupleExpression(tuple.fields);
+                case TUPLE:
+                    return new DBSPTupleExpression(tuple.fields);
+                // Otherwise this compiles into an None.unwrap().
+                default:
+                    break;
+            }
+        }
+        return this;
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPVariantExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPVariantExpression.java
@@ -55,6 +55,11 @@ public class DBSPVariantExpression extends DBSPExpression implements ISameValue,
     }
 
     @Override
+    public boolean isNull() {
+        return this.value == null;
+    }
+
+    @Override
     public void accept(InnerVisitor visitor) {
         VisitDecision decision = visitor.preorder(this);
         if (decision.stop()) return;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPZSetExpression.java
@@ -50,6 +50,11 @@ public final class DBSPZSetExpression extends DBSPExpression
         return Linq.all(this.data.keySet(), DBSPExpression::isCompileTimeConstant);
     }
 
+    @Override
+    public boolean isNull() {
+        return false;
+    }
+
     /**
      * Create a ZSet literal from a set of data values.
      *
@@ -172,7 +177,7 @@ public final class DBSPZSetExpression extends DBSPExpression
             DBSPExpression[] fields = new DBSPExpression[tuple.size()];
             if (expression.is(DBSPBaseTupleExpression.class)) {
                 DBSPBaseTupleExpression te = expression.to(DBSPBaseTupleExpression.class);
-                if (te.fields == null) {
+                if (te.isNull()) {
                     return tuple.none();
                 }
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPType.java
@@ -149,11 +149,6 @@ public abstract class DBSPType extends DBSPNode implements IDBSPInnerNode {
         throw new InternalCompilerError("Deref of " + this);
     }
 
-    /** The null value with this type. */
-    public DBSPExpression nullValue() {
-        return DBSPLiteral.none(this);
-    }
-
     /** True if this type has a Rust 'copy' method. */
     public boolean hasCopy() {
         return true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegressionTests.java
@@ -52,9 +52,9 @@ public class IncrementalRegressionTests extends SqlIoTest {
         CompilerOptions options = super.testOptions();
         options.languageOptions.incrementalize = true;
         options.languageOptions.optimizationLevel = 2;
-        // This causes the use of SourceSet operators
+        // This will make the generated code use SourceSet operators:
         // options.ioOptions.emitHandles = false;
-        // Without the following ORDER BY causes failures
+        // Without the following flag ORDER BY causes failures
         options.languageOptions.ignoreOrderBy = true;
         return options;
     }
@@ -818,6 +818,8 @@ public class IncrementalRegressionTests extends SqlIoTest {
     // Tests that are not in the repository; run manually
     @Test @Ignore
     public void extraTests() throws IOException {
+        // Logger.INSTANCE.setLoggingLevel(CalciteOptimizer.class, 2);
+        // this.showFinal();
         String dir = "../extra";
         File file = new File(dir);
         if (file.exists()) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -265,7 +265,7 @@ public class TableParser {
                         trimmed.equalsIgnoreCase("null"))) {
             if (!fieldType.mayBeNull)
                 throw new RuntimeException("Null value in non-nullable column " + fieldType);
-            result = fieldType.nullValue();
+            result = fieldType.none();
         } else {
             result = switch (fieldType.code) {
                 case DOUBLE -> {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -99,9 +99,19 @@
       ],
       "persistent_id": "5e6c4775639ef50da58436d192195ae13fa8cd9681af464d09f0927ebbd24bbf"
     }, "s3": {
-      "operation": "map_index",
+      "operation": "differentiate",
       "inputs": [
         { "node": "s2", "output": 0 }
+      ],
+      "calcite": {
+        "partial": 3
+      },
+      "positions": [],
+      "persistent_id": "75f6aef62d77fe19e76200d21472b7cb2e51629638054899decb829ba3df3859"
+    }, "s4": {
+      "operation": "map_index",
+      "inputs": [
+        { "node": "s3", "output": 0 }
       ],
       "calcite": {
         "seq": [
@@ -112,17 +122,7 @@
           }]
       },
       "positions": [],
-      "persistent_id": "20e32f4b3b66b72a630fe9dfde075dbf6f5685dc5a61574bd7a2ee844174b882"
-    }, "s4": {
-      "operation": "differentiate",
-      "inputs": [
-        { "node": "s3", "output": 0 }
-      ],
-      "calcite": {
-        "partial": 3
-      },
-      "positions": [],
-      "persistent_id": "cc69beadd24044b7aaabbdc61c90ee37b09b25f8d0112c6dd86b082103ea83e0"
+      "persistent_id": "82bbfee37e33a4b0fedde6bc5e8bb31f17ccce1fd1957ad029e9cba1bc79d2b4"
     }, "s5": {
       "operation": "aggregate_linear_postprocess",
       "inputs": [
@@ -134,7 +134,7 @@
       "positions": [
         {"start_line_number":2,"start_column":25,"end_line_number":2,"end_column":33}
       ],
-      "persistent_id": "35319f7c3f4dffb37a6c49346c349c0cd8510e4e9343765ed162f8c5f1d40bea"
+      "persistent_id": "134c6466aaa7694ea35a60b8949ec0a4d70a5bf9bdf014d4fb9426d96aa7dbb7"
     }, "s6": {
       "operation": "map",
       "inputs": [
@@ -144,7 +144,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "40428726132cccaa57814ad5dd5576ae82b360b8adc59a8f48843ffa3bf385d1"
+      "persistent_id": "dcca7337a79939e7a39d07d740288fc49dea2d5b4e594b1a24f018c7662ab5d3"
     }, "s7": {
       "operation": "neg",
       "inputs": [
@@ -154,7 +154,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "c06d9896ad745948c3b6216d72632eef324f59c70f6df91addc7aad305fd393c"
+      "persistent_id": "9bd1251ec7fc9cae72c638cdcb9763dbc2dfee28f4e96a26d1c57179ab227a1f"
     }, "s8": {
       "operation": "integrate",
       "inputs": [
@@ -164,7 +164,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "978a1373f250873321d7f944d10e36e1bef73d6f028f5e29ca23d70e700d4c39"
+      "persistent_id": "7bc400efc53be162b85fdaadf583824555a184e370242b950c422e39488bfd4d"
     }, "s9": {
       "operation": "map",
       "inputs": [
@@ -174,7 +174,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "6b01b4f7f21b8af9652b43da077078b2d89e1a8d79dd76f0d7f14663316111e3"
+      "persistent_id": "bcc438bd472b190d25cfdac257bc4f4263a0003f9f939a63be4497b268ed837f"
     }, "s10": {
       "operation": "integrate",
       "inputs": [
@@ -184,7 +184,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "aaaa9100b40b87df41c85d98c0804ad64319d6b9c3406727c82284427ff35e63"
+      "persistent_id": "7f3b5c52bed875fc3ade540f9bcb1b1fb96f64fca107f34eb8e56469317c7b82"
     }, "s11": {
       "operation": "sum",
       "inputs": [
@@ -196,7 +196,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "80d0d7a785b5c2f8bec019d70851d2b5bb19aab355df35cb22e78ecd18fc33ce"
+      "persistent_id": "040f303a787c124052f91dfb293018d52b0e35aa98fb24e3078bca8c09e7ddb7"
     }, "s12": {
       "operation": "inspect",
       "inputs": [
@@ -210,7 +210,7 @@
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40},
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40}
       ],
-      "persistent_id": "27f2808d833abbabd1bd397a158ccda51e00c5f044166e64613c098f35d498fc"
+      "persistent_id": "c1ffe4f3132e9426e7a70371ee283614d01223417b97444e03f933502c26a854"
     }, "s13": {
       "operation": "inspect",
       "inputs": [

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
@@ -412,7 +412,7 @@
           {"start_line_number":19,"start_column":8,"end_line_number":19,"end_column":26},
           {"start_line_number":20,"start_column":27,"end_line_number":20,"end_column":37}
         ],
-        "persistent_id": "8dab10904e879fd2b4f461f3281c7457c6174c8564b4947de60c8eca065bd95e"
+        "persistent_id": "eea1fb749f276517f2ad1171fc00a889b629d190a675d1cff0ad8f04db1e6a22"
       },
       "s5": {
         "operation": "flat_map_index",
@@ -433,7 +433,7 @@
           {"start_line_number":19,"start_column":17,"end_line_number":19,"end_column":26},
           {"start_line_number":20,"start_column":11,"end_line_number":20,"end_column":21}
         ],
-        "persistent_id": "958477ed0fb64636fab2e45cd593974f814228cbdae788f5cb8b7fcf118b888d"
+        "persistent_id": "532b61244e3f6ecac6e439489956f24fb4bdfedc3708b4dd7601e06c20c5ffc2"
       },
       "s6": {
         "operation": "delta0",
@@ -473,7 +473,7 @@
           {"start_line_number":16,"start_column":9,"end_line_number":16,"end_column":33},
           {"start_line_number":19,"start_column":8,"end_line_number":19,"end_column":26}
         ],
-        "persistent_id": "e250f5920ce49df2b4ed6413e7735bd57f8790a16923c6ceb7000e8d67d766e8"
+        "persistent_id": "d2d417d4519df7cdda5f1b3418fbfdb6b8fd0a9bd9f9b890d0631e73a66cca5a"
       },
       "s9": {
         "operation": "sum",
@@ -485,7 +485,7 @@
           "final": 10
         },
         "positions": [],
-        "persistent_id": "b07b42fc36f39f5204380b749d85d5b9f8dc1a1e7ee8ae329bdfa2ddccabd0a1"
+        "persistent_id": "1b0a54fcd87bb8e0b251dd69693425ae5b5d3b5753a123d5a0d22fe6f5ea740e"
       }
     }, "s10": {
       "operation": "inspect",
@@ -500,7 +500,7 @@
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1},
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1}
       ],
-      "persistent_id": "e2d2a4dd0dfb82283495f1e6c8753a2106cc518b3fca2b3ce4c7b0cedcdb95b5"
+      "persistent_id": "3035407bd189e60ab4a95c6e8e3555453d98937a42f859a252171247c5bd3a46"
     }, "s11": {
       "operation": "inspect",
       "inputs": [


### PR DESCRIPTION
Fixes #5496 

- improved code generation for Chain operators by using smarter inlining; reduces Rust code size by 25% on some customer programs
- improved code generate for GREATEST function
- introduced "fail" expression which always fails at runtime; can be optimized more aggressively
- introduced "safe unwrap" expression, which never fails at runtime; can be optimized more aggressively
- fixed bug which failed to simplify !!a to a
- improved simplification for unary_operation(ifexpression) by pushing the operation in both branches
- removed some useless `clone()` operations introduced after function calls or `unintern()` calls
- push differentiators up in graph; probably all the remaining ones will follow immediately after constant operators
- handle more uniformly constant NULL (None) expressions of all types in the IR
- use the Calcite optimizer pass which combines consecutive filters into one filter

All these improvements were discovered by reading the generated Rust code for various complex programs and looking for inefficient patterns.