### PR TITLE
[SQL] Add two missing visitor methods to CircuitDispatcher

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitDispatcher.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitDispatcher.java
@@ -1,6 +1,8 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.DBSPDeclaration;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPOperatorWithError;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
@@ -25,6 +27,20 @@ public class CircuitDispatcher extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPSimpleOperator operator) {
+        this.innerVisitor.setOperatorContext(operator);
+        operator.accept(this.innerVisitor);
+        this.innerVisitor.setOperatorContext(null);
+    }
+
+    @Override
+    public void postorder(DBSPOperatorWithError operator) {
+        this.innerVisitor.setOperatorContext(operator);
+        operator.accept(this.innerVisitor);
+        this.innerVisitor.setOperatorContext(null);
+    }
+
+    @Override
+    public void postorder(DBSPOperator operator) {
         this.innerVisitor.setOperatorContext(operator);
         operator.accept(this.innerVisitor);
         this.innerVisitor.setOperatorContext(null);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -885,4 +885,22 @@ public class Regression2Tests extends SqlIoTest {
                  36 | 0.36""");
     }
 
+    @Test
+    public void issue5989() {
+        this.getCCS("""
+                CREATE TABLE ee (
+                    ab VARCHAR(110) NOT NULL PRIMARY KEY,
+                    b VARCHAR(70) NOT NULL,
+                    c SMALLINT NOT NULL,
+                    d BIGINT NOT NULL PRIMARY KEY LATENESS 67::BIGINT,
+                    e VARCHAR(60) NOT NULL ,
+                    f VARCHAR(60) NOT NULL ,
+                    g DECIMAL(38, 10),
+                    h DECIMAL(38, 10),
+                    i INT,
+                    j INT,
+                    k BOOLEAN,
+                    l TIMESTAMP
+                ) WITH ('materialized' = 'true');""");
+    }
 }


### PR DESCRIPTION
Fixes #5989

The missing methods were not dispatching some visitors on some types of circuit IR nodes; as a consequence, the wide tuples were not declared for tables that had primary keys and LATENESS.