### PR TITLE
ci: build fda for Windows amd64

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -136,3 +136,47 @@ jobs:
           name: pipeline-manager-${{ matrix.target }}
           path: build-release-artifacts/pipeline-manager
           retention-days: 7
+
+  build-fda-native:
+    name: Build fda (Windows)
+
+    # Builds fda for Windows using GitHub-hosted larger runners.
+    # macOS arm64 will be added once self-hosted macOS runners are available.
+    # Windows arm64 is skipped for now — the runner lacks Rust and MSVC.
+    strategy:
+      matrix:
+        include:
+          - runner: windows-latest-amd64
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.runner }}
+
+    # sccache is not available on Windows GitHub-hosted runners
+    env:
+      RUSTC_WRAPPER: ""
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Cache Cargo registry and index
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ runner.os }}-${{ matrix.target }}-
+
+      - name: Build fda
+        run: cargo build --release --locked -p fda --target=${{ matrix.target }}
+
+      - name: Upload fda
+        uses: actions/upload-artifact@v7
+        with:
+          name: fda-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/fda.exe
+          retention-days: 7

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -111,6 +111,7 @@ jobs:
             pipeline-manager-x86_64-unknown-linux-gnu.zip
             fda-x86_64-unknown-linux-gnu.zip
             fda-aarch64-unknown-linux-gnu.zip
+            fda-x86_64-pc-windows-msvc.zip
             sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
             feldera-sbom-source.spdx.json
             feldera-sbom-image.spdx.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           required-artifacts: |
             fda-x86_64-unknown-linux-gnu
             fda-aarch64-unknown-linux-gnu
+            fda-x86_64-pc-windows-msvc
             pipeline-manager-x86_64-unknown-linux-gnu
             pipeline-manager-aarch64-unknown-linux-gnu
             feldera-test-binaries-x86_64-unknown-linux-gnu

--- a/docs.feldera.com/static/install-fda
+++ b/docs.feldera.com/static/install-fda
@@ -47,31 +47,38 @@ detect_platform() {
     ARCH="$(uname -m)"
 
     case "$OS" in
-        Linux)  ;;
+        Linux)
+            case "$ARCH" in
+                x86_64 | amd64)
+                    TARGET="x86_64-unknown-linux-gnu"
+                    ;;
+                aarch64 | arm64)
+                    TARGET="aarch64-unknown-linux-gnu"
+                    ;;
+                *)
+                    err "unsupported Linux architecture: $ARCH. Supported: x86_64, aarch64"
+                    ;;
+            esac
+            info "Detected platform: Linux $ARCH"
+            ;;
         Darwin)
-            err "MacOS is not currently supported. Install fda with: cargo install fda"
+            case "$ARCH" in
+                arm64 | aarch64)
+                    TARGET="aarch64-apple-darwin"
+                    ;;
+                *)
+                    err "unsupported macOS architecture: $ARCH. Only arm64 (Apple Silicon) is supported. Install fda with: cargo install fda"
+                    ;;
+            esac
+            info "Detected platform: macOS $ARCH"
             ;;
         MINGW* | MSYS* | CYGWIN*)
-            err "Windows is not currently supported. Install fda with: cargo install fda"
+            err "Windows is not currently supported by this installer. Download fda from https://github.com/feldera/feldera/releases or install with: cargo install fda"
             ;;
         *)
             err "unsupported operating system: $OS"
             ;;
     esac
-
-    case "$ARCH" in
-        x86_64 | amd64)
-            TARGET="x86_64-unknown-linux-gnu"
-            ;;
-        aarch64 | arm64)
-            TARGET="aarch64-unknown-linux-gnu"
-            ;;
-        *)
-            err "unsupported architecture: $ARCH. Supported: x86_64, aarch64"
-            ;;
-    esac
-
-    info "Detected platform: Linux $ARCH"
 }
 
 resolve_version() {


### PR DESCRIPTION
Add a build-fda-native job that builds fda on the Windows amd64 GitHub-hosted runner and uploads it as a release artifact.

macOS arm64 is pending self-hosted runner availability. Windows arm64 is skipped for now as it lacks Rust and MSVC on the runner.

Also update the install-fda script to support macOS arm64 once binaries are available, and improve error messages for unsupported platforms.

Adds a build-fda-native job to build and release the fda CLI for Windows amd64 using the GitHub-hosted windows-latest-amd64 runner.

Changes:
- build-rust.yml: new build-fda-native job that builds -p fda for x86_64-pc-windows-msvc and uploads the artifact
- ci.yml: adds fda-x86_64-pc-windows-msvc to the required artifacts check so prior builds can be reused
- ci-release.yml: includes fda-x86_64-pc-windows-msvc.zip in GitHub releases
- install-fda:  adds macOS arm64 support (ready for when binaries are available), improves error messages for unsupported platforms

Not included (follow-up):
- macOS arm64: pending self-hosted macOS runners
- Windows arm64: runner lacks Rust and MSVC; skipped for now as Windows arm64 is not common
- Windows install script support:  tracked in #

Fixes #5734 