### PR TITLE
[adapters] Improve logging around delayed checkpoints.

### DIFF
--- a/crates/adapters/src/util.rs
+++ b/crates/adapters/src/util.rs
@@ -708,6 +708,10 @@ impl LongOperationWarning {
     pub fn next_warning(&self) -> Instant {
         self.start + self.warn_threshold
     }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start.elapsed()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #5169 

The log message we output was misleading: instead of reporting that N records need to be processed by the pipeline, it suggested that N records need to be transmitted by the connectors.

In addition to clarifying the message, this commit extends the message with more detailed info about the delay:
- Is the pipeline still computing or just waiting for outputs
- In the latter case, what connectors it's waiting for and how many records/batches are queued by the connector.

Finally, we add a log message when the commit is unblocked after a delay, which is otherwise unclear in the log.