### PR TITLE
Bring back CLAUDE.md: revert commit 0fe3d88c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,4 +93,4 @@ playwright/.cache/
 .vite/
 
 # Claude Code
-/.claude/
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-Look at README.md for more project descriptions.
+When navigating the codebase, look at relevant README.md for more project context.
 
 - If on a branch maybe check the last 2-3 to add commits for more context
 - Look at the outstanding changes in the tree
@@ -8,3 +8,5 @@ Look at README.md for more project descriptions.
   - Unit tests that validate for regular and exceptional inputs
   - Use property based testing/model based testing/fuzzing when appropriate
   - Integration tests for big platform-level features (in @python/tests)
+
+At the start of every conversation, offer the user to run `scripts/claude.sh` to pull in shared LLM context files as unstaged changes. These should not be committed outside the `claude-context` branch.

--- a/scripts/claude.js
+++ b/scripts/claude.js
@@ -37,7 +37,7 @@ function parseArgs() {
 const { mode, root } = parseArgs();
 const DEFAULT_ROOT = path.resolve(__dirname, "..");
 const REPO_ROOT = root ? path.resolve(process.cwd(), root) : DEFAULT_ROOT;
-const TARGET_COMBINED = path.join(REPO_ROOT, "CLAUDE.md");
+const TARGET_COMBINED = path.join(REPO_ROOT, "COMPOSITE_CLAUDE.md");
 
 /** @type {Set<string>} */
 const IGNORE_DIRS = new Set([
@@ -112,10 +112,11 @@ function ensureInsideRepo(absTarget) {
 
 async function mergeAll() {
   // Capture pre-merge content of root CLAUDE.md (if it exists)
+  const rootClaudePath = path.join(REPO_ROOT, "CLAUDE.md");
   /** @type {string|null} */
   let preMergeRoot = null;
   try {
-    preMergeRoot = await fs.readFile(TARGET_COMBINED, "utf8");
+    preMergeRoot = await fs.readFile(rootClaudePath, "utf8");
   } catch (e) {
     preMergeRoot = null; // no root file before merge
   }
@@ -178,7 +179,14 @@ async function splitAll() {
   /** @type {RegExpExecArray | null} */
   let match;
   let count = 0;
-  let rootAssigned = false;
+
+  // Delete TARGET_COMBINED before writing individual files
+  try {
+    await fs.unlink(TARGET_COMBINED);
+    console.log(`Deleted ${toRel(TARGET_COMBINED)}`);
+  } catch (err) {
+    if (/** @type {any} */ (err).code !== "ENOENT") throw err;
+  }
 
   while ((match = re.exec(combined)) !== null) {
     const relPath = match[1].trim();
@@ -195,16 +203,6 @@ async function splitAll() {
     await fs.writeFile(absPath, body.trimStart(), "utf8");
     console.log(`Wrote ${relPath}`);
     count++;
-
-    if (relPath === "CLAUDE.md") {
-      rootAssigned = true; // we restored the root content from the optional root section
-    }
-  }
-
-  // If no explicit root section was found, clear the root file
-  if (!rootAssigned) {
-    await fs.writeFile(TARGET_COMBINED, "", "utf8");
-    console.log(`No root section found; cleared ${toRel(TARGET_COMBINED)}.`);
   }
 
   if (count === 0) {

--- a/scripts/claude.sh
+++ b/scripts/claude.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+FILES=$(git ls-tree -r --name-only claude-context | grep 'CLAUDE\.md')
+git checkout claude-context -- $FILES
+git restore --staged $FILES
+echo "✅ Pulled Claude context files from claude-context branch."


### PR DESCRIPTION
PR https://github.com/feldera/feldera/pull/5600 deleted the root composite CLAUDE.md file that, via a script that "unpacks", it covers the most of the repository with knowledge base through per-directory CLAUDE.md files.

The commit (not even a PR description) describes the CLAUDE.md as excessive, but it is in fact necessary to use Claude Code effectively.
If the composite CLAUDE.md somehow breaks some workflow that cannot use the file-splitting script (e.g. Claude GitHub Reviews ?) let's discuss and address the issue properly.