### PR TITLE
[SQL] Replace the calcite implementations of TUMBLE and HOP with functions which infer unlimited precision for TIMESTAMPs

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -122,6 +122,8 @@ import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.FelderaSqlHopTableFunction;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.FelderaSqlTumbleTableFunction;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.RelColumnMetadata;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.SqlToRelCompiler;
@@ -228,6 +230,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -658,15 +661,15 @@ public class CalciteToDBSPCompiler extends RelVisitor
         RexNode operation = tf.getCall();
         Utilities.enforce(operation instanceof RexCall);
         RexCall call = (RexCall) operation;
-        switch (call.getOperator().getName()) {
-            case "HOP":
-                this.compileHop(tf, call);
-                return;
-            case "TUMBLE":
-                this.compileTumble(tf, call);
-                return;
-            default:
-                break;
+        String opName = call.getOperator().getName();
+        if (opName.equalsIgnoreCase(FelderaSqlHopTableFunction.NAME) ||
+                opName.equalsIgnoreCase(SqlKind.HOP.name())) {
+            this.compileHop(tf, call);
+            return;
+        } else if (opName.equalsIgnoreCase(FelderaSqlTumbleTableFunction.NAME) ||
+                opName.equalsIgnoreCase(SqlKind.TUMBLE.name())) {
+            this.compileTumble(tf, call);
+            return;
         }
         throw new UnimplementedException("Table function " + tf + " not yet implemented", node);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteFunctions.java
@@ -307,9 +307,6 @@ public class CalciteFunctions implements FunctionDocumentation.FunctionRegistry 
             new Func(SqlStdOperatorTable.STRUCT_ACCESS, "$STRUCT_ACCESS", SqlLibrary.STANDARD, "", FunctionDocumentation.NO_FILE, false),
             new Func(SqlStdOperatorTable.CARDINALITY, "CARDINALITY", SqlLibrary.STANDARD, "array#cardinality,map#cardinality", FunctionDocumentation.NO_FILE, false),
 
-            new Func(SqlStdOperatorTable.TUMBLE, "TUMBLE", SqlLibrary.STANDARD, "table#tumble", FunctionDocumentation.NO_FILE, false),
-            new Func(SqlStdOperatorTable.HOP, "HOP", SqlLibrary.STANDARD, "table#hop", FunctionDocumentation.NO_FILE, false),
-
             // SqlLibraryOperators operators
             // DATEADD is not implemented, but give a better error message
             new Func(SqlLibraryOperators.DATEADD, "DATEADD", SqlLibrary.POSTGRESQL, "", FunctionDocumentation.NO_FILE, false),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/ConvertletTable.java
@@ -1005,9 +1005,10 @@ public class ConvertletTable extends ReflectiveConvertletTable {
         return cx.getRexBuilder().makeCall(call.getParserPosition(), returnType, fun, exprs);
     }
 
+    // Modified to take a FelderaSqlWindowTableFunction
     public RexNode convertWindowFunction(
             SqlRexContext cx,
-            SqlWindowTableFunction fun,
+            FelderaSqlWindowTableFunction fun,
             SqlCall call) {
         // The first operand of window function is actually a query, skip that.
         final List<SqlNode> operands = Util.skip(call.getOperandList());

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CustomFunctions.java
@@ -85,6 +85,8 @@ public class CustomFunctions {
         this.functions.add(new ToJsonFunction());
         this.functions.add(new ConnectorMetadataFunction());
         this.functions.add(new WriteLogFunction());
+        this.functions.add(FelderaSqlTumbleTableFunction.INSTANCE);
+        this.functions.add(FelderaSqlHopTableFunction.INSTANCE);
         this.udf = new HashMap<>();
         this.aggregates = new HashMap<>();
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlHopTableFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlHopTableFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlOperator;
+
+/**
+ * Reimplementation of the Calcite function with a different result type inference.
+ *
+ * <p>SqlHopTableFunction implements an operator for hopping.
+ *
+ * <p>It allows four parameters:
+ *
+ * <ol>
+ *   <li>a table</li>
+ *   <li>a descriptor to provide a watermarked column name from the input table</li>
+ *   <li>an interval parameter to specify the length of window shifting</li>
+ *   <li>an interval parameter to specify the length of window size</li>
+ * </ol>
+ */
+public class FelderaSqlHopTableFunction extends FelderaSqlWindowTableFunction {
+    // Have to use a unique name
+    public static final String NAME = "FELDERA_HOP";
+
+    /** HOP as a table function. */
+    public static final FelderaSqlHopTableFunction INSTANCE = new FelderaSqlHopTableFunction();
+
+    private FelderaSqlHopTableFunction() {
+        super(NAME, new FelderaSqlHopTableFunction.OperandMetadataImpl(),
+                "table#hop", FunctionDocumentation.NO_FILE);
+    }
+
+    /**
+     * Operand type checker for HOP.
+     */
+    private static class OperandMetadataImpl extends AbstractOperandMetadata {
+        OperandMetadataImpl() {
+            super(
+                    ImmutableList.of(PARAM_DATA, PARAM_TIMECOL, PARAM_SLIDE,
+                            PARAM_SIZE, PARAM_OFFSET), 4);
+        }
+
+        @Override
+        public boolean checkOperandTypes(SqlCallBinding callBinding,
+                                         boolean throwOnFailure) {
+            if (!checkTableAndDescriptorOperands(callBinding, 1)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            if (!checkTimeColumnDescriptorOperand(callBinding, 1)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            if (!checkIntervalOperands(callBinding, 2)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            return true;
+        }
+
+        @Override
+        public String getAllowedSignatures(SqlOperator op, String opName) {
+            return "HOP(TABLE table_name, DESCRIPTOR(timecol), "
+                    + "datetime interval, datetime interval[, datetime interval])";
+        }
+    }
+}
+

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlTumbleTableFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlTumbleTableFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlOperator;
+
+/**
+ * Reimplementation of the Calcite function with a different result type inference.
+ *
+ * <p>SqlTumbleTableFunction implements an operator for tumbling.
+ *
+ * <p>It allows three parameters:
+ *
+ * <ol>
+ *   <li>a table</li>
+ *   <li>a descriptor to provide a watermarked column name from the input table</li>
+ *   <li>an interval parameter to specify the length of window size</li>
+ * </ol>
+ */
+public class FelderaSqlTumbleTableFunction extends FelderaSqlWindowTableFunction {
+    // Have to use a unique name
+    public static final String NAME = "FELDERA_TUMBLE";
+
+    /** TUMBLE as a table function. */
+    public static final FelderaSqlTumbleTableFunction INSTANCE = new FelderaSqlTumbleTableFunction();
+
+    private FelderaSqlTumbleTableFunction() {
+        super(NAME, new FelderaSqlTumbleTableFunction.OperandMetadataImpl(),
+                "table#tumble", FunctionDocumentation.NO_FILE);
+    }
+
+    /** Operand type checker for TUMBLE. */
+    private static class OperandMetadataImpl extends AbstractOperandMetadata {
+        OperandMetadataImpl() {
+            super(
+                    ImmutableList.of(PARAM_DATA, PARAM_TIMECOL, PARAM_SIZE, PARAM_OFFSET),
+                    3);
+        }
+
+        @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+                                                   boolean throwOnFailure) {
+            // There should only be three operands, and number of operands are checked before
+            // this call.
+            if (!checkTableAndDescriptorOperands(callBinding, 1)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            if (!checkTimeColumnDescriptorOperand(callBinding, 1)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            if (!checkIntervalOperands(callBinding, 2)) {
+                return throwValidationSignatureErrorOrReturnFalse(callBinding, throwOnFailure);
+            }
+            return true;
+        }
+
+        @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+            return "TUMBLE(TABLE table_name, DESCRIPTOR(timecol), datetime interval"
+                    + "[, datetime interval])";
+        }
+    }
+}
+

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlWindowTableFunction.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/FelderaSqlWindowTableFunction.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.linq4j.Ord;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlOperandMetadata;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlNameMatcher;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.calcite.util.Static.RESOURCE;
+
+/**
+ * A reimplementation of Calcite's SqlWindowTableFunction.
+ * That class uses a hardwired data type of TIMESTAMP(3) for TIMESTAMPS; we
+ * replace this with a TIMESTAMP with unspecified precision in inferRowType.
+ *
+ * <p>Base class for a table-valued function that computes windows. Examples
+ * include {@code TUMBLE}, {@code HOP} and {@code SESSION}.
+ */
+public class FelderaSqlWindowTableFunction extends CustomFunctions.NonOptimizedFunction
+        implements SqlTableFunction {
+
+    /** The data source which the table function computes with. */
+    protected static final String PARAM_DATA = "DATA";
+
+    /** The time attribute column. Also known as the event time. */
+    protected static final String PARAM_TIMECOL = "TIMECOL";
+
+    /** The window duration INTERVAL. */
+    protected static final String PARAM_SIZE = "SIZE";
+
+    /** The optional align offset for each window. */
+    protected static final String PARAM_OFFSET = "OFFSET";
+
+    /** The session key(s), only used for SESSION window. */
+    protected static final String PARAM_KEY = "KEY";
+
+    /** The slide interval, only used for HOP window. */
+    protected static final String PARAM_SLIDE = "SLIDE";
+
+    /**
+     * Type-inference strategy whereby the row type of a table function call is a
+     * ROW, which is combined from the row type of operand #0 (which is a TABLE)
+     * and two additional fields. The fields are as follows:
+     *
+     * <ol>
+     * <li>{@code window_start}: TIMESTAMP type to indicate a window's start
+     * <li>{@code window_end}: TIMESTAMP type to indicate a window's end
+     * </ol>
+     */
+    public static final SqlReturnTypeInference ARG0_TABLE_FUNCTION_WINDOWING =
+            FelderaSqlWindowTableFunction::inferRowType;
+
+    /** Creates a window table function with a given name. */
+    public FelderaSqlWindowTableFunction(String name, SqlOperandMetadata operandMetadata,
+                                         String documented, String tested) {
+        super(name, SqlKind.OTHER_FUNCTION, ReturnTypes.CURSOR,
+                operandMetadata, SqlFunctionCategory.SYSTEM, documented, tested);
+    }
+
+    @Override public @Nullable SqlOperandMetadata getOperandTypeChecker() {
+        return (@Nullable SqlOperandMetadata) super.getOperandTypeChecker();
+    }
+
+    @Override public SqlReturnTypeInference getRowTypeInference() {
+        return ARG0_TABLE_FUNCTION_WINDOWING;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Overrides because the first parameter of
+     * table-value function windowing is an explicit TABLE parameter,
+     * which is not scalar.
+     */
+    @Override public boolean argumentMustBeScalar(int ordinal) {
+        return ordinal != 0;
+    }
+
+    /** Helper for {@link #ARG0_TABLE_FUNCTION_WINDOWING}. */
+    private static RelDataType inferRowType(SqlOperatorBinding opBinding) {
+        final RelDataType inputRowType = opBinding.getOperandType(0);
+        final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+        return typeFactory.builder()
+                .kind(inputRowType.getStructKind())
+                .addAll(inputRowType.getFieldList())
+                .add("window_start", SqlTypeName.TIMESTAMP)
+                .add("window_end", SqlTypeName.TIMESTAMP)
+                .build();
+    }
+
+    /** Partial implementation of operand type checker. */
+    protected abstract static class AbstractOperandMetadata
+            implements SqlOperandMetadata {
+        final List<String> paramNames;
+        final int mandatoryParamCount;
+
+        AbstractOperandMetadata(List<String> paramNames,
+                                int mandatoryParamCount) {
+            this.paramNames = ImmutableList.copyOf(paramNames);
+            this.mandatoryParamCount = mandatoryParamCount;
+            checkArgument(mandatoryParamCount >= 0
+                    && mandatoryParamCount <= paramNames.size());
+        }
+
+        @Override public SqlOperandCountRange getOperandCountRange() {
+            return SqlOperandCountRanges.between(mandatoryParamCount,
+                    paramNames.size());
+        }
+
+        @Override public List<RelDataType> paramTypes(RelDataTypeFactory typeFactory) {
+            return Collections.nCopies(paramNames.size(),
+                    typeFactory.createSqlType(SqlTypeName.ANY));
+        }
+
+        @Override public List<String> paramNames() {
+            return paramNames;
+        }
+
+        @Override public boolean isOptional(int i) {
+            return i > getOperandCountRange().getMin()
+                    && i <= getOperandCountRange().getMax();
+        }
+
+        boolean throwValidationSignatureErrorOrReturnFalse(SqlCallBinding callBinding,
+                                                           boolean throwOnFailure) {
+            if (throwOnFailure) {
+                throw callBinding.newValidationSignatureError();
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Checks whether the heading operands are in the form
+         * {@code (ROW, DESCRIPTOR, DESCRIPTOR ..., other params)},
+         * returning whether successful, and throwing if any columns are not found.
+         *
+         * @param callBinding The call binding
+         * @param descriptorCount The number of descriptors following the first
+         * operand (e.g. the table)
+         *
+         * @return true if validation passes; throws if any columns are not found
+         */
+        boolean checkTableAndDescriptorOperands(SqlCallBinding callBinding,
+                                                int descriptorCount) {
+            final SqlNode operand0 = callBinding.operand(0);
+            final SqlValidator validator = callBinding.getValidator();
+            final RelDataType type = validator.getValidatedNodeType(operand0);
+            if (type.getSqlTypeName() != SqlTypeName.ROW) {
+                return false;
+            }
+            for (int i = 1; i < descriptorCount + 1; i++) {
+                final SqlNode operand = callBinding.operand(i);
+                if (operand.getKind() != SqlKind.DESCRIPTOR) {
+                    return false;
+                }
+                validateColumnNames(validator, type.getFieldNames(),
+                        ((SqlCall) operand).getOperandList());
+            }
+            return true;
+        }
+
+        /**
+         * Checks whether the type that the operand of time col descriptor refers to is valid.
+         *
+         * @param callBinding The call binding
+         * @param pos The position of the descriptor at the operands of the call
+         * @return true if validation passes, false otherwise
+         */
+        boolean checkTimeColumnDescriptorOperand(SqlCallBinding callBinding, int pos) {
+            SqlValidator validator = callBinding.getValidator();
+            SqlNode operand0 = callBinding.operand(0);
+            RelDataType type = validator.getValidatedNodeType(operand0);
+            List<SqlNode> operands = ((SqlCall) callBinding.operand(pos)).getOperandList();
+            SqlIdentifier identifier = (SqlIdentifier) operands.get(0);
+            String columnName = identifier.getSimple();
+            SqlNameMatcher matcher = validator.getCatalogReader().nameMatcher();
+            for (RelDataTypeField field : type.getFieldList()) {
+                if (matcher.matches(field.getName(), columnName)) {
+                    return SqlTypeUtil.isTimestamp(field.getType());
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Checks whether the operands starting from position {@code startPos} are
+         * all of type {@code INTERVAL}, returning whether successful.
+         *
+         * @param callBinding The call binding
+         * @param startPos    The start position to validate (starting index is 0)
+         *
+         * @return true if validation passes
+         */
+        boolean checkIntervalOperands(SqlCallBinding callBinding, int startPos) {
+            final SqlValidator validator = callBinding.getValidator();
+            for (int i = startPos; i < callBinding.getOperandCount(); i++) {
+                final RelDataType type = validator.getValidatedNodeType(callBinding.operand(i));
+                if (!SqlTypeUtil.isInterval(type)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void validateColumnNames(SqlValidator validator,
+                                 List<String> fieldNames, List<SqlNode> columnNames) {
+            final SqlNameMatcher matcher = validator.getCatalogReader().nameMatcher();
+            Ord.forEach(columnNames, (name, i) -> {
+                if (!(name instanceof SqlIdentifier) || !((SqlIdentifier) name).isSimple()) {
+                    throw SqlUtil.newContextException(name.getParserPosition(),
+                            RESOURCE.descriptorMustBeIdentifier());
+                }
+                String simpleName = ((SqlIdentifier) name).getSimple();
+                if (matcher.indexOf(fieldNames, simpleName) < 0) {
+                    final SqlIdentifier columnName = (SqlIdentifier) columnNames.get(i);
+                    throw SqlUtil.newContextException(columnName.getParserPosition(),
+                            RESOURCE.unknownIdentifier(simpleName));
+                }
+            });
+        }
+    }
+}
+

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Logger.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Logger.java
@@ -61,6 +61,9 @@ public class Logger {
      * @param level   Level of message that is being logged.
      * @return        A stream where the message can be appended. */
     public IIndentStream belowLevel(IWritesLogs module, int level) {
+        if (this.loggingLevel.isEmpty())
+            // Fast check
+            return this.noStream;
         return this.belowLevel(module.getClass(), level);
     }
 


### PR DESCRIPTION
Fixes #5573 

Unfortunately I had to copy a lot of code from Calcite.
A test which exhibits this problem will be added by a separate commit in the feldera-qa repository.
