### PR TITLE
[SQL] Introduce a special literal with type void; using the empty tuple does not really work

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -77,6 +77,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU8Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUuidLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVoidLiteral;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.path.DBSPPathSegment;
 import org.dbsp.sqlCompiler.ir.path.DBSPSimplePathSegment;
@@ -172,6 +173,12 @@ public class ToRustInnerVisitor extends InnerVisitor {
     @Override
     public VisitDecision preorder(DBSPNullLiteral literal) {
         this.builder.append("None::<()>");
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPVoidLiteral literal) {
+        this.builder.append("()");
         return VisitDecision.STOP;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerRewriteVisitor.java
@@ -42,6 +42,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU8Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVoidLiteral;
 import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
 import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
 import org.dbsp.sqlCompiler.ir.statement.DBSPFunctionItem;
@@ -648,6 +649,15 @@ public abstract class InnerRewriteVisitor
         this.push(expression);
         this.pop(expression);
         DBSPExpression result = DBSPNullLiteral.INSTANCE;
+        this.map(expression, result);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPVoidLiteral expression) {
+        this.push(expression);
+        this.pop(expression);
+        DBSPExpression result = DBSPVoidLiteral.INSTANCE;
         this.map(expression, result);
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -75,6 +75,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU8Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUuidLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVariantNullLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVoidLiteral;
 import org.dbsp.sqlCompiler.ir.path.DBSPPath;
 import org.dbsp.sqlCompiler.ir.path.DBSPPathSegment;
 import org.dbsp.sqlCompiler.ir.path.DBSPSimplePathSegment;
@@ -733,6 +734,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public VisitDecision preorder(DBSPNullLiteral node) {
+        return this.preorder((DBSPLiteral) node);
+    }
+
+    public VisitDecision preorder(DBSPVoidLiteral node) {
         return this.preorder((DBSPLiteral) node);
     }
 
@@ -1411,6 +1416,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs, IHasId, 
     }
 
     public void postorder(DBSPNullLiteral node) {
+        this.postorder((DBSPLiteral) node);
+    }
+
+    public void postorder(DBSPVoidLiteral node) {
         this.postorder((DBSPLiteral) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -73,6 +73,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU8Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVoidLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.IHasZero;
 import org.dbsp.sqlCompiler.ir.type.IsNumericType;
@@ -518,7 +519,7 @@ public class Simplify extends ExpressionTranslator {
                 } else {
                     result = negative;
                     if (result == null)
-                        result = new DBSPRawTupleExpression();
+                        result = DBSPVoidLiteral.INSTANCE;
                 }
             }
         } else if (negative != null &&

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -96,13 +96,14 @@ public abstract class DBSPLiteral extends DBSPExpression
             case MAP -> new DBSPMapExpression(type.to(DBSPTypeMap.class), null, null);
             case TUPLE -> DBSPTupleExpression.none(type.to(DBSPTypeTuple.class));
             case RAW_TUPLE -> DBSPRawTupleExpression.none(type.to(DBSPTypeRawTuple.class));
-            case NULL -> new DBSPNullLiteral();
             case TIMESTAMP -> new DBSPTimestampLiteral();
             case BYTES -> new DBSPBinaryLiteral(type.getNode(), type, null);
             case VARIANT -> new DBSPVariantExpression(null, type);
             case STRUCT -> type.to(DBSPTypeStruct.class).toTuple().none();
             case UUID -> new DBSPUuidLiteral();
-            case INTERNED_STRING -> new DBSPInternedStringLiteral();
+            case INTERNED_STRING -> DBSPInternedStringLiteral.INSTANCE;
+            case NULL -> DBSPNullLiteral.INSTANCE;
+            case VOID -> DBSPVoidLiteral.INSTANCE;
             default -> throw new InternalCompilerError("Unexpected type for NULL literal " + type, type);
         };
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVoidLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPVoidLiteral.java
@@ -1,0 +1,52 @@
+package org.dbsp.sqlCompiler.ir.expression.literal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
+import org.dbsp.sqlCompiler.ir.ISameValue;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
+import org.dbsp.util.IIndentStream;
+
+/** In literal the () value has type void, but that's confusing.
+ * There should exist an empty tuple.  This is a literal of type void. */
+public class DBSPVoidLiteral extends DBSPLiteral {
+    public static final DBSPVoidLiteral INSTANCE = new DBSPVoidLiteral();
+
+    DBSPVoidLiteral() {
+        super(CalciteObject.EMPTY, DBSPTypeVoid.INSTANCE, false);
+    }
+
+    @Override
+    public DBSPLiteral getWithNullable(boolean mayBeNull) {
+        if (mayBeNull)
+            throw new RuntimeException("nullable void literal does not exist");
+        return this;
+    }
+
+    @Override
+    public String toSqlString() {
+        return "";
+    }
+
+    @Override
+    public boolean sameValue(ISameValue expression) {
+        return expression.is(DBSPVoidLiteral.class);
+    }
+
+    @Override
+    public DBSPExpression deepCopy() {
+        return this;
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        return builder.append("()");
+    }
+
+    @SuppressWarnings("unused")
+    public static DBSPVoidLiteral fromJson(JsonNode node, JsonDecoder decoder) {
+        return INSTANCE;
+    }
+
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeVoid.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeVoid.java
@@ -7,6 +7,7 @@ import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVoidLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 
 import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.VOID;
@@ -41,7 +42,7 @@ public class DBSPTypeVoid extends DBSPTypeBaseType {
 
     @Override
     public DBSPExpression defaultValue() {
-        throw new UnsupportedException(this.getNode());
+        return DBSPVoidLiteral.INSTANCE;
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This fixes a crash cause by simplifying 
```
if (false) { return z; }
```
to 
```
()
```
In Rust this works, but in our compiler these objects have different types: the empty tuple is not void.
