### PR TITLE
[python tests] make bootstrap reject->allow recovery deterministic

### DIFF
--- a/python/tests/platform/test_bootstrapping.py
+++ b/python/tests/platform/test_bootstrapping.py
@@ -61,7 +61,9 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         deadline = start + timeout_s
         last = None
         while time.time() < deadline:
-            p = pipeline.client.get_pipeline(pipeline.name, PipelineFieldSelector.STATUS)
+            p = pipeline.client.get_pipeline(
+                pipeline.name, PipelineFieldSelector.STATUS
+            )
             status = p.deployment_status
             desired = p.deployment_desired_status
             error_msg = (p.deployment_error or {}).get("message", "")


### PR DESCRIPTION
  After start(bootstrap_policy=reject), the pipeline can be in a valid Stopped state if there is a diff and with deployment_error set. Because start/stop are asynchronous, calling start(allow) immediately from that state is racy and can fail.

  This test now makes the sequence deterministic:

  - wait for Stopped after expected reject failure
  - issue a non-blocking start(allow) and wait until start is actually observed and deployment_error is cleared
  - stop again and wait for Stopped to return to a clean baseline
  - continue with the normal start(allow) assertions

See https://github.com/feldera/cloud/issues/1447

## Checklist

- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
