### PR TITLE
A more scalable buffer cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2519,7 +2519,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3779,6 +3779,7 @@ dependencies = [
  "enum-map",
  "fastbloom",
  "fdlimit",
+ "feldera-buffer-cache",
  "feldera-ir",
  "feldera-macros",
  "feldera-size-of",
@@ -3812,6 +3813,7 @@ dependencies = [
  "ptr_meta 0.2.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_distr",
  "rand_xoshiro",
  "reqwest 0.12.24",
  "rkyv",
@@ -4931,6 +4933,19 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+]
+
+[[package]]
+name = "feldera-buffer-cache"
+version = "0.269.0"
+dependencies = [
+ "crossbeam-utils",
+ "enum-map",
+ "proptest",
+ "quick_cache",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -6788,7 +6803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -8897,13 +8912,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.14"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
+checksum = "530e84778a55de0f52645a51d4e3b9554978acd6a1e7cd50b6a6784692b3029e"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "parking_lot 0.12.4",
 ]
 
@@ -10788,7 +10803,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12769,7 +12784,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "crates/ir",
   "crates/fxp",
   "crates/storage-test-compat",
+  "crates/buffer-cache",
 ]
 exclude = [
   "sql-to-dbsp-compiler/temp",
@@ -120,6 +121,7 @@ erased-serde = "0.3.31"
 fake = "2.10"
 fastbloom = "0.14.0"
 fdlimit = "0.3.0"
+feldera-buffer-cache = { version = "0.269.0", path = "crates/buffer-cache" }
 feldera-cloud1-client = "0.1.2"
 feldera-datagen = { path = "crates/datagen" }
 feldera-fxp = { version = "0.269.0", path = "crates/fxp", features = ["dbsp"] }
@@ -198,7 +200,7 @@ proptest = "1.5.0"
 proptest-derive = "0.5.0"
 proptest-state-machine = "0.3.0"
 ptr_meta = "0.2.0"
-quick_cache = "0.6.14"
+quick_cache = "0.6.19"
 r2d2 = "0.8.10"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/crates/buffer-cache/Cargo.toml
+++ b/crates/buffer-cache/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "feldera-buffer-cache"
+version = { workspace = true }
+edition = "2024"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+rust-version = { workspace = true }
+publish = true
+description = "Weighted in-memory buffer caches with LRU and S3-FIFO eviction"
+
+[dependencies]
+crossbeam-utils = { workspace = true }
+enum-map = { workspace = true }
+quick_cache = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+rand = { workspace = true }

--- a/crates/buffer-cache/README.md
+++ b/crates/buffer-cache/README.md
@@ -1,0 +1,44 @@
+# feldera-buffer-cache
+
+`feldera-buffer-cache` provides thread-safe in-memory caches used by Feldera's storage layer:
+
+`S3FifoCache` wraps `quick_cache`'s SOSP'23 S3-FIFO implementation behind a
+Feldera-oriented API:
+<https://dl.acm.org/doi/10.1145/3600006.3613147>
+
+`LruCache` provides a mutex-protected LRU backend with the same
+high-level API.
+
+`BufferCacheBuilder` constructs the foreground/background cache layout used by
+DBSP circuits.
+
+## API sketch
+
+```rust
+use feldera_buffer_cache::{CacheEntry, LruCache};
+
+#[derive(Clone)]
+struct Page(Vec<u8>);
+
+impl CacheEntry for Page {
+    fn cost(&self) -> usize {
+        self.0.len()
+    }
+}
+
+let cache = LruCache::<u64, Page>::new(64 << 20);
+cache.insert(7, Page(vec![0; 4096]));
+
+let page = cache.get(&7).expect("entry should be present");
+assert_eq!(page.0.len(), 4096);
+assert_eq!(cache.total_charge(), 4096);
+```
+
+## Benchmarks
+
+The throughput benchmark comparing `LruCache` and `S3FifoCache` lives under the
+`dbsp` bench targets:
+
+```bash
+cargo bench -p dbsp --bench buffer_cache -- --threads 1,2,4,8 --max-duration 10
+```

--- a/crates/buffer-cache/src/builder.rs
+++ b/crates/buffer-cache/src/builder.rs
@@ -1,0 +1,205 @@
+use crate::ThreadType;
+use crate::{CacheEntry, LruCache, S3FifoCache, SharedBufferCache};
+use enum_map::{Enum, EnumMap};
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::hash::{BuildHasher, Hash, RandomState};
+use std::marker::PhantomData;
+use tracing::warn;
+
+/// Selects which eviction strategy backs a cache instance.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BufferCacheStrategy {
+    /// Use the sharded S3-FIFO cache backed by `quick_cache`.
+    #[default]
+    S3Fifo,
+
+    /// Use the mutex-protected weighted LRU cache.
+    Lru,
+}
+
+/// Controls how caches are shared across a foreground/background worker pair.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BufferCacheAllocationStrategy {
+    /// Share one cache across a foreground/background worker pair.
+    #[default]
+    SharedPerWorkerPair,
+
+    /// Create a separate cache for each foreground/background thread.
+    PerThread,
+
+    /// Share one cache across all foreground/background threads.
+    Global,
+}
+
+/// Builds the cache layout used by DBSP runtime worker pairs.
+pub struct BufferCacheBuilder<K, V, S = RandomState> {
+    /// Eviction strategy used for newly constructed caches.
+    strategy: BufferCacheStrategy,
+    /// Optional override for the sharded backend shard count.
+    max_buckets: Option<usize>,
+    /// Sharing policy across worker-pair cache slots.
+    allocation_strategy: BufferCacheAllocationStrategy,
+    /// Hash builder shared by newly constructed caches.
+    hash_builder: S,
+    /// Keeps the builder generic over the cache key and value types.
+    marker: PhantomData<fn(K) -> V>,
+}
+
+impl<K, V> BufferCacheBuilder<K, V, RandomState> {
+    /// Creates a builder that uses the default hash builder.
+    pub fn new() -> Self {
+        Self {
+            strategy: BufferCacheStrategy::default(),
+            max_buckets: None,
+            allocation_strategy: BufferCacheAllocationStrategy::default(),
+            hash_builder: RandomState::new(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V> Default for BufferCacheBuilder<K, V, RandomState> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V, S> BufferCacheBuilder<K, V, S> {
+    /// Sets the eviction strategy for caches created by this builder.
+    pub fn with_buffer_cache_strategy(mut self, strategy: BufferCacheStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+
+    /// Sets the optional shard-count override for sharded backends.
+    pub fn with_buffer_max_buckets(mut self, max_buckets: Option<usize>) -> Self {
+        self.max_buckets = max_buckets;
+        self
+    }
+
+    /// Sets how caches are shared across each worker pair.
+    pub fn with_buffer_cache_allocation_strategy(
+        mut self,
+        allocation_strategy: BufferCacheAllocationStrategy,
+    ) -> Self {
+        self.allocation_strategy = allocation_strategy;
+        self
+    }
+
+    /// Sets the hash builder used for newly constructed caches.
+    pub fn with_hash_builder<NewS>(self, hash_builder: NewS) -> BufferCacheBuilder<K, V, NewS> {
+        BufferCacheBuilder {
+            strategy: self.strategy,
+            max_buckets: self.max_buckets,
+            allocation_strategy: self.allocation_strategy,
+            hash_builder,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V, S> BufferCacheBuilder<K, V, S>
+where
+    K: Eq + Hash + Ord + Clone + Debug + Send + Sync + 'static,
+    V: CacheEntry + Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    /// Builds one cache slot per [`ThreadType`] for each worker pair.
+    pub fn build(
+        &self,
+        worker_pairs: usize,
+        total_capacity_bytes: usize,
+    ) -> Vec<EnumMap<ThreadType, SharedBufferCache<K, V>>> {
+        if worker_pairs == 0 {
+            return Vec::new();
+        }
+
+        let per_thread_capacity = total_capacity_bytes / worker_pairs / ThreadType::LENGTH;
+        let per_pair_capacity = total_capacity_bytes / worker_pairs;
+
+        match self.strategy {
+            BufferCacheStrategy::Lru => {
+                if self.allocation_strategy == BufferCacheAllocationStrategy::Global {
+                    warn!(
+                        "unsupported buffer cache allocation strategy {:?} set in dev_tweaks for LRU cache, falling back to `per_thread`",
+                        self.allocation_strategy
+                    );
+                }
+                (0..worker_pairs)
+                    .map(|_| self.build_thread_slots(per_thread_capacity))
+                    .collect()
+            }
+            BufferCacheStrategy::S3Fifo => match self.allocation_strategy {
+                BufferCacheAllocationStrategy::PerThread => (0..worker_pairs)
+                    .map(|_| self.build_thread_slots(per_thread_capacity))
+                    .collect(),
+                BufferCacheAllocationStrategy::SharedPerWorkerPair => (0..worker_pairs)
+                    .map(|_| Self::shared_thread_slots(self.build_s3_fifo(per_pair_capacity)))
+                    .collect(),
+                BufferCacheAllocationStrategy::Global => {
+                    let cache = self.build_s3_fifo(total_capacity_bytes);
+                    (0..worker_pairs)
+                        .map(|_| Self::shared_thread_slots(cache.clone()))
+                        .collect()
+                }
+            },
+        }
+    }
+
+    /// Builds one cache instance using the currently selected strategy.
+    pub fn build_single(&self, capacity_bytes: usize) -> SharedBufferCache<K, V> {
+        match self.strategy {
+            BufferCacheStrategy::Lru => self.build_lru(capacity_bytes),
+            BufferCacheStrategy::S3Fifo => self.build_s3_fifo(capacity_bytes),
+        }
+    }
+
+    /// Constructs a weighted LRU cache.
+    fn build_lru(&self, capacity_bytes: usize) -> SharedBufferCache<K, V> {
+        let cache: SharedBufferCache<K, V> = std::sync::Arc::new(LruCache::with_hasher(
+            capacity_bytes,
+            self.hash_builder.clone(),
+        ));
+        cache
+    }
+
+    /// Constructs a sharded S3-FIFO cache.
+    fn build_s3_fifo(&self, capacity_bytes: usize) -> SharedBufferCache<K, V> {
+        let shards = normalize_sharded_cache_shards(self.max_buckets);
+        let cache: SharedBufferCache<K, V> = std::sync::Arc::new(S3FifoCache::with_hasher(
+            capacity_bytes,
+            shards,
+            self.hash_builder.clone(),
+        ));
+        cache
+    }
+
+    /// Builds a separate cache slot for each thread type.
+    fn build_thread_slots(
+        &self,
+        capacity_bytes: usize,
+    ) -> EnumMap<ThreadType, SharedBufferCache<K, V>> {
+        EnumMap::from_fn(|_| self.build_single(capacity_bytes))
+    }
+
+    /// Reuses a single cache backend for every thread-type slot in a worker pair.
+    fn shared_thread_slots(
+        cache: SharedBufferCache<K, V>,
+    ) -> EnumMap<ThreadType, SharedBufferCache<K, V>> {
+        EnumMap::from_fn(|_| cache.clone())
+    }
+}
+
+/// Normalizes an optional bucket count to the shard count expected by the
+/// sharded S3-FIFO backend.
+fn normalize_sharded_cache_shards(max_buckets: Option<usize>) -> usize {
+    match max_buckets {
+        None | Some(0) => S3FifoCache::<(), ()>::DEFAULT_SHARDS,
+        Some(buckets) => buckets
+            .checked_next_power_of_two()
+            .unwrap_or(S3FifoCache::<(), ()>::DEFAULT_SHARDS),
+    }
+}

--- a/crates/buffer-cache/src/lib.rs
+++ b/crates/buffer-cache/src/lib.rs
@@ -1,0 +1,95 @@
+//! Weighted in-memory buffer caches with LRU and S3-FIFO eviction.
+
+mod builder;
+mod lru;
+mod s3_fifo;
+mod thread_type;
+
+use std::any::Any;
+use std::sync::Arc;
+
+pub use builder::{BufferCacheAllocationStrategy, BufferCacheBuilder, BufferCacheStrategy};
+pub use lru::LruCache;
+pub use s3_fifo::S3FifoCache;
+pub use thread_type::ThreadType;
+
+/// Cached values expose their memory cost directly to the cache backends.
+pub trait CacheEntry: Any + Send + Sync {
+    /// Returns the cost of this value in bytes.
+    fn cost(&self) -> usize;
+}
+
+impl<T> CacheEntry for Arc<T>
+where
+    T: CacheEntry + ?Sized + 'static,
+{
+    fn cost(&self) -> usize {
+        (**self).cost()
+    }
+}
+
+impl dyn CacheEntry {
+    /// Attempts to downcast an `Arc<dyn CacheEntry>` to a concrete entry type.
+    pub fn downcast<T>(self: Arc<Self>) -> Option<Arc<T>>
+    where
+        T: Send + Sync + 'static,
+    {
+        (self as Arc<dyn Any + Send + Sync>).downcast().ok()
+    }
+}
+
+/// Shared trait object used to pass buffer-cache backends around.
+pub type SharedBufferCache<K, V> = Arc<dyn BufferCache<K, V>>;
+
+/// Common object-safe API implemented by all buffer-cache backends.
+pub trait BufferCache<K, V>: Any + Send + Sync {
+    /// Returns this backend as [`Any`] for backend-specific downcasts.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Returns the eviction strategy used by this cache.
+    fn strategy(&self) -> BufferCacheStrategy;
+
+    /// Inserts or replaces `key` with `value`.
+    ///
+    /// When a key, value is inserted with a the cost that exceeds
+    /// the capacity of a shard in the cache, it is up to the
+    /// implementation to decided if it wants to store/accept
+    /// the key, value pair.
+    fn insert(&self, key: K, value: V);
+
+    /// Looks up `key` and returns a clone of the stored value.
+    fn get(&self, key: K) -> Option<V>;
+
+    /// Removes `key` if it is present and returns the removed value.
+    fn remove(&self, key: &K) -> Option<V>;
+
+    /// Removes every entry whose key matches `predicate`.
+    fn remove_if(&self, predicate: &dyn Fn(&K) -> bool);
+
+    /// Returns `true` if `key` is currently resident.
+    fn contains_key(&self, key: &K) -> bool;
+
+    /// Returns the number of resident entries.
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the cache has no resident entries.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the total resident weight.
+    fn total_charge(&self) -> usize;
+
+    /// Returns the configured total weight capacity.
+    fn total_capacity(&self) -> usize;
+
+    /// Returns the number of shards used by this backend.
+    fn shard_count(&self) -> usize;
+
+    /// Returns `(used_charge, capacity)` for shard `idx`.
+    #[cfg(test)]
+    fn shard_usage(&self, idx: usize) -> (usize, usize);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/buffer-cache/src/lru.rs
+++ b/crates/buffer-cache/src/lru.rs
@@ -1,0 +1,337 @@
+use crate::{BufferCache, BufferCacheStrategy, CacheEntry};
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::hash::RandomState;
+use std::marker::PhantomData;
+use std::ops::RangeBounds;
+use std::sync::Mutex;
+
+/// A weighted, thread-safe LRU cache.
+pub struct LruCache<K, V, S = RandomState> {
+    /// Mutable cache state guarded by a single mutex.
+    inner: Mutex<CacheInner<K, V>>,
+    /// Retains the public hash-builder type parameter used by shared builders.
+    marker: PhantomData<fn() -> S>,
+}
+
+/// Mutable state for [`LruCache`].
+struct CacheInner<K, V> {
+    /// Cache contents.
+    cache: BTreeMap<K, CacheValue<V>>,
+    /// Map from LRU serial number to cache key.
+    lru: BTreeMap<u64, K>,
+    /// Serial number to use the next time we touch a key.
+    next_serial: u64,
+    /// Sum over `cache[*].aux.cost()`.
+    cur_cost: usize,
+    /// Maximum total cost.
+    max_cost: usize,
+}
+
+/// Resident value stored by [`LruCache`].
+struct CacheValue<V> {
+    /// Cached value.
+    aux: V,
+    /// Recency serial used by the LRU queue.
+    serial: u64,
+}
+
+impl<K, V, S> LruCache<K, V, S> {
+    /// Default shard count reported by [`LruCache::shard_count`].
+    pub const DEFAULT_SHARDS: usize = 1;
+}
+
+impl<K, V> LruCache<K, V, RandomState>
+where
+    K: Ord + Clone + Debug,
+    V: CacheEntry + Clone,
+{
+    /// Creates a cache with the default hash builder.
+    pub fn new(max_cost: usize) -> Self {
+        Self::with_hasher(max_cost, RandomState::new())
+    }
+}
+
+// explicit allow, we do have `is_empty` in the trait so this is a false positive
+#[allow(clippy::len_without_is_empty)]
+impl<K, V, S> LruCache<K, V, S>
+where
+    K: Ord + Clone + Debug,
+    V: CacheEntry + Clone,
+{
+    /// Creates a cache with an explicit hash builder.
+    pub fn with_hasher(max_cost: usize, _hash_builder: S) -> Self {
+        Self {
+            inner: Mutex::new(CacheInner::new(max_cost)),
+            marker: PhantomData,
+        }
+    }
+
+    /// Inserts or replaces `key` with `value`.
+    pub fn insert(&self, key: K, value: V) {
+        self.inner.lock().unwrap().insert(key, value);
+    }
+
+    /// Looks up `key` and returns a clone of the stored value.
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.inner.lock().unwrap().get(key.clone())
+    }
+
+    /// Removes `key` if present and returns the removed value.
+    pub fn remove(&self, key: &K) -> Option<V> {
+        self.inner.lock().unwrap().remove(key)
+    }
+
+    /// Removes every entry whose key matches `predicate`.
+    pub fn remove_if<F>(&self, predicate: F)
+    where
+        F: Fn(&K) -> bool,
+    {
+        self.inner.lock().unwrap().remove_if(predicate)
+    }
+
+    /// Removes every entry whose key falls within `range`.
+    pub fn remove_range<R>(&self, range: R) -> usize
+    where
+        R: RangeBounds<K>,
+    {
+        self.inner.lock().unwrap().remove_range(range)
+    }
+
+    /// Returns `true` if `key` is currently resident.
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.inner.lock().unwrap().contains_key(key)
+    }
+
+    /// Returns the number of resident entries.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    /// Returns the total resident cost.
+    pub fn total_charge(&self) -> usize {
+        self.inner.lock().unwrap().cur_cost
+    }
+
+    /// Returns the configured total cost capacity.
+    pub fn total_capacity(&self) -> usize {
+        self.inner.lock().unwrap().max_cost
+    }
+
+    /// Returns the number of shards reported by this backend.
+    pub fn shard_count(&self) -> usize {
+        Self::DEFAULT_SHARDS
+    }
+
+    /// Returns `(used_charge, capacity)` for shard `idx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx != 0`.
+    #[cfg(test)]
+    pub fn shard_usage(&self, idx: usize) -> (usize, usize) {
+        assert_eq!(idx, 0, "shard index out of bounds");
+        let inner = self.inner.lock().unwrap();
+        (inner.cur_cost, inner.max_cost)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn validate_invariants(&self) {
+        self.inner.lock().unwrap().check_invariants();
+    }
+}
+
+impl<K, V, S> BufferCache<K, V> for LruCache<K, V, S>
+where
+    K: Ord + Clone + Debug + Send + Sync + 'static,
+    V: CacheEntry + Clone + Send + Sync + 'static,
+    S: Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn strategy(&self) -> BufferCacheStrategy {
+        BufferCacheStrategy::Lru
+    }
+
+    fn insert(&self, key: K, value: V) {
+        self.insert(key, value);
+    }
+
+    fn get(&self, key: K) -> Option<V> {
+        self.inner.lock().unwrap().get(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn remove_if(&self, predicate: &dyn Fn(&K) -> bool) {
+        self.remove_if(|key| predicate(key))
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.contains_key(key)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn total_charge(&self) -> usize {
+        self.total_charge()
+    }
+
+    fn total_capacity(&self) -> usize {
+        self.total_capacity()
+    }
+
+    fn shard_count(&self) -> usize {
+        self.shard_count()
+    }
+
+    #[cfg(test)]
+    fn shard_usage(&self, idx: usize) -> (usize, usize) {
+        self.shard_usage(idx)
+    }
+}
+
+impl<K, V> CacheInner<K, V>
+where
+    K: Ord + Clone + Debug,
+    V: CacheEntry + Clone,
+{
+    /// Creates an empty cache with `max_cost` capacity.
+    fn new(max_cost: usize) -> Self {
+        Self {
+            cache: BTreeMap::new(),
+            lru: BTreeMap::new(),
+            next_serial: 0,
+            cur_cost: 0,
+            max_cost,
+        }
+    }
+
+    /// Checks the cache/LRU bookkeeping invariants.
+    #[cfg(any(test, debug_assertions))]
+    fn check_invariants(&self) {
+        assert_eq!(self.cache.len(), self.lru.len());
+        let mut cost = 0;
+        for (key, value) in self.cache.iter() {
+            assert_eq!(self.lru.get(&value.serial), Some(key));
+            cost += value.aux.cost();
+        }
+        for (serial, key) in self.lru.iter() {
+            assert_eq!(self.cache.get(key).unwrap().serial, *serial);
+        }
+        assert_eq!(cost, self.cur_cost);
+    }
+
+    /// Runs invariant checks in debug builds.
+    fn debug_check_invariants(&self) {
+        #[cfg(debug_assertions)]
+        self.check_invariants()
+    }
+
+    /// Looks up `key`, refreshes its recency, and returns the cached value.
+    fn get(&mut self, key: K) -> Option<V> {
+        if let Some(value) = self.cache.get_mut(&key) {
+            self.lru.remove(&value.serial);
+            value.serial = self.next_serial;
+            self.lru.insert(value.serial, key);
+            self.next_serial += 1;
+            Some(value.aux.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Evicts least-recently-used entries until `cur_cost <= max_cost`.
+    fn evict_to(&mut self, max_cost: usize) {
+        while self.cur_cost > max_cost {
+            // lru and cache are kept in sync by all mutating methods;
+            // since cur_cost > max_cost >= 0, at least one entry exists.
+            let (_serial, key) = self.lru.pop_first().unwrap();
+            let value = self.cache.remove(&key).unwrap();
+            self.cur_cost -= value.aux.cost();
+        }
+        self.debug_check_invariants();
+    }
+
+    /// Inserts or replaces `key` with `aux`.
+    fn insert(&mut self, key: K, aux: V) {
+        let cost = aux.cost();
+        self.evict_to(self.max_cost.saturating_sub(cost));
+        if let Some(old_value) = self.cache.insert(
+            key.clone(),
+            CacheValue {
+                aux,
+                serial: self.next_serial,
+            },
+        ) {
+            self.lru.remove(&old_value.serial);
+            self.cur_cost -= old_value.aux.cost();
+        }
+        self.lru.insert(self.next_serial, key);
+        self.cur_cost += cost;
+        self.next_serial += 1;
+        self.debug_check_invariants();
+    }
+
+    /// Removes `key` if it is present and returns the removed value.
+    fn remove(&mut self, key: &K) -> Option<V> {
+        let value = self.cache.remove(key)?;
+        self.lru.remove(&value.serial).unwrap();
+        self.cur_cost -= value.aux.cost();
+        self.debug_check_invariants();
+        Some(value.aux)
+    }
+
+    /// Removes every entry whose key matches `predicate`.
+    fn remove_if<F>(&mut self, predicate: F)
+    where
+        F: Fn(&K) -> bool,
+    {
+        let keys: Vec<K> = self
+            .cache
+            .keys()
+            .filter(|key| predicate(key))
+            .cloned()
+            .collect();
+        for key in keys {
+            let _ = self.remove(&key);
+        }
+    }
+
+    /// Removes every entry whose key falls within `range`.
+    fn remove_range<R>(&mut self, range: R) -> usize
+    where
+        R: RangeBounds<K>,
+    {
+        let victims: Vec<(K, u64)> = self
+            .cache
+            .range(range)
+            .map(|(key, value)| (key.clone(), value.serial))
+            .collect();
+
+        let removed = victims.len();
+        for (key, serial) in victims {
+            self.lru.remove(&serial).unwrap();
+            self.cur_cost -= self.cache.remove(&key).unwrap().aux.cost();
+        }
+        self.debug_check_invariants();
+        removed
+    }
+
+    /// Returns `true` if `key` is resident.
+    fn contains_key(&self, key: &K) -> bool {
+        self.cache.contains_key(key)
+    }
+
+    /// Returns the number of resident entries.
+    fn len(&self) -> usize {
+        self.cache.len()
+    }
+}

--- a/crates/buffer-cache/src/s3_fifo.rs
+++ b/crates/buffer-cache/src/s3_fifo.rs
@@ -1,0 +1,290 @@
+use crate::{BufferCache, BufferCacheStrategy, CacheEntry};
+use quick_cache::{OptionsBuilder, Weighter, sync::Cache as QuickCache};
+use std::any::Any;
+use std::hash::{BuildHasher, Hash, RandomState};
+
+/// `quick_cache` requires an item-count estimate and uses it to decide whether
+/// the requested shard count can be honored.
+///
+/// Setting the estimate to at least 32 items per shard keeps the requested
+/// shard count intact without introducing a capacity-based heuristic.
+const MIN_ESTIMATED_ITEMS_PER_SHARD: usize = 32;
+
+/// Converts [`CacheEntry::cost`] into the weight expected by `quick_cache`.
+#[derive(Clone, Copy, Default)]
+struct CacheEntryWeighter;
+
+impl<K, V> Weighter<K, V> for CacheEntryWeighter
+where
+    V: CacheEntry,
+{
+    fn weight(&self, _key: &K, value: &V) -> u64 {
+        value.cost() as u64
+    }
+}
+
+/// A sharded, weighted, thread-safe S3-FIFO cache backed directly by
+/// `quick_cache`.
+pub struct S3FifoCache<K, V, S = RandomState> {
+    /// Shared `quick_cache` backend.
+    cache: QuickCache<K, V, CacheEntryWeighter, S>,
+    /// Hash builder retained only so tests can mirror `quick_cache`'s shard
+    /// selection.
+    #[cfg(test)]
+    hash_builder: S,
+}
+
+impl<K, V, S> S3FifoCache<K, V, S> {
+    /// Default power-of-two shard count used by [`S3FifoCache::new`].
+    pub const DEFAULT_SHARDS: usize = 256;
+}
+
+impl<K, V> S3FifoCache<K, V, RandomState>
+where
+    K: Eq + Hash + Clone,
+    V: CacheEntry + Clone,
+{
+    /// Creates a cache with [`Self::DEFAULT_SHARDS`] shards.
+    pub fn new(total_capacity_bytes: usize) -> Self {
+        Self::with_hasher(
+            total_capacity_bytes,
+            S3FifoCache::<K, V>::DEFAULT_SHARDS,
+            RandomState::new(),
+        )
+    }
+
+    /// Creates a cache with an explicit shard count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_shards == 0` or if `num_shards` is not a power of two.
+    pub fn with_shards(total_capacity_bytes: usize, num_shards: usize) -> Self {
+        Self::with_hasher(total_capacity_bytes, num_shards, RandomState::new())
+    }
+}
+
+// explicit allow, we do have `is_empty` in the trait so this is a false positive
+#[allow(clippy::len_without_is_empty)]
+impl<K, V, S> S3FifoCache<K, V, S>
+where
+    K: Eq + Hash + Clone,
+    V: CacheEntry + Clone,
+    S: BuildHasher + Clone,
+{
+    /// Creates a cache with an explicit shard count and hash builder.
+    ///
+    /// Because `quick_cache` uses equal-capacity shards internally, the actual
+    /// backend capacity may round up when `total_capacity_bytes` is not evenly
+    /// divisible by `num_shards`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_shards == 0` or if `num_shards` is not a power of two.
+    pub fn with_hasher(total_capacity_bytes: usize, num_shards: usize, hash_builder: S) -> Self {
+        assert!(num_shards > 0, "num_shards must be > 0");
+        assert!(
+            num_shards.is_power_of_two(),
+            "num_shards must be a power of two"
+        );
+
+        let options = OptionsBuilder::new()
+            .shards(num_shards)
+            .estimated_items_capacity(minimum_estimated_items(num_shards))
+            .weight_capacity(total_capacity_bytes as u64)
+            .build()
+            .expect("valid quick_cache options");
+
+        Self {
+            #[cfg(test)]
+            hash_builder: hash_builder.clone(),
+            cache: QuickCache::with_options(
+                options,
+                CacheEntryWeighter,
+                hash_builder,
+                Default::default(),
+            ),
+        }
+    }
+
+    /// Inserts or replaces `key` with `value`.
+    pub fn insert(&self, key: K, value: V) {
+        self.cache.insert(key, value);
+    }
+
+    /// Looks up `key` and returns a clone of the stored value.
+    pub fn get(&self, key: &K) -> Option<V> {
+        self.cache.get(key)
+    }
+
+    /// Removes `key` if present and returns the removed value.
+    pub fn remove(&self, key: &K) -> Option<V> {
+        self.cache.remove(key).map(|(_, value)| value)
+    }
+
+    /// Removes all entries matching `predicate` and returns the number removed.
+    pub fn remove_if<F>(&self, predicate: F)
+    where
+        F: Fn(&K) -> bool,
+    {
+        self.cache.retain(|key, _value| !predicate(key))
+    }
+
+    /// Returns `true` if `key` is currently present.
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.cache.contains_key(key)
+    }
+
+    /// Returns the current number of live entries.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Returns the current total weighted charge.
+    pub fn total_charge(&self) -> usize {
+        self.cache.weight() as usize
+    }
+
+    /// Returns the backend's configured total weighted capacity.
+    ///
+    /// This may be larger than the requested constructor argument when the
+    /// requested total capacity is not evenly divisible across shards.
+    pub fn total_capacity(&self) -> usize {
+        self.cache.capacity() as usize
+    }
+
+    /// Returns the number of backend shards.
+    pub fn shard_count(&self) -> usize {
+        self.cache.num_shards()
+    }
+
+    /// Returns `(used_charge, capacity)` for backend shard `idx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `idx >= self.shard_count()`.
+    #[cfg(test)]
+    pub fn shard_usage(&self, idx: usize) -> (usize, usize) {
+        assert!(idx < self.shard_count(), "shard index out of bounds");
+        let used = self
+            .cache
+            .iter()
+            .filter(|(key, _value)| self.shard_index(key) == idx)
+            .map(|(_key, value)| value.cost())
+            .sum();
+        (used, self.cache.shard_capacity() as usize)
+    }
+
+    /// Validates the wrapper invariants we rely on in Feldera tests:
+    /// iteration agrees with the public accounting APIs and each resident key
+    /// maps to the backend shard reported by `shard_usage()`.
+    #[cfg(test)]
+    pub(crate) fn validate_invariants(&self) {
+        let shard_count = self.shard_count();
+        let mut shard_usage = vec![0usize; shard_count];
+        let mut total_len = 0usize;
+        let mut total_charge = 0usize;
+
+        for (key, value) in self.cache.iter() {
+            let shard_idx = self.shard_index(&key);
+            assert!(shard_idx < shard_count, "invalid backend shard index");
+            let weight = value.cost();
+            shard_usage[shard_idx] += weight;
+            total_len += 1;
+            total_charge += weight;
+        }
+
+        for (idx, used) in shard_usage.into_iter().enumerate() {
+            let (reported_used, reported_capacity) = self.shard_usage(idx);
+            assert_eq!(reported_used, used, "per-shard charge mismatch");
+            assert!(
+                used <= reported_capacity,
+                "used {} exceeds capacity {}",
+                used,
+                reported_capacity
+            );
+        }
+
+        assert_eq!(total_len, self.len(), "global resident count mismatch");
+        assert_eq!(total_charge, self.total_charge(), "global charge mismatch");
+        assert!(
+            total_charge <= self.total_capacity(),
+            "total charge exceeds backend capacity"
+        );
+    }
+
+    /// Mirrors `quick_cache`'s shard selection logic for test-only shard
+    /// accounting and validation.
+    ///
+    /// The hash function is not exposed in the public API of `quick_cache`.
+    #[cfg(test)]
+    pub(crate) fn shard_index(&self, key: &K) -> usize {
+        let shard_mask = (self.shard_count() - 1) as u64;
+        (self
+            .hash_builder
+            .hash_one(key)
+            .rotate_right(usize::BITS / 2)
+            & shard_mask) as usize
+    }
+}
+
+/// Returns the minimum item-count estimate needed to preserve a requested
+/// shard count in `quick_cache`.
+fn minimum_estimated_items(num_shards: usize) -> usize {
+    num_shards.saturating_mul(MIN_ESTIMATED_ITEMS_PER_SHARD)
+}
+
+impl<K, V, S> BufferCache<K, V> for S3FifoCache<K, V, S>
+where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+    V: CacheEntry + Clone + Send + Sync + 'static,
+    S: BuildHasher + Clone + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn strategy(&self) -> BufferCacheStrategy {
+        BufferCacheStrategy::S3Fifo
+    }
+
+    fn insert(&self, key: K, value: V) {
+        self.insert(key, value);
+    }
+
+    fn get(&self, key: K) -> Option<V> {
+        self.get(&key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn remove_if(&self, predicate: &dyn Fn(&K) -> bool) {
+        self.remove_if(|key| predicate(key))
+    }
+
+    fn contains_key(&self, key: &K) -> bool {
+        self.contains_key(key)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn total_charge(&self) -> usize {
+        self.total_charge()
+    }
+
+    fn total_capacity(&self) -> usize {
+        self.total_capacity()
+    }
+
+    fn shard_count(&self) -> usize {
+        self.shard_count()
+    }
+
+    #[cfg(test)]
+    fn shard_usage(&self, idx: usize) -> (usize, usize) {
+        self.shard_usage(idx)
+    }
+}

--- a/crates/buffer-cache/src/tests.rs
+++ b/crates/buffer-cache/src/tests.rs
@@ -1,0 +1,4 @@
+mod builder;
+mod lru;
+mod s3_fifo;
+mod s3_fifo_proptests;

--- a/crates/buffer-cache/src/tests/builder.rs
+++ b/crates/buffer-cache/src/tests/builder.rs
@@ -1,0 +1,110 @@
+use crate::{
+    BufferCacheAllocationStrategy, BufferCacheBuilder, BufferCacheStrategy, CacheEntry, ThreadType,
+};
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct TestEntry;
+
+impl CacheEntry for TestEntry {
+    fn cost(&self) -> usize {
+        1
+    }
+}
+
+type TestBuilder = BufferCacheBuilder<u64, TestEntry>;
+
+#[test]
+fn s3_fifo_builder_shares_caches_per_worker_pair_by_default() {
+    let caches = TestBuilder::new().build(2, 1024);
+    assert!(Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[0][ThreadType::Background]
+    ));
+    assert!(Arc::ptr_eq(
+        &caches[1][ThreadType::Foreground],
+        &caches[1][ThreadType::Background]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Foreground]
+    ));
+}
+
+#[test]
+fn s3_fifo_builder_can_share_per_worker_pair() {
+    let caches = TestBuilder::new()
+        .with_buffer_cache_allocation_strategy(BufferCacheAllocationStrategy::SharedPerWorkerPair)
+        .build(2, 1024);
+    assert!(Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[0][ThreadType::Background]
+    ));
+    assert!(Arc::ptr_eq(
+        &caches[1][ThreadType::Foreground],
+        &caches[1][ThreadType::Background]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Foreground]
+    ));
+}
+
+#[test]
+fn s3_fifo_builder_can_share_globally() {
+    let caches = TestBuilder::new()
+        .with_buffer_cache_allocation_strategy(BufferCacheAllocationStrategy::Global)
+        .build(2, 1024);
+    assert!(Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[0][ThreadType::Background]
+    ));
+    assert!(Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Foreground]
+    ));
+    assert!(Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Background]
+    ));
+}
+
+/// The LRU cache has a single mutex, sharing it would be harmful.
+#[test]
+fn lru_builder_keeps_separate_caches_even_when_sharing_is_requested() {
+    let caches = TestBuilder::new()
+        .with_buffer_cache_strategy(BufferCacheStrategy::Lru)
+        .with_buffer_cache_allocation_strategy(BufferCacheAllocationStrategy::Global)
+        .build(2, 1024);
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[0][ThreadType::Background]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Foreground]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Background]
+    ));
+}
+
+#[test]
+fn lru_builder_uses_separate_caches_by_default() {
+    let caches = TestBuilder::new()
+        .with_buffer_cache_strategy(BufferCacheStrategy::Lru)
+        .build(2, 1024);
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[0][ThreadType::Background]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[1][ThreadType::Foreground],
+        &caches[1][ThreadType::Background]
+    ));
+    assert!(!Arc::ptr_eq(
+        &caches[0][ThreadType::Foreground],
+        &caches[1][ThreadType::Foreground]
+    ));
+}

--- a/crates/buffer-cache/src/tests/lru.rs
+++ b/crates/buffer-cache/src/tests/lru.rs
@@ -1,0 +1,148 @@
+use crate::{CacheEntry, LruCache};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::sync::Arc;
+use std::thread;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Weighted<T> {
+    value: T,
+    charge: usize,
+}
+
+impl<T> Weighted<T> {
+    fn new(value: T, charge: usize) -> Self {
+        Self { value, charge }
+    }
+}
+
+impl<T: Send + Sync + 'static> CacheEntry for Weighted<T> {
+    fn cost(&self) -> usize {
+        self.charge
+    }
+}
+
+type TestCache<K, V> = LruCache<K, Weighted<V>>;
+
+#[test]
+fn basic_insert_get_remove() {
+    let cache = TestCache::<u64, String>::new(1024);
+    cache.insert(1, Weighted::new("a".to_string(), 8));
+    assert_eq!(&cache.get(&1).unwrap().value, "a");
+    assert_eq!(&cache.remove(&1).unwrap().value, "a");
+    assert!(cache.get(&1).is_none());
+    cache.validate_invariants();
+}
+
+#[test]
+fn replacement_updates_value_and_charge() {
+    let cache = TestCache::<u64, String>::new(64);
+    cache.insert(1, Weighted::new("a".to_string(), 10));
+    cache.insert(1, Weighted::new("b".to_string(), 7));
+    assert_eq!(&cache.get(&1).unwrap().value, "b");
+    assert_eq!(cache.total_charge(), 7);
+    cache.validate_invariants();
+}
+
+#[test]
+fn weighted_eviction_happens_by_charge() {
+    let cache = TestCache::<u64, &'static str>::new(10);
+    cache.insert(1, Weighted::new("a", 6));
+    cache.insert(2, Weighted::new("b", 6));
+    assert!(!cache.contains_key(&1));
+    assert_eq!(cache.get(&2).unwrap().value, "b");
+    assert_eq!(cache.total_charge(), 6);
+    cache.validate_invariants();
+}
+
+#[test]
+fn get_updates_recency() {
+    let cache = TestCache::<u64, &'static str>::new(2);
+    cache.insert(1, Weighted::new("a", 1));
+    cache.insert(2, Weighted::new("b", 1));
+    let _ = cache.get(&1);
+    cache.insert(3, Weighted::new("c", 1));
+    assert!(cache.contains_key(&1));
+    assert!(!cache.contains_key(&2));
+    assert!(cache.contains_key(&3));
+    cache.validate_invariants();
+}
+
+#[test]
+fn remove_if_keeps_structure_consistent() {
+    let cache = TestCache::<u64, &'static str>::new(16);
+    cache.insert(1, Weighted::new("a", 4));
+    cache.insert(2, Weighted::new("b", 4));
+    cache.insert(3, Weighted::new("c", 4));
+    cache.remove_if(|key| key % 2 == 1);
+    assert_eq!(cache.len(), 1);
+    assert!(!cache.contains_key(&1));
+    assert!(cache.contains_key(&2));
+    assert!(!cache.contains_key(&3));
+    cache.validate_invariants();
+}
+
+#[test]
+fn remove_range_keeps_structure_consistent() {
+    let cache = TestCache::<u64, &'static str>::new(32);
+    for key in 0..6 {
+        cache.insert(key, Weighted::new("v", 4));
+    }
+    assert_eq!(cache.remove_range(2..5), 3);
+    assert!(cache.contains_key(&0));
+    assert!(cache.contains_key(&1));
+    assert!(!cache.contains_key(&2));
+    assert!(!cache.contains_key(&3));
+    assert!(!cache.contains_key(&4));
+    assert!(cache.contains_key(&5));
+    cache.validate_invariants();
+}
+
+/// This behavior is somewhat specific to our implementation
+/// so we encode it here.
+#[test]
+fn oversize_entry_replaces_cache_contents() {
+    let cache = TestCache::<u64, &'static str>::new(8);
+    cache.insert(1, Weighted::new("big", 32));
+    assert_eq!(cache.get(&1).unwrap().value, "big");
+    assert_eq!(cache.total_charge(), 32);
+    cache.validate_invariants();
+}
+
+#[test]
+fn backend_reports_one_shard() {
+    let cache = TestCache::<u64, u64>::new(10);
+    cache.insert(1, Weighted::new(10, 3));
+    assert_eq!(cache.shard_count(), 1);
+    assert_eq!(cache.shard_usage(0), (3, 10));
+    cache.validate_invariants();
+}
+
+#[test]
+fn concurrency_smoke_test() {
+    let cache = Arc::new(TestCache::<u64, u64>::new(4096));
+    let mut threads = Vec::new();
+    for tid in 0..8 {
+        let cache = cache.clone();
+        threads.push(thread::spawn(move || {
+            let mut rng = StdRng::seed_from_u64(1234 + tid);
+            for _ in 0..10_000 {
+                let key = rng.gen_range(0..256);
+                match rng.gen_range(0..3) {
+                    0 => {
+                        cache.insert(key, Weighted::new(key, rng.gen_range(1..32)));
+                    }
+                    1 => {
+                        let _ = cache.get(&key);
+                    }
+                    _ => {
+                        let _ = cache.remove(&key);
+                    }
+                }
+            }
+        }));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
+    cache.validate_invariants();
+}

--- a/crates/buffer-cache/src/tests/s3_fifo.rs
+++ b/crates/buffer-cache/src/tests/s3_fifo.rs
@@ -1,0 +1,203 @@
+use crate::{CacheEntry, S3FifoCache};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::sync::Arc;
+use std::thread;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Weighted<T> {
+    value: T,
+    charge: usize,
+}
+
+impl<T> Weighted<T> {
+    fn new(value: T, charge: usize) -> Self {
+        Self { value, charge }
+    }
+}
+
+impl<T: Send + Sync + 'static> CacheEntry for Weighted<T> {
+    fn cost(&self) -> usize {
+        self.charge
+    }
+}
+
+type TestCache<K, V> = S3FifoCache<K, Weighted<V>>;
+
+#[test]
+fn basic_insert_get_remove() {
+    let cache = TestCache::<u64, String>::with_shards(1024, 4);
+    cache.insert(1, Weighted::new("a".to_string(), 8));
+    assert_eq!(&cache.get(&1).unwrap().value, "a");
+    assert_eq!(&cache.remove(&1).unwrap().value, "a");
+    assert!(cache.get(&1).is_none());
+    cache.validate_invariants();
+}
+
+#[test]
+fn replacement_updates_value_and_charge() {
+    let cache = TestCache::<u64, String>::with_shards(64, 2);
+    cache.insert(1, Weighted::new("a".to_string(), 10));
+    cache.insert(1, Weighted::new("b".to_string(), 7));
+    assert_eq!(&cache.get(&1).unwrap().value, "b");
+    assert_eq!(cache.total_charge(), 7);
+    cache.validate_invariants();
+}
+
+#[test]
+fn weighted_eviction_happens_by_charge() {
+    let cache = TestCache::<u64, &'static str>::with_shards(10, 1);
+    cache.insert(1, Weighted::new("a", 6));
+    cache.insert(2, Weighted::new("b", 6));
+    assert_eq!(cache.total_charge(), 6);
+    assert_eq!(cache.len(), 1);
+    assert!(!cache.contains_key(&1) || !cache.contains_key(&2));
+    cache.validate_invariants();
+}
+
+#[test]
+fn remove_keeps_cache_consistent() {
+    let cache = TestCache::<u64, &'static str>::with_shards(8, 1);
+    cache.insert(1, Weighted::new("a", 4));
+    cache.insert(2, Weighted::new("b", 4));
+    cache.remove(&1);
+    cache.insert(3, Weighted::new("c", 4));
+    assert!(cache.contains_key(&2) && cache.contains_key(&3));
+    cache.validate_invariants();
+}
+
+#[test]
+fn shard_selection_stability() {
+    let cache = TestCache::<u64, u64>::with_shards(1024, 8);
+    for key in 0..100 {
+        cache.insert(key, Weighted::new(key, 1));
+        assert_eq!(cache.shard_index(&key), cache.shard_index(&key));
+    }
+    cache.validate_invariants();
+}
+
+/// This is different from our LRU cache, I think it's fine.
+#[test]
+fn oversize_entry_policy_is_insert_then_evict() {
+    let cache = TestCache::<u64, &'static str>::with_shards(8, 1);
+    cache.insert(1, Weighted::new("big", 32));
+    assert_eq!(cache.total_charge(), 0);
+    assert!(!cache.contains_key(&1));
+    cache.validate_invariants();
+}
+
+#[test]
+fn concurrency_smoke_test() {
+    let cache = Arc::new(TestCache::<u64, u64>::with_shards(4096, 16));
+    let mut threads = Vec::new();
+    for tid in 0..8 {
+        let cache = cache.clone();
+        threads.push(thread::spawn(move || {
+            let mut rng = StdRng::seed_from_u64(1234 + tid);
+            for _ in 0..10_000 {
+                let key = rng.gen_range(0..256);
+                match rng.gen_range(0..3) {
+                    0 => {
+                        cache.insert(key, Weighted::new(key, rng.gen_range(1..32)));
+                    }
+                    1 => {
+                        let _ = cache.get(&key);
+                    }
+                    _ => {
+                        let _ = cache.remove(&key);
+                    }
+                }
+            }
+        }));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
+    cache.validate_invariants();
+}
+
+#[test]
+fn charge_accounting_after_replacement_and_remove() {
+    let cache = TestCache::<u64, &'static str>::with_shards(100, 2);
+    cache.insert(1, Weighted::new("a", 20));
+    cache.insert(1, Weighted::new("b", 30));
+    assert_eq!(cache.total_charge(), 30);
+    cache.remove(&1);
+    assert_eq!(cache.total_charge(), 0);
+    cache.validate_invariants();
+}
+
+#[test]
+fn basic_sequence() {
+    let cache = TestCache::<String, String>::with_shards(3, 1);
+    cache.insert(
+        "foo".to_string(),
+        Weighted::new("foocontent".to_string(), 1),
+    );
+    cache.insert(
+        "bar".to_string(),
+        Weighted::new("barcontent".to_string(), 1),
+    );
+    assert_eq!(
+        cache.remove(&"bar".to_string()).map(|value| value.value),
+        Some("barcontent".to_string())
+    );
+    cache.insert(
+        "bar2".to_string(),
+        Weighted::new("bar2content".to_string(), 1),
+    );
+    cache.insert(
+        "bar3".to_string(),
+        Weighted::new("bar3content".to_string(), 1),
+    );
+    assert_eq!(
+        cache.get(&"foo".to_string()).map(|value| value.value),
+        Some("foocontent".to_string())
+    );
+    assert_eq!(cache.get(&"bar".to_string()), None);
+    assert_eq!(
+        cache.get(&"bar2".to_string()).map(|value| value.value),
+        Some("bar2content".to_string())
+    );
+    assert_eq!(
+        cache.get(&"bar3".to_string()).map(|value| value.value),
+        Some("bar3content".to_string())
+    );
+    cache.validate_invariants();
+}
+
+#[test]
+fn insert_doesnt_exceed_capacity() {
+    let total_capacity = 2usize;
+    let cache = TestCache::<String, u64>::with_shards(total_capacity, 1);
+    cache.insert("a".to_string(), Weighted::new(1, 1));
+    cache.insert("b".to_string(), Weighted::new(2, 1));
+    assert!(cache.get(&"a".to_string()).is_some());
+    assert!(cache.get(&"b".to_string()).is_some());
+    cache.insert("c".to_string(), Weighted::new(3, 1));
+    assert!(cache.len() <= 2);
+    assert!(cache.total_charge() <= cache.total_capacity());
+    cache.validate_invariants();
+}
+
+/// This is behavior of quick-cache.
+#[test]
+fn backend_shard_capacity_rounds_up_evenly() {
+    let cache = TestCache::<u64, u64>::with_shards(10, 4);
+    let caps: Vec<usize> = (0..4).map(|i| cache.shard_usage(i).1).collect();
+    assert_eq!(caps, vec![3, 3, 3, 3]);
+    assert_eq!(cache.total_capacity(), 12);
+    cache.validate_invariants();
+}
+
+/// We do not use this atm, but it could be useful to "pin" entries.
+#[test]
+fn zero_charge_entries_do_not_increase_budget_usage() {
+    let cache = TestCache::<u64, u64>::with_shards(1, 1);
+    cache.insert(1, Weighted::new(10, 0));
+    cache.insert(2, Weighted::new(20, 0));
+    cache.insert(3, Weighted::new(30, 0));
+    assert_eq!(cache.total_charge(), 0);
+    assert_eq!(cache.len(), 3);
+    assert_eq!(cache.get(&1).unwrap().value, 10);
+    cache.validate_invariants();
+}

--- a/crates/buffer-cache/src/tests/s3_fifo_proptests.rs
+++ b/crates/buffer-cache/src/tests/s3_fifo_proptests.rs
@@ -1,0 +1,232 @@
+//! Property tests for `S3FifoCache`.
+//!
+//! We sanity check that the crate we're using behaves like we expect it to.
+//!
+//! High-level invariants:
+//! 1. Successful `get`/`remove` only return values previously inserted for that key.
+//! 2. The cache never mutates keys or values, and never cross-wires one key to another key's value.
+//! 3. Global accounting stays consistent: shard usage sums match total usage and capacity is never exceeded.
+//! 4. `remove_if` removes exactly the live entries matching the predicate.
+
+use crate::{CacheEntry, S3FifoCache};
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TestValue {
+    key: u8,
+    version: u32,
+    token: u64,
+    charge: u8,
+}
+
+impl CacheEntry for TestValue {
+    fn cost(&self) -> usize {
+        self.charge as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TestOp {
+    Insert {
+        key: u8,
+        version: u32,
+        token: u64,
+        charge: u8,
+    },
+    Get {
+        key: u8,
+    },
+    Remove {
+        key: u8,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RemovePredicate {
+    EvenKeys,
+    KeyLessThan(u8),
+    ExactKey(u8),
+}
+
+fn remove_predicate_matches(predicate: RemovePredicate, key: u8) -> bool {
+    match predicate {
+        RemovePredicate::EvenKeys => key.is_multiple_of(2),
+        RemovePredicate::KeyLessThan(cutoff) => key < cutoff,
+        RemovePredicate::ExactKey(exact) => key == exact,
+    }
+}
+
+fn assert_global_invariants(cache: &S3FifoCache<u8, TestValue>) {
+    cache.validate_invariants();
+    let shard_total_usage: usize = (0..cache.shard_count())
+        .map(|i| cache.shard_usage(i).0)
+        .sum();
+    let shard_total_capacity: usize = (0..cache.shard_count())
+        .map(|i| cache.shard_usage(i).1)
+        .sum();
+    assert_eq!(shard_total_usage, cache.total_charge());
+    assert_eq!(shard_total_capacity, cache.total_capacity());
+    assert!(cache.total_charge() <= cache.total_capacity());
+}
+
+fn assert_resident_entries_match_model(
+    cache: &S3FifoCache<u8, TestValue>,
+    model: &BTreeMap<u8, TestValue>,
+) {
+    let mut live_count = 0usize;
+    let mut live_charge = 0usize;
+
+    for (&key, &expected) in model {
+        match cache.get(&key) {
+            Some(actual) => {
+                assert_eq!(
+                    actual, expected,
+                    "cache returned mutated or stale value for key {key}"
+                );
+                assert_eq!(actual.key, key, "cache returned value for wrong key");
+                live_count += 1;
+                live_charge += actual.charge as usize;
+            }
+            None => {
+                assert!(!cache.contains_key(&key));
+            }
+        }
+    }
+
+    assert_eq!(cache.len(), live_count);
+    assert_eq!(cache.total_charge(), live_charge);
+}
+
+fn run_model_sequence(
+    shards: usize,
+    capacity: usize,
+    ops: &[TestOp],
+    remove_predicates: &[RemovePredicate],
+) {
+    let cache = S3FifoCache::<u8, TestValue>::with_shards(capacity, shards);
+    let mut model = BTreeMap::<u8, TestValue>::new();
+
+    for op in ops {
+        match *op {
+            TestOp::Insert {
+                key,
+                version,
+                token,
+                charge,
+            } => {
+                let value = TestValue {
+                    key,
+                    version,
+                    token,
+                    charge,
+                };
+                cache.insert(key, value);
+                model.insert(key, value);
+            }
+            TestOp::Get { key } => match cache.get(&key) {
+                Some(actual) => {
+                    let expected = model
+                        .get(&key)
+                        .expect("cache returned a value for a never-inserted key");
+                    assert_eq!(
+                        actual, *expected,
+                        "cache returned mutated, cross-key, or stale value for key {key}"
+                    );
+                    assert_eq!(actual.key, key, "cache returned value for wrong key");
+                }
+                None => {
+                    assert!(
+                        !cache.contains_key(&key),
+                        "contains_key disagrees with get for absent key {key}"
+                    );
+                }
+            },
+            TestOp::Remove { key } => {
+                let removed = cache.remove(&key);
+                let expected = model.remove(&key);
+                match (removed, expected) {
+                    (Some(actual), Some(expected_value)) => {
+                        assert_eq!(
+                            actual, expected_value,
+                            "remove returned mutated or wrong value for key {key}"
+                        );
+                        assert_eq!(actual.key, key, "remove returned value for wrong key");
+                    }
+                    (None, _) => {}
+                    (Some(_), None) => {
+                        panic!("remove returned a value for key {key} absent in model");
+                    }
+                }
+                assert!(cache.get(&key).is_none());
+                assert!(!cache.contains_key(&key));
+            }
+        }
+
+        assert_global_invariants(&cache);
+        assert_resident_entries_match_model(&cache, &model);
+    }
+
+    for &predicate in remove_predicates {
+        let expected_removed = model
+            .keys()
+            .filter(|key| remove_predicate_matches(predicate, **key) && cache.contains_key(key))
+            .count();
+        let len_before_removal = cache.len();
+        match predicate {
+            RemovePredicate::EvenKeys => cache.remove_if(|key| key % 2 == 0),
+            RemovePredicate::KeyLessThan(cutoff) => cache.remove_if(|key| *key < cutoff),
+            RemovePredicate::ExactKey(exact) => cache.remove_if(|key| *key == exact),
+        };
+        let removed = len_before_removal - cache.len();
+        assert_eq!(removed, expected_removed);
+        model.retain(|key, _| !remove_predicate_matches(predicate, *key));
+        assert_global_invariants(&cache);
+        assert_resident_entries_match_model(&cache, &model);
+    }
+}
+
+fn op_strategy() -> impl Strategy<Value = TestOp> {
+    prop_oneof![
+        (0u8..32, any::<u32>(), any::<u64>(), 0u8..8).prop_map(|(key, version, token, charge)| {
+            TestOp::Insert {
+                key,
+                version,
+                token,
+                charge,
+            }
+        }),
+        (0u8..32).prop_map(|key| TestOp::Get { key }),
+        (0u8..32).prop_map(|key| TestOp::Remove { key }),
+    ]
+}
+
+fn predicate_strategy() -> impl Strategy<Value = RemovePredicate> {
+    prop_oneof![
+        Just(RemovePredicate::EvenKeys),
+        (0u8..32).prop_map(RemovePredicate::KeyLessThan),
+        (0u8..32).prop_map(RemovePredicate::ExactKey),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn single_shard_equals_model(
+        ops in prop::collection::vec(op_strategy(), 1..200),
+        remove_predicates in prop::collection::vec(predicate_strategy(), 0..8),
+        capacity in 0usize..48,
+    ) {
+        run_model_sequence(1, capacity, &ops, &remove_predicates);
+    }
+
+    #[test]
+    fn multi_shard_equals_model(
+        ops in prop::collection::vec(op_strategy(), 1..200),
+        remove_predicates in prop::collection::vec(predicate_strategy(), 0..8),
+        shard_pow in 0u8..=3,
+        capacity in 0usize..96,
+    ) {
+        let shards = 1usize << shard_pow;
+        run_model_sequence(shards, capacity, &ops, &remove_predicates);
+    }
+}

--- a/crates/buffer-cache/src/thread_type.rs
+++ b/crates/buffer-cache/src/thread_type.rs
@@ -1,0 +1,23 @@
+use enum_map::Enum;
+use serde::Serialize;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+/// Type of a DBSP worker thread that owns a buffer-cache slot.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Enum, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadType {
+    /// Circuit thread.
+    Foreground,
+
+    /// Merger thread.
+    Background,
+}
+
+impl Display for ThreadType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            ThreadType::Foreground => write!(f, "foreground"),
+            ThreadType::Background => write!(f, "background"),
+        }
+    }
+}

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -98,9 +98,11 @@ smallvec = { workspace = true }
 async-stream = { workspace = true }
 futures-util = { workspace = true }
 rmp-serde = { workspace = true }
+feldera-buffer-cache = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+rand_distr = { workspace = true }
 proptest-derive = { workspace = true }
 proptest = { workspace = true }
 proptest-state-machine = { workspace = true }
@@ -143,6 +145,10 @@ harness = false
 
 [[bench]]
 name = "input_map_ingest"
+harness = false
+
+[[bench]]
+name = "buffer_cache"
 harness = false
 
 [[bench]]

--- a/crates/dbsp/benches/buffer_cache.rs
+++ b/crates/dbsp/benches/buffer_cache.rs
@@ -1,0 +1,508 @@
+//! Throughput comparison between `feldera-buffer-cache`'s weighted LRU and
+//! sharded S3-FIFO caches.
+//!
+//! `cargo bench -p dbsp --bench buffer_cache -- --write-ratios 0,10 --capacity-mib 1024 --strategy s3-fifo,lru --max-duration 30`
+use clap::{Parser, ValueEnum};
+use dbsp::mimalloc::MiMalloc;
+use feldera_buffer_cache::{CacheEntry, LruCache, S3FifoCache};
+use rand::rngs::ThreadRng;
+use rand::{Rng, thread_rng};
+use rand_distr::{Distribution, Zipf};
+use std::sync::{Arc, Barrier, OnceLock};
+use std::time::{Duration, Instant};
+
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
+
+const MIB: usize = 1024 * 1024;
+const DEFAULT_THROUGHPUT_OPS_PER_RATIO: usize = 20_000_000;
+const BLOCK_ALIGNMENT: u64 = 512;
+const SHARDED_CACHE_SHARDS: usize = 256;
+const SIZE_CLASSES: [usize; 6] = [
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+];
+
+#[derive(Parser, Debug, Clone)]
+#[command(name = "buffer_cache")]
+#[command(about = "Multi-thread throughput scaling: weighted LRU vs sharded S3-FIFO")]
+struct Args {
+    /// Total cache capacity in MiB.
+    #[arg(long, default_value_t = 256)]
+    capacity_mib: usize,
+
+    /// Key universe size.
+    #[arg(long, default_value_t = 10_000_000)]
+    key_space: usize,
+
+    /// Operations per thread per write-ratio point.
+    #[arg(long, default_value_t = DEFAULT_THROUGHPUT_OPS_PER_RATIO)]
+    ops_per_ratio: usize,
+
+    /// Comma-separated write ratios in percent.
+    #[arg(long, default_value = "1,10,20,30,40,50")]
+    write_ratios: String,
+
+    /// Zipf skew parameter `a` for key-access distribution.
+    #[arg(long, default_value_t = 1.1)]
+    zipf_a: f64,
+
+    /// Comma-separated thread counts.
+    #[arg(long, default_value = "1,2,4,8")]
+    threads: String,
+
+    /// Comma-separated strategies to run: s3-fifo,lru.
+    #[arg(long, value_delimiter = ',', default_value = "s3-fifo,lru")]
+    strategy: Vec<Strategy>,
+
+    /// Optional max duration (seconds) per run. If reached, stop early and report partial stats.
+    #[arg(long)]
+    max_duration: Option<f64>,
+
+    #[doc(hidden)]
+    #[arg(long = "bench", hide = true)]
+    __bench: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum Strategy {
+    S3Fifo,
+    Lru,
+}
+
+#[derive(Clone, Copy)]
+struct Op {
+    offset: u64,
+    charge: usize,
+    write: bool,
+}
+
+#[derive(Clone, Copy)]
+struct Prefill {
+    offset: u64,
+    charge: usize,
+}
+
+#[derive(Clone)]
+struct CacheValue(Arc<Vec<u8>>);
+
+impl CacheValue {
+    fn new(charge: usize) -> Self {
+        Self(Arc::new(vec![0u8; charge]))
+    }
+}
+
+impl CacheEntry for CacheValue {
+    fn cost(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+struct RunStats {
+    ops_per_sec: f64,
+    total_reads: f64,
+    total_writes: f64,
+    hit_rate: f64,
+    final_charge: usize,
+}
+
+trait BenchCache: Send + Sync + 'static {
+    const NAME: &'static str;
+
+    fn with_capacity(capacity_bytes: usize) -> Self;
+
+    fn insert(&self, key: u64, value: CacheValue);
+
+    fn get(&self, key: &u64) -> Option<CacheValue>;
+
+    fn total_charge(&self) -> usize;
+}
+
+type S3FifoBenchCache = S3FifoCache<u64, CacheValue>;
+type LruBenchCache = LruCache<u64, CacheValue>;
+
+impl BenchCache for S3FifoBenchCache {
+    const NAME: &'static str = "s3-fifo";
+
+    fn with_capacity(capacity_bytes: usize) -> Self {
+        Self::with_shards(capacity_bytes, SHARDED_CACHE_SHARDS)
+    }
+
+    fn insert(&self, key: u64, value: CacheValue) {
+        self.insert(key, value);
+    }
+
+    fn get(&self, key: &u64) -> Option<CacheValue> {
+        self.get(key)
+    }
+
+    fn total_charge(&self) -> usize {
+        self.total_charge()
+    }
+}
+
+impl BenchCache for LruBenchCache {
+    const NAME: &'static str = "lru";
+
+    fn with_capacity(capacity_bytes: usize) -> Self {
+        Self::new(capacity_bytes)
+    }
+
+    fn insert(&self, key: u64, value: CacheValue) {
+        self.insert(key, value);
+    }
+
+    fn get(&self, key: &u64) -> Option<CacheValue> {
+        self.get(key)
+    }
+
+    fn total_charge(&self) -> usize {
+        self.total_charge()
+    }
+}
+
+fn sample_zipf_class(rng: &mut ThreadRng, zipf: &Zipf<f64>) -> usize {
+    let rank = zipf.sample(rng) as usize;
+    rank.saturating_sub(1).min(SIZE_CLASSES.len() - 1)
+}
+
+fn key_offset(key_idx: usize) -> u64 {
+    key_idx as u64 * BLOCK_ALIGNMENT
+}
+
+fn parse_u8_csv(s: &str) -> Vec<u8> {
+    let mut out: Vec<u8> = s
+        .split(',')
+        .filter(|x| !x.trim().is_empty())
+        .map(|x| x.trim().parse::<u8>().expect("invalid u8 in CSV"))
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn parse_usize_csv(s: &str) -> Vec<usize> {
+    let mut out: Vec<usize> = s
+        .split(',')
+        .filter(|x| !x.is_empty())
+        .map(|x| x.trim().parse::<usize>().expect("invalid usize in CSV"))
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn build_universe(key_space: usize) -> Vec<usize> {
+    let zipf = Zipf::new(SIZE_CLASSES.len() as u64, 1.2_f64).expect("valid zipf params");
+    let mut rng = thread_rng();
+    let mut charge_by_key = vec![0usize; key_space];
+
+    for charge in &mut charge_by_key {
+        let class = sample_zipf_class(&mut rng, &zipf);
+        *charge = SIZE_CLASSES[class];
+    }
+
+    charge_by_key
+}
+
+fn build_prefill(charge_by_key: &[usize], capacity_bytes: usize) -> Vec<Prefill> {
+    let mut prefill = Vec::new();
+    let mut total = 0usize;
+    for (key_idx, &charge) in charge_by_key.iter().enumerate() {
+        prefill.push(Prefill {
+            offset: key_offset(key_idx),
+            charge,
+        });
+        total = total.saturating_add(charge);
+        if total >= capacity_bytes {
+            break;
+        }
+    }
+    prefill
+}
+
+fn build_thread_traces(
+    write_ratio: u8,
+    ops_per_thread: usize,
+    charge_by_key: &[usize],
+    zipf_a: f64,
+    threads: usize,
+) -> Vec<Vec<Op>> {
+    let key_space = charge_by_key.len();
+    let zipf = Zipf::new(key_space as u64, zipf_a).expect("valid zipf params");
+
+    (0..threads)
+        .map(|_| {
+            let mut rng = thread_rng();
+            let mut trace = Vec::with_capacity(ops_per_thread);
+            for _ in 0..ops_per_thread {
+                let key_idx = (zipf.sample(&mut rng) as usize)
+                    .saturating_sub(1)
+                    .min(key_space.saturating_sub(1));
+                trace.push(Op {
+                    offset: key_offset(key_idx),
+                    charge: charge_by_key[key_idx],
+                    write: rng.gen_ratio(write_ratio as u32, 100),
+                });
+            }
+            trace
+        })
+        .collect()
+}
+
+fn run_cache_mt<C>(
+    prefill: &[Prefill],
+    traces: &[Vec<Op>],
+    capacity_bytes: usize,
+    max_duration: Option<Duration>,
+) -> RunStats
+where
+    C: BenchCache,
+{
+    let cache = Arc::new(C::with_capacity(capacity_bytes));
+    let workers = traces.len();
+    let prefill_done = Barrier::new(workers + 1);
+    let ready = Barrier::new(workers + 1);
+    let start_gate = Barrier::new(workers + 1);
+    let run_start: Arc<OnceLock<Instant>> = Arc::new(OnceLock::new());
+
+    std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(workers);
+
+        for (worker_idx, trace) in traces.iter().enumerate() {
+            let cache = cache.clone();
+            let prefill_done = &prefill_done;
+            let ready = &ready;
+            let start_gate = &start_gate;
+            let run_start = run_start.clone();
+            let prefill_start = worker_idx * prefill.len() / workers;
+            let prefill_end = (worker_idx + 1) * prefill.len() / workers;
+
+            handles.push(scope.spawn(move || {
+                for p in &prefill[prefill_start..prefill_end] {
+                    cache.insert(p.offset, CacheValue::new(p.charge));
+                }
+
+                prefill_done.wait();
+                ready.wait();
+                start_gate.wait();
+                let run_start = *run_start.get().expect("run start must be initialized");
+
+                let mut ops = 0usize;
+                let mut writes = 0usize;
+                let mut reads = 0usize;
+                let mut hits = 0usize;
+                for op in trace {
+                    if let Some(limit) = max_duration
+                        && run_start.elapsed() >= limit
+                    {
+                        break;
+                    }
+                    ops += 1;
+                    if op.write {
+                        writes += 1;
+                        cache.insert(op.offset, CacheValue::new(op.charge));
+                    } else {
+                        reads += 1;
+                        if cache.get(&op.offset).is_some() {
+                            hits += 1;
+                        }
+                    }
+                }
+                (ops, reads, writes, hits)
+            }));
+        }
+
+        prefill_done.wait();
+        ready.wait();
+        let start = Instant::now();
+        run_start
+            .set(start)
+            .expect("run start should only be set once");
+        start_gate.wait();
+
+        let mut total_ops = 0usize;
+        let mut total_reads = 0usize;
+        let mut total_writes = 0usize;
+        let mut total_hits = 0usize;
+        for handle in handles {
+            let (ops, reads, writes, hits) = handle
+                .join()
+                .unwrap_or_else(|_| panic!("{} thread panicked", C::NAME));
+            total_ops += ops;
+            total_reads += reads;
+            total_writes += writes;
+            total_hits += hits;
+        }
+
+        let elapsed = start.elapsed().as_secs_f64();
+        RunStats {
+            ops_per_sec: total_ops as f64 / elapsed,
+            total_reads: total_reads as f64,
+            total_writes: total_writes as f64,
+            hit_rate: if total_reads == 0 {
+                0.0
+            } else {
+                total_hits as f64 / total_reads as f64
+            },
+            final_charge: cache.total_charge(),
+        }
+    })
+}
+
+fn main() {
+    let args = Args::parse();
+    let capacity_bytes = args.capacity_mib.saturating_mul(MIB);
+    let write_ratios = parse_u8_csv(&args.write_ratios);
+    let thread_counts = parse_usize_csv(&args.threads);
+    let run_s3_fifo = args.strategy.contains(&Strategy::S3Fifo);
+    let run_lru = args.strategy.contains(&Strategy::Lru);
+
+    assert!(args.key_space > 0, "key-space must be > 0");
+    assert!(!write_ratios.is_empty(), "write-ratios cannot be empty");
+    assert!(!thread_counts.is_empty(), "threads cannot be empty");
+    assert!(
+        run_s3_fifo || run_lru,
+        "strategy cannot be empty; choose one or more of s3-fifo,lru"
+    );
+    assert!(args.ops_per_ratio > 0, "ops-per-ratio must be > 0");
+    assert!(args.zipf_a >= 0.0, "zipf-a must be >= 0");
+    if let Some(max_duration) = args.max_duration {
+        assert!(
+            max_duration.is_finite() && max_duration > 0.0,
+            "max-duration must be finite and > 0"
+        );
+    }
+    for &ratio in &write_ratios {
+        assert!(ratio <= 100, "write ratio must be in [0,100]");
+    }
+    for &threads in &thread_counts {
+        assert!(threads > 0, "thread count must be > 0");
+    }
+
+    let charge_by_key = build_universe(args.key_space);
+    let prefill = build_prefill(&charge_by_key, capacity_bytes);
+    let max_duration = args.max_duration.map(Duration::from_secs_f64);
+    let max_duration_str = args
+        .max_duration
+        .map_or_else(|| "none".to_string(), |value| format!("{value:.3}"));
+
+    println!(
+        "capacity_mib={}, key_space={}, base_ops_per_ratio={}, zipf_a={}, max_duration_s={}\n",
+        args.capacity_mib, args.key_space, args.ops_per_ratio, args.zipf_a, max_duration_str
+    );
+    println!(
+        "os,zipf_a,write_ratio,threads,ops_per_thread,total_ops,total_reads,total_writes,s3_fifo_ops_s,lru_ops_s,s3_fifo_hit,lru_hit,s3_fifo_charge,lru_charge,s3_fifo_scaling,lru_scaling,s3_fifo_vs_lru"
+    );
+
+    for &ratio in &write_ratios {
+        let mut s3_fifo_base = None::<f64>;
+        let mut lru_base = None::<f64>;
+
+        for &threads in &thread_counts {
+            let ops_per_thread = ((args.ops_per_ratio as f64) * (threads as f64) * 0.5)
+                .round()
+                .max(1.0) as usize;
+            let total_ops = ops_per_thread.saturating_mul(threads);
+            let traces =
+                build_thread_traces(ratio, ops_per_thread, &charge_by_key, args.zipf_a, threads);
+            let s3_fifo = run_s3_fifo.then(|| {
+                run_cache_mt::<S3FifoBenchCache>(&prefill, &traces, capacity_bytes, max_duration)
+            });
+            let lru = run_lru.then(|| {
+                run_cache_mt::<LruBenchCache>(&prefill, &traces, capacity_bytes, max_duration)
+            });
+
+            if max_duration.is_none() {
+                let mut observed = Vec::new();
+                if let Some(stats) = s3_fifo {
+                    observed.push(("s3-fifo", stats));
+                }
+                if let Some(stats) = lru {
+                    observed.push(("lru", stats));
+                }
+                if let Some((base_name, base_stats)) = observed.first().copied() {
+                    for (name, stats) in observed.iter().skip(1).copied() {
+                        assert!(
+                            base_stats.total_reads == stats.total_reads
+                                && base_stats.total_writes == stats.total_writes,
+                            "read/write totals diverged between {} and {} at write_ratio={}, threads={}: {}(reads={}, writes={}) {}(reads={}, writes={})",
+                            base_name,
+                            name,
+                            ratio,
+                            threads,
+                            base_name,
+                            base_stats.total_reads,
+                            base_stats.total_writes,
+                            name,
+                            stats.total_reads,
+                            stats.total_writes
+                        );
+                    }
+                }
+            }
+
+            let s3_fifo_base_value =
+                s3_fifo.map(|stats| *s3_fifo_base.get_or_insert(stats.ops_per_sec));
+            let lru_base_value = lru.map(|stats| *lru_base.get_or_insert(stats.ops_per_sec));
+
+            let s3_fifo_scaling = match (s3_fifo, s3_fifo_base_value) {
+                (Some(stats), Some(base)) if base > 0.0 => stats.ops_per_sec / base,
+                (Some(_), _) => 0.0,
+                (None, _) => f64::NAN,
+            };
+            let lru_scaling = match (lru, lru_base_value) {
+                (Some(stats), Some(base)) if base > 0.0 => stats.ops_per_sec / base,
+                (Some(_), _) => 0.0,
+                (None, _) => f64::NAN,
+            };
+            let s3_fifo_vs_lru = match (s3_fifo, lru) {
+                (Some(s3_fifo), Some(lru)) if lru.ops_per_sec > 0.0 => {
+                    s3_fifo.ops_per_sec / lru.ops_per_sec
+                }
+                (Some(_), Some(_)) => 0.0,
+                _ => f64::NAN,
+            };
+            let total_reads = s3_fifo
+                .or(lru)
+                .map(|stats| stats.total_reads)
+                .unwrap_or(f64::NAN);
+            let total_writes = s3_fifo
+                .or(lru)
+                .map(|stats| stats.total_writes)
+                .unwrap_or(f64::NAN);
+            let s3_fifo_charge = s3_fifo
+                .map(|stats| stats.final_charge.to_string())
+                .unwrap_or_else(|| "NaN".to_string());
+            let lru_charge = lru
+                .map(|stats| stats.final_charge.to_string())
+                .unwrap_or_else(|| "NaN".to_string());
+
+            println!(
+                "{},{:.3},{},{},{},{},{:.0},{:.0},{:.0},{:.0},{:.3},{:.3},{},{},{:.3},{:.3},{:.3}",
+                std::env::consts::OS,
+                args.zipf_a,
+                ratio,
+                threads,
+                ops_per_thread,
+                total_ops,
+                total_reads,
+                total_writes,
+                s3_fifo.map_or(f64::NAN, |stats| stats.ops_per_sec),
+                lru.map_or(f64::NAN, |stats| stats.ops_per_sec),
+                s3_fifo.map_or(f64::NAN, |stats| stats.hit_rate),
+                lru.map_or(f64::NAN, |stats| stats.hit_rate),
+                s3_fifo_charge,
+                lru_charge,
+                s3_fifo_scaling,
+                lru_scaling,
+                s3_fifo_vs_lru
+            );
+        }
+    }
+}

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1,7 +1,6 @@
 use crate::circuit::GlobalNodeId;
 use crate::circuit::checkpointer::Checkpointer;
 use crate::circuit::metrics::{DBSP_STEP, DBSP_STEP_LATENCY_MICROSECONDS};
-use crate::circuit::runtime::ThreadType;
 use crate::circuit::schedule::CommitProgress;
 use crate::monitor::visual_graph::Graph;
 use crate::operator::dynamic::balance::{
@@ -18,6 +17,7 @@ use crate::{
 };
 use anyhow::Error as AnyError;
 use crossbeam::channel::{Receiver, Select, Sender, TryRecvError, bounded};
+use feldera_buffer_cache::{BufferCacheAllocationStrategy, BufferCacheStrategy, ThreadType};
 use feldera_ir::LirCircuit;
 use feldera_storage::{FileCommitter, StorageBackend, StoragePath};
 use feldera_types::checkpoint::CheckpointMetadata;
@@ -282,6 +282,24 @@ pub struct CircuitConfig {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(default)]
 pub struct DevTweaks {
+    /// Buffer-cache implementation to use for storage reads.
+    ///
+    /// The default is `s3_fifo`.
+    pub buffer_cache_strategy: BufferCacheStrategy,
+
+    /// Override the number of buckets/shards used by sharded buffer caches.
+    ///
+    /// This only applies when `buffer_cache_strategy = "s3_fifo"`. Values are
+    /// rounded up to the next power of two because the current implementation
+    /// shards by `hash(key) & (n - 1)`.
+    pub buffer_max_buckets: Option<usize>,
+
+    /// How S3-FIFO caches are assigned to foreground/background workers.
+    ///
+    /// This only applies when `buffer_cache_strategy = "s3_fifo"`. The
+    /// default is `shared_per_worker_pair`; LRU always uses `per_thread`.
+    pub buffer_cache_allocation_strategy: BufferCacheAllocationStrategy,
+
     /// Whether to asynchronously fetch keys needed for the join operator from
     /// storage.  Asynchronous fetching should be faster for high-latency
     /// storage, such as object storage, but it could use excessive amounts of
@@ -401,6 +419,9 @@ pub struct DevTweaks {
 impl Default for DevTweaks {
     fn default() -> Self {
         Self {
+            buffer_cache_strategy: BufferCacheStrategy::default(),
+            buffer_max_buckets: None,
+            buffer_cache_allocation_strategy: BufferCacheAllocationStrategy::default(),
             fetch_join: false,
             fetch_distinct: false,
             merger: MergerType::default(),
@@ -420,7 +441,7 @@ impl Default for DevTweaks {
 
 impl DevTweaks {
     pub fn from_config(config: &BTreeMap<String, Value>) -> Self {
-        let tweaks = serde_json::to_value(config)
+        let tweaks: Self = serde_json::to_value(config)
             .and_then(serde_json::from_value)
             .inspect_err(|error| {
                 tracing::error!("falling back to default `dev_tweaks` due to error ({error}) with configuration: {config:#?}")
@@ -430,6 +451,15 @@ impl DevTweaks {
             info!("using non-default `dev_tweaks`: {tweaks:#?}")
         }
         tweaks
+    }
+
+    pub(crate) fn effective_buffer_cache_allocation_strategy(
+        &self,
+    ) -> BufferCacheAllocationStrategy {
+        match self.buffer_cache_strategy {
+            BufferCacheStrategy::S3Fifo => self.buffer_cache_allocation_strategy,
+            BufferCacheStrategy::Lru => BufferCacheAllocationStrategy::PerThread,
+        }
     }
 }
 
@@ -538,6 +568,24 @@ impl CircuitConfig {
 
     pub fn with_splitter_chunk_size_records(mut self, records: u64) -> Self {
         self.dev_tweaks.splitter_chunk_size_records = records;
+        self
+    }
+
+    pub fn with_buffer_cache_strategy(mut self, strategy: BufferCacheStrategy) -> Self {
+        self.dev_tweaks.buffer_cache_strategy = strategy;
+        self
+    }
+
+    pub fn with_buffer_max_buckets(mut self, max_buckets: Option<usize>) -> Self {
+        self.dev_tweaks.buffer_max_buckets = max_buckets;
+        self
+    }
+
+    pub fn with_buffer_cache_allocation_strategy(
+        mut self,
+        strategy: BufferCacheAllocationStrategy,
+    ) -> Self {
+        self.dev_tweaks.buffer_cache_allocation_strategy = strategy;
         self
     }
 

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -15,11 +15,16 @@ use crate::storage::file::writer::Parameters;
 use crate::trace::unaligned_deserialize;
 use crate::{
     DetailedError,
-    storage::{backend::StorageError, buffer_cache::BufferCache, dirlock::LockedDirectory},
+    storage::{
+        backend::StorageError,
+        buffer_cache::{BufferCache, build_buffer_caches},
+        dirlock::LockedDirectory,
+    },
 };
 use core_affinity::{CoreId, get_core_ids};
 use crossbeam::sync::{Parker, Unparker};
 use enum_map::{Enum, EnumMap, enum_map};
+use feldera_buffer_cache::ThreadType;
 use feldera_types::config::{StorageCompression, StorageConfig, StorageOptions};
 use indexmap::IndexSet;
 use once_cell::sync::Lazy;
@@ -34,6 +39,7 @@ use std::{
     backtrace::Backtrace,
     borrow::Cow,
     cell::{Cell, RefCell},
+    collections::HashSet,
     error::Error as StdError,
     fmt,
     fmt::{Debug, Display, Error as FmtError, Formatter},
@@ -112,56 +118,19 @@ thread_local! {
     // Returns `0` if the current thread in not running in a multithreaded
     // runtime.
     static WORKER_INDEX: Cell<usize> = const { Cell::new(0) };
+
+    // `None` means that this is an auxiliary thread that runs inside the runtime
+    // but is neither a DBSP foreground nor a background thread.
+    static CURRENT_THREAD_TYPE: Cell<Option<ThreadType>> = const { Cell::new(None) };
 }
 
-mod thread_type {
-    use std::{cell::Cell, fmt::Display};
-
-    #[cfg(doc)]
-    use super::Runtime;
-    use enum_map::Enum;
-    use serde::Serialize;
-
-    thread_local! {
-        /// `None` means that this is an auxiliary thread that runs inside the runtime
-        /// but is neither a DBSP foreground nor a background thread.
-        static CURRENT: Cell<Option<ThreadType>> = const { Cell::new(None) };
-    }
-
-    /// Type of a thread running in a [Runtime].
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Enum, Serialize)]
-    #[serde(rename_all = "snake_case")]
-    pub enum ThreadType {
-        /// Circuit thread.
-        Foreground,
-
-        /// Merger thread.
-        Background,
-    }
-
-    impl ThreadType {
-        /// Returns the kind of thread we're currently running in, if we're in a
-        /// [Runtime].  Outside of a [Runtime], this returns
-        /// [ThreadType::Foreground].
-        pub fn current() -> Option<Self> {
-            CURRENT.get()
-        }
-
-        pub(super) fn set_current(thread_type: Self) {
-            CURRENT.set(Some(thread_type));
-        }
-    }
-
-    impl Display for ThreadType {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                ThreadType::Foreground => write!(f, "foreground"),
-                ThreadType::Background => write!(f, "background"),
-            }
-        }
-    }
+pub(crate) fn current_thread_type() -> Option<ThreadType> {
+    CURRENT_THREAD_TYPE.get()
 }
-pub use thread_type::ThreadType;
+
+fn set_current_thread_type(thread_type: ThreadType) {
+    CURRENT_THREAD_TYPE.set(Some(thread_type));
+}
 
 pub struct LocalStoreMarker;
 
@@ -364,7 +333,11 @@ fn map_pin_cpus(layout: &Layout, pin_cpus: &[usize]) -> Vec<EnumMap<ThreadType, 
 impl RuntimeInner {
     fn new(config: CircuitConfig) -> Result<Self, DbspError> {
         let nworkers = config.layout.local_workers().len();
-
+        let buffer_cache_strategy = config.dev_tweaks.buffer_cache_strategy;
+        let buffer_max_buckets = config.dev_tweaks.buffer_max_buckets;
+        let buffer_cache_allocation_strategy = config
+            .dev_tweaks
+            .effective_buffer_cache_allocation_strategy();
         let storage = if let Some(storage) = config.storage {
             let locked_directory =
                 LockedDirectory::new_blocking(storage.config.path(), Duration::from_secs(60))?;
@@ -389,17 +362,30 @@ impl RuntimeInner {
             None
         };
 
-        let cache_size_bytes = if let Some(storage) = &storage {
-            storage
-                .options
-                .cache_mib
-                .map_or(256 * 1024 * 1024, |cache_mib| {
-                    cache_mib.saturating_mul(1024 * 1024) / nworkers / ThreadType::LENGTH
-                })
+        let total_cache_bytes = if let Some(storage) = &storage {
+            match storage.options.cache_mib {
+                Some(cache_mib) => cache_mib.saturating_mul(1024 * 1024),
+                None => 256usize
+                    .saturating_mul(1024 * 1024)
+                    .saturating_mul(nworkers)
+                    .saturating_mul(ThreadType::LENGTH),
+            }
         } else {
             // Dummy buffer cache.
             1
         };
+
+        info!(
+            "Setting up buffer caches: {buffer_cache_strategy:?} {buffer_cache_allocation_strategy:?} buckets={buffer_max_buckets:?} total_size={:?} MiB",
+            total_cache_bytes / (1024 * 1024)
+        );
+        let buffer_caches = build_buffer_caches(
+            nworkers,
+            total_cache_bytes,
+            buffer_cache_strategy,
+            buffer_max_buckets,
+            buffer_cache_allocation_strategy,
+        );
 
         Ok(Self {
             pin_cpus: map_pin_cpus(&config.layout, &config.pin_cpus),
@@ -411,9 +397,7 @@ impl RuntimeInner {
             kill_signal: AtomicBool::new(false),
             background_threads: Mutex::new(Vec::new()),
             aux_threads: Mutex::new(Vec::new()),
-            buffer_caches: (0..nworkers)
-                .map(|_| EnumMap::from_fn(|_| Arc::new(BufferCache::new(cache_size_bytes))))
-                .collect(),
+            buffer_caches,
             worker_sequence_numbers: (0..nworkers).map(|_| AtomicUsize::new(0)).collect(),
             panic_info: (0..nworkers)
                 .map(|_| EnumMap::from_fn(|_| RwLock::new(None)))
@@ -426,7 +410,7 @@ impl RuntimeInner {
     fn pin_cpu(&self) {
         if !self.pin_cpus.is_empty() {
             let local_worker_offset = Runtime::local_worker_offset();
-            let Some(thread_type) = ThreadType::current() else {
+            let Some(thread_type) = current_thread_type() else {
                 panic!("pin_cpu() called outside of a runtime or on an aux thread");
             };
             let core = self.pin_cpus[local_worker_offset][thread_type];
@@ -561,7 +545,7 @@ impl Runtime {
                     .spawn(move || {
                         // Set the worker's runtime handle and index
                         WORKER_INDEX.set(worker_index);
-                        ThreadType::set_current(ThreadType::Foreground);
+                        set_current_thread_type(ThreadType::Foreground);
                         runtime.inner().pin_cpu();
                         RUNTIME.with(|rt| *rt.borrow_mut() = Some(runtime));
 
@@ -612,8 +596,7 @@ impl Runtime {
             })
     }
 
-    /// Returns this thread's buffer cache.  Every thread has a buffer cache,
-    /// but:
+    /// Returns this thread's buffer-cache handle, but:
     ///
     /// - If the thread's [Runtime] does not have storage configured, the cache
     ///   size is trivially small.
@@ -643,7 +626,7 @@ impl Runtime {
 
         // Slow path for initializing the thread-local.
         let buffer_cache = if let Some(rt) = Runtime::runtime() {
-            if let Some(thread_type) = ThreadType::current() {
+            if let Some(thread_type) = current_thread_type() {
                 rt.get_buffer_cache(Runtime::local_worker_offset(), thread_type)
             } else {
                 // Aux thread: use the global cache.
@@ -689,8 +672,8 @@ impl Runtime {
             .push((handle, unparker))
     }
 
-    /// Returns this runtime's buffer cache for thread type `thread_type` in
-    /// worker with local offset `local_worker_offset`.
+    /// Returns this runtime's buffer-cache handle for thread type `thread_type`
+    /// in worker with local offset `local_worker_offset`.
     ///
     /// Usually it's easier and faster to call [Runtime::buffer_cache] instead.
     pub fn get_buffer_cache(
@@ -705,10 +688,12 @@ impl Runtime {
     /// that is currently used and its maximum size, both in bytes.
     pub fn cache_occupancy(&self) -> (usize, usize) {
         if self.0.storage.is_some() {
+            let mut seen = HashSet::new();
             self.0
                 .buffer_caches
                 .iter()
                 .flat_map(|map| map.values())
+                .filter(|cache| seen.insert(cache.backend_id()))
                 .map(|cache| cache.occupancy())
                 .fold((0, 0), |(a_cur, a_max), (b_cur, b_max)| {
                     (a_cur + b_cur, a_max + b_max)
@@ -940,7 +925,7 @@ impl Runtime {
     // Record information about a worker thread panic in `panic_info`
     fn panic(&self, panic_info: &PanicHookInfo) {
         let local_worker_offset = Self::local_worker_offset();
-        let Some(thread_type) = ThreadType::current() else {
+        let Some(thread_type) = current_thread_type() else {
             // We only install panic hooks on foreground and background threads,
             // so this shouldn't happen, but we cannot panic here.
             error!("panic hook called outside of a runtime or on an aux thread");
@@ -967,7 +952,7 @@ impl Runtime {
         let join_handle = builder
             .spawn(move || {
                 WORKER_INDEX.set(worker_index);
-                ThreadType::set_current(ThreadType::Background);
+                set_current_thread_type(ThreadType::Background);
                 if let Some(runtime) = runtime {
                     runtime.inner().pin_cpu();
                     RUNTIME.with(|rt| *rt.borrow_mut() = Some(runtime));
@@ -1297,7 +1282,7 @@ impl RuntimeHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::Runtime;
+    use super::{Runtime, RuntimeInner};
     use crate::{
         Circuit, RootCircuit,
         circuit::{
@@ -1306,9 +1291,22 @@ mod tests {
             schedule::{DynamicScheduler, Scheduler},
         },
         operator::Generator,
+        storage::backend::FileId,
+    };
+    use enum_map::Enum;
+    use feldera_buffer_cache::{
+        BufferCacheAllocationStrategy, BufferCacheStrategy, CacheEntry, ThreadType,
     };
     use feldera_types::config::{StorageCacheConfig, StorageConfig, StorageOptions};
-    use std::{cell::RefCell, rc::Rc, thread::sleep, time::Duration};
+    use std::{cell::RefCell, rc::Rc, sync::Arc, thread::sleep, time::Duration};
+
+    struct TestCacheEntry(usize);
+
+    impl CacheEntry for TestCacheEntry {
+        fn cost(&self) -> usize {
+            self.0
+        }
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -1346,6 +1344,186 @@ mod tests {
         .expect("failed to start runtime");
         hruntime.join().unwrap();
         assert!(path.exists(), "persistent storage is not cleaned up");
+    }
+
+    #[test]
+    fn s3_fifo_is_the_default_buffer_cache_strategy() {
+        let inner = RuntimeInner::new(CircuitConfig::with_workers(1)).unwrap();
+        assert_eq!(
+            inner.buffer_caches[0][ThreadType::Foreground].strategy(),
+            BufferCacheStrategy::S3Fifo
+        );
+    }
+
+    #[test]
+    fn default_s3_fifo_cache_shares_backend_per_worker_pair() {
+        let inner = RuntimeInner::new(CircuitConfig::with_workers(2)).unwrap();
+        assert!(
+            inner.buffer_caches[0][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[0][ThreadType::Background])
+        );
+        assert!(
+            inner.buffer_caches[1][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[1][ThreadType::Background])
+        );
+        assert!(
+            !inner.buffer_caches[0][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[1][ThreadType::Foreground])
+        );
+    }
+
+    #[test]
+    fn lru_can_still_be_selected_explicitly() {
+        let inner = RuntimeInner::new(
+            CircuitConfig::with_workers(1).with_buffer_cache_strategy(BufferCacheStrategy::Lru),
+        )
+        .unwrap();
+        assert_eq!(
+            inner.buffer_caches[0][ThreadType::Foreground].strategy(),
+            BufferCacheStrategy::Lru
+        );
+        assert!(
+            !inner.buffer_caches[0][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[0][ThreadType::Background])
+        );
+    }
+
+    #[test]
+    fn lru_uses_default_total_cache_capacity_when_cache_mib_is_unset() {
+        let workers = 3usize;
+        let path = tempfile::tempdir().unwrap();
+        let storage = CircuitStorageConfig::for_config(
+            StorageConfig {
+                path: path.path().to_string_lossy().into_owned(),
+                cache: StorageCacheConfig::default(),
+            },
+            StorageOptions::default(),
+        )
+        .unwrap();
+        let runtime = Runtime(Arc::new(
+            RuntimeInner::new(
+                CircuitConfig::with_workers(workers)
+                    .with_storage(storage)
+                    .with_buffer_cache_strategy(BufferCacheStrategy::Lru),
+            )
+            .unwrap(),
+        ));
+
+        assert_eq!(
+            runtime.cache_occupancy(),
+            (0, workers * ThreadType::LENGTH * 256usize * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn s3_fifo_cache_can_share_cache_per_worker_pair_when_requested() {
+        let config = CircuitConfig::with_workers(2).with_buffer_cache_allocation_strategy(
+            BufferCacheAllocationStrategy::SharedPerWorkerPair,
+        );
+        let inner = RuntimeInner::new(config).unwrap();
+        assert!(
+            inner.buffer_caches[0][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[0][ThreadType::Background])
+        );
+        assert!(
+            inner.buffer_caches[1][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[1][ThreadType::Background])
+        );
+    }
+
+    #[test]
+    fn s3_fifo_cache_can_share_one_global_cache_when_requested() {
+        let config = CircuitConfig::with_workers(2)
+            .with_buffer_cache_allocation_strategy(BufferCacheAllocationStrategy::Global);
+        let inner = RuntimeInner::new(config).unwrap();
+        let global = inner.buffer_caches[0][ThreadType::Foreground].clone();
+        assert!(global.shares_backend_with(&inner.buffer_caches[0][ThreadType::Background]));
+        assert!(global.shares_backend_with(&inner.buffer_caches[1][ThreadType::Foreground]));
+        assert!(global.shares_backend_with(&inner.buffer_caches[1][ThreadType::Background]));
+    }
+
+    #[test]
+    fn lru_keeps_separate_foreground_and_background_caches() {
+        let config = CircuitConfig::with_workers(2)
+            .with_buffer_cache_strategy(BufferCacheStrategy::Lru)
+            .with_buffer_cache_allocation_strategy(
+                BufferCacheAllocationStrategy::SharedPerWorkerPair,
+            );
+        let inner = RuntimeInner::new(config).unwrap();
+        assert!(
+            !inner.buffer_caches[0][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[0][ThreadType::Background])
+        );
+        assert!(
+            !inner.buffer_caches[1][ThreadType::Foreground]
+                .shares_backend_with(&inner.buffer_caches[1][ThreadType::Background])
+        );
+    }
+
+    #[test]
+    fn shared_sharded_cache_occupancy_is_not_double_counted() {
+        let path = tempfile::tempdir().unwrap();
+        let storage = CircuitStorageConfig::for_config(
+            StorageConfig {
+                path: path.path().to_string_lossy().into_owned(),
+                cache: StorageCacheConfig::default(),
+            },
+            StorageOptions {
+                cache_mib: Some(8),
+                ..StorageOptions::default()
+            },
+        )
+        .unwrap();
+        let runtime = Runtime(Arc::new(
+            RuntimeInner::new(
+                CircuitConfig::with_workers(1)
+                    .with_storage(storage)
+                    .with_buffer_cache_allocation_strategy(
+                        BufferCacheAllocationStrategy::SharedPerWorkerPair,
+                    ),
+            )
+            .unwrap(),
+        ));
+
+        runtime.get_buffer_cache(0, ThreadType::Foreground).insert(
+            FileId::new(),
+            0,
+            Arc::new(TestCacheEntry(1024)),
+        );
+
+        assert_eq!(runtime.cache_occupancy(), (1024, 8 * 1024 * 1024));
+    }
+
+    #[test]
+    fn global_sharded_cache_occupancy_is_not_double_counted() {
+        let path = tempfile::tempdir().unwrap();
+        let storage = CircuitStorageConfig::for_config(
+            StorageConfig {
+                path: path.path().to_string_lossy().into_owned(),
+                cache: StorageCacheConfig::default(),
+            },
+            StorageOptions {
+                cache_mib: Some(8),
+                ..StorageOptions::default()
+            },
+        )
+        .unwrap();
+        let runtime = Runtime(Arc::new(
+            RuntimeInner::new(
+                CircuitConfig::with_workers(2)
+                    .with_storage(storage)
+                    .with_buffer_cache_allocation_strategy(BufferCacheAllocationStrategy::Global),
+            )
+            .unwrap(),
+        ));
+
+        runtime.get_buffer_cache(1, ThreadType::Background).insert(
+            FileId::new(),
+            0,
+            Arc::new(TestCacheEntry(1024)),
+        );
+
+        assert_eq!(runtime.cache_occupancy(), (1024, 8 * 1024 * 1024));
     }
 
     fn test_runtime<S>()

--- a/crates/dbsp/src/profile.rs
+++ b/crates/dbsp/src/profile.rs
@@ -12,10 +12,10 @@ use crate::{
             MetricReading, OperatorMeta, RUNTIME_PERCENT, RUNTIME_SECONDS,
             SPINE_STORAGE_SIZE_BYTES, STEPS_COUNT, USED_MEMORY_BYTES,
         },
-        runtime::ThreadType,
     },
     monitor::{TraceMonitor, visual_graph::Graph},
 };
+use feldera_buffer_cache::ThreadType;
 use serde::Serialize;
 use size_of::HumanBytes;
 use std::{

--- a/crates/dbsp/src/storage/buffer_cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache.rs
@@ -1,11 +1,12 @@
 //! Buffer cache that can be used to cache reads.
 
-/// A buffer-cache based on LRU eviction.
+/// Buffer-cache implementations and cache statistics.
 mod cache;
 
 pub use feldera_storage::fbuf::{FBuf, FBufSerializer, LimitExceeded};
 
 pub use cache::{
-    AtomicCacheCounts, AtomicCacheStats, BufferCache, CacheAccess, CacheCounts, CacheEntry,
-    CacheStats,
+    AtomicCacheCounts, AtomicCacheStats, BufferCache, CacheAccess, CacheCounts, CacheStats,
 };
+
+pub(crate) use cache::build_buffer_caches;

--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -1,16 +1,15 @@
-//! A buffer-cache based on LRU eviction.
-//!
-//! This is a layer over a storage backend that adds a cache of a
-//! client-provided function of the blocks.
-use std::any::Any;
 use std::fmt::{Debug, Display};
+use std::ops::Range;
 use std::ops::{Add, AddAssign};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::{collections::BTreeMap, ops::Range};
 
 use enum_map::{Enum, EnumMap};
+use feldera_buffer_cache::{
+    BufferCacheAllocationStrategy, BufferCacheBuilder, BufferCacheStrategy, CacheEntry, LruCache,
+    SharedBufferCache, ThreadType,
+};
 use serde::{Deserialize, Serialize};
 use size_of::SizeOf;
 
@@ -19,7 +18,7 @@ use crate::circuit::metadata::{
     CACHE_FOREGROUND_HIT_RATE_PERCENT, CACHE_FOREGROUND_HITS, CACHE_FOREGROUND_MISSES, MetaItem,
     MetricId, MetricReading, OperatorMeta,
 };
-use crate::circuit::runtime::ThreadType;
+use crate::circuit::runtime::current_thread_type;
 use crate::storage::backend::{BlockLocation, FileId, FileReader};
 
 /// A key for the block cache.
@@ -27,9 +26,8 @@ use crate::storage::backend::{BlockLocation, FileId, FileReader};
 /// The block size could be part of the key, but we'll never read a given offset
 /// with more than one size so it's also not necessary.
 ///
-/// It's important that the sort order is by `fd` first and `offset` second, so
-/// that [`CacheKey::fd_range`] can work.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// It's important that the sort order is by `fd` first and `offset` second.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct CacheKey {
     /// File being cached.
     file_id: FileId,
@@ -43,9 +41,8 @@ impl CacheKey {
         Self { file_id, offset }
     }
 
-    /// Returns a range that would contain all of the blocks for the specified
-    /// `fd`.
-    fn file_range(file_id: FileId) -> Range<CacheKey> {
+    /// Returns the key range that covers every cached block for `file_id`.
+    fn file_range(file_id: FileId) -> Range<Self> {
         Self { file_id, offset: 0 }..Self {
             file_id: file_id.after(),
             offset: 0,
@@ -53,159 +50,32 @@ impl CacheKey {
     }
 }
 
-/// A value in the block cache.
-struct CacheValue {
-    /// Cached interpretation of `block`.
-    aux: Arc<dyn CacheEntry>,
-
-    /// Serial number for LRU purposes.  Blocks with higher serial numbers have
-    /// been used more recently.
-    serial: u64,
-}
-
-pub trait CacheEntry: Any + Send + Sync {
-    fn cost(&self) -> usize;
-}
-
-impl dyn CacheEntry {
-    pub fn downcast<T>(self: Arc<Self>) -> Option<Arc<T>>
-    where
-        T: Send + Sync + 'static,
-    {
-        (self as Arc<dyn Any + Send + Sync>).downcast().ok()
-    }
-}
-
-struct CacheInner {
-    /// Cache contents.
-    cache: BTreeMap<CacheKey, CacheValue>,
-
-    /// Map from LRU serial number to cache key.  The element with the smallest
-    /// serial number was least recently used.
-    lru: BTreeMap<u64, CacheKey>,
-
-    /// Serial number to use the next time we touch a block.
-    next_serial: u64,
-
-    /// Sum over `cache[*].block.cost()`.
-    cur_cost: usize,
-
-    /// Maximum `size`, in bytes.
-    max_cost: usize,
-}
-
-impl CacheInner {
-    fn new(max_cost: usize) -> Self {
-        Self {
-            cache: BTreeMap::new(),
-            lru: BTreeMap::new(),
-            next_serial: 0,
-            cur_cost: 0,
-            max_cost,
-        }
-    }
-
-    #[allow(dead_code)]
-    fn check_invariants(&self) {
-        assert_eq!(self.cache.len(), self.lru.len());
-        let mut cost = 0;
-        for (key, value) in self.cache.iter() {
-            assert_eq!(self.lru.get(&value.serial), Some(key));
-            cost += value.aux.cost();
-        }
-        for (serial, key) in self.lru.iter() {
-            assert_eq!(self.cache.get(key).unwrap().serial, *serial);
-        }
-        assert_eq!(cost, self.cur_cost);
-    }
-
-    fn debug_check_invariants(&self) {
-        #[cfg(debug_assertions)]
-        self.check_invariants()
-    }
-
-    fn delete_file(&mut self, file_id: FileId) {
-        let offsets: Vec<_> = self
-            .cache
-            .range(CacheKey::file_range(file_id))
-            .map(|(k, v)| (k.offset, v.serial))
-            .collect();
-        for (offset, serial) in offsets {
-            self.lru.remove(&serial).unwrap();
-            self.cur_cost -= self
-                .cache
-                .remove(&CacheKey::new(file_id, offset))
-                .unwrap()
-                .aux
-                .cost();
-        }
-        self.debug_check_invariants();
-    }
-
-    fn get(&mut self, key: CacheKey) -> Option<Arc<dyn CacheEntry>> {
-        if let Some(value) = self.cache.get_mut(&key) {
-            self.lru.remove(&value.serial);
-            value.serial = self.next_serial;
-            self.lru.insert(value.serial, key);
-            self.next_serial += 1;
-            Some(value.aux.clone())
-        } else {
-            None
-        }
-    }
-
-    fn evict_to(&mut self, max_size: usize) {
-        while self.cur_cost > max_size {
-            let (_serial, key) = self.lru.pop_first().unwrap();
-            let value = self.cache.remove(&key).unwrap();
-            self.cur_cost -= value.aux.cost();
-        }
-        self.debug_check_invariants();
-    }
-
-    fn insert(&mut self, key: CacheKey, aux: Arc<dyn CacheEntry>) {
-        let cost = aux.cost();
-        self.evict_to(self.max_cost.saturating_sub(cost));
-        if let Some(old_value) = self.cache.insert(
-            key,
-            CacheValue {
-                aux,
-                serial: self.next_serial,
-            },
-        ) {
-            self.lru.remove(&old_value.serial);
-            self.cur_cost -= old_value.aux.cost();
-        }
-        self.lru.insert(self.next_serial, key);
-        self.cur_cost += cost;
-        self.next_serial += 1;
-        self.debug_check_invariants();
-    }
-}
-
 /// A cache on top of a storage [backend](crate::storage::backend).
 pub struct BufferCache {
-    inner: Mutex<CacheInner>,
+    inner: SharedBufferCache<CacheKey, Arc<dyn CacheEntry>>,
 }
 
 impl Debug for BufferCache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BufferCache").finish()
+        f.debug_struct("BufferCache")
+            .field("strategy", &self.strategy())
+            .finish()
     }
 }
 
 impl BufferCache {
-    /// Creates a new cache on top of `backend`.
+    /// Creates a new cache using the default [`BufferCacheStrategy`].
     ///
-    /// It's best to use a single `StorageCache` for all uses of a given
-    /// `backend`, because otherwise the cache will end up with duplicates.
-    ///
-    /// `max_cost` limits the size of the cache. It is denominated in terms of
-    /// [CacheEntry::cost].
+    /// `max_cost` limits the size of the cache in terms of [CacheEntry::cost].
     pub fn new(max_cost: usize) -> Self {
-        Self {
-            inner: Mutex::new(CacheInner::new(max_cost)),
-        }
+        Self::from_inner(
+            BufferCacheBuilder::<CacheKey, Arc<dyn CacheEntry>>::new().build_single(max_cost),
+        )
+    }
+
+    /// Returns the strategy backing this cache.
+    pub fn strategy(&self) -> BufferCacheStrategy {
+        self.inner.strategy()
     }
 
     pub fn get(
@@ -214,30 +84,71 @@ impl BufferCache {
         location: BlockLocation,
     ) -> Option<Arc<dyn CacheEntry>> {
         self.inner
-            .lock()
-            .unwrap()
             .get(CacheKey::new(file.file_id(), location.offset))
-            .clone()
     }
 
     pub fn insert(&self, file_id: FileId, offset: u64, aux: Arc<dyn CacheEntry>) {
-        self.inner
-            .lock()
-            .unwrap()
-            .insert(CacheKey::new(file_id, offset), aux);
+        self.inner.insert(CacheKey::new(file_id, offset), aux);
     }
 
     pub fn evict(&self, file: &dyn FileReader) {
-        self.inner.lock().unwrap().delete_file(file.file_id());
+        let file_id = file.file_id();
+        if let Some(lru) = self
+            .inner
+            .as_any()
+            .downcast_ref::<LruCache<CacheKey, Arc<dyn CacheEntry>>>()
+        {
+            lru.remove_range(CacheKey::file_range(file_id));
+        } else {
+            let predicate = |key: &CacheKey| key.file_id == file_id;
+            self.inner.remove_if(&predicate);
+        }
     }
 
     /// Returns `(cur_cost, max_cost)`, reporting the amount of the cache that
     /// is currently used and the maximum value, both denominated in terms of
     /// [CacheEntry::cost] for `CacheEntry`.
     pub fn occupancy(&self) -> (usize, usize) {
-        let inner = self.inner.lock().unwrap();
-        (inner.cur_cost, inner.max_cost)
+        (self.inner.total_charge(), self.inner.total_capacity())
     }
+
+    /// Builds a wrapper around an already-constructed cache backend.
+    fn from_inner(inner: SharedBufferCache<CacheKey, Arc<dyn CacheEntry>>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns an identifier for the shared cache backend used by this wrapper.
+    pub(crate) fn backend_id(&self) -> usize {
+        Arc::as_ptr(&self.inner) as *const () as usize
+    }
+
+    /// Returns `true` if `self` and `other` share the same cache backend.
+    #[cfg(test)]
+    pub(crate) fn shares_backend_with(&self, other: &Self) -> bool {
+        self.backend_id() == other.backend_id()
+    }
+}
+
+/// Creates the runtime cache layout for DBSP worker pairs.
+pub(crate) fn build_buffer_caches(
+    worker_pairs: usize,
+    total_capacity_bytes: usize,
+    strategy: BufferCacheStrategy,
+    max_buckets: Option<usize>,
+    allocation_strategy: BufferCacheAllocationStrategy,
+) -> Vec<EnumMap<ThreadType, Arc<BufferCache>>> {
+    BufferCacheBuilder::<CacheKey, Arc<dyn CacheEntry>>::new()
+        .with_buffer_cache_strategy(strategy)
+        .with_buffer_max_buckets(max_buckets)
+        .with_buffer_cache_allocation_strategy(allocation_strategy)
+        .build(worker_pairs, total_capacity_bytes)
+        .into_iter()
+        .map(|caches| {
+            EnumMap::from_fn(|thread_type| {
+                Arc::new(BufferCache::from_inner(caches[thread_type].clone()))
+            })
+        })
+        .collect()
 }
 
 /// Cache statistics that can be accessed atomically for multithread updates.
@@ -248,7 +159,7 @@ pub struct AtomicCacheStats(EnumMap<ThreadType, EnumMap<CacheAccess, AtomicCache
 impl AtomicCacheStats {
     /// Records that `location` was access in the cache with effect `access`.
     pub fn record(&self, access: CacheAccess, duration: Duration, location: BlockLocation) {
-        let Some(thread_type) = ThreadType::current() else {
+        let Some(thread_type) = current_thread_type() else {
             // TODO: record stats for aux threads.
             return;
         };

--- a/crates/dbsp/src/storage/file/reader.rs
+++ b/crates/dbsp/src/storage/file/reader.rs
@@ -5,7 +5,7 @@
 use super::format::{Compression, FileTrailer};
 use super::{AnyFactories, Deserializer, Factories};
 use crate::dynamic::{DynVec, WeightTrait};
-use crate::storage::buffer_cache::{CacheAccess, CacheEntry};
+use crate::storage::buffer_cache::CacheAccess;
 use crate::storage::file::format::FilterBlock;
 use crate::storage::tracking_bloom_filter::{BloomFilterStats, TrackingBloomFilter};
 use crate::storage::{
@@ -29,6 +29,7 @@ use binrw::{
 };
 use crc32c::crc32c;
 use dyn_clone::clone_box;
+use feldera_buffer_cache::CacheEntry;
 use feldera_storage::StoragePath;
 use feldera_storage::file::FileId;
 use size_of::SizeOf;

--- a/crates/dbsp/src/storage/file/writer.rs
+++ b/crates/dbsp/src/storage/file/writer.rs
@@ -6,7 +6,7 @@
 //! `pub`.
 use crate::storage::{
     backend::{BlockLocation, FileReader, FileWriter, StorageBackend, StorageError},
-    buffer_cache::{BufferCache, CacheEntry, FBuf, FBufSerializer, LimitExceeded},
+    buffer_cache::{BufferCache, FBuf, FBufSerializer, LimitExceeded},
     file::{
         BLOOM_FILTER_SEED,
         format::{
@@ -26,6 +26,7 @@ use crc32c::crc32c;
 #[cfg(debug_assertions)]
 use dyn_clone::clone_box;
 use fastbloom::BloomFilter;
+use feldera_buffer_cache::CacheEntry;
 use feldera_storage::StoragePath;
 use snap::raw::{Encoder, max_compress_len};
 use std::{


### PR DESCRIPTION
storage: add s3-fifo buffer cache, more config options
    
The buffer cache used to be simple. A single mutex protected it.
That design worked because only one thread accessed the cache.
    
We now want multiple threads to run merges in parallel.
That requires a cache that many threads can access without collapsing under contention.
    
This change introduces a new multi-threaded buffer cache. It also switches adds a
supposedly better eviction policy, the S3-FIFO algorithm.
    
For compatibility, this change also adds configuration flags to revert the behavior:

```
"dev_tweaks": {
        "buffer_cache_allocation_strategy": "per_thread" | "global" | "shared_per_worker_pair",
        "buffer_cache_strategy": "s3_fifo" | "lru"
      },
    
    // new defaults: s3_fifo AND shared_per_worker_pair
    // previously: lru AND per_thread
```


### Describe Manual Test Plan

Ran a few pipelines, wrote lots of tests and benchmark programs.

## Checklist

- [x] Unit tests added/updated

## Breaking Changes?

Potential for performance regressions, since it changes a critical piece of our infra. Benchmarks are promising though.
We can revert back to the old cache with a dev-tweak.