### PR TITLE
[web-console] Improve Samply profile download UX

### DIFF
--- a/js-packages/web-console/src/lib/components/dialogs/DownloadProgressDisplay.svelte
+++ b/js-packages/web-console/src/lib/components/dialogs/DownloadProgressDisplay.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { Progress } from '@skeletonlabs/skeleton-svelte'
+  import { humanSize } from '$lib/functions/common/string'
+
+  const {
+    progress,
+    label
+  }: {
+    progress: { percent: number | null; bytes: { downloaded: number; total: number } }
+    label: string
+  } = $props()
+</script>
+
+<div class="flex flex-col items-center gap-3 py-4">
+  <Progress class="h-1" value={progress.percent} max={100}>
+    <Progress.Track>
+      <Progress.Range class="bg-primary-500" />
+    </Progress.Track>
+  </Progress>
+  <div class="flex w-full justify-between gap-2">
+    <span>{label}</span>
+    {#if progress.bytes.downloaded > 0}
+      <span>
+        {humanSize(progress.bytes.downloaded)}{progress.bytes.total > 0
+          ? ` / ${humanSize(progress.bytes.total)}`
+          : ''}
+      </span>
+    {/if}
+  </div>
+</div>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/DownloadSupportBundle.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/DownloadSupportBundle.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { Progress, Switch } from '@skeletonlabs/skeleton-svelte'
   import Tooltip from '$lib/components/common/Tooltip.svelte'
   import GenericDialog from '$lib/components/dialogs/GenericDialog.svelte'
+  import DownloadProgressDisplay from '$lib/components/dialogs/DownloadProgressDisplay.svelte'
   import { useGlobalDialog } from '$lib/compositions/layout/useGlobalDialog.svelte'
   import { useDownloadProgress } from '$lib/compositions/useDownloadProgress.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
-  import { humanSize } from '$lib/functions/common/string'
   import type { SupportBundleOptions } from '$lib/services/pipelineManager'
 
   const { pipelineName }: { pipelineName: string } = $props()
@@ -26,6 +25,7 @@
         result.cancel()
         isDownloading = false
       }
+      globalDialog.onclose = () => cancelDownload?.()
 
       await result.dataPromise
     }
@@ -118,19 +118,7 @@
     {/snippet}
     <div class="-mt-2 pb-2 font-semibold">{pipelineName}</div>
     {#if isDownloading}
-      <div class="flex flex-col items-center gap-3 py-4">
-        <Progress class="h-1" value={progress.percent} max={100}>
-          <Progress.Track>
-            <Progress.Range class="bg-primary-500" />
-          </Progress.Track>
-        </Progress>
-        <div class="flex w-full justify-between gap-2">
-          <span>Downloading support bundle...</span>
-          {#if progress.percent}
-            <span>{humanSize(progress.bytes.downloaded)} / {humanSize(progress.bytes.total)}</span>
-          {/if}
-        </div>
-      </div>
+      <DownloadProgressDisplay {progress} label="Downloading support bundle..." />
     {:else}
       Select the details you want to include in the bundle
       {@render supportBundleForm()}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabSamplyProfile.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabSamplyProfile.svelte
@@ -26,8 +26,8 @@
   import { useGlobalDialog } from '$lib/compositions/layout/useGlobalDialog.svelte'
   import { useDownloadProgress } from '$lib/compositions/useDownloadProgress.svelte'
   import { useToast } from '$lib/compositions/useToastNotification'
-  import { humanSize } from '$lib/functions/common/string'
   import { triggerFileDownload } from '$lib/services/browser'
+  import DownloadProgressDisplay from '$lib/components/dialogs/DownloadProgressDisplay.svelte'
 
   let { pipeline }: { pipeline: { current: ExtendedPipeline } } = $props()
 
@@ -147,22 +147,28 @@
 
   // Download profile handler
   const handleDownloadProfile = async (latest: boolean) => {
-    try {
-      isDownloading = true
-      downloadProgress.reset()
-      downloadCancelFn = null
+    isDownloading = true
+    downloadProgress.reset()
+    downloadCancelFn = null
 
+    // Show dialog immediately so the indeterminate animation plays while the request is pending
+    globalDialog.dialog = downloadDialog
+    globalDialog.onclose = () => {
+      downloadCancelFn?.()
+      isDownloading = false
+    }
+
+    try {
       const result = await api.getSamplyProfile(
         pipeline.current.name,
         latest,
         downloadProgress.onProgress
       )
       if ('expectedInSeconds' in result) {
-        // Profile is still being collected, update countdown with the server's expected time
+        // Profile is still being collected, close the dialog and update countdown
+        globalDialog.dialog = null
         const now = Date.now()
         expectedCompletion = now + result.expectedInSeconds * 1000
-
-        // Ensure collecting state is active
         if (!isCollecting) {
           isCollecting = true
           profileReady = false
@@ -172,15 +178,15 @@
         return
       }
 
-      // Store cancel function
+      // If user dismissed the dialog while the request was pending, stop
+      if (!isDownloading) {
+        result.cancel()
+        return
+      }
+
       downloadCancelFn = result.cancel
 
-      // Show download dialog for actual download
-      globalDialog.dialog = downloadDialog
-
       const download = await result.downloadPromise
-
-      // Await the download to complete
       triggerFileDownload(download.filename, await download.dataPromise)
 
       globalDialog.dialog = null
@@ -355,22 +361,6 @@
     {#snippet title()}
       Downloading Samply Profile
     {/snippet}
-    <div class="flex flex-col items-center gap-3 py-4">
-      <Progress class="h-1" value={downloadProgress.percent ?? 0} max={100}>
-        <Progress.Track>
-          <Progress.Range class="bg-primary-500" />
-        </Progress.Track>
-      </Progress>
-      <div class="flex w-full justify-between gap-2">
-        <span>Downloading profile...</span>
-        {#if downloadProgress.percent}
-          <span
-            >{humanSize(downloadProgress.bytes.downloaded)} / {humanSize(
-              downloadProgress.bytes.total
-            )}</span
-          >
-        {/if}
-      </div>
-    </div>
+    <DownloadProgressDisplay progress={downloadProgress} label="Downloading profile..." />
   </GenericDialog>
 {/snippet}

--- a/js-packages/web-console/src/lib/services/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/services/pipelineManager.ts
@@ -721,10 +721,9 @@ const streamToDownload = (
     response.headers.get('content-length')
   )
 
-  const streamWithProgress =
-    nonNull(totalBytes) && onProgress
-      ? response.body!.pipeThrough(progressTransform(totalBytes, onProgress))
-      : response.body
+  const streamWithProgress = onProgress
+    ? response.body!.pipeThrough(progressTransform(totalBytes ?? 0, onProgress))
+    : response.body
 
   // Extract filename from Content-Disposition header
   const contentDisposition = response.headers.get('Content-Disposition')


### PR DESCRIPTION
Display download progress immediately and properly

Avoid resuming the download when user clicked away from the dialog

Unify download dialog implementation between Samply profile and Support bundle

Testing: manual
[Screencast from 2026-03-18 04-16-31.webm](https://github.com/user-attachments/assets/216c34d1-5a79-4260-8faf-f3748507a81a)
