### PR TITLE
py: add remaining illegal argument tests

### DIFF
--- a/python/tests/runtime_aggtest/aggtst_base.py
+++ b/python/tests/runtime_aggtest/aggtst_base.py
@@ -396,7 +396,7 @@ class TstAccumulator:
             )
 
     def run_expected_failures(self, pipeline_name_prefix: str):
-        """Loop through each view that is expected to fail in a separate pipeline"""
+        """Loop through each view that is expected to fail and run it in a separate pipeline"""
         # Only use passing tables when testing views
         passing_tables = self.filter_by_expected_error(self.tables, should_fail=False)
         failing_views = self.filter_by_expected_error(self.views, should_fail=True)

--- a/python/tests/runtime_aggtest/illarg_tests/test_cmp_operators.py
+++ b/python/tests/runtime_aggtest/illarg_tests/test_cmp_operators.py
@@ -1558,3 +1558,63 @@ class illarg_is_not_unknown_illegal(TstView):
                       FROM illegal_tbl
                       WHERE id = 2"""
         self.expected_error = " Cannot apply 'IS NOT UNKNOWN' to arguments of type"
+
+
+# OVERLAPS
+class illarg_overlaps_legal_timestamp(TstView):
+    def __init__(self):
+        self.data = [{"res": True}]
+        self.sql = """CREATE MATERIALIZED VIEW overlaps_legal_timestamp AS SELECT
+                      (tmestmp, tmestmp)
+                      OVERLAPS
+                      (TIMESTAMP '2020-06-21 14:23:44.123654',
+                       TIMESTAMP '2020-06-21 14:23:44.123654') AS res
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+
+
+# Negative Test
+class illarg_overlaps_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW overlaps_illegal AS SELECT
+                      (datee)
+                      OVERLAPS
+                      (DATE '2020-06-21') AS res
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = "Cannot apply 'OVERLAPS' to arguments of type"
+
+
+class illarg_interval_overlap_illegal(TstView):
+    def __init__(self):
+        self.data = []
+        self.sql = """CREATE LOCAL VIEW ats_minus_ts AS SELECT
+                      (tmestmp - TIMESTAMP'2018-06-21 14:23:44')YEAR AS interval_yr
+                      FROM illegal_tbl
+                      WHERE id = 0;
+
+                      CREATE MATERIALIZED VIEW interval_overlap_illegal AS SELECT
+                      (interval_yr, interval_yr)
+                      OVERLAPS
+                      (INTERVAL '2' YEAR, INTERVAL '2' YEAR) AS res
+                      FROM ats_minus_ts"""
+        self.expected_error = "Cannot apply 'OVERLAPS' to arguments of type"
+
+
+# CONTAINS
+class illarg_contains_legal(TstView):
+    def __init__(self):
+        self.data = [{"datee": True}]
+        self.sql = """CREATE MATERIALIZED VIEW contains_legal AS SELECT
+                      (datee, datee + INTERVAL '1' DAY) CONTAINS datee as datee
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+
+
+class illarg_contains_illegal_timestamp(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW contains_illegal_timestamp AS SELECT
+                      tmestmp CONTAINS TIMESTAMP '2020-06-21 14:23:44.123654' AS res
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = "Cannot apply 'CONTAINS' to arguments of type"

--- a/python/tests/runtime_aggtest/illarg_tests/test_grammar_tbl_fn.py
+++ b/python/tests/runtime_aggtest/illarg_tests/test_grammar_tbl_fn.py
@@ -502,3 +502,77 @@ class illarg_over_illegal(TstView):
                       FROM illegal_tbl
                       GROUP BY GROUPING SETS (str + 1)"""
         self.expected_error = "Window 'intt' not found"
+
+
+# QUALIFY
+class illarg_qualify_top_k_legal(TstView):
+    def __init__(self):
+        self.data = [{"id": 0, "intt": -12}, {"id": 1, "intt": -1}]
+        self.sql = """CREATE MATERIALIZED VIEW qualify_top_k_legal AS SELECT
+                      id, intt
+                      FROM illegal_tbl
+                      QUALIFY
+                      ROW_NUMBER() OVER (ORDER BY intt DESC) <= 2"""
+
+
+# Negative Test
+class illarg_qualify_top_k_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW qualify_top_k_illegal AS SELECT
+                      id, intt
+                      FROM illegal_tbl
+                      QUALIFY
+                      ROW_NUMBER() OVER (ORDER BY intt DESC) <= 2 OR
+                      RANK() OVER (ORDER BY intt DESC) <= 2 OR
+                      DENSE_RANK() OVER (ORDER BY intt DESC) <= 2"""
+        self.expected_error = "Not yet implemented"
+
+
+# IS TRUE/IS FALSE/IS NOT TRUE/IS NOT FALSE
+class illarg_is_true_false_legal(TstView):
+    def __init__(self):
+        self.data = [{"booll": True, "booll1": False, "booll2": False, "booll3": True}]
+        self.sql = """CREATE MATERIALIZED VIEW is_true_legal AS SELECT
+                      booll IS TRUE AS booll,
+                      booll IS NOT TRUE AS booll1,
+                      booll IS FALSE AS booll2,
+                      booll IS NOT FALSE AS booll3
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+
+
+# Negative Tests
+class illarg_is_true_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW is_true_illegal AS SELECT
+                      udt IS TRUE AS udt
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = " Cannot apply 'IS TRUE' to arguments of type"
+
+
+class illarg_is_false_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW is_false_illegal AS SELECT
+                      intt IS FALSE AS intt
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = " Cannot apply 'IS FALSE' to arguments of type"
+
+
+class illarg_is_not_true_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW is_not_true_illegal AS SELECT
+                      udt IS NOT TRUE AS udt
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = " Cannot apply 'IS NOT TRUE' to arguments of type"
+
+
+class illarg_is_not_false_illegal(TstView):
+    def __init__(self):
+        self.sql = """CREATE MATERIALIZED VIEW is_not_false_illegal AS SELECT
+                      intt IS NOT FALSE AS intt
+                      FROM illegal_tbl
+                      WHERE id = 0"""
+        self.expected_error = " Cannot apply 'IS NOT FALSE' to arguments of type"


### PR DESCRIPTION
**Changes made in this PR:**

Added tests for: **CONNECTOR_METADATA** function and **DEFAULT** table expression. 

Since these features are table-level and some tests are expected to fail, modified [aggtst_base](https://github.com/feldera/feldera/blob/247b89e68b4a7f2a49473c659f6d6437de0ff6bc/python/tests/runtime_aggtest/aggtst_base.py) to support the following:
1.  Tables are supplied the `expected_error` attribute
2.  Passing tables are run together in a single pipeline prior to running views
3. Failing tables are run separately in individual pipelines (similar to failing views)
4. All views (both passing and failing) reference only passing tables
