### PR TITLE
pipeline-manager: dismiss deployment error and clear bootstrap policy

### DIFF
--- a/crates/fda/src/bench.rs
+++ b/crates/fda/src/bench.rs
@@ -547,6 +547,7 @@ pub(crate) async fn bench(client: Client, format: OutputFormat, args: BenchmarkA
             no_wait: false,
             initial: "running".to_string(),
             bootstrap_policy: "allow".to_string(),
+            no_dismiss_error: false,
         },
         client.clone(),
     ))

--- a/crates/fda/src/cli.rs
+++ b/crates/fda/src/cli.rs
@@ -333,6 +333,9 @@ pub enum PipelineAction {
         // TODO: auto-complete
         #[arg(long, short = 'b', default_value = "await_approval")]
         bootstrap_policy: String,
+        /// Do not dismiss any deployment error before starting.
+        #[arg(long, default_value_t = false)]
+        no_dismiss_error: bool,
     },
     /// Approve pipeline changes. Called in the AwaitingApproval state to allow
     /// the pipeline to proceed with bootstrapping the modified components.
@@ -393,6 +396,9 @@ pub enum PipelineAction {
         /// The bootstrap policy to use.
         #[arg(long, short = 'b', default_value = "await_approval")]
         bootstrap_policy: String,
+        /// Do not dismiss any deployment error before starting.
+        #[arg(long, default_value_t = false)]
+        no_dismiss_error: bool,
     },
     /// Stop a pipeline.
     #[clap(aliases = &["shutdown"])]
@@ -589,6 +595,9 @@ pub enum PipelineAction {
         /// The bootstrap policy to use.
         #[arg(long, short = 'b', default_value = "await_approval")]
         bootstrap_policy: String,
+        /// Do not dismiss any deployment error before starting.
+        #[arg(long, default_value_t = false, requires("start"))]
+        no_dismiss_error: bool,
     },
     /// Execute an ad-hoc query against a pipeline and return the result.
     #[clap(aliases = &["exec"])]
@@ -696,6 +705,12 @@ pub enum PipelineAction {
     Bench {
         #[command(flatten)]
         args: BenchmarkArgs,
+    },
+    /// Dismisses the deployment error of a pipeline.
+    DismissError {
+        /// The name of the pipeline.
+        #[arg(value_hint = ValueHint::Other, add = ArgValueCompleter::new(pipeline_names))]
+        name: String,
     },
 }
 

--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -716,6 +716,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
             no_wait,
             initial,
             bootstrap_policy,
+            no_dismiss_error,
         } => {
             if initial != "standby" && initial != "paused" && initial != "running" {
                 eprintln!("Unsupported `--initial`: {}", initial);
@@ -815,11 +816,27 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                 sleep(Duration::from_millis(500)).await;
             }
 
+            if !no_dismiss_error {
+                let response = client
+                    .post_pipeline_dismiss_error()
+                    .pipeline_name(name.clone())
+                    .send()
+                    .await
+                    .map_err(handle_errors_fatal(
+                        client.baseurl().clone(),
+                        "Failed to dismiss pipeline deployment error",
+                        1,
+                    ))
+                    .unwrap();
+                trace!("{:#?}", response);
+            }
+
             let response = client
                 .post_pipeline_start()
                 .pipeline_name(name.clone())
                 .initial(&initial)
                 .bootstrap_policy(&bootstrap_policy)
+                .dismiss_error(false) // It has already been separately dismissed
                 .send()
                 .await
                 .map_err(handle_errors_fatal(
@@ -986,6 +1003,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
             no_wait,
             initial,
             bootstrap_policy,
+            no_dismiss_error,
         } => {
             let current_status = client
                 .get_pipeline()
@@ -1032,6 +1050,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                     no_wait,
                     initial,
                     bootstrap_policy,
+                    no_dismiss_error,
                 },
                 client,
             ))
@@ -1618,6 +1637,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
             start,
             initial,
             bootstrap_policy,
+            no_dismiss_error,
         } => {
             let client2 = client.clone();
             if start {
@@ -1629,6 +1649,7 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
                         no_wait: false,
                         initial,
                         bootstrap_policy,
+                        no_dismiss_error,
                     },
                     client,
                 ))
@@ -1864,6 +1885,21 @@ async fn pipeline(format: OutputFormat, action: PipelineAction, client: Client) 
             println!("Initiated rebalancing for pipeline {name}.");
         }
         PipelineAction::Bench { args } => bench::bench(client, format, args).await,
+        PipelineAction::DismissError { name } => {
+            let response = client
+                .post_pipeline_dismiss_error()
+                .pipeline_name(name.clone())
+                .send()
+                .await
+                .map_err(handle_errors_fatal(
+                    client.baseurl().clone(),
+                    "Failed to dismiss pipeline deployment error",
+                    1,
+                ))
+                .unwrap();
+            println!("Pipeline deployment error dismissed successfully.");
+            trace!("{:#?}", response);
+        }
     }
 }
 

--- a/crates/fda/test.bash
+++ b/crates/fda/test.bash
@@ -96,6 +96,8 @@ compare_output "fda program get p1 --udf-rs" "fda program get p2 --udf-rs"
 
 fda config p1
 
+fda dismiss-error p1
+fda start p1 --no-dismiss-error
 fda start p1
 fda --format json stats p1 | jq '.metrics'
 fda log p1

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -659,6 +659,11 @@ fn default_pipeline_start_desired() -> String {
     "running".to_string()
 }
 
+/// Default for the `dismiss_error` query parameter when POST a pipeline start.
+fn default_pipeline_start_dismiss_error() -> bool {
+    true
+}
+
 /// Query parameters to POST a pipeline start.
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
 pub struct PostStartPipelineParameters {
@@ -668,6 +673,8 @@ pub struct PostStartPipelineParameters {
     initial: String,
     #[serde(default)]
     bootstrap_policy: BootstrapPolicy,
+    #[serde(default = "default_pipeline_start_dismiss_error")]
+    dismiss_error: bool,
 }
 
 /// Default for the `force` query parameter when POST a pipeline stop.
@@ -1339,6 +1346,7 @@ pub(crate) async fn post_pipeline_start(
     let PostStartPipelineParameters {
         initial,
         bootstrap_policy,
+        dismiss_error,
     } = query.into_inner();
 
     let pipeline_id = match initial.as_str() {
@@ -1352,6 +1360,7 @@ pub(crate) async fn post_pipeline_start(
                     &pipeline_name,
                     RuntimeDesiredStatus::Standby,
                     bootstrap_policy,
+                    dismiss_error,
                 )
                 .await?
         }
@@ -1365,6 +1374,7 @@ pub(crate) async fn post_pipeline_start(
                     &pipeline_name,
                     RuntimeDesiredStatus::Paused,
                     bootstrap_policy,
+                    dismiss_error,
                 )
                 .await?
         }
@@ -1378,6 +1388,7 @@ pub(crate) async fn post_pipeline_start(
                     &pipeline_name,
                     RuntimeDesiredStatus::Running,
                     bootstrap_policy,
+                    dismiss_error,
                 )
                 .await?
         }
@@ -1544,6 +1555,48 @@ pub(crate) async fn post_pipeline_stop(
             }
         }
     }
+}
+
+/// Dismiss Pipeline Deployment Error
+///
+/// Clears the `deployment_error` field of the pipeline, such that a subsequent call to
+/// `/start?dismiss_error=false` succeeds. It will return an error if the pipeline is not fully
+/// stopped (i.e., both current and desired status must be `Stopped`) AND a deployment error
+/// is present.
+#[utoipa::path(
+    context_path = "/v0",
+    security(("JSON web token (JWT) or API key" = [])),
+    params(
+        ("pipeline_name" = String, Path, description = "Unique pipeline name")
+    ),
+    responses(
+        (status = OK
+            , description = "Deployment error has been dismissed"),
+        (status = NOT_FOUND
+            , description = "Pipeline with that name does not exist"
+            , body = ErrorResponse
+            , example = json!(examples::error_unknown_pipeline_name())),
+        (status = BAD_REQUEST
+            , description = "Action could not be performed"
+            , body = ErrorResponse),
+        (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
+    ),
+    tag = "Pipeline Lifecycle"
+)]
+#[post("/pipelines/{pipeline_name}/dismiss_error")]
+pub(crate) async fn post_pipeline_dismiss_error(
+    state: WebData<ServerState>,
+    tenant_id: ReqData<TenantId>,
+    path: web::Path<String>,
+) -> Result<HttpResponse, ManagerError> {
+    let pipeline_name = path.into_inner();
+    state
+        .db
+        .lock()
+        .await
+        .dismiss_deployment_error(*tenant_id, &pipeline_name)
+        .await?;
+    Ok(HttpResponse::Ok().json(json!("Pipeline deployment error has been dismissed")))
 }
 
 /// Clear Storage

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -194,6 +194,7 @@ It contains the following fields:
         endpoints::pipeline_management::delete_pipeline,
         endpoints::pipeline_management::post_pipeline_start,
         endpoints::pipeline_management::post_pipeline_stop,
+        endpoints::pipeline_management::post_pipeline_dismiss_error,
         endpoints::pipeline_management::post_pipeline_clear,
         endpoints::pipeline_management::get_pipeline_logs,
 
@@ -539,6 +540,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_management::delete_pipeline)
         .service(endpoints::pipeline_management::post_pipeline_start)
         .service(endpoints::pipeline_management::post_pipeline_stop)
+        .service(endpoints::pipeline_management::post_pipeline_dismiss_error)
         .service(endpoints::pipeline_management::post_pipeline_clear)
         .service(endpoints::pipeline_management::get_pipeline_logs)
         // Pipeline interaction endpoints

--- a/crates/pipeline-manager/src/api/support_data_collector.rs
+++ b/crates/pipeline-manager/src/api/support_data_collector.rs
@@ -1463,6 +1463,7 @@ mod tests {
                 "test_pipeline",
                 RuntimeDesiredStatus::Running,
                 BootstrapPolicy::default(),
+                false,
             )
             .await
             .unwrap();
@@ -1663,6 +1664,7 @@ mod tests {
                 "test_pipeline",
                 RuntimeDesiredStatus::Running,
                 BootstrapPolicy::default(),
+                false,
             )
             .await
             .unwrap();
@@ -1844,6 +1846,7 @@ mod tests {
                 "test_pipeline",
                 RuntimeDesiredStatus::Running,
                 BootstrapPolicy::default(),
+                false,
             )
             .await
             .unwrap();
@@ -1955,6 +1958,7 @@ mod tests {
                 "test_pipeline",
                 RuntimeDesiredStatus::Running,
                 BootstrapPolicy::default(),
+                false,
             )
             .await
             .unwrap();

--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -198,6 +198,8 @@ pub enum DBError {
     InvalidBootstrap(String),
     NoRuntimeStatusWhileProvisioned,
     PreconditionViolation(String),
+    CannotStartWithUndismissedError,
+    DismissErrorRestrictedToFullyStopped,
     InitialImmutableUnlessStopped,
     InitialStandbyNotAllowed,
     InvalidMonitorStatus(String),
@@ -650,6 +652,20 @@ impl Display for DBError {
                     "Cannot delete pipeline unless its storage is cleared. Clear storage first using `/clear`."
                 )
             }
+            DBError::CannotStartWithUndismissedError => {
+                write!(
+                    f,
+                    "Cannot process `/start?dismiss_error=false` if the `deployment_error` is set. \
+                    You can dismiss the error by calling `/start?dismiss_error=true`, or alternatively \
+                    first call `/dismiss_error`, after which `/start?dismiss_error=false` is again possible."
+                )
+            }
+            DBError::DismissErrorRestrictedToFullyStopped => {
+                write!(
+                    f,
+                    "The pipeline must have both status `Stopped` and desired status `Stopped` to dismiss the `deployment_error` if it is set."
+                )
+            }
             DBError::InitialImmutableUnlessStopped => {
                 write!(
                     f,
@@ -764,6 +780,10 @@ impl DetailedError for DBError {
             Self::NoRuntimeStatusWhileProvisioned => Cow::from("NoRuntimeStatusWhileProvisioned"),
             Self::PreconditionViolation(..) => Cow::from("PreconditionViolation"),
             Self::ResumeWhileNotProvisioned => Cow::from("ResumeWhileNotProvisioned"),
+            Self::CannotStartWithUndismissedError => Cow::from("CannotStartWithUndismissedError"),
+            Self::DismissErrorRestrictedToFullyStopped => {
+                Cow::from("DismissErrorRestrictedToFullyStopped")
+            }
             Self::InitialImmutableUnlessStopped => Cow::from("InitialImmutableUnlessStopped"),
             Self::InitialStandbyNotAllowed => Cow::from("InitialStandbyNotAllowed"),
             Self::InvalidMonitorStatus(..) => Cow::from("InvalidMonitorStatus"),
@@ -834,6 +854,8 @@ impl ResponseError for DBError {
             Self::InvalidBootstrap(..) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NoRuntimeStatusWhileProvisioned => StatusCode::INTERNAL_SERVER_ERROR,
             Self::PreconditionViolation(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::CannotStartWithUndismissedError => StatusCode::BAD_REQUEST,
+            Self::DismissErrorRestrictedToFullyStopped => StatusCode::BAD_REQUEST,
             Self::InitialImmutableUnlessStopped => StatusCode::BAD_REQUEST,
             Self::InitialStandbyNotAllowed => StatusCode::BAD_REQUEST,
             Self::InvalidMonitorStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -1124,6 +1124,39 @@ fn check_precondition(condition: bool, info: &str) -> Result<(), DBError> {
     }
 }
 
+/// Dismisses the deployment error.
+pub(crate) async fn dismiss_deployment_error(
+    txn: &Transaction<'_>,
+    tenant_id: TenantId,
+    pipeline_name: &str,
+) -> Result<(), DBError> {
+    let current = get_pipeline(txn, tenant_id, pipeline_name).await?;
+
+    // If an error has to be cleared, then it is only possible if it is fully stopped
+    if (current.deployment_resources_status != ResourcesStatus::Stopped
+        || current.deployment_resources_desired_status != ResourcesDesiredStatus::Stopped)
+        && current.deployment_error.is_some()
+    {
+        return Err(DBError::DismissErrorRestrictedToFullyStopped);
+    }
+
+    let stmt = txn
+        .prepare_cached(
+            "UPDATE pipeline
+             SET deployment_error = NULL
+             WHERE tenant_id = $1 AND id = $2",
+        )
+        .await?;
+    let modified_rows = txn.execute(&stmt, &[&tenant_id.0, &current.id.0]).await?;
+    if modified_rows > 0 {
+        Ok(())
+    } else {
+        Err(DBError::UnknownPipeline {
+            pipeline_id: current.id,
+        })
+    }
+}
+
 /// Sets pipeline desired resources status.
 pub(crate) async fn set_deployment_resources_desired_status(
     txn: &Transaction<'_>,
@@ -1132,13 +1165,22 @@ pub(crate) async fn set_deployment_resources_desired_status(
     new_desired_status: ResourcesDesiredStatus,
     initial_runtime_desired_status: Option<RuntimeDesiredStatus>,
     bootstrap_policy: Option<BootstrapPolicy>,
+    dismiss_error: bool,
 ) -> Result<PipelineId, DBError> {
     let current = get_pipeline(txn, tenant_id, pipeline_name).await?;
+
+    // Deployment error will be automatically dismissed if this is wanted
+    let final_deployment_error = if dismiss_error {
+        None
+    } else {
+        current.deployment_error
+    };
 
     // Check that the desired status can be set
     validate_resources_desired_status_transition(
         current.deployment_resources_status,
         current.deployment_resources_desired_status,
+        final_deployment_error.clone(),
         new_desired_status,
     )?;
 
@@ -1209,8 +1251,9 @@ pub(crate) async fn set_deployment_resources_desired_status(
              SET deployment_resources_desired_status = $1,
                  deployment_resources_desired_status_since = CASE WHEN deployment_resources_desired_status = $1::VARCHAR THEN deployment_resources_desired_status_since ELSE NOW() END,
                  deployment_initial = $2,
-                 bootstrap_policy = $3
-             WHERE tenant_id = $4 AND id = $5",
+                 bootstrap_policy = $3,
+                 deployment_error = $4
+             WHERE tenant_id = $5 AND id = $6",
         )
         .await?;
     let modified_rows = txn
@@ -1220,6 +1263,10 @@ pub(crate) async fn set_deployment_resources_desired_status(
                 &new_desired_status.to_string(),
                 &final_deployment_initial.map(runtime_desired_status_to_string),
                 &final_bootstrap.map(bootstrap_policy_to_string),
+                &match final_deployment_error {
+                    None => None,
+                    Some(v) => Some(serialize_error_response(&v)?),
+                },
                 &tenant_id.0,
                 &current.id.0,
             ],
@@ -1328,6 +1375,7 @@ pub(crate) async fn set_deployment_resources_status_stopped(
         None,
         current.suspend_info,
         None,
+        None,
     )
     .await
 }
@@ -1366,6 +1414,7 @@ pub(crate) async fn set_deployment_resources_status_provisioning(
         None,
         None,
         current.deployment_initial,
+        current.bootstrap_policy,
     )
     .await
 }
@@ -1437,6 +1486,7 @@ pub(crate) async fn set_deployment_resources_status_provisioned(
         Some(new_deployment_location),
         None,
         current.deployment_initial,
+        current.bootstrap_policy,
     )
     .await
 }
@@ -1508,6 +1558,7 @@ pub(crate) async fn set_deployment_resources_status_stopping(
         None,
         new_suspend_info,
         None,
+        None,
     )
     .await
 }
@@ -1562,6 +1613,7 @@ async fn set_deployment_resources_status(
     final_deployment_location: Option<String>,
     final_suspend_info: Option<serde_json::Value>,
     final_deployment_initial: Option<RuntimeDesiredStatus>,
+    final_bootstrap_policy: Option<BootstrapPolicy>,
 ) -> Result<(), DBError> {
     // Validate that the new or existing deployment configuration is valid
     if let Some(deployment_config) = &final_deployment_config {
@@ -1583,16 +1635,17 @@ async fn set_deployment_resources_status(
                      suspend_info = $4,
                      deployment_id = $5,
                      deployment_initial = $6,
-                     deployment_resources_status = $7,
-                     deployment_resources_status_details = $8::VARCHAR,
-                     deployment_resources_status_since = CASE WHEN deployment_resources_status = $7::VARCHAR THEN deployment_resources_status_since ELSE NOW() END,
-                     deployment_runtime_status = $9::VARCHAR,
-                     deployment_runtime_status_details = $10::VARCHAR,
-                     deployment_runtime_status_since = CASE WHEN $9::VARCHAR IS NULL THEN NULL ELSE (CASE WHEN deployment_runtime_status = $9::VARCHAR THEN deployment_runtime_status_since ELSE NOW() END) END,
-                     deployment_runtime_desired_status = $11::VARCHAR,
-                     deployment_runtime_desired_status_since = CASE WHEN $11::VARCHAR IS NULL THEN NULL ELSE (CASE WHEN deployment_runtime_desired_status = $11::VARCHAR THEN deployment_runtime_desired_status_since ELSE NOW() END) END,
+                     bootstrap_policy = $7,
+                     deployment_resources_status = $8,
+                     deployment_resources_status_details = $9::VARCHAR,
+                     deployment_resources_status_since = CASE WHEN deployment_resources_status = $8::VARCHAR THEN deployment_resources_status_since ELSE NOW() END,
+                     deployment_runtime_status = $10::VARCHAR,
+                     deployment_runtime_status_details = $11::VARCHAR,
+                     deployment_runtime_status_since = CASE WHEN $10::VARCHAR IS NULL THEN NULL ELSE (CASE WHEN deployment_runtime_status = $10::VARCHAR THEN deployment_runtime_status_since ELSE NOW() END) END,
+                     deployment_runtime_desired_status = $12::VARCHAR,
+                     deployment_runtime_desired_status_since = CASE WHEN $12::VARCHAR IS NULL THEN NULL ELSE (CASE WHEN deployment_runtime_desired_status = $12::VARCHAR THEN deployment_runtime_desired_status_since ELSE NOW() END) END,
                      refresh_version = refresh_version + 1
-                 WHERE tenant_id = $12 AND id = $13",
+                 WHERE tenant_id = $13 AND id = $14",
         )
         .await?;
     let rows_affected = txn
@@ -1608,13 +1661,14 @@ async fn set_deployment_resources_status(
                 &final_suspend_info.map(|v| v.to_string()),      // $4: suspend_info
                 &final_deployment_id,                            // $5: deployment_id
                 &final_deployment_initial.map(runtime_desired_status_to_string), // $6: deployment_initial
-                &final_deployment_resources_status.to_string(), // $7: deployment_resources_status,
-                &final_deployment_resources_status_details.map(|v| v.to_string()), // $8: deployment_resources_status_details,
-                &final_deployment_runtime_status.map(runtime_status_to_string), // $9: deployment_runtime_status,
-                &final_deployment_runtime_status_details.map(|v| v.to_string()), // $10: deployment_runtime_status_details,
-                &final_deployment_runtime_desired_status.map(runtime_desired_status_to_string), // $11: deployment_runtime_desired_status,
-                &tenant_id.0,   // $12: tenant_id
-                &pipeline_id.0, // $13: id
+                &final_bootstrap_policy.map(bootstrap_policy_to_string), // $7: bootstrap_policy
+                &final_deployment_resources_status.to_string(), // $8: deployment_resources_status,
+                &final_deployment_resources_status_details.map(|v| v.to_string()), // $9: deployment_resources_status_details,
+                &final_deployment_runtime_status.map(runtime_status_to_string), // $10: deployment_runtime_status,
+                &final_deployment_runtime_status_details.map(|v| v.to_string()), // $11: deployment_runtime_status_details,
+                &final_deployment_runtime_desired_status.map(runtime_desired_status_to_string), // $12: deployment_runtime_desired_status,
+                &tenant_id.0,   // $13: tenant_id
+                &pipeline_id.0, // $14: id
             ],
         )
         .await?;

--- a/crates/pipeline-manager/src/db/storage.rs
+++ b/crates/pipeline-manager/src/db/storage.rs
@@ -301,6 +301,13 @@ pub(crate) trait Storage {
         system_error: &str,
     ) -> Result<(), DBError>;
 
+    /// Dismisses the `deployment_error`.
+    async fn dismiss_deployment_error(
+        &self,
+        tenant_id: TenantId,
+        pipeline_name: &str,
+    ) -> Result<(), DBError>;
+
     /// Sets deployment desired status to `Provisioned`.
     async fn set_deployment_resources_desired_status_provisioned(
         &self,
@@ -308,6 +315,7 @@ pub(crate) trait Storage {
         pipeline_name: &str,
         initial: RuntimeDesiredStatus,
         bootstrap_policy: BootstrapPolicy,
+        dismiss_error: bool,
     ) -> Result<PipelineId, DBError>;
 
     /// Sets deployment desired status to `Stopped` if it is not in currently `Provisioned`.

--- a/crates/pipeline-manager/src/db/storage_postgres.rs
+++ b/crates/pipeline-manager/src/db/storage_postgres.rs
@@ -695,12 +695,25 @@ impl Storage for StoragePostgres {
         Ok(())
     }
 
+    async fn dismiss_deployment_error(
+        &self,
+        tenant_id: TenantId,
+        pipeline_name: &str,
+    ) -> Result<(), DBError> {
+        let mut client = self.pool.get().await?;
+        let txn = client.transaction().await?;
+        operations::pipeline::dismiss_deployment_error(&txn, tenant_id, pipeline_name).await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
     async fn set_deployment_resources_desired_status_provisioned(
         &self,
         tenant_id: TenantId,
         pipeline_name: &str,
         initial: RuntimeDesiredStatus,
         bootstrap_policy: BootstrapPolicy,
+        dismiss_error: bool,
     ) -> Result<PipelineId, DBError> {
         let mut client = self.pool.get().await?;
         let txn = client.transaction().await?;
@@ -711,6 +724,7 @@ impl Storage for StoragePostgres {
             ResourcesDesiredStatus::Provisioned,
             Some(initial),
             Some(bootstrap_policy),
+            dismiss_error,
         )
         .await?;
         txn.commit().await?;
@@ -731,6 +745,7 @@ impl Storage for StoragePostgres {
             ResourcesDesiredStatus::Stopped,
             None,
             None,
+            false,
         )
         .await?;
         txn.commit().await?;
@@ -755,6 +770,7 @@ impl Storage for StoragePostgres {
                 ResourcesDesiredStatus::Stopped,
                 None,
                 None,
+                false,
             )
             .await?;
             true
@@ -888,6 +904,7 @@ impl Storage for StoragePostgres {
             ResourcesDesiredStatus::Stopped,
             None,
             None,
+            false,
         )
         .await?;
         operations::pipeline::set_deployment_resources_status_stopping(

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -1580,6 +1580,7 @@ async fn pipeline_deployment() {
             "example1",
             RuntimeDesiredStatus::Paused,
             BootstrapPolicy::default(),
+            false,
         )
         .await
         .unwrap();
@@ -1704,6 +1705,7 @@ async fn pipeline_deployment() {
             "example1",
             RuntimeDesiredStatus::Paused,
             BootstrapPolicy::default(),
+            false,
         )
         .await
         .unwrap();
@@ -1717,7 +1719,7 @@ async fn pipeline_deployment() {
             serde_json::to_value(generate_pipeline_config(
                 pipeline1.id,
                 &pipeline1.name,
-                &serde_json::from_value(pipeline1.runtime_config).unwrap(),
+                &serde_json::from_value(pipeline1.runtime_config.clone()).unwrap(),
                 Some(&ProgramInfo::default()),
             ))
             .unwrap(),
@@ -1774,6 +1776,131 @@ async fn pipeline_deployment() {
     handle
         .db
         .transit_deployment_resources_status_to_stopped(tenant_id, pipeline1.id, Version(1))
+        .await
+        .unwrap();
+    handle
+        .db
+        .set_deployment_resources_desired_status_provisioned(
+            tenant_id,
+            "example1",
+            RuntimeDesiredStatus::Paused,
+            BootstrapPolicy::default(),
+            false,
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_provisioning(
+            tenant_id,
+            pipeline1.id,
+            Version(1),
+            Uuid::nil(),
+            serde_json::to_value(generate_pipeline_config(
+                pipeline1.id,
+                &pipeline1.name,
+                &serde_json::from_value(pipeline1.runtime_config).unwrap(),
+                Some(&ProgramInfo::default()),
+            ))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_provisioned(
+            tenant_id,
+            pipeline1.id,
+            Version(1),
+            "location1",
+            json!({ "a": "1" }),
+            ExtendedRuntimeStatus {
+                runtime_status: RuntimeStatus::Initializing,
+                runtime_status_details: json!(""),
+                runtime_desired_status: RuntimeDesiredStatus::Paused,
+            },
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_stopping(
+            tenant_id,
+            pipeline1.id,
+            Version(1),
+            Some(ErrorResponse {
+                message: "abc".to_string(),
+                error_code: Cow::from("Def"),
+                details: json!("ghi"),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_stopped(tenant_id, pipeline1.id, Version(1))
+        .await
+        .unwrap();
+    assert!(matches!(
+        handle
+            .db
+            .set_deployment_resources_desired_status_provisioned(
+                tenant_id,
+                "example1",
+                RuntimeDesiredStatus::Paused,
+                BootstrapPolicy::default(),
+                false,
+            )
+            .await
+            .unwrap_err(),
+        DBError::CannotStartWithUndismissedError
+    ));
+    handle
+        .db
+        .dismiss_deployment_error(tenant_id, &pipeline1.name)
+        .await
+        .unwrap();
+    handle
+        .db
+        .set_deployment_resources_desired_status_provisioned(
+            tenant_id,
+            "example1",
+            RuntimeDesiredStatus::Paused,
+            BootstrapPolicy::default(),
+            false,
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_stopping(
+            tenant_id,
+            pipeline1.id,
+            Version(1),
+            Some(ErrorResponse {
+                message: "abc".to_string(),
+                error_code: Cow::from("Def"),
+                details: json!("ghi"),
+            }),
+            None,
+        )
+        .await
+        .unwrap();
+    handle
+        .db
+        .transit_deployment_resources_status_to_stopped(tenant_id, pipeline1.id, Version(1))
+        .await
+        .unwrap();
+    handle
+        .db
+        .set_deployment_resources_desired_status_provisioned(
+            tenant_id,
+            "example1",
+            RuntimeDesiredStatus::Paused,
+            BootstrapPolicy::default(),
+            true,
+        )
         .await
         .unwrap();
 }
@@ -2091,6 +2218,7 @@ enum StorageAction {
         TenantId,
         #[proptest(strategy = "limited_pipeline_name()")] String,
         #[proptest(strategy = "arbitrary_runtime_desired_status()")] RuntimeDesiredStatus,
+        bool,
     ),
     SetDeploymentResourcesDesiredStatusStoppedIfNotProvisioned(
         TenantId,
@@ -2164,6 +2292,10 @@ enum StorageAction {
         #[proptest(strategy = "limited_new_cluster_monitor_event()")] NewClusterMonitorEvent,
     ),
     DeleteClusterMonitorEventsBeyondRetention(u16, u16),
+    DismissDeploymentError(
+        TenantId,
+        #[proptest(strategy = "limited_pipeline_name()")] String,
+    ),
 }
 
 /// Alias for a result from the database.
@@ -2707,10 +2839,10 @@ fn db_impl_behaves_like_model() {
                                 let impl_response = handle.db.transit_program_status_to_system_error(tenant_id, pipeline_id, program_version_guard, &system_error).await;
                                 check_responses(i, model_response, impl_response);
                             }
-                            StorageAction::SetDeploymentResourcesDesiredStatusProvisioned(tenant_id, pipeline_name, initial) => {
+                            StorageAction::SetDeploymentResourcesDesiredStatusProvisioned(tenant_id, pipeline_name, initial, dismiss_error) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
-                                let model_response = model.set_deployment_resources_desired_status_provisioned(tenant_id, &pipeline_name, initial, BootstrapPolicy::default()).await;
-                                let impl_response = handle.db.set_deployment_resources_desired_status_provisioned(tenant_id, &pipeline_name, initial, BootstrapPolicy::default()).await;
+                                let model_response = model.set_deployment_resources_desired_status_provisioned(tenant_id, &pipeline_name, initial, BootstrapPolicy::default(), dismiss_error).await;
+                                let impl_response = handle.db.set_deployment_resources_desired_status_provisioned(tenant_id, &pipeline_name, initial, BootstrapPolicy::default(), dismiss_error).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::SetDeploymentResourcesDesiredStatusStoppedIfNotProvisioned(tenant_id, pipeline_name) => {
@@ -2851,6 +2983,12 @@ fn db_impl_behaves_like_model() {
                             StorageAction::DeleteClusterMonitorEventsBeyondRetention(retention_hours, retention_num) => {
                                 let model_response = model.delete_cluster_monitor_events_beyond_retention(retention_hours, retention_num).await;
                                 let impl_response = handle.db.delete_cluster_monitor_events_beyond_retention(retention_hours, retention_num).await;
+                                check_responses(i, model_response, impl_response);
+                            }
+                            StorageAction::DismissDeploymentError(tenant_id, pipeline_name) => {
+                                create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
+                                let model_response = model.dismiss_deployment_error(tenant_id, &pipeline_name).await;
+                                let impl_response = handle.db.dismiss_deployment_error(tenant_id, &pipeline_name).await;
                                 check_responses(i, model_response, impl_response);
                             }
                         }
@@ -3889,13 +4027,20 @@ impl Storage for Mutex<DbModel> {
         pipeline_name: &str,
         initial: RuntimeDesiredStatus,
         bootstrap_policy: BootstrapPolicy,
+        dismiss_error: bool,
     ) -> Result<PipelineId, DBError> {
         // Validate
         let mut pipeline = self.get_pipeline(tenant_id, pipeline_name).await?;
+        let new_deployment_error = if dismiss_error {
+            None
+        } else {
+            pipeline.deployment_error.clone()
+        };
         let new_resources_desired_status = ResourcesDesiredStatus::Provisioned;
         validate_resources_desired_status_transition(
             pipeline.deployment_resources_status,
             pipeline.deployment_resources_desired_status,
+            new_deployment_error.clone(),
             new_resources_desired_status,
         )?;
         if pipeline.deployment_initial.is_some_and(|v| v != initial) {
@@ -3925,6 +4070,7 @@ impl Storage for Mutex<DbModel> {
         pipeline.bootstrap_policy = Some(bootstrap_policy);
         pipeline.deployment_resources_desired_status = new_resources_desired_status;
         pipeline.deployment_resources_desired_status_since = Utc::now();
+        pipeline.deployment_error = new_deployment_error;
         self.lock()
             .await
             .pipelines
@@ -3944,6 +4090,7 @@ impl Storage for Mutex<DbModel> {
             validate_resources_desired_status_transition(
                 pipeline.deployment_resources_status,
                 pipeline.deployment_resources_desired_status,
+                pipeline.deployment_error.clone(),
                 new_resources_desired_status,
             )?;
 
@@ -3977,6 +4124,7 @@ impl Storage for Mutex<DbModel> {
         validate_resources_desired_status_transition(
             pipeline.deployment_resources_status,
             pipeline.deployment_resources_desired_status,
+            pipeline.deployment_error.clone(),
             new_resources_desired_status,
         )?;
 
@@ -4030,6 +4178,7 @@ impl Storage for Mutex<DbModel> {
         pipeline.storage_status = StorageStatus::InUse;
         pipeline.deployment_id = Some(deployment_id);
         // Retain: pipeline.deployment_initial
+        // Retain: pipeline.bootstrap_policy
         pipeline.deployment_config = Some(deployment_config);
         pipeline.deployment_location = None;
         pipeline.deployment_error = None;
@@ -4103,6 +4252,7 @@ impl Storage for Mutex<DbModel> {
         // Apply changes
         // Retain: pipeline.deployment_id
         // Retain: pipeline.deployment_initial
+        // Retain: pipeline.bootstrap_policy
         // Retain: pipeline.deployment_config
         pipeline.deployment_location = Some(deployment_location.to_string());
         pipeline.deployment_error = None;
@@ -4179,6 +4329,7 @@ impl Storage for Mutex<DbModel> {
         // Apply changes
         pipeline.deployment_id = None;
         pipeline.deployment_initial = None;
+        pipeline.bootstrap_policy = None;
         pipeline.deployment_config = None;
         pipeline.deployment_location = None;
         pipeline.deployment_error = deployment_error;
@@ -4192,7 +4343,6 @@ impl Storage for Mutex<DbModel> {
         pipeline.deployment_runtime_status_since = None;
         pipeline.deployment_runtime_desired_status = None;
         pipeline.deployment_runtime_desired_status_since = None;
-        pipeline.bootstrap_policy = None;
         pipeline.refresh_version = Version(pipeline.refresh_version.0 + 1);
         self.lock()
             .await
@@ -4247,6 +4397,7 @@ impl Storage for Mutex<DbModel> {
         // Apply changes
         pipeline.deployment_id = None;
         pipeline.deployment_initial = None;
+        pipeline.bootstrap_policy = None;
         pipeline.deployment_config = None;
         pipeline.deployment_location = None;
         // Retain: pipeline.deployment_error
@@ -4720,5 +4871,25 @@ impl Storage for Mutex<DbModel> {
         db_model.cluster_events = new_cluster_events;
 
         Ok((s1 - s2, s2 - s3))
+    }
+
+    async fn dismiss_deployment_error(
+        &self,
+        tenant_id: TenantId,
+        pipeline_name: &str,
+    ) -> Result<(), DBError> {
+        let mut pipeline = self.get_pipeline(tenant_id, pipeline_name).await?;
+        if (pipeline.deployment_resources_status != ResourcesStatus::Stopped
+            || pipeline.deployment_resources_desired_status != ResourcesDesiredStatus::Stopped)
+            && pipeline.deployment_error.is_some()
+        {
+            return Err(DBError::DismissErrorRestrictedToFullyStopped);
+        }
+        pipeline.deployment_error = None;
+        self.lock()
+            .await
+            .pipelines
+            .insert((tenant_id, pipeline.id), pipeline.clone());
+        Ok(())
     }
 }

--- a/crates/pipeline-manager/src/db/types/resources_status.rs
+++ b/crates/pipeline-manager/src/db/types/resources_status.rs
@@ -1,5 +1,6 @@
 use crate::db::error::DBError;
 use crate::db::types::storage::StorageStatus;
+use feldera_types::error::ErrorResponse;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
@@ -196,6 +197,7 @@ pub fn validate_resources_status_transition(
 pub fn validate_resources_desired_status_transition(
     status: ResourcesStatus,
     current_desired_status: ResourcesDesiredStatus,
+    new_deployment_error: Option<ErrorResponse>,
     new_desired_status: ResourcesDesiredStatus,
 ) -> Result<(), DBError> {
     // Check rules on changing desired resources status
@@ -216,6 +218,10 @@ pub fn validate_resources_desired_status_transition(
                     hint: "Cannot restart the pipeline while it is stopping. Wait until it is stopped before starting the pipeline again.".to_string(),
                 });
             };
+            if new_deployment_error.is_some() {
+                // If it experienced an error, it needs to be dismissed first
+                return Err(DBError::CannotStartWithUndismissedError);
+            }
             Ok(())
         }
     }

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -1825,6 +1825,7 @@ mod test {
                     &pipeline.name,
                     initial,
                     BootstrapPolicy::default(),
+                    true,
                 )
                 .await
                 .unwrap();

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -13,6 +13,18 @@ import TabItem from '@theme/TabItem';
     <TabItem className="changelogItem" value="enterprise"
         label="Enterprise">
 
+        ## Unreleased
+
+        The `ignore_deployment_error` parameter has been removed from the Python
+        `pipeline.start()` method. Instead, make use of the newly added `dismiss_error` parameter.
+        If you do not want the pipeline to start if there is a pre-existing deployment error,
+        you should call `pipeline.start(dismiss_error=False)`. Otherwise call `pipeline.start()`
+        which is by default equivalent to `pipeline.start(dismiss_error=True)` (preserving
+        existing behavior). If the start results in an error occurring, the method will still
+        throw an error as before. A pipeline deployment error can now also be separately dismissed
+        using a dedicated endpoint and the corresponding client functions (e.g.,
+        `pipeline.dismiss_error()` for the Python client).
+
         ## 0.227.0
 
         Loading data from checkpoints made in earlier versions of feldera (0.226.0 and below)

--- a/docs.feldera.com/docs/pipelines/lifecycle.md
+++ b/docs.feldera.com/docs/pipelines/lifecycle.md
@@ -47,8 +47,11 @@ state is tracked by the storage status.
 **Relevant API fields:**
 - `deployment_id` (set becoming `Provisioning`, unset becoming `Stopping`)
 - `deployment_config` (set becoming `Provisioning`, unset becoming `Stopping`)
-- `deployment_error` (set becoming `Stopping` (if error), unset becoming `Provisioning`)
+- `deployment_error` (set becoming `Stopping` (if error), must be unset to have desired status
+   become `Provisioned` (either via `/start?dismiss_error=true` (default) or `/dismiss_error`))
 - `deployment_initial` (set when desired status becomes `Provisioned`, unset becoming `Stopping`
+  or desired status becomes `Stopped` while status is still `Stopped`)
+- `bootstrap_policy` (set when desired status becomes `Provisioned`, unset becoming `Stopping`
   or desired status becomes `Stopped` while status is still `Stopped`)
 - `deployment_resources_status`
 - `deployment_resources_status_details` (unset becoming `Stopped`)
@@ -93,6 +96,8 @@ state is tracked by the storage status.
 - **Graceful stop:** Use `/stop?force=false` (default) to request the pipeline to stop cleanly: shut down the circuit
   and checkpoint before compute is deprovisioned. Only applies when resources are `Provisioned`; the `force` parameter
   is ignored otherwise.
+- **Error dismissal:** the `deployment_error` must be dismissed before starting again. This can be done
+  using `/start?dismiss_error=true` (default) or by calling `/dismiss_error` in advance.
 
 ## Storage status
 

--- a/openapi.json
+++ b/openapi.json
@@ -3284,6 +3284,74 @@
         ]
       }
     },
+    "/v0/pipelines/{pipeline_name}/dismiss_error": {
+      "post": {
+        "tags": [
+          "Pipeline Lifecycle"
+        ],
+        "summary": "Dismiss Pipeline Deployment Error",
+        "description": "Clears the `deployment_error` field of the pipeline, such that a subsequent call to\n`/start?dismiss_error=false` succeeds. It will return an error if the pipeline is not fully\nstopped (i.e., both current and desired status must be `Stopped`) AND a deployment error\nis present.",
+        "operationId": "post_pipeline_dismiss_error",
+        "parameters": [
+          {
+            "name": "pipeline_name",
+            "in": "path",
+            "description": "Unique pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment error has been dismissed"
+          },
+          "400": {
+            "description": "Action could not be performed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pipeline with that name does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "message": "Unknown pipeline name 'non-existent-pipeline'",
+                  "error_code": "UnknownPipelineName",
+                  "details": {
+                    "pipeline_name": "non-existent-pipeline"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JSON web token (JWT) or API key": []
+          }
+        ]
+      }
+    },
     "/v0/pipelines/{pipeline_name}/egress/{table_name}": {
       "post": {
         "tags": [
@@ -4694,6 +4762,14 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/BootstrapPolicy"
+            }
+          },
+          {
+            "name": "dismiss_error",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/python/README.md
+++ b/python/README.md
@@ -112,7 +112,11 @@ uv run python -m pytest tests/platform/
 # Specific test file
 uv run python -m pytest tests/platform/test_pipeline_crud.py
 
+# Specific test
+uv run python -m pytest tests/platform/test_pipeline_crud.py::test_pipeline_post
+
 # Tip: add argument -x at the end for it to fail fast
+# Tip: add argument -s at the end to show stdout/stderr
 ```
 
 For further information about the tests, please see `tests/README.md`.

--- a/python/feldera/enums.py
+++ b/python/feldera/enums.py
@@ -358,6 +358,13 @@ class BootstrapPolicy(Enum):
     ALLOW = "allow"
     REJECT = "reject"
 
+    @staticmethod
+    def from_str(value):
+        for member in BootstrapPolicy:
+            if member.name.lower() == value.lower():
+                return member
+        raise ValueError(f"Unknown value '{value}' for enum {BootstrapPolicy.__name__}")
+
 
 class CompletionTokenStatus(Enum):
     COMPLETE = "complete"

--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -475,7 +475,7 @@ metrics"""
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
-        ignore_deployment_error: bool = False,
+        dismiss_error: bool = True,
     ):
         """
         .. _start:
@@ -490,9 +490,8 @@ metrics"""
         :param timeout_s: The maximum time (in seconds) to wait for the
             pipeline to start.
         :param wait: Set True to wait for the pipeline to start. True by default
-        :param ignore_deployment_error: Set True to ignore deployment errors while waiting
-            for START transition. False by default.
-
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         :raises RuntimeError: If the pipeline is not in STOPPED state.
         """
 
@@ -501,7 +500,7 @@ metrics"""
             bootstrap_policy=bootstrap_policy,
             wait=wait,
             timeout_s=timeout_s,
-            ignore_deployment_error=ignore_deployment_error,
+            dismiss_error=dismiss_error,
         )
 
     def start_paused(
@@ -509,13 +508,18 @@ metrics"""
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
+        dismiss_error: bool = True,
     ):
         """
         Starts the pipeline in the paused state.
         """
 
         return self.client.start_pipeline_as_paused(
-            self.name, bootstrap_policy=bootstrap_policy, wait=wait, timeout_s=timeout_s
+            self.name,
+            bootstrap_policy=bootstrap_policy,
+            wait=wait,
+            timeout_s=timeout_s,
+            dismiss_error=dismiss_error,
         )
 
     def start_standby(
@@ -523,19 +527,25 @@ metrics"""
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
+        dismiss_error: bool = True,
     ):
         """
         Starts the pipeline in the standby state.
         """
 
         self.client.start_pipeline_as_standby(
-            self.name, bootstrap_policy=bootstrap_policy, wait=wait, timeout_s=timeout_s
+            self.name,
+            bootstrap_policy=bootstrap_policy,
+            wait=wait,
+            timeout_s=timeout_s,
+            dismiss_error=dismiss_error,
         )
 
     def restart(
         self,
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         timeout_s: Optional[float] = None,
+        dismiss_error: bool = True,
     ):
         """
         Restarts the pipeline.
@@ -547,10 +557,16 @@ metrics"""
         :param bootstrap_policy: The bootstrap policy to use.
         :param timeout_s: The maximum time (in seconds) to wait for the
             pipeline to restart.
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         """
 
         self.stop(force=True, timeout_s=timeout_s)
-        self.start(bootstrap_policy=bootstrap_policy, timeout_s=timeout_s)
+        self.start(
+            bootstrap_policy=bootstrap_policy,
+            timeout_s=timeout_s,
+            dismiss_error=dismiss_error,
+        )
 
     def pause(self, wait: bool = True, timeout_s: Optional[float] = None):
         """
@@ -584,6 +600,13 @@ metrics"""
         self.client.stop_pipeline(
             self.name, force=force, wait=wait, timeout_s=timeout_s
         )
+
+    def dismiss_error(self):
+        """
+        Dismisses the `deployment_error` of the pipeline.
+        """
+
+        self.client.dismiss_error_pipeline(self.name)
 
     def approve(self):
         """
@@ -1243,6 +1266,17 @@ pipeline '{self.name}' to sync checkpoint '{uuid}'"""
 
         self.refresh(PipelineFieldSelector.ALL)
         return self._inner.deployment_config
+
+    def bootstrap_policy(self) -> Optional[BootstrapPolicy]:
+        """
+        Return the bootstrap policy of the pipeline.
+        """
+
+        self.refresh(PipelineFieldSelector.STATUS)
+        if self._inner.bootstrap_policy is None:
+            return None
+        else:
+            return BootstrapPolicy.from_str(self._inner.bootstrap_policy)
 
     def deployment_desired_status(self) -> DeploymentDesiredStatus:
         """

--- a/python/feldera/pipeline_builder.py
+++ b/python/feldera/pipeline_builder.py
@@ -107,6 +107,7 @@ class PipelineBuilder:
             p = Pipeline.get(self.name, self.client)
             p.stop(force=True)
             p.clear_storage()
+            p.dismiss_error()
 
         except FelderaAPIError:
             # pipeline doesn't exist, no worries

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -238,7 +238,6 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         states: list[str],
         timeout_s: float | None = None,
         start: bool = True,
-        ignore_deployment_error: bool = False,
     ) -> PipelineStatus:
         start_time = time.monotonic()
         poll_interval_s = 0.1
@@ -263,14 +262,6 @@ Reason: The pipeline is in a STOPPED state due to the following error:
                 and len(resp.deployment_error or {}) > 0
                 and resp.deployment_desired_status == "Stopped"
             ):
-                if ignore_deployment_error:
-                    logging.debug(
-                        "ignoring stopped deployment error while waiting for %s to start: %s",
-                        pipeline_name,
-                        (resp.deployment_error or {}).get("message", ""),
-                    )
-                    time.sleep(poll_interval_s)
-                    continue
                 err_msg = "Unable to START the pipeline:\n" if start else ""
                 raise RuntimeError(
                     f"""{err_msg}Unable to transition the pipeline to one of the states: {states}.
@@ -454,7 +445,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
-        ignore_deployment_error: bool = False,
+        dismiss_error: bool = True,
     ) -> Optional[PipelineStatus]:
         """
 
@@ -464,39 +455,33 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         :param wait: Set True to wait for the pipeline to start. True by default
         :param timeout_s: The amount of time in seconds to wait for the
             pipeline to start.
-        :param ignore_deployment_error: Set True to ignore deployment errors while waiting for
-            START transition. If `timeout_s` is not provided, a default timeout is
-            used to avoid indefinite waiting.
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         """
+        start_params = {}
 
-        params = {"initial": initial}
+        # Any error is dismissed separately in order to make sure we only dismiss any error
+        # BEFORE it was started, not after it has been started by this call
+        if dismiss_error:
+            self.http.post(path=f"/pipelines/{pipeline_name}/dismiss_error")
+        start_params["dismiss_error"] = "false"
+
+        start_params["initial"] = initial
         if bootstrap_policy is not None:
-            params["bootstrap_policy"] = bootstrap_policy.value
+            start_params["bootstrap_policy"] = bootstrap_policy.value
 
         self.http.post(
             path=f"/pipelines/{pipeline_name}/start",
-            params=params,
+            params=start_params,
         )
 
         if not wait:
             return None
 
-        effective_timeout_s = timeout_s
-        if ignore_deployment_error and effective_timeout_s is None:
-            # ignore_deployment_error can intentionally skip the stopped+error failure guard.
-            # Bound the wait so callers don't get an unbounded polling loop.
-            effective_timeout_s = 60.0
-            logging.warning(
-                "start_pipeline(ignore_deployment_error=True) called without timeout; "
-                "defaulting to %.0fs",
-                effective_timeout_s,
-            )
-
         return self.__wait_for_pipeline_state_one_of(
             pipeline_name,
             [initial, "AwaitingApproval"],
-            effective_timeout_s,
-            ignore_deployment_error=ignore_deployment_error,
+            timeout_s,
         )
 
     def start_pipeline(
@@ -505,7 +490,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
-        ignore_deployment_error: bool = False,
+        dismiss_error: bool = True,
     ) -> Optional[PipelineStatus]:
         """
 
@@ -514,8 +499,8 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             True by default
         :param timeout_s: The amount of time in seconds to wait for the
             pipeline to start.
-        :param ignore_deployment_error: Set True to ignore deployment errors while waiting
-            for START transition.
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         """
 
         return self._inner_start_pipeline(
@@ -524,7 +509,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             bootstrap_policy,
             wait,
             timeout_s,
-            ignore_deployment_error,
+            dismiss_error,
         )
 
     def start_pipeline_as_paused(
@@ -533,6 +518,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: float | None = None,
+        dismiss_error: bool = True,
     ) -> Optional[PipelineStatus]:
         """
         :param pipeline_name: The name of the pipeline to start as paused.
@@ -540,10 +526,17 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             True by default
         :param timeout_s: The amount of time in seconds to wait for the
             pipeline to start.
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         """
 
         return self._inner_start_pipeline(
-            pipeline_name, "paused", bootstrap_policy, wait, timeout_s
+            pipeline_name,
+            "paused",
+            bootstrap_policy,
+            wait,
+            timeout_s,
+            dismiss_error,
         )
 
     def start_pipeline_as_standby(
@@ -552,6 +545,7 @@ Reason: The pipeline is in a STOPPED state due to the following error:
         bootstrap_policy: Optional[BootstrapPolicy] = None,
         wait: bool = True,
         timeout_s: Optional[float] = None,
+        dismiss_error: bool = True,
     ):
         """
         :param pipeline_name: The name of the pipeline to start as standby.
@@ -559,10 +553,17 @@ Reason: The pipeline is in a STOPPED state due to the following error:
             True by default
         :param timeout_s: The amount of time in seconds to wait for the
             pipeline to start.
+        :param dismiss_error: Set True to dismiss any deployment error before starting;
+            set False to make it fail in that case. True by default.
         """
 
         self._inner_start_pipeline(
-            pipeline_name, "standby", bootstrap_policy, wait, timeout_s
+            pipeline_name,
+            "standby",
+            bootstrap_policy,
+            wait,
+            timeout_s,
+            dismiss_error,
         )
 
     def resume_pipeline(
@@ -671,6 +672,17 @@ Reason: The pipeline is in a STOPPED state due to the following error:
                 pipeline_name,
             )
             time.sleep(0.1)
+
+    def dismiss_error_pipeline(
+        self,
+        pipeline_name: str,
+    ):
+        """
+        Dismisses the deployment error of a pipeline.
+
+        :param pipeline_name: The name of the pipeline for which to dismiss the deployment error
+        """
+        self.http.post(path=f"/pipelines/{pipeline_name}/dismiss_error")
 
     def clear_storage(self, pipeline_name: str, timeout_s: Optional[float] = None):
         """

--- a/python/feldera/rest/pipeline.py
+++ b/python/feldera/rest/pipeline.py
@@ -50,6 +50,7 @@ class Pipeline:
         self.deployment_desired_status_since: Optional[str] = None
         self.deployment_id: Optional[str] = None
         self.deployment_initial: Optional[str] = None
+        self.bootstrap_policy: Optional[str] = None
         self.deployment_error: Optional[dict] = None
         self.deployment_location: Optional[str] = None
         self.program_info: Optional[dict] = (

--- a/python/tests/platform/test_bootstrapping.py
+++ b/python/tests/platform/test_bootstrapping.py
@@ -67,12 +67,9 @@ CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) AS c FROM t1;
         pass
 
     print(
-        "Starting pipeline with bootstrap_policy='allow' and ignoring expected deployment error from previous reject start"
+        "Starting pipeline with bootstrap_policy='allow' and dismissing deployment error from previous reject start"
     )
-    pipeline.start(
-        bootstrap_policy=BootstrapPolicy.ALLOW,
-        ignore_deployment_error=True,
-    )
+    pipeline.start(bootstrap_policy=BootstrapPolicy.ALLOW, dismiss_error=True)
     assert pipeline.status() == PipelineStatus.RUNNING
 
     pipeline.execute("INSERT INTO t1 VALUES (4), (5), (6);")

--- a/python/tests/platform/test_pipeline_error.py
+++ b/python/tests/platform/test_pipeline_error.py
@@ -1,0 +1,102 @@
+import time
+from feldera import PipelineBuilder
+from feldera.rest.errors import FelderaAPIError
+from feldera.enums import PipelineStatus
+from .helper import (
+    gen_pipeline_name,
+    post_json,
+    api_url,
+)
+from tests import TEST_CLIENT
+
+
+@gen_pipeline_name
+def test_pipeline_error_dismissal(pipeline_name):
+    sql = """
+    CREATE TABLE t1(c1 INTEGER);
+    CREATE VIEW v1 AS SELECT ELEMENT(ARRAY [2, 3]) FROM t1;
+    """
+    pipeline = PipelineBuilder(TEST_CLIENT, pipeline_name, sql).create_or_replace()
+    pipeline.stop(force=True)
+    pipeline.clear_storage()
+    pipeline.dismiss_error()
+
+    # Beginning: no deployment error is present
+    assert pipeline.deployment_error() is None
+
+    # Normal start and stop (idempotent): no deployment error is present afterward
+    pipeline.start()
+    pipeline.start(dismiss_error=True)
+    pipeline.start(dismiss_error=False)
+    pipeline.dismiss_error()
+    pipeline.start()
+    pipeline.stop(force=True)
+    assert pipeline.deployment_error() is None
+
+    # Without any error present, dismissal works both using the standalone
+    # function and as argument for start()
+    pipeline.dismiss_error()
+    pipeline.start(dismiss_error=True)
+    pipeline.stop(force=True)
+    assert pipeline.deployment_error() is None
+    pipeline.start(dismiss_error=False)
+    pipeline.stop(force=True)
+    assert pipeline.deployment_error() is None
+
+    # Cannot start pipeline without dismissing error
+    pipeline.start()
+    cause_error_and_wait_for_stopped(pipeline)
+    assert pipeline.deployment_error() is not None
+    error_occurred = False
+    try:
+        pipeline.start(dismiss_error=False)
+    except FelderaAPIError as e:
+        error_occurred = True
+        assert e.status_code == 400
+        assert e.error_code == "CannotStartWithUndismissedError"
+    assert error_occurred
+    assert pipeline.deployment_error() is not None
+    pipeline.stop(force=True)
+    pipeline.dismiss_error()
+
+    # Can start pipeline with dismissed error (separate call)
+    pipeline.start()
+    cause_error_and_wait_for_stopped(pipeline)
+    assert pipeline.deployment_error() is not None
+    pipeline.dismiss_error()
+    pipeline.start(dismiss_error=False)
+    assert pipeline.deployment_error() is None
+    pipeline.stop(force=True)
+
+    # Can start pipeline with dismissed error (integrated)
+    pipeline.start()
+    cause_error_and_wait_for_stopped(pipeline)
+    assert pipeline.deployment_error() is not None
+    pipeline.start(dismiss_error=True)
+    assert pipeline.deployment_error() is None
+    pipeline.stop(force=True)
+
+
+def cause_error_and_wait_for_stopped(pipeline):
+    # This data causes the pipeline to panic
+    response = post_json(
+        api_url(
+            f"/pipelines/{pipeline.name}/ingress/t1?format=json&array=true&update_format=raw"
+        ),
+        [{"c1": 1}, {"c1": 2}, {"c1": 3}],
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Response should be 200 OK but is: {response.status_code} with body: {response.json()}"
+        )
+
+    # It should stop with an error within 60 seconds
+    timeout_s = 60
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if pipeline.status() == PipelineStatus.STOPPED:
+            return
+        time.sleep(0.2)
+    raise TimeoutError(
+        f"Timed out waiting for pipeline '{pipeline.name}' to stop with an error"
+    )

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -1,6 +1,8 @@
 import time
 from http import HTTPStatus
-
+from feldera import PipelineBuilder
+from feldera.enums import BootstrapPolicy
+from tests import TEST_CLIENT
 from .helper import (
     create_pipeline,
     post_json,
@@ -343,3 +345,19 @@ def test_start_as_standby_fails(pipeline_name):
     )
     assert r.status_code == HTTPStatus.BAD_REQUEST
     assert r.json()["error_code"] == "InitialStandbyNotAllowed"
+
+
+@gen_pipeline_name
+def test_pipeline_bootstrap_policy_is_removed(pipeline_name):
+    pipeline = PipelineBuilder(TEST_CLIENT, pipeline_name, "").create_or_replace()
+    for expectation in [
+        BootstrapPolicy.ALLOW,
+        BootstrapPolicy.REJECT,
+        BootstrapPolicy.AWAIT_APPROVAL,
+    ]:
+        assert pipeline.bootstrap_policy() is None
+        pipeline.start(bootstrap_policy=expectation)
+        assert pipeline.bootstrap_policy() == expectation
+        assert pipeline.bootstrap_policy() is not None
+        pipeline.stop(force=True)
+        assert pipeline.bootstrap_policy() is None


### PR DESCRIPTION
Add the `/dismiss_error` endpoint for the user to dismiss the content of the `deployment_error` field, which is set when the pipeline becomes `Stopping`/`Stopped` due to an fatal error occurring deployment. The functionality is also integrated into the `/start` endpoint with the parameter `?dismiss_error=false/true` (default: `true`).

Python API changes:
- `pipeline.start()` has the `ignore_deployment_error` parameter removed (not backward compatible)
- `pipeline.start()` has the `dismiss_error` parameter added which is by default `True`
- `pipeline.dismiss_error()` is added

CLI client `fda` changes:
- `fda start` has the `--no-dismiss-error` parameter added
- `fda dismiss-error` is added

The `bootstrap_policy` field is fixed to be cleared along with `deployment_initial` when the pipeline is stopping or has stopped.

**PR information**

- Testing: database unit test, database fuzzing inclusion, Python integration test, simple `fda` test
- Documentation updated
- Changelog updated
- Backward incompatible change: removal of the `ignore_deployment_error` parameter for the Python API `pipeline.start()` method