### PR TITLE
[dbsp] Avoid one data copy on remote exchange.

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -25,6 +25,7 @@ use core_affinity::{CoreId, get_core_ids};
 use crossbeam::sync::{Parker, Unparker};
 use enum_map::{Enum, EnumMap, enum_map};
 use feldera_buffer_cache::ThreadType;
+use feldera_storage::fbuf::FBuf;
 use feldera_storage::fbuf::slab::{FBufSlabs, FBufSlabsStats, set_thread_slab_pool};
 use feldera_types::config::{StorageCompression, StorageConfig, StorageOptions};
 use feldera_types::memory_pressure::{
@@ -1342,7 +1343,7 @@ impl Consensus {
                 while !exchange.try_send_all_with_serializer(
                     Runtime::worker_index(),
                     repeat(local),
-                    |local| vec![local as u8],
+                    |local| FBuf::from_slice(&[local as u8]),
                 ) {
                     if Runtime::kill_in_progress() {
                         return Err(SchedulerError::Killed);
@@ -1432,7 +1433,11 @@ where
                 while !exchange.try_send_all_with_serializer(
                     Runtime::worker_index(),
                     repeat(local.clone()),
-                    |local| rmp_serde::to_vec(&local).unwrap(),
+                    |local| {
+                        let mut fbuf = FBuf::new();
+                        rmp_serde::encode::write(&mut fbuf, &local).unwrap();
+                        fbuf
+                    },
                 ) {
                     if Runtime::kill_in_progress() {
                         return Err(SchedulerError::Killed);

--- a/crates/dbsp/src/operator/communication/exchange.rs
+++ b/crates/dbsp/src/operator/communication/exchange.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 use binrw::{BinRead, BinWrite};
 use crossbeam_utils::CachePadded;
+use feldera_storage::fbuf::FBuf;
 use futures::{prelude::*, stream::FuturesUnordered};
 use itertools::Itertools;
 use rkyv::AlignedVec;
@@ -159,7 +160,7 @@ impl ExchangeServiceClient {
         &self,
         exchange_id: ExchangeId,
         senders: Range<usize>,
-        data: Vec<Vec<Vec<u8>>>,
+        data: Vec<Vec<FBuf>>,
     ) -> std::io::Result<()> {
         // We want to write each data buffer preceded by a header and followed
         // by padding.  To minimize the system calls required to do this, we
@@ -585,13 +586,13 @@ impl InnerExchange {
 
 #[derive(Clone, Debug)]
 pub enum Mailbox<T> {
-    Tx(Vec<u8>),
+    Tx(FBuf),
     Rx(AlignedVec),
     Plain(T),
 }
 
 impl<T> Mailbox<T> {
-    fn into_tx(self) -> Option<Vec<u8>> {
+    fn into_tx(self) -> Option<FBuf> {
         match self {
             Mailbox::Tx(bytes) => Some(bytes),
             Mailbox::Rx(_) | Mailbox::Plain(_) => None,
@@ -792,7 +793,7 @@ where
         mut serialize: F,
     ) -> bool
     where
-        F: FnMut(T) -> Vec<u8> + Send + Sync,
+        F: FnMut(T) -> FBuf + Send + Sync,
     {
         self.try_send_all(
             sender,
@@ -870,7 +871,7 @@ where
             for host in runtime.layout().other_hosts() {
                 let receivers = &host.workers;
                 let mut serialized_bytes = 0;
-                let items: Vec<Vec<_>> = senders
+                let items: Vec<Vec<FBuf>> = senders
                     .clone()
                     .map(|sender| {
                         receivers
@@ -1134,7 +1135,7 @@ where
 ///                     match location {
 ///                         WorkerLocation::Local => vals.push(Mailbox::Plain(n)),
 ///                         WorkerLocation::Remote => {
-///                             vals.push(Mailbox::Tx(to_bytes_dyn(&n).unwrap().into_vec()))
+///                             vals.push(Mailbox::Tx(to_bytes_dyn(&n).unwrap()))
 ///                         }
 ///                     }
 ///                 }
@@ -1631,7 +1632,7 @@ mod tests {
                     if exchange.try_send_all_with_serializer(
                         Runtime::worker_index(),
                         repeat(round),
-                        |round| to_bytes(&round).unwrap().into_vec(),
+                        |round| to_bytes(&round).unwrap(),
                     ) {
                         break;
                     }
@@ -1693,7 +1694,7 @@ mod tests {
                                 match location {
                                     WorkerLocation::Local => vals.push(Mailbox::Plain(n)),
                                     WorkerLocation::Remote => {
-                                        vals.push(Mailbox::Tx(to_bytes_dyn(&n).unwrap().into_vec()))
+                                        vals.push(Mailbox::Tx(to_bytes_dyn(&n).unwrap()))
                                     }
                                 }
                             }

--- a/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
@@ -1231,16 +1231,16 @@ where
         fn serialize_with_flush<B, K, V, R>(
             (batch, flush): (B, bool),
             serializer_inner: &mut Option<SerializerInner>,
-        ) -> Vec<u8>
+        ) -> FBuf
         where
             B: BatchReader<Key = K, Val = V, Time = (), R = R>,
             K: DataTrait + ?Sized,
             V: DataTrait + ?Sized,
             R: WeightTrait + ?Sized,
         {
-            let mut vec = serialize_indexed_wset(&batch, serializer_inner.get_or_insert_default());
-            vec.push(flush as u8);
-            vec
+            let mut fbuf = serialize_indexed_wset(&batch, serializer_inner.get_or_insert_default());
+            fbuf.push(flush as u8);
+            fbuf
         }
 
         stream! {

--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -398,13 +398,13 @@ impl PairsSerializer {
             .unwrap();
     }
 
-    pub fn done(mut self, serializer: &mut SerializerInner) -> Vec<u8> {
+    pub fn done(mut self, serializer: &mut SerializerInner) -> FBuf {
         serializer
             .with(FBufSerializer::new(&mut self.fbuf), |s| {
                 s.serialize_value(&self.offsets)
             })
             .unwrap();
-        self.fbuf.into_vec()
+        self.fbuf
     }
 }
 

--- a/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
+++ b/crates/dbsp/src/operator/dynamic/time_series/waterline.rs
@@ -1,4 +1,5 @@
 use dyn_clone::clone_box;
+use feldera_storage::fbuf::FBuf;
 use size_of::SizeOf;
 
 use crate::circuit::checkpointer::Checkpoint;
@@ -94,9 +95,9 @@ where
                             WorkerLocation::Local => {
                                 waterlines.push(Mailbox::Plain(clone_box(waterline.as_ref())))
                             }
-                            WorkerLocation::Remote => {
-                                waterlines.push(Mailbox::Tx(waterline.checkpoint().unwrap()))
-                            }
+                            WorkerLocation::Remote => waterlines.push(Mailbox::Tx(
+                                FBuf::from_slice(&waterline.checkpoint().unwrap()),
+                            )),
                         };
                     }
                 },
@@ -175,9 +176,9 @@ where
                             WorkerLocation::Local => {
                                 waterlines.push(Mailbox::Plain(clone_box(waterline.as_ref())))
                             }
-                            WorkerLocation::Remote => {
-                                waterlines.push(Mailbox::Tx(waterline.checkpoint().unwrap()))
-                            }
+                            WorkerLocation::Remote => waterlines.push(Mailbox::Tx(
+                                FBuf::from_slice(&waterline.checkpoint().unwrap()),
+                            )),
                         };
                     }
                 },

--- a/crates/dbsp/src/trace.rs
+++ b/crates/dbsp/src/trace.rs
@@ -1454,7 +1454,7 @@ impl IndexedWSetSerializer {
         });
     }
 
-    pub fn done(mut self, serializer_inner: &mut SerializerInner) -> Vec<u8> {
+    pub fn done(mut self, serializer_inner: &mut SerializerInner) -> FBuf {
         #[cfg(debug_assertions)]
         debug_assert_eq!(self.state, State::Key);
         self.offsets[0] = self.n_keys;
@@ -1462,14 +1462,11 @@ impl IndexedWSetSerializer {
         serializer_inner.with(FBufSerializer::new(&mut self.fbuf), |s| {
             s.serialize_value(&self.offsets).unwrap()
         });
-        self.fbuf.into_vec()
+        self.fbuf
     }
 }
 
-pub fn serialize_indexed_wset<B, K, V, R>(
-    batch: &B,
-    serializer_inner: &mut SerializerInner,
-) -> Vec<u8>
+pub fn serialize_indexed_wset<B, K, V, R>(batch: &B, serializer_inner: &mut SerializerInner) -> FBuf
 where
     B: BatchReader<Key = K, Val = V, Time = (), R = R>,
     K: DataTrait + ?Sized,

--- a/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
+++ b/crates/dbsp/src/trace/ord/fallback/indexed_wset.rs
@@ -743,7 +743,7 @@ where
     R: WeightTrait + ?Sized,
 {
     fn checkpoint(&self) -> Result<Vec<u8>, Error> {
-        Ok(serialize_indexed_wset(self, &mut SerializerInner::new()))
+        Ok(serialize_indexed_wset(self, &mut SerializerInner::new()).into_vec())
     }
 
     fn restore(&mut self, data: &[u8]) -> Result<(), Error> {

--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -976,7 +976,7 @@ where
     R: WeightTrait + ?Sized,
 {
     fn checkpoint(&self) -> Result<Vec<u8>, Error> {
-        Ok(serialize_indexed_wset(self, &mut SerializerInner::new()))
+        Ok(serialize_indexed_wset(self, &mut SerializerInner::new()).into_vec())
     }
 
     fn restore(&mut self, data: &[u8]) -> Result<(), Error> {

--- a/crates/sqllib/src/string_interner.rs
+++ b/crates/sqllib/src/string_interner.rs
@@ -298,15 +298,13 @@ pub fn build_string_interner(
             let mut locations = WorkerLocations::new();
             match locations.next().unwrap() {
                 WorkerLocation::Local => outputs.push(Mailbox::Plain(spine.clone())),
-                WorkerLocation::Remote => {
-                    outputs.push(Mailbox::Tx(to_bytes(&spine).unwrap().into_vec()))
-                }
+                WorkerLocation::Remote => outputs.push(Mailbox::Tx(to_bytes(&spine).unwrap())),
             };
             for location in locations {
                 match location {
                     WorkerLocation::Local => outputs.push(Mailbox::Plain(empty_by_id())),
                     WorkerLocation::Remote => {
-                        outputs.push(Mailbox::Tx(to_bytes(&empty_by_id()).unwrap().into_vec()))
+                        outputs.push(Mailbox::Tx(to_bytes(&empty_by_id()).unwrap()))
                     }
                 }
             }

--- a/crates/storage/src/fbuf.rs
+++ b/crates/storage/src/fbuf.rs
@@ -458,6 +458,13 @@ impl FBuf {
         self.into_vec().into_boxed_slice()
     }
 
+    /// Creates an `FBuf` by copying the slice.
+    pub fn from_slice(slice: &[u8]) -> Self {
+        let mut fbuf = FBuf::new();
+        fbuf.extend_from_slice(slice);
+        fbuf
+    }
+
     /// Converts the vector into `Vec<u8>`.
     ///
     /// This method reallocates and copies the underlying bytes. Any excess


### PR DESCRIPTION
The serializer we use for `rkyv` outputs into an FBuf, which has 512-byte alignment (because we think we might want to use O_DIRECT someday, which requires 4096- or 512-byte alignment depending on the device).  However, our exchange code was then copying the FBuf's contents into a Vec<u8>. This commit eliminates the copy by using the FBuf for exchange directly instead of Vec<u8>.

(It's questionable whether there's benefit to using FBuf at all.  We might be able to get rid of it.)

### Describe Manual Test Plan

I ran the dbsp unit tests.