### PR TITLE
adapters: custom metrics support for input connectors

### DIFF
--- a/crates/adapterlib/src/lib.rs
+++ b/crates/adapterlib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod catalog;
 mod connector_metadata;
 pub mod errors;
 pub mod format;
+pub mod metrics;
 pub mod transport;
 pub mod utils;
 

--- a/crates/adapterlib/src/metrics.rs
+++ b/crates/adapterlib/src/metrics.rs
@@ -1,0 +1,30 @@
+/// The type of a connector metric.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ValueType {
+    /// A monotonically increasing counter.
+    Counter,
+    /// An instantaneous gauge.
+    Gauge,
+}
+
+impl ValueType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ValueType::Counter => "counter",
+            ValueType::Gauge => "gauge",
+        }
+    }
+}
+
+/// Connector-specific metrics exported via the Prometheus `/metrics` endpoint.
+///
+/// Connectors that have metrics beyond the standard [`InputEndpointMetrics`]
+/// should implement this trait and register themselves via
+/// [`InputConsumer::set_custom_metrics`] during [`TransportInputEndpoint::open`].
+pub trait ConnectorMetrics: Send + Sync {
+    /// Return a list of `(name, help, value_type, value)` tuples.
+    ///
+    /// The returned `name`s must be valid Prometheus metric name components
+    /// (no spaces, no special characters other than `_`).
+    fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)>;
+}

--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -10,8 +10,8 @@ use serde_json::Value as JsonValue;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::marker::PhantomData;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::mpsc::error::TryRecvError;
 use xxhash_rust::xxh3::Xxh3Default;
@@ -19,6 +19,7 @@ use xxhash_rust::xxh3::Xxh3Default;
 use crate::PipelineState;
 use crate::catalog::InputCollectionHandle;
 use crate::format::{BufferSize, InputBuffer, ParseError, Parser};
+use crate::metrics::ConnectorMetrics;
 
 /// Step number for fault-tolerant circuits.
 ///
@@ -753,6 +754,14 @@ pub trait InputConsumer: Send + Sync + DynClone {
     /// belong to the the transaction, immediately before calling `extended`. The connector cannot
     /// queue any more updates after this function is invoked, until the next `Queue` command.
     fn commit_transaction(&self);
+
+    /// Register connector-specific metrics for Prometheus export.
+    ///
+    /// A connector may call this once during [`TransportInputEndpoint::open`]
+    /// to provide an [`Arc<dyn ConnectorMetrics>`] whose [`ConnectorMetrics::metrics`]
+    /// will be polled on every scrape.  The default implementation is a no-op,
+    /// so connectors that have no custom metrics need not override it.
+    fn set_custom_metrics(&self, _metrics: Arc<dyn ConnectorMetrics>) {}
 
     /// Endpoint failed.
     ///

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -31,9 +31,7 @@ use crate::controller::sync::{
     CHECKPOINT_SYNC_PUSH_TRANSFER_SPEED, CHECKPOINT_SYNC_PUSH_TRANSFERRED_BYTES, SYNCHRONIZER,
 };
 use crate::samply::SamplySpan;
-use crate::server::metrics::{
-    HistogramDiv, LabelStack, MetricsFormatter, MetricsWriter, Value, ValueType,
-};
+use crate::server::metrics::{HistogramDiv, LabelStack, MetricsFormatter, MetricsWriter, Value};
 use crate::server::{InitializationState, ServerState};
 use crate::transport::Step;
 use crate::transport::clock::now_endpoint_config;
@@ -71,6 +69,7 @@ use dbsp::{
 use dbsp::{Runtime, WeakRuntime};
 use enum_map::EnumMap;
 use feldera_adapterlib::format::BufferSize;
+use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{Resume, Watermark};
 use feldera_ir::LirCircuit;
 use feldera_storage::histogram::{ExponentialHistogram, ExponentialHistogramSnapshot};
@@ -1558,18 +1557,16 @@ impl Controller {
             |s| s.reader.as_ref().map_or(0, |reader| reader.memory()),
         );
 
-        // Export paused state as a metric (1 = paused, 0 = running)
         write_input_metric(
             metrics,
             labels,
             status,
-            "input_connector_paused",
-            "Whether the input connector is paused by the user (1 for true, 0 for false).",
+            "input_connector_running",
+            "Whether the input connector is running (1) or paused by the user (0).",
             ValueType::Gauge,
-            |s| s.is_paused_by_user() as u8,
+            |s| !s.is_paused_by_user(),
         );
 
-        // Export barrier state as a metric (1 = barrier active, 0 = not active)
         write_input_metric(
             metrics,
             labels,
@@ -1577,7 +1574,7 @@ impl Controller {
             "input_connector_barrier",
             "Whether the input connector is currently a barrier for checkpointing/suspend (1 for true, 0 for false).",
             ValueType::Gauge,
-            |s| s.is_barrier() as u8,
+            |s| s.is_barrier(),
         );
 
         write_input_metric(
@@ -1587,7 +1584,7 @@ impl Controller {
             "input_connector_end_of_input",
             "Whether the input connector has reached end of input (1 for true, 0 for false).",
             ValueType::Gauge,
-            |s| s.metrics.end_of_input.load(Ordering::Relaxed) as u8,
+            |s| s.metrics.end_of_input.load(Ordering::Relaxed),
         );
 
         fn write_input_histogram<F, M>(
@@ -1644,6 +1641,10 @@ impl Controller {
                 )
             },
         );
+
+        // Export connector-specific (custom) metrics registered via
+        // `InputConsumer::set_custom_metrics`.
+        write_custom_metrics(status, metrics, labels);
 
         fn write_output_metric<F, M>(
             metrics: &mut MetricsWriter<F>,
@@ -1867,6 +1868,43 @@ impl Controller {
 
     pub fn workers(&self) -> Range<usize> {
         self.inner.workers.clone()
+    }
+}
+
+/// Write connector-specific (custom) metrics registered via
+/// [`InputConsumer::set_custom_metrics`] into `metrics`.
+///
+/// Groups values by `(name, help, ValueType)` so that all endpoints' values
+/// for the same metric are emitted in a single Prometheus block (the
+/// Prometheus exposition format requires that all values for a given metric
+/// appear together under one `# TYPE` header).
+pub(crate) fn write_custom_metrics<F>(
+    status: &ControllerStatus,
+    metrics: &mut MetricsWriter<F>,
+    labels: &LabelStack,
+) where
+    F: MetricsFormatter,
+{
+    type MetricKey = (&'static str, &'static str, ValueType);
+    type EndpointValues = Vec<(String, f64)>;
+
+    let mut grouped: BTreeMap<MetricKey, EndpointValues> = BTreeMap::new();
+    for input in status.input_status().values() {
+        if let Some(cm) = &input.custom_metrics {
+            for (name, help, vtype, value) in cm.metrics() {
+                grouped
+                    .entry((name, help, vtype))
+                    .or_default()
+                    .push((input.endpoint_name.clone(), value));
+            }
+        }
+    }
+    for ((name, help, vtype), entries) in &grouped {
+        metrics.values(name, help, *vtype, |w| {
+            for (endpoint_name, value) in entries {
+                w.write_value(&labels.with("endpoint", endpoint_name), *value);
+            }
+        });
     }
 }
 
@@ -6637,6 +6675,12 @@ impl InputConsumer for InputProbe {
             error,
             tag,
         );
+    }
+
+    fn set_custom_metrics(&self, metrics: Arc<dyn ConnectorMetrics>) {
+        self.controller
+            .status
+            .set_custom_metrics(self.endpoint_id, metrics);
     }
 }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -49,6 +49,7 @@ use crossbeam::sync::Unparker;
 use feldera_adapterlib::{
     errors::journal::ControllerError,
     format::BufferSize,
+    metrics::ConnectorMetrics,
     transport::{InputReader, Resume, Step, Watermark},
 };
 use feldera_storage::histogram::SlidingHistogram;
@@ -71,7 +72,7 @@ use serde_json::Value as JsonValue;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     sync::{
-        Mutex,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -721,6 +722,13 @@ impl ControllerStatus {
     /// Input endpoint stats.
     pub fn input_status(&self) -> RwLockReadGuard<'_, BTreeMap<EndpointId, InputEndpointStatus>> {
         self.inputs.read_recursive()
+    }
+
+    /// Register connector-specific metrics for an input endpoint.
+    pub fn set_custom_metrics(&self, endpoint_id: EndpointId, metrics: Arc<dyn ConnectorMetrics>) {
+        if let Some(status) = self.inputs.write().get_mut(&endpoint_id) {
+            status.custom_metrics = Some(metrics);
+        }
     }
 
     /// Output endpoint stats.
@@ -1947,6 +1955,10 @@ pub struct InputEndpointStatus {
     /// endpoint or endpoints advance beyond the barriers.
     pub barrier: AtomicBool,
 
+    /// Connector-specific metrics for Prometheus export, registered via
+    /// [`InputConsumer::set_custom_metrics`].
+    pub custom_metrics: Option<Arc<dyn ConnectorMetrics>>,
+
     /// Completion tokens associated with the endpoint.
     completion_tokens: TokenList,
 
@@ -1995,6 +2007,7 @@ impl InputEndpointStatus {
             barrier: AtomicBool::new(false),
             reader: None,
             fault_tolerance,
+            custom_metrics: None,
             completion_tokens: TokenList::new(),
             completed_frontier: WatermarkTracker::new(),
         }

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2405,3 +2405,174 @@ fn test_external_controller_status_serialization() {
         "http_output should have 8 encode errors"
     );
 }
+
+/// Test that custom connector metrics registered via `set_custom_metrics` are
+/// included in the Prometheus output produced by the custom-metrics loop in
+/// `write_metrics`.
+#[test]
+fn test_custom_connector_metrics_prometheus_output() {
+    use crate::{
+        ControllerStatus,
+        controller::{stats::InputEndpointStatus, write_custom_metrics},
+        server::metrics::{LabelStack, MetricsWriter, PrometheusFormatter},
+    };
+    use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    struct MockMetrics;
+
+    impl ConnectorMetrics for MockMetrics {
+        fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)> {
+            vec![
+                (
+                    "kafka_consumer_lag",
+                    "Consumer lag for the Kafka topic partition.",
+                    ValueType::Gauge,
+                    42.0,
+                ),
+                (
+                    "kafka_messages_fetched_total",
+                    "Total number of messages fetched from Kafka.",
+                    ValueType::Counter,
+                    1000.0,
+                ),
+            ]
+        }
+    }
+
+    let config = serde_json::from_value(json!({
+        "name": "test_custom_metrics",
+        "workers": 1,
+    }))
+    .unwrap();
+
+    let status = ControllerStatus::new(config, 0, None, Uuid::nil());
+
+    let endpoint = InputEndpointStatus::new(
+        "kafka_in",
+        serde_json::from_value(json!({
+            "stream": "s",
+            "transport": { "name": "kafka_input", "config": { "topics": ["t"], "bootstrap.servers": "localhost:9092" } },
+            "format": { "name": "json", "config": {} }
+        }))
+        .unwrap(),
+        None,
+        None,
+    );
+    status.inputs.write().insert(0, endpoint);
+
+    // Register custom metrics on the endpoint.
+    status.set_custom_metrics(0, Arc::new(MockMetrics));
+
+    let mut writer = MetricsWriter::<PrometheusFormatter>::new();
+    let labels = LabelStack::new();
+    write_custom_metrics(&status, &mut writer, &labels);
+    let output = writer.into_output();
+
+    // Verify custom metric names and values appear with the endpoint label.
+    assert!(
+        output.contains("kafka_consumer_lag"),
+        "output missing kafka_consumer_lag:\n{output}"
+    );
+    assert!(
+        output.contains("kafka_messages_fetched_total"),
+        "output missing kafka_messages_fetched_total:\n{output}"
+    );
+    assert!(
+        output.contains(r#"endpoint="kafka_in""#),
+        "output missing endpoint label:\n{output}"
+    );
+    assert!(
+        output.contains("42"),
+        "output missing gauge value 42:\n{output}"
+    );
+    assert!(
+        output.contains("1000"),
+        "output missing counter value 1000:\n{output}"
+    );
+}
+
+/// Test that when two endpoints register the same custom metric name, the
+/// grouping logic emits a single `# TYPE` header for that metric (Prometheus
+/// format violation fix).
+#[test]
+fn test_custom_connector_metrics_prometheus_grouping() {
+    use crate::{
+        ControllerStatus,
+        controller::{stats::InputEndpointStatus, write_custom_metrics},
+        server::metrics::{LabelStack, MetricsWriter, PrometheusFormatter},
+    };
+    use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    struct MockMetrics;
+
+    impl ConnectorMetrics for MockMetrics {
+        fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)> {
+            vec![(
+                "kafka_consumer_lag",
+                "Consumer lag for the Kafka topic partition.",
+                ValueType::Gauge,
+                42.0,
+            )]
+        }
+    }
+
+    let config = serde_json::from_value(json!({
+        "name": "test_grouping",
+        "workers": 1,
+    }))
+    .unwrap();
+
+    let status = ControllerStatus::new(config, 0, None, Uuid::nil());
+
+    for (id, name) in [(0u64, "kafka_in_1"), (1u64, "kafka_in_2")] {
+        let endpoint = InputEndpointStatus::new(
+            name,
+            serde_json::from_value(json!({
+                "stream": "s",
+                "transport": { "name": "kafka_input", "config": { "topics": ["t"], "bootstrap.servers": "localhost:9092" } },
+                "format": { "name": "json", "config": {} }
+            }))
+            .unwrap(),
+            None,
+            None,
+        );
+        status.inputs.write().insert(id, endpoint);
+        status.set_custom_metrics(id, Arc::new(MockMetrics));
+    }
+
+    let mut writer = MetricsWriter::<PrometheusFormatter>::new();
+    let labels = LabelStack::new();
+    write_custom_metrics(&status, &mut writer, &labels);
+    let output = writer.into_output();
+
+    // `# TYPE kafka_consumer_lag gauge` must appear exactly once.
+    let type_header = "# TYPE kafka_consumer_lag gauge";
+    let occurrences = output.matches(type_header).count();
+    assert_eq!(
+        occurrences, 1,
+        "expected exactly one '# TYPE kafka_consumer_lag gauge', got {occurrences}:\n{output}"
+    );
+
+    // Both endpoint labels must appear in the output.
+    assert!(
+        output.contains(r#"endpoint="kafka_in_1""#),
+        "output missing kafka_in_1 label:\n{output}"
+    );
+    assert!(
+        output.contains(r#"endpoint="kafka_in_2""#),
+        "output missing kafka_in_2 label:\n{output}"
+    );
+
+    // There must be no second `# TYPE` header between the two endpoint values.
+    let first_pos = output.find(r#"endpoint="kafka_in_1""#).unwrap();
+    let second_pos = output.find(r#"endpoint="kafka_in_2""#).unwrap();
+    let between = &output[first_pos.min(second_pos)..first_pos.max(second_pos)];
+    assert!(
+        !between.contains("# TYPE"),
+        "unexpected '# TYPE' header between endpoint values:\n{output}"
+    );
+}

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -26,6 +26,7 @@ use deltalake::logstore::{self, IORuntime};
 use deltalake::table::builder::ensure_table_uri;
 use deltalake::{DeltaTable, DeltaTableBuilder, datafusion};
 use feldera_adapterlib::format::{ParseError, StagedInputBuffer};
+use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{InputQueueEntry, Resume, Watermark, parse_resume_info};
 use feldera_adapterlib::utils::datafusion::{
     array_to_string, execute_query_collect, execute_singleton_query, timestamp_to_sql_expression,
@@ -40,10 +41,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::cmp::min;
 use std::collections::{BTreeSet, HashMap};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::select;
 use tokio::sync::watch::{Receiver, Sender, channel};
 use tokio::sync::{Semaphore, mpsc};
@@ -279,6 +280,10 @@ impl DeltaTableInputReader {
         }
 
         if eoi {
+            endpoint
+                .metrics
+                .phase
+                .store(DeltaPhase::Completed as u64, Ordering::Relaxed);
             endpoint.consumer.eoi();
         } else {
             let endpoint_clone = endpoint.clone();
@@ -463,6 +468,66 @@ impl DeltaResumeInfo {
     }
 }
 
+/// Current phase of a delta table input connector.
+// Using repr u64 as we using AtomicU64 to store the phase in metrics
+#[repr(u64)]
+enum DeltaPhase {
+    LoadingSnapshot = 0,
+    Follow = 1,
+    Completed = 2,
+}
+
+struct DeltaTableMetrics {
+    /// Current phase of the connector (see [DeltaPhase]).
+    phase: AtomicU64,
+    /// Unix epoch seconds when snapshot phase finished; 0 if not yet complete.
+    snapshot_completed_ts: AtomicU64,
+    /// Total records loaded during snapshot phase.
+    snapshot_records_total: AtomicU64,
+}
+
+impl DeltaTableMetrics {
+    fn new() -> Self {
+        Self {
+            phase: AtomicU64::new(DeltaPhase::LoadingSnapshot as u64),
+            snapshot_completed_ts: AtomicU64::new(0),
+            snapshot_records_total: AtomicU64::new(0),
+        }
+    }
+}
+
+impl ConnectorMetrics for DeltaTableMetrics {
+    fn metrics(&self) -> Vec<(&'static str, &'static str, ValueType, f64)> {
+        vec![
+            (
+                "input_connector_delta_phase",
+                "Current phase: 0=loading_snapshot, 1=follow/streaming, 2=completed.",
+                ValueType::Gauge,
+                self.phase.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "input_connector_delta_snapshot_completed_seconds",
+                "Unix epoch seconds when the snapshot phase finished (0 if not yet complete).",
+                ValueType::Gauge,
+                self.snapshot_completed_ts.load(Ordering::Relaxed) as f64,
+            ),
+            (
+                "input_connector_delta_snapshot_records_total",
+                "Total records loaded during the snapshot phase.",
+                ValueType::Counter,
+                self.snapshot_records_total.load(Ordering::Relaxed) as f64,
+            ),
+        ]
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 struct DeltaTableInputEndpointInner {
     endpoint_name: String,
     schema: Relation,
@@ -482,6 +547,7 @@ struct DeltaTableInputEndpointInner {
     ///   in follow mode or after ingesting the initial snapshot.
     last_resume_status: Mutex<Option<DeltaResumeInfo>>,
     queue: Arc<InputQueue<Option<DeltaResumeInfo>, StagedInputBuffer>>,
+    metrics: Arc<DeltaTableMetrics>,
 }
 
 impl DeltaTableInputEndpointInner {
@@ -500,6 +566,9 @@ impl DeltaTableInputEndpointInner {
             false,
         );
 
+        let metrics = Arc::new(DeltaTableMetrics::new());
+        consumer.set_custom_metrics(Arc::clone(&metrics) as Arc<dyn ConnectorMetrics>);
+
         Self {
             endpoint_name: endpoint_name.to_string(),
             schema,
@@ -513,6 +582,7 @@ impl DeltaTableInputEndpointInner {
                 resume_info.unwrap_or_else(DeltaResumeInfo::initial),
             )),
             queue,
+            metrics,
         }
     }
 
@@ -687,6 +757,9 @@ impl DeltaTableInputEndpointInner {
         let record_count = self
             .execute_snapshot_query(&snapshot_query, "initial snapshot", input_stream, receiver)
             .await;
+        self.metrics
+            .snapshot_records_total
+            .fetch_add(record_count as u64, Ordering::Relaxed);
 
         // Empty buffer to indicate checkpointable state.
         self.queue.push_entry(
@@ -865,6 +938,9 @@ impl DeltaTableInputEndpointInner {
             let range_record_count = self
                 .execute_snapshot_query(&range_query, "range", input_stream, receiver)
                 .await;
+            self.metrics
+                .snapshot_records_total
+                .fetch_add(range_record_count as u64, Ordering::Relaxed);
             total_records += range_record_count;
 
             start = end.clone();
@@ -971,12 +1047,21 @@ impl DeltaTableInputEndpointInner {
             // Log the appropriate message based on whether we just completed a snapshot
             if self.config.snapshot() && snapshot_incomplete {
                 // We just completed reading a snapshot, now switching to follow mode
+                self.metrics
+                    .snapshot_completed_ts
+                    .store(now_unix_secs(), Ordering::Relaxed);
+                self.metrics
+                    .phase
+                    .store(DeltaPhase::Follow as u64, Ordering::Relaxed);
                 info!(
                     "delta_table {}: snapshot phase completed, switching to follow mode (records: {}, version: {})",
                     &self.endpoint_name, snapshot_record_count, version
                 );
             } else if !self.config.snapshot() {
                 // Pure CDC follow mode (no snapshot configured)
+                self.metrics
+                    .phase
+                    .store(DeltaPhase::Follow as u64, Ordering::Relaxed);
                 info!(
                     "delta_table {}: CDC follow started (from version: {})",
                     &self.endpoint_name, version
@@ -1041,6 +1126,9 @@ impl DeltaTableInputEndpointInner {
                                 &self.endpoint_name,
                                 self.config.end_version.unwrap()
                             );
+                            self.metrics
+                                .phase
+                                .store(DeltaPhase::Completed as u64, Ordering::Relaxed);
                             self.consumer.eoi();
                             break;
                         }
@@ -1051,6 +1139,9 @@ impl DeltaTableInputEndpointInner {
                             &self.endpoint_name,
                             self.config.end_version.unwrap()
                         );
+                        self.metrics
+                            .phase
+                            .store(DeltaPhase::Completed as u64, Ordering::Relaxed);
                         self.consumer.eoi();
 
                         // Empty buffer to indicate eoi.
@@ -1085,6 +1176,15 @@ impl DeltaTableInputEndpointInner {
                 }
             }
         } else {
+            // Snapshot-only mode: record completion timestamp and transition to Completed.
+            if self.config.snapshot() && snapshot_incomplete {
+                self.metrics
+                    .snapshot_completed_ts
+                    .store(now_unix_secs(), Ordering::Relaxed);
+            }
+            self.metrics
+                .phase
+                .store(DeltaPhase::Completed as u64, Ordering::Relaxed);
             self.consumer.eoi();
         }
     }

--- a/crates/adapters/src/server/metrics.rs
+++ b/crates/adapters/src/server/metrics.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, TimeZone};
+use feldera_adapterlib::metrics::ValueType;
 use feldera_storage::histogram::ExponentialHistogramSnapshot;
 use itertools::Itertools;
 use std::{
@@ -242,31 +243,6 @@ where
 {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// The type of a metric whose values are [Value].
-pub enum ValueType {
-    /// A counter.
-    ///
-    /// The value of a counter never decreases, but it can increase.  For
-    /// example, a counter might report the amount of CPU time used by a
-    /// process.
-    Counter,
-
-    /// A gauge.
-    ///
-    /// A gauge can vary over time.  For example, a gauge might report the
-    /// amount of memory used by a process.
-    Gauge,
-}
-
-impl ValueType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ValueType::Counter => "counter",
-            ValueType::Gauge => "gauge",
-        }
     }
 }
 
@@ -684,6 +660,13 @@ macro_rules! from_cast {
         }
     };
 }
+
+impl Value for bool {
+    fn as_f64(&self) -> f64 {
+        *self as u8 as f64
+    }
+}
+
 from_cast!(f32);
 from_cast!(u8);
 from_cast!(u16);

--- a/docs.feldera.com/docs/operations/metrics.md
+++ b/docs.feldera.com/docs/operations/metrics.md
@@ -138,15 +138,21 @@ invisible to users unless a pause or checkpoint happens mid-batch.
 
 | Name | Type | Description |
 | :--- | :--- | :---------- |
+| <a name='input_connector_barrier'>`input_connector_barrier`</a> |gauge | Whether the input connector is currently a barrier for checkpointing/suspend (1 for true, 0 for false). |
 | <a name='input_connector_buffered_records'>`input_connector_buffered_records`</a> |gauge | Amount of data currently buffered by an input connector, in records. |
 | <a name='input_connector_buffered_records_bytes'>`input_connector_buffered_records_bytes`</a> |gauge | Amount of data currently buffered by an input connector, in bytes. |
 | <a name='input_connector_bytes_total'>`input_connector_bytes_total`</a> |counter | Total number of bytes received by an input connector. |
 | <a name='input_connector_completion_latency_seconds'>`input_connector_completion_latency_seconds`</a> |histogram | Time between when the connector receives new data and when the pipeline processes this data, computes output updates, and sends these updates to all output connectors, over the last 600 seconds or 10,000 samples. |
+| <a name='input_connector_delta_phase'>`input_connector_delta_phase`</a> |gauge | Current phase: 0=loading_snapshot, 1=follow/streaming, 2=completed. |
+| <a name='input_connector_delta_snapshot_completed_seconds'>`input_connector_delta_snapshot_completed_seconds`</a> |gauge | Unix epoch seconds when the snapshot phase finished (0 if not yet complete). |
+| <a name='input_connector_delta_snapshot_records_total'>`input_connector_delta_snapshot_records_total`</a> |counter | Total records loaded during the snapshot phase. |
+| <a name='input_connector_end_of_input'>`input_connector_end_of_input`</a> |gauge | Whether the input connector has reached end of input (1 for true, 0 for false). |
 | <a name='input_connector_errors_parse_total'>`input_connector_errors_parse_total`</a> |counter | Total number of errors encountered parsing records received by the input connector. |
 | <a name='input_connector_errors_transport_total'>`input_connector_errors_transport_total`</a> |counter | Total number of errors encountered by the input connector at the transport layer. |
 | <a name='input_connector_extra_memory_bytes'>`input_connector_extra_memory_bytes`</a> |gauge | Additional memory used by an input connector beyond that used for buffered records. |
 | <a name='input_connector_processing_latency_seconds'>`input_connector_processing_latency_seconds`</a> |histogram | Time between when the connector receives new data and when the pipeline processes this data and computes output updates, over the last 600 seconds or 10,000 samples. |
 | <a name='input_connector_records_total'>`input_connector_records_total`</a> |counter | Total number of records received by an input connector. |
+| <a name='input_connector_running'>`input_connector_running`</a> |gauge | Whether the input connector is running (1) or paused by the user (0). |
 
 ## Output Connectors
 


### PR DESCRIPTION
Fixes #5676 

- Exports additional metrics for input connectors, including paused, barrier, and end-of-input (eoi) states.
- Enhances logging for delta lake connector mode transitions with more detailed information.
- Introduces the ConnectorMetrics trait and ValueType enum, enabling connectors to register and export custom Prometheus metrics via InputConsumer::set_custom_metrics. Implements custom metrics for the Delta Lake input connector, tracking phase transitions, timestamps, and record counts.

### Describe Manual Test Plan

Ran pipeline locally and checked the logs and Prometheus metrics manually

## Checklist

- [x] Unit tests added/updated


## Breaking Changes?

No incompatible changes. Existing connectors and configurations remain compatible; new metrics are additive.
