### PR TITLE
[SQL] Make sure that cargo.lock exists before compiling Rust

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
@@ -278,8 +278,10 @@ public class MultiCrateTests extends BaseSQLTests {
                     this.appendCargoDependencies(cargoContents);
                 }
             }
-            if (!BaseSQLTests.skipRust && !Utilities.inCI())
+            if (!BaseSQLTests.skipRust && !Utilities.inCI()) {
+                setupCargoLock();
                 Utilities.compileAndCheckRust(BaseSQLTests.RUST_MULTI_DIRECTORY, true);
+            }
             Utilities.deleteFile(udf, true);
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -180,6 +180,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         File file = createInputScript(sql);
         CompilerMain.execute("-TSqlToRelCompiler=2", "-TPasses=2",
                 "-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
+        BaseSQLTests.compileAndCheckRust(true);
         Logger.INSTANCE.setDebugStream(save);
         String messages = builder.toString();
         Assert.assertTrue(messages.contains("After optimizer"));
@@ -290,8 +291,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         if (messages.errorCount() > 0)
             throw new RuntimeException(messages.toString());
-        if (!BaseSQLTests.skipRust)
-            Utilities.compileAndCheckRust(BaseSQLTests.RUST_DIRECTORY, true);
+        BaseSQLTests.compileAndCheckRust(true);
     }
 
     void compileFile(String file, boolean run) throws SQLException, IOException, InterruptedException {
@@ -299,8 +299,8 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
                 "-i", "--alltables", "-q", "--ignoreOrder", "-o", BaseSQLTests.TEST_FILE_PATH, file);
         messages.print();
         Assert.assertEquals(0, messages.errorCount());
-        if (run && !BaseSQLTests.skipRust)
-            Utilities.compileAndCheckRust(BaseSQLTests.RUST_DIRECTORY, true);
+        if (run)
+            BaseSQLTests.compileAndCheckRust(true);
         // cleanup after ourselves
         createEmptyStubs();
     }
@@ -399,8 +399,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         CompilerMessages messages = CompilerMain.execute("-q", "-o", BaseSQLTests.TEST_FILE_PATH, file.getPath());
         messages.print();
         Assert.assertEquals(0, messages.exitCode);
-        if (!BaseSQLTests.skipRust)
-            Utilities.compileAndCheckRust(BaseSQLTests.RUST_DIRECTORY, true);
+        BaseSQLTests.compileAndCheckRust(true);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/QATests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/QATests.java
@@ -21,8 +21,7 @@ public class QATests {
             messages.print();
             throw new RuntimeException("Error during compilation");
         }
-        if (!BaseSQLTests.skipRust)
-            Utilities.compileAndCheckRust(BaseSQLTests.PROJECT_DIRECTORY, true);
+        BaseSQLTests.compileAndCheckRust(true);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -186,6 +186,13 @@ public class BaseSQLTests {
         }
     }
 
+    public static void compileAndCheckRust(boolean quiet) throws IOException, InterruptedException {
+        if (!BaseSQLTests.skipRust) {
+            BaseSQLTests.setupCargoLock();
+            Utilities.compileAndCheckRust(BaseSQLTests.RUST_DIRECTORY, quiet);
+        }
+    }
+
     /** Compile a set of statements that are expected to give a warning at compile time.
      * @param statements  Statement to run.
      * @param regex       This regular expression should match the warning message. */
@@ -355,12 +362,11 @@ public class BaseSQLTests {
             outputStream.close();
         stubsWriter.write(compiler);
         if (!skipRust) {
-            if (Utilities.inCI()) {
-                // In CI we use multi-crate compilation
+            if (multiCrates) {
                 MultiCrateTests.setupCargoLock();
+            } else {
+                BaseSQLTests.setupCargoLock();
             }
-
-            BaseSQLTests.setupCargoLock();
             if (check) {
                 Utilities.compileAndCheckRust(directory, true, testCrate);
             } else {


### PR DESCRIPTION
Hopefully this will fix some nondeterministic errors that appear in CI due to missing cargo.lock files.

The errors look like this:

```
error[E0308]: mismatched types
   --> /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/jemalloc_pprof-0.7.0/src/lib.rs:167:49
    |
167 |         let profile = parse_jeheap(dump_reader, MAPPINGS.as_deref())?;
    |                       ------------              ^^^^^^^^^^^^^^^^^^^ expected `Mapping`, found `pprof_util::Mapping`
    |                       |
    |                       arguments to this function are incorrect
    |
note: two different versions of crate `pprof_util` are being used; two types coming from two different versions of the same crate are different types even if they look the same
```

### Describe Manual Test Plan

Ran Java tests

