### PR TITLE
ci: cancel in-progress jobs immediately when a sibling fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  # NOTE: For every job added here, add a matching cancel-if-<name>-failed
+  # sentinel job in the cancel-if-* section below.
   invoke-build-rust:
     name: Build Rust
     uses: ./.github/workflows/build-rust.yml


### PR DESCRIPTION
GitHub does not automatically abort running parallel jobs when one fails, they keep running until completion, which wastes runner time on long builds and tests.

Add a cancel sentinel job for each workflow job. Each sentinel depends only on its paired job ('needs: [invoke-X]') and runs 'if: failure()', so it starts the moment that job fails. It then calls the GitHub API to cancel the entire workflow run, stopping all other in-progress jobs.

Fixes #5534 