### PR TITLE
[adapters] Delta: debug-print error

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1487,7 +1487,7 @@ impl DeltaTableInputEndpointInner {
         let mut stream = match dataframe.execute_stream().await {
             Err(e) => {
                 self.consumer
-                    .error(true, anyhow!("error retrieving {descr}: {e}"), None);
+                    .error(true, anyhow!("error retrieving {descr}: {e:?}"), None);
                 return;
             }
             Ok(stream) => stream,


### PR DESCRIPTION
When using `Display` (`{e}`) to format datafusion errors that originate from objest-store, only limited error info is printed, e.g., `Generic S3 error: Error performing HEAD https://s3.us-east-1.amazonaws.com/....parquet in 239.10272ms - HTTP error: error sending request`. 

In my experience, debug-print (`{e:?}`) produces more detailed info.
