### PR TITLE
[dbsp] Use approximate size for size of in-memory batches.

### DIFF
--- a/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/indexed_wset_batch.rs
@@ -158,7 +158,6 @@ where
 type Layers<K, V, R, O> = Layer<K, Leaf<V, R>, O>;
 
 /// An immutable collection of update tuples.
-#[derive(SizeOf)]
 pub struct VecIndexedWSet<K, V, R, O = usize>
 where
     K: DataTrait + ?Sized,
@@ -169,9 +168,7 @@ where
     /// Where all the data is.
     #[doc(hidden)]
     pub layer: Layers<K, V, R, O>,
-    #[size_of(skip)]
     factories: VecIndexedWSetFactories<K, V, R>,
-    #[size_of(skip)]
     negative_weight_count: u64,
 }
 
@@ -200,6 +197,20 @@ where
             factories,
             negative_weight_count,
         }
+    }
+}
+
+impl<K, V, R, O> SizeOf for VecIndexedWSet<K, V, R, O>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+    O: OrdOffset,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        // This is only approximate but it is *much* cheaper than measuring all
+        // the elements individually.
+        context.add(self.approximate_byte_size());
     }
 }
 

--- a/crates/dbsp/src/trace/ord/vec/key_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/key_batch.rs
@@ -148,7 +148,6 @@ pub type VecKeyBatchLayer<K, T, R, O> = Layer<K, Leaf<DynDataTyped<T>, R>, O>;
 
 /// An immutable collection of update tuples, from a contiguous interval of
 /// logical times.
-#[derive(SizeOf)]
 pub struct VecKeyBatch<K, T, R, O = usize>
 where
     K: DataTrait + ?Sized,
@@ -158,8 +157,21 @@ where
 {
     /// Where all the dataz is.
     pub layer: VecKeyBatchLayer<K, T, R, O>,
-    #[size_of(skip)]
     factories: VecKeyBatchFactories<K, T, R>,
+}
+
+impl<K, T, R, O> SizeOf for VecKeyBatch<K, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+    T: Timestamp,
+    O: OrdOffset,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        // This is only approximate but it is *much* cheaper than measuring all
+        // the elements individually.
+        context.add(self.approximate_byte_size());
+    }
 }
 
 impl<K, T, R, O> Debug for VecKeyBatch<K, T, R, O>

--- a/crates/dbsp/src/trace/ord/vec/val_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/val_batch.rs
@@ -182,7 +182,6 @@ where
 
 /// An immutable collection of update tuples, from a contiguous interval of
 /// logical times.
-#[derive(SizeOf)]
 pub struct VecValBatch<K, V, T, R, O = usize>
 where
     K: DataTrait + ?Sized,
@@ -191,7 +190,6 @@ where
     T: Timestamp,
     O: OrdOffset,
 {
-    #[size_of(skip)]
     factories: VecValBatchFactories<K, V, T, R>,
 
     // #[size_of(skip)]
@@ -202,6 +200,21 @@ where
     // batch_item_factory: &'static BatchItemVTable<K, V, Pair<K, V>, R>,
     /// Where all the dataz is.
     pub layer: VecValBatchLayer<K, V, T, R, O>,
+}
+
+impl<K, V, T, R, O> SizeOf for VecValBatch<K, V, T, R, O>
+where
+    K: DataTrait + ?Sized,
+    V: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+    T: Timestamp,
+    O: OrdOffset,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        // This is only approximate but it is *much* cheaper than measuring all
+        // the elements individually.
+        context.add(self.approximate_byte_size());
+    }
 }
 
 unsafe impl<K, V, T, R, O> Send for VecValBatch<K, V, T, R, O>

--- a/crates/dbsp/src/trace/ord/vec/wset_batch.rs
+++ b/crates/dbsp/src/trace/ord/vec/wset_batch.rs
@@ -113,7 +113,6 @@ impl<K: DataTrait + ?Sized, R: WeightTrait + ?Sized> BatchFactories<K, DynUnit, 
 }
 
 /// An immutable collection of `(key, weight)` pairs without timing information.
-#[derive(SizeOf)]
 pub struct VecWSet<K, R>
 where
     K: DataTrait + ?Sized,
@@ -121,9 +120,20 @@ where
 {
     #[doc(hidden)]
     pub layer: Leaf<K, R>,
-    #[size_of(skip)]
     factories: VecWSetFactories<K, R>,
     negative_weight_count: u64,
+}
+
+impl<K, R> SizeOf for VecWSet<K, R>
+where
+    K: DataTrait + ?Sized,
+    R: WeightTrait + ?Sized,
+{
+    fn size_of_children(&self, context: &mut size_of::Context) {
+        // This is only approximate but it is *much* cheaper than measuring all
+        // the elements individually.
+        context.add(self.approximate_byte_size());
+    }
 }
 
 impl<K, R> VecWSet<K, R>


### PR DESCRIPTION
When Feldera takes a profile, it measures the size of all the batches in each spine using SizeOf.  This is very expensive for large batches, in some cases taking over a second of CPU time.  This commit fixes the problem.

Another way to fix the problem would be to calculate the exact size and save it.  This could be done at batch creation time unconditionally, or the first time we measure it and cached.  But this would still take the same large amount of CPU time, we'd just be able to avoid taking it more than once.  And if we did it lazily and cached it, it would still take a lot of time in profiles, especially the first time a profile runs.

### Describe Manual Test Plan

I am running the unit tests.