### PR TITLE
cargo: MSRV from `1.91.1` to `1.93.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/feldera/feldera"
 keywords = ["ivm", "analytics", "database", "incremental", "sql"]
 readme = "README.md"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.91.1"
+rust-version = "1.93.1"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
Minimum Supported Rust Version (MSRV) from `1.91.1` to `1.93.1`.