### PR TITLE
manager: expose the checkpoints api

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -580,10 +580,6 @@ impl Controller {
         })
     }
 
-    pub(crate) fn last_checkpoint(&self) -> LastCheckpoint {
-        self.inner.last_checkpoint()
-    }
-
     pub(crate) fn last_checkpoint_sync(&self) -> LastCheckpoint {
         self.inner.last_checkpoint_sync()
     }

--- a/crates/feldera-types/src/checkpoint.rs
+++ b/crates/feldera-types/src/checkpoint.rs
@@ -75,7 +75,7 @@ pub struct CheckpointSyncFailure {
 
 /// Holds meta-data about a checkpoint that was taken for persistent storage
 /// and recovery of a circuit's state.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct CheckpointMetadata {
     /// A unique identifier for the given checkpoint.
     ///

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -215,6 +215,7 @@ It contains the following fields:
         endpoints::pipeline_interaction::get_checkpoint_status,
         endpoints::pipeline_interaction::sync_checkpoint,
         endpoints::pipeline_interaction::get_checkpoint_sync_status,
+        endpoints::pipeline_interaction::get_checkpoints,
         endpoints::pipeline_interaction::post_pipeline_pause,
         endpoints::pipeline_interaction::post_pipeline_resume,
         endpoints::pipeline_interaction::post_pipeline_activate,
@@ -423,6 +424,7 @@ It contains the following fields:
         feldera_types::checkpoint::CheckpointStatus,
         feldera_types::checkpoint::CheckpointResponse,
         feldera_types::checkpoint::CheckpointFailure,
+        feldera_types::checkpoint::CheckpointMetadata,
         feldera_types::transaction::StartTransactionResponse,
         feldera_types::time_series::TimeSeries,
         feldera_types::time_series::SampleStatistics,
@@ -546,6 +548,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_interaction::sync_checkpoint)
         .service(endpoints::pipeline_interaction::get_checkpoint_status)
         .service(endpoints::pipeline_interaction::get_checkpoint_sync_status)
+        .service(endpoints::pipeline_interaction::get_checkpoints)
         .service(endpoints::pipeline_interaction::post_pipeline_pause)
         .service(endpoints::pipeline_interaction::post_pipeline_resume)
         .service(endpoints::pipeline_interaction::post_pipeline_activate)

--- a/openapi.json
+++ b/openapi.json
@@ -2509,6 +2509,127 @@
         ]
       }
     },
+    "/v0/pipelines/{pipeline_name}/checkpoints": {
+      "get": {
+        "tags": [
+          "Pipeline Lifecycle"
+        ],
+        "summary": "Get the checkpoints for a pipeline",
+        "description": "Retrieve the current checkpoints made by a pipeline.",
+        "operationId": "get_checkpoints",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Checkpoints retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckpointMetadata"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "Disconnected during response": {
+                    "value": {
+                      "message": "Error sending HTTP request to pipeline: the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs. Failed request: /pause pipeline-id=N/A pipeline-name=\"my_pipeline\"",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
+                        "error": "the pipeline disconnected while it was processing this HTTP request. This could be because the pipeline either (a) encountered a fatal error or panic, (b) was stopped, or (c) experienced network issues -- retrying might help in the last case. Alternatively, check the pipeline logs."
+                      }
+                    }
+                  },
+                  "Pipeline is currently unavailable": {
+                    "value": {
+                      "message": "Error sending HTTP request to pipeline: deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again Failed request: /pause pipeline-id=N/A pipeline-name=\"my_pipeline\"",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
+                        "error": "deployment status is currently 'unavailable' -- wait for it to become 'running' or 'paused' again"
+                      }
+                    }
+                  },
+                  "Pipeline is not deployed": {
+                    "value": {
+                      "message": "Unable to interact with pipeline because the deployment status (stopped) indicates it is not (yet) fully provisioned pipeline-id=N/A pipeline-name=\"my_pipeline\"",
+                      "error_code": "PipelineInteractionNotDeployed",
+                      "details": {
+                        "pipeline_name": "my_pipeline",
+                        "status": "Stopped",
+                        "desired_status": "Provisioned"
+                      }
+                    }
+                  },
+                  "Response timeout": {
+                    "value": {
+                      "message": "Error sending HTTP request to pipeline: timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response) Failed request: /pause pipeline-id=N/A pipeline-name=\"my_pipeline\"",
+                      "error_code": "PipelineInteractionUnreachable",
+                      "details": {
+                        "pipeline_name": "my_pipeline",
+                        "request": "/pause",
+                        "error": "timeout (10s) was reached: this means the pipeline took too long to respond -- this can simply be because the request was too difficult to process in time, or other reasons (e.g., deadlock): the pipeline logs might contain additional information (original send request error: Timeout while waiting for response)"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
     "/v0/pipelines/{pipeline_name}/circuit_json_profile": {
       "get": {
         "tags": [
@@ -6506,6 +6627,53 @@
             "format": "int64",
             "description": "Sequence number of the failed checkpoint.",
             "minimum": 0
+          }
+        }
+      },
+      "CheckpointMetadata": {
+        "type": "object",
+        "description": "Holds meta-data about a checkpoint that was taken for persistent storage\nand recovery of a circuit's state.",
+        "required": [
+          "uuid",
+          "fingerprint"
+        ],
+        "properties": {
+          "fingerprint": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Fingerprint of the circuit at the time of the checkpoint.",
+            "minimum": 0
+          },
+          "identifier": {
+            "type": "string",
+            "description": "An optional name for the checkpoint.",
+            "nullable": true
+          },
+          "processed_records": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of records processed.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total size of the checkpoint files in bytes.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "steps": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of steps made.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "A unique identifier for the given checkpoint.\n\nThis is used to identify the checkpoint in the file-system hierarchy."
           }
         }
       },

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -34,6 +34,7 @@ from feldera.rest.sql_table import SQLTable
 from feldera.rest.sql_view import SQLView
 from feldera.runtime_config import RuntimeConfig
 from feldera.stats import PipelineStatistics
+from feldera.types import CheckpointMetadata
 
 
 class Pipeline:
@@ -1493,3 +1494,13 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
         """
 
         self.client.wait_for_token(self.name, token)
+
+    def checkpoints(self) -> List[CheckpointMetadata]:
+        """
+        Returns the list of checkpoints for this pipeline.
+        """
+
+        return [
+            CheckpointMetadata.from_dict(chk)
+            for chk in self.client.get_checkpoints(self.name)
+        ]

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -1328,3 +1328,6 @@ Reason: The pipeline is in a STOPPED state due to the following error:
 
     def rebalance_pipeline(self, pipeline_name: str):
         self.http.post(path=f"/pipelines/{pipeline_name}/rebalance")
+
+    def get_checkpoints(self, pipeline_name: str):
+        return self.http.get(path=f"/pipelines/{pipeline_name}/checkpoints")

--- a/python/feldera/types.py
+++ b/python/feldera/types.py
@@ -1,0 +1,39 @@
+class CheckpointMetadata:
+    def __init__(
+        self,
+        uuid: str,
+        size: int,
+        steps: int,
+        processed_records: int,
+        fingerprint: int,
+        identifier: str | None = None,
+    ):
+        self.uuid = uuid
+        self.size = size
+        self.steps = steps
+        self.processed_records = processed_records
+        self.fingerprint = fingerprint
+        self.identifier = identifier
+
+    @classmethod
+    def from_dict(self, chk_dict: dict):
+        return CheckpointMetadata(
+            uuid=chk_dict["uuid"],
+            size=chk_dict["size"],
+            steps=chk_dict["steps"],
+            processed_records=chk_dict["processed_records"],
+            fingerprint=chk_dict["fingerprint"],
+            identifier=chk_dict.get("identifier"),
+        )
+
+    def to_dict(self) -> dict:
+        chk_dict = {
+            "uuid": self.uuid,
+            "size": self.size,
+            "steps": self.steps,
+            "processed_records": self.processed_records,
+            "fingerprint": self.fingerprint,
+        }
+        if self.identifier is not None:
+            chk_dict["identifier"] = self.identifier
+        return chk_dict


### PR DESCRIPTION
Expose the `/checkpoints` api that allows us to list a pipeline's current checkpoints.
Adapts the downstream tests to use this api instead of blindly waiting.

Also, adapts the `/checkpoint/sync` api to use the same logic as the `/checkpoints` api, as for some reason, there seems to be a delay between when the `checkpoints.feldera` file shows checkpoints vs when the `controller.inner.last_checkpoint()` method shows it. From the code, I cannot tell why there is this delay, but it causes the downstream tests to be flaky. This commit fixes it.

## Checklist

- [x] Documentation updated
- [ ] Changelog updated


