### PR TITLE
Mirror pubsub emulator to ghcr

### DIFF
--- a/.github/workflows/test-adapters.yml
+++ b/.github/workflows/test-adapters.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest-amd64
     services:
       pubsub:
-        image: thekevjames/gcloud-pubsub-emulator:e852273e07
+        image: ghcr.io/feldera/gcloud-pubsub-emulator:e852273e07
         ports:
           - 8681:8681
         options: >-


### PR DESCRIPTION
Docker Hub is rejecting unauthenticated pulls of the pubsub emulator image, causing the PubSub adapter tests to fail. Mirrors the image to GHCR (ghcr.io/feldera/gcloud-pubsub-emulator:e852273e07, public) and updates the workflow to pull from there instead.