### PR TITLE
manager: Ability to override env vars in pipeline

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -4111,6 +4111,7 @@ impl ControllerInit {
                 checkpoint_during_suspend: config.global.checkpoint_during_suspend,
                 http_workers: config.global.http_workers,
                 io_workers: config.global.io_workers,
+                env: config.global.env.clone(),
                 dev_tweaks: config.global.dev_tweaks.clone(),
                 logging: config.global.logging,
                 pipeline_template_configmap: config.global.pipeline_template_configmap.clone(),

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -871,6 +871,15 @@ pub struct RuntimeConfig {
     /// If not specified, the default is set to `workers`.
     pub io_workers: Option<u64>,
 
+    /// Environment variables for the pipeline process.
+    ///
+    /// These are key-value pairs injected into the pipeline process environment.
+    /// Some variable names are reserved by the platform and cannot be overridden
+    /// (for example `RUST_LOG`, and variables in the `FELDERA_`,
+    /// `KUBERNETES_`, and `TOKIO_` namespaces).
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+
     /// Optional settings for tweaking Feldera internals.
     ///
     /// The available key-value pairs change from one version of Feldera to
@@ -1030,6 +1039,7 @@ impl Default for RuntimeConfig {
             checkpoint_during_suspend: true,
             io_workers: None,
             http_workers: None,
+            env: BTreeMap::default(),
             dev_tweaks: BTreeMap::default(),
             logging: None,
             pipeline_template_configmap: None,

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -121,6 +121,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
             checkpoint_during_suspend: false,
             io_workers: None,
             http_workers: None,
+            env: BTreeMap::new(),
             dev_tweaks: BTreeMap::new(),
             logging: None,
             pipeline_template_configmap: None,

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -319,6 +319,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> serde_json::V
             checkpoint_during_suspend: val.val17,
             http_workers: val.val18,
             io_workers: val.val19,
+            env: BTreeMap::new(),
             dev_tweaks: BTreeMap::new(),
             logging: None,
             pipeline_template_configmap: None,
@@ -1202,6 +1203,7 @@ async fn pipeline_versioning() {
         checkpoint_during_suspend: true,
         http_workers: None,
         io_workers: None,
+        env: BTreeMap::new(),
         dev_tweaks: BTreeMap::new(),
         logging: None,
         pipeline_template_configmap: None,
@@ -2219,6 +2221,7 @@ async fn pipeline_provision_version_guard() {
                     dev_tweaks: BTreeMap::new(),
                     http_workers: None,
                     io_workers: None,
+                    env: BTreeMap::new(),
                     logging: None,
                     pipeline_template_configmap: None,
                 })

--- a/crates/pipeline-manager/src/db/types/utils.rs
+++ b/crates/pipeline-manager/src/db/types/utils.rs
@@ -1,5 +1,6 @@
 use crate::db::error::DBError;
 use crate::db::types::program::{ProgramConfig, ProgramInfo};
+use crate::pipeline_env::validate_pipeline_env;
 use feldera_types::config::{PipelineConfig, RuntimeConfig};
 use regex::Regex;
 use serde::Serialize;
@@ -50,6 +51,8 @@ pub enum ValidationError {
     DeserializationFailed(String),
     #[error("enterprise feature: {0}")]
     EnterpriseFeature(String),
+    #[error("invalid pipeline environment: {0}")]
+    InvalidPipelineEnv(String),
 }
 
 /// Deserializes generic JSON value into [`RuntimeConfig`] and performs any additional validation.
@@ -65,6 +68,13 @@ pub(crate) fn validate_runtime_config(
             #[cfg(not(feature = "feldera-enterprise"))]
             if runtime_config.fault_tolerance.is_enabled() {
                 let e = ValidationError::EnterpriseFeature("fault tolerance".to_string());
+                if log_if_invalid {
+                    error!("Backward incompatibility detected: the following JSON:\n{value:#}\n\n... is no longer a valid runtime configuration due to: {e}");
+                }
+                return Err(e);
+            }
+            if let Err(e) = validate_pipeline_env(&runtime_config.env) {
+                let e = ValidationError::InvalidPipelineEnv(e);
                 if log_if_invalid {
                     error!("Backward incompatibility detected: the following JSON:\n{value:#}\n\n... is no longer a valid runtime configuration due to: {e}");
                 }
@@ -113,12 +123,23 @@ pub(crate) fn validate_program_info(
 pub(crate) fn validate_deployment_config(
     value: &serde_json::Value,
 ) -> Result<PipelineConfig, ValidationError> {
-    let deserialize_result = serde_json::from_value(value.clone())
+    let deserialize_result = serde_json::from_value::<PipelineConfig>(value.clone())
         .map_err(|e| ValidationError::DeserializationFailed(e.to_string()));
-    if let Err(e) = &deserialize_result {
-        error!("Backward incompatibility detected: the following JSON:\n{value:#}\n\n... is no longer a valid deployment configuration due to: {e}");
+    match deserialize_result {
+        Ok(deployment_config) => {
+            if let Err(e) = validate_pipeline_env(&deployment_config.global.env) {
+                let e = ValidationError::InvalidPipelineEnv(e);
+                error!("Backward incompatibility detected: the following JSON:\n{value:#}\n\n... is no longer a valid deployment configuration due to: {e}");
+                Err(e)
+            } else {
+                Ok(deployment_config)
+            }
+        }
+        Err(e) => {
+            error!("Backward incompatibility detected: the following JSON:\n{value:#}\n\n... is no longer a valid deployment configuration due to: {e}");
+            Err(e)
+        }
     }
-    deserialize_result
 }
 
 #[cfg(test)]
@@ -205,6 +226,11 @@ mod tests {
             validate_runtime_config(&json!({ "fault_tolerance": {} }), true),
             Err(ValidationError::EnterpriseFeature(s)) if s == "fault tolerance"
         ));
+
+        assert!(matches!(
+            validate_runtime_config(&json!({ "env": { "TOKIO_WORKER_THREADS": "1" } }), true),
+            Err(ValidationError::InvalidPipelineEnv(_))
+        ));
     }
 
     #[test]
@@ -276,6 +302,13 @@ mod tests {
         assert!(matches!(
             validate_deployment_config(&json!({ "name": 123 })),
             Err(ValidationError::DeserializationFailed(_))
+        ));
+
+        assert!(matches!(
+            validate_deployment_config(
+                &json!({ "workers": 8, "env": { "TOKIO_WORKER_THREADS": "1" } })
+            ),
+            Err(ValidationError::InvalidPipelineEnv(_))
         ));
     }
 }

--- a/crates/pipeline-manager/src/lib.rs
+++ b/crates/pipeline-manager/src/lib.rs
@@ -14,6 +14,7 @@ pub mod db;
 pub mod error;
 pub mod license;
 pub mod logging;
+pub mod pipeline_env;
 pub mod runner;
 
 /// Feature gate for new/unstable features that aren't rolled out or will change

--- a/crates/pipeline-manager/src/pipeline_env.rs
+++ b/crates/pipeline-manager/src/pipeline_env.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+
+/// Environment variable names that users cannot override in pipeline configuration.
+pub const ENV_VAR_BLOCKLIST: &[&str] = &["HOSTNAME", "RUST_LOG", "TOKIO_WORKER_THREADS"];
+
+/// Environment variable prefixes that users cannot override in pipeline configuration.
+pub const ENV_VAR_PREFIX_BLOCKLIST: &[&str] = &["FELDERA_", "KUBERNETES_", "TOKIO_"];
+
+/// Validate user-provided pipeline environment variables and
+/// avoid overrides of certain ENV 'namespaces'.
+///
+/// The 'blocked' names are often set by feldera itself and can cause
+/// unexpected behavior when overridden with this mechanism by the
+/// user.
+///
+/// - Don't allow anything starting with `FELDERA_`
+/// - Don't allow anything starting with `KUBERNETES_`
+/// - Don't allow anything starting with `TOKIO_`
+/// - Don't allow explicit control variables such as `RUST_LOG`
+pub fn validate_pipeline_env(env: &BTreeMap<String, String>) -> Result<(), String> {
+    let forbidden: Vec<String> = env
+        .keys()
+        .filter(|key| {
+            ENV_VAR_BLOCKLIST.contains(&key.as_str())
+                || ENV_VAR_PREFIX_BLOCKLIST
+                    .iter()
+                    .any(|prefix| key.starts_with(prefix))
+        })
+        .cloned()
+        .collect();
+
+    if forbidden.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "the following environment variable(s) are reserved and cannot be overridden: {}",
+            forbidden.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_pipeline_env;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn accepts_non_reserved_env_vars() {
+        let env = BTreeMap::from([("TEST_ENV".to_string(), "x".to_string())]);
+        assert!(validate_pipeline_env(&env).is_ok());
+    }
+
+    #[test]
+    fn rejects_feldera_env_vars() {
+        let env = BTreeMap::from([("FELDERA_TEST_ENV".to_string(), "x".to_string())]);
+        assert!(validate_pipeline_env(&env).is_err());
+    }
+
+    #[test]
+    fn rejects_reserved_env_vars() {
+        let env = BTreeMap::from([
+            ("TOKIO_WORKER_THREADS".to_string(), "1".to_string()),
+            ("RUST_LOG".to_string(), "debug".to_string()),
+        ]);
+        assert!(validate_pipeline_env(&env).is_err());
+    }
+
+    #[test]
+    fn rejects_kubernetes_env_vars() {
+        let env = BTreeMap::from([("KUBERNETES_SERVICE_HOST".to_string(), "x".to_string())]);
+        assert!(validate_pipeline_env(&env).is_err());
+    }
+}

--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -8,6 +8,7 @@ use crate::db::types::pipeline::{
 };
 use crate::db::types::version::Version;
 use crate::error::{source_error, ManagerError};
+use crate::pipeline_env::validate_pipeline_env;
 use crate::runner::error::RunnerError;
 use crate::runner::pipeline_executor::{PipelineExecutor, ProvisionStatus};
 use crate::runner::pipeline_logs::{LogMessage, LogsSender};
@@ -434,6 +435,10 @@ impl PipelineExecutor for LocalRunner {
             .into());
         }
 
+        if let Err(e) = validate_pipeline_env(&deployment_config.global.env) {
+            return Err(RunnerError::RunnerProvisionError { error: e }.into());
+        }
+
         // (Re-)create pipeline working directory (which will contain storage directory)
         let pipeline_dir = self.config.pipeline_dir(self.pipeline_id);
         create_dir_all(&pipeline_dir).await.map_err(|e| {
@@ -556,6 +561,13 @@ impl PipelineExecutor for LocalRunner {
                         .io_workers
                         .unwrap_or(deployment_config.global.workers as u64)
                         .to_string(),
+                )
+                .envs(
+                    deployment_config
+                        .global
+                        .env
+                        .iter()
+                        .map(|(key, value)| (key.as_str(), value.as_str())),
                 )
                 .current_dir(&pipeline_dir)
                 .arg("--config-file")

--- a/docs.feldera.com/docs/operations/memory.md
+++ b/docs.feldera.com/docs/operations/memory.md
@@ -125,27 +125,43 @@ Feldera pipelines primarily use memory for the following purposes:
 
 ### jemalloc Configuration
 
-Users can fine-tune the performance of jemalloc with the `MALLOC_CONF` environment variable. Possible configuration values are detailed in the [jemalloc reference](https://jemalloc.net/jemalloc.3.html#tuning). [Feldera sets default `MALLOC_CONF`](https://github.com/feldera/feldera/blob/5bcdf945525c87cbc22d4036609455d8159e029b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/BaseRustCodeGenerator.java#L102) values to collect heap profile data. values to collect heap profile data. These defaults are prof:true,prof_active:true,lg_prof_sample:19. When setting custom configuration, preserve Feldera's defaults by taking the union of both sets of values.
+You can fine-tune jemalloc with the `MALLOC_CONF` environment variable.
+Possible values are documented in the
+[jemalloc reference](https://jemalloc.net/jemalloc.3.html#tuning).
 
-- **With Docker**: [Docker Quickstart](/get-started/docker#docker-quickstart) users can set the `MALLOC_CONF` environment variable by passing `-e MALLOC_CONF='prof:true,prof_active:true,lg_prof_sample:19,custom_config_value:true'` where `'custom_config_value:true'` is replaced with the values the user wants to configure.
+Feldera sets default `MALLOC_CONF` values to collect heap profile data:
+`prof:true,prof_active:true,lg_prof_sample:19`.
+When setting custom configuration, preserve these defaults and add your
+own options.
 
-  If using [Docker Compose](/get-started/docker#optional-docker-compose-quickstart), customize the pipeline manager environment.
-  ```yaml
-  services:
-    pipeline-manager:
-      # ...
-      environment:
-        # prof, prof_active, and lg_prof_sample are Feldera defaults that should be preserved
-        MALLOC_CONF: prof:true,prof_active:true,lg_prof_sample:19,background_thread:true,stats_print:true
-  ```
+Environment variables can be overridden by setting them in the pipeline runtime configuration in `env`:
 
-- **With Helm (Enterprise Users Only)**: Enterprise users can add the `MALLOC_CONF` environment variable to the `values.yaml` file.
+```json
+// ...
+"env": {
+  "MALLOC_CONF": "prof:true,prof_active:true,lg_prof_sample:19,background_thread:true,stats_print:true"
+}
+// ...
+```
 
-  Example usage:
-  ```yaml
-  pipeline:
-    env:
-     - name: MALLOC_CONF
-     # prof, prof_active, and lg_prof_sample are Feldera defaults that should be preserved
-       value: prof:true,prof_active:true,lg_prof_sample:19,background_thread:true,stats_print:true
-  ```
+Some environment variable names are reserved and cannot be overridden through
+`runtime_config.env` (for example names in the `FELDERA_`, `KUBERNETES_`, and
+`TOKIO_` namespaces, plus control variables such as `RUST_LOG`).
+
+Python SDK example:
+
+```python
+from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+
+pipeline = PipelineBuilder(
+    client,
+    name="my-pipeline",
+    sql="CREATE TABLE t(i INT);",
+    runtime_config=RuntimeConfig(
+        env={
+            "MALLOC_CONF": "prof:true,prof_active:true,lg_prof_sample:19,background_thread:true,stats_print:true"
+        }
+    ),
+).create_or_replace()
+```

--- a/docs.feldera.com/docusaurus.config.ts
+++ b/docs.feldera.com/docusaurus.config.ts
@@ -21,7 +21,11 @@ const config: Config = {
   projectName: "feldera", // Usually your repo name.
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -35,6 +39,7 @@ const config: Config = {
     [
       "docusaurus-preset-openapi",
       {
+        proxy: false,
         api: {
           path: "../openapi.json",
           routeBasePath: "/api",

--- a/openapi.json
+++ b/openapi.json
@@ -620,6 +620,7 @@
                       "checkpoint_during_suspend": true,
                       "http_workers": null,
                       "io_workers": null,
+                      "env": {},
                       "dev_tweaks": {},
                       "logging": null,
                       "pipeline_template_configmap": null
@@ -707,6 +708,7 @@
                       "checkpoint_during_suspend": false,
                       "http_workers": null,
                       "io_workers": null,
+                      "env": {},
                       "dev_tweaks": {},
                       "logging": null,
                       "pipeline_template_configmap": null
@@ -824,6 +826,7 @@
                   "checkpoint_during_suspend": true,
                   "http_workers": null,
                   "io_workers": null,
+                  "env": {},
                   "dev_tweaks": {},
                   "logging": null,
                   "pipeline_template_configmap": null
@@ -895,6 +898,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -1075,6 +1079,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -1219,6 +1224,7 @@
                   "checkpoint_during_suspend": true,
                   "http_workers": null,
                   "io_workers": null,
+                  "env": {},
                   "dev_tweaks": {},
                   "logging": null,
                   "pipeline_template_configmap": null
@@ -1290,6 +1296,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -1387,6 +1394,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -1653,6 +1661,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -6185,6 +6194,7 @@
                     "checkpoint_during_suspend": true,
                     "http_workers": null,
                     "io_workers": null,
+                    "env": {},
                     "dev_tweaks": {},
                     "logging": null,
                     "pipeline_template_configmap": null
@@ -9629,6 +9639,14 @@
                 "default": {},
                 "additionalProperties": {}
               },
+              "env": {
+                "type": "object",
+                "description": "Environment variables for the pipeline process.\n\nThese are key-value pairs injected into the pipeline process environment.\nSome variable names are reserved by the platform and cannot be overridden\n(for example `RUST_LOG`, and variables in the `FELDERA_`,\n`KUBERNETES_`, and `TOKIO_` namespaces).",
+                "default": {},
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
               "fault_tolerance": {
                 "allOf": [
                   {
@@ -11294,6 +11312,14 @@
             "description": "Optional settings for tweaking Feldera internals.\n\nThe available key-value pairs change from one version of Feldera to\nanother, so users should not depend on particular settings being\navailable, or on their behavior.",
             "default": {},
             "additionalProperties": {}
+          },
+          "env": {
+            "type": "object",
+            "description": "Environment variables for the pipeline process.\n\nThese are key-value pairs injected into the pipeline process environment.\nSome variable names are reserved by the platform and cannot be overridden\n(for example `RUST_LOG`, and variables in the `FELDERA_`,\n`KUBERNETES_`, and `TOKIO_` namespaces).",
+            "default": {},
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "fault_tolerance": {
             "allOf": [

--- a/python/feldera/runtime_config.py
+++ b/python/feldera/runtime_config.py
@@ -1,4 +1,5 @@
-from typing import Optional, Any, Mapping
+from typing import Any, Mapping, Optional
+
 from feldera.enums import FaultToleranceModel
 
 
@@ -82,6 +83,7 @@ class RuntimeConfig:
         fault_tolerance_model: Optional[FaultToleranceModel] = None,
         checkpoint_interval_secs: Optional[int] = None,
         dev_tweaks: Optional[dict] = None,
+        env: Optional[dict[str, str]] = None,
         logging: Optional[str] = None,
     ):
         self.workers = workers
@@ -108,6 +110,7 @@ class RuntimeConfig:
             else:
                 raise ValueError(f"Unknown value '{storage}' for storage")
         self.dev_tweaks = dev_tweaks
+        self.env = env
         self.logging = logging
 
     @staticmethod

--- a/python/tests/platform/test_pipeline_configs.py
+++ b/python/tests/platform/test_pipeline_configs.py
@@ -2,11 +2,11 @@ from http import HTTPStatus
 
 from .helper import (
     API_PREFIX,
+    cleanup_pipeline,
+    gen_pipeline_name,
+    patch_json,
     post_json,
     put_json,
-    patch_json,
-    gen_pipeline_name,
-    cleanup_pipeline,
 )
 
 
@@ -50,6 +50,10 @@ def test_pipeline_runtime_config(pipeline_name):
             and rc.get("resources", {}).get("storage_mb_max") == 2000
             and rc.get("resources", {}).get("storage_class") == "normal",
         ),
+        (
+            {"env": {"TEST_ENV": "value"}},
+            lambda rc: rc.get("env", {}).get("TEST_ENV") == "value",
+        ),
     ]
 
     for idx, (runtime_config, predicate) in enumerate(valid_cases):
@@ -70,6 +74,7 @@ def test_pipeline_runtime_config(pipeline_name):
     invalid_cases = [
         {"workers": "not-a-number"},
         {"resources": {"storage_mb_max": "not-a-number"}},
+        {"env": {"TOKIO_WORKER_THREADS": "1"}},
     ]
     for invalid in invalid_cases:
         body = {

--- a/python/tests/platform/test_pipeline_env.py
+++ b/python/tests/platform/test_pipeline_env.py
@@ -1,0 +1,65 @@
+from feldera import PipelineBuilder
+from feldera.runtime_config import RuntimeConfig
+from tests import TEST_CLIENT
+
+from .helper import cleanup_pipeline, gen_pipeline_name
+
+
+@gen_pipeline_name
+def test_pipeline_runtime_env_is_visible_in_udf(pipeline_name):
+    # First verify that reserved env vars are rejected.
+    cleanup_pipeline(pipeline_name)
+    try:
+        PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql="CREATE TABLE t(i INT);",
+            runtime_config=RuntimeConfig(workers=1, env={"RUST_LOG": "debug"}),
+        ).create_or_replace()
+        assert False, "Expected pipeline creation to fail for reserved env variable"
+    except Exception as e:
+        error_text = str(e)
+        assert (
+            "InvalidRuntimeConfig" in error_text
+            or "reserved and cannot be overridden" in error_text
+        ), error_text
+
+    # Then verify allowed env vars are injected and visible to UDFs.
+    sql = """
+        CREATE TABLE t(i INT NOT NULL);
+        CREATE FUNCTION read_env(i INT NOT NULL) RETURNS VARCHAR;
+        CREATE MATERIALIZED VIEW v AS
+            SELECT read_env(i) AS env_value FROM t;
+    """
+
+    udf_rust = """
+        use crate::*;
+
+        pub fn read_env(_i: i32) -> Result<Option<SqlString>, Box<dyn std::error::Error>> {
+            Ok(std::env::var("PIPELINE_E2E_ENV").ok().map(SqlString::from))
+        }
+    """
+
+    pipeline = None
+    cleanup_pipeline(pipeline_name)
+    try:
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            pipeline_name,
+            sql=sql,
+            udf_rust=udf_rust,
+            runtime_config=RuntimeConfig(
+                workers=1, env={"PIPELINE_E2E_ENV": "expected-value"}
+            ),
+        ).create_or_replace()
+
+        pipeline.start()
+        pipeline.input_json("t", [{"i": 1}])
+
+        rows = list(pipeline.query("SELECT env_value FROM v ORDER BY env_value"))
+        assert rows == [{"env_value": "expected-value"}], rows
+    finally:
+        if pipeline is not None:
+            pipeline.stop(force=True)
+            pipeline.clear_storage()
+        cleanup_pipeline(pipeline_name)


### PR DESCRIPTION
This allows a pipeline operator to customize configuration in low-level systems configurations like `MALLOC_CONF` on a per-pipeline basis.

### Describe Manual Test Plan

There is an new integration test which runs successfully 

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

No