### PR TITLE
[qa] Fixup connector status test.

### DIFF
--- a/python/tests/runtime/test_connector_status.py
+++ b/python/tests/runtime/test_connector_status.py
@@ -201,10 +201,7 @@ def test_connector_status(pipeline_name):
         "name": "kafka_out",
         "transport": {
             "name": "kafka_output",
-            "config": {
-                "topic": output_topic,
-                "bootstrap.servers": KAFKA_BOOTSTRAP
-            },
+            "config": {"topic": output_topic, "bootstrap.servers": KAFKA_BOOTSTRAP},
         },
         "format": {
             "name": "avro",


### PR DESCRIPTION
The test used `auto.offset.reset` instead if `start_from` (required as per our docs). This could lead to race conditions where the connector doesn't ingest some of the records.

