### PR TITLE
Ci fast fail on job failure

### DIFF
--- a/.github/actions/find-artifacts-run/action.yml
+++ b/.github/actions/find-artifacts-run/action.yml
@@ -1,0 +1,94 @@
+name: Find Run with Artifacts
+description: >
+  Searches prior workflow runs for the given commit and returns the ID of the
+  first run that contains all specified non-expired artifacts.
+  When run-id is provided, only that specific run is checked instead of
+  searching all prior runs.
+
+inputs:
+  required-artifacts:
+    description: Newline-separated list of artifact names that must all be present.
+    required: true
+  token:
+    description: GitHub token with actions:read permission.
+    required: true
+  workflow-file:
+    description: >
+      Workflow filename to search when no run-id is provided (e.g. ci.yml).
+      Ignored when run-id is set.
+    required: false
+    default: ci.yml
+  run-id:
+    description: >
+      If set, check only this specific run rather than searching all prior runs
+      for the commit.
+    required: false
+    default: ""
+
+outputs:
+  run-id:
+    description: >
+      Run ID of the eligible run that contains all required artifacts, or empty
+      string if none was found.
+    value: ${{ steps.find.outputs.run_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find run with all artifacts
+      id: find
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        REQUIRED_ARTIFACTS: ${{ inputs.required-artifacts }}
+        WORKFLOW_FILE: ${{ inputs.workflow-file }}
+        CHECK_RUN_ID: ${{ inputs.run-id }}
+        CURRENT_RUN_ID: ${{ github.run_id }}
+        REPOSITORY: ${{ github.repository }}
+        SHA: ${{ github.sha }}
+      run: |
+        mapfile -t required < <(
+          printf '%s\n' "$REQUIRED_ARTIFACTS" \
+            | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+            | grep -v '^$'
+        )
+
+        # Build the list of run IDs to check.
+        if [ -n "$CHECK_RUN_ID" ]; then
+          run_ids="$CHECK_RUN_ID"
+        else
+          run_ids=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${SHA}&per_page=20" \
+            | jq -r --argjson cur "$CURRENT_RUN_ID" \
+              '.workflow_runs[] | select(.id != $cur) | .id') || true
+        fi
+
+        found_run_id=""
+        for run_id in $run_ids; do
+          names=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=200" \
+            | jq -r '.artifacts[] | select(.expired == false) | .name') || continue
+
+          all_found=true
+          for artifact in "${required[@]}"; do
+            if ! printf '%s\n' "$names" | grep -qx "$artifact"; then
+              all_found=false
+              break
+            fi
+          done
+
+          if $all_found; then
+            echo "Found all required artifacts in run $run_id"
+            found_run_id="$run_id"
+            break
+          fi
+        done
+
+        if [ -z "$found_run_id" ]; then
+          echo "No run found with all required artifacts"
+        fi
+        echo "run_id=${found_run_id}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: read
 
 env:
   REGISTRY: ghcr.io
@@ -200,3 +201,15 @@ jobs:
             "${{ vars.FELDERA_IMAGE_NAME }}" \
             "${{ steps.meta.outputs.version }}" \
             "amd64,arm64"
+
+      # Upload after the image is verified so check-prior-build knows the
+      # sha-{sha} tag actually exists in GHCR (not just that digests were pushed).
+      - name: Signal docker image ready
+        run: echo "${{ steps.meta.outputs.version }}" > /tmp/docker-image-ready.txt
+
+      - name: Upload docker-image-ready artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-ready
+          path: /tmp/docker-image-ready.txt
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,86 +26,47 @@ jobs:
       artifacts_run_id: ${{ steps.result.outputs.artifacts_run_id }}
       skip_docker: ${{ steps.result.outputs.skip_docker }}
     steps:
-      - name: Find prior run with all build artifacts for this commit
-        id: find
+      - uses: actions/checkout@v4
+
+      # Finds the first prior run for this commit that has all Rust/Java build
+      # artifacts. If found, its run ID is used by downstream jobs to download
+      # artifacts instead of rebuilding.
+      - name: Find prior run with all Rust/Java build artifacts
+        id: find-builds
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set +e
-          rust_java_required=(
-            "fda-x86_64-unknown-linux-gnu"
-            "fda-aarch64-unknown-linux-gnu"
-            "pipeline-manager-x86_64-unknown-linux-gnu"
-            "pipeline-manager-aarch64-unknown-linux-gnu"
-            "feldera-test-binaries-x86_64-unknown-linux-gnu"
-            "feldera-test-binaries-aarch64-unknown-linux-gnu"
-            "feldera-sql-compiler"
-          )
-          # These tiny (~244B) digest artifacts are uploaded when each platform
-          # Docker build completes. Checking them is faster than docker manifest inspect.
-          docker_required=(
-            "digests-linux-amd64"
-            "digests-linux-arm64"
-          )
+        uses: ./.github/actions/find-artifacts-run
+        with:
+          required-artifacts: |
+            fda-x86_64-unknown-linux-gnu
+            fda-aarch64-unknown-linux-gnu
+            pipeline-manager-x86_64-unknown-linux-gnu
+            pipeline-manager-aarch64-unknown-linux-gnu
+            feldera-test-binaries-x86_64-unknown-linux-gnu
+            feldera-test-binaries-aarch64-unknown-linux-gnu
+            feldera-sql-compiler
+          token: ${{ github.token }}
 
-          run_ids=$(curl -fsSL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&per_page=20" \
-            | jq -r --argjson cur '${{ github.run_id }}' \
-              '.workflow_runs[] | select(.id != $cur) | .id') || true
+      # Checks whether the run found above also has the Docker image artifact.
+      # This artifact is uploaded by merge-manifests only after the image is
+      # verified in GHCR, so its presence guarantees the sha-{sha} tag exists.
+      - name: Check if Docker image artifact also present
+        id: find-docker
+        if: steps.find-builds.outputs.run-id != ''
+        continue-on-error: true
+        uses: ./.github/actions/find-artifacts-run
+        with:
+          required-artifacts: docker-image-ready
+          token: ${{ github.token }}
+          run-id: ${{ steps.find-builds.outputs.run-id }}
 
-          for run_id in $run_ids; do
-            names=$(curl -fsSL \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts?per_page=100" \
-              | jq -r '.artifacts[] | select(.expired == false) | .name') || continue
-
-            all_rust_java=true
-            for artifact in "${rust_java_required[@]}"; do
-              if ! printf '%s\n' $names | grep -qx "$artifact"; then
-                all_rust_java=false
-                break
-              fi
-            done
-
-            if $all_rust_java; then
-              echo "Found all Rust/Java build artifacts in prior run $run_id"
-              echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-
-              all_docker=true
-              for artifact in "${docker_required[@]}"; do
-                if ! printf '%s\n' $names | grep -qx "$artifact"; then
-                  all_docker=false
-                  break
-                fi
-              done
-
-              if $all_docker; then
-                echo "Docker digest artifacts also found, Docker build will be skipped"
-                echo "skip_docker=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "Docker digest artifacts not found, Docker build will run"
-                echo "skip_docker=false" >> "$GITHUB_OUTPUT"
-              fi
-              exit 0
-            fi
-          done
-
-          echo "No prior run found with all build artifacts, builds will run"
-          echo "run_id=" >> "$GITHUB_OUTPUT"
-          echo "skip_docker=false" >> "$GITHUB_OUTPUT"
-
-      # Consolidates outputs so both are always set even if the find step failed.
+      # Consolidates outputs so both are always set even if a find step failed.
       # Defaults: artifacts_run_id='' (run builds), skip_docker=false (run Docker build).
       - name: Consolidate outputs
         id: result
         if: always()
         run: |
-          echo "artifacts_run_id=${{ steps.find.outputs.run_id }}" >> "$GITHUB_OUTPUT"
-          echo "skip_docker=${{ steps.find.outputs.skip_docker || 'false' }}" >> "$GITHUB_OUTPUT"
+          echo "artifacts_run_id=${{ steps.find-builds.outputs.run-id }}" >> "$GITHUB_OUTPUT"
+          echo "skip_docker=${{ steps.find-docker.outputs.run-id != '' && 'true' || 'false' }}" >> "$GITHUB_OUTPUT"
 
   invoke-build-rust:
     name: Build Rust

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -14,6 +14,10 @@ on:
         description: "ID of the workflow run that uploaded the artifact"
         required: true
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   adapter-tests:
     if: ${{ !contains(vars.CI_SKIP_JOBS, 'adapter-tests') }}

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -153,6 +153,10 @@ jobs:
   oss-platform-tests:
     if: ${{ !contains(vars.CI_SKIP_JOBS, 'oss-platform-tests') }}
     name: Platform Integration Tests (OSS Docker Image)
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     strategy:
       matrix:
         include:
@@ -194,7 +198,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-          --cap-add=PERFMON
 
     steps:
       - name: Show Kubernetes node

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -13,6 +13,10 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   rust-unit-tests:
     name: Rust Unit Tests


### PR DESCRIPTION
Add a check-prior-build job to ci.yml that queries the GitHub API for a prior run on the same commit SHA. If all required binary and Docker artifacts are found unexpired, the Rust, Java, and Docker build jobs are skipped and test workflows download artifacts from that prior run instead of rebuilding from scratch.

Each test workflow now accepts an artifacts_run_id input passed through from ci.yml, and uses it as run-id in actions/download-artifact so cross-run artifact fetches work with the built-in action.

Validated in feldera/feldera-ci-test: Run 1 built everything and passed; Run 2 skipped all build phases and reused artifacts from Run 1.

Fixes: #5531 