### PR TITLE
[web-console] Make pipelines table header sticky

### DIFF
--- a/js-packages/web-console/src/lib/components/layout/AppHeader.svelte
+++ b/js-packages/web-console/src/lib/components/layout/AppHeader.svelte
@@ -15,7 +15,7 @@
   const healthStatus = useClusterHealth()
 </script>
 
-<div class="flex w-full flex-row items-center justify-between gap-4 px-2 py-2 md:px-8">
+<div class="flex flex-row items-center justify-between gap-4 px-2 py-2 md:px-8">
   <a class="py-3 lg:pt-2 lg:pr-6 lg:pb-4" href={resolve('/')}>
     <span class="hidden lg:block">
       {#if darkMode.current === 'dark'}

--- a/js-packages/web-console/src/lib/components/pipelines/Table.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/Table.svelte
@@ -20,9 +20,18 @@
 
   let {
     pipelines,
+    header,
     preHeaderEnd,
     selectedPipelines = $bindable()
-  }: { pipelines: PipelineThumb[]; preHeaderEnd?: Snippet; selectedPipelines: string[] } = $props()
+  }: {
+    pipelines: PipelineThumb[]
+    header?: Snippet
+    preHeaderEnd?: Snippet
+    selectedPipelines: string[]
+  } = $props()
+
+  let controlsHeight = $state(0)
+
   const pipelinesWithLastChange = $derived(
     pipelines.map((pipeline) => ({
       ...pipeline,
@@ -78,165 +87,191 @@
   const td = 'py-1 text-base border-t-[0.5px]'
 </script>
 
-<div class="relative mb-2 flex flex-col items-stretch gap-2 sm:flex-row sm:items-end sm:justify-end sm:gap-4 lg:-mt-7 lg:mb-0">
-  <input
-    data-testid="input-pipeline-search"
-    class="input h-9 sm:w-60"
-    type="search"
-    placeholder="Search pipelines..."
-    oninput={(e) => {
-      nameSearch = e.currentTarget.value
-    }}
-  />
-  <select
-    data-testid="select-pipeline-status"
-    class="h_-9 select sm:w-40"
-    onchange={(e) => {
-      statusFilter.value = filterStatuses.find((v) => e.currentTarget.value === v[0])![0]
-      statusFilter.set()
-    }}
-  >
-    {#each filterStatuses as filter (filter[0])}
-      <option value={filter[0]}>{filter[0]}</option>
-    {/each}
-  </select>
-  {@render preHeaderEnd?.()}
-</div>
-<Datatable headless {table}>
-  <table class="p-1">
-    <thead>
-      <tr>
-        <th class="w-10 px-2 text-left"
-          ><input
-            class="checkbox"
-            type="checkbox"
-            checked={table.isAllSelected}
-            onclick={() => table.selectAll()}
-          /></th
+<div class="pipeline-table-wrapper bg-white-dark">
+  <div class="bg-white-dark sticky top-0 z-10 pb-2" bind:clientHeight={controlsHeight}>
+    <div class="sticky left-0 max-w-[100cqi] px-2 md:px-8">
+      {#if header}
+        {@render header()}
+      {/if}
+      <div
+        class="relative mt-2 flex items-stretch gap-2 flex-row sm:items-end sm:justify-end sm:gap-4"
+        class:lg:-mt-7={!!header}
+        class:lg:mb-0={!!header}
+      >
+        <input
+          data-testid="input-pipeline-search"
+          class="input h-9 sm:w-60"
+          type="search"
+          placeholder="Search pipelines..."
+          oninput={(e) => {
+            nameSearch = e.currentTarget.value
+          }}
+        />
+        <select
+          data-testid="select-pipeline-status"
+          class="h_-9 select sm:w-40"
+          onchange={(e) => {
+            statusFilter.value = filterStatuses.find((v) => e.currentTarget.value === v[0])![0]
+            statusFilter.set()
+          }}
         >
-        <ThSort class="px-1 py-1" {table} field="name"
-          ><span class="text-base font-normal text-surface-950-50">Pipeline name</span></ThSort
-        >
-        <th class="px-1 py-1 text-left"
-          ><span class="text-base font-normal text-surface-950-50">Storage</span></th
-        >
-        <ThSort {table} class="px-1 py-1" field="status"
-          ><span class="ml-8 text-base font-normal text-surface-950-50">Status</span></ThSort
-        >
-        <th class="px-1 py-1 text-left"
-          ><span class="text-base font-normal text-surface-950-50">Message</span></th
-        >
-        <ThSort
-          {table}
-          class="w-20 py-1 pr-4 text-right xl:w-32"
-          field={(p) => p.connectors?.numErrors}
-        >
-          <span class="text-base font-normal text-surface-950-50">
-            <span class="inline xl:hidden">Errors</span>
-            <span class="hidden xl:!inline">Runtime errors</span>
-          </span>
-        </ThSort>
-        <ThSort {table} class="w-20 px-1 py-1 xl:w-32" field="platformVersion">
-          <span class="text-base font-normal text-surface-950-50">
-            Runtime <span class="hidden xl:!inline">version</span>
-          </span>
-        </ThSort>
-        <ThSort {table} class="px-1 py-1" field="lastStatusSince"
-          ><span class="text-base font-normal text-surface-950-50">Status changed</span></ThSort
-        >
-        <ThSort {table} class="px-1 py-1" field="deploymentResourcesStatusSince"
-          ><span class="text-base font-normal text-surface-950-50">Deployed on</span></ThSort
-        >
-      </tr>
-    </thead>
-    <tbody>
-      {#each table.rows as pipeline}
-        <tr class="group" data-testid="box-row-{pipeline.name}"
-          ><td class="{td} border-surface-100-900 px-2 group-hover:bg-surface-50-950">
-            <input
+          {#each filterStatuses as filter (filter[0])}
+            <option value={filter[0]}>{filter[0]}</option>
+          {/each}
+        </select>
+        {@render preHeaderEnd?.()}
+      </div>
+    </div>
+  </div>
+  <Datatable headless {table}>
+    <table class="md:px-6">
+      <thead style="top: {controlsHeight}px; z-index: 1;">
+        <tr>
+          <th class="w-10 px-2 text-left"
+            ><input
               class="checkbox"
               type="checkbox"
-              checked={table.selected.includes(pipeline.name)}
-              onclick={() => table.select(pipeline.name)}
-            />
-          </td>
-          <td class="{td} relative w-3/12 border-surface-100-900 group-hover:bg-surface-50-950"
-            ><a
-              class=" absolute top-2 w-full overflow-hidden overflow-ellipsis whitespace-nowrap"
-              href="/pipelines/{pipeline.name}/">{pipeline.name}</a
-            ></td
+              checked={table.isAllSelected}
+              onclick={() => table.selectAll()}
+            /></th
           >
-          <td class="{td} relative w-12 border-surface-100-900 group-hover:bg-surface-50-950">
-            <div
-              class="fd {pipeline.storageStatus === 'Cleared'
-                ? 'fd-database-off text-surface-500'
-                : 'fd-database'} text-center text-[20px]"
-            ></div>
-            <Tooltip
-              >{match(pipeline.storageStatus)
-                .with('InUse', () => 'Storage in use')
-                .with('Clearing', () => 'Clearing storage')
-                .with('Cleared', () => 'Storage cleared')
-                .exhaustive()}</Tooltip
-            >
-          </td>
-          <td class="pr-2 {td} w-36 border-surface-100-900 group-hover:bg-surface-50-950"
-            ><PipelineStatus status={pipeline.status}></PipelineStatus></td
+          <ThSort class="px-1 py-1" {table} field="name"
+            ><span class="text-base font-normal text-surface-950-50">Pipeline name</span></ThSort
           >
-          <td
-            class="{td} relative border-surface-100-900 whitespace-pre-wrap group-hover:bg-surface-50-950"
+          <th class="px-1 py-1 text-left"
+            ><span class="text-base font-normal text-surface-950-50">Storage</span></th
           >
-            <span
-              class="absolute top-1.5 w-full overflow-hidden align-middle overflow-ellipsis whitespace-nowrap"
-            >
-              {#if pipeline.deploymentError}
-                {@const message = pipeline.deploymentError.message}
-                <span class="fd fd-circle-alert pr-2 text-[20px] text-error-500"></span>
-                <Popover class="z-10" strategy="fixed">
-                  <div
-                    class="scrollbar flex max-h-[50vh] max-w-[80vw] overflow-auto whitespace-pre-wrap"
-                  >
-                    {message}
-                  </div>
-                </Popover>
-                {message.slice(0, ((idx) => (idx > 0 ? idx : undefined))(message.indexOf('\n')))}
-              {/if}
+          <ThSort {table} class="px-1 py-1" field="status"
+            ><span class="ml-8 text-base font-normal text-surface-950-50">Status</span></ThSort
+          >
+          <th class="px-1 py-1 text-left"
+            ><span class="text-base font-normal text-surface-950-50">Message</span></th
+          >
+          <ThSort
+            {table}
+            class="w-20 py-1 pr-4 text-right xl:w-32"
+            field={(p) => p.connectors?.numErrors}
+          >
+            <span class="text-base font-normal text-surface-950-50">
+              <span class="inline xl:hidden">Errors</span>
+              <span class="hidden xl:!inline">Runtime errors</span>
             </span>
-          </td>
-          <td class="{td} border-surface-100-900 pr-4 group-hover:bg-surface-50-950">
-            <div class="text-right text-nowrap">
-              {pipeline.connectors?.numErrors ?? '-'}
-            </div>
-          </td>
-          <td class="{td} relative border-surface-100-900 group-hover:bg-surface-50-950">
-            <div class="flex w-full flex-nowrap items-center gap-2 text-nowrap">
-              <PipelineVersion
-                pipelineName={pipeline.name}
-                runtimeVersion={pipeline.platformVersion}
-                baseRuntimeVersion={page.data.feldera!.version}
-                configuredRuntimeVersion={pipeline.programConfig.runtime_version}
-              ></PipelineVersion>
-            </div>
-          </td>
-          <td class="{td} relative w-28 border-surface-100-900 group-hover:bg-surface-50-950">
-            <div class="w-32 text-right text-nowrap">
-              {formatElapsedTime(pipeline.lastStatusSince, 'dhm')} ago
-            </div>
-          </td>
-          <td class="{td} relative w-40 border-surface-100-900 group-hover:bg-surface-50-950">
-            <div class="pr-1 text-right text-nowrap">
-              {pipeline.deploymentResourcesStatus === 'Provisioned'
-                ? formatDateTime(pipeline.deploymentResourcesStatusSince)
-                : ''}
-            </div>
-          </td>
+          </ThSort>
+          <ThSort {table} class="w-20 px-1 py-1 xl:w-32" field="platformVersion">
+            <span class="text-base font-normal text-surface-950-50">
+              Runtime <span class="hidden xl:!inline">version</span>
+            </span>
+          </ThSort>
+          <ThSort {table} class="px-1 py-1" field="lastStatusSince"
+            ><span class="text-base font-normal text-surface-950-50">Status changed</span></ThSort
+          >
+          <ThSort {table} class="px-1 py-1" field="deploymentResourcesStatusSince"
+            ><span class="text-base font-normal text-surface-950-50">Deployed on</span></ThSort
+          >
         </tr>
-      {:else}
-        <tr>
-          <td class={td}></td>
-          <td class={td} colspan={99}>No pipelines found</td>
-        </tr>
-      {/each}
-    </tbody>
-  </table>
-</Datatable>
+      </thead>
+      <tbody>
+        {#each table.rows as pipeline}
+          <tr class="group" data-testid="box-row-{pipeline.name}"
+            ><td class="{td} border-surface-100-900 px-2 group-hover:bg-surface-50-950">
+              <input
+                class="checkbox"
+                type="checkbox"
+                checked={table.selected.includes(pipeline.name)}
+                onclick={() => table.select(pipeline.name)}
+              />
+            </td>
+            <td class="{td} relative w-3/12 border-surface-100-900 group-hover:bg-surface-50-950"
+              ><a
+                class=" absolute top-2 w-full overflow-hidden overflow-ellipsis whitespace-nowrap"
+                href="/pipelines/{pipeline.name}/">{pipeline.name}</a
+              ></td
+            >
+            <td class="{td} relative w-12 border-surface-100-900 group-hover:bg-surface-50-950">
+              <div
+                class="fd {pipeline.storageStatus === 'Cleared'
+                  ? 'fd-database-off text-surface-500'
+                  : 'fd-database'} text-center text-[20px]"
+              ></div>
+              <Tooltip
+                >{match(pipeline.storageStatus)
+                  .with('InUse', () => 'Storage in use')
+                  .with('Clearing', () => 'Clearing storage')
+                  .with('Cleared', () => 'Storage cleared')
+                  .exhaustive()}</Tooltip
+              >
+            </td>
+            <td class="pr-2 {td} w-36 border-surface-100-900 group-hover:bg-surface-50-950"
+              ><PipelineStatus status={pipeline.status}></PipelineStatus></td
+            >
+            <td
+              class="{td} relative border-surface-100-900 whitespace-pre-wrap group-hover:bg-surface-50-950"
+            >
+              <span
+                class="absolute top-1.5 w-full overflow-hidden align-middle overflow-ellipsis whitespace-nowrap"
+              >
+                {#if pipeline.deploymentError}
+                  {@const message = pipeline.deploymentError.message}
+                  <span class="fd fd-circle-alert pr-2 text-[20px] text-error-500"></span>
+                  <Popover class="z-10" strategy="fixed">
+                    <div
+                      class="scrollbar flex max-h-[50vh] max-w-[80vw] overflow-auto whitespace-pre-wrap"
+                    >
+                      {message}
+                    </div>
+                  </Popover>
+                  {message.slice(0, ((idx) => (idx > 0 ? idx : undefined))(message.indexOf('\n')))}
+                {/if}
+              </span>
+            </td>
+            <td class="{td} border-surface-100-900 pr-4 group-hover:bg-surface-50-950">
+              <div class="text-right text-nowrap">
+                {pipeline.connectors?.numErrors ?? '-'}
+              </div>
+            </td>
+            <td class="{td} relative border-surface-100-900 group-hover:bg-surface-50-950">
+              <div class="flex w-full flex-nowrap items-center gap-2 text-nowrap">
+                <PipelineVersion
+                  pipelineName={pipeline.name}
+                  runtimeVersion={pipeline.platformVersion}
+                  baseRuntimeVersion={page.data.feldera!.version}
+                  configuredRuntimeVersion={pipeline.programConfig.runtime_version}
+                ></PipelineVersion>
+              </div>
+            </td>
+            <td class="{td} relative w-28 border-surface-100-900 group-hover:bg-surface-50-950">
+              <div class="w-32 text-right text-nowrap">
+                {formatElapsedTime(pipeline.lastStatusSince, 'dhm')} ago
+              </div>
+            </td>
+            <td class="{td} relative w-40 border-surface-100-900 group-hover:bg-surface-50-950">
+              <div class="pr-1 text-right text-nowrap">
+                {pipeline.deploymentResourcesStatus === 'Provisioned'
+                  ? formatDateTime(pipeline.deploymentResourcesStatusSince)
+                  : ''}
+              </div>
+            </td>
+          </tr>
+        {:else}
+          <tr>
+            <td class={td}></td>
+            <td class={td} colspan={99}>No pipelines found</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </Datatable>
+</div>
+
+<style>
+  .pipeline-table-wrapper {
+    width: fit-content;
+    min-width: 100%;
+  }
+  .pipeline-table-wrapper :global(article.thin-scrollbar) {
+    overflow: visible !important;
+  }
+  .pipeline-table-wrapper :global(table) {
+    background: inherit;
+  }
+</style>

--- a/js-packages/web-console/src/lib/components/pipelines/list/PipelineStatus.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/list/PipelineStatus.svelte
@@ -7,6 +7,6 @@
   const chipClass = $derived(pipelineStatusColor(status).chip)
 </script>
 
-<div class={'chip w-28 uppercase ' + chipClass + ' ' + _class}>
+<div class={'chip w-28 uppercase transition-none ' + chipClass + ' ' + _class}>
   {getPipelineStatusLabel(status)}
 </div>

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
@@ -120,7 +120,7 @@
   ignoreAfterNavigate={() => false}
 ></SvelteKitTopLoader>
 <div
-  class="flex h-full w-full flex-col {api.isNetworkHealthy
+  class="flex h-full flex-col {api.isNetworkHealthy
     ? ''
     : 'disabled pointer-events-auto select-text [&_.monaco-editor-background]:pointer-events-none [&_[role="button"]]:pointer-events-none [&_[role="separator"]]:pointer-events-none [&_a]:pointer-events-none [&_button]:pointer-events-none'}"
   style={api.isNetworkHealthy ? '' : ''}

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+page.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+page.svelte
@@ -77,104 +77,112 @@
   {/snippet}
 </AppHeader>
 <div class="scrollbar flex h-full flex-col justify-between overflow-y-auto">
-  <div class="flex flex-col gap-8 p-2 pt-0 md:p-8 md:pt-0">
-    {#if !welcomed.value}
-      <div class="relative flex min-h-40 w-full gap-4 p-6 sm:gap-12">
-        <div class="absolute top-0 left-0 -z-10 flex h-full w-full overflow-clip card">
-          <div
-            class="w-1/2 bg-gradient-to-br from-fuchsia-300 via-amber-50 to-orange-300 dark:from-fuchsia-700 dark:via-amber-950 dark:to-orange-700"
-          ></div>
-          <div
-            class="w-1/2 bg-gradient-to-tr from-orange-300 via-amber-50 to-amber-50 dark:from-orange-700 dark:via-amber-950 dark:to-amber-950"
-          ></div>
-        </div>
-        {#if darkMode.current === 'dark'}
-          <FelderaLogomarkDark class="hidden h-full max-h-28 sm:inline"></FelderaLogomarkDark>
-        {:else}
-          <FelderaLogomarkLight class="hidden h-full max-h-28 sm:inline"></FelderaLogomarkLight>
-        {/if}
-        <div class="flex w-full flex-col justify-between gap-y-4">
-          <div class="flex flex-nowrap justify-between">
-            <div class="text-2xl font-semibold">Explore our communities and documentation</div>
-            <button
-              class="fd fd-x w-7 text-[24px]"
-              aria-label="Close"
-              onclick={() => (welcomed.value = !welcomed.value)}
-            ></button>
-          </div>
-
-          <div class="flex flex-col gap-x-8 gap-y-4 lg:flex-row">
-            {#each featured as link}
-              <a
-                class="bg-white-dark btn px-6! py-3!"
-                href={link.href}
-                target="_blank"
-                rel="noreferrer"
-                ><link.icon class="h-6 w-6 fill-surface-950-50"></link.icon>{link.title}</a
-              >
-            {/each}
-          </div>
-        </div>
-      </div>
-    {/if}
-    <div class="flex flex-col">
-      <div class="flex flex-nowrap items-center gap-4 text-xl font-semibold">
-        <span class="fd fd-network text-surface-500"></span><span>Your pipelines</span>
-      </div>
-      {#if pipelines.pipelines.length}
-        <PipelineTable pipelines={pipelines.pipelines} bind:selectedPipelines>
-          {#snippet preHeaderEnd()}
-            <AvailableActions pipelines={pipelines.pipelines} bind:selectedPipelines
-            ></AvailableActions>
-            {#if !selectedPipelines.length}
-              <CreatePipelineButton
-                inputClass="max-w-64"
-                btnClass="hidden sm:flex preset-filled-surface-50-950"
-              ></CreatePipelineButton>
+  <div class="@container">
+    <div class="flex flex-col gap-8 pb-2 md:pb-8" style="width: max-content; min-width: 100%;">
+      {#if !welcomed.value}
+        <div class="sticky left-0 max-w-[100cqi] px-2 pt-0 md:px-8">
+          <div class="relative flex min-h-40 w-full gap-4 p-6 sm:gap-12">
+            <div class="absolute top-0 left-0 -z-10 flex h-full w-full overflow-clip card">
+              <div
+                class="w-1/2 bg-gradient-to-br from-fuchsia-300 via-amber-50 to-orange-300 dark:from-fuchsia-700 dark:via-amber-950 dark:to-orange-700"
+              ></div>
+              <div
+                class="w-1/2 bg-gradient-to-tr from-orange-300 via-amber-50 to-amber-50 dark:from-orange-700 dark:via-amber-950 dark:to-amber-950"
+              ></div>
+            </div>
+            {#if darkMode.current === 'dark'}
+              <FelderaLogomarkDark class="hidden h-full max-h-28 sm:inline"></FelderaLogomarkDark>
+            {:else}
+              <FelderaLogomarkLight class="hidden h-full max-h-28 sm:inline"></FelderaLogomarkLight>
             {/if}
-          {/snippet}
-        </PipelineTable>
-      {:else}
-        <div class="flex w-full flex-col items-center gap-4 pt-8 sm:pt-16">
-          <ImageBox class="h-9 fill-surface-200-800"></ImageBox>
-          <div class="">Your pipelines will appear here</div>
-          <div class="relative flex gap-5">
-            <CreatePipelineButton btnClass="preset-filled-surface-50-950"></CreatePipelineButton>
-            <a class="btn preset-tonal-surface" href="https://docs.feldera.com">
-              <span class="fd fd-book-open text-2xl"></span>
-              Documentation
-            </a>
+            <div class="flex w-full flex-col justify-between gap-y-4">
+              <div class="flex flex-nowrap justify-between">
+                <div class="text-2xl font-semibold">Explore our communities and documentation</div>
+                <button
+                  class="fd fd-x w-7 text-[24px]"
+                  aria-label="Close"
+                  onclick={() => (welcomed.value = !welcomed.value)}
+                ></button>
+              </div>
+
+              <div class="flex flex-col gap-x-8 gap-y-4 lg:flex-row">
+                {#each featured as link}
+                  <a
+                    class="bg-white-dark btn px-6! py-3!"
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    ><link.icon class="h-6 w-6 fill-surface-950-50"></link.icon>{link.title}</a
+                  >
+                {/each}
+              </div>
+            </div>
           </div>
         </div>
       {/if}
-    </div>
-    {#if data.demos.length}
-      <div>
-        <InlineDropdown bind:open={showSuggestedDemos.value}>
-          {#snippet header(open, toggle)}
-            <div
-              class="flex w-fit cursor-pointer items-center gap-2 py-2"
-              onclick={toggle}
-              role="presentation"
-            >
-              <div
-                class={'fd fd-chevron-down text-[20px] transition-transform ' +
-                  (open ? 'rotate-180' : '')}
-              ></div>
-
-              <div class="flex flex-nowrap items-center gap-4">
-                <div class="text-xl font-semibold">Explore use cases and tutorials</div>
-                <a
-                  class="whitespace-nowrap text-primary-500"
-                  href={resolve('/demos/')}
-                  onclick={(e) => e.stopPropagation()}>View all</a
-                >
+      <div class="flex flex-col">
+        {#if pipelines.pipelines.length}
+          <PipelineTable pipelines={pipelines.pipelines} bind:selectedPipelines>
+            {#snippet header()}
+              <div class="flex flex-nowrap items-center gap-4 text-xl font-semibold">
+                <span class="fd fd-network text-surface-500"></span><span>Your pipelines</span>
               </div>
+            {/snippet}
+            {#snippet preHeaderEnd()}
+              <AvailableActions pipelines={pipelines.pipelines} bind:selectedPipelines
+              ></AvailableActions>
+              {#if !selectedPipelines.length}
+                <CreatePipelineButton
+                  inputClass="max-w-64"
+                  btnClass="hidden sm:flex preset-filled-surface-50-950"
+                ></CreatePipelineButton>
+              {/if}
+            {/snippet}
+          </PipelineTable>
+        {:else}
+          <div class="flex flex-nowrap items-center gap-4 text-xl font-semibold">
+            <span class="fd fd-network text-surface-500"></span><span>Your pipelines</span>
+          </div>
+          <div class="flex w-full flex-col items-center gap-4 pt-8 sm:pt-16">
+            <ImageBox class="h-9 fill-surface-200-800"></ImageBox>
+            <div class="">Your pipelines will appear here</div>
+            <div class="relative flex gap-5">
+              <CreatePipelineButton btnClass="preset-filled-surface-50-950"></CreatePipelineButton>
+              <a class="btn preset-tonal-surface" href="https://docs.feldera.com">
+                <span class="fd fd-book-open text-2xl"></span>
+                Documentation
+              </a>
             </div>
-          {/snippet}
-          {#snippet content()}
-            <div transition:slide={{ duration: 150 }}>
+          </div>
+        {/if}
+      </div>
+      {#if data.demos.length}
+        <div class="sticky left-0 max-w-[100cqi] px-2 md:px-8">
+          <InlineDropdown bind:open={showSuggestedDemos.value}>
+            {#snippet header(open, toggle)}
               <div
+                class="flex w-fit cursor-pointer items-center gap-2 py-2"
+                onclick={toggle}
+                role="presentation"
+              >
+                <div
+                  class={'fd fd-chevron-down text-[20px] transition-transform ' +
+                    (open ? 'rotate-180' : '')}
+                ></div>
+
+                <div class="flex flex-nowrap items-center gap-4">
+                  <div class="text-xl font-semibold">Explore use cases and tutorials</div>
+                  <a
+                    class="whitespace-nowrap text-primary-500"
+                    href={resolve('/demos/')}
+                    onclick={(e) => e.stopPropagation()}>View all</a
+                  >
+                </div>
+              </div>
+            {/snippet}
+            {#snippet content()}
+              <div
+                transition:slide={{ duration: 150 }}
                 class="grid grid-cols-1 gap-x-6 gap-y-5 py-2 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5"
               >
                 {#each data.demos.slice(0, maxShownDemos) as demo}
@@ -188,11 +196,11 @@
                   </a>
                 </div>
               </div>
-            </div>
-          {/snippet}
-        </InlineDropdown>
-      </div>
-    {/if}
+            {/snippet}
+          </InlineDropdown>
+        </div>
+      {/if}
+    </div>
   </div>
-  <Footer></Footer>
+  <div class="sticky left-0"><Footer></Footer></div>
 </div>

--- a/js-packages/web-console/tests/pipelineSearch.e2e.ts
+++ b/js-packages/web-console/tests/pipelineSearch.e2e.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { client } from '$lib/services/manager/client.gen'
-import {
-  deletePipeline,
-  getExtendedPipeline,
-  putPipeline
-} from '$lib/services/pipelineManager'
+import { deletePipeline, getExtendedPipeline, putPipeline } from '$lib/services/pipelineManager'
 
 const API_ORIGIN = (process.env.PLAYWRIGHT_API_ORIGIN ?? 'http://localhost:8080').replace(/\/$/, '')
 client.setConfig({ baseUrl: API_ORIGIN })


### PR DESCRIPTION
Made the table controls and header sticky:
[Screencast from 2026-04-06 16-22-47.webm](https://github.com/user-attachments/assets/5e403b60-715d-42e6-82e3-5559b85222d7)

The PR is basically a layout and style change.

Testing: manually tested the desktop-size and mobile-size behavior of pipelines page in a chrome-based browser and Firefox