### PR TITLE
[SQL] Use a single WINDOW operator for temporal filters instead of two when possible

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -691,6 +691,13 @@ public class Simplify extends ExpressionTranslator {
                             result = right;
                         }
                     }
+                } else if (left instanceof DBSPUnaryExpression unaryLeft &&
+                        right instanceof DBSPUnaryExpression unaryRight &&
+                        unaryLeft.opcode == DBSPOpcode.WRAP_BOOL &&
+                        unaryRight.opcode == DBSPOpcode.WRAP_BOOL) {
+                    // (bool) a && (bool) b => (bool)(a && b)
+                    result = new DBSPBinaryExpression(expression.getNode(), unaryLeft.source.getType(),
+                            DBSPOpcode.AND, unaryLeft.source, unaryRight.source).wrapBoolIfNeeded();
                 }
             } else if (opcode == DBSPOpcode.OR) {
                 if (left.is(DBSPBoolLiteral.class)) {
@@ -890,6 +897,7 @@ public class Simplify extends ExpressionTranslator {
                     .appendSupplier(result::toString)
                     .newline();
         }
+        Utilities.enforce(expression.getType().sameType(result.getType()));
         super.map(expression, result);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/BooleanExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/BooleanExpression.java
@@ -1,0 +1,17 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.util.ICastable;
+
+/** Boolean expression that appear as a conjunct in a filter expression */
+public interface BooleanExpression extends ICastable {
+    /** true if these two Boolean expressions can be evaluated together */
+    boolean compatible(BooleanExpression other);
+
+    /** Combine two compatible boolean expressions */
+    BooleanExpression combine(BooleanExpression other);
+
+    /** Returns the final form of this Boolean expression */
+    BooleanExpression seal();
+
+    boolean isNullable();
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/FindComparisons.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/FindComparisons.java
@@ -1,0 +1,159 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.monotone.IMaybeMonotoneType;
+import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneExpression;
+import org.dbsp.sqlCompiler.compiler.visitors.monotone.MonotoneTransferFunctions;
+import org.dbsp.sqlCompiler.compiler.visitors.monotone.NonMonotoneType;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
+import org.dbsp.util.Utilities;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Break a Boolean expression into a series of conjunctions, some of which
+ * may be implemented as temporal filters.
+ */
+class FindComparisons {
+    final DBSPParameter parameter;
+    /**
+     * List of Boolean expressions; a NonTemporalComparison may appear in the last position only
+     */
+    final List<BooleanExpression> comparisons;
+    final MonotoneTransferFunctions mono;
+    final ContainsNow containsNow;
+    final Set<DBSPOpcode> compOpcodes;
+
+    FindComparisons(DBSPClosureExpression closure, MonotoneTransferFunctions mono) {
+        this.mono = mono;
+        this.comparisons = new ArrayList<>();
+        this.containsNow = new ContainsNow(mono.compiler, true);
+        this.compOpcodes = new HashSet<>() {{
+            add(DBSPOpcode.LT);
+            add(DBSPOpcode.LTE);
+            add(DBSPOpcode.GTE);
+            add(DBSPOpcode.GT);
+            add(DBSPOpcode.EQ);
+        }};
+
+        DBSPClosureExpression clo = closure.to(DBSPClosureExpression.class);
+        Utilities.enforce(clo.parameters.length == 1);
+        this.parameter = clo.parameters[0];
+
+        DBSPExpression expression = clo.body;
+        if (expression.is(DBSPUnaryExpression.class)) {
+            DBSPUnaryExpression unary = expression.to(DBSPUnaryExpression.class);
+            // If the filter is wrap_bool(expression), analyze expression
+            if (unary.opcode == DBSPOpcode.WRAP_BOOL)
+                expression = unary.source;
+        }
+        this.analyzeConjunction(expression);
+    }
+
+    /** Analyze a filter expression from a filter operator.
+     * @param function A function to decompose.  May not be exactly
+     *                 the closure of the operator -- it may be rewritten as a tree.
+     * @return A decomposition of the function into a list of comparisons */
+    public static List<BooleanExpression> decomposeIntoTemporalFilters(
+            DBSPCompiler compiler, DBSPFilterOperator operator, DBSPClosureExpression function) {
+        Utilities.enforce(function.parameters.length == 1);
+        DBSPParameter param = function.parameters[0];
+        IMaybeMonotoneType nonMonotone = NonMonotoneType.nonMonotone(param.getType().deref());
+        MonotoneTransferFunctions mono = new MonotoneTransferFunctions(
+                compiler, operator, MonotoneTransferFunctions.ArgumentKind.ZSet, nonMonotone);
+        mono.apply(function);
+
+        FindComparisons analyzer = new FindComparisons(function, mono);
+        return analyzer.comparisons;
+    }
+
+    BooleanExpression nonTemporal(DBSPExpression expression) {
+        this.containsNow.apply(expression);
+        if (this.containsNow.found)
+            return new NonTemporalFilter(expression);
+        return new NoNow(expression);
+    }
+
+    /**
+     * Analyze a conjunction; return 'false' if some NonTemporalFilters were found.
+     * When this function returns, this.comparisons contains a full
+     * decomposition of 'expression'.
+     */
+    boolean analyzeConjunction(DBSPExpression expression) {
+        DBSPBinaryExpression binary = expression.as(DBSPBinaryExpression.class);
+        if (binary == null) {
+            this.comparisons.add(this.nonTemporal(expression));
+            return false;
+        }
+        if (binary.opcode == DBSPOpcode.AND) {
+            boolean foundLeft = this.analyzeConjunction(binary.left);
+            if (!foundLeft) {
+                BooleanExpression last = Utilities.removeLast(this.comparisons);
+                BooleanExpression right = this.nonTemporal(binary.right);
+                if (last.is(NonTemporalFilter.class) ||
+                        (last.is(NoNow.class) && right.is(NoNow.class)))
+                    this.comparisons.add(last.combine(right));
+                else {
+                    this.comparisons.add(last);
+                    this.comparisons.add(right);
+                }
+                return false;
+            }
+            return this.analyzeConjunction(binary.right);
+        } else {
+            boolean decomposed = this.findComparison(binary);
+            if (!decomposed) {
+                BooleanExpression be = this.nonTemporal(expression);
+                this.comparisons.add(be);
+            }
+            return decomposed;
+        }
+    }
+
+    /**
+     * See if a binary expression can be implemented as a temporal filter.
+     * Return 'false' if the expression contains now() but is not a temporal filter.
+     * If it returns 'true', the expression is added to this.comparisons.
+     */
+    boolean findComparison(DBSPBinaryExpression binary) {
+        this.containsNow.apply(binary);
+        if (!this.containsNow.found) {
+            NoNow expression = new NoNow(binary);
+            this.comparisons.add(expression);
+            return true;
+        }
+
+        if (!this.compOpcodes.contains(binary.opcode))
+            return false;
+        this.containsNow.apply(binary.left);
+        boolean leftHasNow = this.containsNow.found;
+        this.containsNow.apply(binary.right);
+        boolean rightHasNow = this.containsNow.found;
+        if (leftHasNow == rightHasNow) {
+            // Both true or both false
+            return false;
+        }
+
+        DBSPExpression withNow = leftHasNow ? binary.left : binary.right;
+        DBSPExpression withoutNow = leftHasNow ? binary.right : binary.left;
+
+        // The expression containing now() must be monotone
+        MonotoneExpression me = this.mono.maybeGet(withNow);
+        if (me == null || !me.mayBeMonotone())
+            return false;
+
+        DBSPOpcode opcode = leftHasNow ? RewriteNow.inverse(binary.opcode) : binary.opcode;
+        TemporalFilter comp = new TemporalFilter(this.parameter, withoutNow, withNow, opcode);
+        this.comparisons.add(comp);
+        return true;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ImplementNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/ImplementNow.java
@@ -20,10 +20,12 @@ public class ImplementNow extends Passes {
         RewriteNow rewriteNow = new RewriteNow(compiler);
         CircuitContainsNow cn = new CircuitContainsNow(compiler);
         CircuitTransform breakFilters = new Repeat(compiler, new BreakFilters(compiler));
+        CircuitTransform mergeFilters = new MergeFilters(compiler);
         // Check if there is any operator containing NOW
         this.passes.add(cn);
         // If there is, break filters that contain NOW into simpler filters
         this.passes.add(new Conditional(compiler, breakFilters, cn::found));
+        this.passes.add(new Conditional(compiler, mergeFilters, cn::found));
         // Rewrite MAP and FILTER operators
         this.passes.add(new Conditional(compiler, rewriteNow, cn::found));
         // Remove the NOW table

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/MergeFilters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/MergeFilters.java
@@ -1,0 +1,77 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPFilterOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitCloneVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
+import org.dbsp.util.Utilities;
+
+/** Visitor which finds consecutive filters that contain NOW expressions that can be implemented in a single WINDOW
+ * operator and merges them into a single filter operation. */
+public class MergeFilters extends CircuitCloneVisitor {
+    final ContainsNow cn;
+
+    public MergeFilters(DBSPCompiler compiler) {
+        super(compiler, false);
+        this.cn = new ContainsNow(compiler, true);
+    }
+
+    private boolean canBeMerged(DBSPFilterOperator source, DBSPFilterOperator filter) {
+        // We want to only merge filters that can be combined into a single window.
+        // They should look like "col > expression0" and "col < expression1", respectively, for the same column.
+        var s = FindComparisons.decomposeIntoTemporalFilters(this.compiler, source,
+                source.getClosureFunction().ensureTree(this.compiler).to(DBSPClosureExpression.class));
+        var f = FindComparisons.decomposeIntoTemporalFilters(this.compiler, filter,
+                filter.getClosureFunction().ensureTree(this.compiler).to(DBSPClosureExpression.class));
+        if (s.size() != 1 || f.size() != 1)
+            return false;
+        BooleanExpression se = s.get(0);
+        BooleanExpression fe = f.get(0);
+        if (!se.is(TemporalFilter.class) || !fe.is(TemporalFilter.class))
+            return false;
+        return se.compatible(fe);
+    }
+
+    @Override
+    public void postorder(DBSPFilterOperator filter) {
+        OutputPort input = this.mapped(filter.input());
+        if (!input.node().is(DBSPFilterOperator.class) || filter.outputType().is(DBSPTypeIndexedZSet.class)) {
+            super.postorder(filter);
+            return;
+        }
+
+        DBSPFilterOperator source = input.to(DBSPFilterOperator.class);
+        DBSPClosureExpression sourceFunction = source.getClosureFunction();
+        DBSPClosureExpression function = filter.getClosureFunction();
+        this.cn.apply(function);
+        boolean found = this.cn.found;
+        this.cn.apply(sourceFunction);
+        if (!found || !this.cn.found) {
+            super.postorder(filter);
+            return;
+        }
+
+        if (!this.canBeMerged(source, filter)) {
+            super.postorder(filter);
+            return;
+        }
+
+        Utilities.enforce(sourceFunction.parameters.length == 1);
+        Utilities.enforce(function.parameters.length == 1);
+        DBSPVariablePath var = sourceFunction.parameters[0].getType().var();
+        DBSPExpression combined = ExpressionCompiler.makeBinaryExpression(
+                sourceFunction.getNode(),
+                function.getResultType(),
+                DBSPOpcode.AND,
+                sourceFunction.call(var),
+                function.call(var)).closure(var).reduce(this.compiler);
+        DBSPFilterOperator newFilter = new DBSPFilterOperator(filter.getRelNode(), combined, source.input());
+        this.map(filter, newFilter);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/NoNow.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/NoNow.java
@@ -1,0 +1,34 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+
+/**
+ * A Boolean expression that does not involve now
+ */
+record NoNow(DBSPExpression noNow) implements BooleanExpression {
+    @Override
+    public boolean compatible(BooleanExpression other) {
+        return other.is(NoNow.class);
+    }
+
+    @Override
+    public BooleanExpression combine(BooleanExpression other) {
+        return new NoNow(
+                ExpressionCompiler.makeBinaryExpression(this.noNow().getNode(),
+                        DBSPTypeBool.create(this.isNullable() || other.isNullable()), DBSPOpcode.AND,
+                        this.noNow, other.to(NoNow.class).noNow).wrapBoolIfNeeded());
+    }
+
+    @Override
+    public BooleanExpression seal() {
+        return this;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return this.noNow.getType().mayBeNull;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/NonTemporalFilter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/NonTemporalFilter.java
@@ -1,0 +1,43 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+
+/**
+ * A Boolean expression that may involve now(), but is not a temporal filter
+ */
+record NonTemporalFilter(DBSPExpression expression) implements BooleanExpression {
+    @Override
+    public boolean compatible(BooleanExpression other) {
+        // This is compatible with anything else
+        return true;
+    }
+
+    @Override
+    public BooleanExpression combine(BooleanExpression other) {
+        DBSPExpression otherExpression;
+        if (other.is(NoNow.class))
+            otherExpression = other.to(NoNow.class).noNow();
+        else if (other.is(NonTemporalFilter.class))
+            otherExpression = other.to(NonTemporalFilter.class).expression;
+        else
+            throw new InternalCompilerError("Unexpected temporal filter " + other);
+        return new NonTemporalFilter(
+                ExpressionCompiler.makeBinaryExpression(this.expression().getNode(),
+                        DBSPTypeBool.create(this.isNullable() || other.isNullable()), DBSPOpcode.AND,
+                        this.expression, otherExpression).wrapBoolIfNeeded());
+    }
+
+    @Override
+    public BooleanExpression seal() {
+        return this;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return this.expression.getType().mayBeNull;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilter.java
@@ -1,0 +1,60 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.util.Linq;
+
+/**
+ * A Boolean expression that is a comparison involving now() that can be implemented as a temporal filter.
+ *
+ * @param parameter Parameter of the original filter comparison function
+ * @param noNow     left expression, which does not involve now.
+ * @param withNow   right expression, which must be a monotone expression of now(),
+ *                  and which does not involve other fields
+ * @param opcode    comparison
+ */
+record TemporalFilter(DBSPParameter parameter, DBSPExpression noNow,
+                      DBSPExpression withNow, DBSPOpcode opcode)
+        implements BooleanExpression {
+    @Override
+    public boolean compatible(BooleanExpression other) {
+        TemporalFilter o = other.as(TemporalFilter.class);
+        if (o == null)
+            return false;
+
+        // To be compatible the operations must be on different sides, or have the same inclusivity
+        boolean thisGe = RewriteNow.isGreater(this.opcode);
+        boolean otherGe = RewriteNow.isGreater(o.opcode);
+        if (thisGe == otherGe) {
+            boolean thisInclusive = RewriteNow.isInclusive(this.opcode);
+            boolean otherInclusive = RewriteNow.isInclusive(o.opcode);
+            if (thisInclusive != otherInclusive)
+                return false;
+        }
+
+        EquivalenceContext context = new EquivalenceContext();
+        context.leftDeclaration.newContext();
+        context.rightDeclaration.newContext();
+        context.leftDeclaration.substitute(this.parameter.name, this.parameter);
+        context.rightDeclaration.substitute(this.parameter.name, this.parameter);
+        context.leftToRight.put(this.parameter, this.parameter);
+        return context.equivalent(this.noNow, o.noNow);
+    }
+
+    @Override
+    public BooleanExpression combine(BooleanExpression other) {
+        return new TemporalFilterList(Linq.list(this, other.to(TemporalFilter.class)));
+    }
+
+    public BooleanExpression seal() {
+        // return a singleton list
+        return new TemporalFilterList(Linq.list(this));
+    }
+
+    @Override
+    public boolean isNullable() {
+        return this.noNow.getType().mayBeNull || this.withNow.getType().mayBeNull;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilterList.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/TemporalFilterList.java
@@ -1,0 +1,69 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.ir.DBSPParameter;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.util.Linq;
+import org.dbsp.util.Utilities;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A List of {@link TemporalFilter} objects that are "compatible" with each other.
+ * These have the shape "(t.field > now() + constant)",
+ * where the same field is used in all comparisons. */
+record TemporalFilterList(List<TemporalFilter> comparisons) implements BooleanExpression {
+    @Override
+    public boolean compatible(BooleanExpression other) {
+        return Linq.all(this.comparisons, c -> c.compatible(other));
+    }
+
+    @Override
+    public BooleanExpression combine(BooleanExpression other) {
+        this.comparisons.add(other.to(TemporalFilter.class));
+        return this;
+    }
+
+    /** Combine two window bounds.  At least one must be non-null */
+    static WindowBound combine(@Nullable WindowBound left, @Nullable WindowBound right, boolean lower) {
+        if (left == null)
+            return Objects.requireNonNull(right);
+        if (right == null)
+            return left;
+        return left.combine(right, lower);
+    }
+
+    public WindowBounds getWindowBounds(DBSPCompiler compiler) {
+        WindowBound lower = null;
+        WindowBound upper = null;
+        Utilities.enforce(!this.comparisons.isEmpty());
+        DBSPExpression common = this.comparisons.get(0).noNow();
+        for (TemporalFilter comp : this.comparisons) {
+            boolean inclusive = RewriteNow.isInclusive(comp.opcode());
+            boolean toLower = RewriteNow.isGreater(comp.opcode());
+            WindowBound result = new WindowBound(inclusive, comp.withNow());
+            if (toLower) {
+                lower = combine(lower, result, toLower);
+            } else {
+                upper = combine(upper, result, toLower);
+            }
+        }
+        return new WindowBounds(compiler, lower, upper, common);
+    }
+
+    @Override
+    public BooleanExpression seal() {
+        return this;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return Linq.any(this.comparisons, BooleanExpression::isNullable);
+    }
+
+    public DBSPParameter getParameter() {
+        return this.comparisons.get(0).parameter();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBound.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBound.java
@@ -1,0 +1,20 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.frontend.ExpressionCompiler;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
+import org.dbsp.util.Utilities;
+
+record WindowBound(boolean inclusive, DBSPExpression expression) {
+    WindowBound combine(WindowBound with, boolean lower) {
+        Utilities.enforce(this.inclusive == with.inclusive);
+        DBSPOpcode opcode = lower ? DBSPOpcode.MIN : DBSPOpcode.MAX;
+        DBSPExpression expression = ExpressionCompiler.makeBinaryExpression(this.expression.getNode(),
+                this.expression.getType(), opcode, this.expression, with.expression);
+        return new WindowBound(this.inclusive, expression);
+    }
+
+    public String toString() {
+        return this.expression.toString();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBounds.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/temporal/WindowBounds.java
@@ -1,0 +1,64 @@
+package org.dbsp.sqlCompiler.compiler.visitors.outer.temporal;
+
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.IsBoundedType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeTypedBox;
+
+import javax.annotation.Nullable;
+
+record WindowBounds(
+        DBSPCompiler compiler,
+        @Nullable WindowBound lower,
+        @Nullable WindowBound upper,
+        DBSPExpression common) {
+    DBSPClosureExpression makeWindow() {
+        DBSPType type = ContainsNow.timestampType();
+        // The input has type Tup1<Timestamp>
+        DBSPVariablePath var = new DBSPTypeTuple(type).ref().var();
+        RewriteNow.RewriteNowExpression rn = new RewriteNow.RewriteNowExpression(this.compiler(), var.deref().field(0));
+        final DBSPExpression lowerBound, upperBound;
+        CalciteObject node = CalciteObject.EMPTY;
+        if (this.lower != null) {
+            lowerBound = rn.apply(this.lower().expression()).to(DBSPExpression.class);
+            node = this.lower.expression().getNode();
+        } else {
+            lowerBound = type.to(IsBoundedType.class).getMinValue();
+        }
+        if (this.upper != null) {
+            upperBound = rn.apply(this.upper.expression()).to(DBSPExpression.class);
+            if (!node.getPositionRange().isValid())
+                node = this.upper.expression().getNode();
+        } else {
+            upperBound = type.to(IsBoundedType.class).getMaxValue();
+        }
+        return new DBSPRawTupleExpression(node,
+                DBSPTypeTypedBox.wrapTypedBox(lowerBound, false),
+                DBSPTypeTypedBox.wrapTypedBox(upperBound, false))
+                .closure(node, var);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(this.common).append(" in ");
+        if (this.lower == null)
+            builder.append("(*");
+        else
+            builder.append(this.lower.inclusive() ? "[" : "(")
+                    .append(this.lower);
+        builder.append(", ");
+        if (this.upper == null)
+            builder.append("*)");
+        else
+            builder.append(this.upper)
+                    .append(this.upper.inclusive() ? "]" : ")");
+        return builder.toString();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/StreamingTests.java
@@ -1169,7 +1169,7 @@ public class StreamingTests extends StreamingTestBase {
                 FROM transactions
                 WHERE ts BETWEEN now() - INTERVAL 1 DAY AND now() + INTERVAL 1 DAY""";
         CompilerCircuitStream ccs = this.getCCS(sql);
-        CircuitVisitor visitor = new Inspector(ccs.compiler, 2, 1, 1);
+        CircuitVisitor visitor = new Inspector(ccs.compiler, 1, 1, 1);
         ccs.visit(visitor);
         ccs.step("""
                  INSERT INTO transactions VALUES (1, '2024-01-01 00:00:10');
@@ -1224,7 +1224,7 @@ public class StreamingTests extends StreamingTestBase {
                 WHERE id + ts/2 - SIN(id) >= year(now()) + 10 AND
                       id + ts/2 - SIN(id) <= EXTRACT(CENTURY FROM now()) * 20;""";
         CompilerCircuit cc = this.getCC(sql);
-        CircuitVisitor visitor = new Inspector(cc.compiler, 2, 1, 1);
+        CircuitVisitor visitor = new Inspector(cc.compiler, 1, 1, 1);
         cc.visit(visitor);
     }
 
@@ -1245,7 +1245,7 @@ public class StreamingTests extends StreamingTestBase {
                       id >= EXTRACT(CENTURY FROM now()) * 20 AND
                       id = 4;""";
         CompilerCircuit cc = this.getCC(sql);
-        CircuitVisitor visitor = new Inspector(cc.compiler, 3, 1, 1);
+        CircuitVisitor visitor = new Inspector(cc.compiler, 2, 1, 1);
         cc.visit(visitor);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TemporalFilterTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/visitors/outer/TemporalFilterTests.java
@@ -6,6 +6,7 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.CanonicalForm;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.BooleanExpression;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.temporal.RewriteNow;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
@@ -31,7 +32,7 @@ public class TemporalFilterTests extends SqlIoTest {
                 CREATE TABLE T(a INT, b DOUBLE, c BIGINT, ts TIMESTAMP);""");
     }
 
-    List<RewriteNow.BooleanExpression> findFilters(DBSPFilterOperator operator) {
+    List<BooleanExpression> findFilters(DBSPFilterOperator operator) {
         DBSPCompiler compiler = new DBSPCompiler(new CompilerOptions());
         RewriteNow in = new RewriteNow(compiler);
         return in.findTemporalFilters(operator, operator.getClosureFunction());


### PR DESCRIPTION
In the past we used to implement filters such as `WHERE x < NOW() - expr1 AND x > NOW() - expr2` using a single DBSP WINDOW primitive with bounds for left and right. Then we added support for disjunctive queries, using OR, and the algorithm became much simpler, decomposing predicates using NOW into complex networks of filters and sums using de Morgan's rules. In the process we started compiling such filters into a pair of windows, one with a left bound and one with a right bound.

This PR adds a little step which will merge back two filters into one if their predicates are "compatible" in this way. This is not necessarily optimal, since it may not recognize more complex patterns where the predicate terms can be reordered, but it regained the ability to compile some filters into a single WINDOW, which can be potentially much more effective in reducing memory consumption.

The PR looks big because I moved (using automatic refactoring tools, none of that AI crap) many inner classes to the toplevel to enable both analyses to reuse them. The only new stuff is really in `MergeFilters`.