### PR TITLE
cargo: update `lz4_flex` to `0.12.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6936,9 +6936,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]


### PR DESCRIPTION
Done using `cargo update lz4_flex`.