### PR TITLE
Add a user-friendly fda install UX via release binaries

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -49,15 +49,18 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Download Binaries
+      - name: Download fda
         id: binaries
         uses: actions/download-artifact@v4
         with:
-          name: feldera-binaries-${{ matrix.rust_target }}
+          name: fda-${{ matrix.rust_target }}
           path: build
-          #run-id: ${{ inputs.run-id }}
-          # Token is only needed when run-id is set
-          #github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download pipeline-manager
+        uses: actions/download-artifact@v4
+        with:
+          name: pipeline-manager-${{ matrix.rust_target }}
+          path: build
 
       - name: Download Compiler Binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -123,10 +123,16 @@ jobs:
           path: build-artifacts
           retention-days: 7
 
-      # Upload binaries to run the product as another artifact
-      - name: Upload release artifacts
+      - name: Upload fda
         uses: actions/upload-artifact@v4
         with:
-          name: feldera-binaries-${{ matrix.target }}
-          path: build-release-artifacts
+          name: fda-${{ matrix.target }}
+          path: build-release-artifacts/fda
+          retention-days: 7
+
+      - name: Upload pipeline-manager
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-manager-${{ matrix.target }}
+          path: build-release-artifacts/pipeline-manager
           retention-days: 7

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -70,33 +70,22 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
           commit: ${{ env.SHA_TO_RELEASE }}
-          name: feldera-sql-compiler-*|feldera-binaries-*|feldera-docs|feldera-sbom
+          name: feldera-sql-compiler-*|fda-*|pipeline-manager-*|feldera-docs|feldera-sbom
           name_is_regexp: true
           skip_unpack: true
           if_no_artifact_found: fail
           github_token: ${{ steps.app-token.outputs.token }}
 
-      - name: Extract standalone fda binaries
+      - name: Prepare release artifacts
         run: |
-          for arch in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
-            unzip -jo "feldera-binaries-${arch}.zip" fda -d .
-            zip "fda-${arch}.zip" fda
-            rm fda
-          done
-
-      - name: Attach version to binaries
-        run: |
-          mv feldera-binaries-aarch64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
-          mv feldera-binaries-x86_64-unknown-linux-gnu.zip feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
           unzip -jo feldera-sql-compiler.zip 'sql2dbsp-jar-with-dependencies.jar' -d .
           mv sql2dbsp-jar-with-dependencies.jar sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
-          mv feldera-docs.zip feldera-docs-v${{ env.CURRENT_VERSION }}.zip
 
       - name: Prepare SBOM files
         run: |
           unzip feldera-sbom.zip
-          mv feldera-sbom-source-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-source-v${{ env.CURRENT_VERSION }}.spdx.json
-          mv feldera-sbom-image-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-image-v${{ env.CURRENT_VERSION }}.spdx.json
+          mv feldera-sbom-source-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-source.spdx.json
+          mv feldera-sbom-image-${{ env.SHA_TO_RELEASE }}.spdx.json feldera-sbom-image.spdx.json
 
       - name: Generate Release token
         id: release-token
@@ -118,13 +107,13 @@ jobs:
           generate_release_notes: true
           make_latest: true
           files: |
-            feldera-binaries-v${{ env.CURRENT_VERSION }}-aarch64-unknown-linux-gnu.zip
-            feldera-binaries-v${{ env.CURRENT_VERSION }}-x86_64-unknown-linux-gnu.zip
+            pipeline-manager-aarch64-unknown-linux-gnu.zip
+            pipeline-manager-x86_64-unknown-linux-gnu.zip
             fda-x86_64-unknown-linux-gnu.zip
             fda-aarch64-unknown-linux-gnu.zip
             sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
-            feldera-sbom-source-v${{ env.CURRENT_VERSION }}.spdx.json
-            feldera-sbom-image-v${{ env.CURRENT_VERSION }}.spdx.json
+            feldera-sbom-source.spdx.json
+            feldera-sbom-image.spdx.json
           # A custom token is necessary so the ci-post-release.yml workflow is triggered
           # see also https://github.com/softprops/action-gh-release/issues/59
           token: ${{ steps.release-token.outputs.token }}
@@ -136,7 +125,7 @@ jobs:
           role-session-name: gha-${{ github.run_id }}
           aws-region: ${{ vars.SQL2DBSP_S3_REGION }}
 
-      - name: Upload JAR to S3 with SHA in filename
+      - name: Upload JAR to S3
         run: |
           JAR_FILE=sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
           aws s3 cp "$JAR_FILE" "s3://${{ vars.SQL2DBSP_S3_BUCKET }}/$JAR_FILE" \
@@ -144,7 +133,7 @@ jobs:
 
       # Update docs.feldera.com
       - name: Update docs.feldera.com
-        run: unzip feldera-docs-v${{ env.CURRENT_VERSION }}.zip -d docs
+        run: unzip feldera-docs.zip -d docs
 
       - name: Deploy docs.feldera.com
         if: ${{ vars.RELEASE_DRY_RUN == 'false' }}

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Download fda binary
         uses: actions/download-artifact@v4
         with:
-          name: feldera-binaries-${{ matrix.target }}
+          name: fda-${{ matrix.target }}
           path: build
 
       # Remove if https://github.com/actions/upload-artifact/issues/38 ever gets fixed

--- a/docs.feldera.com/docs/interface/cli.md
+++ b/docs.feldera.com/docs/interface/cli.md
@@ -17,6 +17,8 @@ curl -fsSL https://feldera.com/install | bash
 | linux-x86_64 |
 | linux-aarch64 |
 
+Requires glibc >= 2.39 (Ubuntu 24.04+, Debian 13+, Fedora 40+, RHEL 10+).
+
 
 ### Installing a Specific Version
 
@@ -58,11 +60,6 @@ following commands:
 cd crates/fda
 cargo install --path .
 ```
-
-### From release binaries
-
-We supply pre-built binaries for `fda` as part of our release artifacts. You can find them in the
-`feldera-binaries` ZIP file in the [github release page](https://github.com/feldera/feldera/releases/latest).
 
 ### Optional: Shell completion
 

--- a/docs.feldera.com/static/install-fda
+++ b/docs.feldera.com/static/install-fda
@@ -7,8 +7,6 @@
 
 set -eu
 
-GITHUB_REPO="feldera/feldera"
-
 main() {
     need_cmd curl
     need_cmd unzip
@@ -79,25 +77,11 @@ detect_platform() {
 resolve_version() {
     if [ -n "${FDA_VERSION:-}" ]; then
         VERSION="$FDA_VERSION"
-        DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/${VERSION}/fda-${TARGET}.zip"
+        DOWNLOAD_URL="https://github.com/feldera/feldera/releases/download/${VERSION}/fda-${TARGET}.zip"
         info "Installing fda ${VERSION}"
     else
-        # Try to get the latest version from GitHub API
-        VERSION=""
-        API_RESPONSE=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" 2>/dev/null) || true
-        if [ -n "$API_RESPONSE" ]; then
-            # Extract tag_name from JSON without jq
-            VERSION=$(printf '%s' "$API_RESPONSE" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-        fi
-
-        if [ -n "$VERSION" ]; then
-            DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/${VERSION}/fda-${TARGET}.zip"
-            info "Installing fda ${VERSION} (latest)"
-        else
-            # Fall back to latest/download URL if API call fails
-            DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/latest/download/fda-${TARGET}.zip"
-            info "Installing fda (latest)"
-        fi
+        DOWNLOAD_URL="https://github.com/feldera/feldera/releases/latest/download/fda-${TARGET}.zip"
+        info "Installing fda (latest)"
     fi
 }
 
@@ -113,7 +97,7 @@ download_and_install() {
         case "$HTTP_CODE" in
             404)
                 if [ -n "${FDA_VERSION:-}" ]; then
-                    err "version ${FDA_VERSION} not found. Check available versions at https://github.com/$GITHUB_REPO/releases"
+                    err "version ${FDA_VERSION} not found. Check available versions at https://github.com/feldera/feldera/releases"
                 else
                     err "release asset not found. The latest release may not include standalone fda binaries yet."
                 fi
@@ -150,25 +134,32 @@ setup_path() {
 
     case "$SHELL_NAME" in
         bash)
-            if [ -f "$HOME/.bashrc" ]; then
+            if [ -f "$HOME/.bashrc" ] && ! grep -q FELDERA_INSTALL "$HOME/.bashrc"; then
                 printf '\n# Feldera fda CLI\n%b\n' "$RC_LINES" >> "$HOME/.bashrc"
+                # shellcheck disable=SC2088
                 UPDATED_RC="~/.bashrc"
-            elif [ -f "$HOME/.bash_profile" ]; then
+            elif [ -f "$HOME/.bash_profile" ] && ! grep -q FELDERA_INSTALL "$HOME/.bash_profile"; then
                 printf '\n# Feldera fda CLI\n%b\n' "$RC_LINES" >> "$HOME/.bash_profile"
+                # shellcheck disable=SC2088
                 UPDATED_RC="~/.bash_profile"
             fi
             ;;
         zsh)
-            if [ -f "$HOME/.zshrc" ] || [ -d "$HOME" ]; then
+            if [ -f "$HOME/.zshrc" ] && ! grep -q FELDERA_INSTALL "$HOME/.zshrc"; then
                 printf '\n# Feldera fda CLI\n%b\n' "$RC_LINES" >> "$HOME/.zshrc"
+                # shellcheck disable=SC2088
                 UPDATED_RC="~/.zshrc"
             fi
             ;;
         fish)
             FISH_CONFIG="$HOME/.config/fish/config.fish"
             if [ -d "$HOME/.config/fish" ] || mkdir -p "$HOME/.config/fish"; then
-                printf '\n# Feldera fda CLI\nset -gx FELDERA_INSTALL %s\nset -gx PATH $FELDERA_INSTALL/bin $PATH\n' "$FELDERA_INSTALL" >> "$FISH_CONFIG"
-                UPDATED_RC="~/.config/fish/config.fish"
+                if ! grep -q FELDERA_INSTALL "$FISH_CONFIG" 2>/dev/null; then
+                    # shellcheck disable=SC2016
+                    printf '\n# Feldera fda CLI\nset -gx FELDERA_INSTALL %s\nset -gx PATH $FELDERA_INSTALL/bin $PATH\n' "$FELDERA_INSTALL" >> "$FISH_CONFIG"
+                    # shellcheck disable=SC2088
+                    UPDATED_RC="~/.config/fish/config.fish"
+                fi
             fi
             ;;
     esac


### PR DESCRIPTION
The script sets FELDERA_INSTALL to ~/.feldera by default, installs `fda` into $FELDERA_INSTALL/bin and adds it to PATH.
The binary gets packaged in a separate .zip for a faster download.

To use this change I will need to add a page to feldera.com that redirects to the raw.githubusercontent URL of the new install script. Overwriting with a different `fda` version works, too

Testing:
Tested by modifying the script's download URL so that it downloads the feldera-binaries-*.zip from the last release, and running the script.
