### PR TITLE
ci: bump github-pages-deploy-action to v4.7.5

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Deploy docs.feldera.com
         if: ${{ vars.RELEASE_DRY_RUN == 'false' }}
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
+        uses: JamesIves/github-pages-deploy-action@4ef313c6a410f0883308623d45510e4a11625465 # v4.7.5
         with:
           folder: docs
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
actions/checkout@v6 changed credential storage to use git's includeIf directive, scoped to the repo directory. This broke cross-repo deployments in github-pages-deploy-action (v4.7.3) as the credentials don't carry over to the temp directory used for pushing to feldera/docs.feldera.com, causing git exit code 128 and skipping Docker image tagging for 0.270.0 and 0.271.0.

v4.7.5 explicitly fixes cross-repo deployment with checkout@v6 credentials.