### PR TITLE
dbsp: add size estimate for bloom filter blocks.

### DIFF
--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -183,7 +183,7 @@ impl Default for Parameters {
 }
 
 trait IntoBlock {
-    fn into_block(self) -> FBuf;
+    fn into_block(self, expected_capacity: usize) -> FBuf;
     fn overwrite_head(&self, dst: &mut FBuf)
     where
         Self: FixedLen;
@@ -193,8 +193,8 @@ impl<B> IntoBlock for B
 where
     B: for<'a> BinWrite<Args<'a> = ()>,
 {
-    fn into_block(self) -> FBuf {
-        let mut block = NoSeek::new(FBuf::with_capacity(4096));
+    fn into_block(self, expected_capacity: usize) -> FBuf {
+        let mut block = NoSeek::new(FBuf::with_capacity(expected_capacity));
         self.write_le(&mut block).unwrap();
         block.into_inner()
     }
@@ -1201,8 +1201,16 @@ impl Writer {
 
         // Write the Bloom filter.
         let filter_location = if let Some(bloom_filter) = &self.bloom_filter {
+            let filter_block = FilterBlockRef::from(bloom_filter);
+            // std::mem::size_of::<FilterBlockRef>() should be an
+            // upper bound: in-memory struct size + bloom payload bytes.
+            let estimated_block_size = (std::mem::size_of::<FilterBlockRef>()
+                + std::mem::size_of_val(filter_block.data))
+            // our binrw min block size is 512 so we round it up to avoid another
+            // reallocation
+            .next_multiple_of(512);
             self.writer
-                .write_block(FilterBlockRef::from(bloom_filter).into_block(), None)?
+                .write_block(filter_block.into_block(estimated_block_size), None)?
                 .1
         } else {
             BlockLocation { offset: 0, size: 0 }
@@ -1236,7 +1244,7 @@ impl Writer {
         }
         let (_block, location) = self
             .writer
-            .write_block(file_trailer.clone().into_block(), None)?;
+            .write_block(file_trailer.clone().into_block(4096), None)?;
         self.writer
             .insert_cache_entry(location, Arc::new(file_trailer));
 


### PR DESCRIPTION
This passes an accurate size estimate for bloom filter blocks when we build them so we can appropriately size the FBuf for it in advance.

The problem surfaced when I changed the FBuf grow policy to strictly grow to the requested size instead of power of two increments. I do think this can be a problem in practice: say a 9 GiB bloom filter is built we will grow the buffer from 4 KiB all the way to 16 GiB. With this it should just do one allocation of 9 GiB upfront.

The other place where we used this was for footer blocks, where 4KiB is a fine (over)estimate.

### Describe Manual Test Plan

I ran a bunch of tests looking at FBuf resizing and confirmed there is no resize anymore for writing the bloom filter.
