### PR TITLE
py: add integration test for kafka input and output connector

### DIFF
--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -62,3 +62,5 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/python
           FELDERA_TLS_INSECURE: true
+          KAFKA_BOOTSTRAP_SERVERS: ${{ vars.CI_KAFKA_BOOTSTRAP }}
+          SCHEMA_REGISTRY_URL: ${{ vars.CI_SCHEMA_REGISTRY }}

--- a/python/tests/workloads/test_kafka_avro.py
+++ b/python/tests/workloads/test_kafka_avro.py
@@ -16,8 +16,8 @@ def env(name: str, default: str) -> str:
 
 # Set these before running the test:
 # Example(terminal/shell):
-#   export KAFKA_BOOTSTRAP_SERVERS = localhost:9092
-#   export SCHEMA_REGISTRY_URL = http://localhost:8081
+#   export KAFKA_BOOTSTRAP_SERVERS= localhost:9092
+#   export SCHEMA_REGISTRY_URL= http://localhost:8081
 
 KAFKA_BOOTSTRAP = env(
     "KAFKA_BOOTSTRAP_SERVERS", "ci-kafka-bootstrap.korat-vibes.ts.net:9094"


### PR DESCRIPTION
This PR contains an integration test for the Kafka input and output connector that does the following:

- Generates 1000000 records of data using the Datagen connector
- Sets environment variables for Kafka artifacts
- Writes input to Kafka and the schema registry in Avro format
- Reads input from Kafka to loopback table
- Covers multiple supported column types
- Monitors completion of message ingestion to and from Kafka
- Validates that the loopback table contains all generated values based on pipeline hash
- Deletes Kafka topics and schema subjects after test completion

## Checklist
- [ ] Integration tests added/updated

