### PR TITLE
[RFC][Connectors]: Add native s2 input and output connector support in Feldera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "impl-more",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
@@ -605,8 +605,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -629,8 +629,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "uuid",
  "zstd 0.13.3",
@@ -1269,7 +1269,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.3.1",
+ "http 1.4.2",
  "sha1 0.10.6",
  "time",
  "tokio",
@@ -1365,7 +1365,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -1393,7 +1393,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1417,7 +1417,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1447,7 +1447,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -1476,7 +1476,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1500,7 +1500,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1524,7 +1524,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1549,7 +1549,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -1571,7 +1571,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "p256",
  "percent-encoding",
  "ring",
@@ -1604,7 +1604,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "md-5",
@@ -1638,7 +1638,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -1656,9 +1656,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.13",
- "http 1.3.1",
- "hyper 1.6.0",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -1714,7 +1714,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1734,7 +1734,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -1752,7 +1752,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bigdecimal"
@@ -2201,7 +2201,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2279,9 +2279,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2389,6 +2389,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbc"
@@ -2646,6 +2655,21 @@ dependencies = [
  "crossterm",
  "unicode-segmentation",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3189,6 +3213,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +3251,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3281,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -4187,6 +4245,7 @@ dependencies = [
  "rmpv",
  "roaring",
  "rustls",
+ "s2-sdk",
  "schema_registry_converter",
  "semver",
  "sentry",
@@ -4439,7 +4498,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlparser",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4949,6 +5008,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,7 +5232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
- "http 1.3.1",
+ "http 1.4.2",
  "rand 0.8.6",
  "url-escape",
 ]
@@ -5903,7 +5983,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c0bd8a7c986d35cbe8acd226b34a2a9ff4ffcaa2b00c47e6fb74b730d351f1"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.2",
  "thiserror 2.0.18",
  "token-source",
  "tokio",
@@ -6152,16 +6232,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.2",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -6374,12 +6454,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -6401,7 +6480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -6412,7 +6491,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -6476,15 +6555,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.13",
- "http 1.3.1",
+ "futures-core",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -6501,8 +6581,8 @@ version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "http 1.3.1",
- "hyper 1.6.0",
+ "http 1.4.2",
+ "hyper 1.11.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs 0.8.1",
@@ -6519,7 +6599,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -6534,7 +6614,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -6553,14 +6633,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -6637,7 +6717,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "strum",
+ "strum 0.27.2",
  "tokio",
  "tracing",
  "typed-builder 0.20.1",
@@ -6670,7 +6750,7 @@ source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306
 dependencies = [
  "async-trait",
  "chrono",
- "http 1.3.1",
+ "http 1.4.2",
  "iceberg",
  "itertools 0.13.0",
  "reqwest 0.12.24",
@@ -7032,6 +7112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7313,9 +7402,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -7690,14 +7779,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8083,11 +8172,11 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "itertools 0.14.0",
  "md-5",
  "parking_lot 0.12.4",
@@ -8123,11 +8212,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "itertools 0.14.0",
  "md-5",
  "parking_lot 0.12.4",
@@ -8211,7 +8300,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "jiff",
  "log",
@@ -8236,7 +8325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
 dependencies = [
  "futures",
- "http 1.3.1",
+ "http 1.4.2",
  "mea",
  "opendal-core",
 ]
@@ -8294,7 +8383,7 @@ checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.3.1",
+ "http 1.4.2",
  "log",
  "opendal-core",
  "percent-encoding",
@@ -8316,7 +8405,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "crc32c",
- "http 1.3.1",
+ "http 1.4.2",
  "log",
  "md-5",
  "opendal-core",
@@ -9845,7 +9934,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10319,7 +10408,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "http 1.3.1",
+ "http 1.4.2",
  "log",
  "percent-encoding",
  "quick-xml 0.40.1",
@@ -10344,7 +10433,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac 0.13.0",
- "http 1.3.1",
+ "http 1.4.2",
  "jiff",
  "log",
  "percent-encoding",
@@ -10374,7 +10463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb215d0876a18b6bd9cdd380b589e5292aaa638ca15266de794b1122d898b6b2"
 dependencies = [
  "form_urlencoded",
- "http 1.3.1",
+ "http 1.4.2",
  "log",
  "percent-encoding",
  "reqsign-aws-v4",
@@ -10435,11 +10524,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.3.1",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -10483,11 +10572,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.3.1",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -10521,7 +10610,7 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.3.1",
+ "http 1.4.2",
  "reqwest 0.12.24",
  "serde",
  "thiserror 1.0.69",
@@ -10538,8 +10627,8 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.16",
- "http 1.3.1",
- "hyper 1.6.0",
+ "http 1.4.2",
+ "hyper 1.11.0",
  "parking_lot 0.11.2",
  "reqwest 0.12.24",
  "reqwest-middleware",
@@ -10559,7 +10648,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "getrandom 0.2.16",
- "http 1.3.1",
+ "http 1.4.2",
  "matchit",
  "reqwest 0.12.24",
  "reqwest-middleware",
@@ -11025,6 +11114,90 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "s2-api"
+version = "0.30.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682ebfe560316dfc2ee0afc6354511b214005b87aab16f80053dd68843db4d46"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "compact_str",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "itertools 0.15.0",
+ "mime",
+ "prost 0.14.3",
+ "s2-common",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "time",
+ "tokio-util",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "s2-common"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7e23d63211c1bb5154d040156edfa708097ac22ce21bea93666a34c749813e"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "compact_str",
+ "enumset",
+ "http 1.4.2",
+ "rand 0.10.1",
+ "secrecy",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "s2-sdk"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a820d0f43eb7dfb43d6e0d7304ccac9cc5b01ebeef6dca3c809c9b6e87a86ad9"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "prost 0.14.3",
+ "rand 0.10.1",
+ "rustls",
+ "s2-api",
+ "s2-common",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-muxt",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "urlencoding",
+ "uuid",
+]
 
 [[package]]
 name = "salsa20"
@@ -11699,9 +11872,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -11856,12 +12029,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12328,7 +12501,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -12336,6 +12518,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -12842,9 +13036,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -12852,20 +13046,30 @@ dependencies = [
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-muxt"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79eac432d68f5cc5ca99654adddb6ffc9501618bc267303d18a1f768ea01e7c"
+dependencies = [
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -12998,6 +13202,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -13013,7 +13218,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.2",
  "httparse",
  "rand 0.8.6",
  "ring",
@@ -13075,10 +13280,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -13133,7 +13338,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -13275,7 +13480,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -13555,7 +13760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -13659,13 +13864,13 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -14673,9 +14878,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool 0.10.0",
  "futures",
- "http 1.3.1",
+ "http 1.4.2",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ rmpv = "1.3.0"
 # Rust and may start requiring newer compiler features in patch releases.
 roaring = "=0.11.3"
 rstest = "0.15"
-s2-sdk = "0.26.0"
+s2-sdk = "0.31.10"
 # Make sure this is the same rustls version used by the `tonic` crate.
 # See the `ensure_default_crypto_provider` function.
 rustls = "0.23.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ rmpv = "1.3.0"
 # Rust and may start requiring newer compiler features in patch releases.
 roaring = "=0.11.3"
 rstest = "0.15"
+s2-sdk = "0.24.4"
 # Make sure this is the same rustls version used by the `tonic` crate.
 # See the `ensure_default_crypto_provider` function.
 rustls = "0.23.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ rmpv = "1.3.0"
 # Rust and may start requiring newer compiler features in patch releases.
 roaring = "=0.11.3"
 rstest = "0.15"
-s2-sdk = "0.24.4"
+s2-sdk = "0.26.0"
 # Make sure this is the same rustls version used by the `tonic` crate.
 # See the `ensure_default_crypto_provider` function.
 rustls = "0.23.12"

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -27,6 +27,7 @@ default = [
     "with-postgres-cdc",
     "with-dynamodb",
     "with-heap-profiling",
+    "with-s2",
 ]
 with-kafka = ["rdkafka"]
 # `parquet/async` + `parquet/object_store` serve only the deletion-vector
@@ -53,6 +54,7 @@ with-dynamodb = [
 with-nexmark = ["dbsp_nexmark"]
 with-redis = ["redis", "r2d2"]
 with-nats = []
+with-s2 = ["s2-sdk"]
 # Run delta table tests against an S3 bucket.  Requires S3 authentication key
 # to be provided via an environment variable.
 delta-s3-test = []
@@ -91,6 +93,7 @@ awc = { workspace = true, features = [
 async-nats = { workspace = true }
 async-stream = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
+s2-sdk = { workspace = true, optional = true }
 bytestring = "1.4.0"
 circular-queue = { workspace = true, features = ["serde_support"] }
 crossbeam = { workspace = true }

--- a/crates/adapters/README.md
+++ b/crates/adapters/README.md
@@ -126,6 +126,7 @@ where any string key is valid and should not be reported as an error.
 | `postgres_cdc_input` | `PostgresCdcReaderConfig` |
 | `pub_sub_input`      | `PubSubInputConfig`       |
 | `s3_input`           | `S3InputConfig`           |
+| `s2_input`           | `S2InputConfig`           |
 | `url_input`          | `UrlInputConfig`          |
 
 #### Transport (output)
@@ -138,6 +139,7 @@ where any string key is valid and should not be reported as an error.
 | `kafka_output`       | `KafkaOutputConfig`      |
 | `postgres_output`    | `PostgresWriterConfig`   |
 | `redis_output`       | `RedisOutputConfig`      |
+| `s2_output`          | `S2OutputConfig`         |
 
 Not validated by the SQL compiler: `datagen`, `nexmark`.
 

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -16,8 +16,8 @@ use feldera_adapterlib::format::Splitter;
 use feldera_sqllib::Variant;
 use feldera_types::format::json::{JsonLines, JsonParserConfig, JsonUpdateFormat};
 use serde::Deserialize;
-use serde_json::json;
 use serde_json::value::RawValue;
+use serde_json::{Value as JsonValue, json};
 use serde_urlencoded::Deserializer as UrlDeserializer;
 use std::borrow::Cow;
 
@@ -255,6 +255,51 @@ fn validate_parser_config(
     Ok(())
 }
 
+fn is_insert_delete_action_key(key: &str) -> bool {
+    matches!(key, "insert" | "delete" | "update")
+}
+
+fn looks_like_insert_delete_envelope_object(value: &JsonValue) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    let mut action_key = None;
+    for key in object.keys() {
+        if key == "table" {
+            continue;
+        }
+        if is_insert_delete_action_key(key) {
+            if action_key.is_some() {
+                return false;
+            }
+            action_key = Some(key);
+        } else {
+            return false;
+        }
+    }
+
+    let Some(action_key) = action_key else {
+        return false;
+    };
+
+    matches!(
+        object.get(action_key),
+        Some(JsonValue::Object(_) | JsonValue::Array(_))
+    )
+}
+
+fn looks_like_insert_delete_envelope(update: &RawValue) -> bool {
+    let Ok(value) = serde_json::from_str::<JsonValue>(update.get()) else {
+        return false;
+    };
+
+    looks_like_insert_delete_envelope_object(&value)
+        || value.as_array().is_some_and(|array| {
+            !array.is_empty() && array.iter().all(looks_like_insert_delete_envelope_object)
+        })
+}
+
 struct JsonParser {
     /// Input handle to push parsed data to.
     input_stream: Box<dyn DeCollectionStream>,
@@ -263,6 +308,18 @@ struct JsonParser {
 }
 
 impl JsonParser {
+    fn raw_format_insert_delete_mismatch_error(update: &RawValue) -> Option<ParseError> {
+        looks_like_insert_delete_envelope(update).then(|| {
+            ParseError::text_envelope_error(
+                "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                update.get(),
+                Some(Cow::from(
+                    "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",
+                )),
+            )
+        })
+    }
+
     fn new(input_stream: Box<dyn DeCollectionStream>, config: JsonParserConfig) -> Self {
         Self {
             input_stream,
@@ -404,7 +461,12 @@ impl Parser for JsonParser {
                     self.apply_update::<WeightedUpdate<_>>(update, &metadata, &mut errors)
                 }
                 JsonUpdateFormat::Raw => {
-                    self.apply_update::<&RawValue>(update, &metadata, &mut errors)
+                    if let Some(error) = Self::raw_format_insert_delete_mismatch_error(update) {
+                        errors.push(error);
+                        self.last_event_number += 1;
+                    } else {
+                        self.apply_update::<&RawValue>(update, &metadata, &mut errors);
+                    }
                 }
                 JsonUpdateFormat::Redis | JsonUpdateFormat::Snowflake => {
                     panic!("Unexpected update format: {:?}", &self.config.update_format)
@@ -850,6 +912,45 @@ mod test {
                 vec![ (r#"[[true, 0, "e"]]"#.to_string(), Vec::new())
                             , (r#"[[false, 100, "foo"]]"#.to_string(), Vec::new())],
                 vec![MockUpdate::with_polarity(TestStruct::new(true, 0, Some("e")), true), MockUpdate::with_polarity(TestStruct::new(false, 100, Some("foo")), true)],
+            ),
+            // raw: insert/delete envelope hint.
+            TestCase::new(
+                JsonParserConfig {
+                    update_format: JsonUpdateFormat::Raw,
+                    json_flavor: JsonFlavor::Default,
+                    array: false,
+                    lines: JsonLines::Single,
+                },
+                vec![(
+                    r#"{"insert": {"b": true, "i": 0}}"#.to_string(),
+                    vec![ParseError::text_envelope_error(
+                        "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                        "{\"insert\": {\"b\": true, \"i\": 0}}",
+                        Some(Cow::from(
+                            "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",
+                        )),
+                    )],
+                )],
+                Vec::new(),
+            ),
+            TestCase::new(
+                JsonParserConfig {
+                    update_format: JsonUpdateFormat::Raw,
+                    json_flavor: JsonFlavor::Default,
+                    array: true,
+                    lines: JsonLines::Single,
+                },
+                vec![(
+                    r#"[{"insert": {"b": true, "i": 0}}]"#.to_string(),
+                    vec![ParseError::text_envelope_error(
+                        "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                        "[{\"insert\": {\"b\": true, \"i\": 0}}]",
+                        Some(Cow::from(
+                            "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",
+                        )),
+                    )],
+                )],
+                Vec::new(),
             ),
             // raw: invalid json.
             TestCase::new(

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -461,11 +461,17 @@ impl Parser for JsonParser {
                     self.apply_update::<WeightedUpdate<_>>(update, &metadata, &mut errors)
                 }
                 JsonUpdateFormat::Raw => {
-                    if let Some(error) = Self::raw_format_insert_delete_mismatch_error(update) {
-                        errors.push(error);
-                        self.last_event_number += 1;
-                    } else {
-                        self.apply_update::<&RawValue>(update, &metadata, &mut errors);
+                    let errors_before = errors.len();
+                    self.apply_update::<&RawValue>(update, &metadata, &mut errors);
+                    // On parse failure, check if the user sent insert/delete
+                    // envelopes with the raw format and provide a better hint.
+                    if errors.len() > errors_before {
+                        if let Some(error) =
+                            Self::raw_format_insert_delete_mismatch_error(update)
+                        {
+                            errors.truncate(errors_before);
+                            errors.push(error);
+                        }
                     }
                 }
                 JsonUpdateFormat::Redis | JsonUpdateFormat::Snowflake => {

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -466,9 +466,7 @@ impl Parser for JsonParser {
                     // On parse failure, check if the user sent insert/delete
                     // envelopes with the raw format and provide a better hint.
                     if errors.len() > errors_before {
-                        if let Some(error) =
-                            Self::raw_format_insert_delete_mismatch_error(update)
-                        {
+                        if let Some(error) = Self::raw_format_insert_delete_mismatch_error(update) {
                             errors.truncate(errors_before);
                             errors.push(error);
                         }

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -465,11 +465,11 @@ impl Parser for JsonParser {
                     self.apply_update::<&RawValue>(update, &metadata, &mut errors);
                     // On parse failure, check if the user sent insert/delete
                     // envelopes with the raw format and provide a better hint.
-                    if errors.len() > errors_before {
-                        if let Some(error) = Self::raw_format_insert_delete_mismatch_error(update) {
-                            errors.truncate(errors_before);
-                            errors.push(error);
-                        }
+                    if errors.len() > errors_before
+                        && let Some(error) = Self::raw_format_insert_delete_mismatch_error(update)
+                    {
+                        errors.truncate(errors_before);
+                        errors.push(error);
                     }
                 }
                 JsonUpdateFormat::Redis | JsonUpdateFormat::Snowflake => {

--- a/crates/adapters/src/format/json/input.rs
+++ b/crates/adapters/src/format/json/input.rs
@@ -255,38 +255,25 @@ fn validate_parser_config(
     Ok(())
 }
 
-fn is_insert_delete_action_key(key: &str) -> bool {
-    matches!(key, "insert" | "delete" | "update")
-}
-
 fn looks_like_insert_delete_envelope_object(value: &JsonValue) -> bool {
     let Some(object) = value.as_object() else {
         return false;
     };
 
-    let mut action_key = None;
-    for key in object.keys() {
-        if key == "table" {
-            continue;
-        }
-        if is_insert_delete_action_key(key) {
-            if action_key.is_some() {
-                return false;
+    let mut has_action_key = false;
+    for (key, value) in object {
+        match key.as_str() {
+            "table" => (),
+            "insert" | "delete" | "update" => {
+                if has_action_key || (!value.is_object() && !value.is_array()) {
+                    return false;
+                }
+                has_action_key = true;
             }
-            action_key = Some(key);
-        } else {
-            return false;
+            _ => return false,
         }
     }
-
-    let Some(action_key) = action_key else {
-        return false;
-    };
-
-    matches!(
-        object.get(action_key),
-        Some(JsonValue::Object(_) | JsonValue::Array(_))
-    )
+    has_action_key
 }
 
 fn looks_like_insert_delete_envelope(update: &RawValue) -> bool {
@@ -311,7 +298,7 @@ impl JsonParser {
     fn raw_format_insert_delete_mismatch_error(update: &RawValue) -> Option<ParseError> {
         looks_like_insert_delete_envelope(update).then(|| {
             ParseError::text_envelope_error(
-                "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                "payload looks like an insert/delete envelope; the configured `raw` update format expects plain rows".to_string(),
                 update.get(),
                 Some(Cow::from(
                     "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",
@@ -928,7 +915,7 @@ mod test {
                 vec![(
                     r#"{"insert": {"b": true, "i": 0}}"#.to_string(),
                     vec![ParseError::text_envelope_error(
-                        "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                        "payload looks like an insert/delete envelope; the configured `raw` update format expects plain rows".to_string(),
                         "{\"insert\": {\"b\": true, \"i\": 0}}",
                         Some(Cow::from(
                             "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",
@@ -947,7 +934,7 @@ mod test {
                 vec![(
                     r#"[{"insert": {"b": true, "i": 0}}]"#.to_string(),
                     vec![ParseError::text_envelope_error(
-                        "raw JSON update format expects plain rows, but received an insert/delete/update envelope".to_string(),
+                        "payload looks like an insert/delete envelope; the configured `raw` update format expects plain rows".to_string(),
                         "[{\"insert\": {\"b\": true, \"i\": 0}}]",
                         Some(Cow::from(
                             "Set `format.config.update_format` to `insert_delete` for payloads like {\"insert\": {...}} or {\"delete\": {...}}.",

--- a/crates/adapters/src/transport.rs
+++ b/crates/adapters/src/transport.rs
@@ -76,7 +76,7 @@ use crate::transport::null::NullOutputEndpoint;
 use crate::transport::nats::NatsInputEndpoint;
 
 #[cfg(feature = "with-s2")]
-use crate::transport::s2::S2InputEndpoint;
+use crate::transport::s2::{S2InputEndpoint, S2OutputEndpoint};
 
 #[cfg(feature = "with-nexmark")]
 use crate::transport::nexmark::NexmarkEndpoint;
@@ -138,6 +138,7 @@ pub fn input_transport_config_to_endpoint(
         | TransportConfig::HttpOutput(_)
         | TransportConfig::RedisOutput(_)
         | TransportConfig::IcebergInput(_)
+        | TransportConfig::S2Output(_)
         | TransportConfig::NullOutput => return Ok(None),
     };
     Ok(Some(endpoint))
@@ -173,6 +174,10 @@ pub fn output_transport_config_to_endpoint(
         #[cfg(feature = "with-redis")]
         TransportConfig::RedisOutput(config) => {
             Ok(Some(Box::new(RedisOutputEndpoint::new(config)?)))
+        }
+        #[cfg(feature = "with-s2")]
+        TransportConfig::S2Output(config) => {
+            Ok(Some(Box::new(S2OutputEndpoint::new(config)?)))
         }
         TransportConfig::NullOutput => Ok(Some(Box::new(NullOutputEndpoint))),
         _ => Ok(None),

--- a/crates/adapters/src/transport.rs
+++ b/crates/adapters/src/transport.rs
@@ -47,6 +47,9 @@ pub(crate) mod kafka;
 #[cfg(feature = "with-nats")]
 pub(crate) mod nats;
 
+#[cfg(feature = "with-s2")]
+pub(crate) mod s2;
+
 #[cfg(feature = "with-nexmark")]
 mod nexmark;
 
@@ -71,6 +74,9 @@ use crate::transport::null::NullOutputEndpoint;
 
 #[cfg(feature = "with-nats")]
 use crate::transport::nats::NatsInputEndpoint;
+
+#[cfg(feature = "with-s2")]
+use crate::transport::s2::S2InputEndpoint;
 
 #[cfg(feature = "with-nexmark")]
 use crate::transport::nexmark::NexmarkEndpoint;
@@ -102,6 +108,10 @@ pub fn input_transport_config_to_endpoint(
         TransportConfig::NatsInput(config) => Box::new(NatsInputEndpoint::new(config)?),
         #[cfg(not(feature = "with-nats"))]
         TransportConfig::NatsInput(_) => return Ok(None),
+        #[cfg(feature = "with-s2")]
+        TransportConfig::S2Input(config) => Box::new(S2InputEndpoint::new(config)?),
+        #[cfg(not(feature = "with-s2"))]
+        TransportConfig::S2Input(_) => return Ok(None),
         #[cfg(feature = "with-pubsub")]
         TransportConfig::PubSubInput(config) => Box::new(PubSubInputEndpoint::new(config.clone())?),
         #[cfg(not(feature = "with-pubsub"))]

--- a/crates/adapters/src/transport.rs
+++ b/crates/adapters/src/transport.rs
@@ -176,9 +176,7 @@ pub fn output_transport_config_to_endpoint(
             Ok(Some(Box::new(RedisOutputEndpoint::new(config)?)))
         }
         #[cfg(feature = "with-s2")]
-        TransportConfig::S2Output(config) => {
-            Ok(Some(Box::new(S2OutputEndpoint::new(config)?)))
-        }
+        TransportConfig::S2Output(config) => Ok(Some(Box::new(S2OutputEndpoint::new(config)?))),
         TransportConfig::NullOutput => Ok(Some(Box::new(NullOutputEndpoint))),
         _ => Ok(None),
     }

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -13,19 +13,26 @@ use feldera_types::{
     transport::s2::{S2InputConfig, S2StartFrom},
 };
 use futures::StreamExt;
-use s2_sdk::{S2, types::{AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, S2Config, S2Endpoints}};
+use s2_sdk::{
+    S2,
+    types::{
+        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, S2Config, S2Endpoints,
+    },
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::hash::Hasher;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::{
     select,
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     task::JoinHandle,
+    time::sleep,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, error, info, info_span};
+use tracing::{Instrument, error, info, info_span, warn};
 use xxhash_rust::xxh3::Xxh3Default;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,6 +104,14 @@ fn config_to_read_input(config: &S2InputConfig) -> ReadInput {
     ReadInput::new().with_start(start)
 }
 
+fn read_input_for_position(config: &S2InputConfig, next_seq: u64) -> ReadInput {
+    if next_seq > 0 {
+        make_read_input(next_seq)
+    } else {
+        config_to_read_input(config)
+    }
+}
+
 struct S2Reader {
     command_sender: UnboundedSender<InputReaderCommand>,
 }
@@ -132,7 +147,9 @@ impl S2Reader {
                     };
                     let client = S2::new(s2_config)?;
                     let basin = client.basin(config.basin.parse().map_err(|e| anyhow!("{e}"))?);
-                    Ok::<_, AnyError>(basin.stream(config.stream.parse().map_err(|e| anyhow!("{e}"))?))
+                    Ok::<_, AnyError>(
+                        basin.stream(config.stream.parse().map_err(|e| anyhow!("{e}"))?),
+                    )
                 }
                 .instrument(span.clone()),
             )
@@ -146,10 +163,17 @@ impl S2Reader {
 
         let consumer_clone = consumer.clone();
         TOKIO.spawn(async move {
-            Self::worker_task(config, resume_info, s2_stream, consumer_clone, parser, command_receiver)
-                .instrument(span)
-                .await
-                .unwrap_or_else(|e| consumer.error(true, e, Some("s2-input")));
+            Self::worker_task(
+                config,
+                resume_info,
+                s2_stream,
+                consumer_clone,
+                parser,
+                command_receiver,
+            )
+            .instrument(span)
+            .await
+            .unwrap_or_else(|e| consumer.error(true, e, Some("s2-input")));
         });
 
         Ok(Self { command_sender })
@@ -178,10 +202,9 @@ impl S2Reader {
                 let last = metadata.seq_num_range.end - 1;
 
                 let read_input = make_read_input(first);
-                let mut session = s2_stream
-                    .read_session(read_input)
-                    .await
-                    .with_context(|| format!("Failed to create read session for replay from {first}"))?;
+                let mut session = s2_stream.read_session(read_input).await.with_context(|| {
+                    format!("Failed to create read session for replay from {first}")
+                })?;
 
                 let mut hasher = Xxh3Default::new();
                 let mut buffer_size = BufferSize::default();
@@ -202,7 +225,10 @@ impl S2Reader {
                             buffer.hash(&mut hasher);
                             buffer.flush();
                         }
-                        let amt = BufferSize { records: 1, bytes: data.len() };
+                        let amt = BufferSize {
+                            records: 1,
+                            bytes: data.len(),
+                        };
                         consumer.buffered(amt);
                         buffer_size += amt;
                         if record.seq_num == last {
@@ -238,7 +264,9 @@ impl S2Reader {
                         }
                     };
                     info!("Queued {:?} records ({seq_range:?})", buffer_size);
-                    let metadata_json = serde_json::to_value(&Metadata { seq_num_range: seq_range })?;
+                    let metadata_json = serde_json::to_value(&Metadata {
+                        seq_num_range: seq_range,
+                    })?;
                     let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
                     let hash = hasher.map(|h| h.finish()).unwrap_or(0);
                     let resume = Resume::Replay {
@@ -261,19 +289,9 @@ impl S2Reader {
                     let cur_seq = next_seq.load(Ordering::Acquire);
                     info!("Extend from {cur_seq}");
                     if canceller.is_none() {
-                        let read_input = if cur_seq > 0 {
-                            make_read_input(cur_seq)
-                        } else {
-                            config_to_read_input(&config)
-                        };
-
-                        let session = s2_stream
-                            .read_session(read_input)
-                            .await
-                            .with_context(|| format!("Failed to create S2 read session from seq {cur_seq}"))?;
-
                         canceller = Some(spawn_s2_reader(
-                            session,
+                            s2_stream.clone(),
+                            config.clone(),
                             next_seq.clone(),
                             queue.clone(),
                             consumer.clone(),
@@ -292,44 +310,92 @@ impl S2Reader {
 }
 
 fn spawn_s2_reader(
-    mut session: impl futures::Stream<Item = Result<s2_sdk::types::ReadBatch, s2_sdk::types::S2Error>> + Send + Unpin + 'static,
+    s2_stream: Arc<s2_sdk::S2Stream>,
+    config: Arc<S2InputConfig>,
     next_seq: Arc<AtomicU64>,
     queue: Arc<InputQueue<u64>>,
     consumer: Box<dyn InputConsumer>,
     mut parser: Box<dyn Parser>,
 ) -> Canceller {
+    const RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+    const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
+
     let cancel_token = CancellationToken::new();
     let join_handle = tokio::spawn({
         let cancel_token_copy = cancel_token.clone();
         async move {
+            let mut retry_delay = RETRY_BASE_DELAY;
             loop {
-                select! {
-                    _ = cancel_token_copy.cancelled() => break,
-                    result = session.next() => {
-                        let Some(result) = result else {
-                            consumer.error(true, anyhow!("Unexpected end of S2 stream"), Some("s2-input"));
-                            return;
-                        };
-                        match result {
-                            Ok(batch) => {
-                                for record in &batch.records {
-                                    info!("Got record #{}", record.seq_num);
-                                    next_seq.store(record.seq_num + 1, Ordering::Release);
-                                    let data = &record.body;
-                                    queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
-                                }
-                            }
-                            Err(error) => {
-                                consumer.error(false, anyhow!("S2 error: {error}"), Some("s2-input"));
+                let start_seq = next_seq.load(Ordering::Acquire);
+                let read_input = read_input_for_position(&config, start_seq);
+
+                let mut session = match s2_stream.read_session(read_input).await {
+                    Ok(session) => {
+                        retry_delay = RETRY_BASE_DELAY;
+                        session
+                    }
+                    Err(error) => {
+                        consumer.error(
+                            false,
+                            anyhow!("Failed to create S2 read session: {error}"),
+                            Some("s2-input"),
+                        );
+                        warn!(
+                            next_seq = start_seq,
+                            "S2 session setup failed; retrying in {:?}: {error}", retry_delay
+                        );
+                        select! {
+                            _ = cancel_token_copy.cancelled() => break,
+                            _ = sleep(retry_delay) => {
+                                retry_delay = std::cmp::min(retry_delay.saturating_mul(2), RETRY_MAX_DELAY);
                             }
                         }
+                        continue;
+                    }
+                };
+
+                loop {
+                    select! {
+                        _ = cancel_token_copy.cancelled() => break,
+                        result = session.next() => {
+                            let Some(result) = result else {
+                                consumer.error(false, anyhow!("S2 read session ended; reconnecting"), Some("s2-input"));
+                                warn!("S2 read session ended; reconnecting in {:?}", retry_delay);
+                                break;
+                            };
+                            match result {
+                                Ok(batch) => {
+                                    for record in &batch.records {
+                                        info!("Got record #{}", record.seq_num);
+                                        next_seq.store(record.seq_num + 1, Ordering::Release);
+                                        let data = &record.body;
+                                        queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
+                                    }
+                                }
+                                Err(error) => {
+                                    consumer.error(false, anyhow!("S2 error: {error}"), Some("s2-input"));
+                                    warn!("S2 stream error; reconnecting in {:?}: {error}", retry_delay);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                select! {
+                    _ = cancel_token_copy.cancelled() => break,
+                    _ = sleep(retry_delay) => {
+                        retry_delay = std::cmp::min(retry_delay.saturating_mul(2), RETRY_MAX_DELAY);
                     }
                 }
             }
         }
     });
 
-    Canceller { cancel_token, join_handle }
+    Canceller {
+        cancel_token,
+        join_handle,
+    }
 }
 
 struct Canceller {

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -1,0 +1,355 @@
+use crate::{
+    InputConsumer, InputEndpoint, InputReader, Parser, TransportInputEndpoint,
+    transport::{InputQueue, InputReaderCommand},
+};
+use anyhow::{Context, Error as AnyError, Result as AnyResult, anyhow};
+use chrono::Utc;
+use dbsp::circuit::tokio::TOKIO;
+use feldera_adapterlib::format::BufferSize;
+use feldera_adapterlib::transport::{InputCommandReceiver, Resume, Watermark};
+use feldera_types::{
+    config::FtModel,
+    program_schema::Relation,
+    transport::s2::{S2InputConfig, S2StartFrom},
+};
+use futures::StreamExt;
+use s2_sdk::{S2, types::{AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, S2Config, S2Endpoints}};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::hash::Hasher;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::{
+    select,
+    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, error, info, info_span};
+use xxhash_rust::xxh3::Xxh3Default;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Metadata {
+    pub(crate) seq_num_range: std::ops::Range<u64>,
+}
+
+impl Metadata {
+    pub(crate) fn from_resume_info(resume_info: Option<JsonValue>) -> Result<Self, AnyError> {
+        Ok(resume_info
+            .map(serde_json::from_value)
+            .transpose()?
+            .unwrap_or(Self {
+                seq_num_range: 0..0,
+            }))
+    }
+}
+
+pub struct S2InputEndpoint {
+    config: Arc<S2InputConfig>,
+}
+
+impl S2InputEndpoint {
+    pub fn new(config: S2InputConfig) -> Result<Self, AnyError> {
+        Ok(Self {
+            config: Arc::new(config),
+        })
+    }
+}
+
+impl InputEndpoint for S2InputEndpoint {
+    fn fault_tolerance(&self) -> Option<FtModel> {
+        Some(FtModel::ExactlyOnce)
+    }
+}
+
+impl TransportInputEndpoint for S2InputEndpoint {
+    fn open(
+        &self,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        schema: Relation,
+        resume_info: Option<JsonValue>,
+    ) -> AnyResult<Box<dyn InputReader>> {
+        let resume_info = Metadata::from_resume_info(resume_info)?;
+        info!("Resume info: {:?}", resume_info);
+        Ok(Box::new(S2Reader::new(
+            self.config.clone(),
+            resume_info,
+            consumer,
+            parser,
+            &schema.name.name(),
+        )?))
+    }
+}
+
+fn make_read_input(start_seq: u64) -> ReadInput {
+    ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::SeqNum(start_seq)))
+}
+
+fn config_to_read_input(config: &S2InputConfig) -> ReadInput {
+    let start = match &config.start_from {
+        S2StartFrom::SeqNum(n) => ReadStart::new().with_from(ReadFrom::SeqNum(*n)),
+        S2StartFrom::Timestamp(ts) => ReadStart::new().with_from(ReadFrom::Timestamp(*ts)),
+        S2StartFrom::TailOffset(n) => ReadStart::new().with_from(ReadFrom::TailOffset(*n)),
+        S2StartFrom::Beginning => ReadStart::new().with_from(ReadFrom::SeqNum(0)),
+        S2StartFrom::Tail => ReadStart::new().with_from(ReadFrom::TailOffset(0)),
+    };
+    ReadInput::new().with_start(start)
+}
+
+struct S2Reader {
+    command_sender: UnboundedSender<InputReaderCommand>,
+}
+
+impl S2Reader {
+    fn new(
+        config: Arc<S2InputConfig>,
+        resume_info: Metadata,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        table_name: &str,
+    ) -> AnyResult<Self> {
+        let span = info_span!(
+            "s2_input",
+            table = %table_name,
+            basin = %config.basin,
+            stream = %config.stream,
+        );
+        let (command_sender, command_receiver) = unbounded_channel();
+
+        let s2_stream = TOKIO
+            .block_on(
+                async {
+                    let s2_config = S2Config::new(config.auth_token.clone());
+                    let s2_config = if let Some(ref endpoint) = config.endpoint {
+                        let endpoints = S2Endpoints::new(
+                            AccountEndpoint::new(endpoint)?,
+                            BasinEndpoint::new(endpoint)?,
+                        )?;
+                        s2_config.with_endpoints(endpoints)
+                    } else {
+                        s2_config
+                    };
+                    let client = S2::new(s2_config)?;
+                    let basin = client.basin(config.basin.parse().map_err(|e| anyhow!("{e}"))?);
+                    Ok::<_, AnyError>(basin.stream(config.stream.parse().map_err(|e| anyhow!("{e}"))?))
+                }
+                .instrument(span.clone()),
+            )
+            .map_err(|e| {
+                error!(basin = %config.basin, stream = %config.stream, "S2 init failed: {e:#}");
+                e.context(format!(
+                    "S2 initialization failed for stream '{}' in basin '{}'",
+                    config.stream, config.basin,
+                ))
+            })?;
+
+        let consumer_clone = consumer.clone();
+        TOKIO.spawn(async move {
+            Self::worker_task(config, resume_info, s2_stream, consumer_clone, parser, command_receiver)
+                .instrument(span)
+                .await
+                .unwrap_or_else(|e| consumer.error(true, e, Some("s2-input")));
+        });
+
+        Ok(Self { command_sender })
+    }
+
+    async fn worker_task(
+        config: Arc<S2InputConfig>,
+        resume_info: Metadata,
+        s2_stream: s2_sdk::S2Stream,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        command_receiver: UnboundedReceiver<InputReaderCommand>,
+    ) -> Result<(), AnyError> {
+        let mut canceller: Option<Canceller> = None;
+        let queue = Arc::new(InputQueue::<u64>::new(consumer.clone()));
+        let next_seq = Arc::new(AtomicU64::new(resume_info.seq_num_range.end));
+        let s2_stream = Arc::new(s2_stream);
+
+        let mut command_receiver = InputCommandReceiver::<Metadata, ()>::new(command_receiver);
+
+        // Handle replay commands
+        while let Some((metadata, ())) = command_receiver.recv_replay().await? {
+            info!("Replay: {:?}", metadata);
+            if !metadata.seq_num_range.is_empty() {
+                let first = metadata.seq_num_range.start;
+                let last = metadata.seq_num_range.end - 1;
+
+                let read_input = make_read_input(first);
+                let mut session = s2_stream
+                    .read_session(read_input)
+                    .await
+                    .with_context(|| format!("Failed to create read session for replay from {first}"))?;
+
+                let mut hasher = Xxh3Default::new();
+                let mut buffer_size = BufferSize::default();
+                let mut replay_parser = parser.fork();
+                let mut done = false;
+
+                while let Some(result) = session.next().await {
+                    let batch = result.map_err(|e| anyhow!("S2 read error during replay: {e}"))?;
+                    for record in &batch.records {
+                        if record.seq_num > last {
+                            done = true;
+                            break;
+                        }
+                        let data = &record.body;
+                        let (buffer, errors) = replay_parser.parse(data, None);
+                        consumer.parse_errors(errors);
+                        if let Some(mut buffer) = buffer {
+                            buffer.hash(&mut hasher);
+                            buffer.flush();
+                        }
+                        let amt = BufferSize { records: 1, bytes: data.len() };
+                        consumer.buffered(amt);
+                        buffer_size += amt;
+                        if record.seq_num == last {
+                            done = true;
+                            break;
+                        }
+                    }
+                    if done {
+                        break;
+                    }
+                }
+
+                consumer.replayed(buffer_size, hasher.finish());
+                next_seq.store(last + 1, Ordering::Release);
+            } else {
+                consumer.replayed(BufferSize::default(), Xxh3Default::new().finish());
+            }
+        }
+
+        loop {
+            let command = command_receiver.recv().await?;
+            match command {
+                command @ InputReaderCommand::Replay { .. } => {
+                    unreachable!("{command:?} must be at the beginning of the command stream")
+                }
+                InputReaderCommand::Queue { .. } => {
+                    let (buffer_size, hasher, batches) = queue.flush_with_aux();
+                    let seq_range = match (batches.first(), batches.last()) {
+                        (Some((_, first)), Some((_, last))) => *first..*last + 1,
+                        _ => {
+                            let pos = next_seq.load(Ordering::Acquire);
+                            pos..pos
+                        }
+                    };
+                    info!("Queued {:?} records ({seq_range:?})", buffer_size);
+                    let metadata_json = serde_json::to_value(&Metadata { seq_num_range: seq_range })?;
+                    let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
+                    let hash = hasher.map(|h| h.finish()).unwrap_or(0);
+                    let resume = Resume::Replay {
+                        hash,
+                        seek: metadata_json.clone(),
+                        replay: rmpv::Value::Nil,
+                    };
+                    consumer.extended(
+                        buffer_size,
+                        Some(resume),
+                        vec![Watermark::new(timestamp, Some(metadata_json))],
+                    );
+                }
+                InputReaderCommand::Pause => {
+                    if let Some(c) = canceller.take() {
+                        c.cancel_and_join().await;
+                    }
+                }
+                InputReaderCommand::Extend => {
+                    let cur_seq = next_seq.load(Ordering::Acquire);
+                    info!("Extend from {cur_seq}");
+                    if canceller.is_none() {
+                        let read_input = if cur_seq > 0 {
+                            make_read_input(cur_seq)
+                        } else {
+                            config_to_read_input(&config)
+                        };
+
+                        let session = s2_stream
+                            .read_session(read_input)
+                            .await
+                            .with_context(|| format!("Failed to create S2 read session from seq {cur_seq}"))?;
+
+                        canceller = Some(spawn_s2_reader(
+                            session,
+                            next_seq.clone(),
+                            queue.clone(),
+                            consumer.clone(),
+                            parser.fork(),
+                        ));
+                    }
+                }
+                InputReaderCommand::Disconnect => break,
+            }
+        }
+        if let Some(c) = canceller.take() {
+            c.cancel_and_join().await;
+        }
+        Ok(())
+    }
+}
+
+fn spawn_s2_reader(
+    mut session: impl futures::Stream<Item = Result<s2_sdk::types::ReadBatch, s2_sdk::types::S2Error>> + Send + Unpin + 'static,
+    next_seq: Arc<AtomicU64>,
+    queue: Arc<InputQueue<u64>>,
+    consumer: Box<dyn InputConsumer>,
+    mut parser: Box<dyn Parser>,
+) -> Canceller {
+    let cancel_token = CancellationToken::new();
+    let join_handle = tokio::spawn({
+        let cancel_token_copy = cancel_token.clone();
+        async move {
+            loop {
+                select! {
+                    _ = cancel_token_copy.cancelled() => break,
+                    result = session.next() => {
+                        let Some(result) = result else {
+                            consumer.error(true, anyhow!("Unexpected end of S2 stream"), Some("s2-input"));
+                            return;
+                        };
+                        match result {
+                            Ok(batch) => {
+                                for record in &batch.records {
+                                    info!("Got record #{}", record.seq_num);
+                                    next_seq.store(record.seq_num + 1, Ordering::Release);
+                                    let data = &record.body;
+                                    queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
+                                }
+                            }
+                            Err(error) => {
+                                consumer.error(false, anyhow!("S2 error: {error}"), Some("s2-input"));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Canceller { cancel_token, join_handle }
+}
+
+struct Canceller {
+    cancel_token: CancellationToken,
+    join_handle: JoinHandle<()>,
+}
+
+impl Canceller {
+    async fn cancel_and_join(self) {
+        self.cancel_token.cancel();
+        let _ = self.join_handle.await;
+    }
+}
+
+impl InputReader for S2Reader {
+    fn request(&self, command: InputReaderCommand) {
+        let _ = self.command_sender.send(command);
+    }
+
+    fn is_closed(&self) -> bool {
+        self.command_sender.is_closed()
+    }
+}

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -33,7 +33,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, error, info, info_span};
+use tracing::{Instrument, error, info, info_span, trace};
 use xxhash_rust::xxh3::Xxh3Default;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -368,7 +368,7 @@ fn spawn_s2_reader(
                             Some(Ok(batch)) => {
                                 // Successfully received a batch
                                 for record in &batch.records {
-                                    info!("Got record #{}", record.seq_num);
+                                    trace!("Got record #{}", record.seq_num);
                                     next_seq.store(record.seq_num + 1, Ordering::Release);
                                     let data = &record.body;
                                     queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -16,12 +16,14 @@ use futures::StreamExt;
 use s2_sdk::{
     S2,
     types::{
-        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, S2Config, S2Endpoints,
+        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, RetryConfig, S2Config,
+        S2Endpoints,
     },
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::hash::Hasher;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -29,10 +31,9 @@ use tokio::{
     select,
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     task::JoinHandle,
-    time::sleep,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, error, info, info_span, warn};
+use tracing::{Instrument, error, info, info_span};
 use xxhash_rust::xxh3::Xxh3Default;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -135,16 +136,25 @@ impl S2Reader {
         let s2_stream = TOKIO
             .block_on(
                 async {
-                    let s2_config = S2Config::new(config.auth_token.clone());
-                    let s2_config = if let Some(ref endpoint) = config.endpoint {
+                    // Configure retry policy: more attempts with longer delays than SDK defaults
+                    let retry_config = RetryConfig::new()
+                        .with_max_attempts(NonZeroU32::new(10).unwrap())
+                        .with_min_base_delay(Duration::from_millis(100))
+                        .with_max_base_delay(Duration::from_secs(10));
+
+                    let mut s2_config = S2Config::new(config.auth_token.clone())
+                        .with_connection_timeout(Duration::from_secs(10))
+                        .with_request_timeout(Duration::from_secs(30))
+                        .with_retry(retry_config);
+
+                    if let Some(ref endpoint) = config.endpoint {
                         let endpoints = S2Endpoints::new(
                             AccountEndpoint::new(endpoint)?,
                             BasinEndpoint::new(endpoint)?,
                         )?;
-                        s2_config.with_endpoints(endpoints)
-                    } else {
-                        s2_config
-                    };
+                        s2_config = s2_config.with_endpoints(endpoints);
+                    }
+
                     let client = S2::new(s2_config)?;
                     let basin = client.basin(config.basin.parse().map_err(|e| anyhow!("{e}"))?);
                     Ok::<_, AnyError>(
@@ -317,75 +327,70 @@ fn spawn_s2_reader(
     consumer: Box<dyn InputConsumer>,
     mut parser: Box<dyn Parser>,
 ) -> Canceller {
-    const RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
-    const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
-
     let cancel_token = CancellationToken::new();
     let join_handle = tokio::spawn({
         let cancel_token_copy = cancel_token.clone();
         async move {
-            let mut retry_delay = RETRY_BASE_DELAY;
-            loop {
-                let start_seq = next_seq.load(Ordering::Acquire);
-                let read_input = read_input_for_position(&config, start_seq);
+            let start_seq = next_seq.load(Ordering::Acquire);
+            let read_input = read_input_for_position(&config, start_seq);
 
-                let mut session = match s2_stream.read_session(read_input).await {
-                    Ok(session) => {
-                        retry_delay = RETRY_BASE_DELAY;
-                        session
-                    }
-                    Err(error) => {
-                        consumer.error(
-                            false,
-                            anyhow!("Failed to create S2 read session: {error}"),
-                            Some("s2-input"),
-                        );
-                        warn!(
-                            next_seq = start_seq,
-                            "S2 session setup failed; retrying in {:?}: {error}", retry_delay
-                        );
-                        select! {
-                            _ = cancel_token_copy.cancelled() => break,
-                            _ = sleep(retry_delay) => {
-                                retry_delay = std::cmp::min(retry_delay.saturating_mul(2), RETRY_MAX_DELAY);
-                            }
-                        }
-                        continue;
-                    }
-                };
-
-                loop {
-                    select! {
-                        _ = cancel_token_copy.cancelled() => break,
-                        result = session.next() => {
-                            let Some(result) = result else {
-                                consumer.error(false, anyhow!("S2 read session ended; reconnecting"), Some("s2-input"));
-                                warn!("S2 read session ended; reconnecting in {:?}", retry_delay);
-                                break;
-                            };
-                            match result {
-                                Ok(batch) => {
-                                    for record in &batch.records {
-                                        info!("Got record #{}", record.seq_num);
-                                        next_seq.store(record.seq_num + 1, Ordering::Release);
-                                        let data = &record.body;
-                                        queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
-                                    }
-                                }
-                                Err(error) => {
-                                    consumer.error(false, anyhow!("S2 error: {error}"), Some("s2-input"));
-                                    warn!("S2 stream error; reconnecting in {:?}: {error}", retry_delay);
-                                    break;
-                                }
-                            }
-                        }
-                    }
+            // Create read session. The SDK will automatically retry transient failures
+            // according to the configured RetryConfig (10 attempts, 100ms-10s delays).
+            let mut session = match s2_stream.read_session(read_input).await {
+                Ok(session) => session,
+                Err(error) => {
+                    // SDK has exhausted all retries. This is a fatal error.
+                    consumer.error(
+                        true,
+                        anyhow!("Failed to create S2 read session after retries: {error}"),
+                        Some("s2-input"),
+                    );
+                    error!(
+                        next_seq = start_seq,
+                        "S2 session setup failed after SDK retries: {error}"
+                    );
+                    return;
                 }
+            };
 
+            // Read loop. The SDK's read_session automatically handles:
+            // - Reconnection on transient failures
+            // - Heartbeat timeout detection (20 seconds)
+            // - Automatic retry with exponential backoff
+            loop {
                 select! {
-                    _ = cancel_token_copy.cancelled() => break,
-                    _ = sleep(retry_delay) => {
-                        retry_delay = std::cmp::min(retry_delay.saturating_mul(2), RETRY_MAX_DELAY);
+                    _ = cancel_token_copy.cancelled() => {
+                        info!("S2 reader cancelled");
+                        break;
+                    }
+                    result = session.next() => {
+                        match result {
+                            Some(Ok(batch)) => {
+                                // Successfully received a batch
+                                for record in &batch.records {
+                                    info!("Got record #{}", record.seq_num);
+                                    next_seq.store(record.seq_num + 1, Ordering::Release);
+                                    let data = &record.body;
+                                    queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
+                                }
+                            }
+                            Some(Err(error)) => {
+                                // SDK has exhausted all retries for this error.
+                                // This is a fatal error (e.g., auth failure, non-retryable error).
+                                consumer.error(
+                                    true,
+                                    anyhow!("S2 stream error after SDK retries: {error}"),
+                                    Some("s2-input"),
+                                );
+                                error!("S2 stream error after SDK retries: {error}");
+                                break;
+                            }
+                            None => {
+                                // Stream ended normally (reached end of data or end condition)
+                                info!("S2 read session ended normally");
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -2,7 +2,8 @@ use crate::{
     InputConsumer, InputEndpoint, InputReader, Parser, TransportInputEndpoint,
     transport::{InputQueue, InputReaderCommand},
 };
-use anyhow::{Context, Error as AnyError, Result as AnyResult, anyhow};
+use anyhow::{Error as AnyError, Result as AnyResult, anyhow};
+use async_trait::async_trait;
 use chrono::Utc;
 use dbsp::circuit::tokio::TOKIO;
 use feldera_adapterlib::format::BufferSize;
@@ -12,29 +13,35 @@ use feldera_types::{
     program_schema::Relation,
     transport::s2::{S2InputConfig, S2StartFrom},
 };
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use s2_sdk::{
-    S2,
+    S2, S2Stream,
     types::{
-        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadLimits, ReadStart, ReadStop,
-        RetryConfig, S2Config, S2Endpoints,
+        AccountEndpoint, AppendConditionFailed, BasinEndpoint, ReadFrom, ReadInput, ReadLimits,
+        ReadStart, ReadStop, RetryConfig, S2Config, S2Endpoints, S2Error,
     },
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::hash::Hasher;
 use std::num::NonZeroU32;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
 use std::time::Duration;
 use tokio::{
     select,
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     task::JoinHandle,
+    time::{Instant, sleep_until},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, error, info, info_span, trace};
 use xxhash_rust::xxh3::Xxh3Default;
+
+const RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Metadata {
@@ -97,9 +104,14 @@ fn make_read_input(start_seq: u64) -> ReadInput {
     ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::SeqNum(start_seq)))
 }
 
+#[cfg(test)]
 pub(crate) fn make_replay_read_input(seq_num_range: &std::ops::Range<u64>) -> ReadInput {
-    let count = usize::try_from(seq_num_range.end - seq_num_range.start).unwrap_or(usize::MAX);
-    make_read_input(seq_num_range.start)
+    make_replay_read_input_from(seq_num_range.start, seq_num_range.end)
+}
+
+fn make_replay_read_input_from(start: u64, end: u64) -> ReadInput {
+    let count = usize::try_from(end - start).unwrap_or(usize::MAX);
+    make_read_input(start)
         .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(count)))
 }
 
@@ -114,11 +126,207 @@ fn config_to_read_input(config: &S2InputConfig) -> ReadInput {
     ReadInput::new().with_start(start)
 }
 
-fn read_input_for_position(config: &S2InputConfig, next_seq: u64) -> ReadInput {
-    if next_seq > 0 {
+fn read_input_for_position(
+    config: &S2InputConfig,
+    next_seq: u64,
+    position_resolved: bool,
+) -> ReadInput {
+    if position_resolved {
         make_read_input(next_seq)
     } else {
         config_to_read_input(config)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum S2ErrorKind {
+    Retryable,
+    Fatal,
+}
+
+fn classify_s2_error(error: &S2Error) -> S2ErrorKind {
+    match error {
+        S2Error::MalformedAccessToken(_) | S2Error::Validation(_) | S2Error::ReadUnwritten(_) => {
+            S2ErrorKind::Fatal
+        }
+        S2Error::AppendConditionFailed(AppendConditionFailed::FencingTokenMismatch(_))
+        | S2Error::AppendConditionFailed(AppendConditionFailed::SeqNumMismatch(_)) => {
+            S2ErrorKind::Fatal
+        }
+        S2Error::Server(response) => classify_s2_server_code(&response.code),
+        S2Error::Client(message) => classify_s2_client_message(message),
+    }
+}
+
+fn classify_s2_server_code(code: &str) -> S2ErrorKind {
+    match code {
+        "request_timeout"
+        | "rate_limited"
+        | "other"
+        | "storage"
+        | "hot_server"
+        | "unavailable"
+        | "upstream_timeout"
+        | "transaction_conflict" => S2ErrorKind::Retryable,
+        _ => S2ErrorKind::Fatal,
+    }
+}
+
+fn classify_s2_client_message(message: &str) -> S2ErrorKind {
+    if message == "heartbeat timeout"
+        || message == "timeout"
+        || message.starts_with("connect:")
+        || message.starts_with("connection closed early:")
+        || message.starts_with("request canceled:")
+        || message.starts_with("unexpected eof:")
+        || message.starts_with("connection reset:")
+        || message.starts_with("connection aborted:")
+        || message.starts_with("connection refused:")
+    {
+        S2ErrorKind::Retryable
+    } else {
+        S2ErrorKind::Fatal
+    }
+}
+
+#[derive(Debug, Clone)]
+struct S2Position {
+    seq_num: u64,
+}
+
+#[derive(Debug, Clone)]
+struct S2Record {
+    seq_num: u64,
+    body: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct S2Batch {
+    records: Vec<S2Record>,
+    tail: Option<S2Position>,
+}
+
+type S2ReadSession = Pin<Box<dyn Send + Stream<Item = Result<S2Batch, S2Error>>>>;
+
+#[derive(Clone)]
+struct LiveReaderShared {
+    next_seq: Arc<AtomicU64>,
+    position_resolved: Arc<AtomicBool>,
+    queue: Arc<InputQueue<u64>>,
+    ingest_lock: Arc<StdMutex<()>>,
+}
+
+#[async_trait]
+trait S2StreamClient: Send + Sync {
+    async fn check_tail(&self) -> Result<S2Position, S2Error>;
+    async fn read_session(&self, input: ReadInput) -> Result<S2ReadSession, S2Error>;
+}
+
+#[async_trait]
+impl S2StreamClient for S2Stream {
+    async fn check_tail(&self) -> Result<S2Position, S2Error> {
+        let tail = S2Stream::check_tail(self).await?;
+        Ok(S2Position {
+            seq_num: tail.seq_num,
+        })
+    }
+
+    async fn read_session(&self, input: ReadInput) -> Result<S2ReadSession, S2Error> {
+        let session = S2Stream::read_session(self, input).await?;
+        Ok(Box::pin(session.map(|result| {
+            result.map(|batch| S2Batch {
+                records: batch
+                    .records
+                    .into_iter()
+                    .map(|record| S2Record {
+                        seq_num: record.seq_num,
+                        body: record.body.to_vec(),
+                    })
+                    .collect(),
+                tail: batch.tail.map(|tail| S2Position {
+                    seq_num: tail.seq_num,
+                }),
+            })
+        })))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BackoffConfig {
+    initial: Duration,
+    max: Duration,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            initial: RECONNECT_INITIAL_BACKOFF,
+            max: RECONNECT_MAX_BACKOFF,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BackoffState {
+    config: BackoffConfig,
+    current: Duration,
+}
+
+impl BackoffState {
+    fn new(config: BackoffConfig) -> Self {
+        Self {
+            config,
+            current: config.initial,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.current = self.config.initial;
+    }
+
+    fn next_deadline(&mut self) -> Instant {
+        let delay = self.current;
+        self.current = (self.current * 2).min(self.config.max);
+        Instant::now() + delay
+    }
+}
+
+#[derive(Debug)]
+struct ClassifiedError {
+    kind: S2ErrorKind,
+    error: AnyError,
+    made_progress: bool,
+}
+
+impl ClassifiedError {
+    fn new(context: impl std::fmt::Display, error: S2Error) -> Self {
+        let kind = classify_s2_error(&error);
+        Self {
+            kind,
+            error: anyhow!("{context}: {error}"),
+            made_progress: false,
+        }
+    }
+
+    fn retryable(context: impl std::fmt::Display) -> Self {
+        Self {
+            kind: S2ErrorKind::Retryable,
+            error: anyhow!(context.to_string()),
+            made_progress: false,
+        }
+    }
+
+    fn fatal(context: impl std::fmt::Display) -> Self {
+        Self {
+            kind: S2ErrorKind::Fatal,
+            error: anyhow!(context.to_string()),
+            made_progress: false,
+        }
+    }
+
+    fn after_progress(mut self, made_progress: bool) -> Self {
+        self.made_progress = made_progress;
+        self
     }
 }
 
@@ -145,7 +353,8 @@ impl S2Reader {
         let s2_stream = TOKIO
             .block_on(
                 async {
-                    // Configure retry policy: more attempts with longer delays than SDK defaults
+                    // Configure retry policy: more attempts with longer delays than SDK defaults.
+                    // The connector owns the lifecycle after the SDK exhausts these finite retries.
                     let retry_config = RetryConfig::new()
                         .with_max_attempts(NonZeroU32::new(10).unwrap())
                         .with_min_base_delay(Duration::from_millis(100))
@@ -185,7 +394,7 @@ impl S2Reader {
             Self::worker_task(
                 config,
                 resume_info,
-                s2_stream,
+                Arc::new(s2_stream),
                 consumer_clone,
                 parser,
                 command_receiver,
@@ -201,142 +410,242 @@ impl S2Reader {
     async fn worker_task(
         config: Arc<S2InputConfig>,
         resume_info: Metadata,
-        s2_stream: s2_sdk::S2Stream,
+        s2_stream: Arc<dyn S2StreamClient>,
         consumer: Box<dyn InputConsumer>,
         parser: Box<dyn Parser>,
         command_receiver: UnboundedReceiver<InputReaderCommand>,
     ) -> Result<(), AnyError> {
-        let mut canceller: Option<Canceller> = None;
+        Self::worker_task_with_backoff(
+            config,
+            resume_info,
+            s2_stream,
+            consumer,
+            parser,
+            command_receiver,
+            BackoffConfig::default(),
+        )
+        .await
+    }
+
+    async fn worker_task_with_backoff(
+        config: Arc<S2InputConfig>,
+        resume_info: Metadata,
+        s2_stream: Arc<dyn S2StreamClient>,
+        consumer: Box<dyn InputConsumer>,
+        parser: Box<dyn Parser>,
+        command_receiver: UnboundedReceiver<InputReaderCommand>,
+        backoff_config: BackoffConfig,
+    ) -> Result<(), AnyError> {
         let queue = Arc::new(InputQueue::<u64>::new(consumer.clone()));
         let next_seq = Arc::new(AtomicU64::new(resume_info.seq_num_range.end));
         let position_resolved = Arc::new(AtomicBool::new(resume_info.position_resolved));
-        let s2_stream = Arc::new(s2_stream);
+        let ingest_lock = Arc::new(StdMutex::new(()));
+        let live_shared = LiveReaderShared {
+            next_seq: next_seq.clone(),
+            position_resolved: position_resolved.clone(),
+            queue: queue.clone(),
+            ingest_lock: ingest_lock.clone(),
+        };
 
         let mut command_receiver = InputCommandReceiver::<Metadata, ()>::new(command_receiver);
 
-        // Handle replay commands
+        // Handle replay commands before normal operation. Replays retry transient S2 failures
+        // from the absolute sequence number that remains to be replayed, while preserving the
+        // cumulative parser/hash/buffer state collected so far.
         while let Some((metadata, ())) = command_receiver.recv_replay().await? {
             info!("Replay: {:?}", metadata);
-            if !metadata.seq_num_range.is_empty() {
-                let first = metadata.seq_num_range.start;
-                let end = metadata.seq_num_range.end;
-
-                let read_input = make_replay_read_input(&metadata.seq_num_range);
-                let mut session = s2_stream.read_session(read_input).await.with_context(|| {
-                    format!("Failed to create read session for replay from {first}")
-                })?;
-
-                let mut hasher = Xxh3Default::new();
-                let mut buffer_size = BufferSize::default();
-                let mut replay_parser = parser.fork();
-                let mut expected_seq = first;
-
-                while let Some(result) = session.next().await {
-                    let batch = result.map_err(|e| anyhow!("S2 read error during replay: {e}"))?;
-                    for record in &batch.records {
-                        if record.seq_num != expected_seq {
-                            return Err(anyhow!(
-                                "S2 replay expected sequence number {expected_seq}, but received {}",
-                                record.seq_num
-                            ));
-                        }
-                        let data = &record.body;
-                        let (buffer, errors) = replay_parser.parse(data, None);
-                        consumer.parse_errors(errors);
-                        if let Some(mut buffer) = buffer {
-                            buffer.hash(&mut hasher);
-                            buffer.flush();
-                        }
-                        let amt = BufferSize {
-                            records: 1,
-                            bytes: data.len(),
-                        };
-                        consumer.buffered(amt);
-                        buffer_size += amt;
-                        expected_seq += 1;
-                    }
+            match replay_checkpoint(
+                s2_stream.clone(),
+                consumer.clone(),
+                parser.fork(),
+                &mut command_receiver,
+                &metadata,
+                backoff_config,
+            )
+            .await?
+            {
+                ReplayOutcome::Completed => {
+                    next_seq.store(metadata.seq_num_range.end, Ordering::Release);
+                    // Preserve the checkpoint's resolved flag rather than forcing it true.
+                    // An empty checkpoint taken before the start position was resolved
+                    // (e.g. a Tail start that had not yet anchored) must stay unresolved so
+                    // the live reader reapplies the configured start_from on resume instead
+                    // of reading from absolute sequence 0.
+                    position_resolved.store(metadata.position_resolved, Ordering::Release);
                 }
-
-                if expected_seq != end {
-                    return Err(anyhow!(
-                        "S2 replay ended at sequence number {expected_seq}, before expected end {end}; the checkpointed records may have been trimmed"
-                    ));
-                }
-
-                consumer.replayed(buffer_size, hasher.finish());
-                next_seq.store(end, Ordering::Release);
-                position_resolved.store(true, Ordering::Release);
-            } else {
-                consumer.replayed(BufferSize::default(), Xxh3Default::new().finish());
+                ReplayOutcome::Disconnected => return Ok(()),
             }
         }
+
+        let (reader_error_sender, mut reader_error_receiver) =
+            unbounded_channel::<ClassifiedError>();
+        let mut canceller: Option<Canceller> = None;
+        let mut state = ReaderLifecycleState::Paused;
+        let mut backoff = BackoffState::new(backoff_config);
+        let mut next_retry_at: Option<Instant> = None;
 
         loop {
-            let command = command_receiver.recv().await?;
-            match command {
-                command @ InputReaderCommand::Replay { .. } => {
-                    unreachable!("{command:?} must be at the beginning of the command stream")
-                }
-                InputReaderCommand::Queue { .. } => {
-                    let (buffer_size, hasher, batches) = queue.flush_with_aux();
-                    let seq_range = match (batches.first(), batches.last()) {
-                        (Some((_, first)), Some((_, last))) => *first..*last + 1,
-                        _ => {
-                            let pos = next_seq.load(Ordering::Acquire);
-                            pos..pos
+            match state {
+                ReaderLifecycleState::Paused => {
+                    let command = command_receiver.recv().await?;
+                    match command {
+                        command @ InputReaderCommand::Replay { .. } => {
+                            unreachable!(
+                                "{command:?} must be at the beginning of the command stream"
+                            )
                         }
-                    };
-                    info!("Queued {:?} records ({seq_range:?})", buffer_size);
-                    let metadata_json = serde_json::to_value(&Metadata {
-                        seq_num_range: seq_range,
-                        position_resolved: position_resolved.load(Ordering::Acquire),
-                    })?;
-                    let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
-                    let hash = hasher.map(|h| h.finish()).unwrap_or(0);
-                    let resume = Resume::Replay {
-                        hash,
-                        seek: metadata_json.clone(),
-                        replay: rmpv::Value::Nil,
-                    };
-                    consumer.extended(
-                        buffer_size,
-                        Some(resume),
-                        vec![Watermark::new(timestamp, Some(metadata_json))],
-                    );
-                }
-                InputReaderCommand::Pause => {
-                    if let Some(c) = canceller.take() {
-                        c.cancel_and_join().await;
+                        InputReaderCommand::Queue { .. } => {
+                            flush_queue(
+                                &queue,
+                                &next_seq,
+                                &position_resolved,
+                                &ingest_lock,
+                                consumer.as_ref(),
+                            )?;
+                        }
+                        InputReaderCommand::Pause => {}
+                        InputReaderCommand::Extend => {
+                            drain_reader_errors(&mut reader_error_receiver);
+                            match resolve_tail(s2_stream.clone(), &live_shared, &config).await {
+                                Ok(()) => {
+                                    canceller = Some(spawn_live_reader(
+                                        s2_stream.clone(),
+                                        config.clone(),
+                                        live_shared.clone(),
+                                        parser.fork(),
+                                        reader_error_sender.clone(),
+                                    ));
+                                    backoff.reset();
+                                    state = ReaderLifecycleState::Running;
+                                }
+                                Err(e) => {
+                                    apply_start_error(
+                                        e,
+                                        consumer.as_ref(),
+                                        &mut state,
+                                        &mut backoff,
+                                        &mut next_retry_at,
+                                    );
+                                }
+                            }
+                        }
+                        InputReaderCommand::Disconnect => break,
                     }
                 }
-                InputReaderCommand::Extend => {
-                    let cur_seq = next_seq.load(Ordering::Acquire);
-                    info!("Extend from {cur_seq}");
-                    if canceller.is_none() {
-                        if !position_resolved.load(Ordering::Acquire)
-                            && matches!(config.start_from, S2StartFrom::Tail)
-                        {
-                            let tail = s2_stream
-                                .check_tail()
-                                .await
-                                .context("Failed to resolve the S2 tail position")?;
-                            next_seq.store(tail.seq_num, Ordering::Release);
-                            position_resolved.store(true, Ordering::Release);
+                ReaderLifecycleState::Running => {
+                    select! {
+                        biased;
+                        maybe_error = reader_error_receiver.recv() => {
+                            if let Some(c) = canceller.take() {
+                                c.cancel_and_join().await;
+                            }
+                            let error = maybe_error.unwrap_or_else(|| ClassifiedError::retryable("S2 reader task stopped without reporting an error"));
+                            drain_reader_errors(&mut reader_error_receiver);
+                            match error.kind {
+                                S2ErrorKind::Retryable => {
+                                    if error.made_progress {
+                                        backoff.reset();
+                                    }
+                                    consumer.error(false, error.error, Some("s2-input"));
+                                    next_retry_at = Some(backoff.next_deadline());
+                                    state = ReaderLifecycleState::ErrorRetrying;
+                                }
+                                S2ErrorKind::Fatal => {
+                                    consumer.error(true, error.error, Some("s2-input"));
+                                    state = ReaderLifecycleState::Stopped;
+                                }
+                            }
                         }
-                        canceller = Some(spawn_s2_reader(
-                            s2_stream.clone(),
-                            config.clone(),
-                            next_seq.clone(),
-                            position_resolved.clone(),
-                            queue.clone(),
-                            consumer.clone(),
-                            parser.fork(),
-                        ));
+                        command = command_receiver.recv() => {
+                            match command? {
+                                command @ InputReaderCommand::Replay { .. } => {
+                                    unreachable!("{command:?} must be at the beginning of the command stream")
+                                }
+                                InputReaderCommand::Queue { .. } => {
+                                    flush_queue(
+                                    &queue,
+                                    &next_seq,
+                                    &position_resolved,
+                                    &ingest_lock,
+                                    consumer.as_ref(),
+                                )?;
+                                }
+                                InputReaderCommand::Pause => {
+                                    if let Some(c) = canceller.take() {
+                                        c.cancel_and_join().await;
+                                    }
+                                    drain_reader_errors(&mut reader_error_receiver);
+                                    backoff.reset();
+                                    state = ReaderLifecycleState::Paused;
+                                }
+                                InputReaderCommand::Extend => {}
+                                InputReaderCommand::Disconnect => break,
+                            }
+                        }
                     }
                 }
-                InputReaderCommand::Disconnect => break,
+                ReaderLifecycleState::ErrorRetrying => {
+                    let retry_at = next_retry_at.get_or_insert_with(|| backoff.next_deadline());
+                    select! {
+                        command = command_receiver.recv() => {
+                            match command? {
+                                command @ InputReaderCommand::Replay { .. } => {
+                                    unreachable!("{command:?} must be at the beginning of the command stream")
+                                }
+                                InputReaderCommand::Queue { .. } => {
+                                    flush_queue(
+                                    &queue,
+                                    &next_seq,
+                                    &position_resolved,
+                                    &ingest_lock,
+                                    consumer.as_ref(),
+                                )?;
+                                }
+                                InputReaderCommand::Pause => {
+                                    if let Some(c) = canceller.take() {
+                                        c.cancel_and_join().await;
+                                    }
+                                    drain_reader_errors(&mut reader_error_receiver);
+                                    next_retry_at = None;
+                                    backoff.reset();
+                                    state = ReaderLifecycleState::Paused;
+                                }
+                                InputReaderCommand::Extend => {}
+                                InputReaderCommand::Disconnect => break,
+                            }
+                        }
+                        _ = sleep_until(*retry_at) => {
+                            next_retry_at = None;
+                            drain_reader_errors(&mut reader_error_receiver);
+                            match resolve_tail(s2_stream.clone(), &live_shared, &config).await {
+                                Ok(()) => {
+                                    canceller = Some(spawn_live_reader(
+                                        s2_stream.clone(),
+                                        config.clone(),
+                                        live_shared.clone(),
+                                        parser.fork(),
+                                        reader_error_sender.clone(),
+                                    ));
+                                    backoff.reset();
+                                    state = ReaderLifecycleState::Running;
+                                }
+                                Err(e) => {
+                                    apply_start_error(
+                                        e,
+                                        consumer.as_ref(),
+                                        &mut state,
+                                        &mut backoff,
+                                        &mut next_retry_at,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                ReaderLifecycleState::Stopped => break,
             }
         }
+
         if let Some(c) = canceller.take() {
             c.cancel_and_join().await;
         }
@@ -344,45 +653,135 @@ impl S2Reader {
     }
 }
 
-fn spawn_s2_reader(
-    s2_stream: Arc<s2_sdk::S2Stream>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReaderLifecycleState {
+    Running,
+    ErrorRetrying,
+    Paused,
+    Stopped,
+}
+
+fn drain_reader_errors(reader_error_receiver: &mut UnboundedReceiver<ClassifiedError>) {
+    while reader_error_receiver.try_recv().is_ok() {}
+}
+
+fn lock_ingest(ingest_lock: &StdMutex<()>) -> StdMutexGuard<'_, ()> {
+    ingest_lock
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn flush_queue(
+    queue: &InputQueue<u64>,
+    next_seq: &AtomicU64,
+    position_resolved: &AtomicBool,
+    ingest_lock: &StdMutex<()>,
+    consumer: &dyn InputConsumer,
+) -> Result<(), AnyError> {
+    let _guard = lock_ingest(ingest_lock);
+    let (buffer_size, hasher, batches) = queue.flush_with_aux();
+    let seq_range = match (batches.first(), batches.last()) {
+        (Some((_, first)), Some((_, last))) => *first..*last + 1,
+        _ => {
+            let pos = next_seq.load(Ordering::Acquire);
+            pos..pos
+        }
+    };
+    info!("Queued {:?} records ({seq_range:?})", buffer_size);
+    let metadata_json = serde_json::to_value(&Metadata {
+        seq_num_range: seq_range,
+        position_resolved: position_resolved.load(Ordering::Acquire),
+    })?;
+    let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
+    let hash = hasher.map(|h| h.finish()).unwrap_or(0);
+    let resume = Resume::Replay {
+        hash,
+        seek: metadata_json.clone(),
+        replay: rmpv::Value::Nil,
+    };
+    consumer.extended(
+        buffer_size,
+        Some(resume),
+        vec![Watermark::new(timestamp, Some(metadata_json))],
+    );
+    Ok(())
+}
+
+/// Resolves the S2 tail position when the start position has not yet been anchored.
+///
+/// This runs in the worker (not the spawned reader) so that a checkpoint `Queue`
+/// cannot observe an unresolved, zero-anchored position. Once the tail is known,
+/// the live reader always resumes from the absolute sequence number, including
+/// sequence 0.
+async fn resolve_tail(
+    s2_stream: Arc<dyn S2StreamClient>,
+    shared: &LiveReaderShared,
+    config: &S2InputConfig,
+) -> Result<(), ClassifiedError> {
+    if shared.position_resolved.load(Ordering::Acquire)
+        || !matches!(config.start_from, S2StartFrom::Tail)
+    {
+        return Ok(());
+    }
+    let tail = s2_stream
+        .check_tail()
+        .await
+        .map_err(|e| ClassifiedError::new("failed to resolve S2 tail position", e))?;
+    shared.next_seq.store(tail.seq_num, Ordering::Release);
+    shared.position_resolved.store(true, Ordering::Release);
+    Ok(())
+}
+
+/// Applies a tail/session-setup error in the worker, updating lifecycle state.
+fn apply_start_error(
+    error: ClassifiedError,
+    consumer: &dyn InputConsumer,
+    state: &mut ReaderLifecycleState,
+    backoff: &mut BackoffState,
+    next_retry_at: &mut Option<Instant>,
+) {
+    match error.kind {
+        S2ErrorKind::Retryable => {
+            consumer.error(false, error.error, Some("s2-input"));
+            *next_retry_at = Some(backoff.next_deadline());
+            *state = ReaderLifecycleState::ErrorRetrying;
+        }
+        S2ErrorKind::Fatal => {
+            consumer.error(true, error.error, Some("s2-input"));
+            *state = ReaderLifecycleState::Stopped;
+        }
+    }
+}
+
+fn spawn_live_reader(
+    s2_stream: Arc<dyn S2StreamClient>,
     config: Arc<S2InputConfig>,
-    next_seq: Arc<AtomicU64>,
-    position_resolved: Arc<AtomicBool>,
-    queue: Arc<InputQueue<u64>>,
-    consumer: Box<dyn InputConsumer>,
+    shared: LiveReaderShared,
     mut parser: Box<dyn Parser>,
+    reader_error_sender: UnboundedSender<ClassifiedError>,
 ) -> Canceller {
     let cancel_token = CancellationToken::new();
     let join_handle = tokio::spawn({
         let cancel_token_copy = cancel_token.clone();
         async move {
-            let start_seq = next_seq.load(Ordering::Acquire);
-            let read_input = read_input_for_position(&config, start_seq);
-
-            // Create read session. The SDK will automatically retry transient failures
-            // according to the configured RetryConfig (10 attempts, 100ms-10s delays).
-            let mut session = match s2_stream.read_session(read_input).await {
-                Ok(session) => session,
-                Err(error) => {
-                    // SDK has exhausted all retries. This is a fatal error.
-                    consumer.error(
-                        true,
-                        anyhow!("Failed to create S2 read session after retries: {error}"),
-                        Some("s2-input"),
-                    );
-                    error!(
-                        next_seq = start_seq,
-                        "S2 session setup failed after SDK retries: {error}"
-                    );
-                    return;
+            let start_seq = shared.next_seq.load(Ordering::Acquire);
+            let resolved = shared.position_resolved.load(Ordering::Acquire);
+            let read_input = read_input_for_position(&config, start_seq, resolved);
+            let mut session = select! {
+                _ = cancel_token_copy.cancelled() => return,
+                result = s2_stream.read_session(read_input) => match result {
+                    Ok(session) => session,
+                    Err(error) => {
+                        let _ = reader_error_sender.send(ClassifiedError::new(
+                            format!("failed to create S2 read session from {start_seq}"),
+                            error,
+                        ));
+                        return;
+                    }
                 }
             };
 
-            // Read loop. The SDK's read_session automatically handles:
-            // - Reconnection on transient failures
-            // - Heartbeat timeout detection (20 seconds)
-            // - Automatic retry with exponential backoff
+            let mut made_progress = false;
             loop {
                 select! {
                     _ = cancel_token_copy.cancelled() => {
@@ -392,32 +791,25 @@ fn spawn_s2_reader(
                     result = session.next() => {
                         match result {
                             Some(Ok(batch)) => {
-                                if let Some(tail) = &batch.tail {
-                                    next_seq.fetch_max(tail.seq_num, Ordering::AcqRel);
-                                    position_resolved.store(true, Ordering::Release);
-                                }
-                                for record in &batch.records {
-                                    trace!("Got record #{}", record.seq_num);
-                                    next_seq.store(record.seq_num + 1, Ordering::Release);
-                                    position_resolved.store(true, Ordering::Release);
-                                    let data = &record.body;
-                                    queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
+                                made_progress = true;
+                                if let Err(error) = process_live_batch(
+                                    batch,
+                                    &shared.next_seq,
+                                    &shared.position_resolved,
+                                    &shared.queue,
+                                    &shared.ingest_lock,
+                                    parser.as_mut(),
+                                ) {
+                                    let _ = reader_error_sender.send(error.after_progress(made_progress));
+                                    break;
                                 }
                             }
                             Some(Err(error)) => {
-                                // SDK has exhausted all retries for this error.
-                                // This is a fatal error (e.g., auth failure, non-retryable error).
-                                consumer.error(
-                                    true,
-                                    anyhow!("S2 stream error after SDK retries: {error}"),
-                                    Some("s2-input"),
-                                );
-                                error!("S2 stream error after SDK retries: {error}");
+                                let _ = reader_error_sender.send(ClassifiedError::new("S2 stream error after SDK retries", error).after_progress(made_progress));
                                 break;
                             }
                             None => {
-                                // Stream ended normally (reached end of data or end condition)
-                                info!("S2 read session ended normally");
+                                let _ = reader_error_sender.send(ClassifiedError::retryable("S2 read session ended; reconnecting").after_progress(made_progress));
                                 break;
                             }
                         }
@@ -431,6 +823,191 @@ fn spawn_s2_reader(
         cancel_token,
         join_handle,
     }
+}
+
+fn process_live_batch(
+    batch: S2Batch,
+    next_seq: &AtomicU64,
+    position_resolved: &AtomicBool,
+    queue: &InputQueue<u64>,
+    ingest_lock: &StdMutex<()>,
+    parser: &mut dyn Parser,
+) -> Result<(), ClassifiedError> {
+    let _guard = lock_ingest(ingest_lock);
+    let mut expected_seq = next_seq.load(Ordering::Acquire);
+    let mut resolved = position_resolved.load(Ordering::Acquire);
+
+    for record in &batch.records {
+        trace!("Got record #{}", record.seq_num);
+        if resolved && record.seq_num != expected_seq {
+            return Err(ClassifiedError::fatal(format!(
+                "S2 live read expected sequence number {expected_seq}, but received {}",
+                record.seq_num
+            )));
+        }
+        if !resolved {
+            resolved = true;
+            position_resolved.store(true, Ordering::Release);
+        }
+        expected_seq = record.seq_num + 1;
+        next_seq.store(expected_seq, Ordering::Release);
+        queue.push_with_aux(parser.parse(&record.body, None), Utc::now(), record.seq_num);
+    }
+
+    if let Some(tail) = &batch.tail {
+        if resolved && tail.seq_num != expected_seq {
+            return Err(ClassifiedError::fatal(format!(
+                "S2 live read tail sequence number {} does not match expected sequence number {expected_seq}",
+                tail.seq_num
+            )));
+        }
+        next_seq.store(tail.seq_num, Ordering::Release);
+        position_resolved.store(true, Ordering::Release);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplayOutcome {
+    Completed,
+    Disconnected,
+}
+
+async fn replay_checkpoint(
+    s2_stream: Arc<dyn S2StreamClient>,
+    consumer: Box<dyn InputConsumer>,
+    mut parser: Box<dyn Parser>,
+    command_receiver: &mut InputCommandReceiver<Metadata, ()>,
+    metadata: &Metadata,
+    backoff_config: BackoffConfig,
+) -> Result<ReplayOutcome, AnyError> {
+    let first = metadata.seq_num_range.start;
+    let end = metadata.seq_num_range.end;
+    if first == end {
+        consumer.replayed(BufferSize::default(), Xxh3Default::new().finish());
+        return Ok(ReplayOutcome::Completed);
+    }
+
+    let mut hasher = Xxh3Default::new();
+    let mut buffer_size = BufferSize::default();
+    let mut expected_seq = first;
+    let mut backoff = BackoffState::new(backoff_config);
+
+    while expected_seq < end {
+        let read_input = make_replay_read_input_from(expected_seq, end);
+        let mut session = match s2_stream.read_session(read_input).await {
+            Ok(session) => session,
+            Err(error) => {
+                let classified = ClassifiedError::new(
+                    format!("failed to create S2 read session for replay from {expected_seq}"),
+                    error,
+                );
+                match classified.kind {
+                    S2ErrorKind::Retryable => {
+                        consumer.error(false, classified.error, Some("s2-input"));
+                        if wait_replay_backoff(&mut backoff, command_receiver).await?
+                            == ReplayOutcome::Disconnected
+                        {
+                            return Ok(ReplayOutcome::Disconnected);
+                        }
+                        continue;
+                    }
+                    S2ErrorKind::Fatal => return Err(classified.error),
+                }
+            }
+        };
+
+        loop {
+            match session.next().await {
+                Some(Ok(batch)) => {
+                    backoff.reset();
+                    for record in &batch.records {
+                        if record.seq_num != expected_seq {
+                            return Err(anyhow!(
+                                "S2 replay expected sequence number {expected_seq}, but received {}",
+                                record.seq_num
+                            ));
+                        }
+                        let data = &record.body;
+                        let (buffer, errors) = parser.parse(data, None);
+                        consumer.parse_errors(errors);
+                        if let Some(mut buffer) = buffer {
+                            buffer.hash(&mut hasher);
+                            buffer.flush();
+                        }
+                        let amt = BufferSize {
+                            records: 1,
+                            bytes: data.len(),
+                        };
+                        consumer.buffered(amt);
+                        buffer_size += amt;
+                        expected_seq += 1;
+                    }
+                    if expected_seq == end {
+                        consumer.replayed(buffer_size, hasher.finish());
+                        return Ok(ReplayOutcome::Completed);
+                    }
+                }
+                Some(Err(error)) => {
+                    let classified = ClassifiedError::new(
+                        format!("S2 read error during replay from {expected_seq}"),
+                        error,
+                    );
+                    match classified.kind {
+                        S2ErrorKind::Retryable => {
+                            consumer.error(false, classified.error, Some("s2-input"));
+                            if wait_replay_backoff(&mut backoff, command_receiver).await?
+                                == ReplayOutcome::Disconnected
+                            {
+                                return Ok(ReplayOutcome::Disconnected);
+                            }
+                            break;
+                        }
+                        S2ErrorKind::Fatal => return Err(classified.error),
+                    }
+                }
+                None => {
+                    return Err(anyhow!(
+                        "S2 replay ended at sequence number {expected_seq}, before expected end {end}; the checkpointed records may have been trimmed"
+                    ));
+                }
+            }
+        }
+    }
+
+    consumer.replayed(buffer_size, hasher.finish());
+    Ok(ReplayOutcome::Completed)
+}
+
+async fn wait_replay_backoff(
+    backoff: &mut BackoffState,
+    command_receiver: &mut InputCommandReceiver<Metadata, ()>,
+) -> Result<ReplayOutcome, AnyError> {
+    let retry_at = backoff.next_deadline();
+    // Hold any non-Disconnect control command locally (instead of put_back) so the
+    // backoff timer still elapses. Otherwise a buffered command would be re-received
+    // immediately on the next retry, busy-looping read_session against S2.
+    // `put_back` is single-slot, so a second pending command stays in the channel and
+    // is handled on the following backoff iteration; no command is lost.
+    let mut held: Option<InputReaderCommand> = None;
+    let outcome = loop {
+        select! {
+            _ = sleep_until(retry_at) => break ReplayOutcome::Completed,
+            command = command_receiver.recv() => match command? {
+                InputReaderCommand::Disconnect => break ReplayOutcome::Disconnected,
+                other if held.is_none() => held = Some(other),
+                other => {
+                    command_receiver.put_back(other);
+                    break ReplayOutcome::Completed;
+                }
+            },
+        }
+    };
+    if let Some(command) = held {
+        command_receiver.put_back(command);
+    }
+    Ok(outcome)
 }
 
 struct Canceller {
@@ -456,5 +1033,784 @@ impl InputReader for S2Reader {
 
     fn is_closed(&self) -> bool {
         self.command_sender.is_closed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::{InputBuffer, Splitter};
+    use dbsp::operator::StagedBuffers;
+    use feldera_adapterlib::ConnectorMetadata;
+    use feldera_adapterlib::format::ParseError;
+    use feldera_types::adapter_stats::ConnectorHealth;
+    use feldera_types::config::FtModel;
+    use futures::stream;
+    use rmpv::Value as RmpValue;
+    use s2_sdk::types::{FencingToken, ValidationError};
+    use std::collections::VecDeque;
+    use std::sync::{Mutex, MutexGuard};
+    use tokio::time::{Duration, timeout};
+
+    #[test]
+    fn classifies_server_codes_exactly() {
+        for code in [
+            "request_timeout",
+            "rate_limited",
+            "other",
+            "storage",
+            "hot_server",
+            "unavailable",
+            "upstream_timeout",
+            "transaction_conflict",
+        ] {
+            assert_eq!(
+                classify_s2_server_code(code),
+                S2ErrorKind::Retryable,
+                "{code}"
+            );
+        }
+        for code in ["", "not_found", "permission_denied", "rate_limited_extra"] {
+            assert_eq!(classify_s2_server_code(code), S2ErrorKind::Fatal, "{code}");
+        }
+    }
+
+    #[test]
+    fn classifies_client_messages_exactly() {
+        for message in [
+            "heartbeat timeout",
+            "timeout",
+            "connect: dns",
+            "connection closed early: eof",
+            "request canceled: dropped",
+            "unexpected eof: body",
+            "connection reset: reset",
+            "connection aborted: aborted",
+            "connection refused: refused",
+        ] {
+            assert_eq!(
+                classify_s2_client_message(message),
+                S2ErrorKind::Retryable,
+                "{message}"
+            );
+        }
+        for message in ["", "heart beat timeout", "timeout: later", "unknown"] {
+            assert_eq!(
+                classify_s2_client_message(message),
+                S2ErrorKind::Fatal,
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_constructible_s2_error_variants() {
+        assert_eq!(
+            classify_s2_error(&S2Error::Client("timeout".to_string())),
+            S2ErrorKind::Retryable
+        );
+        assert_eq!(
+            classify_s2_error(&S2Error::Client("unknown".to_string())),
+            S2ErrorKind::Fatal
+        );
+        assert_eq!(
+            classify_s2_error(&S2Error::MalformedAccessToken("bad".to_string())),
+            S2ErrorKind::Fatal
+        );
+        assert_eq!(
+            classify_s2_error(&S2Error::Validation(ValidationError("bad".to_string()))),
+            S2ErrorKind::Fatal
+        );
+        assert_eq!(
+            classify_s2_error(&S2Error::AppendConditionFailed(
+                AppendConditionFailed::SeqNumMismatch(1)
+            )),
+            S2ErrorKind::Fatal
+        );
+        assert_eq!(
+            classify_s2_error(&S2Error::AppendConditionFailed(
+                AppendConditionFailed::FencingTokenMismatch(
+                    "token".parse::<FencingToken>().unwrap()
+                )
+            )),
+            S2ErrorKind::Fatal
+        );
+    }
+
+    #[test]
+    fn resolved_zero_uses_absolute_sequence_zero() {
+        let config = basic_config(S2StartFrom::Tail);
+        let input = read_input_for_position(&config, 0, true);
+        assert!(matches!(input.start.from, ReadFrom::SeqNum(0)));
+
+        let input = read_input_for_position(&config, 0, false);
+        assert!(matches!(input.start.from, ReadFrom::TailOffset(0)));
+    }
+
+    #[tokio::test]
+    async fn empty_unresolved_checkpoint_reuses_configured_start_from() {
+        // A checkpoint taken before the start position was resolved must not force the
+        // live reader to read from absolute sequence 0; the configured start_from still
+        // applies on resume.
+        let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
+            FakeSession::Pending,
+        ))]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream.clone(),
+            consumer,
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            },
+            S2StartFrom::SeqNum(5),
+        );
+
+        sender
+            .send(InputReaderCommand::Replay {
+                metadata: serde_json::to_value(Metadata {
+                    seq_num_range: 0..0,
+                    position_resolved: false,
+                })
+                .unwrap(),
+                data: RmpValue::Nil,
+            })
+            .unwrap();
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| stream.read_inputs().len() == 1).await;
+        assert!(matches!(
+            stream.read_inputs()[0].start.from,
+            ReadFrom::SeqNum(5)
+        ));
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolved_tail_is_anchored_before_first_queue_checkpoint() {
+        // The tail must be resolved (and the position anchored) before a Queue can emit a
+        // replayable checkpoint, so an empty checkpoint carries the resolved sequence
+        // rather than an unresolved zero.
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Tail(Ok(S2Position { seq_num: 7 })),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream.clone(),
+            consumer.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            },
+            S2StartFrom::Tail,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| stream.read_inputs().len() == 1).await;
+        sender
+            .send(InputReaderCommand::Queue {
+                checkpoint_requested: false,
+            })
+            .unwrap();
+        wait_for(|| !consumer.extended().is_empty()).await;
+        assert_eq!(consumer.extended()[0].seq_num_range, 7..7);
+        assert!(consumer.extended()[0].position_resolved);
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn tail_transient_recovers_and_starts_from_resolved_zero() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Tail(Err(retryable_error())),
+            FakeAction::Tail(Ok(S2Position { seq_num: 0 })),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream.clone(),
+            consumer.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            },
+            S2StartFrom::Tail,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| consumer.error_count() >= 1).await;
+        wait_for(|| stream.read_inputs().len() == 1).await;
+        assert_eq!(consumer.errors()[0].0, false);
+        assert!(matches!(
+            stream.read_inputs()[0].start.from,
+            ReadFrom::SeqNum(0)
+        ));
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_setup_and_midstream_transients_recover() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Session(Err(retryable_error())),
+            FakeAction::Session(Ok(FakeSession::Events(vec![
+                Ok(batch(vec![(0, b"a")], None)),
+                Err(retryable_error()),
+            ]))),
+            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+                vec![(1, b"b")],
+                None,
+            ))]))),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let parser = RecordingParser::new();
+        let handle = spawn_worker_with_parser(
+            stream,
+            consumer.clone(),
+            parser.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| parser.data() == b"ab".to_vec()).await;
+        assert!(consumer.errors().iter().any(|(fatal, _)| !fatal));
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_none_reconnects() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+                vec![(0, b"a")],
+                None,
+            ))]))),
+            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+                vec![(1, b"b")],
+                None,
+            ))]))),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let parser = RecordingParser::new();
+        let handle = spawn_worker_with_parser(
+            stream,
+            consumer,
+            parser.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| parser.data() == b"ab".to_vec()).await;
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn queue_responds_while_retrying() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Session(Ok(FakeSession::Events(vec![
+                Ok(batch(vec![(0, b"a")], None)),
+                Err(retryable_error()),
+            ]))),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream,
+            consumer.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| consumer.error_count() >= 1).await;
+        sender
+            .send(InputReaderCommand::Queue {
+                checkpoint_requested: false,
+            })
+            .unwrap();
+        wait_for(|| !consumer.extended().is_empty()).await;
+        assert_eq!(consumer.extended()[0].seq_num_range, 0..1);
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn pause_cancels_retry_backoff_and_extend_restarts() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Session(Err(retryable_error())),
+            FakeAction::Session(Ok(FakeSession::Pending)),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream.clone(),
+            consumer,
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| stream.session_attempts() == 1).await;
+        sender.send(InputReaderCommand::Pause).unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(stream.session_attempts(), 1);
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| stream.session_attempts() == 2).await;
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn fatal_setup_error_stops() {
+        let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Err(
+            fatal_error(),
+        ))]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream,
+            consumer.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| consumer.error_count() == 1).await;
+        assert!(consumer.errors()[0].0);
+        handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_gap_duplicate_or_tail_mismatch_is_fatal() {
+        for (records, tail) in [
+            (vec![(1, b"gap" as &[u8])], None),
+            (vec![(0, b"a" as &[u8]), (0, b"dup" as &[u8])], None),
+            (vec![(0, b"a" as &[u8])], Some(0)),
+            (Vec::new(), Some(1)),
+        ] {
+            let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
+                FakeSession::Events(vec![Ok(batch(records, tail))]),
+            ))]));
+            let (sender, receiver) = unbounded_channel();
+            let consumer = RecordingConsumer::new();
+            consumer.allow_errors();
+            let handle = spawn_worker(
+                stream,
+                consumer.clone(),
+                receiver,
+                Metadata {
+                    seq_num_range: 0..0,
+                    position_resolved: true,
+                },
+                S2StartFrom::Beginning,
+            );
+            sender.send(InputReaderCommand::Extend).unwrap();
+            wait_for(|| consumer.error_count() == 1).await;
+            assert!(consumer.errors()[0].0);
+            handle.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_partial_transient_resumes_without_duplicates() {
+        let stream = Arc::new(FakeS2Stream::new(vec![
+            FakeAction::Session(Ok(FakeSession::Events(vec![
+                Ok(batch(vec![(0, b"a")], None)),
+                Err(retryable_error()),
+            ]))),
+            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+                vec![(1, b"b"), (2, b"c")],
+                None,
+            ))]))),
+        ]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let parser = RecordingParser::new();
+        let handle = spawn_worker_with_parser(
+            stream.clone(),
+            consumer.clone(),
+            parser.clone(),
+            receiver,
+            Metadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            },
+            S2StartFrom::Beginning,
+        );
+
+        sender
+            .send(InputReaderCommand::Replay {
+                metadata: serde_json::to_value(Metadata {
+                    seq_num_range: 0..3,
+                    position_resolved: true,
+                })
+                .unwrap(),
+                data: RmpValue::Nil,
+            })
+            .unwrap();
+        wait_for(|| consumer.replayed_count() == 1).await;
+        sender.send(InputReaderCommand::Disconnect).unwrap();
+        handle.await.unwrap().unwrap();
+        assert_eq!(parser.data(), b"abc".to_vec());
+        let inputs = stream.read_inputs();
+        assert!(matches!(inputs[0].start.from, ReadFrom::SeqNum(0)));
+        assert_eq!(inputs[0].stop.limits.count, Some(3));
+        assert!(matches!(inputs[1].start.from, ReadFrom::SeqNum(1)));
+        assert_eq!(inputs[1].stop.limits.count, Some(2));
+    }
+
+    #[tokio::test]
+    async fn replay_gap_short_and_read_unwritten_are_fatal() {
+        let cases = vec![
+            (
+                vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
+                    batch(vec![(1, b"gap")], None),
+                )])))],
+                1,
+            ),
+            (
+                vec![FakeAction::Session(Ok(FakeSession::Events(vec![])))],
+                1,
+            ),
+            (
+                vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
+                    batch(vec![(0, b"short")], None),
+                )])))],
+                2,
+            ),
+            (vec![FakeAction::Session(Err(fatal_error()))], 1),
+        ];
+        for (case_index, (actions, replay_end)) in cases.into_iter().enumerate() {
+            let stream = Arc::new(FakeS2Stream::new(actions));
+            let (sender, receiver) = unbounded_channel();
+            let consumer = RecordingConsumer::new();
+            consumer.allow_errors();
+            let handle = spawn_worker(
+                stream,
+                consumer.clone(),
+                receiver,
+                Metadata {
+                    seq_num_range: 0..0,
+                    position_resolved: false,
+                },
+                S2StartFrom::Beginning,
+            );
+            sender
+                .send(InputReaderCommand::Replay {
+                    metadata: serde_json::to_value(Metadata {
+                        seq_num_range: 0..replay_end,
+                        position_resolved: true,
+                    })
+                    .unwrap(),
+                    data: RmpValue::Nil,
+                })
+                .unwrap();
+            timeout(Duration::from_secs(1), handle)
+                .await
+                .unwrap_or_else(|_| panic!("replay fatal case {case_index} timed out"))
+                .unwrap()
+                .unwrap_err();
+        }
+    }
+
+    fn spawn_worker(
+        stream: Arc<FakeS2Stream>,
+        consumer: RecordingConsumer,
+        receiver: UnboundedReceiver<InputReaderCommand>,
+        metadata: Metadata,
+        start_from: S2StartFrom,
+    ) -> JoinHandle<Result<(), AnyError>> {
+        spawn_worker_with_parser(
+            stream,
+            consumer,
+            RecordingParser::new(),
+            receiver,
+            metadata,
+            start_from,
+        )
+    }
+
+    fn spawn_worker_with_parser(
+        stream: Arc<FakeS2Stream>,
+        consumer: RecordingConsumer,
+        parser: RecordingParser,
+        receiver: UnboundedReceiver<InputReaderCommand>,
+        metadata: Metadata,
+        start_from: S2StartFrom,
+    ) -> JoinHandle<Result<(), AnyError>> {
+        tokio::spawn(S2Reader::worker_task_with_backoff(
+            Arc::new(basic_config(start_from)),
+            metadata,
+            stream,
+            Box::new(consumer),
+            Box::new(parser),
+            receiver,
+            BackoffConfig {
+                initial: Duration::from_millis(1),
+                max: Duration::from_millis(2),
+            },
+        ))
+    }
+
+    fn basic_config(start_from: S2StartFrom) -> S2InputConfig {
+        S2InputConfig {
+            basin: "basin".to_string(),
+            stream: "stream".to_string(),
+            auth_token: "token".to_string(),
+            endpoint: None,
+            start_from,
+        }
+    }
+
+    fn retryable_error() -> S2Error {
+        S2Error::Client("timeout".to_string())
+    }
+
+    fn fatal_error() -> S2Error {
+        S2Error::Client("unknown".to_string())
+    }
+
+    fn batch(records: Vec<(u64, &[u8])>, tail: Option<u64>) -> S2Batch {
+        S2Batch {
+            records: records
+                .into_iter()
+                .map(|(seq_num, body)| S2Record {
+                    seq_num,
+                    body: body.to_vec(),
+                })
+                .collect(),
+            tail: tail.map(|seq_num| S2Position { seq_num }),
+        }
+    }
+
+    async fn wait_for(mut condition: impl FnMut() -> bool) {
+        timeout(Duration::from_secs(1), async move {
+            while !condition() {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for condition");
+    }
+
+    enum FakeAction {
+        Tail(Result<S2Position, S2Error>),
+        Session(Result<FakeSession, S2Error>),
+    }
+
+    enum FakeSession {
+        Events(Vec<Result<S2Batch, S2Error>>),
+        Pending,
+    }
+
+    struct FakeS2Stream {
+        actions: Mutex<VecDeque<FakeAction>>,
+        read_inputs: Mutex<Vec<ReadInput>>,
+    }
+
+    impl FakeS2Stream {
+        fn new(actions: Vec<FakeAction>) -> Self {
+            Self {
+                actions: Mutex::new(actions.into()),
+                read_inputs: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn read_inputs(&self) -> Vec<ReadInput> {
+            self.read_inputs.lock().unwrap().clone()
+        }
+
+        fn session_attempts(&self) -> usize {
+            self.read_inputs.lock().unwrap().len()
+        }
+
+        fn next_action(&self) -> FakeAction {
+            self.actions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("missing fake S2 action")
+        }
+    }
+
+    #[async_trait]
+    impl S2StreamClient for FakeS2Stream {
+        async fn check_tail(&self) -> Result<S2Position, S2Error> {
+            match self.next_action() {
+                FakeAction::Tail(result) => result,
+                FakeAction::Session(_) => panic!("expected tail action"),
+            }
+        }
+
+        async fn read_session(&self, input: ReadInput) -> Result<S2ReadSession, S2Error> {
+            self.read_inputs.lock().unwrap().push(input);
+            match self.next_action() {
+                FakeAction::Session(Ok(FakeSession::Events(events))) => {
+                    Ok(Box::pin(stream::iter(events)))
+                }
+                FakeAction::Session(Ok(FakeSession::Pending)) => Ok(Box::pin(stream::pending())),
+                FakeAction::Session(Err(error)) => Err(error),
+                FakeAction::Tail(_) => panic!("expected session action"),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingConsumer(Arc<Mutex<ConsumerState>>);
+
+    #[derive(Default)]
+    struct ConsumerState {
+        errors: Vec<(bool, String)>,
+        extended: Vec<Metadata>,
+        replayed: usize,
+        allow_errors: bool,
+    }
+
+    impl RecordingConsumer {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(ConsumerState::default())))
+        }
+
+        fn state(&self) -> MutexGuard<'_, ConsumerState> {
+            self.0.lock().unwrap()
+        }
+
+        fn allow_errors(&self) {
+            self.state().allow_errors = true;
+        }
+
+        fn errors(&self) -> Vec<(bool, String)> {
+            self.state().errors.clone()
+        }
+
+        fn error_count(&self) -> usize {
+            self.state().errors.len()
+        }
+
+        fn extended(&self) -> Vec<Metadata> {
+            self.state()
+                .extended
+                .iter()
+                .map(|m| Metadata {
+                    seq_num_range: m.seq_num_range.clone(),
+                    position_resolved: m.position_resolved,
+                })
+                .collect()
+        }
+
+        fn replayed_count(&self) -> usize {
+            self.state().replayed
+        }
+    }
+
+    impl InputConsumer for RecordingConsumer {
+        fn max_batch_size(&self) -> usize {
+            usize::MAX
+        }
+        fn pipeline_fault_tolerance(&self) -> Option<FtModel> {
+            Some(FtModel::ExactlyOnce)
+        }
+        fn parse_errors(&self, _errors: Vec<ParseError>) {}
+        fn buffered(&self, _amt: BufferSize) {}
+        fn replayed(&self, _num_records: BufferSize, _hash: u64) {
+            self.state().replayed += 1;
+        }
+        fn request_step(&self) {}
+        fn extended(&self, _amt: BufferSize, _resume: Option<Resume>, watermarks: Vec<Watermark>) {
+            let metadata = watermarks.into_iter().find_map(|w| w.metadata).unwrap();
+            self.state()
+                .extended
+                .push(serde_json::from_value(metadata).unwrap());
+        }
+        fn eoi(&self) {}
+        fn start_transaction(&self, _label: Option<&str>) {}
+        fn commit_transaction(&self) {}
+        fn error(&self, fatal: bool, error: AnyError, _tag: Option<&'static str>) {
+            let mut state = self.state();
+            assert!(state.allow_errors, "unexpected error: {error}");
+            state.errors.push((fatal, error.to_string()));
+        }
+        fn update_connector_health(&self, _health: ConnectorHealth) {}
+        fn completion_watcher(
+            &self,
+        ) -> Option<tokio::sync::watch::Receiver<feldera_types::coordination::Completion>> {
+            None
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingParser(Arc<Mutex<Vec<u8>>>);
+
+    impl RecordingParser {
+        fn new() -> Self {
+            Self(Arc::new(Mutex::new(Vec::new())))
+        }
+        fn data(&self) -> Vec<u8> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl Parser for RecordingParser {
+        fn parse(
+            &mut self,
+            data: &[u8],
+            _metadata: Option<ConnectorMetadata>,
+        ) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
+            self.0.lock().unwrap().extend_from_slice(data);
+            (None, Vec::new())
+        }
+        fn stage(&self, _buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+            panic!("stage not used")
+        }
+        fn splitter(&self) -> Box<dyn Splitter> {
+            panic!("splitter not used")
+        }
+        fn fork(&self) -> Box<dyn Parser> {
+            Box::new(self.clone())
+        }
     }
 }

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -27,7 +27,7 @@ use std::hash::Hasher;
 use std::num::NonZeroU32;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
 use std::time::Duration;
 use tokio::{
@@ -37,20 +37,30 @@ use tokio::{
     time::{Instant, sleep_until},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, error, info, info_span, trace};
+use tracing::{Instrument, debug, error, info, info_span, trace};
 use xxhash_rust::xxh3::Xxh3Default;
 
 const RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(10);
 
+/// Checkpoint/resume metadata persisted by the S2 input connector.
+///
+/// `seq_num_range` is the half-open `[start, end)` range of S2 sequence numbers
+/// covered by a checkpoint step; `end` is the position to resume from. For an
+/// empty (no-record) checkpoint it is `pos..pos`. `position_resolved` records
+/// whether the start position has been anchored to an absolute S2 sequence number
+/// (by consuming a record or resolving a tail) — once true, the connector always
+/// resumes from `end` as an absolute sequence rather than recomputing the
+/// configured `start_from`. It defaults to `false` so checkpoints written before
+/// this field existed still deserialize and re-anchor on resume.
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct Metadata {
+pub(crate) struct S2CheckpointMetadata {
     pub(crate) seq_num_range: std::ops::Range<u64>,
     #[serde(default)]
     pub(crate) position_resolved: bool,
 }
 
-impl Metadata {
+impl S2CheckpointMetadata {
     pub(crate) fn from_resume_info(resume_info: Option<JsonValue>) -> Result<Self, AnyError> {
         Ok(resume_info
             .map(serde_json::from_value)
@@ -88,7 +98,7 @@ impl TransportInputEndpoint for S2InputEndpoint {
         schema: Relation,
         resume_info: Option<JsonValue>,
     ) -> AnyResult<Box<dyn InputReader>> {
-        let resume_info = Metadata::from_resume_info(resume_info)?;
+        let resume_info = S2CheckpointMetadata::from_resume_info(resume_info)?;
         info!("Resume info: {:?}", resume_info);
         Ok(Box::new(S2Reader::new(
             self.config.clone(),
@@ -116,14 +126,14 @@ fn make_replay_read_input_from(start: u64, end: u64) -> ReadInput {
 }
 
 fn config_to_read_input(config: &S2InputConfig) -> ReadInput {
-    let start = match &config.start_from {
-        S2StartFrom::SeqNum(n) => ReadStart::new().with_from(ReadFrom::SeqNum(*n)),
-        S2StartFrom::Timestamp(ts) => ReadStart::new().with_from(ReadFrom::Timestamp(*ts)),
-        S2StartFrom::TailOffset(n) => ReadStart::new().with_from(ReadFrom::TailOffset(*n)),
-        S2StartFrom::Beginning => ReadStart::new().with_from(ReadFrom::SeqNum(0)),
-        S2StartFrom::Tail => ReadStart::new().with_from(ReadFrom::TailOffset(0)),
+    let from = match &config.start_from {
+        S2StartFrom::SeqNum(n) => ReadFrom::SeqNum(*n),
+        S2StartFrom::Timestamp(ts) => ReadFrom::Timestamp(*ts),
+        S2StartFrom::TailOffset(n) => ReadFrom::TailOffset(*n),
+        S2StartFrom::Beginning => ReadFrom::SeqNum(0),
+        S2StartFrom::Tail => ReadFrom::TailOffset(0),
     };
-    ReadInput::new().with_start(start)
+    ReadInput::new().with_start(ReadStart::new().with_from(from))
 }
 
 fn read_input_for_position(
@@ -172,6 +182,13 @@ fn classify_s2_server_code(code: &str) -> S2ErrorKind {
     }
 }
 
+/// Classifies a public `S2Error::Client(String)` after the SDK has exhausted its
+/// own retries. The SDK exposes client-transport errors only as a formatted
+/// string, so this matches the exact messages/prefixes that `s2-sdk` 0.31.10
+/// produces (see `ClientError` in `s2-sdk/src/api.rs`). An unknown message is
+/// treated as fatal rather than retrying blindly: if a future SDK rewords a
+/// message, the connector fails closed instead of looping forever. Update this
+/// list (and the `classifies_client_messages_exactly` test) when bumping s2-sdk.
 fn classify_s2_client_message(message: &str) -> S2ErrorKind {
     if message == "heartbeat timeout"
         || message == "timeout"
@@ -208,12 +225,39 @@ struct S2Batch {
 
 type S2ReadSession = Pin<Box<dyn Send + Stream<Item = Result<S2Batch, S2Error>>>>;
 
-#[derive(Clone)]
+/// State shared between the worker and the live reader task.
+///
+/// Wrapped in a single `Arc` and passed by shared reference, rather than a
+/// struct of individual `Arc`s. `position_resolved` is an atomic flag read
+/// lock-free by the reader; `ingest` guards the data that must stay consistent
+/// between ingestion and checkpointing (see [`IngestState`]).
 struct LiveReaderShared {
-    next_seq: Arc<AtomicU64>,
-    position_resolved: Arc<AtomicBool>,
-    queue: Arc<InputQueue<u64>>,
-    ingest_lock: Arc<StdMutex<()>>,
+    position_resolved: AtomicBool,
+    ingest: StdMutex<IngestState>,
+}
+
+/// The next S2 sequence number and the input queue, guarded together so that a
+/// checkpoint flush (`Queue`) can never observe a `next_seq` advanced past a
+/// record that has not yet been queued. This is the invariant that keeps
+/// exactly-once checkpoints honest.
+struct IngestState {
+    next_seq: u64,
+    queue: InputQueue<u64>,
+}
+
+impl LiveReaderShared {
+    fn new(position_resolved: bool, next_seq: u64, queue: InputQueue<u64>) -> Self {
+        Self {
+            position_resolved: AtomicBool::new(position_resolved),
+            ingest: StdMutex::new(IngestState { next_seq, queue }),
+        }
+    }
+
+    fn lock_ingest(&self) -> StdMutexGuard<'_, IngestState> {
+        self.ingest
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 #[async_trait]
@@ -324,7 +368,7 @@ impl ClassifiedError {
         }
     }
 
-    fn after_progress(mut self, made_progress: bool) -> Self {
+    fn with_progress(mut self, made_progress: bool) -> Self {
         self.made_progress = made_progress;
         self
     }
@@ -337,7 +381,7 @@ struct S2Reader {
 impl S2Reader {
     fn new(
         config: Arc<S2InputConfig>,
-        resume_info: Metadata,
+        resume_info: S2CheckpointMetadata,
         consumer: Box<dyn InputConsumer>,
         parser: Box<dyn Parser>,
         table_name: &str,
@@ -409,7 +453,7 @@ impl S2Reader {
 
     async fn worker_task(
         config: Arc<S2InputConfig>,
-        resume_info: Metadata,
+        resume_info: S2CheckpointMetadata,
         s2_stream: Arc<dyn S2StreamClient>,
         consumer: Box<dyn InputConsumer>,
         parser: Box<dyn Parser>,
@@ -429,25 +473,21 @@ impl S2Reader {
 
     async fn worker_task_with_backoff(
         config: Arc<S2InputConfig>,
-        resume_info: Metadata,
+        resume_info: S2CheckpointMetadata,
         s2_stream: Arc<dyn S2StreamClient>,
         consumer: Box<dyn InputConsumer>,
         parser: Box<dyn Parser>,
         command_receiver: UnboundedReceiver<InputReaderCommand>,
         backoff_config: BackoffConfig,
     ) -> Result<(), AnyError> {
-        let queue = Arc::new(InputQueue::<u64>::new(consumer.clone()));
-        let next_seq = Arc::new(AtomicU64::new(resume_info.seq_num_range.end));
-        let position_resolved = Arc::new(AtomicBool::new(resume_info.position_resolved));
-        let ingest_lock = Arc::new(StdMutex::new(()));
-        let live_shared = LiveReaderShared {
-            next_seq: next_seq.clone(),
-            position_resolved: position_resolved.clone(),
-            queue: queue.clone(),
-            ingest_lock: ingest_lock.clone(),
-        };
+        let live_shared = Arc::new(LiveReaderShared::new(
+            resume_info.position_resolved,
+            resume_info.seq_num_range.end,
+            InputQueue::<u64>::new(consumer.clone()),
+        ));
 
-        let mut command_receiver = InputCommandReceiver::<Metadata, ()>::new(command_receiver);
+        let mut command_receiver =
+            InputCommandReceiver::<S2CheckpointMetadata, ()>::new(command_receiver);
 
         // Handle replay commands before normal operation. Replays retry transient S2 failures
         // from the absolute sequence number that remains to be replayed, while preserving the
@@ -465,13 +505,18 @@ impl S2Reader {
             .await?
             {
                 ReplayOutcome::Completed => {
-                    next_seq.store(metadata.seq_num_range.end, Ordering::Release);
+                    {
+                        let mut ingest = live_shared.lock_ingest();
+                        ingest.next_seq = metadata.seq_num_range.end;
+                    }
                     // Preserve the checkpoint's resolved flag rather than forcing it true.
                     // An empty checkpoint taken before the start position was resolved
                     // (e.g. a Tail start that had not yet anchored) must stay unresolved so
                     // the live reader reapplies the configured start_from on resume instead
                     // of reading from absolute sequence 0.
-                    position_resolved.store(metadata.position_resolved, Ordering::Release);
+                    live_shared
+                        .position_resolved
+                        .store(metadata.position_resolved, Ordering::Release);
                 }
                 ReplayOutcome::Disconnected => return Ok(()),
             }
@@ -495,13 +540,7 @@ impl S2Reader {
                             )
                         }
                         InputReaderCommand::Queue { .. } => {
-                            flush_queue(
-                                &queue,
-                                &next_seq,
-                                &position_resolved,
-                                &ingest_lock,
-                                consumer.as_ref(),
-                            )?;
+                            flush_queue(&live_shared, consumer.as_ref())?;
                         }
                         InputReaderCommand::Pause => {}
                         InputReaderCommand::Extend => {
@@ -539,8 +578,27 @@ impl S2Reader {
                             if let Some(c) = canceller.take() {
                                 c.cancel_and_join().await;
                             }
-                            let error = maybe_error.unwrap_or_else(|| ClassifiedError::retryable("S2 reader task stopped without reporting an error"));
-                            drain_reader_errors(&mut reader_error_receiver);
+                            // Collect every queued reader error rather than acting on only the
+                            // first and discarding the rest. If any of them is fatal, treat the
+                            // batch as fatal so a terminal failure is not masked by an earlier
+                            // retryable one. S2 normally surfaces a single terminal error per
+                            // session, so this is mostly defensive.
+                            let mut errors: Vec<ClassifiedError> = maybe_error.into_iter().collect();
+                            while let Ok(e) = reader_error_receiver.try_recv() {
+                                errors.push(e);
+                            }
+                            let error = if errors.is_empty() {
+                                ClassifiedError::retryable(
+                                    "S2 reader task stopped without reporting an error",
+                                )
+                            } else if errors.iter().any(|e| e.kind == S2ErrorKind::Fatal) {
+                                errors
+                                    .into_iter()
+                                    .find(|e| e.kind == S2ErrorKind::Fatal)
+                                    .expect("a fatal error was present")
+                            } else {
+                                errors.into_iter().next().expect("non-empty")
+                            };
                             match error.kind {
                                 S2ErrorKind::Retryable => {
                                     if error.made_progress {
@@ -562,13 +620,7 @@ impl S2Reader {
                                     unreachable!("{command:?} must be at the beginning of the command stream")
                                 }
                                 InputReaderCommand::Queue { .. } => {
-                                    flush_queue(
-                                    &queue,
-                                    &next_seq,
-                                    &position_resolved,
-                                    &ingest_lock,
-                                    consumer.as_ref(),
-                                )?;
+                                    flush_queue(&live_shared, consumer.as_ref())?;
                                 }
                                 InputReaderCommand::Pause => {
                                     if let Some(c) = canceller.take() {
@@ -593,13 +645,7 @@ impl S2Reader {
                                     unreachable!("{command:?} must be at the beginning of the command stream")
                                 }
                                 InputReaderCommand::Queue { .. } => {
-                                    flush_queue(
-                                    &queue,
-                                    &next_seq,
-                                    &position_resolved,
-                                    &ingest_lock,
-                                    consumer.as_ref(),
-                                )?;
+                                    flush_queue(&live_shared, consumer.as_ref())?;
                                 }
                                 InputReaderCommand::Pause => {
                                     if let Some(c) = canceller.take() {
@@ -610,6 +656,9 @@ impl S2Reader {
                                     backoff.reset();
                                     state = ReaderLifecycleState::Paused;
                                 }
+                                // No-op: this state is only reachable from Running (on a
+                                // reader error), so a restart is already pending via the
+                                // retry timer; an Extend here would just duplicate it.
                                 InputReaderCommand::Extend => {}
                                 InputReaderCommand::Disconnect => break,
                             }
@@ -665,32 +714,24 @@ fn drain_reader_errors(reader_error_receiver: &mut UnboundedReceiver<ClassifiedE
     while reader_error_receiver.try_recv().is_ok() {}
 }
 
-fn lock_ingest(ingest_lock: &StdMutex<()>) -> StdMutexGuard<'_, ()> {
-    ingest_lock
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-fn flush_queue(
-    queue: &InputQueue<u64>,
-    next_seq: &AtomicU64,
-    position_resolved: &AtomicBool,
-    ingest_lock: &StdMutex<()>,
-    consumer: &dyn InputConsumer,
-) -> Result<(), AnyError> {
-    let _guard = lock_ingest(ingest_lock);
-    let (buffer_size, hasher, batches) = queue.flush_with_aux();
+fn flush_queue(shared: &LiveReaderShared, consumer: &dyn InputConsumer) -> Result<(), AnyError> {
+    let ingest = shared.lock_ingest();
+    let (buffer_size, hasher, batches) = ingest.queue.flush_with_aux();
     let seq_range = match (batches.first(), batches.last()) {
         (Some((_, first)), Some((_, last))) => *first..*last + 1,
+        // No records were queued; checkpoint the current resume position as a
+        // zero-length range. hash is 0 because there is nothing to verify on
+        // replay of an empty range.
         _ => {
-            let pos = next_seq.load(Ordering::Acquire);
+            let pos = ingest.next_seq;
             pos..pos
         }
     };
-    info!("Queued {:?} records ({seq_range:?})", buffer_size);
-    let metadata_json = serde_json::to_value(&Metadata {
+    drop(ingest);
+    debug!("Queued {:?} records ({seq_range:?})", buffer_size);
+    let metadata_json = serde_json::to_value(&S2CheckpointMetadata {
         seq_num_range: seq_range,
-        position_resolved: position_resolved.load(Ordering::Acquire),
+        position_resolved: shared.position_resolved.load(Ordering::Acquire),
     })?;
     let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
     let hash = hasher.map(|h| h.finish()).unwrap_or(0);
@@ -727,7 +768,10 @@ async fn resolve_tail(
         .check_tail()
         .await
         .map_err(|e| ClassifiedError::new("failed to resolve S2 tail position", e))?;
-    shared.next_seq.store(tail.seq_num, Ordering::Release);
+    {
+        let mut ingest = shared.lock_ingest();
+        ingest.next_seq = tail.seq_num;
+    }
     shared.position_resolved.store(true, Ordering::Release);
     Ok(())
 }
@@ -756,7 +800,7 @@ fn apply_start_error(
 fn spawn_live_reader(
     s2_stream: Arc<dyn S2StreamClient>,
     config: Arc<S2InputConfig>,
-    shared: LiveReaderShared,
+    shared: Arc<LiveReaderShared>,
     mut parser: Box<dyn Parser>,
     reader_error_sender: UnboundedSender<ClassifiedError>,
 ) -> Canceller {
@@ -764,7 +808,7 @@ fn spawn_live_reader(
     let join_handle = tokio::spawn({
         let cancel_token_copy = cancel_token.clone();
         async move {
-            let start_seq = shared.next_seq.load(Ordering::Acquire);
+            let start_seq = shared.lock_ingest().next_seq;
             let resolved = shared.position_resolved.load(Ordering::Acquire);
             let read_input = read_input_for_position(&config, start_seq, resolved);
             let mut session = select! {
@@ -794,22 +838,19 @@ fn spawn_live_reader(
                                 made_progress = true;
                                 if let Err(error) = process_live_batch(
                                     batch,
-                                    &shared.next_seq,
-                                    &shared.position_resolved,
-                                    &shared.queue,
-                                    &shared.ingest_lock,
+                                    &shared,
                                     parser.as_mut(),
                                 ) {
-                                    let _ = reader_error_sender.send(error.after_progress(made_progress));
+                                    let _ = reader_error_sender.send(error.with_progress(made_progress));
                                     break;
                                 }
                             }
                             Some(Err(error)) => {
-                                let _ = reader_error_sender.send(ClassifiedError::new("S2 stream error after SDK retries", error).after_progress(made_progress));
+                                let _ = reader_error_sender.send(ClassifiedError::new("S2 stream error after SDK retries", error).with_progress(made_progress));
                                 break;
                             }
                             None => {
-                                let _ = reader_error_sender.send(ClassifiedError::retryable("S2 read session ended; reconnecting").after_progress(made_progress));
+                                let _ = reader_error_sender.send(ClassifiedError::retryable("S2 read session ended; reconnecting").with_progress(made_progress));
                                 break;
                             }
                         }
@@ -827,15 +868,12 @@ fn spawn_live_reader(
 
 fn process_live_batch(
     batch: S2Batch,
-    next_seq: &AtomicU64,
-    position_resolved: &AtomicBool,
-    queue: &InputQueue<u64>,
-    ingest_lock: &StdMutex<()>,
+    shared: &LiveReaderShared,
     parser: &mut dyn Parser,
 ) -> Result<(), ClassifiedError> {
-    let _guard = lock_ingest(ingest_lock);
-    let mut expected_seq = next_seq.load(Ordering::Acquire);
-    let mut resolved = position_resolved.load(Ordering::Acquire);
+    let mut ingest = shared.lock_ingest();
+    let mut expected_seq = ingest.next_seq;
+    let mut resolved = shared.position_resolved.load(Ordering::Acquire);
 
     for record in &batch.records {
         trace!("Got record #{}", record.seq_num);
@@ -847,11 +885,13 @@ fn process_live_batch(
         }
         if !resolved {
             resolved = true;
-            position_resolved.store(true, Ordering::Release);
+            shared.position_resolved.store(true, Ordering::Release);
         }
         expected_seq = record.seq_num + 1;
-        next_seq.store(expected_seq, Ordering::Release);
-        queue.push_with_aux(parser.parse(&record.body, None), Utc::now(), record.seq_num);
+        ingest.next_seq = expected_seq;
+        ingest
+            .queue
+            .push_with_aux(parser.parse(&record.body, None), Utc::now(), record.seq_num);
     }
 
     if let Some(tail) = &batch.tail {
@@ -861,8 +901,8 @@ fn process_live_batch(
                 tail.seq_num
             )));
         }
-        next_seq.store(tail.seq_num, Ordering::Release);
-        position_resolved.store(true, Ordering::Release);
+        ingest.next_seq = tail.seq_num;
+        shared.position_resolved.store(true, Ordering::Release);
     }
 
     Ok(())
@@ -878,8 +918,8 @@ async fn replay_checkpoint(
     s2_stream: Arc<dyn S2StreamClient>,
     consumer: Box<dyn InputConsumer>,
     mut parser: Box<dyn Parser>,
-    command_receiver: &mut InputCommandReceiver<Metadata, ()>,
-    metadata: &Metadata,
+    command_receiver: &mut InputCommandReceiver<S2CheckpointMetadata, ()>,
+    metadata: &S2CheckpointMetadata,
     backoff_config: BackoffConfig,
 ) -> Result<ReplayOutcome, AnyError> {
     let first = metadata.seq_num_range.start;
@@ -982,32 +1022,22 @@ async fn replay_checkpoint(
 
 async fn wait_replay_backoff(
     backoff: &mut BackoffState,
-    command_receiver: &mut InputCommandReceiver<Metadata, ()>,
+    command_receiver: &mut InputCommandReceiver<S2CheckpointMetadata, ()>,
 ) -> Result<ReplayOutcome, AnyError> {
-    let retry_at = backoff.next_deadline();
-    // Hold any non-Disconnect control command locally (instead of put_back) so the
-    // backoff timer still elapses. Otherwise a buffered command would be re-received
-    // immediately on the next retry, busy-looping read_session against S2.
-    // `put_back` is single-slot, so a second pending command stays in the channel and
-    // is handled on the following backoff iteration; no command is lost.
-    let mut held: Option<InputReaderCommand> = None;
-    let outcome = loop {
-        select! {
-            _ = sleep_until(retry_at) => break ReplayOutcome::Completed,
-            command = command_receiver.recv() => match command? {
-                InputReaderCommand::Disconnect => break ReplayOutcome::Disconnected,
-                other if held.is_none() => held = Some(other),
-                other => {
-                    command_receiver.put_back(other);
-                    break ReplayOutcome::Completed;
-                }
-            },
+    // Check for control commands *before* sleeping. Disconnect stops replay
+    // immediately; any other command is buffered back for the worker to handle
+    // once this backoff elapses (it cannot be serviced mid-replay). We take at
+    // most one command per call — `put_back` is single-slot, so taking a second
+    // before draining the first would assert-fail. The sleep then always elapses,
+    // so a buffered command cannot busy-loop `read_session` against S2.
+    if let Some(command) = command_receiver.try_recv()? {
+        match command {
+            InputReaderCommand::Disconnect => return Ok(ReplayOutcome::Disconnected),
+            other => command_receiver.put_back(other),
         }
-    };
-    if let Some(command) = held {
-        command_receiver.put_back(command);
     }
-    Ok(outcome)
+    sleep_until(backoff.next_deadline()).await;
+    Ok(ReplayOutcome::Completed)
 }
 
 struct Canceller {
@@ -1037,780 +1067,4 @@ impl InputReader for S2Reader {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::format::{InputBuffer, Splitter};
-    use dbsp::operator::StagedBuffers;
-    use feldera_adapterlib::ConnectorMetadata;
-    use feldera_adapterlib::format::ParseError;
-    use feldera_types::adapter_stats::ConnectorHealth;
-    use feldera_types::config::FtModel;
-    use futures::stream;
-    use rmpv::Value as RmpValue;
-    use s2_sdk::types::{FencingToken, ValidationError};
-    use std::collections::VecDeque;
-    use std::sync::{Mutex, MutexGuard};
-    use tokio::time::{Duration, timeout};
-
-    #[test]
-    fn classifies_server_codes_exactly() {
-        for code in [
-            "request_timeout",
-            "rate_limited",
-            "other",
-            "storage",
-            "hot_server",
-            "unavailable",
-            "upstream_timeout",
-            "transaction_conflict",
-        ] {
-            assert_eq!(
-                classify_s2_server_code(code),
-                S2ErrorKind::Retryable,
-                "{code}"
-            );
-        }
-        for code in ["", "not_found", "permission_denied", "rate_limited_extra"] {
-            assert_eq!(classify_s2_server_code(code), S2ErrorKind::Fatal, "{code}");
-        }
-    }
-
-    #[test]
-    fn classifies_client_messages_exactly() {
-        for message in [
-            "heartbeat timeout",
-            "timeout",
-            "connect: dns",
-            "connection closed early: eof",
-            "request canceled: dropped",
-            "unexpected eof: body",
-            "connection reset: reset",
-            "connection aborted: aborted",
-            "connection refused: refused",
-        ] {
-            assert_eq!(
-                classify_s2_client_message(message),
-                S2ErrorKind::Retryable,
-                "{message}"
-            );
-        }
-        for message in ["", "heart beat timeout", "timeout: later", "unknown"] {
-            assert_eq!(
-                classify_s2_client_message(message),
-                S2ErrorKind::Fatal,
-                "{message}"
-            );
-        }
-    }
-
-    #[test]
-    fn classifies_constructible_s2_error_variants() {
-        assert_eq!(
-            classify_s2_error(&S2Error::Client("timeout".to_string())),
-            S2ErrorKind::Retryable
-        );
-        assert_eq!(
-            classify_s2_error(&S2Error::Client("unknown".to_string())),
-            S2ErrorKind::Fatal
-        );
-        assert_eq!(
-            classify_s2_error(&S2Error::MalformedAccessToken("bad".to_string())),
-            S2ErrorKind::Fatal
-        );
-        assert_eq!(
-            classify_s2_error(&S2Error::Validation(ValidationError("bad".to_string()))),
-            S2ErrorKind::Fatal
-        );
-        assert_eq!(
-            classify_s2_error(&S2Error::AppendConditionFailed(
-                AppendConditionFailed::SeqNumMismatch(1)
-            )),
-            S2ErrorKind::Fatal
-        );
-        assert_eq!(
-            classify_s2_error(&S2Error::AppendConditionFailed(
-                AppendConditionFailed::FencingTokenMismatch(
-                    "token".parse::<FencingToken>().unwrap()
-                )
-            )),
-            S2ErrorKind::Fatal
-        );
-    }
-
-    #[test]
-    fn resolved_zero_uses_absolute_sequence_zero() {
-        let config = basic_config(S2StartFrom::Tail);
-        let input = read_input_for_position(&config, 0, true);
-        assert!(matches!(input.start.from, ReadFrom::SeqNum(0)));
-
-        let input = read_input_for_position(&config, 0, false);
-        assert!(matches!(input.start.from, ReadFrom::TailOffset(0)));
-    }
-
-    #[tokio::test]
-    async fn empty_unresolved_checkpoint_reuses_configured_start_from() {
-        // A checkpoint taken before the start position was resolved must not force the
-        // live reader to read from absolute sequence 0; the configured start_from still
-        // applies on resume.
-        let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
-            FakeSession::Pending,
-        ))]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream.clone(),
-            consumer,
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: false,
-            },
-            S2StartFrom::SeqNum(5),
-        );
-
-        sender
-            .send(InputReaderCommand::Replay {
-                metadata: serde_json::to_value(Metadata {
-                    seq_num_range: 0..0,
-                    position_resolved: false,
-                })
-                .unwrap(),
-                data: RmpValue::Nil,
-            })
-            .unwrap();
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| stream.read_inputs().len() == 1).await;
-        assert!(matches!(
-            stream.read_inputs()[0].start.from,
-            ReadFrom::SeqNum(5)
-        ));
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn resolved_tail_is_anchored_before_first_queue_checkpoint() {
-        // The tail must be resolved (and the position anchored) before a Queue can emit a
-        // replayable checkpoint, so an empty checkpoint carries the resolved sequence
-        // rather than an unresolved zero.
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Tail(Ok(S2Position { seq_num: 7 })),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream.clone(),
-            consumer.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: false,
-            },
-            S2StartFrom::Tail,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| stream.read_inputs().len() == 1).await;
-        sender
-            .send(InputReaderCommand::Queue {
-                checkpoint_requested: false,
-            })
-            .unwrap();
-        wait_for(|| !consumer.extended().is_empty()).await;
-        assert_eq!(consumer.extended()[0].seq_num_range, 7..7);
-        assert!(consumer.extended()[0].position_resolved);
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn tail_transient_recovers_and_starts_from_resolved_zero() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Tail(Err(retryable_error())),
-            FakeAction::Tail(Ok(S2Position { seq_num: 0 })),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream.clone(),
-            consumer.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: false,
-            },
-            S2StartFrom::Tail,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| consumer.error_count() >= 1).await;
-        wait_for(|| stream.read_inputs().len() == 1).await;
-        assert_eq!(consumer.errors()[0].0, false);
-        assert!(matches!(
-            stream.read_inputs()[0].start.from,
-            ReadFrom::SeqNum(0)
-        ));
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn live_setup_and_midstream_transients_recover() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Session(Err(retryable_error())),
-            FakeAction::Session(Ok(FakeSession::Events(vec![
-                Ok(batch(vec![(0, b"a")], None)),
-                Err(retryable_error()),
-            ]))),
-            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
-                vec![(1, b"b")],
-                None,
-            ))]))),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let parser = RecordingParser::new();
-        let handle = spawn_worker_with_parser(
-            stream,
-            consumer.clone(),
-            parser.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: true,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| parser.data() == b"ab".to_vec()).await;
-        assert!(consumer.errors().iter().any(|(fatal, _)| !fatal));
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn live_none_reconnects() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
-                vec![(0, b"a")],
-                None,
-            ))]))),
-            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
-                vec![(1, b"b")],
-                None,
-            ))]))),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let parser = RecordingParser::new();
-        let handle = spawn_worker_with_parser(
-            stream,
-            consumer,
-            parser.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: true,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| parser.data() == b"ab".to_vec()).await;
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn queue_responds_while_retrying() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Session(Ok(FakeSession::Events(vec![
-                Ok(batch(vec![(0, b"a")], None)),
-                Err(retryable_error()),
-            ]))),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream,
-            consumer.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: true,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| consumer.error_count() >= 1).await;
-        sender
-            .send(InputReaderCommand::Queue {
-                checkpoint_requested: false,
-            })
-            .unwrap();
-        wait_for(|| !consumer.extended().is_empty()).await;
-        assert_eq!(consumer.extended()[0].seq_num_range, 0..1);
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn pause_cancels_retry_backoff_and_extend_restarts() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Session(Err(retryable_error())),
-            FakeAction::Session(Ok(FakeSession::Pending)),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream.clone(),
-            consumer,
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: true,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| stream.session_attempts() == 1).await;
-        sender.send(InputReaderCommand::Pause).unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        assert_eq!(stream.session_attempts(), 1);
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| stream.session_attempts() == 2).await;
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn fatal_setup_error_stops() {
-        let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Err(
-            fatal_error(),
-        ))]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let handle = spawn_worker(
-            stream,
-            consumer.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: true,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender.send(InputReaderCommand::Extend).unwrap();
-        wait_for(|| consumer.error_count() == 1).await;
-        assert!(consumer.errors()[0].0);
-        handle.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn live_gap_duplicate_or_tail_mismatch_is_fatal() {
-        for (records, tail) in [
-            (vec![(1, b"gap" as &[u8])], None),
-            (vec![(0, b"a" as &[u8]), (0, b"dup" as &[u8])], None),
-            (vec![(0, b"a" as &[u8])], Some(0)),
-            (Vec::new(), Some(1)),
-        ] {
-            let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
-                FakeSession::Events(vec![Ok(batch(records, tail))]),
-            ))]));
-            let (sender, receiver) = unbounded_channel();
-            let consumer = RecordingConsumer::new();
-            consumer.allow_errors();
-            let handle = spawn_worker(
-                stream,
-                consumer.clone(),
-                receiver,
-                Metadata {
-                    seq_num_range: 0..0,
-                    position_resolved: true,
-                },
-                S2StartFrom::Beginning,
-            );
-            sender.send(InputReaderCommand::Extend).unwrap();
-            wait_for(|| consumer.error_count() == 1).await;
-            assert!(consumer.errors()[0].0);
-            handle.await.unwrap().unwrap();
-        }
-    }
-
-    #[tokio::test]
-    async fn replay_partial_transient_resumes_without_duplicates() {
-        let stream = Arc::new(FakeS2Stream::new(vec![
-            FakeAction::Session(Ok(FakeSession::Events(vec![
-                Ok(batch(vec![(0, b"a")], None)),
-                Err(retryable_error()),
-            ]))),
-            FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
-                vec![(1, b"b"), (2, b"c")],
-                None,
-            ))]))),
-        ]));
-        let (sender, receiver) = unbounded_channel();
-        let consumer = RecordingConsumer::new();
-        consumer.allow_errors();
-        let parser = RecordingParser::new();
-        let handle = spawn_worker_with_parser(
-            stream.clone(),
-            consumer.clone(),
-            parser.clone(),
-            receiver,
-            Metadata {
-                seq_num_range: 0..0,
-                position_resolved: false,
-            },
-            S2StartFrom::Beginning,
-        );
-
-        sender
-            .send(InputReaderCommand::Replay {
-                metadata: serde_json::to_value(Metadata {
-                    seq_num_range: 0..3,
-                    position_resolved: true,
-                })
-                .unwrap(),
-                data: RmpValue::Nil,
-            })
-            .unwrap();
-        wait_for(|| consumer.replayed_count() == 1).await;
-        sender.send(InputReaderCommand::Disconnect).unwrap();
-        handle.await.unwrap().unwrap();
-        assert_eq!(parser.data(), b"abc".to_vec());
-        let inputs = stream.read_inputs();
-        assert!(matches!(inputs[0].start.from, ReadFrom::SeqNum(0)));
-        assert_eq!(inputs[0].stop.limits.count, Some(3));
-        assert!(matches!(inputs[1].start.from, ReadFrom::SeqNum(1)));
-        assert_eq!(inputs[1].stop.limits.count, Some(2));
-    }
-
-    #[tokio::test]
-    async fn replay_gap_short_and_read_unwritten_are_fatal() {
-        let cases = vec![
-            (
-                vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
-                    batch(vec![(1, b"gap")], None),
-                )])))],
-                1,
-            ),
-            (
-                vec![FakeAction::Session(Ok(FakeSession::Events(vec![])))],
-                1,
-            ),
-            (
-                vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
-                    batch(vec![(0, b"short")], None),
-                )])))],
-                2,
-            ),
-            (vec![FakeAction::Session(Err(fatal_error()))], 1),
-        ];
-        for (case_index, (actions, replay_end)) in cases.into_iter().enumerate() {
-            let stream = Arc::new(FakeS2Stream::new(actions));
-            let (sender, receiver) = unbounded_channel();
-            let consumer = RecordingConsumer::new();
-            consumer.allow_errors();
-            let handle = spawn_worker(
-                stream,
-                consumer.clone(),
-                receiver,
-                Metadata {
-                    seq_num_range: 0..0,
-                    position_resolved: false,
-                },
-                S2StartFrom::Beginning,
-            );
-            sender
-                .send(InputReaderCommand::Replay {
-                    metadata: serde_json::to_value(Metadata {
-                        seq_num_range: 0..replay_end,
-                        position_resolved: true,
-                    })
-                    .unwrap(),
-                    data: RmpValue::Nil,
-                })
-                .unwrap();
-            timeout(Duration::from_secs(1), handle)
-                .await
-                .unwrap_or_else(|_| panic!("replay fatal case {case_index} timed out"))
-                .unwrap()
-                .unwrap_err();
-        }
-    }
-
-    fn spawn_worker(
-        stream: Arc<FakeS2Stream>,
-        consumer: RecordingConsumer,
-        receiver: UnboundedReceiver<InputReaderCommand>,
-        metadata: Metadata,
-        start_from: S2StartFrom,
-    ) -> JoinHandle<Result<(), AnyError>> {
-        spawn_worker_with_parser(
-            stream,
-            consumer,
-            RecordingParser::new(),
-            receiver,
-            metadata,
-            start_from,
-        )
-    }
-
-    fn spawn_worker_with_parser(
-        stream: Arc<FakeS2Stream>,
-        consumer: RecordingConsumer,
-        parser: RecordingParser,
-        receiver: UnboundedReceiver<InputReaderCommand>,
-        metadata: Metadata,
-        start_from: S2StartFrom,
-    ) -> JoinHandle<Result<(), AnyError>> {
-        tokio::spawn(S2Reader::worker_task_with_backoff(
-            Arc::new(basic_config(start_from)),
-            metadata,
-            stream,
-            Box::new(consumer),
-            Box::new(parser),
-            receiver,
-            BackoffConfig {
-                initial: Duration::from_millis(1),
-                max: Duration::from_millis(2),
-            },
-        ))
-    }
-
-    fn basic_config(start_from: S2StartFrom) -> S2InputConfig {
-        S2InputConfig {
-            basin: "basin".to_string(),
-            stream: "stream".to_string(),
-            auth_token: "token".to_string(),
-            endpoint: None,
-            start_from,
-        }
-    }
-
-    fn retryable_error() -> S2Error {
-        S2Error::Client("timeout".to_string())
-    }
-
-    fn fatal_error() -> S2Error {
-        S2Error::Client("unknown".to_string())
-    }
-
-    fn batch(records: Vec<(u64, &[u8])>, tail: Option<u64>) -> S2Batch {
-        S2Batch {
-            records: records
-                .into_iter()
-                .map(|(seq_num, body)| S2Record {
-                    seq_num,
-                    body: body.to_vec(),
-                })
-                .collect(),
-            tail: tail.map(|seq_num| S2Position { seq_num }),
-        }
-    }
-
-    async fn wait_for(mut condition: impl FnMut() -> bool) {
-        timeout(Duration::from_secs(1), async move {
-            while !condition() {
-                tokio::time::sleep(Duration::from_millis(1)).await;
-            }
-        })
-        .await
-        .expect("timed out waiting for condition");
-    }
-
-    enum FakeAction {
-        Tail(Result<S2Position, S2Error>),
-        Session(Result<FakeSession, S2Error>),
-    }
-
-    enum FakeSession {
-        Events(Vec<Result<S2Batch, S2Error>>),
-        Pending,
-    }
-
-    struct FakeS2Stream {
-        actions: Mutex<VecDeque<FakeAction>>,
-        read_inputs: Mutex<Vec<ReadInput>>,
-    }
-
-    impl FakeS2Stream {
-        fn new(actions: Vec<FakeAction>) -> Self {
-            Self {
-                actions: Mutex::new(actions.into()),
-                read_inputs: Mutex::new(Vec::new()),
-            }
-        }
-
-        fn read_inputs(&self) -> Vec<ReadInput> {
-            self.read_inputs.lock().unwrap().clone()
-        }
-
-        fn session_attempts(&self) -> usize {
-            self.read_inputs.lock().unwrap().len()
-        }
-
-        fn next_action(&self) -> FakeAction {
-            self.actions
-                .lock()
-                .unwrap()
-                .pop_front()
-                .expect("missing fake S2 action")
-        }
-    }
-
-    #[async_trait]
-    impl S2StreamClient for FakeS2Stream {
-        async fn check_tail(&self) -> Result<S2Position, S2Error> {
-            match self.next_action() {
-                FakeAction::Tail(result) => result,
-                FakeAction::Session(_) => panic!("expected tail action"),
-            }
-        }
-
-        async fn read_session(&self, input: ReadInput) -> Result<S2ReadSession, S2Error> {
-            self.read_inputs.lock().unwrap().push(input);
-            match self.next_action() {
-                FakeAction::Session(Ok(FakeSession::Events(events))) => {
-                    Ok(Box::pin(stream::iter(events)))
-                }
-                FakeAction::Session(Ok(FakeSession::Pending)) => Ok(Box::pin(stream::pending())),
-                FakeAction::Session(Err(error)) => Err(error),
-                FakeAction::Tail(_) => panic!("expected session action"),
-            }
-        }
-    }
-
-    #[derive(Clone)]
-    struct RecordingConsumer(Arc<Mutex<ConsumerState>>);
-
-    #[derive(Default)]
-    struct ConsumerState {
-        errors: Vec<(bool, String)>,
-        extended: Vec<Metadata>,
-        replayed: usize,
-        allow_errors: bool,
-    }
-
-    impl RecordingConsumer {
-        fn new() -> Self {
-            Self(Arc::new(Mutex::new(ConsumerState::default())))
-        }
-
-        fn state(&self) -> MutexGuard<'_, ConsumerState> {
-            self.0.lock().unwrap()
-        }
-
-        fn allow_errors(&self) {
-            self.state().allow_errors = true;
-        }
-
-        fn errors(&self) -> Vec<(bool, String)> {
-            self.state().errors.clone()
-        }
-
-        fn error_count(&self) -> usize {
-            self.state().errors.len()
-        }
-
-        fn extended(&self) -> Vec<Metadata> {
-            self.state()
-                .extended
-                .iter()
-                .map(|m| Metadata {
-                    seq_num_range: m.seq_num_range.clone(),
-                    position_resolved: m.position_resolved,
-                })
-                .collect()
-        }
-
-        fn replayed_count(&self) -> usize {
-            self.state().replayed
-        }
-    }
-
-    impl InputConsumer for RecordingConsumer {
-        fn max_batch_size(&self) -> usize {
-            usize::MAX
-        }
-        fn pipeline_fault_tolerance(&self) -> Option<FtModel> {
-            Some(FtModel::ExactlyOnce)
-        }
-        fn parse_errors(&self, _errors: Vec<ParseError>) {}
-        fn buffered(&self, _amt: BufferSize) {}
-        fn replayed(&self, _num_records: BufferSize, _hash: u64) {
-            self.state().replayed += 1;
-        }
-        fn request_step(&self) {}
-        fn extended(&self, _amt: BufferSize, _resume: Option<Resume>, watermarks: Vec<Watermark>) {
-            let metadata = watermarks.into_iter().find_map(|w| w.metadata).unwrap();
-            self.state()
-                .extended
-                .push(serde_json::from_value(metadata).unwrap());
-        }
-        fn eoi(&self) {}
-        fn start_transaction(&self, _label: Option<&str>) {}
-        fn commit_transaction(&self) {}
-        fn error(&self, fatal: bool, error: AnyError, _tag: Option<&'static str>) {
-            let mut state = self.state();
-            assert!(state.allow_errors, "unexpected error: {error}");
-            state.errors.push((fatal, error.to_string()));
-        }
-        fn update_connector_health(&self, _health: ConnectorHealth) {}
-        fn completion_watcher(
-            &self,
-        ) -> Option<tokio::sync::watch::Receiver<feldera_types::coordination::Completion>> {
-            None
-        }
-    }
-
-    #[derive(Clone)]
-    struct RecordingParser(Arc<Mutex<Vec<u8>>>);
-
-    impl RecordingParser {
-        fn new() -> Self {
-            Self(Arc::new(Mutex::new(Vec::new())))
-        }
-        fn data(&self) -> Vec<u8> {
-            self.0.lock().unwrap().clone()
-        }
-    }
-
-    impl Parser for RecordingParser {
-        fn parse(
-            &mut self,
-            data: &[u8],
-            _metadata: Option<ConnectorMetadata>,
-        ) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
-            self.0.lock().unwrap().extend_from_slice(data);
-            (None, Vec::new())
-        }
-        fn stage(&self, _buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
-            panic!("stage not used")
-        }
-        fn splitter(&self) -> Box<dyn Splitter> {
-            panic!("splitter not used")
-        }
-        fn fork(&self) -> Box<dyn Parser> {
-            Box::new(self.clone())
-        }
-    }
-}
+mod tests;

--- a/crates/adapters/src/transport/s2/input.rs
+++ b/crates/adapters/src/transport/s2/input.rs
@@ -16,8 +16,8 @@ use futures::StreamExt;
 use s2_sdk::{
     S2,
     types::{
-        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadStart, RetryConfig, S2Config,
-        S2Endpoints,
+        AccountEndpoint, BasinEndpoint, ReadFrom, ReadInput, ReadLimits, ReadStart, ReadStop,
+        RetryConfig, S2Config, S2Endpoints,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ use serde_json::Value as JsonValue;
 use std::hash::Hasher;
 use std::num::NonZeroU32;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::{
     select,
@@ -39,6 +39,8 @@ use xxhash_rust::xxh3::Xxh3Default;
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Metadata {
     pub(crate) seq_num_range: std::ops::Range<u64>,
+    #[serde(default)]
+    pub(crate) position_resolved: bool,
 }
 
 impl Metadata {
@@ -48,6 +50,7 @@ impl Metadata {
             .transpose()?
             .unwrap_or(Self {
                 seq_num_range: 0..0,
+                position_resolved: false,
             }))
     }
 }
@@ -92,6 +95,12 @@ impl TransportInputEndpoint for S2InputEndpoint {
 
 fn make_read_input(start_seq: u64) -> ReadInput {
     ReadInput::new().with_start(ReadStart::new().with_from(ReadFrom::SeqNum(start_seq)))
+}
+
+pub(crate) fn make_replay_read_input(seq_num_range: &std::ops::Range<u64>) -> ReadInput {
+    let count = usize::try_from(seq_num_range.end - seq_num_range.start).unwrap_or(usize::MAX);
+    make_read_input(seq_num_range.start)
+        .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(count)))
 }
 
 fn config_to_read_input(config: &S2InputConfig) -> ReadInput {
@@ -200,6 +209,7 @@ impl S2Reader {
         let mut canceller: Option<Canceller> = None;
         let queue = Arc::new(InputQueue::<u64>::new(consumer.clone()));
         let next_seq = Arc::new(AtomicU64::new(resume_info.seq_num_range.end));
+        let position_resolved = Arc::new(AtomicBool::new(resume_info.position_resolved));
         let s2_stream = Arc::new(s2_stream);
 
         let mut command_receiver = InputCommandReceiver::<Metadata, ()>::new(command_receiver);
@@ -209,9 +219,9 @@ impl S2Reader {
             info!("Replay: {:?}", metadata);
             if !metadata.seq_num_range.is_empty() {
                 let first = metadata.seq_num_range.start;
-                let last = metadata.seq_num_range.end - 1;
+                let end = metadata.seq_num_range.end;
 
-                let read_input = make_read_input(first);
+                let read_input = make_replay_read_input(&metadata.seq_num_range);
                 let mut session = s2_stream.read_session(read_input).await.with_context(|| {
                     format!("Failed to create read session for replay from {first}")
                 })?;
@@ -219,14 +229,16 @@ impl S2Reader {
                 let mut hasher = Xxh3Default::new();
                 let mut buffer_size = BufferSize::default();
                 let mut replay_parser = parser.fork();
-                let mut done = false;
+                let mut expected_seq = first;
 
                 while let Some(result) = session.next().await {
                     let batch = result.map_err(|e| anyhow!("S2 read error during replay: {e}"))?;
                     for record in &batch.records {
-                        if record.seq_num > last {
-                            done = true;
-                            break;
+                        if record.seq_num != expected_seq {
+                            return Err(anyhow!(
+                                "S2 replay expected sequence number {expected_seq}, but received {}",
+                                record.seq_num
+                            ));
                         }
                         let data = &record.body;
                         let (buffer, errors) = replay_parser.parse(data, None);
@@ -241,18 +253,19 @@ impl S2Reader {
                         };
                         consumer.buffered(amt);
                         buffer_size += amt;
-                        if record.seq_num == last {
-                            done = true;
-                            break;
-                        }
-                    }
-                    if done {
-                        break;
+                        expected_seq += 1;
                     }
                 }
 
+                if expected_seq != end {
+                    return Err(anyhow!(
+                        "S2 replay ended at sequence number {expected_seq}, before expected end {end}; the checkpointed records may have been trimmed"
+                    ));
+                }
+
                 consumer.replayed(buffer_size, hasher.finish());
-                next_seq.store(last + 1, Ordering::Release);
+                next_seq.store(end, Ordering::Release);
+                position_resolved.store(true, Ordering::Release);
             } else {
                 consumer.replayed(BufferSize::default(), Xxh3Default::new().finish());
             }
@@ -276,6 +289,7 @@ impl S2Reader {
                     info!("Queued {:?} records ({seq_range:?})", buffer_size);
                     let metadata_json = serde_json::to_value(&Metadata {
                         seq_num_range: seq_range,
+                        position_resolved: position_resolved.load(Ordering::Acquire),
                     })?;
                     let timestamp = batches.last().map(|(ts, _)| *ts).unwrap_or_else(Utc::now);
                     let hash = hasher.map(|h| h.finish()).unwrap_or(0);
@@ -299,10 +313,21 @@ impl S2Reader {
                     let cur_seq = next_seq.load(Ordering::Acquire);
                     info!("Extend from {cur_seq}");
                     if canceller.is_none() {
+                        if !position_resolved.load(Ordering::Acquire)
+                            && matches!(config.start_from, S2StartFrom::Tail)
+                        {
+                            let tail = s2_stream
+                                .check_tail()
+                                .await
+                                .context("Failed to resolve the S2 tail position")?;
+                            next_seq.store(tail.seq_num, Ordering::Release);
+                            position_resolved.store(true, Ordering::Release);
+                        }
                         canceller = Some(spawn_s2_reader(
                             s2_stream.clone(),
                             config.clone(),
                             next_seq.clone(),
+                            position_resolved.clone(),
                             queue.clone(),
                             consumer.clone(),
                             parser.fork(),
@@ -323,6 +348,7 @@ fn spawn_s2_reader(
     s2_stream: Arc<s2_sdk::S2Stream>,
     config: Arc<S2InputConfig>,
     next_seq: Arc<AtomicU64>,
+    position_resolved: Arc<AtomicBool>,
     queue: Arc<InputQueue<u64>>,
     consumer: Box<dyn InputConsumer>,
     mut parser: Box<dyn Parser>,
@@ -366,10 +392,14 @@ fn spawn_s2_reader(
                     result = session.next() => {
                         match result {
                             Some(Ok(batch)) => {
-                                // Successfully received a batch
+                                if let Some(tail) = &batch.tail {
+                                    next_seq.fetch_max(tail.seq_num, Ordering::AcqRel);
+                                    position_resolved.store(true, Ordering::Release);
+                                }
                                 for record in &batch.records {
                                     trace!("Got record #{}", record.seq_num);
                                     next_seq.store(record.seq_num + 1, Ordering::Release);
+                                    position_resolved.store(true, Ordering::Release);
                                     let data = &record.body;
                                     queue.push_with_aux(parser.parse(data, None), Utc::now(), record.seq_num);
                                 }
@@ -416,6 +446,10 @@ impl Canceller {
 }
 
 impl InputReader for S2Reader {
+    fn as_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+        self
+    }
+
     fn request(&self, command: InputReaderCommand) {
         let _ = self.command_sender.send(command);
     }

--- a/crates/adapters/src/transport/s2/input/tests.rs
+++ b/crates/adapters/src/transport/s2/input/tests.rs
@@ -1,0 +1,773 @@
+use super::*;
+use crate::format::{InputBuffer, Splitter};
+use dbsp::operator::StagedBuffers;
+use feldera_adapterlib::ConnectorMetadata;
+use feldera_adapterlib::format::ParseError;
+use feldera_types::adapter_stats::ConnectorHealth;
+use feldera_types::config::FtModel;
+use futures::stream;
+use rmpv::Value as RmpValue;
+use s2_sdk::types::{FencingToken, ValidationError};
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard};
+use tokio::time::{Duration, timeout};
+
+#[test]
+fn classifies_server_codes_exactly() {
+    for code in [
+        "request_timeout",
+        "rate_limited",
+        "other",
+        "storage",
+        "hot_server",
+        "unavailable",
+        "upstream_timeout",
+        "transaction_conflict",
+    ] {
+        assert_eq!(
+            classify_s2_server_code(code),
+            S2ErrorKind::Retryable,
+            "{code}"
+        );
+    }
+    for code in ["", "not_found", "permission_denied", "rate_limited_extra"] {
+        assert_eq!(classify_s2_server_code(code), S2ErrorKind::Fatal, "{code}");
+    }
+}
+
+#[test]
+fn classifies_client_messages_exactly() {
+    for message in [
+        "heartbeat timeout",
+        "timeout",
+        "connect: dns",
+        "connection closed early: eof",
+        "request canceled: dropped",
+        "unexpected eof: body",
+        "connection reset: reset",
+        "connection aborted: aborted",
+        "connection refused: refused",
+    ] {
+        assert_eq!(
+            classify_s2_client_message(message),
+            S2ErrorKind::Retryable,
+            "{message}"
+        );
+    }
+    for message in ["", "heart beat timeout", "timeout: later", "unknown"] {
+        assert_eq!(
+            classify_s2_client_message(message),
+            S2ErrorKind::Fatal,
+            "{message}"
+        );
+    }
+}
+
+#[test]
+fn classifies_constructible_s2_error_variants() {
+    assert_eq!(
+        classify_s2_error(&S2Error::Client("timeout".to_string())),
+        S2ErrorKind::Retryable
+    );
+    assert_eq!(
+        classify_s2_error(&S2Error::Client("unknown".to_string())),
+        S2ErrorKind::Fatal
+    );
+    assert_eq!(
+        classify_s2_error(&S2Error::MalformedAccessToken("bad".to_string())),
+        S2ErrorKind::Fatal
+    );
+    assert_eq!(
+        classify_s2_error(&S2Error::Validation(ValidationError("bad".to_string()))),
+        S2ErrorKind::Fatal
+    );
+    assert_eq!(
+        classify_s2_error(&S2Error::AppendConditionFailed(
+            AppendConditionFailed::SeqNumMismatch(1)
+        )),
+        S2ErrorKind::Fatal
+    );
+    assert_eq!(
+        classify_s2_error(&S2Error::AppendConditionFailed(
+            AppendConditionFailed::FencingTokenMismatch("token".parse::<FencingToken>().unwrap())
+        )),
+        S2ErrorKind::Fatal
+    );
+}
+
+#[test]
+fn resolved_zero_uses_absolute_sequence_zero() {
+    let config = basic_config(S2StartFrom::Tail);
+    let input = read_input_for_position(&config, 0, true);
+    assert!(matches!(input.start.from, ReadFrom::SeqNum(0)));
+
+    let input = read_input_for_position(&config, 0, false);
+    assert!(matches!(input.start.from, ReadFrom::TailOffset(0)));
+}
+
+#[tokio::test]
+async fn empty_unresolved_checkpoint_reuses_configured_start_from() {
+    // A checkpoint taken before the start position was resolved must not force the
+    // live reader to read from absolute sequence 0; the configured start_from still
+    // applies on resume.
+    let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
+        FakeSession::Pending,
+    ))]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream.clone(),
+        consumer,
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: false,
+        },
+        S2StartFrom::SeqNum(5),
+    );
+
+    sender
+        .send(InputReaderCommand::Replay {
+            metadata: serde_json::to_value(S2CheckpointMetadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            })
+            .unwrap(),
+            data: RmpValue::Nil,
+        })
+        .unwrap();
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| stream.read_inputs().len() == 1).await;
+    assert!(matches!(
+        stream.read_inputs()[0].start.from,
+        ReadFrom::SeqNum(5)
+    ));
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn resolved_tail_is_anchored_before_first_queue_checkpoint() {
+    // The tail must be resolved (and the position anchored) before a Queue can emit a
+    // replayable checkpoint, so an empty checkpoint carries the resolved sequence
+    // rather than an unresolved zero.
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Tail(Ok(S2Position { seq_num: 7 })),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream.clone(),
+        consumer.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: false,
+        },
+        S2StartFrom::Tail,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| stream.read_inputs().len() == 1).await;
+    sender
+        .send(InputReaderCommand::Queue {
+            checkpoint_requested: false,
+        })
+        .unwrap();
+    wait_for(|| !consumer.extended().is_empty()).await;
+    assert_eq!(consumer.extended()[0].seq_num_range, 7..7);
+    assert!(consumer.extended()[0].position_resolved);
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn tail_transient_recovers_and_starts_from_resolved_zero() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Tail(Err(retryable_error())),
+        FakeAction::Tail(Ok(S2Position { seq_num: 0 })),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream.clone(),
+        consumer.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: false,
+        },
+        S2StartFrom::Tail,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| consumer.error_count() >= 1).await;
+    wait_for(|| stream.read_inputs().len() == 1).await;
+    assert_eq!(consumer.errors()[0].0, false);
+    assert!(matches!(
+        stream.read_inputs()[0].start.from,
+        ReadFrom::SeqNum(0)
+    ));
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn live_setup_and_midstream_transients_recover() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Session(Err(retryable_error())),
+        FakeAction::Session(Ok(FakeSession::Events(vec![
+            Ok(batch(vec![(0, b"a")], None)),
+            Err(retryable_error()),
+        ]))),
+        FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+            vec![(1, b"b")],
+            None,
+        ))]))),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let parser = RecordingParser::new();
+    let handle = spawn_worker_with_parser(
+        stream,
+        consumer.clone(),
+        parser.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: true,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| parser.data() == b"ab".to_vec()).await;
+    assert!(consumer.errors().iter().any(|(fatal, _)| !fatal));
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn live_none_reconnects() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+            vec![(0, b"a")],
+            None,
+        ))]))),
+        FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+            vec![(1, b"b")],
+            None,
+        ))]))),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let parser = RecordingParser::new();
+    let handle = spawn_worker_with_parser(
+        stream,
+        consumer,
+        parser.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: true,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| parser.data() == b"ab".to_vec()).await;
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn queue_responds_while_retrying() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Session(Ok(FakeSession::Events(vec![
+            Ok(batch(vec![(0, b"a")], None)),
+            Err(retryable_error()),
+        ]))),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream,
+        consumer.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: true,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| consumer.error_count() >= 1).await;
+    sender
+        .send(InputReaderCommand::Queue {
+            checkpoint_requested: false,
+        })
+        .unwrap();
+    wait_for(|| !consumer.extended().is_empty()).await;
+    assert_eq!(consumer.extended()[0].seq_num_range, 0..1);
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn pause_cancels_retry_backoff_and_extend_restarts() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Session(Err(retryable_error())),
+        FakeAction::Session(Ok(FakeSession::Pending)),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream.clone(),
+        consumer,
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: true,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| stream.session_attempts() == 1).await;
+    sender.send(InputReaderCommand::Pause).unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(stream.session_attempts(), 1);
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| stream.session_attempts() == 2).await;
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn fatal_setup_error_stops() {
+    let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Err(
+        fatal_error(),
+    ))]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let handle = spawn_worker(
+        stream,
+        consumer.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: true,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender.send(InputReaderCommand::Extend).unwrap();
+    wait_for(|| consumer.error_count() == 1).await;
+    assert!(consumer.errors()[0].0);
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn live_gap_duplicate_or_tail_mismatch_is_fatal() {
+    for (records, tail) in [
+        (vec![(1, b"gap" as &[u8])], None),
+        (vec![(0, b"a" as &[u8]), (0, b"dup" as &[u8])], None),
+        (vec![(0, b"a" as &[u8])], Some(0)),
+        (Vec::new(), Some(1)),
+    ] {
+        let stream = Arc::new(FakeS2Stream::new(vec![FakeAction::Session(Ok(
+            FakeSession::Events(vec![Ok(batch(records, tail))]),
+        ))]));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream,
+            consumer.clone(),
+            receiver,
+            S2CheckpointMetadata {
+                seq_num_range: 0..0,
+                position_resolved: true,
+            },
+            S2StartFrom::Beginning,
+        );
+        sender.send(InputReaderCommand::Extend).unwrap();
+        wait_for(|| consumer.error_count() == 1).await;
+        assert!(consumer.errors()[0].0);
+        handle.await.unwrap().unwrap();
+    }
+}
+
+#[tokio::test]
+async fn replay_partial_transient_resumes_without_duplicates() {
+    let stream = Arc::new(FakeS2Stream::new(vec![
+        FakeAction::Session(Ok(FakeSession::Events(vec![
+            Ok(batch(vec![(0, b"a")], None)),
+            Err(retryable_error()),
+        ]))),
+        FakeAction::Session(Ok(FakeSession::Events(vec![Ok(batch(
+            vec![(1, b"b"), (2, b"c")],
+            None,
+        ))]))),
+    ]));
+    let (sender, receiver) = unbounded_channel();
+    let consumer = RecordingConsumer::new();
+    consumer.allow_errors();
+    let parser = RecordingParser::new();
+    let handle = spawn_worker_with_parser(
+        stream.clone(),
+        consumer.clone(),
+        parser.clone(),
+        receiver,
+        S2CheckpointMetadata {
+            seq_num_range: 0..0,
+            position_resolved: false,
+        },
+        S2StartFrom::Beginning,
+    );
+
+    sender
+        .send(InputReaderCommand::Replay {
+            metadata: serde_json::to_value(S2CheckpointMetadata {
+                seq_num_range: 0..3,
+                position_resolved: true,
+            })
+            .unwrap(),
+            data: RmpValue::Nil,
+        })
+        .unwrap();
+    wait_for(|| consumer.replayed_count() == 1).await;
+    sender.send(InputReaderCommand::Disconnect).unwrap();
+    handle.await.unwrap().unwrap();
+    assert_eq!(parser.data(), b"abc".to_vec());
+    let inputs = stream.read_inputs();
+    assert!(matches!(inputs[0].start.from, ReadFrom::SeqNum(0)));
+    assert_eq!(inputs[0].stop.limits.count, Some(3));
+    assert!(matches!(inputs[1].start.from, ReadFrom::SeqNum(1)));
+    assert_eq!(inputs[1].stop.limits.count, Some(2));
+}
+
+#[tokio::test]
+async fn replay_gap_short_and_read_unwritten_are_fatal() {
+    let cases = vec![
+        (
+            vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
+                batch(vec![(1, b"gap")], None),
+            )])))],
+            1,
+        ),
+        (
+            vec![FakeAction::Session(Ok(FakeSession::Events(vec![])))],
+            1,
+        ),
+        (
+            vec![FakeAction::Session(Ok(FakeSession::Events(vec![Ok(
+                batch(vec![(0, b"short")], None),
+            )])))],
+            2,
+        ),
+        (vec![FakeAction::Session(Err(fatal_error()))], 1),
+    ];
+    for (case_index, (actions, replay_end)) in cases.into_iter().enumerate() {
+        let stream = Arc::new(FakeS2Stream::new(actions));
+        let (sender, receiver) = unbounded_channel();
+        let consumer = RecordingConsumer::new();
+        consumer.allow_errors();
+        let handle = spawn_worker(
+            stream,
+            consumer.clone(),
+            receiver,
+            S2CheckpointMetadata {
+                seq_num_range: 0..0,
+                position_resolved: false,
+            },
+            S2StartFrom::Beginning,
+        );
+        sender
+            .send(InputReaderCommand::Replay {
+                metadata: serde_json::to_value(S2CheckpointMetadata {
+                    seq_num_range: 0..replay_end,
+                    position_resolved: true,
+                })
+                .unwrap(),
+                data: RmpValue::Nil,
+            })
+            .unwrap();
+        timeout(Duration::from_secs(1), handle)
+            .await
+            .unwrap_or_else(|_| panic!("replay fatal case {case_index} timed out"))
+            .unwrap()
+            .unwrap_err();
+    }
+}
+
+fn spawn_worker(
+    stream: Arc<FakeS2Stream>,
+    consumer: RecordingConsumer,
+    receiver: UnboundedReceiver<InputReaderCommand>,
+    metadata: S2CheckpointMetadata,
+    start_from: S2StartFrom,
+) -> JoinHandle<Result<(), AnyError>> {
+    spawn_worker_with_parser(
+        stream,
+        consumer,
+        RecordingParser::new(),
+        receiver,
+        metadata,
+        start_from,
+    )
+}
+
+fn spawn_worker_with_parser(
+    stream: Arc<FakeS2Stream>,
+    consumer: RecordingConsumer,
+    parser: RecordingParser,
+    receiver: UnboundedReceiver<InputReaderCommand>,
+    metadata: S2CheckpointMetadata,
+    start_from: S2StartFrom,
+) -> JoinHandle<Result<(), AnyError>> {
+    tokio::spawn(S2Reader::worker_task_with_backoff(
+        Arc::new(basic_config(start_from)),
+        metadata,
+        stream,
+        Box::new(consumer),
+        Box::new(parser),
+        receiver,
+        BackoffConfig {
+            initial: Duration::from_millis(1),
+            max: Duration::from_millis(2),
+        },
+    ))
+}
+
+fn basic_config(start_from: S2StartFrom) -> S2InputConfig {
+    S2InputConfig {
+        basin: "basin".to_string(),
+        stream: "stream".to_string(),
+        auth_token: "token".to_string(),
+        endpoint: None,
+        start_from,
+    }
+}
+
+fn retryable_error() -> S2Error {
+    S2Error::Client("timeout".to_string())
+}
+
+fn fatal_error() -> S2Error {
+    S2Error::Client("unknown".to_string())
+}
+
+fn batch(records: Vec<(u64, &[u8])>, tail: Option<u64>) -> S2Batch {
+    S2Batch {
+        records: records
+            .into_iter()
+            .map(|(seq_num, body)| S2Record {
+                seq_num,
+                body: body.to_vec(),
+            })
+            .collect(),
+        tail: tail.map(|seq_num| S2Position { seq_num }),
+    }
+}
+
+async fn wait_for(mut condition: impl FnMut() -> bool) {
+    timeout(Duration::from_secs(1), async move {
+        while !condition() {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for condition");
+}
+
+enum FakeAction {
+    Tail(Result<S2Position, S2Error>),
+    Session(Result<FakeSession, S2Error>),
+}
+
+enum FakeSession {
+    Events(Vec<Result<S2Batch, S2Error>>),
+    Pending,
+}
+
+struct FakeS2Stream {
+    actions: Mutex<VecDeque<FakeAction>>,
+    read_inputs: Mutex<Vec<ReadInput>>,
+}
+
+impl FakeS2Stream {
+    fn new(actions: Vec<FakeAction>) -> Self {
+        Self {
+            actions: Mutex::new(actions.into()),
+            read_inputs: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn read_inputs(&self) -> Vec<ReadInput> {
+        self.read_inputs.lock().unwrap().clone()
+    }
+
+    fn session_attempts(&self) -> usize {
+        self.read_inputs.lock().unwrap().len()
+    }
+
+    fn next_action(&self) -> FakeAction {
+        self.actions
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("missing fake S2 action")
+    }
+}
+
+#[async_trait]
+impl S2StreamClient for FakeS2Stream {
+    async fn check_tail(&self) -> Result<S2Position, S2Error> {
+        match self.next_action() {
+            FakeAction::Tail(result) => result,
+            FakeAction::Session(_) => panic!("expected tail action"),
+        }
+    }
+
+    async fn read_session(&self, input: ReadInput) -> Result<S2ReadSession, S2Error> {
+        self.read_inputs.lock().unwrap().push(input);
+        match self.next_action() {
+            FakeAction::Session(Ok(FakeSession::Events(events))) => {
+                Ok(Box::pin(stream::iter(events)))
+            }
+            FakeAction::Session(Ok(FakeSession::Pending)) => Ok(Box::pin(stream::pending())),
+            FakeAction::Session(Err(error)) => Err(error),
+            FakeAction::Tail(_) => panic!("expected session action"),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RecordingConsumer(Arc<Mutex<ConsumerState>>);
+
+#[derive(Default)]
+struct ConsumerState {
+    errors: Vec<(bool, String)>,
+    extended: Vec<S2CheckpointMetadata>,
+    replayed: usize,
+    allow_errors: bool,
+}
+
+impl RecordingConsumer {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(ConsumerState::default())))
+    }
+
+    fn state(&self) -> MutexGuard<'_, ConsumerState> {
+        self.0.lock().unwrap()
+    }
+
+    fn allow_errors(&self) {
+        self.state().allow_errors = true;
+    }
+
+    fn errors(&self) -> Vec<(bool, String)> {
+        self.state().errors.clone()
+    }
+
+    fn error_count(&self) -> usize {
+        self.state().errors.len()
+    }
+
+    fn extended(&self) -> Vec<S2CheckpointMetadata> {
+        self.state()
+            .extended
+            .iter()
+            .map(|m| S2CheckpointMetadata {
+                seq_num_range: m.seq_num_range.clone(),
+                position_resolved: m.position_resolved,
+            })
+            .collect()
+    }
+
+    fn replayed_count(&self) -> usize {
+        self.state().replayed
+    }
+}
+
+impl InputConsumer for RecordingConsumer {
+    fn max_batch_size(&self) -> usize {
+        usize::MAX
+    }
+    fn pipeline_fault_tolerance(&self) -> Option<FtModel> {
+        Some(FtModel::ExactlyOnce)
+    }
+    fn parse_errors(&self, _errors: Vec<ParseError>) {}
+    fn buffered(&self, _amt: BufferSize) {}
+    fn replayed(&self, _num_records: BufferSize, _hash: u64) {
+        self.state().replayed += 1;
+    }
+    fn request_step(&self) {}
+    fn extended(&self, _amt: BufferSize, _resume: Option<Resume>, watermarks: Vec<Watermark>) {
+        let metadata = watermarks.into_iter().find_map(|w| w.metadata).unwrap();
+        self.state()
+            .extended
+            .push(serde_json::from_value(metadata).unwrap());
+    }
+    fn eoi(&self) {}
+    fn start_transaction(&self, _label: Option<&str>) {}
+    fn commit_transaction(&self) {}
+    fn error(&self, fatal: bool, error: AnyError, _tag: Option<&'static str>) {
+        let mut state = self.state();
+        assert!(state.allow_errors, "unexpected error: {error}");
+        state.errors.push((fatal, error.to_string()));
+    }
+    fn update_connector_health(&self, _health: ConnectorHealth) {}
+    fn completion_watcher(
+        &self,
+    ) -> Option<tokio::sync::watch::Receiver<feldera_types::coordination::Completion>> {
+        None
+    }
+}
+
+#[derive(Clone)]
+struct RecordingParser(Arc<Mutex<Vec<u8>>>);
+
+impl RecordingParser {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+    fn data(&self) -> Vec<u8> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+impl Parser for RecordingParser {
+    fn parse(
+        &mut self,
+        data: &[u8],
+        _metadata: Option<ConnectorMetadata>,
+    ) -> (Option<Box<dyn InputBuffer>>, Vec<ParseError>) {
+        self.0.lock().unwrap().extend_from_slice(data);
+        (None, Vec::new())
+    }
+    fn stage(&self, _buffers: Vec<Box<dyn InputBuffer>>) -> Box<dyn StagedBuffers> {
+        panic!("stage not used")
+    }
+    fn splitter(&self) -> Box<dyn Splitter> {
+        panic!("splitter not used")
+    }
+    fn fork(&self) -> Box<dyn Parser> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/adapters/src/transport/s2/mod.rs
+++ b/crates/adapters/src/transport/s2/mod.rs
@@ -2,5 +2,6 @@ mod input;
 #[cfg(test)]
 mod test;
 
-pub use input::S2InputEndpoint;
+#[cfg(test)]
 pub(crate) use input::Metadata as S2Metadata;
+pub use input::S2InputEndpoint;

--- a/crates/adapters/src/transport/s2/mod.rs
+++ b/crates/adapters/src/transport/s2/mod.rs
@@ -1,0 +1,6 @@
+mod input;
+#[cfg(test)]
+mod test;
+
+pub use input::S2InputEndpoint;
+pub(crate) use input::Metadata as S2Metadata;

--- a/crates/adapters/src/transport/s2/mod.rs
+++ b/crates/adapters/src/transport/s2/mod.rs
@@ -1,7 +1,9 @@
 mod input;
+mod output;
 #[cfg(test)]
 mod test;
 
 #[cfg(test)]
 pub(crate) use input::Metadata as S2Metadata;
 pub use input::S2InputEndpoint;
+pub use output::S2OutputEndpoint;

--- a/crates/adapters/src/transport/s2/mod.rs
+++ b/crates/adapters/src/transport/s2/mod.rs
@@ -3,7 +3,7 @@ mod output;
 #[cfg(test)]
 mod test;
 
-#[cfg(test)]
-pub(crate) use input::Metadata as S2Metadata;
 pub use input::S2InputEndpoint;
+#[cfg(test)]
+pub(crate) use input::{Metadata as S2Metadata, make_replay_read_input};
 pub use output::S2OutputEndpoint;

--- a/crates/adapters/src/transport/s2/mod.rs
+++ b/crates/adapters/src/transport/s2/mod.rs
@@ -5,5 +5,5 @@ mod test;
 
 pub use input::S2InputEndpoint;
 #[cfg(test)]
-pub(crate) use input::{Metadata as S2Metadata, make_replay_read_input};
+pub(crate) use input::{S2CheckpointMetadata as S2Metadata, make_replay_read_input};
 pub use output::S2OutputEndpoint;

--- a/crates/adapters/src/transport/s2/output.rs
+++ b/crates/adapters/src/transport/s2/output.rs
@@ -1,0 +1,137 @@
+use anyhow::{Context, Error as AnyError, Result as AnyResult, anyhow};
+use dbsp::circuit::tokio::TOKIO;
+use feldera_adapterlib::transport::{AsyncErrorCallback, OutputEndpoint};
+use feldera_types::transport::s2::S2OutputConfig;
+use s2_sdk::{
+    S2, S2Stream,
+    producer::{Producer, ProducerConfig},
+    types::{
+        AccountEndpoint, AppendRecord, BasinEndpoint, RetryConfig, S2Config, S2Endpoints,
+    },
+};
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{error, info, info_span, span::EnteredSpan, Instrument};
+
+pub struct S2OutputEndpoint {
+    config: S2OutputConfig,
+    s2_stream: Arc<S2Stream>,
+    producer: Option<Producer>,
+}
+
+impl S2OutputEndpoint {
+    pub fn new(config: S2OutputConfig) -> Result<Self, AnyError> {
+        let s2_stream = TOKIO
+            .block_on(
+                async {
+                    let retry_config = RetryConfig::new()
+                        .with_max_attempts(NonZeroU32::new(10).unwrap())
+                        .with_min_base_delay(Duration::from_millis(100))
+                        .with_max_base_delay(Duration::from_secs(10));
+
+                    let mut s2_config = S2Config::new(config.auth_token.clone())
+                        .with_connection_timeout(Duration::from_secs(10))
+                        .with_request_timeout(Duration::from_secs(30))
+                        .with_retry(retry_config);
+
+                    if let Some(ref endpoint) = config.endpoint {
+                        let endpoints = S2Endpoints::new(
+                            AccountEndpoint::new(endpoint)?,
+                            BasinEndpoint::new(endpoint)?,
+                        )?;
+                        s2_config = s2_config.with_endpoints(endpoints);
+                    }
+
+                    let client = S2::new(s2_config)?;
+                    let basin = client.basin(config.basin.parse().map_err(|e| anyhow!("{e}"))?);
+                    Ok::<_, AnyError>(
+                        basin.stream(config.stream.parse().map_err(|e| anyhow!("{e}"))?),
+                    )
+                }
+                .instrument(info_span!(
+                    "s2_output_init",
+                    basin = %config.basin,
+                    stream = %config.stream,
+                )),
+            )
+            .map_err(|e| {
+                error!(basin = %config.basin, stream = %config.stream, "S2 output init failed: {e:#}");
+                e.context(format!(
+                    "S2 output initialization failed for stream '{}' in basin '{}'",
+                    config.stream, config.basin,
+                ))
+            })?;
+
+        Ok(Self {
+            config,
+            s2_stream: Arc::new(s2_stream),
+            producer: None,
+        })
+    }
+
+    fn span(&self) -> EnteredSpan {
+        info_span!(
+            "s2_output",
+            basin = %self.config.basin,
+            stream = %self.config.stream,
+        )
+        .entered()
+    }
+}
+
+impl OutputEndpoint for S2OutputEndpoint {
+    fn connect(&mut self, _async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
+        let _guard = self.span();
+        let producer = TOKIO.block_on(async {
+            self.s2_stream.producer(ProducerConfig::new())
+        });
+        info!("S2 producer connected");
+        self.producer = Some(producer);
+        Ok(())
+    }
+
+    fn max_buffer_size_bytes(&self) -> usize {
+        usize::MAX
+    }
+
+    fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
+        let _guard = self.span();
+        let producer = self
+            .producer
+            .as_ref()
+            .ok_or_else(|| anyhow!("s2: push_buffer called before connect"))?;
+
+        let record = AppendRecord::new(buffer.to_vec())
+            .context("s2: failed to create AppendRecord from buffer")?;
+
+        TOKIO
+            .block_on(async {
+                let ticket = producer
+                    .submit(record)
+                    .await
+                    .map_err(|e| anyhow!("s2: failed to submit record: {e}"))?;
+                ticket
+                    .await
+                    .map_err(|e| anyhow!("s2: failed to get ack for record: {e}"))?;
+                Ok::<_, AnyError>(())
+            })
+            .map_err(|e| {
+                error!("S2 push_buffer failed: {e:#}");
+                e
+            })
+    }
+
+    fn push_key(
+        &mut self,
+        _key: Option<&[u8]>,
+        _val: Option<&[u8]>,
+        _headers: &[(&str, Option<&[u8]>)],
+    ) -> AnyResult<()> {
+        anyhow::bail!("s2: push_key is not supported; S2 is not a key-value store")
+    }
+
+    fn is_fault_tolerant(&self) -> bool {
+        false
+    }
+}

--- a/crates/adapters/src/transport/s2/output.rs
+++ b/crates/adapters/src/transport/s2/output.rs
@@ -92,7 +92,9 @@ impl OutputEndpoint for S2OutputEndpoint {
     }
 
     fn max_buffer_size_bytes(&self) -> usize {
-        usize::MAX
+        // S2 enforces a 1MB limit per AppendRecord.
+        // Use a conservative limit to leave room for framing overhead.
+        1_000_000
     }
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {

--- a/crates/adapters/src/transport/s2/output.rs
+++ b/crates/adapters/src/transport/s2/output.rs
@@ -4,18 +4,19 @@ use feldera_adapterlib::transport::{AsyncErrorCallback, OutputEndpoint};
 use feldera_types::transport::s2::S2OutputConfig;
 use s2_sdk::{
     S2, S2Stream,
-    producer::{Producer, ProducerConfig},
-    types::{AccountEndpoint, AppendRecord, BasinEndpoint, RetryConfig, S2Config, S2Endpoints},
+    types::{
+        AccountEndpoint, AppendInput, AppendRecord, AppendRecordBatch, BasinEndpoint,
+        RECORD_BATCH_MAX, RetryConfig, S2Config, S2Endpoints,
+    },
 };
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{Instrument, error, info, info_span, span::EnteredSpan};
+use tracing::{Instrument, error, info_span, span::EnteredSpan};
 
 pub struct S2OutputEndpoint {
     config: S2OutputConfig,
     s2_stream: Arc<S2Stream>,
-    producer: Option<Producer>,
 }
 
 impl S2OutputEndpoint {
@@ -64,7 +65,6 @@ impl S2OutputEndpoint {
         Ok(Self {
             config,
             s2_stream: Arc::new(s2_stream),
-            producer: None,
         })
     }
 
@@ -80,38 +80,45 @@ impl S2OutputEndpoint {
 
 impl OutputEndpoint for S2OutputEndpoint {
     fn connect(&mut self, _async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
-        let _guard = self.span();
-        let producer = TOKIO.block_on(async { self.s2_stream.producer(ProducerConfig::new()) });
-        info!("S2 producer connected");
-        self.producer = Some(producer);
         Ok(())
     }
 
     fn max_buffer_size_bytes(&self) -> usize {
-        // S2 enforces a 1MB limit per AppendRecord.
+        // S2 enforces a 1MB metered size limit per AppendRecordBatch.
         // Use a conservative limit to leave room for framing overhead.
         1_000_000
     }
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
         let _guard = self.span();
-        let producer = self
-            .producer
-            .as_ref()
-            .ok_or_else(|| anyhow!("s2: push_buffer called before connect"))?;
+        let s2_stream = self.s2_stream.clone();
 
-        let record = AppendRecord::new(buffer.to_vec())
-            .context("s2: failed to create AppendRecord from buffer")?;
+        // The output format emits one record per line. Split the buffer into
+        // individual S2 records and append them as native S2 batches, honoring
+        // the SDK's per-batch record-count limit.
+        let records = buffer
+            .split(|&b| b == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                AppendRecord::new(line.to_vec())
+                    .context("s2: failed to create AppendRecord from line")
+            })
+            .collect::<AnyResult<Vec<_>>>()?;
+
+        if records.is_empty() {
+            return Ok(());
+        }
 
         TOKIO
-            .block_on(async {
-                let ticket = producer
-                    .submit(record)
-                    .await
-                    .map_err(|e| anyhow!("s2: failed to submit record: {e}"))?;
-                ticket
-                    .await
-                    .map_err(|e| anyhow!("s2: failed to get ack for record: {e}"))?;
+            .block_on(async move {
+                for chunk in records.chunks(RECORD_BATCH_MAX.count) {
+                    let batch = AppendRecordBatch::try_from_iter(chunk.iter().cloned())
+                        .map_err(|e| anyhow!("s2: failed to create AppendRecordBatch: {e}"))?;
+                    s2_stream
+                        .append(AppendInput::new(batch))
+                        .await
+                        .map_err(|e| anyhow!("s2: failed to append records: {e}"))?;
+                }
                 Ok::<_, AnyError>(())
             })
             .map_err(|e| {

--- a/crates/adapters/src/transport/s2/output.rs
+++ b/crates/adapters/src/transport/s2/output.rs
@@ -90,6 +90,9 @@ impl OutputEndpoint for S2OutputEndpoint {
     }
 
     fn push_buffer(&mut self, buffer: &[u8]) -> AnyResult<()> {
+        // TODO: each batch is appended and awaited synchronously (one round-trip
+        // per batch). For higher throughput, pipeline appends and drain acks at
+        // flush/disconnect. Not a correctness issue for the non-FT output path.
         let _guard = self.span();
         let s2_stream = self.s2_stream.clone();
 

--- a/crates/adapters/src/transport/s2/output.rs
+++ b/crates/adapters/src/transport/s2/output.rs
@@ -5,14 +5,12 @@ use feldera_types::transport::s2::S2OutputConfig;
 use s2_sdk::{
     S2, S2Stream,
     producer::{Producer, ProducerConfig},
-    types::{
-        AccountEndpoint, AppendRecord, BasinEndpoint, RetryConfig, S2Config, S2Endpoints,
-    },
+    types::{AccountEndpoint, AppendRecord, BasinEndpoint, RetryConfig, S2Config, S2Endpoints},
 };
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{error, info, info_span, span::EnteredSpan, Instrument};
+use tracing::{Instrument, error, info, info_span, span::EnteredSpan};
 
 pub struct S2OutputEndpoint {
     config: S2OutputConfig,
@@ -83,9 +81,7 @@ impl S2OutputEndpoint {
 impl OutputEndpoint for S2OutputEndpoint {
     fn connect(&mut self, _async_error_callback: AsyncErrorCallback) -> AnyResult<()> {
         let _guard = self.span();
-        let producer = TOKIO.block_on(async {
-            self.s2_stream.producer(ProducerConfig::new())
-        });
+        let producer = TOKIO.block_on(async { self.s2_stream.producer(ProducerConfig::new()) });
         info!("S2 producer connected");
         self.producer = Some(producer);
         Ok(())

--- a/crates/adapters/src/transport/s2/test.rs
+++ b/crates/adapters/src/transport/s2/test.rs
@@ -1,7 +1,13 @@
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
+    use feldera_types::config::{
+        ConnectorConfig, FormatConfig, OutputBufferConfig, TransportConfig,
+        default_max_queued_records,
+    };
     use feldera_types::transport::s2::{S2InputConfig, S2StartFrom};
-    use serde_json;
+    use serde_json::{self, json};
 
     #[test]
     fn config_serialization_roundtrip() {
@@ -33,9 +39,8 @@ mod tests {
             (r#""Beginning""#, S2StartFrom::Beginning),
             (r#""Tail""#, S2StartFrom::Tail),
         ] {
-            let json = format!(
-                r#"{{"basin":"b","stream":"s","auth_token":"t","start_from":{variant}}}"#
-            );
+            let json =
+                format!(r#"{{"basin":"b","stream":"s","auth_token":"t","start_from":{variant}}}"#);
             let config: S2InputConfig = serde_json::from_str(&json).unwrap();
             assert_eq!(config.start_from, expected);
         }
@@ -46,13 +51,17 @@ mod tests {
         use crate::transport::s2::S2Metadata as Metadata;
 
         // Empty range (no messages processed)
-        let meta = Metadata { seq_num_range: 0..0 };
+        let meta = Metadata {
+            seq_num_range: 0..0,
+        };
         let json = serde_json::to_value(&meta).unwrap();
         let restored = Metadata::from_resume_info(Some(json)).unwrap();
         assert_eq!(restored.seq_num_range, 0..0);
 
         // Non-empty range
-        let meta = Metadata { seq_num_range: 6..10 };
+        let meta = Metadata {
+            seq_num_range: 6..10,
+        };
         let json = serde_json::to_value(&meta).unwrap();
         let restored = Metadata::from_resume_info(Some(json)).unwrap();
         assert_eq!(restored.seq_num_range, 6..10);
@@ -116,5 +125,36 @@ mod tests {
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(!json.contains("endpoint"));
+    }
+
+    #[test]
+    fn connector_config_insert_delete_format_roundtrip() {
+        let config = ConnectorConfig {
+            transport: TransportConfig::S2Input(S2InputConfig {
+                basin: "test-basin".to_string(),
+                stream: "test-stream".to_string(),
+                auth_token: "tok_test123".to_string(),
+                endpoint: Some("http://localhost:8080".to_string()),
+                start_from: S2StartFrom::Beginning,
+            }),
+            format: Some(FormatConfig {
+                name: Cow::from("json"),
+                config: json!({
+                    "update_format": "insert_delete"
+                }),
+            }),
+            index: None,
+            output_buffer_config: OutputBufferConfig::default(),
+            max_batch_size: None,
+            max_worker_batch_size: None,
+            max_queued_records: default_max_queued_records(),
+            paused: false,
+            labels: Vec::new(),
+            start_after: None,
+        };
+
+        let serialized = serde_json::to_value(&config).unwrap();
+        let deserialized: ConnectorConfig = serde_json::from_value(serialized).unwrap();
+        assert_eq!(config, deserialized);
     }
 }

--- a/crates/adapters/src/transport/s2/test.rs
+++ b/crates/adapters/src/transport/s2/test.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use feldera_types::transport::s2::{S2InputConfig, S2StartFrom};
+    use serde_json;
+
+    #[test]
+    fn config_serialization_roundtrip() {
+        let config = S2InputConfig {
+            basin: "my-basin".to_string(),
+            stream: "my-stream".to_string(),
+            auth_token: "tok_test123".to_string(),
+            endpoint: None,
+            start_from: S2StartFrom::SeqNum(42),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: S2InputConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn config_default_start_from() {
+        let json = r#"{"basin":"b","stream":"s","auth_token":"t"}"#;
+        let config: S2InputConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.start_from, S2StartFrom::Beginning);
+    }
+
+    #[test]
+    fn config_all_start_from_variants() {
+        for (variant, expected) in [
+            (r#"{"SeqNum":10}"#, S2StartFrom::SeqNum(10)),
+            (r#"{"Timestamp":1000}"#, S2StartFrom::Timestamp(1000)),
+            (r#"{"TailOffset":5}"#, S2StartFrom::TailOffset(5)),
+            (r#""Beginning""#, S2StartFrom::Beginning),
+            (r#""Tail""#, S2StartFrom::Tail),
+        ] {
+            let json = format!(
+                r#"{{"basin":"b","stream":"s","auth_token":"t","start_from":{variant}}}"#
+            );
+            let config: S2InputConfig = serde_json::from_str(&json).unwrap();
+            assert_eq!(config.start_from, expected);
+        }
+    }
+
+    #[test]
+    fn metadata_checkpoint_roundtrip() {
+        use crate::transport::s2::S2Metadata as Metadata;
+
+        // Empty range (no messages processed)
+        let meta = Metadata { seq_num_range: 0..0 };
+        let json = serde_json::to_value(&meta).unwrap();
+        let restored = Metadata::from_resume_info(Some(json)).unwrap();
+        assert_eq!(restored.seq_num_range, 0..0);
+
+        // Non-empty range
+        let meta = Metadata { seq_num_range: 6..10 };
+        let json = serde_json::to_value(&meta).unwrap();
+        let restored = Metadata::from_resume_info(Some(json)).unwrap();
+        assert_eq!(restored.seq_num_range, 6..10);
+
+        // None resume info -> start from beginning
+        let restored = Metadata::from_resume_info(None).unwrap();
+        assert_eq!(restored.seq_num_range, 0..0);
+    }
+
+    #[test]
+    fn transport_config_name() {
+        use feldera_types::config::TransportConfig;
+        let config = TransportConfig::S2Input(S2InputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: None,
+            start_from: S2StartFrom::default(),
+        });
+        assert_eq!(config.name(), "s2_input");
+    }
+
+    #[test]
+    fn transport_config_serde_roundtrip() {
+        use feldera_types::config::TransportConfig;
+        let config = TransportConfig::S2Input(S2InputConfig {
+            basin: "test-basin".to_string(),
+            stream: "test-stream".to_string(),
+            auth_token: "tok_abc".to_string(),
+            endpoint: None,
+            start_from: S2StartFrom::Tail,
+        });
+        let json = serde_json::to_value(&config).unwrap();
+        let deserialized: TransportConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn config_with_endpoint() {
+        let config = S2InputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: Some("http://localhost:8080".to_string()),
+            start_from: S2StartFrom::default(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("localhost:8080"));
+        let deserialized: S2InputConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn config_endpoint_omitted_when_none() {
+        let config = S2InputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: None,
+            start_from: S2StartFrom::default(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("endpoint"));
+    }
+}

--- a/crates/adapters/src/transport/s2/test.rs
+++ b/crates/adapters/src/transport/s2/test.rs
@@ -6,7 +6,7 @@ mod tests {
         ConnectorConfig, FormatConfig, OutputBufferConfig, TransportConfig,
         default_max_queued_records,
     };
-    use feldera_types::transport::s2::{S2InputConfig, S2StartFrom};
+    use feldera_types::transport::s2::{S2InputConfig, S2OutputConfig, S2StartFrom};
     use serde_json::{self, json};
 
     #[test]
@@ -156,5 +156,70 @@ mod tests {
         let serialized = serde_json::to_value(&config).unwrap();
         let deserialized: ConnectorConfig = serde_json::from_value(serialized).unwrap();
         assert_eq!(config, deserialized);
+    }
+
+    // --- S2 Output Config tests ---
+
+    #[test]
+    fn config_output_serialization_roundtrip() {
+        let config = S2OutputConfig {
+            basin: "my-basin".to_string(),
+            stream: "my-stream".to_string(),
+            auth_token: "tok_test123".to_string(),
+            endpoint: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: S2OutputConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn transport_config_s2_output_name() {
+        let config = TransportConfig::S2Output(S2OutputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: None,
+        });
+        assert_eq!(config.name(), "s2_output");
+    }
+
+    #[test]
+    fn transport_config_s2_output_serde_roundtrip() {
+        let config = TransportConfig::S2Output(S2OutputConfig {
+            basin: "test-basin".to_string(),
+            stream: "test-stream".to_string(),
+            auth_token: "tok_abc".to_string(),
+            endpoint: None,
+        });
+        let json = serde_json::to_value(&config).unwrap();
+        let deserialized: TransportConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn config_output_with_endpoint() {
+        let config = S2OutputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: Some("http://localhost:8080".to_string()),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("localhost:8080"));
+        let deserialized: S2OutputConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn config_output_endpoint_omitted_when_none() {
+        let config = S2OutputConfig {
+            basin: "b".to_string(),
+            stream: "s".to_string(),
+            auth_token: "t".to_string(),
+            endpoint: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("endpoint"));
     }
 }

--- a/crates/adapters/src/transport/s2/test.rs
+++ b/crates/adapters/src/transport/s2/test.rs
@@ -2,10 +2,7 @@
 mod tests {
     use std::borrow::Cow;
 
-    use feldera_types::config::{
-        ConnectorConfig, FormatConfig, OutputBufferConfig, TransportConfig,
-        default_max_queued_records,
-    };
+    use feldera_types::config::{ConnectorConfig, FormatConfig, TransportConfig};
     use feldera_types::transport::s2::{S2InputConfig, S2OutputConfig, S2StartFrom};
     use serde_json::{self, json};
 
@@ -53,22 +50,48 @@ mod tests {
         // Empty range (no messages processed)
         let meta = Metadata {
             seq_num_range: 0..0,
+            position_resolved: true,
         };
         let json = serde_json::to_value(&meta).unwrap();
         let restored = Metadata::from_resume_info(Some(json)).unwrap();
         assert_eq!(restored.seq_num_range, 0..0);
+        assert!(restored.position_resolved);
 
         // Non-empty range
         let meta = Metadata {
             seq_num_range: 6..10,
+            position_resolved: true,
         };
         let json = serde_json::to_value(&meta).unwrap();
         let restored = Metadata::from_resume_info(Some(json)).unwrap();
         assert_eq!(restored.seq_num_range, 6..10);
+        assert!(restored.position_resolved);
 
-        // None resume info -> start from beginning
+        // None resume info -> start from the configured position.
         let restored = Metadata::from_resume_info(None).unwrap();
         assert_eq!(restored.seq_num_range, 0..0);
+        assert!(!restored.position_resolved);
+    }
+
+    #[test]
+    fn legacy_metadata_defaults_to_unresolved_position() {
+        use crate::transport::s2::S2Metadata as Metadata;
+
+        let restored = Metadata::from_resume_info(Some(json!({
+            "seq_num_range": { "start": 0, "end": 0 }
+        })))
+        .unwrap();
+        assert!(!restored.position_resolved);
+    }
+
+    #[test]
+    fn replay_read_is_bounded_to_checkpoint_range() {
+        use crate::transport::s2::make_replay_read_input;
+        use s2_sdk::types::ReadFrom;
+
+        let input = make_replay_read_input(&(6..10));
+        assert!(matches!(input.start.from, ReadFrom::SeqNum(6)));
+        assert_eq!(input.stop.limits.count, Some(4));
     }
 
     #[test]
@@ -129,29 +152,21 @@ mod tests {
 
     #[test]
     fn connector_config_insert_delete_format_roundtrip() {
-        let config = ConnectorConfig {
-            transport: TransportConfig::S2Input(S2InputConfig {
+        let config = ConnectorConfig::new(
+            TransportConfig::S2Input(S2InputConfig {
                 basin: "test-basin".to_string(),
                 stream: "test-stream".to_string(),
                 auth_token: "tok_test123".to_string(),
                 endpoint: Some("http://localhost:8080".to_string()),
                 start_from: S2StartFrom::Beginning,
             }),
-            format: Some(FormatConfig {
+            Some(FormatConfig {
                 name: Cow::from("json"),
                 config: json!({
                     "update_format": "insert_delete"
                 }),
             }),
-            index: None,
-            output_buffer_config: OutputBufferConfig::default(),
-            max_batch_size: None,
-            max_worker_batch_size: None,
-            max_queued_records: default_max_queued_records(),
-            paused: false,
-            labels: Vec::new(),
-            start_after: None,
-        };
+        );
 
         let serialized = serde_json::to_value(&config).unwrap();
         let deserialized: ConnectorConfig = serde_json::from_value(serialized).unwrap();

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -24,6 +24,7 @@ use crate::transport::postgres::{
 };
 use crate::transport::pubsub::PubSubInputConfig;
 use crate::transport::redis::RedisOutputConfig;
+use crate::transport::s2::S2InputConfig;
 use crate::transport::s3::S3InputConfig;
 use crate::transport::url::UrlInputConfig;
 use core::fmt;
@@ -1891,6 +1892,7 @@ pub enum TransportConfig {
     /// Ad hoc input: cannot be instantiated through API
     AdHocInput(AdHocInputConfig),
     ClockInput(ClockConfig),
+    S2Input(S2InputConfig),
     /// Output connector that discards all data.
     NullOutput,
     /// Input connector that produces no data.
@@ -1922,6 +1924,7 @@ impl TransportConfig {
             TransportConfig::AdHocInput(_) => "adhoc_input".to_string(),
             TransportConfig::RedisOutput(_) => "redis_output".to_string(),
             TransportConfig::ClockInput(_) => "clock".to_string(),
+            TransportConfig::S2Input(_) => "s2_input".to_string(),
             TransportConfig::NullOutput => "null_output".to_string(),
             TransportConfig::EmptyInput => "empty_input".to_string(),
         }

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -24,7 +24,7 @@ use crate::transport::postgres::{
 };
 use crate::transport::pubsub::PubSubInputConfig;
 use crate::transport::redis::RedisOutputConfig;
-use crate::transport::s2::S2InputConfig;
+use crate::transport::s2::{S2InputConfig, S2OutputConfig};
 use crate::transport::s3::S3InputConfig;
 use crate::transport::url::UrlInputConfig;
 use core::fmt;
@@ -1893,6 +1893,7 @@ pub enum TransportConfig {
     AdHocInput(AdHocInputConfig),
     ClockInput(ClockConfig),
     S2Input(S2InputConfig),
+    S2Output(S2OutputConfig),
     /// Output connector that discards all data.
     NullOutput,
     /// Input connector that produces no data.
@@ -1925,6 +1926,7 @@ impl TransportConfig {
             TransportConfig::RedisOutput(_) => "redis_output".to_string(),
             TransportConfig::ClockInput(_) => "clock".to_string(),
             TransportConfig::S2Input(_) => "s2_input".to_string(),
+            TransportConfig::S2Output(_) => "s2_output".to_string(),
             TransportConfig::NullOutput => "null_output".to_string(),
             TransportConfig::EmptyInput => "empty_input".to_string(),
         }

--- a/crates/feldera-types/src/transport.rs
+++ b/crates/feldera-types/src/transport.rs
@@ -12,5 +12,6 @@ pub mod nexmark;
 pub mod postgres;
 pub mod pubsub;
 pub mod redis;
+pub mod s2;
 pub mod s3;
 pub mod url;

--- a/crates/feldera-types/src/transport/s2.rs
+++ b/crates/feldera-types/src/transport/s2.rs
@@ -39,3 +39,18 @@ pub struct S2InputConfig {
     #[serde(default)]
     pub start_from: S2StartFrom,
 }
+
+/// Configuration for writing to an S2 stream.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct S2OutputConfig {
+    /// S2 basin name.
+    pub basin: String,
+    /// S2 stream name.
+    pub stream: String,
+    /// S2 authentication token.
+    pub auth_token: String,
+    /// Custom S2 endpoint URL (e.g., "http://localhost:8080").
+    /// If not set, uses the default S2 cloud endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}

--- a/crates/feldera-types/src/transport/s2.rs
+++ b/crates/feldera-types/src/transport/s2.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Where to start reading from the S2 stream.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub enum S2StartFrom {
+    /// Start from a specific sequence number.
+    SeqNum(u64),
+    /// Start from a specific timestamp (milliseconds since epoch).
+    Timestamp(u64),
+    /// Start from N records before the tail.
+    TailOffset(u64),
+    /// Start from the beginning (sequence number 0).
+    Beginning,
+    /// Start from the tail (new records only).
+    Tail,
+}
+
+impl Default for S2StartFrom {
+    fn default() -> Self {
+        Self::Beginning
+    }
+}
+
+/// Configuration for reading from an S2 stream.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+pub struct S2InputConfig {
+    /// S2 basin name.
+    pub basin: String,
+    /// S2 stream name.
+    pub stream: String,
+    /// S2 authentication token.
+    pub auth_token: String,
+    /// Custom S2 endpoint URL (e.g., "http://localhost:8080").
+    /// If not set, uses the default S2 cloud endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Where to start reading when no checkpoint exists.
+    #[serde(default)]
+    pub start_from: S2StartFrom,
+}

--- a/crates/feldera-types/src/transport/s2.rs
+++ b/crates/feldera-types/src/transport/s2.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Where to start reading from the S2 stream.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize, ToSchema)]
 pub enum S2StartFrom {
     /// Start from a specific sequence number.
     SeqNum(u64),
@@ -11,15 +11,10 @@ pub enum S2StartFrom {
     /// Start from N records before the tail.
     TailOffset(u64),
     /// Start from the beginning (sequence number 0).
+    #[default]
     Beginning,
     /// Start from the tail (new records only).
     Tail,
-}
-
-impl Default for S2StartFrom {
-    fn default() -> Self {
-        Self::Beginning
-    }
 }
 
 /// Configuration for reading from an S2 stream.

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -863,12 +863,12 @@ pub fn generate_pipeline_config(
 mod tests {
     use super::{determine_connector_endpoint_names, generate_program_info, RuntimeSelector};
     use crate::db::types::program::ConnectorGenerationError::RelationConnectorNameCollision;
-    use std::collections::BTreeMap;
     use feldera_types::config::{ConnectorConfig, TransportConfig};
     use feldera_types::program_schema::{
         ProgramSchema, PropertyValue, Relation, SourcePosition, SqlIdentifier,
     };
     use feldera_types::transport::datagen::DatagenInputConfig;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_runtime_version_validation() {
@@ -1042,8 +1042,15 @@ mod tests {
             outputs: vec![],
         };
 
-        let program_info =
-            generate_program_info(schema, String::new(), String::new(), None).unwrap();
-        assert!(program_info.input_connectors.contains_key("events.unnamed-0"));
+        let program_info = generate_program_info(
+            serde_json::to_value(schema).unwrap(),
+            String::new(),
+            String::new(),
+            None,
+        )
+        .unwrap();
+        assert!(program_info
+            .input_connectors
+            .contains_key("events.unnamed-0"));
     }
 }

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -729,6 +729,7 @@ pub fn generate_program_info(
                 | TransportConfig::DeltaTableInput(_)
                 | TransportConfig::PostgresInput(_)
                 | TransportConfig::IcebergInput(_)
+                | TransportConfig::S2Input(_)
                 | TransportConfig::Datagen(_)
                 | TransportConfig::Nexmark(_)
                 | TransportConfig::EmptyInput => {}
@@ -859,10 +860,13 @@ pub fn generate_pipeline_config(
 
 #[cfg(test)]
 mod tests {
-    use super::{determine_connector_endpoint_names, RuntimeSelector};
+    use super::{determine_connector_endpoint_names, generate_program_info, RuntimeSelector};
     use crate::db::types::program::ConnectorGenerationError::RelationConnectorNameCollision;
+    use std::collections::BTreeMap;
     use feldera_types::config::{ConnectorConfig, TransportConfig};
-    use feldera_types::program_schema::{PropertyValue, SourcePosition};
+    use feldera_types::program_schema::{
+        ProgramSchema, PropertyValue, Relation, SourcePosition, SqlIdentifier,
+    };
     use feldera_types::transport::datagen::DatagenInputConfig;
 
     #[test]
@@ -985,5 +989,60 @@ mod tests {
                 connector_name: "example".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_generate_program_info_accepts_s2_input() {
+        let connectors = serde_json::json!([{
+            "transport": {
+                "name": "s2_input",
+                "config": {
+                    "basin": "my-basin",
+                    "stream": "my-stream",
+                    "auth_token": "token",
+                    "start_from": "Beginning"
+                }
+            },
+            "format": {
+                "name": "json",
+                "config": {
+                    "update_format": "raw"
+                }
+            }
+        }])
+        .to_string();
+
+        let property_value = PropertyValue {
+            value: connectors,
+            key_position: SourcePosition {
+                start_line_number: 1,
+                start_column: 1,
+                end_line_number: 1,
+                end_column: 10,
+            },
+            value_position: SourcePosition {
+                start_line_number: 1,
+                start_column: 11,
+                end_line_number: 1,
+                end_column: 100,
+            },
+        };
+
+        let mut properties = BTreeMap::new();
+        properties.insert("connectors".to_string(), property_value);
+
+        let schema = ProgramSchema {
+            inputs: vec![Relation::new(
+                SqlIdentifier::from("events"),
+                vec![],
+                false,
+                properties,
+            )],
+            outputs: vec![],
+        };
+
+        let program_info =
+            generate_program_info(schema, String::new(), String::new(), None).unwrap();
+        assert!(program_info.input_connectors.contains_key("events.unnamed-0"));
     }
 }

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -781,6 +781,7 @@ pub fn generate_program_info(
                 | TransportConfig::DeltaTableOutput(_)
                 | TransportConfig::DynamoDBOutput(_)
                 | TransportConfig::RedisOutput(_)
+                | TransportConfig::S2Output(_)
                 | TransportConfig::NullOutput => {}
                 _ => {
                     return Err(ConnectorGenerationError::ExpectedOutputConnector {

--- a/docs.feldera.com/docs/connectors/sinks/s2.md
+++ b/docs.feldera.com/docs/connectors/sinks/s2.md
@@ -1,0 +1,56 @@
+# S2 output connector
+
+:::caution Experimental feature
+S2 support is an experimental feature of Feldera.
+:::
+
+Feldera can append encoded SQL view updates to an [S2](https://s2.dev/) stream
+with the `s2_output` connector.
+
+## Configuration
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `basin` | string | Yes | S2 basin name. |
+| `stream` | string | Yes | S2 stream name. |
+| `auth_token` | string | Yes | S2 authentication token. Use a [secret reference](/connectors/secret-references) in production. |
+| `endpoint` | string | No | Custom S2 endpoint, primarily for local development. When omitted, the S2 cloud endpoint is used. |
+
+The connector submits each encoded output buffer as one S2 record. S2 limits a
+record body to 1 MiB, so the connector asks the encoder to keep each buffer below
+that limit. The connector waits for S2 to acknowledge the append before returning.
+It is not a fault-tolerant output connector; a failure after S2 accepted a record
+but before Feldera observed its acknowledgement can produce a duplicate after a
+retry.
+
+## Example
+
+```sql
+CREATE TABLE orders (
+    id BIGINT,
+    amount DECIMAL(12, 2)
+);
+
+CREATE VIEW large_orders WITH (
+    'connectors' = '[{
+        "transport": {
+            "name": "s2_output",
+            "config": {
+                "basin": "commerce",
+                "stream": "large-orders",
+                "auth_token": "${secret:kubernetes:s2/auth-token}"
+            }
+        },
+        "format": {
+            "name": "json",
+            "config": {
+                "update_format": "insert_delete"
+            }
+        }
+    }]'
+) AS
+SELECT * FROM orders WHERE amount >= 1000;
+```
+
+S2 is not a key-value store, so output formats or indexes that require keyed
+writes are not supported by this connector.

--- a/docs.feldera.com/docs/connectors/sinks/s2.md
+++ b/docs.feldera.com/docs/connectors/sinks/s2.md
@@ -16,12 +16,16 @@ with the `s2_output` connector.
 | `auth_token` | string | Yes | S2 authentication token. Use a [secret reference](/connectors/secret-references) in production. |
 | `endpoint` | string | No | Custom S2 endpoint, primarily for local development. When omitted, the S2 cloud endpoint is used. |
 
-The connector submits each encoded output buffer as one S2 record. S2 limits a
-record body to 1 MiB, so the connector asks the encoder to keep each buffer below
-that limit. The connector waits for S2 to acknowledge the append before returning.
-It is not a fault-tolerant output connector; a failure after S2 accepted a record
-but before Feldera observed its acknowledgement can produce a duplicate after a
-retry.
+The connector splits each encoded output buffer into one S2 record per line and
+appends them as native S2 batches, chunked to S2's per-batch record limit. S2
+enforces a 1 MiB metered limit per `AppendRecordBatch` (including per-record
+framing overhead); this is a hard, server-side limit, not a Feldera setting. The
+connector asks the encoder to keep each buffer below that limit, but a single
+oversized record — for example, a row with a very long string column — can still
+exceed it and will be rejected by the append call. The connector waits for S2 to
+acknowledge each batch before returning. It is not a fault-tolerant output
+connector; a failure after S2 accepted a batch but before Feldera observed its
+acknowledgement can produce duplicates after a retry.
 
 ## Example
 

--- a/docs.feldera.com/docs/connectors/sources/s2.md
+++ b/docs.feldera.com/docs/connectors/sources/s2.md
@@ -27,8 +27,25 @@ checkpointed ranges when a pipeline resumes.
 - `{"TailOffset": 100}`: start 100 records before the current tail.
 
 Once a checkpoint exists, its sequence number takes precedence over `start_from`.
-If S2 has trimmed records required to replay a checkpoint, the connector fails
-rather than silently skipping data.
+The connector preserves ordered delivery across reconnects and validates sequence
+contiguity after the start position has been resolved. Gaps, duplicates, or S2
+trimmed records required to replay a checkpoint fail the connector rather than
+silently skipping or duplicating data.
+
+## Retry behavior
+
+The S2 SDK performs finite retries for transient service and network failures.
+If those retries are exhausted, Feldera classifies the resulting S2 error. Errors
+that are safe to retry, such as rate limiting, service unavailability, request or
+heartbeat timeouts, and common connection resets, are reported as non-fatal and
+retried indefinitely with bounded backoff from the last resolved S2 sequence
+number. The pipeline can still flush records that were already buffered while the
+connector is waiting to reconnect.
+
+Fatal errors, such as malformed access tokens, validation failures, append
+condition failures, reads from unwritten positions, replay gaps or short reads,
+and unknown S2 error codes, stop the connector and require operator action. Pause
+and disconnect requests cancel any in-progress reconnect backoff promptly.
 
 ## Example
 

--- a/docs.feldera.com/docs/connectors/sources/s2.md
+++ b/docs.feldera.com/docs/connectors/sources/s2.md
@@ -1,0 +1,62 @@
+# S2 input connector
+
+:::caution Experimental feature
+S2 support is an experimental feature of Feldera.
+:::
+
+Feldera can consume ordered records from an [S2](https://s2.dev/) stream with the
+`s2_input` connector. The connector checkpoints S2 sequence numbers and replays
+checkpointed ranges when a pipeline resumes.
+
+## Configuration
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `basin` | string | Yes | S2 basin name. |
+| `stream` | string | Yes | S2 stream name. |
+| `auth_token` | string | Yes | S2 authentication token. Use a [secret reference](/connectors/secret-references) in production. |
+| `endpoint` | string | No | Custom S2 endpoint, primarily for local development. When omitted, the S2 cloud endpoint is used. |
+| `start_from` | variant | No | Initial read position when no checkpoint exists. Defaults to `"Beginning"`. |
+
+`start_from` accepts the following values:
+
+- `"Beginning"`: start at sequence number 0.
+- `"Tail"`: consume records appended after the connector starts.
+- `{"SeqNum": 42}`: start at sequence number 42.
+- `{"Timestamp": 1773900000000}`: start at a Unix timestamp in milliseconds.
+- `{"TailOffset": 100}`: start 100 records before the current tail.
+
+Once a checkpoint exists, its sequence number takes precedence over `start_from`.
+If S2 has trimmed records required to replay a checkpoint, the connector fails
+rather than silently skipping data.
+
+## Example
+
+```sql
+CREATE TABLE orders (
+    id BIGINT,
+    amount DECIMAL(12, 2)
+) WITH (
+    'connectors' = '[{
+        "transport": {
+            "name": "s2_input",
+            "config": {
+                "basin": "commerce",
+                "stream": "orders",
+                "auth_token": "${secret:kubernetes:s2/auth-token}",
+                "start_from": "Beginning"
+            }
+        },
+        "format": {
+            "name": "json",
+            "config": {
+                "update_format": "raw"
+            }
+        }
+    }]'
+);
+```
+
+Each S2 record body is passed to the configured Feldera input format. For JSON
+streams containing insert/delete envelopes, set `update_format` to
+`"insert_delete"` instead of `"raw"`.

--- a/docs.feldera.com/docs/connectors/sources/s2.md
+++ b/docs.feldera.com/docs/connectors/sources/s2.md
@@ -21,12 +21,19 @@ checkpointed ranges when a pipeline resumes.
 `start_from` accepts the following values:
 
 - `"Beginning"`: start at sequence number 0.
-- `"Tail"`: consume records appended after the connector starts.
+- `"Tail"`: consume records appended after the connector starts. The tail is
+  resolved once, right before the first record is read, and that sequence number
+  is then checkpointed, so it does not keep drifting as the stream grows. Before
+  the first record, the anchor is time-dependent; if you need a fully
+  deterministic start, use `SeqNum` or `Timestamp`.
 - `{"SeqNum": 42}`: start at sequence number 42.
 - `{"Timestamp": 1773900000000}`: start at a Unix timestamp in milliseconds.
 - `{"TailOffset": 100}`: start 100 records before the current tail.
 
 Once a checkpoint exists, its sequence number takes precedence over `start_from`.
+If the checkpoint was taken after the start position was resolved (a record was
+consumed or a tail was anchored), the connector always resumes from that absolute
+sequence number — including sequence 0 — rather than recomputing `start_from`.
 The connector preserves ordered delivery across reconnects and validates sequence
 contiguity after the start position has been resolved. Gaps, duplicates, or S2
 trimmed records required to replay a checkpoint fail the connector rather than

--- a/python/tests/platform/test_checkpoint_suspend.py
+++ b/python/tests/platform/test_checkpoint_suspend.py
@@ -241,7 +241,8 @@ def test_suspend_enterprise(pipeline_name):
 
     wait_for_condition(
         "9 total records after c2/c3",
-        lambda: _adhoc_count(pipeline_name) == 9,
+        lambda: _adhoc_count(pipeline_name) == 9
+        ,
         timeout_s=15.0,
         poll_interval_s=1.0,
     )

--- a/python/tests/platform/test_checkpoint_suspend.py
+++ b/python/tests/platform/test_checkpoint_suspend.py
@@ -241,8 +241,7 @@ def test_suspend_enterprise(pipeline_name):
 
     wait_for_condition(
         "9 total records after c2/c3",
-        lambda: _adhoc_count(pipeline_name) == 9
-        ,
+        lambda: _adhoc_count(pipeline_name) == 9,
         timeout_s=15.0,
         poll_interval_s=1.0,
     )

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/ConnectorValidator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/ConnectorValidator.java
@@ -244,6 +244,10 @@ public final class ConnectorValidator {
                     validateConfig(transportConfig, outerJson, configPointer,
                             outerStart, S3InputConfig.class, reporter);
                     break;
+                case "s2_input":
+                    validateConfig(transportConfig, outerJson, configPointer,
+                            outerStart, S2InputConfig.class, reporter);
+                    break;
                 case "clock":
                     validateConfig(transportConfig, outerJson, configPointer,
                             outerStart, ClockConfig.class, reporter);
@@ -299,6 +303,10 @@ public final class ConnectorValidator {
                 case "redis_output":
                     validateConfig(transportConfig, outerJson, configPointer,
                             outerStart, RedisOutputConfig.class, reporter);
+                    break;
+                case "s2_output":
+                    validateConfig(transportConfig, outerJson, configPointer,
+                            outerStart, S2OutputConfig.class, reporter);
                     break;
                 case "null":
                     break;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/S2InputConfig.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/S2InputConfig.java
@@ -1,0 +1,69 @@
+package org.dbsp.sqlCompiler.compiler.frontend.connectors.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.compiler.frontend.connectors.ConfigReporter;
+import org.dbsp.sqlCompiler.compiler.frontend.connectors.IValidateConfig;
+
+import javax.annotation.Nullable;
+
+/** Configuration for the S2 input connector. */
+@SuppressWarnings("unused")
+public class S2InputConfig implements IValidateConfig {
+    @JsonProperty("basin")
+    public String basin = "";
+
+    @JsonProperty("stream")
+    public String stream = "";
+
+    @JsonProperty("auth_token")
+    public String authToken = "";
+
+    @Nullable
+    @JsonProperty("endpoint")
+    public String endpoint = null;
+
+    @Nullable
+    @JsonProperty("start_from")
+    public JsonNode startFrom = null;
+
+    @Override
+    public boolean validate(ConfigReporter reporter) {
+        boolean ok = true;
+        if (basin.isBlank()) {
+            reporter.warnPath("basin", "Invalid configuration",
+                    "required field \"basin\" is missing or empty");
+            ok = false;
+        }
+        if (stream.isBlank()) {
+            reporter.warnPath("stream", "Invalid configuration",
+                    "required field \"stream\" is missing or empty");
+            ok = false;
+        }
+        if (authToken.isBlank()) {
+            reporter.warnPath("auth_token", "Invalid configuration",
+                    "required field \"auth_token\" is missing or empty");
+            ok = false;
+        }
+        if (startFrom != null && !isValidStartFrom(startFrom)) {
+            reporter.warnPath("start_from", "Invalid configuration",
+                    "\"start_from\" must be \"Beginning\", \"Tail\", or an object containing exactly one of \"SeqNum\", \"Timestamp\", or \"TailOffset\" with a non-negative integer value");
+            ok = false;
+        }
+        return ok;
+    }
+
+    private static boolean isValidStartFrom(JsonNode value) {
+        if (value.isTextual()) {
+            String text = value.asText();
+            return text.equals("Beginning") || text.equals("Tail");
+        }
+        if (!value.isObject() || value.size() != 1)
+            return false;
+        String field = value.fieldNames().next();
+        if (!field.equals("SeqNum") && !field.equals("Timestamp") && !field.equals("TailOffset"))
+            return false;
+        JsonNode position = value.get(field);
+        return position.isIntegralNumber() && position.canConvertToLong() && position.asLong() >= 0;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/S2OutputConfig.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/connectors/config/S2OutputConfig.java
@@ -1,0 +1,45 @@
+package org.dbsp.sqlCompiler.compiler.frontend.connectors.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.dbsp.sqlCompiler.compiler.frontend.connectors.ConfigReporter;
+import org.dbsp.sqlCompiler.compiler.frontend.connectors.IValidateConfig;
+
+import javax.annotation.Nullable;
+
+/** Configuration for the S2 output connector. */
+@SuppressWarnings("unused")
+public class S2OutputConfig implements IValidateConfig {
+    @JsonProperty("basin")
+    public String basin = "";
+
+    @JsonProperty("stream")
+    public String stream = "";
+
+    @JsonProperty("auth_token")
+    public String authToken = "";
+
+    @Nullable
+    @JsonProperty("endpoint")
+    public String endpoint = null;
+
+    @Override
+    public boolean validate(ConfigReporter reporter) {
+        boolean ok = true;
+        if (basin.isBlank()) {
+            reporter.warnPath("basin", "Invalid configuration",
+                    "required field \"basin\" is missing or empty");
+            ok = false;
+        }
+        if (stream.isBlank()) {
+            reporter.warnPath("stream", "Invalid configuration",
+                    "required field \"stream\" is missing or empty");
+            ok = false;
+        }
+        if (authToken.isBlank()) {
+            reporter.warnPath("auth_token", "Invalid configuration",
+                    "required field \"auth_token\" is missing or empty");
+            ok = false;
+        }
+        return ok;
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ConnectorTests.java
@@ -1270,6 +1270,78 @@ public class ConnectorTests extends BaseSQLTests {
                 }""");
     }
 
+    // ---- S2 transport config ----
+
+    @Test
+    public void s2InputValidConfig() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "s2_input",
+                  "config": {
+                    "basin": "events",
+                    "stream": "orders",
+                    "auth_token": "${env:S2_AUTH_TOKEN}",
+                    "start_from": {"SeqNum": 42}
+                  }
+                }""");
+    }
+
+    @Test
+    public void s2InputInvalidStartFrom() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "s2_input",
+                  "config": {
+                    "basin": "events",
+                    "stream": "orders",
+                    "auth_token": "token",
+                    "start_from": {"SeqNum": -1}
+                  }
+                }""",
+                "\"start_from\" must be \"Beginning\", \"Tail\"");
+    }
+
+    @Test
+    public void s2InputMissingStream() {
+        tableConnectorTest("""
+                "transport": {
+                  "name": "s2_input",
+                  "config": {
+                    "basin": "events",
+                    "auth_token": "token"
+                  }
+                }""",
+                "required field \"stream\" is missing or empty");
+    }
+
+    @Test
+    public void s2OutputValidConfig() {
+        viewConnectorTest("""
+                "transport": {
+                  "name": "s2_output",
+                  "config": {
+                    "basin": "events",
+                    "stream": "results",
+                    "auth_token": "${env:S2_AUTH_TOKEN}"
+                  }
+                }""");
+    }
+
+    @Test
+    public void s2OutputUnknownField() {
+        viewConnectorTest("""
+                "transport": {
+                  "name": "s2_output",
+                  "config": {
+                    "basin": "events",
+                    "stream": "results",
+                    "auth_token": "token",
+                    "batch_size": 100
+                  }
+                }""",
+                "unknown field \"batch_size\"");
+    }
+
     // ---- NATS transport config ----
 
     @Test


### PR DESCRIPTION
### Describe Manual Test Plan
RFC : https://github.com/feldera/feldera/issues/5726
<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
