### PR TITLE
Add 'Force stop' button when pipeline is already stopping

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/list/Actions.svelte
@@ -176,8 +176,8 @@ groups related actions into multi-action dropdowns when multiple options are ava
         '_delete'
       ])
       .with('Suspending', () => [
-        '_spinner',
         '_kill',
+        '_spinner',
         '_saveFile',
         '_configurations',
         '_storage_indicator',
@@ -223,6 +223,7 @@ groups related actions into multi-action dropdowns when multiple options are ava
         '_delete'
       ])
       .with('Stopping', () => [
+        '_kill',
         '_spinner',
         '_saveFile',
         '_configurations',


### PR DESCRIPTION
<img width="2022" height="567" alt="image" src="https://github.com/user-attachments/assets/f546dc62-43a2-4cca-b93a-65cfa0009197" />
The position of the stop button was made consistent with the position in the "Suspending" state, because both are displayed as "Stopping" for the user.

Testing:
Stopped a running pipeline, observed that the button appeared as expected.