### PR TITLE
[adapters] Panic in logging code.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2637,7 +2637,7 @@ impl CircuitThread {
                     info!(
                         "checkpoint delayed {} seconds because of: {}",
                         elapsed.as_secs(),
-                        reasons.iter().format(", ")
+                        reasons.iter().format(", ").to_string()
                     )
                 });
 


### PR DESCRIPTION
A user reported a panic with the following call stack:

```
thread 'circuit-thread' (17) panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/itertools-0.14.0/src/format.rs:95:21:
Format: was already formatted once
stack backtrace:
   0: std::panicking::begin_panic
   1: <itertools::format::Format<I> as core::fmt::Display>::fmt
   2: core::fmt::write
   3: core::fmt::write
   4: alloc::fmt::format::format_inner
   5: <sentry_tracing::converters::FieldVisitor as tracing_core::field::Visit>::record_debug
   6: tracing_core::field::ValueSet::record
   7: sentry_tracing::converters::extract_event_data
   8: sentry_tracing::converters::extract_event_data_with_context
   9: sentry_tracing::converters::breadcrumb_from_event
  10: <sentry_tracing::layer::SentryLayer<S> as tracing_subscriber::layer::Layer<S>>::on_event
  11: tracing_core::event::Event::dispatch
  12: dbsp_adapters::util::LongOperationWarning::check
  13: dbsp_adapters::controller::CircuitThread::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

which points to this line:

```rust
            self.checkpoint_delay_warning
                .get_or_insert_with(|| LongOperationWarning::new(Duration::from_secs(1)))
                .check(|elapsed| {
                    info!(
                        "checkpoint delayed {} seconds because of: {}",
                        elapsed.as_secs(),
                        reasons.iter().format(", ")
                    )
                });

```

The panic can happen if the iterator returned by the `format` method is evaluated twice. This happens inside the internals of the tracing crate. Not sure why we haven't seen this in the past. The fix just converts the iterator to string, so there is no way it can get evaluated twice.