### PR TITLE
[SQL] Better validation to reject ROWS window queries

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
@@ -68,9 +68,7 @@ import java.util.Objects;
 
 import static org.dbsp.sqlCompiler.ir.type.DBSPTypeCode.*;
 
-/**
- * Implements a window aggregate with a RANGE
- */
+/** Implements a window aggregate with a RANGE */
 public class RangeAggregates extends WindowAggregates {
     final int orderColumnIndex;
     final RelFieldCollation collation;
@@ -78,13 +76,16 @@ public class RangeAggregates extends WindowAggregates {
     protected RangeAggregates(CalciteToDBSPCompiler compiler, Window window, Window.Group group, int windowFieldIndex) {
         super(compiler, window, group, windowFieldIndex);
 
+        CalciteObject object = CalciteObject.create(group.aggCalls.get(0).pos);
         List<RelFieldCollation> orderKeys = this.group.orderKeys.getFieldCollations();
+        if (group.isRows)
+            throw new UnimplementedException("Window aggregates with ROWS", 457, object);
         if (orderKeys.isEmpty())
-            throw new CompilationError("Missing ORDER BY in OVER", node);
+            throw new CompilationError("Missing ORDER BY in OVER", object);
         if (orderKeys.size() > 1)
-            throw new UnimplementedException("ORDER BY in OVER requires exactly 1 column", 457, node);
+            throw new UnimplementedException("ORDER BY in OVER requires exactly 1 column", 457, object);
         if (group.exclude != RexWindowExclusion.EXCLUDE_NO_OTHER)
-            throw new UnimplementedException("EXCLUDE BY in OVER", 457, node);
+            throw new UnimplementedException("EXCLUDE BY in OVER", 457, object);
 
         this.collation = orderKeys.get(0);
         this.orderColumnIndex = this.collation.getFieldIndex();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/WindowTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/WindowTests.java
@@ -210,13 +210,13 @@ public class WindowTests extends ScottBaseTests {
         String[] aggregates = new String[] {
                 "account_id", """
                 LAG(runtime_elapsed_msecs) OVER (
-                            PARTITION BY account_id
-                            ORDER BY event_timestamp
-                        ) AS daily_runtime_increment""", """
+                    PARTITION BY account_id
+                    ORDER BY event_timestamp
+                ) AS daily_runtime_increment""", """
                 ROW_NUMBER() OVER (
-                            PARTITION BY account_id
-                            ORDER BY event_timestamp DESC
-                        ) AS event_rank"""
+                    PARTITION BY account_id
+                    ORDER BY event_timestamp DESC
+                ) AS event_rank"""
         };
         String tail = """
                   FROM T

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -787,8 +787,23 @@ public class Regression2Tests extends SqlIoTest {
                   SUM(amount) OVER (
                     PARTITION BY customer_id
                     ORDER BY payment_time
-                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                   ) AS running_amount
                 FROM payments""", "Not yet implemented: ROW_NUMBER only supported in a TopK pattern");
+    }
+
+    @Test
+    public void rowsTest() {
+        this.statementsFailingInCompilation("""
+                CREATE TABLE purchase (
+                    ts TIMESTAMP NOT NULL,
+                    amount BIGINT,
+                    value BIGINT LATENESS 5
+                );
+                
+                CREATE MATERIALIZED VIEW rolling_sum AS
+                SELECT ts,
+                    SUM(value) OVER (ORDER BY ts ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS rolling_sum
+                    FROM purchase;""", "Not yet implemented: Window aggregates with ROWS");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/streaming/ProfilingTests.java
@@ -389,6 +389,8 @@ public class ProfilingTests extends StreamingTestBase {
                 let _ = circuit.transaction().expect("could not run circuit");
                 let _ = circuit.transaction().expect("could not run circuit");
                 """);
+        if (BaseSQLTests.skipRust)
+            return;
         this.measure(sql, main);
     }
 }


### PR DESCRIPTION
This PR adds a test with a program that should have been rejected by the compiler, but wasn't.
I had to edit two qa programs for this to pass as well.
It is conceivable that (at least some forms) of ROWS could be supported, but some DBSP help is needed.