### PR TITLE
[SQL] Support for OVER window queries with UNSIGNED and UUID NOT NULL sort orders

### DIFF
--- a/crates/sqllib/src/aggregates.rs
+++ b/crates/sqllib/src/aggregates.rs
@@ -13,8 +13,11 @@ use std::marker::Copy;
 
 /// Holds some methods for wrapping values into unsigned values
 /// This is used by partitioned_rolling_aggregate
+/// Note: I have changed the name of this class because I have
+/// changed how it works internally; the name change will prevent
+/// programs from reusing incorrectly old state.
 #[doc(hidden)]
-pub struct UnsignedWrapper {}
+pub struct UnsignedWrappers {}
 
 /// The conversion involves four types:
 /// O: the original type which is being converted
@@ -22,9 +25,8 @@ pub struct UnsignedWrapper {}
 /// I: an intermediate signed type wider than S
 /// U: an unsigned type the same width as I
 //  None of the 'unwrap' calls below should ever fail.
-impl UnsignedWrapper {
+impl UnsignedWrappers {
     // Conversion from O to U
-    // O cannot be nullable, so nullsLast is irrelevant
     #[doc(hidden)]
     pub fn from_signed<O, S, I, U>(value: O, ascending: bool, _nullsLast: bool) -> U
     where
@@ -45,31 +47,73 @@ impl UnsignedWrapper {
         result
     }
 
-    // Conversion from O to U
+    // Conversion from Option<O> to U
     #[doc(hidden)]
     pub fn from_option<O, S, I, U>(value: Option<O>, ascending: bool, nullsLast: bool) -> U
     where
         O: ToInteger<S> + Debug,
         S: SignedPrimInt,
         I: SignedPrimInt + From<S>,
-        U: UnsignedPrimInt + TryFrom<I> + HasZero + Debug,
+        U: UnsignedPrimInt + TryFrom<I> + HasZero + HasOne + Debug,
         <U as TryFrom<I>>::Error: Debug,
     {
         match value {
             None => {
                 if nullsLast {
-                    U::large()
+                    // Add two because abs(MIN) is actually MAX+1 for
+                    // signed types, and we leave space for None
+                    U::large() + <U as HasOne>::one() + <U as HasOne>::one()
                 } else {
                     <U as HasZero>::zero()
                 }
             }
-            Some(value) => UnsignedWrapper::from_signed::<O, S, I, U>(value, ascending, nullsLast),
+            Some(value) => UnsignedWrappers::from_signed::<O, S, I, U>(value, ascending, nullsLast),
+        }
+    }
+
+    // Conversion from U to U, where U is the original unsigned type
+    #[doc(hidden)]
+    pub fn from_unsigned<U>(value: U, ascending: bool, _nullsLast: bool) -> U
+    where
+        U: UnsignedPrimInt + Debug,
+    {
+        let result = if ascending {
+            value
+        } else {
+            U::max_value() - value
+        };
+        // println!("Encoded {:?} as {:?}", value, result);
+        result
+    }
+
+    // Conversion from Option<O> to U, where O is unsigned
+    #[doc(hidden)]
+    pub fn from_unsigned_option<O, U>(value: Option<O>, ascending: bool, nullsLast: bool) -> U
+    where
+        O: UnsignedPrimInt + Debug,
+        U: UnsignedPrimInt + HasZero + HasOne + Debug + From<O>,
+    {
+        match value {
+            None => {
+                if nullsLast {
+                    U::large() + <U as HasOne>::one()
+                } else {
+                    <U as HasZero>::zero()
+                }
+            }
+            Some(value) => {
+                let n = if ascending {
+                    value
+                } else {
+                    O::max_value() - value
+                };
+                let i = <U as From<O>>::from(n);
+                i + <U as HasOne>::one()
+            }
         }
     }
 
     // Conversion from U to O
-    // O cannot be nullable, so nullsLast is irrelevant
-    // However, we still have it so that the signature of both
     // functions is the same.
     #[doc(hidden)]
     pub fn to_signed<O, S, I, U>(value: U, ascending: bool, _nullsLast: bool) -> O
@@ -90,27 +134,773 @@ impl UnsignedWrapper {
         result
     }
 
-    // Conversion from U to O where the 0 of U is converted to None
+    // Conversion from U to Option<O> where the 0 of U is converted to None
     #[doc(hidden)]
     pub fn to_signed_option<O, S, I, U>(value: U, ascending: bool, nullsLast: bool) -> Option<O>
     where
         O: FromInteger<S> + Debug,
         S: SignedPrimInt + TryFrom<U> + TryFrom<I>,
         I: SignedPrimInt + From<S> + TryFrom<U>,
-        U: UnsignedPrimInt + TryFrom<I> + Debug,
+        U: UnsignedPrimInt + HasOne + TryFrom<I> + Debug,
         <I as TryFrom<U>>::Error: Debug,
         <S as TryFrom<I>>::Error: Debug,
     {
         if nullsLast {
-            if <U as FirstLargeValue>::large() == value {
+            if <U as FirstLargeValue>::large() + <U as HasOne>::one() + <U as HasOne>::one()
+                == value
+            {
                 return None;
             }
         } else if <U as HasZero>::is_zero(&value) {
             return None;
         }
-        let o = UnsignedWrapper::to_signed::<O, S, I, U>(value, ascending, nullsLast);
+        let o = UnsignedWrappers::to_signed::<O, S, I, U>(value, ascending, nullsLast);
         Some(o)
     }
+
+    #[doc(hidden)]
+    pub fn to_unsigned<U>(value: U, ascending: bool, nullsLast: bool) -> U
+    where
+        U: UnsignedPrimInt + Debug,
+    {
+        UnsignedWrappers::from_unsigned::<U>(value, ascending, nullsLast)
+    }
+
+    // Conversion from Option<O> to U, where O is unsigned
+    #[doc(hidden)]
+    pub fn to_unsigned_option<O, U>(value: U, ascending: bool, nullsLast: bool) -> Option<O>
+    where
+        O: UnsignedPrimInt + Debug + TryFrom<U>,
+        <O as TryFrom<U>>::Error: Debug,
+        U: UnsignedPrimInt + HasZero + HasOne + Debug,
+    {
+        if nullsLast {
+            if value == U::large() + <U as HasOne>::one() {
+                return None;
+            }
+        } else if value == <U as HasZero>::zero() {
+            return None;
+        }
+        let i = value - <U as HasOne>::one();
+        let o = O::try_from(i).unwrap();
+        if ascending {
+            Some(o)
+        } else {
+            Some(O::max_value() - o)
+        }
+    }
+}
+
+#[test]
+fn testUnsignedWrapper() {
+    let i32max = i32::MAX as u64;
+
+    // ascending, nullsFirst
+    // The i32 range is mapped as follows with nullsFirst
+    // null         => 0
+    // i32::MIN     => 1
+    // i32::MIN + 1 => 2
+    // -1           => i32::MAX + 1
+    // 0            => i32::MAX + 2
+    // 1            => i32::MAX + 3
+    // i32::MAX     => i32::MAX * 2 + 2
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN, true, false)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN + 1, true, false)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(-1i32, true, false)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(0i32, true, false)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(1i32, true, false)
+    );
+    assert_eq!(
+        i32max * 2 + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX, true, false)
+    );
+
+    // ascending, nullsFirst, option types
+    assert_eq!(
+        0u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(None, true, false)
+    );
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN), true, false)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN + 1), true, false)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(-1i32), true, false)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(0i32), true, false)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(1i32), true, false)
+    );
+    assert_eq!(
+        i32max * 2 + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX), true, false)
+    );
+
+    // ascending, nullsLast
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN, true, true)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN + 1, true, true)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(-1i32, true, true)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(0i32, true, true)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(1i32, true, true)
+    );
+    assert_eq!(
+        i32max * 2 + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX, true, true)
+    );
+
+    // ascending, nullsLast, option types
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN), true, true)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN + 1), true, true)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(-1i32), true, true)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(0i32), true, true)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(1i32), true, true)
+    );
+    assert_eq!(
+        i32max * 2 + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX), true, true)
+    );
+    assert_eq!(
+        i32max * 2 + 4,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(None, true, true)
+    );
+
+    // descending: flip around 0
+    // The i32 range is mapped as follows with nullsFirst
+    // i32::MAX     => 2
+    // i32::MAX - 1 => 3
+    // 1            => i32::MAX + 1
+    // 0            => i32::MAX + 2
+    // -1           => i32::MAX + 3
+    // i32::MIN     => i32::MAX * 2 + 3
+    // null         => i32::MAX * 2 + 4
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX, false, false)
+    );
+    assert_eq!(
+        3u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX - 1, false, false)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(1i32, false, false)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(0i32, false, false)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(-1i32, false, false)
+    );
+    assert_eq!(
+        i32max * 2 + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN, false, false)
+    );
+
+    // descending, nullsFirst, option types
+    assert_eq!(
+        0u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(None, false, false)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX), false, false)
+    );
+    assert_eq!(
+        3u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX - 1), false, false)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(1i32), false, false)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(0i32), false, false)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(-1i32), false, false)
+    );
+    assert_eq!(
+        i32max * 2 + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN), false, false)
+    );
+
+    // descending, nullsLast
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX, false, true)
+    );
+    assert_eq!(
+        3u64,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MAX - 1, false, true)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(1i32, false, true)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(0i32, false, true)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(-1i32, false, true)
+    );
+    assert_eq!(
+        i32max * 2 + 3,
+        UnsignedWrappers::from_signed::<i32, i32, i64, u64>(i32::MIN, false, true)
+    );
+
+    // descending, nullsLast, option types
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX), false, true)
+    );
+    assert_eq!(
+        3u64,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MAX - 1), false, true)
+    );
+    assert_eq!(
+        i32max + 1,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(1i32), false, true)
+    );
+    assert_eq!(
+        i32max + 2,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(0i32), false, true)
+    );
+    assert_eq!(
+        i32max + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(-1i32), false, true)
+    );
+    assert_eq!(
+        i32max * 2 + 3,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(Some(i32::MIN), false, true)
+    );
+    assert_eq!(
+        i32max * 2 + 4,
+        UnsignedWrappers::from_option::<i32, i32, i64, u64>(None, false, true)
+    );
+}
+
+#[test]
+fn testUnsignedWrapperUnsigned() {
+    let u32max = u32::MAX as u64;
+
+    // ascending, nullsLast
+    assert_eq!(0u32, UnsignedWrappers::from_unsigned::<u32>(0, true, false));
+    assert_eq!(1u32, UnsignedWrappers::from_unsigned::<u32>(1, true, false));
+    assert_eq!(
+        u32::MAX - 1,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX - 1, true, false)
+    );
+    assert_eq!(
+        u32::MAX,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX, true, false)
+    );
+
+    // ascending, nullsFirst, option types
+    assert_eq!(
+        0u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(None, true, false)
+    );
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(0u32), true, false)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(1u32), true, false)
+    );
+    assert_eq!(
+        u32max,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX - 1u32), true, false)
+    );
+    assert_eq!(
+        u32max + 1,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX), true, false)
+    );
+
+    // ascending, nullsLast
+    assert_eq!(0u32, UnsignedWrappers::from_unsigned::<u32>(0, true, true));
+    assert_eq!(1u32, UnsignedWrappers::from_unsigned::<u32>(1, true, true));
+    assert_eq!(
+        u32::MAX - 1,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX - 1, true, true)
+    );
+    assert_eq!(
+        u32::MAX,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX, true, true)
+    );
+
+    // ascending, nullsLast, option types
+    assert_eq!(
+        u32max + 2,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(None, true, true)
+    );
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(0u32), true, true)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(1u32), true, true)
+    );
+    assert_eq!(
+        u32max,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX - 1u32), true, true)
+    );
+    assert_eq!(
+        u32max + 1,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX), true, true)
+    );
+
+    //////////// descending
+
+    // descending, nullsLast
+    assert_eq!(
+        u32::MAX,
+        UnsignedWrappers::from_unsigned::<u32>(0, false, true)
+    );
+    assert_eq!(
+        u32::MAX - 1u32,
+        UnsignedWrappers::from_unsigned::<u32>(1, false, true)
+    );
+    assert_eq!(
+        1u32,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX - 1, false, true)
+    );
+    assert_eq!(
+        0u32,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX, false, true)
+    );
+
+    // descending, nullsLast, option types
+    assert_eq!(
+        u32max + 2,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(None, false, true)
+    );
+    assert_eq!(
+        u32max + 1,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(0u32), false, true)
+    );
+    assert_eq!(
+        u32max,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(1u32), false, true)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX - 1u32), false, true)
+    );
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX), false, true)
+    );
+
+    // descending, nullsFirst
+    assert_eq!(
+        u32::MAX,
+        UnsignedWrappers::from_unsigned::<u32>(0, false, false)
+    );
+    assert_eq!(
+        u32::MAX - 1u32,
+        UnsignedWrappers::from_unsigned::<u32>(1, false, false)
+    );
+    assert_eq!(
+        1u32,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX - 1, false, false)
+    );
+    assert_eq!(
+        0u32,
+        UnsignedWrappers::from_unsigned::<u32>(u32::MAX, false, false)
+    );
+
+    // descending, nullsFirst, option types
+    assert_eq!(
+        0u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(None, false, false)
+    );
+    assert_eq!(
+        u32max + 1,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(0u32), false, false)
+    );
+    assert_eq!(
+        u32max,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(1u32), false, false)
+    );
+    assert_eq!(
+        2u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX - 1u32), false, false)
+    );
+    assert_eq!(
+        1u64,
+        UnsignedWrappers::from_unsigned_option::<u32, u64>(Some(u32::MAX), false, false)
+    );
+}
+
+#[cfg(test)]
+static DATA: &[i32] = &[
+    i32::MIN,
+    i32::MIN + 1,
+    -2i32,
+    -1i32,
+    0i32,
+    1i32,
+    2i32,
+    i32::MAX - 1,
+    i32::MAX,
+];
+
+#[cfg(test)]
+fn optData() -> Vec<Option<i32>> {
+    let mut result = DATA.iter().map(|v| Some(*v)).collect::<Vec<Option<i32>>>();
+    result.push(None);
+    result
+}
+
+#[test]
+fn testUnsignedWrapperInverse() {
+    // Check that to_signed is the inverse of from_signed
+    for asc in [false, true] {
+        for nullsLast in [false, true] {
+            for v in DATA {
+                let u = UnsignedWrappers::from_signed::<i32, i32, i64, u64>(*v, asc, nullsLast);
+                let s = UnsignedWrappers::to_signed::<i32, i32, i64, u64>(u, asc, nullsLast);
+                assert_eq!(*v, s);
+            }
+        }
+    }
+
+    // check that to_signed_option is the inverse of from_option
+    let optVals = optData();
+    for asc in [false, true] {
+        for nullsLast in [false, true] {
+            for v in &optVals {
+                let u = UnsignedWrappers::from_option::<i32, i32, i64, u64>(*v, asc, nullsLast);
+                let s = UnsignedWrappers::to_signed_option::<i32, i32, i64, u64>(u, asc, nullsLast);
+                assert_eq!(*v, s);
+            }
+        }
+    }
+}
+
+#[test]
+fn testUnsignedWrapperOrderDescending() {
+    let mut reverse = DATA.to_vec();
+    reverse.reverse();
+
+    // Check that the unsigned conversion preservers order
+    let mut uvals = DATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_signed::<i32, i32, i64, u64>(*v, false, true))
+        .collect::<Vec<u64>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed::<i32, i32, i64, u64>(*v, false, true))
+        .collect::<Vec<i32>>();
+    assert_eq!(reverse, inverse);
+
+    // Same holds for nulls first...
+    let mut uvals = DATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_signed::<i32, i32, i64, u64>(*v, false, false))
+        .collect::<Vec<u64>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed::<i32, i32, i64, u64>(*v, false, false))
+        .collect::<Vec<i32>>();
+    assert_eq!(reverse, inverse);
+
+    // Test for option types, nulls last
+    let mut opts = optData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_option::<i32, i32, i64, u64>(*v, false, true))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed_option::<i32, i32, i64, u64>(*v, false, true))
+        .collect::<Vec<Option<i32>>>();
+    // None will be first now
+    opts.rotate_right(1);
+    opts.reverse();
+    assert_eq!(opts, inverse);
+
+    // Test for option types, nulls first
+    let mut opts = optData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_option::<i32, i32, i64, u64>(*v, false, false))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed_option::<i32, i32, i64, u64>(*v, false, false))
+        .collect::<Vec<Option<i32>>>();
+    opts.reverse();
+    assert_eq!(opts, inverse);
+}
+
+#[test]
+fn testUnsignedWrapperOrderAscending() {
+    // Check that the unsigned conversion preservers order
+    let mut uvals = DATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_signed::<i32, i32, i64, u64>(*v, true, true))
+        .collect::<Vec<u64>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed::<i32, i32, i64, u64>(*v, true, true))
+        .collect::<Vec<i32>>();
+    assert_eq!(DATA, inverse);
+
+    // Same holds for nulls first...
+    let mut uvals = DATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_signed::<i32, i32, i64, u64>(*v, true, false))
+        .collect::<Vec<u64>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed::<i32, i32, i64, u64>(*v, true, false))
+        .collect::<Vec<i32>>();
+    assert_eq!(DATA, inverse);
+
+    // Test for option types, nulls last
+    let opts = optData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_option::<i32, i32, i64, u64>(*v, true, true))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed_option::<i32, i32, i64, u64>(*v, true, true))
+        .collect::<Vec<Option<i32>>>();
+    assert_eq!(opts, inverse);
+
+    // Test for option types, nulls first
+    let mut opts = optData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_option::<i32, i32, i64, u64>(*v, true, false))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_signed_option::<i32, i32, i64, u64>(*v, true, false))
+        .collect::<Vec<Option<i32>>>();
+    // None will be first now
+    opts.rotate_right(1);
+    assert_eq!(opts, inverse);
+}
+
+#[cfg(test)]
+static UDATA: &[u32] = &[0u32, 1u32, 2u32, u32::MAX - 1, u32::MAX];
+
+#[cfg(test)]
+fn optUData() -> Vec<Option<u32>> {
+    let mut result = UDATA.iter().map(|v| Some(*v)).collect::<Vec<Option<u32>>>();
+    result.push(None);
+    result
+}
+
+#[test]
+fn testUnsignedWrapperUnsignedInverse() {
+    // Check that to_unsigned is the inverse of from_unsigned
+    for asc in [false, true] {
+        for nullsLast in [false, true] {
+            for v in UDATA {
+                let u = UnsignedWrappers::from_unsigned::<u32>(*v, asc, nullsLast);
+                let s = UnsignedWrappers::to_unsigned::<u32>(u, asc, nullsLast);
+                assert_eq!(*v, s);
+            }
+        }
+    }
+
+    // check that to_unsigned_option is the inverse of from_unsigned_option
+    let optVals = optUData();
+    for asc in [false, true] {
+        for nullsLast in [false, true] {
+            for v in &optVals {
+                let u = UnsignedWrappers::from_unsigned_option::<u32, u64>(*v, asc, nullsLast);
+                let s = UnsignedWrappers::to_unsigned_option::<u32, u64>(u, asc, nullsLast);
+                assert_eq!(*v, s);
+            }
+        }
+    }
+}
+
+#[test]
+fn testUnsignedWrapperUnsignedOrderDescending() {
+    let mut reverse = UDATA.to_vec();
+    reverse.reverse();
+
+    // Check that the unsigned conversion preservers order
+    let mut uvals = UDATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned::<u32>(*v, false, true))
+        .collect::<Vec<u32>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned::<u32>(*v, false, true))
+        .collect::<Vec<u32>>();
+    assert_eq!(reverse, inverse);
+
+    // Same holds for nulls first...
+    let mut uvals = UDATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned::<u32>(*v, false, false))
+        .collect::<Vec<u32>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned::<u32>(*v, false, false))
+        .collect::<Vec<u32>>();
+    assert_eq!(reverse, inverse);
+
+    // Test for option types, nulls last
+    let mut opts = optUData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned_option::<u32, u64>(*v, false, true))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned_option::<u32, u64>(*v, false, true))
+        .collect::<Vec<Option<u32>>>();
+    // None will be first now
+    opts.rotate_right(1);
+    opts.reverse();
+    assert_eq!(opts, inverse);
+
+    // Test for option types, nulls first
+    let mut opts = optUData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned_option::<u32, u64>(*v, false, false))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned_option::<u32, u64>(*v, false, false))
+        .collect::<Vec<Option<u32>>>();
+    opts.reverse();
+    assert_eq!(opts, inverse);
+}
+
+#[test]
+fn testUnsignedWrapperOrderUnsignedAscending() {
+    // Check that the unsigned conversion preservers order
+    let mut uvals = UDATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned::<u32>(*v, true, true))
+        .collect::<Vec<u32>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned::<u32>(*v, true, true))
+        .collect::<Vec<u32>>();
+    assert_eq!(UDATA, inverse);
+
+    // Same holds for nulls first...
+    let mut uvals = UDATA
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned::<u32>(*v, true, false))
+        .collect::<Vec<u32>>();
+    uvals.sort();
+    let inverse = uvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned::<u32>(*v, true, false))
+        .collect::<Vec<u32>>();
+    assert_eq!(UDATA, inverse);
+
+    // Test for option types, nulls last
+    let opts = optUData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned_option::<u32, u64>(*v, true, true))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned_option::<u32, u64>(*v, true, true))
+        .collect::<Vec<Option<u32>>>();
+    assert_eq!(opts, inverse);
+
+    // Test for option types, nulls first
+    let mut opts = optUData();
+    let mut optUvals = opts
+        .iter()
+        .map(|v| UnsignedWrappers::from_unsigned_option::<u32, u64>(*v, true, false))
+        .collect::<Vec<u64>>();
+    optUvals.sort();
+    let inverse = optUvals
+        .iter()
+        .map(|v| UnsignedWrappers::to_unsigned_option::<u32, u64>(*v, true, false))
+        .collect::<Vec<Option<u32>>>();
+    // None will be first now
+    opts.rotate_right(1);
+    assert_eq!(opts, inverse);
 }
 
 // Macro to create variants of an aggregation function

--- a/crates/sqllib/src/binary.rs
+++ b/crates/sqllib/src/binary.rs
@@ -527,3 +527,50 @@ pub fn xxhash_bytes_i64(source: ByteArray, seed: i64) -> i64 {
 }
 
 some_polymorphic_function2!(xxhash, bytes, ByteArray, i64, i64, i64);
+
+#[doc(hidden)]
+pub fn binary_to_u8(b: ByteArray) -> u8 {
+    assert!(b.length() <= 1);
+    b.data[0]
+}
+
+#[doc(hidden)]
+pub fn binary_to_u16(b: ByteArray) -> u16 {
+    assert!(b.length() <= 2);
+    let mut buf = [0u8; 2];
+    buf[2 - b.length()..].copy_from_slice(&b.data);
+    u16::from_be_bytes(buf)
+}
+
+#[doc(hidden)]
+pub fn binary_to_u32(b: ByteArray) -> u32 {
+    assert!(b.length() <= 4);
+    let mut buf = [0u8; 4];
+    buf[4 - b.length()..].copy_from_slice(&b.data);
+    u32::from_be_bytes(buf)
+}
+
+#[doc(hidden)]
+pub fn binary_to_u64(b: ByteArray) -> u64 {
+    assert!(b.length() <= 8);
+    let mut buf = [0u8; 8];
+    buf[8 - b.length()..].copy_from_slice(&b.data);
+    u64::from_be_bytes(buf)
+}
+
+#[doc(hidden)]
+pub fn binary_to_u128(b: ByteArray) -> u128 {
+    assert!(b.length() <= 16);
+    let mut buf = [0u8; 16];
+    buf[16 - b.length()..].copy_from_slice(&b.data);
+    u128::from_be_bytes(buf)
+}
+
+#[test]
+pub fn testBinaryToInteger() {
+    let bin = ByteArray::new(&[0x12, 0x34]);
+    assert_eq!(0x1234, binary_to_u16(bin.clone()));
+    assert_eq!(0x1234, binary_to_u32(bin.clone()));
+    assert_eq!(0x1234, binary_to_u64(bin.clone()));
+    assert_eq!(0x1234, binary_to_u128(bin));
+}

--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -126,55 +126,55 @@ pub fn abs_ShortInterval(value: ShortInterval) -> ShortInterval {
 some_polymorphic_function1!(abs, ShortInterval, ShortInterval, ShortInterval);
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_ShortInterval_u128(value: &ShortInterval) -> u128 {
     value.microseconds as u128
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Date_u128(value: &ShortInterval) -> u128 {
     // express value in days
     (value.microseconds / 1_000_000_i64 / 86400) as u128
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Date_u64(value: &ShortInterval) -> u64 {
     // express value in days
     (value.microseconds / 1_000_000_i64 / 86400) as u64
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Timestamp_u128(value: &ShortInterval) -> u128 {
     // express value in milliseconds
     value.microseconds as u128
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Timestamp_u64(value: &ShortInterval) -> u64 {
     // express value in milliseconds
     value.microseconds as u64
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Time_u128(value: &ShortInterval) -> u128 {
     // express value in nanoseconds
     (value.microseconds * 1_000) as u128
 }
 
 #[doc(hidden)]
-/// This function is used in rolling window computations, which require all
-/// values to be expressed using unsigned types.
+/// This function is used in rolling window computations, to compute a window bound.
+/// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Time_u64(value: &ShortInterval) -> u64 {
     // express value in nanoseconds
     (value.microseconds * 1_000) as u64

--- a/crates/sqllib/src/uuid.rs
+++ b/crates/sqllib/src/uuid.rs
@@ -171,3 +171,13 @@ impl Display for Uuid {
         Display::fmt(&self.value, f)
     }
 }
+
+#[doc(hidden)]
+pub fn uuid_to_u128(u: Uuid) -> u128 {
+    u128::from_be_bytes(*u.to_bytes())
+}
+
+#[doc(hidden)]
+pub fn u128_to_uuid(n: u128) -> Uuid {
+    Uuid::from_bytes(n.to_be_bytes())
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -388,19 +388,23 @@ public class ToRustInnerVisitor extends InnerVisitor {
         this.builder.append("<");
         // In the type parameter we do not put the Option<>
         sequence.dataType.withMayBeNull(false).accept(this);
-        this.builder.append(", ");
-        sequence.dataConvertedType.accept(this);
-        this.builder.append(", ");
-        sequence.intermediateType.accept(this);
-        this.builder.append(", ");
-        sequence.unsignedType.accept(this);
+        if (sequence.dataConvertedType.signed) {
+            this.builder.append(", ");
+            sequence.dataConvertedType.accept(this);
+            this.builder.append(", ");
+            sequence.intermediateType.accept(this);
+        }
+        if (!sequence.unsignedType.sameType(sequence.dataType)) {
+            this.builder.append(", ");
+            sequence.unsignedType.accept(this);
+        }
         this.builder.append(">");
     }
 
     @Override
     public VisitDecision preorder(DBSPUnsignedWrapExpression expression) {
         this.push(expression);
-        this.builder.append("UnsignedWrapper")
+        this.builder.append(DBSPUnsignedWrapExpression.RUST_IMPLEMENTATION)
                 .append("::")
                 .append(expression.getMethod())
                 .append("::");
@@ -430,7 +434,7 @@ public class ToRustInnerVisitor extends InnerVisitor {
     @Override
     public VisitDecision preorder(DBSPUnsignedUnwrapExpression expression) {
         this.push(expression);
-        this.builder.append("UnsignedWrapper")
+        this.builder.append(DBSPUnsignedWrapExpression.RUST_IMPLEMENTATION)
                 .append("::")
                 .append(expression.getMethod())
                 .append("::");
@@ -1897,7 +1901,9 @@ public class ToRustInnerVisitor extends InnerVisitor {
             this.pop(expression);
             return VisitDecision.STOP;
         } else if (expression.opcode == DBSPOpcode.INTEGER_TO_SHORT_INTERVAL ||
-                expression.opcode == DBSPOpcode.SHORT_INTERVAL_TO_INTEGER) {
+                expression.opcode == DBSPOpcode.SHORT_INTERVAL_TO_INTEGER ||
+                expression.opcode == DBSPOpcode.INTEGER_TO_UUID ||
+                expression.opcode == DBSPOpcode.UUID_TO_INTEGER) {
             this.builder.append(expression.opcode.toString())
                     .append("(");
             expression.source.accept(this);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/aggregates/RangeAggregates.java
@@ -53,6 +53,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeLongInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeShortInterval;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTime;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeUuid;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeIndexedZSet;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
@@ -98,6 +99,7 @@ public class RangeAggregates extends WindowAggregates {
 
         // we ignore nullability because window bounds are constants and cannot be null
         // BEWARE: this function name structure is hardwired in the monotonicity analysis
+        // NOTE: This function requires the arguments to be positive
         return "to_bound_" +
                 deltaType.withMayBeNull(false).to(DBSPTypeBaseType.class).shortName() + "_" +
                 sortType.withMayBeNull(false).to(DBSPTypeBaseType.class).shortName() + "_" +
@@ -194,6 +196,14 @@ public class RangeAggregates extends WindowAggregates {
                 sortType = DBSPTypeInteger.getType(node, INT64, originalSortType.mayBeNull);
                 convertToSigned = new DBSPUnaryExpression(
                         this.node, sortType, DBSPOpcode.SHORT_INTERVAL_TO_INTEGER, var).closure(var);
+            } else if (originalSortType.is(DBSPTypeUuid.class)) {
+                if (originalSortType.mayBeNull) {
+                    // This is 128 bits, but we need one more to represent the NULL value.
+                    throw new UnimplementedException("OVER currently cannot sort on columns with type UUID NULL. Can you convert the type to UUID NOT NULL?", 457, node);
+                }
+                sortType = DBSPTypeInteger.getType(node, UINT128, originalSortType.mayBeNull);
+                convertToSigned = new DBSPUnaryExpression(
+                        this.node, sortType, DBSPOpcode.UUID_TO_INTEGER, var.applyClone()).closure(var);
             } else {
                 sortType = originalSortType;
             }
@@ -304,6 +314,9 @@ public class RangeAggregates extends WindowAggregates {
             } else if (originalSortType.is(DBSPTypeShortInterval.class)) {
                 unwrap = new DBSPUnaryExpression(this.node, originalSortType,
                         DBSPOpcode.INTEGER_TO_SHORT_INTERVAL, unwrap);
+            } else if (originalSortType.is(DBSPTypeUuid.class)) {
+                unwrap = new DBSPUnaryExpression(this.node, originalSortType,
+                        DBSPOpcode.INTEGER_TO_UUID, unwrap);
             }
 
             DBSPExpression ixKey = var.field(0).deref();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/monotone/MonotoneTransferFunctions.java
@@ -743,7 +743,9 @@ public class MonotoneTransferFunctions extends TranslateVisitor<MonotoneExpressi
     static final Set<DBSPOpcode> monotoneUnary = Set.of(
             DBSPOpcode.UNARY_PLUS, DBSPOpcode.TYPEDBOX,
             DBSPOpcode.DECIMAL_TO_INTEGER, DBSPOpcode.INTEGER_TO_DECIMAL,
-            DBSPOpcode.SHORT_INTERVAL_TO_INTEGER, DBSPOpcode.INTEGER_TO_SHORT_INTERVAL);
+            DBSPOpcode.SHORT_INTERVAL_TO_INTEGER, DBSPOpcode.INTEGER_TO_SHORT_INTERVAL,
+            DBSPOpcode.UUID_TO_INTEGER, DBSPOpcode.INTEGER_TO_UUID
+    );
 
     @Override
     public void postorder(DBSPUnaryExpression expression) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -25,6 +25,9 @@ public enum DBSPOpcode {
     // Lossless, order-preserving conversion between short interval and INTEGER, used for range aggregates
     SHORT_INTERVAL_TO_INTEGER("short_interval_to_integer", false),
     INTEGER_TO_SHORT_INTERVAL("integer_to_short_interval", false),
+    // Lossless, order-preserving conversion between UUID and INTEGER, used for range aggregates
+    UUID_TO_INTEGER("uuid_to_u128", false),
+    INTEGER_TO_UUID("u128_to_uuid", false),
 
     // Binary operations
     ADD("+", false),
@@ -133,7 +136,7 @@ public enum DBSPOpcode {
                  AGG_MAX, AGG_XOR, AGG_OR, AGG_AND, IS_DISTINCT, CONCAT, MIN, MAX, OR, AND, IS_NOT_FALSE, IS_NOT_TRUE,
                  AGG_MAX1, AGG_MIN1, INDICATOR -> false;
             case NEG, DIV_INTERVAL, DIV_INTERVAL_NULL, MUL_INTERVAL, DECIMAL_TO_INTEGER, INTEGER_TO_DECIMAL,
-                 SHORT_INTERVAL_TO_INTEGER, INTEGER_TO_SHORT_INTERVAL,
+                 SHORT_INTERVAL_TO_INTEGER, INTEGER_TO_SHORT_INTERVAL, INTEGER_TO_UUID, UUID_TO_INTEGER,
                  RUST_INDEX, VARIANT_INDEX, MAP_INDEX,
                  SQL_INDEX, XOR, BW_OR, MUL_WEIGHT, BW_AND, GTE, LTE, GT, LT, NEQ, EQ, MOD, DIV_NULL, DIV, MUL, SUB,
                  ADD, TYPEDBOX, IS_TRUE, IS_FALSE, NOT, UNARY_PLUS -> true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnaryExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnaryExpression.java
@@ -80,7 +80,9 @@ public final class DBSPUnaryExpression extends DBSPExpression {
                 this.opcode == DBSPOpcode.INTEGER_TO_DECIMAL ||
                 this.opcode == DBSPOpcode.SHORT_INTERVAL_TO_INTEGER ||
                 this.opcode == DBSPOpcode.INTEGER_TO_SHORT_INTERVAL ||
-                this.opcode == DBSPOpcode.REINTERPRET) {
+                this.opcode == DBSPOpcode.REINTERPRET ||
+                this.opcode == DBSPOpcode.INTEGER_TO_UUID ||
+                this.opcode == DBSPOpcode.UUID_TO_INTEGER) {
             return builder.append(this.opcode.toString())
                     .append("(")
                     .append(this.source)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedUnwrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedUnwrapExpression.java
@@ -11,7 +11,7 @@ import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
-/** This is the dual of the UnsignedWrapExpression: it unwraps an unsigned number */
+/** This is the dual of {@link DBSPUnsignedWrapExpression}: it unwraps an unsigned number */
 public final class DBSPUnsignedUnwrapExpression extends DBSPExpression {
     public final DBSPExpression source;
     public final DBSPUnsignedWrapExpression.TypeSequence sequence;
@@ -51,12 +51,15 @@ public final class DBSPUnsignedUnwrapExpression extends DBSPExpression {
     }
 
     public String getMethod() {
-        return this.getType().mayBeNull ? "to_signed_option" : "to_signed";
+        if (this.sequence.dataConvertedType.signed)
+            return this.getType().mayBeNull ? "to_signed_option" : "to_signed";
+        else
+            return this.getType().mayBeNull ? "to_unsigned_option" : "to_unsigned";
     }
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append("UnsignedWrapper")
+        return builder.append(DBSPUnsignedWrapExpression.RUST_IMPLEMENTATION)
                 .append("::")
                 .append(this.getMethod())
                 .append("(")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPUnsignedWrapExpression.java
@@ -2,7 +2,7 @@ package org.dbsp.sqlCompiler.ir.expression;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
-import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.EquivalenceContext;
@@ -15,8 +15,10 @@ import org.dbsp.util.IIndentStream;
 import org.dbsp.util.Utilities;
 
 /** An unsigned wrap expression just wraps a signed integer into an unsigned one
- * preserving order. */
+ * preserving order.  See also {@link DBSPUnsignedUnwrapExpression} */
 public final class DBSPUnsignedWrapExpression extends DBSPExpression {
+    public static final String RUST_IMPLEMENTATION = "UnsignedWrappers";
+
     public static class TypeSequence {
         public final DBSPType dataType;
         public final DBSPTypeInteger dataConvertedType;
@@ -27,13 +29,18 @@ public final class DBSPUnsignedWrapExpression extends DBSPExpression {
             this.dataType = dataType;
             this.dataConvertedType = getInitialIntegerType(this.dataType);
             if (!this.dataConvertedType.signed) {
-                throw new InternalCompilerError("The data type encoding " + dataType +
-                        " must be signed, but it is " + this.dataConvertedType);
+                int width = this.dataConvertedType.getWidth();
+                int useWidth = dataType.mayBeNull ? width * 2 : width;
+                this.intermediateType = new DBSPTypeInteger(dataType.getNode(), useWidth, false, false);
+                this.unsignedType = new DBSPTypeInteger(dataType.getNode(), useWidth, false, false);
             } else {
                 int width = this.dataConvertedType.getWidth();
-                if (width > 64)
+                if (width > 64) {
+                    throw new UnimplementedException("Not yet supported: OVER sorting over " + dataType,
+                            dataType.getNode());
                     // This may cause runtime overflows, but this is the best we can do
-                    width = 64;
+                    // width = 64;
+                }
                 this.intermediateType = new DBSPTypeInteger(dataType.getNode(), width * 2, true, false);
                 this.unsignedType = new DBSPTypeInteger(dataType.getNode(), width * 2, false, false);
             }
@@ -50,7 +57,8 @@ public final class DBSPUnsignedWrapExpression extends DBSPExpression {
                 case INT8, INT16, INT32, INT64, INT128 -> sourceType.withMayBeNull(false).to(DBSPTypeInteger.class);
                 case DATE -> DBSPTypeInteger.getType(sourceType.getNode(), DBSPTypeCode.INT32, false);
                 case TIMESTAMP, TIME -> DBSPTypeInteger.getType(sourceType.getNode(), DBSPTypeCode.INT64, false);
-                default -> throw new InternalCompilerError("Not yet supported wrappers for " + sourceType, sourceType.getNode());
+                case UINT8, UINT16, UINT32, UINT64, UINT128 -> sourceType.withMayBeNull(false).to(DBSPTypeInteger.class);
+                default -> throw new UnimplementedException("OVER sorting over " + sourceType, sourceType.getNode());
             };
         }
     }
@@ -96,12 +104,15 @@ public final class DBSPUnsignedWrapExpression extends DBSPExpression {
     }
 
     public String getMethod() {
-        return this.source.getType().mayBeNull ? "from_option" : "from_signed";
+        if (this.sequence.dataConvertedType.signed)
+            return this.source.getType().mayBeNull ? "from_option" : "from_signed";
+        else
+            return this.source.getType().mayBeNull ? "from_unsigned_option" : "from_unsigned";
     }
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append("UnsignedWrapper")
+        return builder.append(RUST_IMPLEMENTATION)
                 .append("::")
                 .append(this.getMethod())
                 .append("(")

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -100,19 +100,19 @@ public class FunctionsTest extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE FUNCTION dbl(x INTEGER) RETURNS INTEGER AS x * 2;
                 CREATE VIEW V AS SELECT dbl(3);""");
-        ccs.step("", """
-                 r | weight
-                ------------
-                 6 | 1""");
+        ccs.stepWeightOne("", """
+                 r
+                ---
+                 6""");
         ccs = this.getCCS("""
                 CREATE FUNCTION contains_number(str VARCHAR NOT NULL, value INTEGER)
                 RETURNS BOOLEAN NOT NULL
                 AS (str LIKE ('%' || COALESCE(CAST(value AS VARCHAR), 'NULL') || '%'));
                 CREATE VIEW V AS SELECT contains_number(CAST('YES: 10 NO:5' AS VARCHAR), 5)""");
-        ccs.step("", """
-                 result | weight
-                -----------------
-                 t      | 1""");
+        ccs.stepWeightOne("", """
+                 result
+                --------
+                 t""");
     }
 
     @Test
@@ -1920,11 +1920,11 @@ public class FunctionsTest extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE TABLE T(x VARCHAR, y VARBINARY);
                 CREATE VIEW V AS SELECT MD5(x), MD5(y) FROM T;""");
-        ccs.step("INSERT INTO T VALUES('Feldera', x'0123456789ABCDEF');",
+        ccs.stepWeightOne("INSERT INTO T VALUES('Feldera', x'0123456789ABCDEF');",
                 """
-                         s                               | binary                          | weight
-                        ----------------------------------------------------------------------------
-                         841afc2f65b5763600818ef42a56d7d1| a1cd1d1fc6491068d91007283ed84489| 1""");
+                         s                               | binary
+                        --------------------------------------------------------------------
+                         841afc2f65b5763600818ef42a56d7d1| a1cd1d1fc6491068d91007283ed84489""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/AggregateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/AggregateTests.java
@@ -191,7 +191,7 @@ public class AggregateTests extends SqlIoTest {
                     SIZE => INTERVAL '1' HOUR))
                 GROUP BY
                   window_start, window_end;""");
-        ccs.step("""
+        ccs.stepWeightOne("""
                 INSERT INTO data VALUES(1.0, '2024-01-01 00:00:00');
                 INSERT INTO DATA VALUES(2.0, '2024-01-01 00:00:10');
                 INSERT INTO DATA VALUES(3.0, '2024-01-01 00:00:20');
@@ -199,10 +199,10 @@ public class AggregateTests extends SqlIoTest {
                 INSERT INTO DATA VALUES(4.0, '2024-01-01 00:00:30');
                 INSERT INTO DATA VALUES(6.0, '2024-01-01 02:00:00');
                 INSERT INTO DATA VALUES(5.0, '2024-01-01 02:00:10');""", """
-                  ws                 | we                  | f   | max | min | last | weight
-                ----------------------------------------------------------------------------
-                 2024-01-01 00:00:00 | 2024-01-01 01:00:00 | 1.0 | 4.0 | 1.0 | 4.0  | 1
-                 2024-01-01 02:00:00 | 2024-01-01 03:00:00 | 6.0 | 6.0 | 5.0 | 5.0  | 1""");
+                  ws                 | we                  | f   | max | min | last
+                --------------------------------------------------------------------
+                 2024-01-01 00:00:00 | 2024-01-01 01:00:00 | 1.0 | 4.0 | 1.0 | 4.0
+                 2024-01-01 02:00:00 | 2024-01-01 03:00:00 | 6.0 | 6.0 | 5.0 | 5.0""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayFunctionsTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/ArrayFunctionsTests.java
@@ -1253,14 +1253,14 @@ public class ArrayFunctionsTests extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE TABLE T(x INT ARRAY);
                 CREATE VIEW V AS SELECT ARRAY_EXISTS(x, e -> e % 2 = 0) FROM T;""");
-        ccs.step("INSERT INTO T VALUES(ARRAY[1, 2, 3])", """
-                  r     | weight
-                 ----------------
-                  true  | 1""");
-        ccs.step("INSERT INTO T VALUES(ARRAY())", """
-                  r     | weight
-                 ----------------
-                  false | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(ARRAY[1, 2, 3])", """
+                  r
+                 ------
+                  true""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(ARRAY())", """
+                  r
+                 -------
+                  false""");
     }
 
     @Test
@@ -1362,14 +1362,14 @@ public class ArrayFunctionsTests extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE TABLE T(x INT ARRAY);
                 CREATE VIEW V AS SELECT TRANSFORM(x, e -> e % 2) FROM T;""");
-        ccs.step("INSERT INTO T VALUES(ARRAY[1, 2, 3])", """
-                  r           | weight
-                 ----------------
-                  { 1, 0, 1 } | 1""");
-        ccs.step("INSERT INTO T VALUES(ARRAY())", """
-                  r     | weight
-                 ----------------
-                  {}    | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(ARRAY[1, 2, 3])", """
+                  r
+                 -------------
+                  { 1, 0, 1 }""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(ARRAY())", """
+                  r
+                 -------
+                  {}""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression1Tests.java
@@ -90,11 +90,11 @@ public class Regression1Tests extends SqlIoTest {
                 CAST(ABS(yr0) AS BIGINT), CAST(ABS(yr1) AS BIGINT),
                 CAST(ABS(d0) AS BIGINT), CAST(ABS(d1) AS BIGINT)
                 FROM intervalv;""");
-        ccs.step("INSERT INTO tbl VALUES(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2019-01-01 00:00:00')",
+        ccs.stepWeightOne("INSERT INTO tbl VALUES(TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2019-01-01 00:00:00')",
                 """
-                  v0 | v1 |  v2  |  v3  | weight
-                 ----------------------------
-                   5 |  6 | 1998 | 2363 | 1""");
+                  v0 | v1 |  v2  |  v3
+                 ----------------------
+                   5 |  6 | 1998 | 2363""");
     }
 
     @Test
@@ -274,10 +274,10 @@ public class Regression1Tests extends SqlIoTest {
                 TIMESTAMPDIFF(MINUTE, TIMESTAMP '2020-06-21 14:23:44.123', TIMESTAMP '2022-01-22 20:24:44.332') AS min1,
                 TIMESTAMPDIFF(SECOND, TIMESTAMP '2020-06-21 14:23:44.123', TIMESTAMP '2022-01-22 20:24:44.332') AS sec1
                 FROM t;""");
-        ccs.step("INSERT INTO T VALUES(TIMESTAMP '2020-06-21 14:23:44.123');", """
-                 min | sec | min1 | sec1 | weight
-                --------------------------------------------
-                 835561 | 50133660 | 835561 | 50133660 | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(TIMESTAMP '2020-06-21 14:23:44.123');", """
+                 min | sec | min1 | sec1
+                ----------------------------------------
+                 835561 | 50133660 | 835561 | 50133660""");
 
         ccs = this.getCCS("""
                 CREATE TABLE t(tmestmp TIMESTAMP);
@@ -288,10 +288,10 @@ public class Regression1Tests extends SqlIoTest {
                 TIMESTAMPDIFF(MINUTE, '2020-06-21 14:23:44.123'::TIMESTAMP, '2022-01-22 20:24:44.332'::TIMESTAMP) AS min1,
                 TIMESTAMPDIFF(SECOND, '2020-06-21 14:23:44.123'::TIMESTAMP, '2022-01-22 20:24:44.332'::TIMESTAMP) AS sec1
                 FROM t;""");
-        ccs.step("INSERT INTO T VALUES(TIMESTAMP '2020-06-21 14:23:44.123');", """
-                 min | sec | min1 | sec1 | weight
-                --------------------------------------------
-                 835561 | 50133660 | 835561 | 50133660 | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(TIMESTAMP '2020-06-21 14:23:44.123');", """
+                 min | sec | min1 | sec1
+                ----------------------------------------
+                 835561 | 50133660 | 835561 | 50133660""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -1268,4 +1268,359 @@ public class Regression2Tests extends SqlIoTest {
                 SELECT /*+ broadcast(T) */ * FROM T JOIN TMP USING (X);
                 """, "Ambiguous hint: Hint 'broadcast(t)' matches 2 different collections");
     }
+
+    @Test
+    public void issue5890() {
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq INT UNSIGNED
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq) AS previous
+                FROM T;""";
+        // Validated on postgres, which is NULLS LAST, so this needs explicit NULLS FIRST
+        String data = """
+                INSERT INTO T VALUES
+                  -- Customer 1: clean increasing seq
+                  (1, 1, 10, 1),
+                  (2, 1, 20, 2),
+                  (3, 1, -5, 3),
+                  -- Customer 2: out‑of‑order seq, zero amount
+                  (4, 2, 7,  5),
+                  (5, 2, 0,  2),
+                  (6, 2, 3,  4),
+                  -- Customer 3: single row partition
+                  (7, 3, 100, 10),
+                  -- Customer 4: duplicate seq values (tests deterministic ordering)
+                  (8, 4, 1,  1),
+                  (9, 4, 2,  1),
+                  (10,4, 3,  2),
+                  -- Null seq
+                  (11,1, 3, NULL);
+                """;
+        String expected = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | 3
+                 1 	         | 13
+                 1 	         | 33
+                 1 	         | 28
+                 2 	         | 0
+                 2 	         | 3
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 3
+                 4 	         | 6""";
+
+        var ccs = this.getCCS(program);
+        ccs.stepWeightOne(data, expected);
+
+        var program1 = program.replace("ORDER BY seq", "ORDER BY seq NULLS FIRST");
+        ccs = this.getCCS(program1);
+        ccs.stepWeightOne(data, expected);
+
+        var program2 = program.replace("ORDER BY seq", "ORDER BY seq NULLS LAST");
+        ccs = this.getCCS(program2);
+        String expected2 = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | 10
+                 1 	         | 30
+                 1 	         | 25
+                 1 	         | 28
+                 2 	         | 0
+                 2 	         | 3
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 3
+                 4 	         | 6""";
+        ccs.stepWeightOne(data, expected2);
+    }
+
+    @Test
+    public void issue5890a() {
+        // Validated on postgres
+        // same as before, non-nullable unsigned type for seq
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq INT UNSIGNED NOT NULL
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq) AS previous
+                FROM T;""";
+        // Same data as before, without the NULL value
+        String data = """
+                INSERT INTO T VALUES
+                  -- Customer 1: clean increasing seq
+                  (1, 1, 10, 1),
+                  (2, 1, 20, 2),
+                  (3, 1, -5, 3),
+                  -- Customer 2: out‑of‑order seq, zero amount
+                  (4, 2, 7,  5),
+                  (5, 2, 0,  2),
+                  (6, 2, 3,  4),
+                  -- Customer 3: single row partition
+                  (7, 3, 100, 10),
+                  -- Customer 4: duplicate seq values (tests deterministic ordering)
+                  (8, 4, 1,  1),
+                  (9, 4, 2,  1),
+                  (10,4, 3,  2);
+                """;
+        String expected = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | 10
+                 1 	         | 30
+                 1 	         | 25
+                 2 	         | 0
+                 2 	         | 3
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 3
+                 4 	         | 6""";
+
+        var ccs = this.getCCS(program);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference, since the sorted value is not nullable
+        var program1 = program.replace("ORDER BY seq", "ORDER BY seq NULLS FIRST");
+        ccs = this.getCCS(program1);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference
+        var program2 = program.replace("ORDER BY seq", "ORDER BY seq NULLS LAST");
+        ccs = this.getCCS(program2);
+        ccs.stepWeightOne(data, expected);
+    }
+
+    @Test
+    public void issue5890b() {
+        // Same test as before, with descending sorting
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq INT UNSIGNED
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq DESC) AS previous
+                FROM T;""";
+        // Validated on postgres
+        String data = """
+                INSERT INTO T VALUES
+                  -- Customer 1: clean increasing seq
+                  (1, 1, 10, 1),
+                  (2, 1, 20, 2),
+                  (3, 1, -5, 3),
+                  -- Customer 2: out‑of‑order seq, zero amount
+                  (4, 2, 7,  5),
+                  (5, 2, 0,  2),
+                  (6, 2, 3,  4),
+                  -- Customer 3: single row partition
+                  (7, 3, 100, 10),
+                  -- Customer 4: duplicate seq values (tests deterministic ordering)
+                  (8, 4, 1,  1),
+                  (9, 4, 2,  1),
+                  (10,4, 3,  2),
+                  -- Null seq
+                  (11,1, 3, NULL);
+                """;
+        String expected = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | -5
+                 1 	         | 15
+                 1 	         | 25
+                 1 	         | 28
+                 2 	         | 7
+                 2 	         | 10
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 6
+                 4 	         | 6""";
+
+        var ccs = this.getCCS(program);
+        ccs.stepWeightOne(data, expected);
+
+        var program1 = program.replace("ORDER BY seq DESC", "ORDER BY seq DESC NULLS FIRST");
+        ccs = this.getCCS(program1);
+        String expected1 = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | 3
+                 1 	         | -2
+                 1 	         | 18
+                 1 	         | 28
+                 2 	         | 7
+                 2 	         | 10
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 6
+                 4 	         | 6""";
+        ccs.stepWeightOne(data, expected1);
+
+        var program2 = program.replace("ORDER BY seq DESC", "ORDER BY seq DESC NULLS LAST");
+        ccs = this.getCCS(program2);
+        ccs.stepWeightOne(data, expected);
+    }
+
+    @Test
+    public void issue5890c() {
+        // Sort over UUID
+        // Validated on postgres
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq UUID NOT NULL
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq) AS previous
+                FROM T;""";
+        // The UUID values have been chosen so that they have the same order as the previous test
+        String data = """
+                INSERT INTO T VALUES
+                  -- Customer 1: clean increasing seq
+                  (1, 1, 10, UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (2, 1, 20, UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55'),
+                  (3, 1, -5, UUID '31c4b8f2-6d3e-4f8a-9c77-2e0b4d1f3a28'),
+                  -- Customer 2: out‑of‑order seq, zero amount
+                  (4, 2, 7,  UUID '50b7c2d1-9e3a-4c55-8d11-7a9c0e2b4f66'),
+                  (5, 2, 0,  UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55'),
+                  (6, 2, 3,  UUID '4e1a7c9d-3b22-4f0d-8e44-5c7a1b9f0d33'),
+                  -- Customer 3: single row partition
+                  (7, 3, 100, UUID 'a1c4b8f2-6d3e-4f8a-9c77-2e0b4d1f3a28'),
+                  -- Customer 4: duplicate seq values (tests deterministic ordering)
+                  (8, 4, 1,  UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (9, 4, 2,  UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (10,4, 3,  UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55');
+                """;
+        String expected = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | 10
+                 1 	         | 30
+                 1 	         | 25
+                 2 	         | 0
+                 2 	         | 3
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 3
+                 4 	         | 6""";
+
+        var ccs = this.getCCS(program);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference, since the sorted value is not nullable
+        var program1 = program.replace("ORDER BY seq", "ORDER BY seq NULLS FIRST");
+        ccs = this.getCCS(program1);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference
+        var program2 = program.replace("ORDER BY seq", "ORDER BY seq NULLS LAST");
+        ccs = this.getCCS(program2);
+        ccs.stepWeightOne(data, expected);
+    }
+
+    @Test
+    public void issue5890d() {
+        // Sort over UUID descending
+        // Validated on postgres
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq UUID NOT NULL
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq DESC) AS previous
+                FROM T;""";
+        // The UUID values have been chosen so that they have the same order as the previous test
+        String data = """
+                INSERT INTO T VALUES
+                  -- Customer 1: clean increasing seq
+                  (1, 1, 10, UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (2, 1, 20, UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55'),
+                  (3, 1, -5, UUID '31c4b8f2-6d3e-4f8a-9c77-2e0b4d1f3a28'),
+                  -- Customer 2: out‑of‑order seq, zero amount
+                  (4, 2, 7,  UUID '50b7c2d1-9e3a-4c55-8d11-7a9c0e2b4f66'),
+                  (5, 2, 0,  UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55'),
+                  (6, 2, 3,  UUID '4e1a7c9d-3b22-4f0d-8e44-5c7a1b9f0d33'),
+                  -- Customer 3: single row partition
+                  (7, 3, 100, UUID 'a1c4b8f2-6d3e-4f8a-9c77-2e0b4d1f3a28'),
+                  -- Customer 4: duplicate seq values (tests deterministic ordering)
+                  (8, 4, 1,  UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (9, 4, 2,  UUID '1f6c1e4b-2b8d-4c3e-9f0a-1d6b2e4c7a91'),
+                  (10,4, 3,  UUID '2d92f0c7-8a44-4e0e-bc3d-0f6b1a2c9e55');
+                """;
+        String expected = """
+                 customer_id | previous
+                ------------------------
+                 1 	         | -5
+                 1 	         | 15
+                 1 	         | 25
+                 2 	         | 7
+                 2 	         | 10
+                 2 	         | 10
+                 3 	         | 100
+                 4 	         | 3
+                 4 	         | 6
+                 4 	         | 6""";
+
+        var ccs = this.getCCS(program);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference, since the sorted value is not nullable
+        var program1 = program.replace("ORDER BY seq DESC", "ORDER BY seq DESC NULLS FIRST");
+        ccs = this.getCCS(program1);
+        ccs.stepWeightOne(data, expected);
+
+        // This should make no difference
+        var program2 = program.replace("ORDER BY seq DESC", "ORDER BY seq DESC NULLS LAST");
+        ccs = this.getCCS(program2);
+        ccs.stepWeightOne(data, expected);
+    }
+
+    @Test
+    public void issue5890e() {
+        String program = """
+                CREATE TABLE T (
+                  payment_id INT,
+                  customer_id INT,
+                  amount INT,
+                  seq UUID
+                );
+                
+                CREATE VIEW V AS SELECT
+                  customer_id,
+                  SUM(amount) OVER (PARTITION BY customer_id ORDER BY seq DESC) AS previous
+                FROM T;""";
+        this.statementsFailingInCompilation(program, """
+                OVER currently cannot sort on columns with type UUID NULL""");
+    }
 }


### PR DESCRIPTION
Fixes #5890

Rolling aggregates use radix sort, and require unsigned values as sort keys. To actually sort signed values, the compiler encodes signed values into unsigned values by using twice the number of bits. (One extra bit is needed in general to encode the NULL value as well).

OVER windows were previously rejecting sorting over unsigned values - this PR fixes this omission. Twice as many bits are still needed for nullable unsigned types.

UUID is treated as a u128 type. Unfortunately this means that UUID NULL needs actually 256 bits (129 to be more precise, but we always use powers of two currently)... so we cannot do it.

By adding unit tests I realized that there is a bug in the implementation for signed types too. Fixing this bug required changing the encoding of the integers into the rolling aggregate tree. As a consequence, programs using the new encoding won't be able to load the state from programs using the old encoding. To prevent this, I have renamed some functions, which should cause the compiler to generate new hashes for the operators around rolling aggregates.

I decided to leave OVER windows for BINARY objects for a later PR.