### PR TITLE
Ci fast fail on job failure

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: read
 
 env:
   REGISTRY: ghcr.io
@@ -200,3 +201,15 @@ jobs:
             "${{ vars.FELDERA_IMAGE_NAME }}" \
             "${{ steps.meta.outputs.version }}" \
             "amd64,arm64"
+
+      # Upload after the image is verified so check-prior-build knows the
+      # sha-{sha} tag actually exists in GHCR (not just that digests were pushed).
+      - name: Signal docker image ready
+        run: echo "${{ steps.meta.outputs.version }}" > /tmp/docker-image-ready.txt
+
+      - name: Upload docker-image-ready artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-ready
+          path: /tmp/docker-image-ready.txt
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,10 @@ jobs:
             "feldera-test-binaries-aarch64-unknown-linux-gnu"
             "feldera-sql-compiler"
           )
-          # These tiny (~244B) digest artifacts are uploaded when each platform
-          # Docker build completes. Checking them is faster than docker manifest inspect.
+          # This artifact is uploaded by merge-manifests only after the image is
+          # verified in GHCR, so its presence guarantees the sha-{sha} tag exists.
           docker_required=(
-            "digests-linux-amd64"
-            "digests-linux-arm64"
+            "docker-image-ready"
           )
 
           run_ids=$(curl -fsSL \
@@ -60,7 +59,7 @@ jobs:
             names=$(curl -fsSL \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts?per_page=100" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts?per_page=200" \
               | jq -r '.artifacts[] | select(.expired == false) | .name') || continue
 
             all_rust_java=true

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -14,6 +14,10 @@ on:
         description: "ID of the workflow run that uploaded the artifact"
         required: true
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   adapter-tests:
     if: ${{ !contains(vars.CI_SKIP_JOBS, 'adapter-tests') }}

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -153,6 +153,10 @@ jobs:
   oss-platform-tests:
     if: ${{ !contains(vars.CI_SKIP_JOBS, 'oss-platform-tests') }}
     name: Platform Integration Tests (OSS Docker Image)
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     strategy:
       matrix:
         include:
@@ -194,7 +198,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-          --cap-add=PERFMON
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -13,6 +13,10 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   rust-unit-tests:
     name: Rust Unit Tests


### PR DESCRIPTION
Add a 'check-prior-build' job that queries the GitHub API for a prior run on the same commit SHA. If all required binary and Docker digest artifacts are found unexpired, the Rust, Java, and Docker build jobs are skipped and test workflows download artifacts from that prior run instead of rebuilding.

