### PR TITLE
[dbsp] Drop 32-bit limit on storage block size.

### DIFF
--- a/crates/dbsp/src/storage/file/format.rs
+++ b/crates/dbsp/src/storage/file/format.rs
@@ -58,8 +58,7 @@
 //!
 //! * An array of "child sizes", one for each of
 //!   [`IndexBlockHeader::n_children`].  Each one of these is the size of the
-//!   corresponding child block, expressed in 512-byte units.  Each block must
-//!   be less than 2 GiB.
+//!   corresponding child block, expressed in 512-byte units.
 //!
 //! # Compression
 //!
@@ -166,10 +165,14 @@ pub struct FileTrailer {
 
     /// File offset in bytes of the [FilterBlock].
     ///
-    /// This is 0 if there is no filter block.
+    /// This is 0 if there is no filter block, or if the filter block size is
+    /// bigger than `i32::MAX`.
     pub filter_offset: u64,
 
     /// Size in bytes of the [FilterBlock].
+    ///
+    /// This is 0 if there is no filter block, or if the filter block size is
+    /// bigger than `i32::MAX`.
     pub filter_size: u32,
 
     /// Compatible feature bitmap.
@@ -179,8 +182,7 @@ pub struct FileTrailer {
     /// still read the file (and log that a feature that it does not support is
     /// in use).
     ///
-    /// No compatible features are currently defined.  This bitmap is for future
-    /// expansion.
+    /// One compatible feature is set: [COMPATIBLE_FEATURE_FILTER64].
     pub compatible_features: u64,
 
     /// Incompatible feature bitmap.
@@ -194,7 +196,50 @@ pub struct FileTrailer {
     /// No incompatible features are currently defined.  This bitmap is for
     /// future expansion.
     pub incompatible_features: u64,
+
+    /// File offset in bytes of the [FilterBlock].
+    ///
+    /// This is 0 if there is no filter block, or if the filter block size is
+    /// less than `i32::MAX`.  If this is nonzero, then
+    /// [COMPATIBLE_FEATURE_FILTER64] is set to 1 in
+    /// [FileTrailer::compatible_features].
+    pub filter_offset64: u64,
+
+    /// Size in bytes of the [FilterBlock].
+    ///
+    /// This is 0 if there is no filter block, or if the filter block size is
+    /// less than `i32::MAX`.  If this is nonzero, then
+    /// [COMPATIBLE_FEATURE_FILTER64] is set to 1 in
+    /// [FileTrailer::compatible_features].
+    pub filter_size64: u64,
 }
+
+impl FileTrailer {
+    /// Returns the unsupported compatible features, if any.
+    pub fn unsupported_compatible_features(&self) -> Option<u64> {
+        let unsupported_compatible_features =
+            self.compatible_features & !COMPATIBLE_FEATURE_FILTER64;
+        if unsupported_compatible_features != 0 {
+            Some(unsupported_compatible_features)
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if `feature` is set in the compatible feature bitmap.
+    pub fn has_compatible_feature(&self, feature: u64) -> bool {
+        (self.compatible_features & feature) != 0
+    }
+
+    /// Returns true if this file trailer has a 64-bit filter.
+    pub fn has_filter64(&self) -> bool {
+        self.has_compatible_feature(COMPATIBLE_FEATURE_FILTER64)
+    }
+}
+
+/// Bit set to 1 in [FileTrailer::compatible_features] if a file has a Bloom
+/// filter whose size does not fit in 32 bits.
+pub const COMPATIBLE_FEATURE_FILTER64: u64 = 1 << 0;
 
 /// Information about a column.
 ///

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -1550,11 +1550,10 @@ where
             .into());
         }
 
-        if file_trailer.compatible_features != 0 {
+        if let Some(features) = file_trailer.unsupported_compatible_features() {
             info!(
-                "{}: storage file uses unsupported compatible features {:#x}",
+                "{}: storage file uses unsupported compatible features {features:#x}",
                 file.path(),
-                file_trailer.compatible_features
             );
         }
 
@@ -1595,21 +1594,31 @@ where
             }
         }
 
+        fn read_filter_block(
+            file_handle: &dyn FileReader,
+            offset: u64,
+            size: usize,
+        ) -> Result<TrackingBloomFilter, Error> {
+            Ok(FilterBlock::new(
+                file_handle,
+                BlockLocation::new(offset, size).map_err(|error: InvalidBlockLocation| {
+                    Error::Corruption(CorruptionError::InvalidFilterLocation(error))
+                })?,
+            )?
+            .into())
+        }
         let bloom_filter = match bloom_filter {
             Some(bloom_filter) => Some(bloom_filter),
-            None if file_trailer.filter_offset != 0 => Some(
-                FilterBlock::new(
-                    &*file,
-                    BlockLocation::new(
-                        file_trailer.filter_offset,
-                        file_trailer.filter_size as usize,
-                    )
-                    .map_err(|error: InvalidBlockLocation| {
-                        Error::Corruption(CorruptionError::InvalidFilterLocation(error))
-                    })?,
-                )?
-                .into(),
-            ),
+            None if file_trailer.has_filter64() => Some(read_filter_block(
+                &*file,
+                file_trailer.filter_offset64,
+                file_trailer.filter_size64 as usize,
+            )?),
+            None if file_trailer.filter_offset != 0 => Some(read_filter_block(
+                &*file,
+                file_trailer.filter_offset,
+                file_trailer.filter_size as usize,
+            )?),
             None => None,
         };
 

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -10,9 +10,9 @@ use crate::storage::{
     file::{
         BLOOM_FILTER_SEED,
         format::{
-            BlockHeader, DATA_BLOCK_MAGIC, DataBlockHeader, FILE_TRAILER_BLOCK_MAGIC, FileTrailer,
-            FileTrailerColumn, FilterBlockRef, FixedLen, INDEX_BLOCK_MAGIC, IndexBlockHeader,
-            NodeType, VERSION_NUMBER, Varint,
+            BlockHeader, COMPATIBLE_FEATURE_FILTER64, DATA_BLOCK_MAGIC, DataBlockHeader,
+            FILE_TRAILER_BLOCK_MAGIC, FileTrailer, FileTrailerColumn, FilterBlockRef, FixedLen,
+            INDEX_BLOCK_MAGIC, IndexBlockHeader, NodeType, VERSION_NUMBER, Varint,
         },
         reader::TreeNode,
         with_serializer,
@@ -256,7 +256,12 @@ impl ColumnWriter {
                 return Ok(FileTrailerColumn {
                     node_type: builder.child_type,
                     node_offset: entry.child.offset,
-                    node_size: entry.child.size as u32,
+                    node_size: entry.child.size.try_into().unwrap_or_else(|_| {
+                        unreachable!(
+                            "Individual blocks should be much less than 4 GiB, tried to write {:?}",
+                            &entry.child
+                        )
+                    }),
                     n_rows: entry.row_total,
                 });
             } else if !self.index_blocks[level].is_empty() {
@@ -1204,16 +1209,31 @@ impl Writer {
         };
 
         // Write the file trailer block.
-        let file_trailer = FileTrailer {
+
+        let mut file_trailer = FileTrailer {
             header: BlockHeader::new(&FILE_TRAILER_BLOCK_MAGIC),
             version: VERSION_NUMBER,
             columns: take(&mut self.finished_columns),
             compression: self.cws[0].parameters.compression,
-            filter_offset: filter_location.offset,
-            filter_size: filter_location.size.try_into().unwrap(),
+            filter_offset: 0,
+            filter_size: 0,
             compatible_features: 0,
             incompatible_features: 0,
+            filter_offset64: 0,
+            filter_size64: 0,
         };
+        if filter_location.size > 0 {
+            if let Ok(size) = u32::try_from(filter_location.size)
+                && size < i32::MAX as u32
+            {
+                file_trailer.filter_offset = filter_location.offset;
+                file_trailer.filter_size = size;
+            } else {
+                file_trailer.compatible_features |= COMPATIBLE_FEATURE_FILTER64;
+                file_trailer.filter_offset64 = filter_location.offset;
+                file_trailer.filter_size64 = filter_location.size as u64;
+            }
+        }
         let (_block, location) = self
             .writer
             .write_block(file_trailer.clone().into_block(), None)?;

--- a/crates/storage/src/block.rs
+++ b/crates/storage/src/block.rs
@@ -7,20 +7,14 @@ pub struct BlockLocation {
     /// Byte offset, a multiple of 512.
     pub offset: u64,
 
-    /// Size in bytes, a multiple of 512, less than `2**31`.
-    ///
-    /// (The upper limit is because some kernel APIs return the number of bytes
-    /// read as an `i32`.)
+    /// Size in bytes, a multiple of 512.
     pub size: usize,
 }
 
 impl BlockLocation {
     /// Constructs a new [BlockLocation], validating `offset` and `size`.
     pub fn new(offset: u64, size: usize) -> Result<Self, InvalidBlockLocation> {
-        if !offset.is_multiple_of(512)
-            || !(512..1 << 31).contains(&size)
-            || !size.is_multiple_of(512)
-        {
+        if !offset.is_multiple_of(512) || !size.is_multiple_of(512) {
             Err(InvalidBlockLocation { offset, size })
         } else {
             Ok(Self { offset, size })


### PR DESCRIPTION
I originally put a `i32::MAX` limit on the size of a block in files for two reasons.  First, I had a notion that relevant system calls took 32-bit arguments and returned 32-bit counts.  It turns out that this is, at best, now obsolete; the relevant system calls now take `usize` and return `isize`[^*].  So this reason is no longer in play.

Second, I knew that we were not going to support individual records bigger than 32-bits and that we only needed to fit a small number of records in one block (say, 32 records), so capping the size did not seem like a problem.  This is still true, but, since then, we added a Bloom filter block.  For large numbers of records (say, 1e9), the Bloom filter block can exceed 2 GiB.  This fixes the problem for that case.

[^*]: Although. on Linux. they still cap the amounts at 0x7fff0000, according to the manpages.  However, libc and the Rust standard library just submit another system call for the remainder in that case.

# Compatibility

This retains compatibility:

- For Bloom filter blocks smaller than 2 GiB, it changes nothing.

- For Bloom filter blocks 2 GiB or larger, older Feldera versions won't see the Bloom filter and will log a warning about an unsupported compatible feature.

# Testing

Manual testing only (it takes too long and too much disk space to run this automatically).

Issue: https://github.com/feldera/feldera/issues/5647
