### PR TITLE
[dbsp] Force update_snapshot to drop the snapshot in a tokio thread.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2579,7 +2579,7 @@ impl CircuitThread {
         // in the circuit thread will directly delay the start of the next step,
         // so drop them in a separate thread.
         TOKIO.spawn_blocking(move || {
-            let _ = old_snapshot;
+            let _ = std::hint::black_box(old_snapshot);
         });
     }
 


### PR DESCRIPTION
It looks like the optimizer moved the call to the spine snapshot destructor back to the calling thread from the tokio thread. We use std::hint::black_box (suggested by @blp) to force it to do the right thing.