### PR TITLE
[adapters] Avoid races updating status.json.

### DIFF
--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -757,7 +757,7 @@ pub fn run_server(
                     };
                     if Some(stored_status) != prev_stored_status {
                         let storage = storage.clone();
-                        spawn_blocking(move || stored_status.write(&*storage));
+                        let _ = spawn_blocking(move || stored_status.write(&*storage)).await;
                     }
                     prev_stored_status = Some(stored_status);
                     notify.await;


### PR DESCRIPTION
This avoids warnings like the following:

```
WARN dbsp::storage::backend::posixio_impl:  /pipeline-storage/status.json.mut: unable to delete dropped file: No such file or directory (os error 2)
WARN dbsp_adapters::server:  status.json: failed to write to storage (/pipeline-storage/status.json.mut: rename failed: entity not found)
```

which occurred because the task to update status.json would start an update before waiting for the previous one to complete.

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
