### PR TITLE
ci: Ability to manually invoke build-sql

### DIFF
--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -2,6 +2,7 @@ name: Build Java Sources
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build-jar:


### PR DESCRIPTION
This makes it easier to use custom runtimes in dev/test cycles because all that's needed to use a custom
runtime is a pre-built java compiler.

ci change only.