### PR TITLE
[SQL] Include struct hash in struct name

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/derived/DBSPTypeStruct.java
@@ -283,7 +283,10 @@ public class DBSPTypeStruct extends DBSPType {
     public IIndentStream toString(IIndentStream builder) {
         return builder.append("struct ")
                 .append(this.mayBeNull ? "?" : "")
-                .append(this.name.name());
+                .append(" ")
+                .append(this.name.name())
+                .append(" ")
+                .append(this.hashName);
     }
 
     /** Generate a tuple type by ignoring the struct and field names. */

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/CatalogTests.java
@@ -890,4 +890,18 @@ public class CatalogTests extends BaseSQLTests {
                     z ROW(x INT, y INT) NOT NULL default ROW(1, 2)
                 );""");
     }
+
+
+    @Test
+    public void issue5390() {
+        this.getCCS("""
+                CREATE TYPE user_def AS(i1 INT);
+                CREATE TYPE user_def_row AS (val ROW(i1 INT));
+                CREATE TYPE user_def_udt AS (val user_def);
+                
+                CREATE MATERIALIZED VIEW v AS SELECT
+                SAFE_CAST(NULL AS user_def_row) AS to_row,
+                SAFE_CAST(NULL AS user_def_udt) AS to_udt
+                ;""");
+    }
 }


### PR DESCRIPTION
Fixes #5390 

This affects how the hash of a structure name is computed; this change makes it possible to distinguish between anonymous and named structs that are otherwise identical, which occur in the example program.