### PR TITLE
Add an option to view per-connector metrics in Performance tab

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/editor/MetricsTables.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MetricsTables.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  import { format } from 'd3-format'
+  import { humanSize } from '$lib/functions/common/string'
+  import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
+
+  const formatQty = (v: number) => format(',.0f')(v)
+
+  let { metrics }: { metrics: { current: PipelineMetrics } } = $props()
+
+  let expandedTables = $state<Set<string>>(new Set())
+  let expandedViews = $state<Set<string>>(new Set())
+
+  const toggleTable = (relation: string) => {
+    if (expandedTables.has(relation)) {
+      expandedTables.delete(relation)
+    } else {
+      expandedTables.add(relation)
+    }
+    expandedTables = new Set(expandedTables)
+  }
+
+  const toggleView = (relation: string) => {
+    if (expandedViews.has(relation)) {
+      expandedViews.delete(relation)
+    } else {
+      expandedViews.add(relation)
+    }
+    expandedViews = new Set(expandedViews)
+  }
+</script>
+
+{#if metrics.current.tables.size}
+  <table class="bg-white-dark table h-min max-w-[1200px] rounded text-base">
+    <thead>
+      <tr>
+        <th class="font-normal">Table</th>
+        <th class="font-normal">Connector</th>
+        <th class="!text-end font-normal">Ingested records</th>
+        <th class="!text-end font-normal">Ingested bytes</th>
+        <th class="!text-end font-normal">Parse errors</th>
+        <th class="!text-end font-normal">Transport errors</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each metrics.current.tables.entries() as [relation, data]}
+        {@const isExpanded = expandedTables.has(relation)}
+        {@const hasMultipleConnectors = data.connectors.length > 1}
+        <tr
+          class={hasMultipleConnectors ? 'cursor-pointer hover:bg-surface-50-950' : ''}
+          onclick={() => hasMultipleConnectors && toggleTable(relation)}
+        >
+          <td class="font-medium">
+            {relation}
+          </td>
+          <td class="">
+            {#if hasMultipleConnectors}
+              <div
+                class="fd fd-chevron-down mr-1 inline-block w-4 text-center text-[16px]"
+                class:rotate-180={isExpanded}
+              ></div>
+              ({data.connectors.length} connectors)
+            {:else if data.connectors.length === 1}
+              {data.connectors[0].endpointName}
+            {:else}
+              —
+            {/if}
+          </td>
+          <td class="text-end font-dm-mono">
+            {formatQty(data.aggregate.total_records)}
+          </td>
+          <td class="text-end font-dm-mono">
+            {humanSize(data.aggregate.total_bytes)}
+          </td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.num_parse_errors)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.num_transport_errors)}</td>
+        </tr>
+        {#if isExpanded && hasMultipleConnectors}
+          {#each data.connectors as connector}
+            <tr class="">
+              <td></td>
+              <td class="">
+                <div class="pl-6">
+                  {connector.endpointName}
+                </div>
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.total_records)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {humanSize(connector.metrics.total_bytes)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.num_parse_errors)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.num_transport_errors)}
+              </td>
+            </tr>
+          {/each}
+        {/if}
+      {/each}
+    </tbody>
+  </table>
+{/if}
+{#if metrics.current.views.size}
+  <table class="bg-white-dark table h-min max-w-[1700px] rounded text-base">
+    <thead>
+      <tr>
+        <th class="font-normal">View</th>
+        <th class="font-normal">Connector</th>
+        <th class="!text-end font-normal">Transmitted records</th>
+        <th class="!text-end font-normal">Transmitted bytes</th>
+        <th class="!text-end font-normal">Buffered records</th>
+        <th class="!text-end font-normal">Queued records</th>
+        <th class="!text-end font-normal">Buffered batches</th>
+        <th class="!text-end font-normal">Queued batches</th>
+        <th class="!text-end font-normal">Encode errors</th>
+        <th class="!text-end font-normal">Transport errors</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each metrics.current.views.entries() as [relation, data]}
+        {@const isExpanded = expandedViews.has(relation)}
+        {@const hasMultipleConnectors = data.connectors.length > 1}
+        <tr
+          class={hasMultipleConnectors ? 'cursor-pointer hover:bg-surface-50-950' : ''}
+          onclick={() => hasMultipleConnectors && toggleView(relation)}
+        >
+          <td class="font-medium">
+            {relation}
+          </td>
+          <td class="">
+            {#if hasMultipleConnectors}
+              <div
+                class="fd fd-chevron-down mr-1 inline-block w-4 text-center text-[16px]"
+                class:rotate-180={isExpanded}
+              ></div>
+              ({data.connectors.length} connectors)
+            {:else if data.connectors.length === 1}
+              {data.connectors[0].endpointName}
+            {:else}
+              —
+            {/if}
+          </td>
+          <td class="text-end font-dm-mono">
+            {formatQty(data.aggregate.transmitted_records)}
+          </td>
+          <td class="text-end font-dm-mono">
+            {humanSize(data.aggregate.transmitted_bytes)}
+          </td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.buffered_records)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.queued_records)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.buffered_batches)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.queued_batches)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.num_encode_errors)}</td>
+          <td class="text-end font-dm-mono">{formatQty(data.aggregate.num_transport_errors)}</td>
+        </tr>
+        {#if isExpanded && hasMultipleConnectors}
+          {#each data.connectors as connector}
+            <tr class="">
+              <td></td>
+              <td class="">
+                <div class="pl-6">
+                  {connector.endpointName}
+                </div>
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.transmitted_records)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {humanSize(connector.metrics.transmitted_bytes)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.buffered_records)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.queued_records)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.buffered_batches)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.queued_batches)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.num_encode_errors)}
+              </td>
+              <td class="text-end font-dm-mono">
+                {formatQty(connector.metrics.num_transport_errors)}
+              </td>
+            </tr>
+          {/each}
+        {/if}
+      {/each}
+    </tbody>
+  </table>
+{/if}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -5,12 +5,12 @@
   import PipelineMemoryGraph from '$lib/components/layout/pipelines/PipelineMemoryGraph.svelte'
   import PipelineStorageGraph from '$lib/components/layout/pipelines/PipelineStorageGraph.svelte'
   import PipelineThroughputGraph from '$lib/components/layout/pipelines/PipelineThroughputGraph.svelte'
+  import MetricsTables from '$lib/components/pipelines/editor/MetricsTables.svelte'
   import { useIsScreenXl } from '$lib/compositions/layout/useIsMobile.svelte'
   import {
     type PipelineManagerApi,
     usePipelineManager
   } from '$lib/compositions/usePipelineManager.svelte'
-  import { humanSize } from '$lib/functions/common/string'
   import { formatDateTime, useElapsedTime } from '$lib/functions/format'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import {
@@ -252,74 +252,7 @@
     </div>
     {#if metrics.current.views.size || metrics.current.tables.size}
       <div class="flex flex-wrap gap-4">
-        {#if metrics.current.tables.size}
-          <table class="bg-white-dark table h-min max-w-[1000px] rounded text-base">
-            <thead>
-              <tr>
-                <th class="font-normal text-surface-600-400">Table</th>
-                <th class="!text-end font-normal text-surface-600-400">Ingested records</th>
-                <th class="!text-end font-normal text-surface-600-400">Ingested bytes</th>
-                <th class="!text-end font-normal text-surface-600-400">Parse errors</th>
-                <th class="!text-end font-normal text-surface-600-400">Transport errors</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each metrics.current.tables.entries() as [relation, stats]}
-                <tr>
-                  <td>
-                    {relation}
-                  </td>
-                  <td class="text-end">
-                    {formatQty(stats.total_records)}
-                  </td>
-                  <td class="text-end">
-                    {humanSize(stats.total_bytes)}
-                  </td>
-                  <td class="text-end">{formatQty(stats.num_parse_errors)} </td>
-                  <td class="text-end">{formatQty(stats.num_transport_errors)} </td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        {/if}
-        {#if metrics.current.views.size}
-          <table class="bg-white-dark table h-min max-w-[1500px] rounded text-base">
-            <thead>
-              <tr>
-                <th class="font-normal text-surface-600-400">View</th>
-                <th class="!text-end font-normal text-surface-600-400">Transmitted records</th>
-                <th class="!text-end font-normal text-surface-600-400">Transmitted bytes</th>
-                <th class="!text-end font-normal text-surface-600-400">Buffered records</th>
-                <th class="!text-end font-normal text-surface-600-400">Queued records</th>
-                <th class="!text-end font-normal text-surface-600-400">Buffered batches</th>
-                <th class="!text-end font-normal text-surface-600-400">Queued batches</th>
-                <th class="!text-end font-normal text-surface-600-400">Encode errors</th>
-                <th class="!text-end font-normal text-surface-600-400">Transport errors</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each metrics.current.views.entries() as [relation, stats]}
-                <tr>
-                  <td>
-                    {relation}
-                  </td>
-                  <td class="text-end">
-                    {formatQty(stats.transmitted_records)}
-                  </td>
-                  <td class="text-end">
-                    {humanSize(stats.transmitted_bytes)}
-                  </td>
-                  <td class="text-end">{formatQty(stats.buffered_records)} </td>
-                  <td class="text-end">{formatQty(stats.queued_records)} </td>
-                  <td class="text-end">{formatQty(stats.buffered_batches)} </td>
-                  <td class="text-end">{formatQty(stats.queued_batches)} </td>
-                  <td class="text-end">{formatQty(stats.num_encode_errors)} </td>
-                  <td class="text-end">{formatQty(stats.num_transport_errors)} </td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        {/if}
+        <MetricsTables {metrics} />
       </div>
     {/if}
   </div>

--- a/js-packages/web-console/src/lib/compositions/useAggregatePipelineStats.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/useAggregatePipelineStats.svelte.ts
@@ -8,7 +8,6 @@ import {
 } from '$lib/functions/pipelineMetrics'
 import { isMetricsAvailable } from '$lib/functions/pipelines/status'
 import type { ExtendedPipeline } from '$lib/services/pipelineManager'
-import { useToast } from './useToastNotification'
 
 const metrics: Record<string, PipelineMetrics> = {} // Disable reactivity for metrics data for better performance
 let getMetrics = $state<() => typeof metrics>(() => metrics)

--- a/js-packages/web-console/src/routes/+layout.svelte
+++ b/js-packages/web-console/src/routes/+layout.svelte
@@ -28,9 +28,7 @@
 
   // Scarf.sh tracking for OSS deployments
   // Only track Open source edition (excludes Enterprise builds)
-  const shouldTrack = $derived(
-    browser && page.data.feldera?.config?.edition === 'Open source'
-  )
+  const shouldTrack = $derived(browser && page.data.feldera?.config?.edition === 'Open source')
   const scarfPixelId = 'c5e8a21a-5f5a-424d-81c4-5ded97174900'
   const scarfTrackingUrl = $derived(
     shouldTrack


### PR DESCRIPTION
Currently all composite rows are collapsed by default.

<img width="2610" height="516" alt="image" src="https://github.com/user-attachments/assets/a186853b-c1c6-462b-a78f-c75e83c1f51e" />
<img width="2610" height="516" alt="image" src="https://github.com/user-attachments/assets/037fd935-6178-4fd0-badb-763f1ced5221" />
