### PR TITLE
Fix/ci release docs deploy

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           fetch-tags: true
           ref: ${{ env.SHA_TO_RELEASE }}
+          persist-credentials: false
 
       - name: Download artifact
         id: download-artifact


### PR DESCRIPTION
add persist-credentials: false to the checkout step so no credentials are stored, and only the deploy action's own app token is used.
