### PR TITLE
[profiler] Don't serialize empty metrics.

### DIFF
--- a/crates/dbsp/src/circuit/metadata.rs
+++ b/crates/dbsp/src/circuit/metadata.rs
@@ -610,6 +610,7 @@ pub struct OperatorMeta {
 #[derive(Serialize)]
 struct MetricReadingRef<'a> {
     metric_id: &'a MetricId,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     labels: &'a MetricLabels,
     value: &'a MetaItem,
 }

--- a/js-packages/profiler-lib/src/profile.ts
+++ b/js-packages/profiler-lib/src/profile.ts
@@ -18,7 +18,7 @@ export interface ProfileMetricDescription {
 // Base class for all metric representations in the new profile representation
 interface JsonMetricBase {
     metric_id: string;
-    labels: Array<[string, string]>;
+    labels?: Array<[string, string]>;
     value: JsonMetricValue;
 }
 
@@ -720,9 +720,11 @@ export class Measurement {
     static parseValues(metric: JsonMetricBase): Array<Measurement> {
         let metric_id = metric.metric_id;
         let kind = metric_id.split("_").pop(); // count, bytes, etc
-        let labels = metric.labels.map(e => e.join(":")).join(".");
-        if (metric.labels.length !== 0) {
-            metric_id = metric_id + "." + labels;
+        if (metric.labels) {
+           let labels = metric.labels.map(e => e.join(":")).join(".");
+           if (metric.labels.length !== 0) {
+               metric_id = metric_id + "." + labels;
+           }
         }
         switch (kind) {
             case "bytes": {


### PR DESCRIPTION
Make the profiles less verbose by only serializing the `labels` field of a metric if it's not empty.

### Describe Manual Test Plan

Tested manually using the web ui and a new profile.

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
