### PR TITLE
[python] In tests, print deployment status while waiting for it to ch…

### DIFF
--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -127,7 +127,8 @@ def wait_for_deployment_status(
     - If 'desired' is a function, until it returns true when passed
       the deployment status.
     """
-    deadline = time.time() + timeout_s
+    start = time.time()
+    deadline = start + timeout_s
     last = None
     while time.time() < deadline:
         r = get_pipeline(name, "status")
@@ -135,7 +136,10 @@ def wait_for_deployment_status(
             time.sleep(0.25)
             continue
         obj = r.json()
-        last = obj.get("deployment_status")
+        status = obj.get("deployment_status")
+        if status != last:
+            print(f"After {time.time() - start:.1f} seconds: status is {status}")
+        last = status
         if last == desired if isinstance(desired, str) else desired(last):
             return obj
         time.sleep(0.25)


### PR DESCRIPTION
…ange.

We've seen timeouts in places where they shouldn't happen.  This ought to help understand what's happening.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
