### PR TITLE
[SQL] Use stable sorting for the circuit graph -- will produce fewer …

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/DBSPCircuit.java
@@ -95,6 +95,7 @@ public final class DBSPCircuit extends DBSPNode
     }
 
     /** Sort the nodes to be compatible with a topological order on the specified graph.
+     * Preserves the order of inputs and outputs with respect to each other.
      * @param graph Topological order to enforce.  Mutated by the method. */
     public void resort(CircuitGraph graph) {
         this.allOperators.clear();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraph.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitGraph.java
@@ -7,16 +7,17 @@ import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
 import org.dbsp.util.IHasId;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.ToIndentableString;
-import org.dbsp.util.graph.DFSOrder;
 import org.dbsp.util.graph.DiGraph;
 import org.dbsp.util.graph.Port;
 import org.dbsp.util.Utilities;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 /* The Graph represents edges source->destination,
@@ -121,9 +122,44 @@ public class CircuitGraph implements DiGraph<DBSPOperator>, IHasId, ToIndentable
         return builder.decrease().append("}");
     }
 
-    /** Return a topological sort of this graph */
+    /** Return a stable topological sort of this graph */
     public Iterable<DBSPOperator> sort() {
-        DFSOrder<DBSPOperator> dfs = new DFSOrder<>(this);
-        return dfs.reversePost();
+        // Uses Kahn's algorithm for a stable sort
+        Map<DBSPOperator, Integer> inDegree = new HashMap<>();
+        for (DBSPOperator op: this.nodes)
+            Utilities.putNew(inDegree, op, 0);
+
+        for (DBSPOperator op : this.edges.keySet()) {
+            for (Port<DBSPOperator> next: this.edges.get(op)) {
+                DBSPOperator v = next.node();
+                inDegree.put(v, inDegree.get(v) + 1);
+            }
+        }
+
+        // Queue of zero-indegree nodes, in *input order*
+        Queue<DBSPOperator> q = new ArrayDeque<>();
+        for (var n : this.nodes) {
+            if (inDegree.get(n) == 0)
+                q.add(n);
+        }
+
+        List<DBSPOperator> result = new ArrayList<>();
+        while (!q.isEmpty()) {
+            DBSPOperator u = q.remove();
+            result.add(u);
+
+            for (Port<DBSPOperator> port : this.edges.get(u)) {
+                DBSPOperator v = port.node();
+                int d = inDegree.get(v) - 1;
+                inDegree.put(v, d);
+                if (d == 0) {
+                    q.add(v);
+                }
+            }
+        }
+
+        if (result.size() != this.nodes.size())
+            throw new IllegalStateException("Graph has a cycle");
+        return result;
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LinearPostprocessRetainKeys.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/LinearPostprocessRetainKeys.java
@@ -90,11 +90,11 @@ public class LinearPostprocessRetainKeys implements CircuitTransform, IWritesLog
             }
         }
 
+        if (toAdd.isEmpty())
+            return circuit;
+
         for (var p: toAdd)
             graph.addEdge(p.left, p.right, 0);
-        // Note: this may reorder the graph dramatically.  We should probably avoid doing this
-        // altogether if the circuit will not change, but this would change dramatically the output
-        // of the compiler for many programs, preventing bootstrapping.
         circuit.resort(graph);
 
         graphs.apply(circuit);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DFSOrder.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/graph/DFSOrder.java
@@ -23,9 +23,10 @@ public class DFSOrder<Node> {
         this.postorder = new ArrayList<>();
         this.preorder = new ArrayList<>();
         this.marked = new HashSet<>();
-        for (Node v: graph.getNodes())
+        for (Node v: graph.getNodes()) {
             if (!this.marked.contains(v))
                 this.dfs(graph, v);
+        }
     }
 
     // run DFS in digraph G from vertex v and compute preorder/postorder

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/OtherTests.java
@@ -119,22 +119,22 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs { // interfa
         String str = circuit.toString();
         String expected = """
                 Circuit circuit {
-                    // DBSPConstantOperator s0
-                    let s0 = constant(zset!());
-                    // DBSPSourceMultisetOperator s1
+                    // DBSPSourceMultisetOperator s0
                     // CREATE TABLE `t` (`col1` INTEGER NOT NULL, `col2` DOUBLE NOT NULL, `col3` BOOLEAN NOT NULL, `col4` VARCHAR NOT NULL, `col5` INTEGER, `col6` DOUBLE)
-                    let s1 = t();
-                    // DBSPMapOperator s2
-                    let s2 = s1.map((|p0: &Tup6<i32, d, b, s, i32?, d?>|
+                    let s0 = t();
+                    // DBSPMapOperator s1
+                    let s1 = s0.map((|p0: &Tup6<i32, d, b, s, i32?, d?>|
                     Tup1::new(((*p0).2), )));
                     // CREATE VIEW `v` AS
                     // SELECT `t`.`col3`
                     // FROM `schema`.`t` AS `t`
-                    let s3 = s2;
+                    let s2 = s1;
+                    // DBSPConstantOperator s3
+                    let s3 = constant(zset!());
                     // CREATE VIEW `error_view` AS
                     // SELECT `feldera_error_table`.`table_or_view_name`, `feldera_error_table`.`message`, `feldera_error_table`.`metadata`
                     // FROM `schema`.`feldera_error_table` AS `feldera_error_table`
-                    let s4 = s0;
+                    let s4 = s3;
                 }
                 """;
         Assert.assertEquals(expected, str);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -71,22 +71,6 @@
   },
   "mir": {
     "s0": {
-      "operation": "constant",
-      "inputs": [],
-      "calcite": {
-        "partial": 0
-      },
-      "positions": [],
-      "persistent_id": "dabdc0517fb639de8ebd480cb4350e3b2054b584a8c9c42515f268f99294f72c"
-    }, "s1": {
-      "operation": "constant",
-      "inputs": [],
-      "calcite": {
-        "partial": 3
-      },
-      "positions": [],
-      "persistent_id": "073120d9c4eea1862d5aae5f99d5753fc61d32b368fde8f3ba9a82dbd532860d"
-    }, "s2": {
       "operation": "source_multiset",
       "inputs": [],
       "table": "t",
@@ -98,20 +82,20 @@
         {"start_line_number":1,"start_column":14,"end_line_number":1,"end_column":14}
       ],
       "persistent_id": "5e6c4775639ef50da58436d192195ae13fa8cd9681af464d09f0927ebbd24bbf"
-    }, "s3": {
+    }, "s1": {
       "operation": "differentiate",
       "inputs": [
-        { "node": "s2", "output": 0 }
+        { "node": "s0", "output": 0 }
       ],
       "calcite": {
         "partial": 3
       },
       "positions": [],
       "persistent_id": "75f6aef62d77fe19e76200d21472b7cb2e51629638054899decb829ba3df3859"
-    }, "s4": {
+    }, "s2": {
       "operation": "map_index",
       "inputs": [
-        { "node": "s3", "output": 0 }
+        { "node": "s1", "output": 0 }
       ],
       "calcite": {
         "seq": [
@@ -123,10 +107,10 @@
       },
       "positions": [],
       "persistent_id": "82bbfee37e33a4b0fedde6bc5e8bb31f17ccce1fd1957ad029e9cba1bc79d2b4"
-    }, "s5": {
+    }, "s3": {
       "operation": "aggregate_linear_postprocess",
       "inputs": [
-        { "node": "s4", "output": 0 }
+        { "node": "s2", "output": 0 }
       ],
       "calcite": {
         "partial": 3
@@ -135,10 +119,30 @@
         {"start_line_number":2,"start_column":25,"end_line_number":2,"end_column":33}
       ],
       "persistent_id": "134c6466aaa7694ea35a60b8949ec0a4d70a5bf9bdf014d4fb9426d96aa7dbb7"
+    }, "s4": {
+      "operation": "map",
+      "inputs": [
+        { "node": "s3", "output": 0 }
+      ],
+      "calcite": {
+        "partial": 3
+      },
+      "positions": [],
+      "persistent_id": "bcc438bd472b190d25cfdac257bc4f4263a0003f9f939a63be4497b268ed837f"
+    }, "s5": {
+      "operation": "integrate",
+      "inputs": [
+        { "node": "s4", "output": 0 }
+      ],
+      "calcite": {
+        "partial": 3
+      },
+      "positions": [],
+      "persistent_id": "7f3b5c52bed875fc3ade540f9bcb1b1fb96f64fca107f34eb8e56469317c7b82"
     }, "s6": {
       "operation": "map",
       "inputs": [
-        { "node": "s5", "output": 0 }
+        { "node": "s3", "output": 0 }
       ],
       "calcite": {
         "partial": 3
@@ -166,41 +170,29 @@
       "positions": [],
       "persistent_id": "7bc400efc53be162b85fdaadf583824555a184e370242b950c422e39488bfd4d"
     }, "s9": {
-      "operation": "map",
+      "operation": "constant",
+      "inputs": [],
+      "calcite": {
+        "partial": 3
+      },
+      "positions": [],
+      "persistent_id": "bd39cf1159208fe39f804045bb097cac071084865503769ca862515fd35f1289"
+    }, "s10": {
+      "operation": "sum",
       "inputs": [
+        { "node": "s9", "output": 0 },
+        { "node": "s8", "output": 0 },
         { "node": "s5", "output": 0 }
       ],
       "calcite": {
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "bcc438bd472b190d25cfdac257bc4f4263a0003f9f939a63be4497b268ed837f"
-    }, "s10": {
-      "operation": "integrate",
-      "inputs": [
-        { "node": "s9", "output": 0 }
-      ],
-      "calcite": {
-        "partial": 3
-      },
-      "positions": [],
-      "persistent_id": "7f3b5c52bed875fc3ade540f9bcb1b1fb96f64fca107f34eb8e56469317c7b82"
+      "persistent_id": "5a531ea30f94f3cc3a4e724e1e9a72540d2a574be0d63565e5caa388c9f59221"
     }, "s11": {
-      "operation": "sum",
-      "inputs": [
-        { "node": "s1", "output": 0 },
-        { "node": "s8", "output": 0 },
-        { "node": "s10", "output": 0 }
-      ],
-      "calcite": {
-        "partial": 3
-      },
-      "positions": [],
-      "persistent_id": "040f303a787c124052f91dfb293018d52b0e35aa98fb24e3078bca8c09e7ddb7"
-    }, "s12": {
       "operation": "inspect",
       "inputs": [
-        { "node": "s11", "output": 0 }
+        { "node": "s10", "output": 0 }
       ],
       "view": "v",
       "calcite": {
@@ -210,11 +202,19 @@
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40},
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40}
       ],
-      "persistent_id": "c1ffe4f3132e9426e7a70371ee283614d01223417b97444e03f933502c26a854"
+      "persistent_id": "a5563f0944296ab7968e9015c9d8ced05a8e9955dec0aa1e727f76c2f4d05489"
+    }, "s12": {
+      "operation": "constant",
+      "inputs": [],
+      "calcite": {
+        "partial": 0
+      },
+      "positions": [],
+      "persistent_id": "dabdc0517fb639de8ebd480cb4350e3b2054b584a8c9c42515f268f99294f72c"
     }, "s13": {
       "operation": "inspect",
       "inputs": [
-        { "node": "s0", "output": 0 }
+        { "node": "s12", "output": 0 }
       ],
       "view": "error_view",
       "calcite": {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDFRecursive.json
@@ -367,38 +367,30 @@
       "operation": "constant",
       "inputs": [],
       "calcite": {
-        "partial": 0
-      },
-      "positions": [],
-      "persistent_id": "dabdc0517fb639de8ebd480cb4350e3b2054b584a8c9c42515f268f99294f72c"
-    }, "s1": {
-      "operation": "constant",
-      "inputs": [],
-      "calcite": {
         "final": 1
       },
       "positions": [],
       "persistent_id": "62ce603a01af7e712aaebdd9b81c3691b1293c14071e805d8aabe46b3d659d74"
-    }, "s2": {
+    }, "s1": {
       "operation": "nested",
       "outputs": [
-        { "node": "s8", "output": 0 }
+        { "node": "s7", "output": 0 }
       ],
-      "s3": {
+      "s2": {
         "operation": "Z",
         "inputs": [],
         "table": "fibonacci-decl",
-        "backedges": [{ "node": "s8", "output": 0 }],
+        "backedges": [{ "node": "s7", "output": 0 }],
         "calcite": {
           "final": 2
         },
         "positions": [],
         "persistent_id": "1cad9022fb9400950c4b4a4d9aaf96ca4433f989b896a5147b0e3335d900fe21"
       },
-      "s4": {
+      "s3": {
         "operation": "flat_map_index",
         "inputs": [
-          { "node": "s3", "output": 0 }
+          { "node": "s2", "output": 0 }
         ],
         "calcite": {
           "seq": [
@@ -414,10 +406,10 @@
         ],
         "persistent_id": "eea1fb749f276517f2ad1171fc00a889b629d190a675d1cff0ad8f04db1e6a22"
       },
-      "s5": {
+      "s4": {
         "operation": "flat_map_index",
         "inputs": [
-          { "node": "s3", "output": 0 }
+          { "node": "s2", "output": 0 }
         ],
         "calcite": {
           "seq": [
@@ -435,10 +427,10 @@
         ],
         "persistent_id": "532b61244e3f6ecac6e439489956f24fb4bdfedc3708b4dd7601e06c20c5ffc2"
       },
-      "s6": {
+      "s5": {
         "operation": "delta0",
         "inputs": [
-          { "node": "s1", "output": 0 }
+          { "node": "s0", "output": 0 }
         ],
         "calcite": {
           "final": 10
@@ -446,11 +438,11 @@
         "positions": [],
         "persistent_id": "af7a20a52ece7365a3b1440e05c39292ac5a55c6c641581b350a01ef95f65dc8"
       },
-      "s7": {
+      "s6": {
         "operation": "join",
         "inputs": [
-          { "node": "s4", "output": 0 },
-          { "node": "s5", "output": 0 }
+          { "node": "s3", "output": 0 },
+          { "node": "s4", "output": 0 }
         ],
         "calcite": {
           "partial": 6
@@ -462,11 +454,11 @@
         ],
         "persistent_id": "d2d417d4519df7cdda5f1b3418fbfdb6b8fd0a9bd9f9b890d0631e73a66cca5a"
       },
-      "s8": {
+      "s7": {
         "operation": "sum",
         "inputs": [
-          { "node": "s6", "output": 0 },
-          { "node": "s7", "output": 0 }
+          { "node": "s5", "output": 0 },
+          { "node": "s6", "output": 0 }
         ],
         "calcite": {
           "final": 10
@@ -474,10 +466,10 @@
         "positions": [],
         "persistent_id": "2f8076b543c6c81cf65784aee26bc1ce6ea646ada4c0be4625030c4f561b1413"
       }
-    }, "s9": {
+    }, "s8": {
       "operation": "inspect",
       "inputs": [
-        { "node": "s2", "output": 0 }
+        { "node": "s1", "output": 0 }
       ],
       "view": "fibonacci",
       "calcite": {
@@ -487,11 +479,19 @@
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1},
         {"start_line_number":4,"start_column":1,"end_line_number":21,"end_column":1}
       ],
-      "persistent_id": "54fa67f4bb42d34f5476863b19a23ce73c84d18ce7911f8c9f59d056e5d9c994"
+      "persistent_id": "b5b3b1df28ef92eb861bfe6cefdd8e57ff39d2d8bee21303fcc12e07d8c9a266"
+    }, "s9": {
+      "operation": "constant",
+      "inputs": [],
+      "calcite": {
+        "partial": 0
+      },
+      "positions": [],
+      "persistent_id": "dabdc0517fb639de8ebd480cb4350e3b2054b584a8c9c42515f268f99294f72c"
     }, "s10": {
       "operation": "inspect",
       "inputs": [
-        { "node": "s0", "output": 0 }
+        { "node": "s9", "output": 0 }
       ],
       "view": "error_view",
       "calcite": {


### PR DESCRIPTION
…changes when program is edited. Today the graph is resorted in some circumstances, and the sort is not stable. This may causes unnecessary changes in the output Rust program when the SQL program is edited, especially with regards to global constants that are shared between multiple operators. A stable sort should make these changes less likely.

Fixes #5752

### Describe Manual Test Plan

Ran all Java tests manually

