### PR TITLE
[dbsp] Fix recently introduced bug in pairs seralizer.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/communication/shard.rs
+++ b/crates/dbsp/src/operator/dynamic/communication/shard.rs
@@ -393,9 +393,11 @@ impl PairsSerializer {
         K: DataTrait + ?Sized,
         V: DataTrait + ?Sized,
     {
-        serializer
-            .with(FBufSerializer::new(&mut self.fbuf), |s| pair.serialize(s))
-            .unwrap();
+        self.offsets.push(
+            serializer
+                .with(FBufSerializer::new(&mut self.fbuf), |s| pair.serialize(s))
+                .unwrap(),
+        );
     }
 
     pub fn done(mut self, serializer: &mut SerializerInner) -> FBuf {


### PR DESCRIPTION
Commit 99cbbbc79267 ("[dbsp] Optimize how we cache rkyv serialization data structures.") dropped the code that adds offsets to the offsets array in PairsSerializer.  This broke multihost pipelines.  This fixes the problem.

Thanks to Swanand Mulay for reporting the issue.

### Describe Manual Test Plan

I ran multihost integration tests.