### PR TITLE
[pipeline-manager] Treat missing `hosts` as 1 for update purposes.

### DIFF
--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -29,6 +29,7 @@ use deadpool_postgres::Transaction;
 use feldera_types::error::ErrorResponse;
 use feldera_types::runtime_status::{BootstrapPolicy, RuntimeDesiredStatus, RuntimeStatus};
 use rmp_serde::{from_slice, to_vec};
+use serde_json::json;
 use tokio_postgres::Row;
 use tracing::{error, warn};
 use uuid::Uuid;
@@ -697,7 +698,10 @@ pub(crate) async fn update_pipeline(
             if runtime_config.get("workers") != current.runtime_config.get("workers") {
                 not_allowed.push("`runtime_config.workers`");
             }
-            if runtime_config.get("hosts") != current.runtime_config.get("hosts") {
+            let one = json!(1);
+            if runtime_config.get("hosts").unwrap_or(&one)
+                != current.runtime_config.get("hosts").unwrap_or(&one)
+            {
                 not_allowed.push("`runtime_config.hosts`");
             }
             if runtime_config.get("fault_tolerance")


### PR DESCRIPTION
The default value of `hosts` is 1, which means that attempting to set pipeline configuration in any way will populate it with 1 if it is not set, but the pipeline manager was rejecting as different a missing old `hosts` and a new `hosts` of 1, which meant that users effectively couldn't change any configuration at all without clearing storage.  This fixes the problem.
