### PR TITLE
[adapters] Fix a bug in watermark tracking.

### DIFF
--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -1720,7 +1720,7 @@ impl WatermarkTrackerInner {
                 // a chance to complete; otherwise we risk always evicting all watermarks before the complete
                 // and never reporting any completed watermarks.
                 if self.watermark_with_metadata_list.len() >= MAX_TRACKED_WATERMARKS {
-                    break;
+                    continue;
                 }
 
                 self.watermark_with_metadata_list
@@ -1731,7 +1731,7 @@ impl WatermarkTrackerInner {
                     });
             } else {
                 if self.watermark_list.len() >= MAX_TRACKED_WATERMARKS {
-                    break;
+                    continue;
                 }
                 self.watermark_list.push_back(WatermarkListEntry {
                     watermark,


### PR DESCRIPTION
We track watermarks with and without metadata separately. The `break` statements in WatermarkTrackerInner::append abandoned the iteration when one of the two queues got full, even though the other queue could still have room (this is why we introduced two queues in the first place).