### PR TITLE
[dbsp] Always GC storage at startup.

### DIFF
--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -70,34 +70,13 @@ impl Checkpointer {
     }
 
     fn init_storage(&self) -> Result<(), Error> {
-        let usage = if !self.checkpoint_list.is_empty() {
-            self.gc_startup()?
-        } else {
-            // There's no checkpoint file, or we couldn't read it. Don't run GC,
-            // to ensure that we don't accidentally remove everything.
-            //
-            // We still know the amount of storage in use.
-            self.measure_storage_use()?
-        };
+        let usage = self.gc_startup()?;
 
         // We measured the amount of storage in use. Give it to the backend as
         // the initial value.
         self.backend.usage().store(usage as i64, Ordering::Relaxed);
 
         Ok(())
-    }
-
-    fn measure_storage_use(&self) -> Result<u64, Error> {
-        let mut usage = 0;
-        StorageError::ignore_notfound(self.backend.list(
-            &StoragePath::default(),
-            &mut |_path, file_type| {
-                if let StorageFileType::File { size } = file_type {
-                    usage += size;
-                }
-            },
-        ))?;
-        Ok(usage)
     }
 
     pub(super) fn measure_checkpoint_storage_use(&self, uuid: uuid::Uuid) -> Result<u64, Error> {


### PR DESCRIPTION
Until now, Feldera has only run GC at startup if a checkpoint file existed and was readable.  This meant that if a pipeline crashed or force-stopped before the first checkpoint, then upon restart, the pipeline did not clear any files that were in storage from previous runs.  This fixes the problem by unconditionally running GC at startup; if we can't read it now then there's no reason to believe that we will be able to read it later.

I tested this manually with a pipeline that writes to storage and force-stop.
