### PR TITLE
ci: fix pre-commit job still passing when pre-commit fails

### DIFF
--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -77,12 +77,11 @@ jobs:
           pre-commit run --show-diff-on-failure --color=always --all-files
         shell: bash
         if: ${{ vars.CI_DRY_RUN != 'true' }}
-        continue-on-error: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Print sccache stats
         run: sccache --show-stats
       - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403
         # Only attempt auto-fix commits for branches in this repo (forks can't be pushed to)
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           commit_message: "[ci] apply automatic fixes"
           commit_user_name: feldera-bot


### PR DESCRIPTION
Problem: continue-on-error was set conditionally, true for branches in this repo, false for forks. The intent was to allow the auto-fix commit step to run even when pre-commit fails. However, continue-on-error: true at the step level also causes the entire job to be marked as succeeded, meaning pre-commit failures on branches within this repo were silently ignored.                                         
                                                                                                                        
For fork PRs, continue-on-error was false, so pre-commit failures correctly failed the job, but the auto-fix commit step would never run (which is fine since we can't push to forks anyway).

Fix: Remove continue-on-error from the pre-commit step entirely, so pre-commit failures always fail the job regardless of whether the PR is from a fork or a branch in this repo. Move the same-repo condition to the auto-commit step using if: always() && head_repo == this_repo, so the auto-fix commit still runs after a pre-commit failure on branches within this repo, while correctly skipping it for forks.