### PR TITLE
[adapters] Log detailed checkpoint info on startup.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3801,6 +3801,8 @@ impl ControllerInit {
         storage: CircuitStorageConfig,
         checkpoint: Checkpoint,
     ) -> Result<Self, ControllerError> {
+        let checkpoint_summary = checkpoint.display_summary();
+
         let Checkpoint {
             circuit,
             step,
@@ -3811,7 +3813,7 @@ impl ControllerInit {
             input_statistics,
             output_statistics,
         } = checkpoint;
-        info!("resuming from checkpoint made at step {step}");
+        info!("Resuming from checkpoint:\n{checkpoint_summary}");
 
         let storage = storage.with_init_checkpoint(circuit.map(|circuit| circuit.uuid));
 


### PR DESCRIPTION
Log metadata about the checkpoint that the pipeline is starting from. We may want to make it less detailed or decrease log level to debug in the future if this info becomes available from the manager via the list checkpoint API prior to starting the pipeline.