### PR TITLE
Update instructions to download Feldera from the new domain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,19 +61,26 @@ RUN ARCH=`dpkg --print-architecture`; \
 
 RUN pip3 install --break-system-packages gdown kafka-python-ng
 
+## Prepare directories for non-root user (for Claude Code)
+RUN mkdir -p /home/$USERNAME/.local/share/claude && chown -R $USERNAME /home/$USERNAME/.local/share/claude
+RUN mkdir -p /home/$USERNAME/.local/state/claude && chown -R $USERNAME /home/$USERNAME/.local/state/claude
+RUN mkdir -p /home/$USERNAME/.local/bin/ && chown -R $USERNAME /home/$USERNAME/.local/bin/
+
 ## Switch to non-root user
 
 USER $USERNAME
 
 ## Install rustup and common components
-
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
 ## Install Bun.js
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.3"
 ENV PATH="$HOME/.bun/bin:$PATH"
-RUN $HOME/.bun/bin/bun install --global @hey-api/openapi-ts @anthropic-ai/claude-code
+RUN $HOME/.bun/bin/bun install --global @hey-api/openapi-ts
+
+## Install Claude Code
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 RUN \
    rustup install $RUST_VERSION && \

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ First, make sure you have [Docker](https://docs.docker.com/) installed. Then run
 following command:
 
 ```text
-docker run -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
+docker run -p 8080:8080 --tty --rm -it images.feldera.com/feldera/pipeline-manager:latest
 ```
 
 Once the container image downloads and you see the Feldera logo on your terminal, visit

--- a/crates/pipeline-manager/src/runner/interaction.rs
+++ b/crates/pipeline-manager/src/runner/interaction.rs
@@ -27,7 +27,7 @@ use feldera_types::runtime_status::RuntimeStatus;
 /// Max non-streaming decompressed HTTP response body size returned by the pipeline.
 /// The awc default is 2MiB, which is not enough to, for example, retrieve
 /// a large circuit profile.
-const RESPONSE_SIZE_LIMIT: usize = 20 * 1024 * 1024;
+const RESPONSE_SIZE_LIMIT: usize = 50 * 1024 * 1024;
 
 pub(crate) struct CachedPipelineDescr {
     pipeline: ExtendedPipelineDescrMonitoring,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,7 +2,7 @@ name: feldera
 services:
   pipeline-manager:
     tty: true
-    image: ghcr.io/feldera/pipeline-manager:${FELDERA_VERSION:-latest}
+    image: images.feldera.com/feldera/pipeline-manager:${FELDERA_VERSION:-latest}
     ports:
       # If you change the host side of the port mapping here, don't forget to
       # also add a corresponding --allowed-origins argument to the pipeline

--- a/docs.feldera.com/docs/get-started/docker.md
+++ b/docs.feldera.com/docs/get-started/docker.md
@@ -7,7 +7,7 @@ use, check out [Feldera Enterprise](/get-started/enterprise).
 ## Docker Quickstart
 
 ```
-docker run --pull always -p 8080:8080 --tty --rm -it ghcr.io/feldera/pipeline-manager:latest
+docker run --pull always -p 8080:8080 --tty --rm -it images.feldera.com/feldera/pipeline-manager:latest
 ```
 
 Once you see the Feldera logo on your terminal, go ahead and open the Web Console


### PR DESCRIPTION
Downloads from images.feldera.com are still served by github but proxied by scarf.sh which tracks them.

Updated Claude Code install method to recommended in devcontainer
Updated pipeline service HTTP response body size limit

Testing: tested that pipeline-manager image served by images.feldera.com matches the ghcr image (docker even identified it as the same and did not re-donwload)