### PR TITLE
ci: test cancel fix (revert this)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,3 +310,4 @@ jobs:
         run: echo "All tasks completed!"
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
+


### PR DESCRIPTION
testing if cancel workflow run button works, after merging the #5978 - Revert "ci: skip build phases on re-enqueue if artifacts already exist".
