### PR TITLE
[web-console] Update web console vite config with dedupe

### DIFF
--- a/js-packages/web-console/vite.config.ts
+++ b/js-packages/web-console/vite.config.ts
@@ -56,6 +56,12 @@ export default defineConfig(async () => {
     build: {
       minify: false
     },
+    resolve: {
+      // When support-bundle-triage is symlinked into node_modules, vite dereferences
+      // the symlink and resolves its imports from the real path outside this workspace.
+      // dedupe forces these packages to always resolve from this workspace root.
+      dedupe: ['profiler-lib', 'triage-types', 'but-unzip']
+    },
     server: {
       watch: {
         ignored: ['**/dist/**', '**/node_modules/**', '**/.svelte-kit/**', '**/build/**']


### PR DESCRIPTION
### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

Added dedupe to the web-console vite config to ensure that when the support bundle package is installed that common dependencies are resolved from the feldera workspace root

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
