### PR TITLE
Fix/ci release docs deploy

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.CI_ACCESS_APP_ID }}
           private-key: ${{ secrets.CI_ACCESS_APP_PKEY }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Generate Release token
         id: release-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.CI_ACCESS_APP_ID }}
           private-key: ${{ secrets.CI_ACCESS_APP_PKEY }}


### PR DESCRIPTION
actions/create-github-app-token@v2 resolved to v2.2.2 which bumped @actions/core from 1.11.1 to 3.0.0. The 3.0.0 release is now ESM-only, which causes the app token to not be set correctly as a step output. 

The docs deploy step then falls back to GITHUB_TOKEN (github-actions[bot]), which doesn't have write access to feldera/docs.feldera.com, resulting in a 403 and skipping Docker image tagging.