### PR TITLE
[dbsp] Use std::unstable_sort in merger.

### DIFF
--- a/crates/dbsp/src/utils/consolidation.rs
+++ b/crates/dbsp/src/utils/consolidation.rs
@@ -129,8 +129,6 @@ where
     }
 
     // Ideally we'd combine the sorting and value merging portions
-    // This line right here is literally the hottest code within the entirety of the
-    // program. It makes up 90% of the work done while joining or merging anything
     slice.sort_unstable_by(|Tup2(key1, _), Tup2(key2, _)| key1.cmp(key2));
 
     consolidate_slice_inner(
@@ -222,8 +220,6 @@ where
     }
 
     // Ideally we'd combine the sorting and value merging portions
-    // This line right here is literally the hottest code within the entirety of the
-    // program. It makes up 90% of the work done while joining or merging anything
     quicksort::quicksort(&mut keys[offset..], &mut diffs[offset..]);
 
     // Deduplicate all difference values
@@ -252,9 +248,6 @@ where
     }
 
     // Ideally we'd combine the sorting and value merging portions
-    // These lines right here are literally the hottest code within the entirety of
-    // the program. They make up 90% of the work done while joining or merging
-    // anything
     quicksort::quicksort(keys, diffs);
 
     // Safety: the keys & diffs slices are the same length and are non-empty


### PR DESCRIPTION
One of the things we do to speed up compilation of pilelines is use a dynamically typed implementation of the vector sorting algorithm. Instead of having to compile a monomorphized implementation of sorting for every time in the pipeline, we have a single implementation that can be parameterized at runtime by a comparison function and the length of the value (the latter is used to swap values in the process of sorting). Unsurprisingly this implementation is less efficient, especially when sorting simple types like (u64, u64). @gz and I have measured the overhead and it seems to range between 4x (when sorting simple types like u64) and 1.5x for a 10-tuple (u64,...,u64).

The main source of the overhead is that the monomorphic implementation cannot rely on compiler optimizations to efficiently copy values (esp small values) and must use std::ptr::copy_nonoverlapping instead.

Sorting is used in two places in the DBSP code:

1. In the MergeBatcher, when building sorted batches out of unsorted vectors. This one is only instantiated for weighted tuples. It's primarily used in arranging input data into sorted batches and by the join operator, which produces unsorted outputs.
2. In `trait Vector`, which is instantiated for almost all types, but is only used in a few random places and is not performance critical.

This PR switches the former to using statically typed sort_unstable_by from the standard library. It appears that the impact on compilation time is <=5% (I've only done very limited testing though). The impact on executable size is even smaller.

As an additional benefit, we now take advantage of unstable sorting (I did not manage to quickly implement unstable sorting in DBSP and gave up on it back in the day, so we were using stable sorting everywhere).
