### PR TITLE
ci: update github actions versions

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -32,7 +32,7 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Platform Environment Variable
         shell: bash
@@ -80,7 +80,7 @@ jobs:
           touch "$RUNNER_TEMP/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -96,7 +96,7 @@ jobs:
     needs: build-docker-ci-dev
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -50,7 +50,7 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -58,7 +58,7 @@ jobs:
 
       - name: Download fda
         id: binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: fda-${{ matrix.rust_target }}
           path: build
@@ -66,7 +66,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download pipeline-manager
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pipeline-manager-${{ matrix.rust_target }}
           path: build
@@ -74,7 +74,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Compiler Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: feldera-sql-compiler
           path: build
@@ -137,7 +137,7 @@ jobs:
           touch "$RUNNER_TEMP/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -153,7 +153,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
@@ -191,7 +191,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ vars.FELDERA_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -208,7 +208,7 @@ jobs:
         run: echo "${{ steps.meta.outputs.version }}" > /tmp/docker-image-ready.txt
 
       - name: Upload docker-image-ready artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-image-ready
           path: /tmp/docker-image-ready.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,7 +7,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest-amd64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v1
         with:
           node-version: 25
@@ -34,7 +34,7 @@ jobs:
           yarn build
 
       - name: Upload docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: feldera-docs
           path: ./docs.feldera.com/build

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -20,9 +20,9 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             /home/ubuntu/.gradle
@@ -52,7 +52,7 @@ jobs:
           cp ./sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar build-artifacts/
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: feldera-sql-compiler
           path: build-artifacts

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -42,10 +42,10 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Cargo registry and index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -117,21 +117,21 @@ jobs:
 
       # Upload test binaries as one artifact
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build-artifacts
           retention-days: 7
 
       - name: Upload fda
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fda-${{ matrix.target }}
           path: build-release-artifacts/fda
           retention-days: 7
 
       - name: Upload pipeline-manager
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-manager-${{ matrix.target }}
           path: build-release-artifacts/pipeline-manager

--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         working-directory: ./python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v2
         with:
@@ -87,7 +87,7 @@ jobs:
           private-key: ${{ secrets.CI_ACCESS_APP_PKEY }}
           permission-contents: write
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # This runs on main because we make the commit on main at the end of the workflow,
           # we use the token so it can circument push to main protection rules

--- a/.github/workflows/ci-pre-mergequeue.yml
+++ b/.github/workflows/ci-pre-mergequeue.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout (internal PRs)
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # This needs to be set to a token to trigger a follow-up workflow
           # in case some changes were corrected.
@@ -50,10 +50,10 @@ jobs:
 
       - name: Checkout (fork/dependabot PRs)
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache uv pre-commit environments
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pre-commit
@@ -61,7 +61,7 @@ jobs:
           key: pre-commit-uv-1|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Cache Cargo registry and index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
           ref: ${{ env.SHA_TO_RELEASE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       artifacts_run_id: ${{ steps.result.outputs.artifacts_run_id }}
       skip_docker: ${{ steps.result.outputs.skip_docker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Finds the first prior run for this commit that has all Rust/Java build
       # artifacts. If found, its run ID is used by downstream jobs to download

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install the default version of uv
         id: setup-uv

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-amd64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@v0.17.4
@@ -33,7 +33,7 @@ jobs:
           syft "$IMAGE_REF" --output spdx-json=feldera-sbom-image-${GITHUB_SHA}.spdx.json
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: feldera-sbom
           path: |

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "K8S node: ${K8S_NODE_NAME}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
 

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -29,7 +29,7 @@ jobs:
       url: https://pypi.org/p/feldera
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
       - name: Install uv

--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -63,10 +63,10 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
@@ -142,10 +142,10 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: feldera-test-binaries-x86_64-unknown-linux-gnu
           path: build

--- a/.github/workflows/test-integration-platform.yml
+++ b/.github/workflows/test-integration-platform.yml
@@ -79,7 +79,7 @@ jobs:
       OIDC_TEST_PASSWORD: ${{ secrets.OIDC_TEST_PASSWORD }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
@@ -206,7 +206,7 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check OIDC configuration and connectivity
         if: vars.OIDC_TEST_ISSUER != '' && vars.OIDC_TEST_CLIENT_ID != ''
@@ -235,7 +235,7 @@ jobs:
           IN_CI: 1 # We use this flag to skip some kafka tests in the python code base
 
       - name: Download fda binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: fda-${{ matrix.target }}
           path: build

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -36,7 +36,7 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Python runtime tests
         if: ${{ vars.CI_DRY_RUN != 'true' && !contains(vars.CI_SKIP_JOBS, 'runtime-pytest') }}

--- a/.github/workflows/test-java-nightly.yml
+++ b/.github/workflows/test-java-nightly.yml
@@ -27,12 +27,12 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             /home/ubuntu/.gradle

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -34,12 +34,12 @@ jobs:
           echo "K8S node: ${K8S_NODE_NAME}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             /home/ubuntu/.gradle

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: feldera-test-binaries-${{ matrix.target }}
           path: build
@@ -47,7 +47,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Compiler Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: feldera-sql-compiler
           path: sql-build


### PR DESCRIPTION
ci chore task.

This is to hopefully tackle flaky downloads in ci due to [download-artifact issue](https://github.com/actions/download-artifact/issues/454)  

while updating other actions as Github might deprecated node20 runners https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#what-you-need-to-do