### PR TITLE
[adapters] Report transaction commit progress through global_stats.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -195,7 +195,11 @@ static CHECKPOINT_WRITTEN_MEGABYTES: ExponentialHistogram = ExponentialHistogram
 /// checkpoint.
 static CHECKPOINT_PROCESSED_RECORDS: AtomicU64 = AtomicU64::new(0);
 
-static COMMIT_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
+/// Interval between updating statistics for transaction commit.
+static COMMIT_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Interval between logging updates about transaction commit.
+static COMMIT_DISPLAY_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Creates a [Controller].
 pub struct ControllerBuilder {
@@ -1423,6 +1427,44 @@ impl Controller {
             &CHECKPOINT_SYNC_PULL_FAILURES,
         );
 
+        metrics.gauge(
+            "transaction_state",
+            "0 when no transaction is active, 1 when a transaction has started, 2 while a transaction is committing.",
+            labels,
+            match self.inner.get_transaction_state() {
+                TransactionState::None => 0,
+                TransactionState::Started(_) => 1,
+                TransactionState::Committing(_) => 2,
+            }
+        );
+        let commit_progress = self
+            .inner
+            .status
+            .global_metrics
+            .commit_progress
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
+        metrics.gauge(
+            "transaction_completed_operators",
+            "Number of operators that have been fully flushed while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing.",
+            labels,
+            commit_progress.completed
+        );
+        metrics.gauge(
+            "transaction_in_progress_operators",
+            "Number of operators that are currently being flushed while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing.",
+            labels,
+            commit_progress.in_progress
+        );
+        metrics.gauge(
+            "transaction_remaining_operators",
+            "Number of operators that have not started flushing while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing.",
+            labels,
+            commit_progress.remaining
+        );
+
         fn write_input_metric<F, M, T>(
             metrics: &mut MetricsWriter<F>,
             labels: &LabelStack,
@@ -1998,7 +2040,47 @@ struct CircuitThread {
     /// record into an endpoint we first need to seek that endpoint.
     input_metadata: HashMap<String, Option<Resume>>,
 
-    last_commit_progress_update: Instant,
+    commit_updates: Option<CommitUpdates>,
+}
+
+struct CommitUpdates {
+    /// Next time we should update global_status.commit_progress.
+    status_update: Instant,
+
+    /// Next time we should display a progress update.
+    display_update: Instant,
+}
+
+impl Default for CommitUpdates {
+    fn default() -> Self {
+        let now = Instant::now();
+        Self {
+            status_update: now,
+            display_update: now + COMMIT_DISPLAY_INTERVAL,
+        }
+    }
+}
+
+impl CommitUpdates {
+    fn should_update_status(&mut self) -> bool {
+        let now = Instant::now();
+        if now >= self.status_update {
+            self.status_update = now + COMMIT_UPDATE_INTERVAL;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn should_display_status(&mut self) -> bool {
+        let now = Instant::now();
+        if now >= self.display_update {
+            self.display_update = now + COMMIT_DISPLAY_INTERVAL;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 /// Detect the following situation:
@@ -2294,7 +2376,7 @@ impl CircuitThread {
             step_sender,
             checkpoint_sender,
             input_metadata: input_metadata.unwrap_or_default(),
-            last_commit_progress_update: Instant::now(),
+            commit_updates: None,
         })
     }
 
@@ -2513,7 +2595,6 @@ impl CircuitThread {
                     self.controller
                         .set_transaction_state(TransactionState::Started(transaction_id));
                 });
-                self.last_commit_progress_update = Instant::now();
             }
             _ => {}
         }
@@ -2533,24 +2614,36 @@ impl CircuitThread {
             debug!("circuit thread: 'circuit.step' returned");
 
             if let TransactionState::Committing(transaction_id) = transaction_state {
-                // Print transaction commit progress every COMMIT_UPDATE_INTERVAL.
-                // This is temporary until we have API/UI for progress reporting.
-                if self.last_commit_progress_update.elapsed() >= COMMIT_UPDATE_INTERVAL {
-                    self.last_commit_progress_update = Instant::now();
-                    match self.circuit.commit_progress() {
-                        Ok(progress) => {
-                            info!(
-                                "Transaction {transaction_id} commit progress: {}",
-                                progress.summary()
-                            )
+                if !committed {
+                    let commit_updates = self.commit_updates.get_or_insert_default();
+                    if commit_updates.should_update_status() {
+                        match self.circuit.commit_progress() {
+                            Ok(progress) => {
+                                let summary = progress.summary();
+                                if commit_updates.should_display_status() {
+                                    info!(
+                                        "Transaction {transaction_id} commit progress: {summary}"
+                                    );
+                                }
+                                self.controller
+                                    .status
+                                    .global_metrics
+                                    .set_commit_progress(Some(summary));
+                            }
+                            Err(e) => {
+                                error!("Error retrieving transaction commit progress: {e}");
+                            }
                         }
-                        Err(e) => error!("Error retrieving transaction commit progress: {e}"),
-                    }
-                }
-                if committed {
+                    };
+                } else {
                     info!("Transaction {transaction_id} committed");
                     self.controller
                         .set_transaction_state(TransactionState::None);
+                    self.commit_updates = None;
+                    self.controller
+                        .status
+                        .global_metrics
+                        .set_commit_progress(None);
                 }
             }
         } else {

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -62,7 +62,7 @@ use feldera_types::{
     coordination::Completion,
     suspend::SuspendError,
     time_series::SampleStatistics,
-    transaction::TransactionId,
+    transaction::{CommitProgressSummary, TransactionId},
 };
 use memory_stats::memory_stats;
 use parking_lot::{RwLock, RwLockReadGuard};
@@ -162,6 +162,9 @@ pub struct GlobalControllerMetrics {
 
     /// Entities that initiated the current transaction.
     pub transaction_initiators: Mutex<TransactionInitiators>,
+
+    /// Transaction commit progress, if a transaction is committing.
+    pub commit_progress: Mutex<Option<CommitProgressSummary>>,
 
     /// Time at which the pipeline process started, in seconds since the epoch.
     pub start_time: DateTime<Utc>,
@@ -278,6 +281,7 @@ impl GlobalControllerMetrics {
             transaction_id: Atomic::new(0),
             transaction_status: Atomic::new(TransactionStatus::NoTransaction),
             transaction_initiators: Mutex::new(TransactionInitiators::default()),
+            commit_progress: Mutex::new(None),
             start_time,
             incarnation_uuid,
             initial_start_time,
@@ -386,6 +390,10 @@ impl GlobalControllerMetrics {
 
     fn set_step_requested(&self) -> bool {
         self.step_requested.swap(true, Ordering::AcqRel)
+    }
+
+    pub fn set_commit_progress(&self, commit_progress: Option<CommitProgressSummary>) {
+        *self.commit_progress.lock().unwrap() = commit_progress;
     }
 }
 
@@ -1132,6 +1140,7 @@ impl ControllerStatus {
                 .transaction_status
                 .load(Ordering::Acquire),
             transaction_id: self.global_metrics.transaction_id.load(Ordering::Acquire),
+            commit_progress: self.global_metrics.commit_progress.lock().unwrap().clone(),
             transaction_initiators: self
                 .global_metrics
                 .transaction_initiators

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -2,7 +2,7 @@ use crate::circuit::GlobalNodeId;
 use crate::circuit::checkpointer::Checkpointer;
 use crate::circuit::metrics::{DBSP_STEP, DBSP_STEP_LATENCY_MICROSECONDS};
 use crate::circuit::runtime::ThreadType;
-use crate::circuit::schedule::{CommitProgress, CommitProgressSummary};
+use crate::circuit::schedule::CommitProgress;
 use crate::monitor::visual_graph::Graph;
 use crate::operator::dynamic::balance::{
     BALANCE_TAX, BalancerHint, KEY_DISTRIBUTION_REFRESH_THRESHOLD,
@@ -21,6 +21,7 @@ use feldera_ir::LirCircuit;
 use feldera_storage::{FileCommitter, StorageBackend, StoragePath};
 use feldera_types::checkpoint::CheckpointMetadata;
 pub use feldera_types::config::{StorageCacheConfig, StorageConfig, StorageOptions};
+use feldera_types::transaction::CommitProgressSummary;
 use itertools::Either;
 use serde::Deserialize;
 use serde_json::Value;

--- a/crates/dbsp/src/circuit/schedule.rs
+++ b/crates/dbsp/src/circuit/schedule.rs
@@ -4,6 +4,7 @@
 
 use super::{Circuit, GlobalNodeId, NodeId, trace::SchedulerEvent};
 use crate::{DetailedError, Position};
+use feldera_types::transaction::CommitProgressSummary;
 use itertools::Itertools;
 use serde::Serialize;
 use std::{
@@ -172,64 +173,6 @@ impl CommitProgress {
             in_progress_processed_records,
             in_progress_total_records,
         }
-    }
-}
-
-/// Summary of the commit progress.
-pub struct CommitProgressSummary {
-    /// Number of operators that have been fully flushed.
-    completed: u64,
-
-    /// Number of operators that are currently being flushed.
-    in_progress: u64,
-
-    /// Number of operators that haven't started flushing.
-    remaining: u64,
-
-    /// Number of records processed by operators that are currently being flushed.
-    in_progress_processed_records: u64,
-
-    // Total number of records that operators that are currently being flushed need to process.
-    in_progress_total_records: u64,
-}
-
-impl Default for CommitProgressSummary {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CommitProgressSummary {
-    pub fn new() -> Self {
-        Self {
-            completed: 0,
-            in_progress: 0,
-            remaining: 0,
-            in_progress_processed_records: 0,
-            in_progress_total_records: 0,
-        }
-    }
-
-    pub fn merge(&mut self, other: &CommitProgressSummary) {
-        self.completed += other.completed;
-        self.in_progress += other.in_progress;
-        self.remaining += other.remaining;
-        self.in_progress_processed_records += other.in_progress_processed_records;
-        self.in_progress_total_records += other.in_progress_total_records;
-    }
-}
-
-impl Display for CommitProgressSummary {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "completed: {} operators, evaluating: {} operators [{}/{} changes processed], remaining: {} operators",
-            self.completed,
-            self.in_progress,
-            self.in_progress_processed_records,
-            self.in_progress_total_records,
-            self.remaining
-        )
     }
 }
 

--- a/crates/feldera-types/src/adapter_stats.rs
+++ b/crates/feldera-types/src/adapter_stats.rs
@@ -6,7 +6,11 @@ use std::collections::BTreeMap;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::{coordination::Step, suspend::SuspendError, transaction::TransactionId};
+use crate::{
+    coordination::Step,
+    suspend::SuspendError,
+    transaction::{CommitProgressSummary, TransactionId},
+};
 
 /// Pipeline state.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -235,6 +239,8 @@ pub struct ExternalGlobalControllerMetrics {
     /// ID of the current transaction or 0 if no transaction is in progress.
     #[schema(value_type = i64)]
     pub transaction_id: TransactionId,
+    /// Progress of the current transaction commit, if one is in progress.
+    pub commit_progress: Option<CommitProgressSummary>,
     /// Entities that initiated the current transaction.
     #[schema(value_type = TransactionInitiators)]
     pub transaction_initiators: ExternalTransactionInitiators,

--- a/crates/feldera-types/src/transaction.rs
+++ b/crates/feldera-types/src/transaction.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -12,5 +14,52 @@ pub struct StartTransactionResponse {
 impl StartTransactionResponse {
     pub fn new(transaction_id: TransactionId) -> Self {
         Self { transaction_id }
+    }
+}
+
+/// Summary of transaction commit progress.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
+pub struct CommitProgressSummary {
+    /// Number of operators that have been fully flushed.
+    pub completed: u64,
+
+    /// Number of operators that are currently being flushed.
+    pub in_progress: u64,
+
+    /// Number of operators that haven't started flushing.
+    pub remaining: u64,
+
+    /// Number of records processed by operators that are currently being flushed.
+    pub in_progress_processed_records: u64,
+
+    /// Total number of records that operators that are currently being flushed need to process.
+    pub in_progress_total_records: u64,
+}
+
+impl CommitProgressSummary {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn merge(&mut self, other: &CommitProgressSummary) {
+        self.completed += other.completed;
+        self.in_progress += other.in_progress;
+        self.remaining += other.remaining;
+        self.in_progress_processed_records += other.in_progress_processed_records;
+        self.in_progress_total_records += other.in_progress_total_records;
+    }
+}
+
+impl Display for CommitProgressSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "completed: {} operators, evaluating: {} operators [{}/{} changes processed], remaining: {} operators",
+            self.completed,
+            self.in_progress,
+            self.in_progress_processed_records,
+            self.in_progress_total_records,
+            self.remaining
+        )
     }
 }

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -427,6 +427,7 @@ It contains the following fields:
         feldera_types::checkpoint::CheckpointFailure,
         feldera_types::checkpoint::CheckpointMetadata,
         feldera_types::transaction::StartTransactionResponse,
+        feldera_types::transaction::CommitProgressSummary,
         feldera_types::time_series::TimeSeries,
         feldera_types::time_series::SampleStatistics,
         feldera_types::suspend::SuspendError,

--- a/docs.feldera.com/docs/operations/metrics.md
+++ b/docs.feldera.com/docs/operations/metrics.md
@@ -67,7 +67,7 @@ which Feldera is built.
 | Name | Type | Description |
 | :--- | :--- | :---------- |
 | <a name='compaction_stall_duration_seconds'>`compaction_stall_duration_seconds`</a> |counter | Time in seconds a worker was stalled waiting for more merges to complete. |
-| <a name='dbsp_operator_checkpoint_latency_seconds'>`dbsp_operator_checkpoint_latency_seconds`</a> |histogram | Latency of individual operator checkpoint operations in seconds. (Because checkpoints run in parallel across workers, these will not add to `feldera_checkpoint_latency_seconds`.) |
+| <a name='dbsp_operator_checkpoint_latency_seconds'>`dbsp_operator_checkpoint_latency_seconds`</a> |histogram | The time that individual operator checkpoint operations delayed the pipeline, in seconds. (Because checkpoints run in parallel across workers, these will add up to more than `feldera_checkpoint_delay_seconds`.) |
 | <a name='dbsp_runtime_elapsed_seconds_total'>`dbsp_runtime_elapsed_seconds_total`</a> |counter | Time elapsed while the pipeline is executing a step, multiplied by the number of foreground and background threads, in seconds. |
 | <a name='dbsp_step_latency_seconds'>`dbsp_step_latency_seconds`</a> |histogram | Latency of DBSP steps over the last 60 seconds or 1000 steps, whichever is less, in seconds |
 | <a name='dbsp_steps_total'>`dbsp_steps_total`</a> |counter | Total number of DBSP steps executed. |
@@ -163,6 +163,8 @@ These metrics accumulate across checkpoint and resume.
 | <a name='output_connector_errors_encode_total'>`output_connector_errors_encode_total`</a> |counter | Total number of errors encountered encoding records to send. |
 | <a name='output_connector_errors_transport_total'>`output_connector_errors_transport_total`</a> |counter | Total number of errors encountered at the transport layer sending records. |
 | <a name='output_connector_extra_memory_bytes'>`output_connector_extra_memory_bytes`</a> |gauge | Additional memory used by an output connector beyond that used for buffered records. |
+| <a name='output_connector_queued_batches'>`output_connector_queued_batches`</a> |gauge | Number of batches of records currently queued by the output connector. |
+| <a name='output_connector_queued_records'>`output_connector_queued_records`</a> |gauge | Number of records currently queued by the output connector. |
 | <a name='output_connector_records_total'>`output_connector_records_total`</a> |counter | Total number of records sent by the output connector. |
 
 ## Checkpoint Synchronization
@@ -183,3 +185,16 @@ These metrics report the status of [checkpoint synchronization].
 | <a name='checkpoint_sync_push_success'>`checkpoint_sync_push_success`</a> |counter | Number of checkpoints pushed successfully. |
 | <a name='checkpoint_sync_push_transfer_speed_bytes_per_second'>`checkpoint_sync_push_transfer_speed_bytes_per_second`</a> |histogram | Transfer speed when pushing a checkpoint, in bytes per second. |
 | <a name='checkpoint_sync_push_transferred_bytes'>`checkpoint_sync_push_transferred_bytes`</a> |histogram | Bytes transferred when pushing a checkpoint. |
+
+## Transactions
+
+These metrics report the status of [transactions].
+
+[transactions]: /pipelines/transactions.md
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| <a name='transaction_completed_operators'>`transaction_completed_operators`</a> |gauge | Number of operators that have been fully flushed while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing. |
+| <a name='transaction_in_progress_operators'>`transaction_in_progress_operators`</a> |gauge | Number of operators that are currently being flushed while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing. |
+| <a name='transaction_remaining_operators'>`transaction_remaining_operators`</a> |gauge | Number of operators that have not started flushing while the current transaction is committing.  This is 0 if no transaction is active, or if a transaction is running but has not yet started committing. |
+| <a name='transaction_state'>`transaction_state`</a> |gauge | 0 when no transaction is active, 1 when a transaction has started, 2 while a transaction is committing. |

--- a/docs.feldera.com/docs/operations/metrics.md.in
+++ b/docs.feldera.com/docs/operations/metrics.md.in
@@ -117,3 +117,11 @@ These metrics report the status of [checkpoint synchronization].
 [checkpoint synchronization]: /pipelines/checkpoint-sync.md
 
 {{checkpoint_sync_}}
+
+## Transactions
+
+These metrics report the status of [transactions].
+
+[transactions]: /pipelines/transactions.md
+
+{{transaction_}}

--- a/docs.feldera.com/docs/pipelines/transactions.md
+++ b/docs.feldera.com/docs/pipelines/transactions.md
@@ -150,6 +150,11 @@ The user can monitor the transaction handling status of the pipeline using the [
 
 When the status is `TransactionInProgress` or `CommitInProgress`, the `transaction_id` attribute contains the current transaction ID.
 
+When the status is `CommitInProgress`, the `commit_progress` attribute
+contains information about progress of the commit.
+
+Transaction status is also available through [metrics](/operations/metrics.md#transactions).
+
 <Tabs>
     <TabItem value="rest" label="REST API">
     ```shell

--- a/js-packages/web-console/README.md
+++ b/js-packages/web-console/README.md
@@ -84,6 +84,29 @@ bun run generate-openapi
 If you get an error like this:
 
 ```
+error: failed to run custom build command for `feldera-rest-api v0.252.0 (/__w/feldera/feldera/crates/rest-api)`
+
+Caused by:
+  process didn't exit successfully: `/__w/feldera/feldera/target/debug/build/feldera-rest-api-a075935d8e5b212d/build-script-build` (exit status: 101)
+  --- stdout
+  cargo:rerun-if-changed=../../openapi.json
+
+  --- stderr
+
+  thread 'main' (297854) panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/typify-impl-0.1.0/src/convert.rs:1183:32:
+  $ref #/components/schemas/CommitProgressSummary is missing
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+then generate a new `openapi.json` with:
+
+```bash
+bun run build-openapi
+```
+
+If you get an error like this:
+
+```
 🔥 Unexpected error occurred. Token "<SomeNewType>" does not exist.
 ```
 

--- a/openapi.json
+++ b/openapi.json
@@ -7040,6 +7040,49 @@
           "Stopping"
         ]
       },
+      "CommitProgressSummary": {
+        "type": "object",
+        "description": "Summary of transaction commit progress.",
+        "required": [
+          "completed",
+          "in_progress",
+          "remaining",
+          "in_progress_processed_records",
+          "in_progress_total_records"
+        ],
+        "properties": {
+          "completed": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of operators that have been fully flushed.",
+            "minimum": 0
+          },
+          "in_progress": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of operators that are currently being flushed.",
+            "minimum": 0
+          },
+          "in_progress_processed_records": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of records processed by operators that are currently being flushed.",
+            "minimum": 0
+          },
+          "in_progress_total_records": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total number of records that operators that are currently being flushed need to process.",
+            "minimum": 0
+          },
+          "remaining": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of operators that haven't started flushing.",
+            "minimum": 0
+          }
+        }
+      },
       "CompilationProfile": {
         "type": "string",
         "description": "Enumeration of possible compilation profiles that can be passed to the Rust compiler\nas an argument via `cargo build --profile <>`. A compilation profile affects among\nother things the compilation speed (how long till the program is ready to be run)\nand runtime speed (the performance while running).",
@@ -8243,6 +8286,14 @@
             "format": "int64",
             "description": "Total number of records currently buffered by all endpoints.",
             "minimum": 0
+          },
+          "commit_progress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommitProgressSummary"
+              }
+            ],
+            "nullable": true
           },
           "cpu_msecs": {
             "type": "integer",


### PR DESCRIPTION
Until now, transaction commit progress has been reported through the pipeline's log, which makes it unavailable in any reasonable way through the API, to the web console, and so on.  This commit adds transaction commit progress to global stats.

This removes the progress updates from the log.  These could be added back in if it's still desirable.

Issue: https://github.com/feldera/feldera/issues/5245

### Describe Manual Test Plan

I tested this by watching the metrics with a command like ` watch -n.1 'curl -sk https://localhost:8888/stats|jq .global_metrics'` while transactions were progressing.
