### PR TITLE
[adapters] Fix regression in S3 connector.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ aws-sdk-s3 = { version = "1.122.0", default-features = false, features = [
   "default-https-client",
   "rt-tokio",
   "sigv4a",
+  "behavior-version-latest"
 ] }
 aws-types = "1.1.7"
 backoff = "0.4.0"


### PR DESCRIPTION
A recent package version upgrade disabled an essential feature that caused the connector to crash with

```
thread 'connector-init' (50) panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-sdk-s3-1.122.0/src/config.rs:1663:80:
Invalid client configuration: A behavior major version must be set when sending a request or constructing a client. You must set it during client construction or by enabling the `behavior-version-latest` cargo feature.
stack backtrace:
```