### PR TITLE
[python] More refinement of integration tests.

### DIFF
--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -127,6 +127,7 @@ def wait_for_deployment_status(
     - If 'desired' is a function, until it returns true when passed
       the deployment status.
     """
+    print(f"Waiting up to {timeout_s} seconds for {name} to transition to {desired}")
     start = time.time()
     deadline = start + timeout_s
     last = None

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -187,7 +187,13 @@ def test_pipeline_stop_force_after_start(pipeline_name):
     create_pipeline(pipeline_name, "CREATE TABLE t1(c1 INTEGER);")
 
     for delay_sec in [0, 0.1, 0.5, 1, 3, 10]:
+        print(f"Testing with {delay_sec} second delay")
         start_pipeline(pipeline_name)
+        # Wait for the pipeline to transition away from "Stopped"
+        #
+        # See big comment in test_pipeline_stop_with_force for
+        # reasoning.
+        wait_for_deployment_status(pipeline_name, lambda status: status != "Stopped")
         # Shortly wait for the pipeline to transition to next state(s)
         time.sleep(delay_sec)
         # Stop force and clear the pipeline


### PR DESCRIPTION
The additional prints should help narrow down test failures.  The added wait_for_deployment_status is a little harder to defend, but it might help too.
