### PR TITLE
[dbsp] Don't rebalance during initial step.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2753,6 +2753,15 @@ impl CircuitThread {
     ) -> Result<(), ControllerError> {
         let config = &self.controller.status.pipeline_config;
 
+        // Disable auto-rebalancing during the first step. This makes sure that the
+        // first step doesn't trigger an expensive rebalancing operation. We don't
+        // want to be stuck in the initialization state, when none of the monitoring
+        // features are enabled, for a long time.
+        if let Err(error) = self.circuit.set_auto_rebalance(false) {
+            let _ = init_status_sender.send(Err(error.into()));
+            return Ok(());
+        }
+
         // Initialize the step trigger with the bootstraping state,
         // so that if the first step() we perform below before entering the loop
         // ends up finishing bootstrapping, we will still perform an extra step to initialize
@@ -2772,13 +2781,26 @@ impl CircuitThread {
         // Run a single step, which is probably empty, before reporting that
         // initialization is complete.  This is needed to make ad-hoc snapshots
         // up-to-date before making them available to the user.
-        if let Err(error) = self.step() {
+        //
+        // Skip this during bootstrap to avoid a slow first step. We don't guarantee
+        // that view snapshots are up-to-date until bootstrap is complete.
+        if !self.circuit.bootstrap_in_progress()
+            && let Err(error) = self.step()
+        {
             let _ = init_status_sender.send(Err(error));
             return Ok(());
-        };
+        }
+
+        // Enable auto-rebalancing after the first step.
+        if let Err(error) = self.circuit.set_auto_rebalance(true) {
+            let _ = init_status_sender.send(Err(error.into()));
+            return Ok(());
+        }
+
         let _ = init_status_sender.send(Ok(self.controller.clone()));
 
         let mut output_backpressure_warning: Option<LongOperationWarning> = None;
+
         loop {
             // Run received commands.  Commands can initiate checkpoint
             // requests, so attempt to execute those afterward.  Executing a

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2662,6 +2662,15 @@ impl CircuitThread {
     ) -> Result<(), ControllerError> {
         let config = &self.controller.status.pipeline_config;
 
+        // Disable auto-rebalancing during the first step. This makes sure that the
+        // first step doesn't trigger an expensive rebalancing operation. We don't
+        // want to be stuck in the initialization state, when none of the monitoring
+        // features are enabled, for a long time.
+        if let Err(error) = self.circuit.set_auto_rebalance(false) {
+            let _ = init_status_sender.send(Err(error.into()));
+            return Ok(());
+        }
+
         // Initialize the step trigger with the bootstraping state,
         // so that if the first step() we perform below before entering the loop
         // ends up finishing bootstrapping, we will still perform an extra step to initialize
@@ -2681,13 +2690,26 @@ impl CircuitThread {
         // Run a single step, which is probably empty, before reporting that
         // initialization is complete.  This is needed to make ad-hoc snapshots
         // up-to-date before making them available to the user.
-        if let Err(error) = self.step() {
+        //
+        // Skip this during bootstrap to avoid a slow first step. We don't guarantee
+        // that view snapshots are up-to-date until bootstrap is complete.
+        if !self.circuit.bootstrap_in_progress()
+            && let Err(error) = self.step()
+        {
             let _ = init_status_sender.send(Err(error));
             return Ok(());
-        };
+        }
+
+        // Enable auto-rebalancing after the first step.
+        if let Err(error) = self.circuit.set_auto_rebalance(true) {
+            let _ = init_status_sender.send(Err(error.into()));
+            return Ok(());
+        }
+
         let _ = init_status_sender.send(Ok(self.controller.clone()));
 
         let mut output_backpressure_warning: Option<LongOperationWarning> = None;
+
         loop {
             // Run received commands.  Commands can initiate checkpoint
             // requests, so attempt to execute those afterward.  Executing a

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -1794,13 +1794,6 @@ pub trait CircuitBase: 'static {
 
     fn check_fixedpoint(&self, scope: Scope) -> bool;
 
-    fn notify_start_transaction(&self) {
-        let _ = self.map_local_nodes_mut(&mut |node| {
-            node.start_transaction();
-            Ok(())
-        });
-    }
-
     /// Return the metadata exchange object associated with the circuit.
     fn metadata_exchange(&self) -> &MetadataExchange;
 

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -6556,11 +6556,11 @@ where
     }
 
     fn flush(&mut self) {
-        self.operator.borrow_mut().flush();
+        self.operator.borrow_mut().flush_input();
     }
 
     fn is_flush_complete(&self) -> bool {
-        self.operator.borrow().is_flush_complete()
+        self.operator.borrow().is_flush_input_complete()
     }
 
     // Don't call `clock_start`/`clock_end` on the operator.  `FeedbackOutputNode`
@@ -7180,7 +7180,7 @@ impl CircuitHandle {
             //             } else {
             //                 None
             //             };
-            //             Some(crate::utils::DotNodeAttributes::new().with_color(color))
+            //             Some(crate::utils::DotNodeAttributes::new().with_color(color).with_label(&format!("{}:{}", node.name(), node.local_id())))
             //         },
             //         |edge| {
             //             let style = if edge.is_dependency() {

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -7132,11 +7132,10 @@ impl CircuitHandle {
                 .collect::<Vec<NodeId>>()
         );
 
+        let replay_nodes = replay_sources.keys().cloned().collect::<BTreeSet<_>>();
+
         assert!(
-            replay_sources
-                .keys()
-                .cloned()
-                .collect::<BTreeSet<_>>()
+            replay_nodes
                 .intersection(&need_backfill)
                 .collect::<Vec<_>>()
                 .is_empty()
@@ -7145,13 +7144,13 @@ impl CircuitHandle {
         // Nodes that will be backfilled from upstream nodes, including need_backfill nodes
         // and their transitive ancestors.
         let nodes_to_backfill = participate_in_backfill
-            .difference(&replay_sources.keys().cloned().collect::<BTreeSet<_>>())
+            .difference(&replay_nodes)
             .cloned()
             .collect::<BTreeSet<_>>();
 
         if !participate_in_backfill.is_empty() {
             // Configure all `replay_nodes` to run in replay mode.
-            for node_id in replay_sources.keys() {
+            for node_id in replay_nodes.iter() {
                 self.circuit
                     .map_local_node_mut(*node_id, &mut |node| node.start_replay())?;
             }

--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -1807,6 +1807,9 @@ pub trait CircuitBase: 'static {
     /// Return the balancer object associated with the circuit.
     fn balancer(&self) -> &Balancer;
 
+    /// Set the auto-rebalancing flag for the circuit.
+    fn set_auto_rebalance(&self, enable: bool) -> Result<(), DbspError>;
+
     /// Set the balancer hint for the operator with the given global node id.
     ///
     /// # Errors
@@ -3418,6 +3421,10 @@ where
 
     fn balancer(&self) -> &Balancer {
         &self.inner().balancer
+    }
+
+    fn set_auto_rebalance(&self, enable: bool) -> Result<(), DbspError> {
+        self.inner().balancer.set_auto_rebalance(enable)
     }
 
     fn set_balancer_hint(
@@ -7546,6 +7553,10 @@ impl CircuitHandle {
     /// Export circuit in LIR format.
     pub fn lir(&self) -> LirCircuit {
         (&self.circuit as &dyn CircuitBase).to_lir()
+    }
+
+    pub fn set_auto_rebalance(&self, enable: bool) -> Result<(), DbspError> {
+        self.circuit.set_auto_rebalance(enable)
     }
 
     pub fn set_balancer_hint(

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -711,6 +711,12 @@ impl Runtime {
                             return;
                         }
                     }
+                    Ok(Command::SetAutoRebalance(enable)) => {
+                        let result = circuit.set_auto_rebalance(enable).map(|_| Response::Unit);
+                        if status_sender.send(result).is_err() {
+                            return;
+                        }
+                    }
                     Ok(Command::SetBalancerHints(hints)) => {
                         let results = hints
                             .into_iter()
@@ -831,6 +837,7 @@ enum Command {
     SetBalancerHints(Vec<(GlobalNodeId, BalancerHint)>),
     GetCurrentBalancerPolicy,
     Rebalance,
+    SetAutoRebalance(bool),
 }
 
 impl Debug for Command {
@@ -861,6 +868,9 @@ impl Debug for Command {
             }
             Command::GetCurrentBalancerPolicy => write!(f, "GetCurrentBalancerPolicy"),
             Command::Rebalance => write!(f, "Rebalance"),
+            Command::SetAutoRebalance(enable) => {
+                f.debug_tuple("SetAutoRebalance").field(enable).finish()
+            }
         }
     }
 }
@@ -1488,6 +1498,22 @@ impl DBSPHandle {
         }
 
         self.kill_inner()
+    }
+
+    /// Enable/disable automatic rebalancing of the circuit.
+    ///
+    /// When enabled, the circuit will automatically rebalance skewed joins based on internal
+    /// heuristics. Rebalancing can introduce pipeline stalls.
+    ///
+    /// When disabled, the circuit will not automatically rebalance skewed joins. Rebalancing can
+    /// be triggered explicitly by calling `rebalance`.
+    pub fn set_auto_rebalance(&mut self, enable: bool) -> Result<(), DbspError> {
+        self.broadcast_command(Command::SetAutoRebalance(enable), |_, resp| {
+            let Response::Unit = resp else {
+                panic!("Expected Unit response, got {resp:?}");
+            };
+        })?;
+        Ok(())
     }
 
     pub fn set_balancer_hint(

--- a/crates/dbsp/src/circuit/operator_traits.rs
+++ b/crates/dbsp/src/circuit/operator_traits.rs
@@ -573,6 +573,22 @@ pub trait StrictUnaryOperator<I, O>: StrictOperator<O> {
     fn input_preference(&self) -> OwnershipPreference {
         OwnershipPreference::INDIFFERENT
     }
+
+    /// Flush the input half of the strict operator.
+    ///
+    /// The strict operator appears in the circuit twice: as a source
+    /// operator that outputs the delayed value at the start of the step,
+    /// and as a sink operator that consumes the new value.
+    ///
+    /// These operators are flushed separately. The `Operator::flush` and
+    /// `Operator::is_flush_complete` methods are invoked on the output half.
+    ///
+    /// The `flush_input` and `is_flush_input_complete` methods are invoked
+    /// on the input half.
+    fn flush_input(&mut self);
+
+    /// See [`StrictUnaryOperator::flush_input`] for more details.
+    fn is_flush_input_complete(&self) -> bool;
 }
 
 /// An import operator makes a stream from the parent circuit

--- a/crates/dbsp/src/circuit/replay_tests.rs
+++ b/crates/dbsp/src/circuit/replay_tests.rs
@@ -163,6 +163,45 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
     O2: TestDataType,
     O3: TestDataType,
 {
+    // Run with replay step size < splitter chunk size.
+    test_replay_with_step_size::<I1, I2, I3, O1, O2, O3>(
+        circuit_constructor1.clone(),
+        circuit_constructor2.clone(),
+        inputs1.clone(),
+        inputs2_1.clone(),
+        inputs2_2.clone(),
+        inputs3.clone(),
+        Some(1),
+    );
+
+    // Run without replay step size > splitter chunk size.
+    test_replay_with_step_size::<I1, I2, I3, O1, O2, O3>(
+        circuit_constructor1,
+        circuit_constructor2,
+        inputs1,
+        inputs2_1,
+        inputs2_2,
+        inputs3,
+        None,
+    );
+}
+
+fn test_replay_with_step_size<I1, I2, I3, O1, O2, O3>(
+    circuit_constructor1: CircuitFn<I1, I2, O1, O2>,
+    circuit_constructor2: CircuitFn<I2, I3, O2, O3>,
+    inputs1: Vec<I1::Chunk>,
+    inputs2_1: Vec<I2::Chunk>,
+    inputs2_2: Vec<I2::Chunk>,
+    inputs3: Vec<I3::Chunk>,
+    replay_step_size: Option<usize>,
+) where
+    I1: TestDataType,
+    I2: TestDataType,
+    I3: TestDataType,
+    O1: TestDataType,
+    O2: TestDataType,
+    O3: TestDataType,
+{
     assert_eq!(inputs1.len(), inputs2_1.len());
     assert_eq!(inputs2_2.len(), inputs3.len());
 
@@ -298,6 +337,10 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
                 Ok(circuit_constructor2_clone(circuit))
             })
             .unwrap();
+
+        if let Some(replay_step_size) = replay_step_size {
+            circuit.set_replay_step_size(replay_step_size);
+        }
 
         while circuit.bootstrap_in_progress() {
             circuit.transaction().unwrap();

--- a/crates/dbsp/src/circuit/replay_tests.rs
+++ b/crates/dbsp/src/circuit/replay_tests.rs
@@ -189,6 +189,7 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
     let mut reference_output3 = Vec::new();
 
     {
+        println!("Running first circuit to get reference output");
         let circuit_constructor1_clone = circuit_constructor1.clone();
         let (mut circuit, (input_handles1, input_handles2, output_handles1, output_handles2)) =
             Runtime::init_circuit(&circuit_config, move |circuit| {
@@ -216,6 +217,7 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
 
         circuit.kill().unwrap();
 
+        println!("Running second circuit to get reference output");
         let circuit_constructor2_clone = circuit_constructor2.clone();
         let (mut circuit, (input_handles2, input_handles3, output_handles2, output_handles3)) =
             Runtime::init_circuit(&circuit_config, move |circuit| {
@@ -252,6 +254,8 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
     let mut actual_output3 = Vec::new();
 
     let checkpoint = {
+        println!("Running first circuit to create checkpoint");
+
         // Create the first circuit.
         let circuit_constructor1_clone = circuit_constructor1.clone();
 
@@ -310,6 +314,8 @@ fn test_replay<I1, I2, I3, O1, O2, O3>(
             actual_output2.push(O2::read_outputs(&output_handles2));
             actual_output3.push(O3::read_outputs(&output_handles3));
         }
+
+        println!("Additional transactions completed");
 
         circuit.kill().unwrap();
     }

--- a/crates/dbsp/src/circuit/replay_tests.rs
+++ b/crates/dbsp/src/circuit/replay_tests.rs
@@ -627,17 +627,25 @@ fn test_linear_circuit_materialized_inputs_with_backfill() {
 //
 // Pipeline 1:
 //
+//        |----------------------|
+//        |                      v
+//        |              |----->join--->
+//        |              |
 // ---> input1 ---> join --> output1
 //                   ^
 // ---> input2 ------|
 //
 // Pipeline 2 (adds another join):
 //
+//        |----------------------|
+//        |                      v
+//        |              |----->join--->
+//        |              |
 // ---> input1 ---> join --> output1
-//                   ^
-// ---> input2 ------|
-//                   v
-// ---> input3 ---> join --> output2
+//                   ^    |
+// ---> input2 ------|    |------------>join-->output2
+//                   v    |
+// ---> input3 ---> join --
 //
 fn join_circuit1(
     balancing: bool,
@@ -665,14 +673,28 @@ fn join_circuit1(
         .map_index(|x| (*x, *x))
         .set_persistent_id(Some("input_stream2_indexed"));
 
-    let output_handle1 = if balancing {
-        input_stream1_indexed
+    let (_j1_indexed, output_handle1) = if balancing {
+        let j1 = input_stream1_indexed
             .join_balanced_inner(&input_stream2_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output1"))
+            .set_persistent_id(Some("j1"));
+
+        let j1_indexed = j1
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j1-indexed"));
+        j1_indexed.join_balanced_inner(&input_stream1_indexed, |key, _v1, _v2| *key);
+
+        (j1_indexed, j1.accumulate_output_persistent(Some("output1")))
     } else {
-        input_stream1_indexed
+        let j1 = input_stream1_indexed
             .join(&input_stream2_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output1"))
+            .set_persistent_id(Some("j1"));
+
+        let j1_indexed = j1
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j1-indexed"));
+        j1_indexed.join(&input_stream1_indexed, |key, _v1, _v2| *key);
+
+        (j1_indexed, j1.accumulate_output_persistent(Some("output1")))
     };
 
     ((), (input_handle1, input_handle2), (), output_handle1)
@@ -711,24 +733,60 @@ fn join_circuit2(
         .map_index(|x| (*x, *x))
         .set_persistent_id(Some("input_stream3_indexed"));
 
-    let output_handle1 = if balancing {
-        input_stream1_indexed
+    let (j1_indexed, output_handle1) = if balancing {
+        let j1 = input_stream1_indexed
             .join_balanced_inner(&input_stream2_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output1"))
+            .set_persistent_id(Some("j1"));
+
+        let j1_indexed = j1
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j1-indexed"));
+
+        j1_indexed.join_balanced_inner(&input_stream1_indexed, |key, _v1, _v2| *key);
+
+        (j1_indexed, j1.accumulate_output_persistent(Some("output1")))
     } else {
-        input_stream1_indexed
+        let j1 = input_stream1_indexed
             .join(&input_stream2_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output1"))
+            .set_persistent_id(Some("j1"));
+
+        let j1_indexed = j1
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j1-indexed"));
+
+        j1_indexed.join(&input_stream1_indexed, |key, _v1, _v2| *key);
+
+        (j1_indexed, j1.accumulate_output_persistent(Some("output1")))
     };
 
     let output_handle2 = if balancing {
-        input_stream2_indexed
+        let j2 = input_stream2_indexed
             .join_balanced_inner(&input_stream3_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output2"))
+            .set_persistent_id(Some("j2"));
+
+        let j2_indexed = j2
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j2-indexed"));
+
+        let j3 = j2_indexed
+            .join_balanced_inner(&j1_indexed, |key, _v1, _v2| *key)
+            .set_persistent_id(Some("j3"));
+
+        j3.accumulate_output_persistent(Some("output2"))
     } else {
-        input_stream2_indexed
+        let j2 = input_stream2_indexed
             .join(&input_stream3_indexed, |key, _v1, _v2| *key)
-            .accumulate_output_persistent(Some("output2"))
+            .set_persistent_id(Some("j2"));
+
+        let j2_indexed = j2
+            .map_index(|x| (*x, *x))
+            .set_persistent_id(Some("j2-indexed"));
+
+        let j3 = j2_indexed
+            .join(&j1_indexed, |key, _v1, _v2| *key)
+            .set_persistent_id(Some("j3"));
+
+        j3.accumulate_output_persistent(Some("output2"))
     };
 
     (

--- a/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
+++ b/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
@@ -270,11 +270,11 @@ impl Inner {
         }
     }
 
-    fn prepare<C>(circuit: &C, nodes: Option<&BTreeSet<NodeId>>) -> Result<Self, Error>
+    fn prepare<C>(circuit: &C, active_nodes: Option<&BTreeSet<NodeId>>) -> Result<Self, Error>
     where
         C: Circuit,
     {
-        let nodes = nodes
+        let nodes = active_nodes
             .map(|nodes| nodes.iter().cloned().collect::<BTreeSet<_>>())
             .unwrap_or_else(|| BTreeSet::from_iter(circuit.node_ids()));
 
@@ -385,7 +385,7 @@ impl Inner {
         }
 
         if circuit.root_scope() == 0 {
-            circuit.balancer().prepare(circuit);
+            circuit.balancer().prepare(circuit, active_nodes);
         }
 
         Ok(scheduler)

--- a/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
+++ b/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
@@ -57,7 +57,7 @@ use crate::{
     Position,
     circuit::{
         Circuit, GlobalNodeId, NodeId,
-        circuit_builder::CircuitMetadata,
+        circuit_builder::{CircuitMetadata, Node},
         runtime::{Broadcast, Runtime},
         schedule::{
             CommitProgress, Error, Scheduler,
@@ -457,7 +457,11 @@ impl Inner {
         }
         self.transaction_phase = TransactionPhase::Started;
 
-        circuit.notify_start_transaction();
+        for node_id in self.tasks.keys() {
+            circuit.map_local_node_mut(*node_id, &mut |node: &mut dyn Node| {
+                node.start_transaction()
+            });
+        }
 
         if circuit.root_scope() == 0 {
             circuit.balancer().start_transaction();

--- a/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
+++ b/crates/dbsp/src/operator/dynamic/accumulate_trace.rs
@@ -726,7 +726,8 @@ pub struct AccumulateZ1Trace<C: Circuit, B: Batch, T: Trace> {
     batch_factories: B::Factories,
     // Stream whose integral this Z1 operator stores, if any.
     delta_stream: Option<Stream<C, B>>,
-    flush: bool,
+    flush_output: bool,
+    flush_input: bool,
 }
 
 impl<C, B, T> AccumulateZ1Trace<C, B, T>
@@ -755,7 +756,8 @@ where
             reset_on_clock_start,
             bounds,
             delta_stream: None,
-            flush: false,
+            flush_output: false,
+            flush_input: false,
         }
     }
 
@@ -928,7 +930,11 @@ where
     }
 
     fn flush(&mut self) {
-        self.flush = true;
+        self.flush_output = true;
+    }
+
+    fn is_flush_complete(&self) -> bool {
+        !self.flush_output
     }
 }
 
@@ -943,7 +949,10 @@ where
         let replay_step_size = Runtime::replay_step_size();
 
         if self.replay_mode {
-            if let Some(replay) = &mut self.replay_state {
+            // One output per transaction.
+            if self.flush_output
+                && let Some(replay) = &mut self.replay_state
+            {
                 //println!("Z1-{}::get_output: replaying", &self.global_id);
                 let mut builder = <B::Builder as Builder<B>>::with_capacity(
                     &self.batch_factories,
@@ -992,6 +1001,8 @@ where
             }
         }
 
+        self.flush_output = false;
+
         let mut result = self.trace.take().unwrap();
         result.clear_dirty_flag();
         result
@@ -1012,6 +1023,14 @@ where
     B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R>,
     T: Trace,
 {
+    fn flush_input(&mut self) {
+        self.flush_input = true;
+    }
+
+    fn is_flush_input_complete(&self) -> bool {
+        !self.flush_input
+    }
+
     async fn eval_strict(&mut self, _i: &T) {
         unimplemented!()
     }
@@ -1019,8 +1038,8 @@ where
     async fn eval_strict_owned(&mut self, mut i: T) {
         // println!("Z1-{}::eval_strict_owned", &self.global_id);
 
-        if self.flush {
-            self.flush = false;
+        if self.flush_input {
+            self.flush_input = false;
             self.time = self.time.advance(0);
         }
 

--- a/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
@@ -361,7 +361,7 @@ impl KeyDistribution {
 /// Checkpointed state of the ExchangeSender operator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct RebalanceExchangeSenderCheckpoint {
-    current_policy: PartitioningPolicy,
+    current_policy: Option<PartitioningPolicy>,
     key_distribution: KeyDistribution,
 }
 
@@ -402,7 +402,11 @@ where
     num_steps_in_transaction: Cell<usize>,
 
     /// Current partitioning policy.
-    current_policy: Cell<PartitioningPolicy>,
+    ///
+    /// The policy is not set when the operator is first created. It must
+    /// be set by the balance before the first step. It is also set when restoring
+    /// from a checkpoint.
+    current_policy: Cell<Option<PartitioningPolicy>>,
 
     /// When Some(), the policy has changed during the current transaction, and the operator must rebalance
     /// accumulator and integral state before committing the transaction.
@@ -461,7 +465,7 @@ where
             input_batch_stats: BatchSizeStats::new(),
             flush_state: Cell::new(FlushState::FlushCompleted),
             num_steps_in_transaction: Cell::new(0),
-            current_policy: Cell::new(PartitioningPolicy::Shard),
+            current_policy: Cell::new(None),
             rebalance_state: RefCell::new(None),
             rebalance_start_time: Cell::new(None),
             num_rebalancings: Cell::new(0),
@@ -538,21 +542,25 @@ where
     ///   of the integral.
     fn update_policy(&self, new_policy: PartitioningPolicy, delayed_accumulator: Vec<Arc<B>>) {
         let old_policy = self.current_policy.get();
-        if old_policy == new_policy {
+        if old_policy == Some(new_policy) {
             return;
         }
 
         // Only log rebalancing in worker 0 to avoid spamming the logs.
         if Runtime::worker_index() == 0 {
             info!(
-                "rebalancing stream {}: {}->{} (key distribution: {})",
+                "Rebalancing stream {}: {}->{} (key distribution: {})",
                 self.input_node_id,
-                old_policy,
-                new_policy,
+                if let Some(policy) = old_policy {
+                    policy.to_string()
+                } else {
+                    "none".to_string()
+                },
+                new_policy.to_string(),
                 self.key_distribution.borrow()
             );
         }
-        self.current_policy.set(new_policy);
+        self.current_policy.set(Some(new_policy));
         self.num_rebalancings.update(|value| value + 1);
 
         // Discard the accumulator state, so we don't need to retract it explicitly.
@@ -561,7 +569,7 @@ where
         // If the accumulator was populated with broadcast policy, we want to re-balance only
         // one copy of the data.
         let accumulator_batches =
-            if old_policy != PartitioningPolicy::Broadcast || self.worker_index == 0 {
+            if old_policy != Some(PartitioningPolicy::Broadcast) || self.worker_index == 0 {
                 delayed_accumulator
             } else {
                 vec![]
@@ -579,7 +587,7 @@ where
                         &self.batch_factories,
                         accumulator_batches,
                     ),
-                    trace_policy: old_policy,
+                    trace_policy: old_policy.unwrap_or(PartitioningPolicy::Shard),
                 });
             }
         }
@@ -589,7 +597,11 @@ where
     ///
     /// Update key distribution stats.
     fn partition_batch(&self, delta: B) -> Vec<B> {
-        match self.current_policy.get() {
+        match self
+            .current_policy
+            .get()
+            .expect("RebalancingExchangeSender::partition_batch: current_policy is not set")
+        {
             PartitioningPolicy::Shard => self.shard_batch(delta),
             PartitioningPolicy::Balance => self.balance_batch(delta),
             PartitioningPolicy::Broadcast => self.broadcast_batch(delta),
@@ -608,7 +620,8 @@ where
     ) where
         TS: Timestamp,
     {
-        assert!(old_policy != self.current_policy.get());
+        assert_ne!(self.current_policy.get(), None);
+        assert_ne!(old_policy, self.current_policy.get().unwrap());
 
         match old_policy {
             PartitioningPolicy::Broadcast => self.repartition_after_broadcast(
@@ -639,7 +652,9 @@ where
     {
         let shards = builders.len();
 
-        match self.current_policy.get() {
+        match self.current_policy.get().expect(
+            "RebalancingExchangeSender::repartition_after_unicast: current policy is not set",
+        ) {
             PartitioningPolicy::Shard => {
                 while cursor.key_valid() {
                     let b = &mut builders[cursor.key().default_hash() as usize % shards];
@@ -747,7 +762,9 @@ where
     {
         let shards = Runtime::num_workers();
 
-        match self.current_policy.get() {
+        match self.current_policy.get().expect(
+            "RebalancingExchangeSender::repartition_after_broadcast: current policy is not set",
+        ) {
             PartitioningPolicy::Shard => {
                 while cursor.key_valid() {
                     let shard = cursor.key().default_hash() as usize % shards;
@@ -1028,7 +1045,7 @@ pub struct RebalancingExchangeSenderExchangeMetadata {
     pub flush_state: FlushState,
 
     /// Currently selected sharding policy.
-    pub current_policy: PartitioningPolicy,
+    pub current_policy: Option<PartitioningPolicy>,
 
     /// Key distribution of the input stream computed based on the inputs received by the current worker.
     pub key_distribution: KeyDistribution,
@@ -1047,7 +1064,7 @@ where
         meta.extend(metadata! {
             INPUT_BATCHES_STATS => self.input_batch_stats.metadata(),
             KEY_DISTRIBUTION => self.key_distribution.borrow().meta_item(),
-            BALANCER_POLICY => MetaItem::String(self.current_policy.get().to_string()),
+            BALANCER_POLICY => MetaItem::String(self.current_policy.get().map(|policy| policy.to_string()).unwrap_or("none".to_string())),
             RABALANCINGS_COUNT => MetaItem::Count(self.num_rebalancings.get()),
             REBALANCING_IN_PROGRESS => MetaItem::Bool(self.rebalancing_in_progress()),
             ACCUMULATOR_RECORDS_TO_REPARTITION_COUNT => MetaItem::Count(self.rebalance_accumulator_size.get()),
@@ -1165,18 +1182,25 @@ where
             })?;
 
         self.current_policy.set(checkpoint.current_policy);
-        self.balancer
-            .set_policy_for_stream(self.input_node_id, checkpoint.current_policy);
-        *self.key_distribution.borrow_mut() = checkpoint.key_distribution;
 
-        // Report current policy to metadata_exchange. See invalidate_clusters_for_bootstrapping.
-        self.update_exchange_metadata();
+        if let Some(policy) = checkpoint.current_policy {
+            // Normally the current policy is communicated to the balancer before every step
+            // via metadata_exchange, but if the restored node is disabled during bootstrapping,
+            // it doesn't participate in steps, so we need to set the policy explicitly.
+            // This policy will be:
+            // - Used to determine if the cluster needs to be invalidated during bootstrapping
+            //   (see `BalancerInner::invalidate_clusters_for_bootstrapping`).
+            // - Frozen during replay (see `BalancerInner::get_fixed_policy`).
+            self.balancer
+                .set_policy_for_stream(self.input_node_id, policy);
+        }
+        *self.key_distribution.borrow_mut() = checkpoint.key_distribution;
 
         Ok(())
     }
 
     fn clear_state(&mut self) -> Result<(), crate::Error> {
-        self.current_policy.set(PartitioningPolicy::Shard);
+        self.current_policy.set(None);
         *self.key_distribution.borrow_mut() = KeyDistribution::new(Runtime::num_workers());
 
         // Clear the metadata. If the operator is deactivated during bootstrapping, its metadata
@@ -1255,7 +1279,7 @@ where
                 // if *self.current_policy.borrow() != new_policy  {
                 //     println!("{}: current_policy: {:?}, new_policy: {:?}", self.input_node_id, *self.current_policy.borrow(), new_policy);
                 // }
-                assert_eq!(self.current_policy.get(), new_policy);
+                assert_eq!(self.current_policy.get().unwrap(), new_policy);
                 // ExchangeReceiver expects precisely one flush per transaction.
                 assert!(self.exchange.try_send_all_with_serializer(
                     self.worker_index,

--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -866,6 +866,14 @@ impl BalancerInner {
 
         // Check if all workers for all nodes in this layer are in state >= FlushRequested
         for stream in nodes_in_layer {
+            if let Some(active_nodes) = &self.active_nodes
+                && !active_nodes.contains(stream)
+            {
+                // During bootstrapping, operators that don't participate in bootstrapping don't report metadata.
+                // Such operators do not prevent a commit.
+                continue;
+            }
+
             let Some(exchange_sender_metadata) = self.metadata.get(stream) else {
                 return false;
             };

--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -263,8 +263,7 @@ struct Cluster {
     /// Used to decide whether it's time to check for a better solution.
     last_distribution: BTreeMap<NodeId, KeyDistribution>,
 
-    /// Compute a new solution for the cluster before the next step. Set either after a hint has changed
-    /// or when the circuit was just started or restored from a checkpoint.
+    /// Compute a new solution for the cluster before the next step. Set after a hint has changed.
     refresh_requested: bool,
 }
 
@@ -323,6 +322,9 @@ struct BalancerInner {
 
     /// True between start_transaction and transaction_committed.
     transaction_in_progress: bool,
+
+    /// True if automatic rebalancing is enabled.
+    auto_rebalance_enabled: bool,
 }
 
 impl BalancerInner {
@@ -336,6 +338,7 @@ impl BalancerInner {
             stream_to_cluster: BTreeMap::new(),
             metadata_exchange: metadata_exchange.clone(),
             transaction_in_progress: false,
+            auto_rebalance_enabled: true,
         }
     }
 
@@ -453,12 +456,16 @@ impl BalancerInner {
     ///
     /// Returns true if either
     /// 1. cluster.refresh_requested is true, or
-    /// 2. the key distribution of at least one stream in the cluster has changed by more than
+    /// 2. auto-rebalancing is enabled and
+    ///    the key distribution of at least one stream in the cluster has changed by more than
     ///    `balancer_key_distribution_refresh_threshold`.
-    fn cluster_needs_refresh(&self, cluster_index: usize) -> bool {
+    fn cluster_needs_refresh(&self, cluster_index: usize, auto_rebalance: bool) -> bool {
         let cluster = &self.clusters[cluster_index];
         if cluster.refresh_requested {
             return true;
+        }
+        if !auto_rebalance {
+            return false;
         }
         cluster.streams.keys().any(|stream| {
             let Some(current_distribution) = self.key_distribution.get(stream) else {
@@ -639,9 +646,8 @@ impl BalancerInner {
         let mut solutions = BTreeMap::new();
 
         for i in 0..num_clusters {
-            // println!("{} solving cluster {i}", Runtime::worker_index());
             //let cluster = &mut self.clusters[cluster_index];
-            if !self.cluster_needs_refresh(i) {
+            if !self.cluster_needs_refresh(i, self.auto_rebalance_enabled) {
                 solutions.extend(self.clusters[i].solution.clone());
                 continue;
             }
@@ -1306,13 +1312,18 @@ impl Balancer {
             .into_iter()
             .map(|(nodes, joins)| {
                 let (layers, streams) = self.compute_layers(&dependencies, &nodes);
+                let solution = BTreeMap::from_iter(
+                    streams
+                        .keys()
+                        .map(|stream| (*stream, PartitioningPolicy::Shard)),
+                );
                 Cluster {
                     streams,
                     joins,
                     layers,
-                    solution: BTreeMap::new(),
+                    solution,
                     last_distribution: BTreeMap::new(),
-                    refresh_requested: true,
+                    refresh_requested: false,
                 }
             })
             .collect();
@@ -1337,6 +1348,11 @@ impl Balancer {
         // - Each join is in exactly one cluster.
         // - Each cluster has at least one stream.
         // - Each cluster has at least one join.
+    }
+
+    pub fn set_auto_rebalance(&self, enable: bool) -> Result<(), Error> {
+        self.inner.borrow_mut().auto_rebalance_enabled = enable;
+        Ok(())
     }
 
     pub fn set_hint(&self, node_id: NodeId, hint: BalancerHint) -> Result<(), Error> {

--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -267,6 +267,13 @@ struct Cluster {
     refresh_requested: bool,
 }
 
+impl Cluster {
+    /// All streams in the cluster have a balancing policy assigned.
+    fn has_complete_solution(&self) -> bool {
+        self.solution.len() == self.streams.len()
+    }
+}
+
 /// Hints allow the user to alter the behavior of the balancer.
 #[derive(Debug, Clone)]
 pub enum BalancerHint {
@@ -311,6 +318,9 @@ struct BalancerInner {
     /// join node id -> (left input node id, right input node id, is left join)
     joins: BTreeMap<NodeId, (NodeId, NodeId, bool)>,
 
+    /// Set the first time `prepare` is called and clusters are computed.
+    prepared: bool,
+
     /// Connected components of the join graph:
     clusters: Vec<Cluster>,
 
@@ -325,6 +335,10 @@ struct BalancerInner {
 
     /// True if automatic rebalancing is enabled.
     auto_rebalance_enabled: bool,
+
+    /// When running in bootstrapping mode, this is the set of nodes that are active.
+    /// Non-active nodes cannot be rebalanced.
+    active_nodes: Option<BTreeSet<NodeId>>,
 }
 
 impl BalancerInner {
@@ -334,11 +348,13 @@ impl BalancerInner {
             metadata: BTreeMap::new(),
             key_distribution: BTreeMap::new(),
             joins: BTreeMap::new(),
+            prepared: false,
             clusters: Vec::new(),
             stream_to_cluster: BTreeMap::new(),
             metadata_exchange: metadata_exchange.clone(),
             transaction_in_progress: false,
             auto_rebalance_enabled: true,
+            active_nodes: None,
         }
     }
 
@@ -391,12 +407,12 @@ impl BalancerInner {
                     .solution
                     .get(stream)
                     .map(|policy| format!(": <{policy:?}>"))
-                    .unwrap_or_default();
+                    .unwrap_or_else(|| ": <none>".to_string());
                 let distribution = self
                     .key_distribution
                     .get(stream)
                     .map(|distribution| format!(" distribution: {distribution}"))
-                    .unwrap_or_default();
+                    .unwrap_or_else(|| " distribution: <none>".to_string());
                 //let flushed = self.flushed_status_for_stream(*stream);
                 format!("{stream}{policy}{distribution}")
             })
@@ -456,12 +472,16 @@ impl BalancerInner {
     ///
     /// Returns true if either
     /// 1. cluster.refresh_requested is true, or
-    /// 2. auto-rebalancing is enabled and
+    /// 2. Not all streams in the cluster have a balancing policy assigned.
+    /// 3. auto-rebalancing is enabled and
     ///    the key distribution of at least one stream in the cluster has changed by more than
     ///    `balancer_key_distribution_refresh_threshold`.
     fn cluster_needs_refresh(&self, cluster_index: usize, auto_rebalance: bool) -> bool {
         let cluster = &self.clusters[cluster_index];
         if cluster.refresh_requested {
+            return true;
+        }
+        if !cluster.has_complete_solution() {
             return true;
         }
         if !auto_rebalance {
@@ -513,11 +533,12 @@ impl BalancerInner {
             if let Some(metadata) = exchange_sender_metadata
                 .first()
                 .and_then(|metadata| metadata.as_ref())
+                && let Some(policy) = metadata.current_policy
             {
-                current_effective_policy.insert(*stream, metadata.current_policy);
+                current_effective_policy.insert(*stream, policy);
             }
 
-            let fixed_policy = self.get_fixed_policy(&exchange_sender_metadata, hints)?;
+            let fixed_policy = self.get_fixed_policy(*stream, &exchange_sender_metadata, hints)?;
 
             // println!(
             //     "{} fixed_policy for {stream} (hints: {hints:?}): {:?}",
@@ -544,8 +565,8 @@ impl BalancerInner {
 
         // if Runtime::worker_index() == 0 {
         //     println!(
-        //         "found new solution: {:?}, current solution: {:?}",
-        //         solution, self.clusters[cluster_index].solution
+        //         "found new solution: {:?}, current solution: {:?}, current effective policy: {:?}",
+        //         solution, self.clusters[cluster_index].solution, current_effective_policy
         //     );
         // }
 
@@ -555,7 +576,12 @@ impl BalancerInner {
         if let Some(current_solution_cost) =
             self.validate_solution(&current_effective_policy, &domains)
         {
+            if !self.auto_rebalance_enabled {
+                return Ok(solution);
+            }
+
             let new_solution_cost = self.validate_solution(&solution, &domains).unwrap();
+            //println!("new_solution_cost: {:?}", new_solution_cost);
 
             if new_solution_cost.0 as f64 * balancer_min_relative_improvement_threshold()
                 < current_solution_cost.0 as f64
@@ -712,11 +738,14 @@ impl BalancerInner {
             (total_size, max_size)
         };
 
+        // We add +1 to broadcast and balance strategies below to break ties in favor of Shard.
+        // This makes sure that on startup, when all collections are empty, all streams get sharded
+        // until we detect skew.
         BTreeMap::from([
             // Shard: the cost is proportional to the maximum size of a partition.
             (PartitioningPolicy::Shard, Cost(max_size)),
             // Broadcast: every worker maintains the entire integral.
-            (PartitioningPolicy::Broadcast, Cost(total_size)),
+            (PartitioningPolicy::Broadcast, Cost(total_size + 1)),
             // Balance: every worker maintains an equal share of the integral.
             // Assuming a perfectly balanced key distribution, this policy is slightly less efficient than Shard,
             // since it requires computing a more expensive hash of the entire key/value pair.
@@ -726,7 +755,8 @@ impl BalancerInner {
                 PartitioningPolicy::Balance,
                 Cost(
                     ((total_size / Runtime::num_workers() as u64) as f64 * balancer_balance_tax())
-                        as u64,
+                        as u64
+                        + 1,
                 ),
             ),
         ])
@@ -861,15 +891,17 @@ impl BalancerInner {
 
     /// Check if the stream has a unique fixed policy that cannot change during the current transaction.
     ///
-    /// Given metadata collected from RebalancingExchangeSender instances in all workers
-    /// and current user hints, returns:
+    /// Given metadata collected from RebalancingExchangeSender instances in all workers,
+    /// current user hints, returns:
     /// * Some(policy) if the stream has a unique fixed policy that cannot change at the current step, i.e.:
     ///   - At least one of the workers has flushed the current transaction, and therefore can no longer rebalance
     ///   - Or the hint specifies a fixed policy
+    ///   - Or the stream is not active during bootstrapping and cannot change the policy until bootstrapping is complete (see `active_nodes`).
     /// * None if the stream doesn't have a fixed policy and can be rebalanced.
     /// * Error if the policy can no longer change during the current transaction and it contradicts the hint.
     fn get_fixed_policy(
         &self,
+        stream: NodeId,
         metadata: &[Option<RebalancingExchangeSenderExchangeMetadata>],
         hints: &BalancerHints,
     ) -> Result<Option<PartitioningPolicy>, BalancerError> {
@@ -879,6 +911,15 @@ impl BalancerInner {
         //     metadata,
         //     hints
         // );
+
+        // We're running in bootstrapping mode and the stream is not active.
+        // It cannot change the policy until bootstrapping is complete.
+        if let Some(active_nodes) = &self.active_nodes
+            && !active_nodes.contains(&stream)
+        {
+            //println!("stream {stream} is not active (policy: {:?})", self.get_policy_for_stream(stream));
+            return Ok(self.get_policy_for_stream(stream));
+        }
 
         // If any worker has started rebalancing its state, the policy for this stream cannot change until the next transaction.
         let any_flushed = metadata.iter().any(|metadata| {
@@ -903,7 +944,7 @@ impl BalancerInner {
                         && worker_metadata.as_ref().unwrap().current_policy
                             == metadata[0].as_ref().unwrap().current_policy)
             );
-            Some(metadata[0].as_ref().unwrap().current_policy)
+            metadata[0].as_ref().unwrap().current_policy
         } else {
             None
         };
@@ -945,10 +986,12 @@ impl BalancerInner {
         )
     }
 
-    /// Detect clusters whose state is inconsistent after restoring from checkpoint and add their
+    /// Detect clusters whose state is inconsistent after restoring from checkpoint
     /// and return the exchange sender node ids that need to be backfilled.
+    ///
+    /// Clears the current solution for the cluster.
     fn invalidate_clusters_for_bootstrapping(
-        &self,
+        &mut self,
         need_backfill: &BTreeSet<NodeId>,
     ) -> BTreeSet<NodeId> {
         let mut additional_need_backfill = BTreeSet::new();
@@ -966,14 +1009,11 @@ impl BalancerInner {
                 exchange_senders.insert(exchange_sender_id);
                 if !need_backfill.contains(&exchange_sender_id) {
                     // The operator reported its policy as part of the restore operation.
-                    let exchange_sender_metadata = self
-                        .metadata_exchange
-                        .get_local_operator_metadata_typed::<RebalancingExchangeSenderExchangeMetadata>(
-                        exchange_sender_id,
-                    ).unwrap();
-
-                    let policy = exchange_sender_metadata.current_policy;
-                    domains.insert(*stream_id, Self::fixed_policy_domain(policy));
+                    if let Some(policy) = self.get_policy_for_stream(*stream_id) {
+                        domains.insert(*stream_id, Self::fixed_policy_domain(policy));
+                    } else {
+                        domains.insert(*stream_id, Self::default_policy_domain());
+                    }
                 } else {
                     domains.insert(*stream_id, Self::default_policy_domain());
                 }
@@ -986,6 +1026,7 @@ impl BalancerInner {
                 info!(
                     "Cluster {cluster_index} has inconsistent partitioning policies after restoring from checkpoint; the state of the cluster will be discarded and backfilled"
                 );
+                self.clusters[cluster_index].solution.clear();
                 additional_need_backfill.extend(exchange_senders);
             }
         }
@@ -1092,17 +1133,39 @@ impl Balancer {
         need_backfill: &BTreeSet<NodeId>,
     ) -> BTreeSet<NodeId> {
         self.inner
-            .borrow()
+            .borrow_mut()
             .invalidate_clusters_for_bootstrapping(need_backfill)
     }
 
     /// Invoked after the circuit has been constructed and before it starts running.
-    pub fn prepare(&self, circuit: &dyn CircuitBase) {
-        // Compute connected components of the join graph.
-        self.compute_clusters(circuit);
+    ///
+    /// Can be invoked several times:
+    /// 1. When the circuit is first instantiated. `active_nodes` is None.
+    /// 2. (Optional) When the circuit is about to start bootstrapping. `active_nodes` contains
+    ///    the subset of nodes that will participate in bootstrapping.
+    /// 3. (Optional) When bootstrapping is complete, before normal execution. `active_nodes` is None.
+    pub fn prepare(&self, circuit: &dyn CircuitBase, active_nodes: Option<&BTreeSet<NodeId>>) {
+        // Don't recompute the clusters if already prepared -- during bootstrapping the clusters
+        // can contain the current balancing policies, which must be frozen during replay.
+        // These policies are set in AccumulateTraceBalanced::restore.
+        if !self.inner.borrow().prepared {
+            self.inner.borrow_mut().prepared = true;
+            // Compute connected components of the join graph.
+            self.compute_clusters(circuit);
+        }
+
+        if let Some(active_nodes) = active_nodes {
+            self.inner.borrow_mut().active_nodes = Some(active_nodes.clone());
+        } else {
+            self.inner.borrow_mut().active_nodes = None;
+        }
         if Runtime::worker_index() == 0 {
             info!("Join balancer state:\n{}", indent(&self.display(), 2));
         }
+    }
+
+    pub fn prepare_for_bootstrapping(&self, active_nodes: &BTreeSet<NodeId>) {
+        self.inner.borrow_mut().active_nodes = Some(active_nodes.clone());
     }
 
     // Invoked at the start of each transaction.
@@ -1312,16 +1375,11 @@ impl Balancer {
             .into_iter()
             .map(|(nodes, joins)| {
                 let (layers, streams) = self.compute_layers(&dependencies, &nodes);
-                let solution = BTreeMap::from_iter(
-                    streams
-                        .keys()
-                        .map(|stream| (*stream, PartitioningPolicy::Shard)),
-                );
                 Cluster {
                     streams,
                     joins,
                     layers,
-                    solution,
+                    solution: BTreeMap::new(),
                     last_distribution: BTreeMap::new(),
                     refresh_requested: false,
                 }

--- a/crates/dbsp/src/operator/dynamic/balance/test.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/test.rs
@@ -399,6 +399,7 @@ fn test_join_with_balancer(
     checkpoints: bool,
     inputs: Vec<JoinTestStep>,
     left_join: bool,
+    auto_rebalance: bool,
 ) {
     init_test_logger();
 
@@ -427,6 +428,7 @@ fn test_join_with_balancer(
             mut output_integral_handle,
         ),
     ) = Runtime::init_circuit(cconf.clone(), constructor).unwrap();
+    circuit.set_auto_rebalance(auto_rebalance).unwrap();
 
     let mut all_left_tuples: Vec<Tup2<Tup2<u64, u64>, ZWeight>> = vec![];
     let mut all_right_tuples: Vec<Tup2<Tup2<u64, u64>, ZWeight>> = vec![];
@@ -452,20 +454,26 @@ fn test_join_with_balancer(
             step, left_policy_hint, right_policy_hint
         );
 
-        circuit
-            .set_balancer_hints(vec![
-                (left_input_node_id.clone(), BalancerHint::Policy(None)),
-                (right_input_node_id.clone(), BalancerHint::Policy(None)),
-            ])
-            .unwrap();
+        if auto_rebalance {
+            circuit
+                .set_balancer_hints(vec![
+                    (left_input_node_id.clone(), BalancerHint::Policy(None)),
+                    (right_input_node_id.clone(), BalancerHint::Policy(None)),
+                ])
+                .unwrap();
+        }
 
-        if let Some(left_policy_hint) = left_policy_hint {
+        if let Some(left_policy_hint) = left_policy_hint
+            && auto_rebalance
+        {
             circuit
                 .set_balancer_hint(&left_input_node_id, BalancerHint::Policy(*left_policy_hint))
                 .unwrap();
         }
 
-        if let Some(right_policy_hint) = right_policy_hint {
+        if let Some(right_policy_hint) = right_policy_hint
+            && auto_rebalance
+        {
             circuit
                 .set_balancer_hint(
                     &right_input_node_id,
@@ -1016,7 +1024,7 @@ fn test_accumulate_trace_with_balancer_round_robin_big_step() {
 /// Join a large left collection with a small right collection. Both are skewed.
 /// The balancer should balance the left collection using Policy::Balance and the
 /// right collection using Policy::Broadcast.
-fn test_skewed_join_left(left_join: bool) {
+fn test_skewed_join_left(left_join: bool, auto_rebalance: bool) {
     let num_partitions = 4;
 
     let mut test_steps = vec![];
@@ -1045,29 +1053,45 @@ fn test_skewed_join_left(left_join: bool) {
             right: right_batch,
             left_policy_hint: None,
             right_policy_hint: None,
-            expected_left_policy: if i >= 5 {
+            expected_left_policy: if !auto_rebalance {
+                Some(PartitioningPolicy::Shard)
+            } else if i >= 5 {
                 Some(PartitioningPolicy::Balance)
             } else {
                 None
             },
-            expected_right_policy: if i >= 5 {
+            expected_right_policy: if !auto_rebalance {
+                Some(PartitioningPolicy::Shard)
+            } else if i >= 5 {
                 Some(PartitioningPolicy::Broadcast)
             } else {
                 None
             },
         });
     }
-    test_join_with_balancer(num_partitions, false, false, test_steps, left_join);
+    test_join_with_balancer(
+        num_partitions,
+        false,
+        false,
+        test_steps,
+        left_join,
+        auto_rebalance,
+    );
 }
 
 #[test]
 fn test_skewed_inner_join_left() {
-    test_skewed_join_left(false);
+    test_skewed_join_left(false, true);
+}
+
+#[test]
+fn test_skewed_inner_join_left_disable_auto_rebalance() {
+    test_skewed_join_left(false, false);
 }
 
 #[test]
 fn test_skewed_left_join_no_checkpoints() {
-    test_skewed_join_left(true);
+    test_skewed_join_left(true, true);
 }
 
 /// Join a small left collection with a large right collection. Both are skewed.
@@ -1123,7 +1147,14 @@ fn test_skewed_join_right(checkpoints: bool, left_join: bool) {
             },
         });
     }
-    test_join_with_balancer(num_partitions, false, checkpoints, test_steps, left_join);
+    test_join_with_balancer(
+        num_partitions,
+        false,
+        checkpoints,
+        test_steps,
+        left_join,
+        true,
+    );
 }
 
 #[test]
@@ -1191,22 +1222,22 @@ proptest! {
 
     #[test]
     fn proptest_join_with_balancer_small_step(inputs in generate_join_test_data(10, 10, 10, 30)) {
-        test_join_with_balancer(4, false, false, inputs, false);
+        test_join_with_balancer(4, false, false, inputs, false, true);
     }
 
     #[test]
     fn proptest_join_with_balancer_big_step(inputs in generate_join_test_data(10, 10, 10, 40)) {
-        test_join_with_balancer(4, true, false, inputs, false);
+        test_join_with_balancer(4, true, false, inputs, false, true);
     }
 
     #[test]
     fn proptest_left_join_with_balancer_small_step(inputs in generate_left_join_test_data(200, 10, 10, 30)) {
-        test_join_with_balancer(4, false, false, inputs, true);
+        test_join_with_balancer(4, false, false, inputs, true, true);
     }
 
     #[test]
     fn proptest_left_join_with_balancer_big_step(inputs in generate_left_join_test_data(200, 10, 10, 40)) {
-        test_join_with_balancer(4, true, false, inputs, true);
+        test_join_with_balancer(4, true, false, inputs, true, true);
     }
 
 }

--- a/crates/dbsp/src/operator/dynamic/trace.rs
+++ b/crates/dbsp/src/operator/dynamic/trace.rs
@@ -958,7 +958,8 @@ pub struct Z1Trace<C: Circuit, B: Batch, T: Trace> {
     batch_factories: B::Factories,
     // Stream whose integral this Z1 operator stores, if any.
     delta_stream: Option<Stream<C, B>>,
-    flush: bool,
+    flush_output: bool,
+    flush_input: bool,
 }
 
 impl<C, B, T> Z1Trace<C, B, T>
@@ -987,7 +988,8 @@ where
             reset_on_clock_start,
             bounds,
             delta_stream: None,
-            flush: false,
+            flush_output: false,
+            flush_input: false,
         }
     }
 
@@ -1156,7 +1158,11 @@ where
     }
 
     fn flush(&mut self) {
-        self.flush = true;
+        self.flush_output = true;
+    }
+
+    fn is_flush_complete(&self) -> bool {
+        !self.flush_output
     }
 }
 
@@ -1171,7 +1177,10 @@ where
         let replay_step_size = Runtime::replay_step_size();
 
         if self.replay_mode {
-            if let Some(replay) = &mut self.replay_state {
+            // One output per transaction.
+            if self.flush_output
+                && let Some(replay) = &mut self.replay_state
+            {
                 //println!("Z1-{}::get_output: replaying", &self.global_id);
                 let mut builder = <B::Builder as Builder<B>>::with_capacity(
                     &self.batch_factories,
@@ -1220,6 +1229,8 @@ where
             }
         }
 
+        self.flush_output = false;
+
         let mut result = self.trace.take().unwrap();
         result.clear_dirty_flag();
         result
@@ -1240,6 +1251,14 @@ where
     B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R>,
     T: Trace,
 {
+    fn flush_input(&mut self) {
+        self.flush_input = true;
+    }
+
+    fn is_flush_input_complete(&self) -> bool {
+        !self.flush_input
+    }
+
     async fn eval_strict(&mut self, _i: &T) {
         unimplemented!()
     }
@@ -1247,9 +1266,9 @@ where
     async fn eval_strict_owned(&mut self, mut i: T) {
         // println!("Z1-{}::eval_strict_owned", &self.global_id);
 
-        if self.flush {
+        if self.flush_input {
             self.time = self.time.advance(0);
-            self.flush = false;
+            self.flush_input = false;
         }
 
         let dirty = i.dirty();

--- a/crates/dbsp/src/operator/z1.rs
+++ b/crates/dbsp/src/operator/z1.rs
@@ -378,6 +378,12 @@ impl<T> StrictUnaryOperator<T, T> for Z1<T>
 where
     T: Checkpoint + SizeOf + NumEntries + Clone + 'static,
 {
+    fn flush_input(&mut self) {}
+
+    fn is_flush_input_complete(&self) -> bool {
+        true
+    }
+
     async fn eval_strict(&mut self, i: &T) {
         self.values = i.clone();
     }
@@ -578,6 +584,12 @@ impl<T> StrictUnaryOperator<T, T> for Z1Nested<T>
 where
     T: Eq + SizeOf + NumEntries + Clone + 'static,
 {
+    fn flush_input(&mut self) {}
+
+    fn is_flush_input_complete(&self) -> bool {
+        true
+    }
+
     async fn eval_strict(&mut self, i: &T) {
         debug_assert!(self.timestamp < self.values.len());
 

--- a/python/tests/runtime/test_adaptive_joins.py
+++ b/python/tests/runtime/test_adaptive_joins.py
@@ -1,0 +1,230 @@
+"""
+Integration tests for adaptive joins: balancer policies in the circuit JSON profile.
+
+Expects a running Feldera instance (see other tests under python/tests/runtime).
+Adaptive join rebalancing is only compiled in when ``num_workers > 1``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from feldera import PipelineBuilder
+from feldera.enums import BootstrapPolicy
+from feldera.runtime_config import RuntimeConfig
+from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
+from tests import TEST_CLIENT, unique_pipeline_name
+from tests.platform.helper import API_PREFIX, http_request, wait_for_condition, wait_for_program_success
+
+
+SQL_JOIN_AB = """
+CREATE TABLE tab_a (
+  k BIGINT NOT NULL,
+  v BIGINT NOT NULL
+) WITH ('materialized' = 'true');
+
+CREATE TABLE tab_b (
+  k BIGINT NOT NULL,
+  w BIGINT NOT NULL
+) WITH ('materialized' = 'true');
+
+CREATE MATERIALIZED VIEW join_ab AS
+SELECT tab_a.k, tab_a.v, tab_b.w
+FROM tab_a JOIN tab_b ON tab_a.k = tab_b.k;
+"""
+
+SQL_JOIN_ABC = """
+CREATE TABLE tab_a (
+  k BIGINT NOT NULL,
+  v BIGINT NOT NULL
+) WITH ('materialized' = 'true');
+
+CREATE TABLE tab_b (
+  k BIGINT NOT NULL,
+  w BIGINT NOT NULL
+) WITH ('materialized' = 'true');
+
+CREATE TABLE tab_c (
+  k BIGINT NOT NULL,
+  u BIGINT NOT NULL
+) WITH ('materialized' = 'true');
+
+CREATE MATERIALIZED VIEW join_ab AS
+SELECT tab_a.k, tab_a.v, tab_b.w
+FROM tab_a JOIN tab_b ON tab_a.k = tab_b.k;
+
+CREATE MATERIALIZED VIEW join_ac AS
+SELECT tab_a.k, tab_a.v, tab_c.u
+FROM tab_a JOIN tab_c ON tab_a.k = tab_c.k;
+"""
+
+# Lower balancer thresholds so modest skew triggers a policy change in CI.
+_ADAPTIVE_DEV_TWEAKS = {
+    "adaptive_joins": True,
+}
+
+
+def _fetch_circuit_json_profile(pipeline_name: str) -> dict:
+    resp = http_request(
+        "GET",
+        f"{API_PREFIX}/pipelines/{pipeline_name}/circuit_json_profile",
+        headers={"Accept-Encoding": "gzip"},
+        timeout=120,
+    )
+    assert resp.status_code == 200, (resp.status_code, resp.text[:500])
+    return resp.json()
+
+
+def _balancer_policy_values(profile: dict) -> list[str]:
+    """
+    Collect ``balancer_policy`` metric values from worker 0.
+
+    Values use the engine's ``Display`` spelling: ``shard``, ``broadcast``, ``balance``.
+    """
+    workers = profile.get("worker_profiles") or []
+    assert workers, "circuit profile missing worker_profiles"
+    wp0 = workers[0]
+    meta = wp0.get("metadata") or {}
+    out: list[str] = []
+    for readings in meta.values():
+        if not isinstance(readings, list):
+            continue
+        for r in readings:
+            if r.get("metric_id") != "balancer_policy":
+                continue
+            val = r.get("value")
+            if isinstance(val, dict) and val.get("type") == "string":
+                out.append(str(val["value"]).lower())
+    return out
+
+
+def _push_chunked_json(pipeline, table: str, rows: list[dict], chunk_size: int = 4000) -> None:
+    for i in range(0, len(rows), chunk_size):
+        pipeline.input_json(table, rows[i : i + chunk_size])
+
+
+class TestAdaptiveJoins(unittest.TestCase):
+    def test_adaptive_joins_balancer_policies(self):
+        if FELDERA_TEST_NUM_WORKERS < 2:
+            self.skipTest("adaptive join balancing requires at least two workers")
+
+        name = unique_pipeline_name("test_adaptive_joins")
+        pipeline = PipelineBuilder(
+            TEST_CLIENT,
+            name=name,
+            sql=SQL_JOIN_AB,
+            runtime_config=RuntimeConfig(
+                workers=FELDERA_TEST_NUM_WORKERS,
+                hosts=FELDERA_TEST_NUM_HOSTS,
+                dev_tweaks=_ADAPTIVE_DEV_TWEAKS,
+            ),
+        ).create_or_replace()
+
+        try:
+            pipeline.start()
+
+            print("Single-join pipeline started; populating tables with balanced inputs")
+            # Uniform keys so both sides are ~evenly sharded (avoid k=0 used later for skew).
+            n_uniform = 4000
+            uniform_a = [{"k": i, "v": i} for i in range(1, n_uniform + 1)]
+            uniform_b = [{"k": i, "w": i} for i in range(1, n_uniform + 1)]
+            _push_chunked_json(pipeline, "tab_a", uniform_a)
+            _push_chunked_json(pipeline, "tab_b", uniform_b)
+            pipeline.wait_for_idle()
+
+            def all_sharded() -> bool:
+                pvals = _balancer_policy_values(_fetch_circuit_json_profile(name))
+                return len(pvals) > 0 and all(v == "shard" for v in pvals)
+
+            wait_for_condition(
+                "all balancer_policy values are shard after uniform load",
+                all_sharded,
+                timeout_s=120.0,
+                poll_interval_s=0.5,
+            )
+
+            # Heavy skew on a single join key to trigger (balance, broadcast).
+            print("Introducing heavy skew to trigger (balance, broadcast)")
+            skew_n = 25_000
+            skew_a = [{"k": 0, "v": i} for i in range(skew_n)]
+            _push_chunked_json(pipeline, "tab_a", skew_a)
+            pipeline.wait_for_idle()
+            pipeline.rebalance()
+            pipeline.wait_for_idle()
+
+            def skew_policies() -> bool:
+                pvals = _balancer_policy_values(_fetch_circuit_json_profile(name))
+                return "balance" in pvals and "broadcast" in pvals
+
+            wait_for_condition(
+                "skewed join uses balance on one stream and broadcast on another",
+                skew_policies,
+                timeout_s=180.0,
+                poll_interval_s=0.5,
+            )
+
+            print("Stopping pipeline to modify SQL")
+            pipeline.stop(force=False)
+
+            prev_ver = pipeline.program_version()
+            pipeline.modify(sql=SQL_JOIN_ABC)
+            wait_for_program_success(name, prev_ver + 1)
+            pipeline.start(bootstrap_policy=BootstrapPolicy.ALLOW)
+
+            print("Running pipeline with three-way join; populating the new table")
+
+            # Same join key cluster: third input should participate with policies compatible
+            # with the existing skewed cluster.
+            uniform_c = [{"k": i, "u": i} for i in range(1, n_uniform + 1)]
+
+            #skew_c = [{"k": 0, "u": i} for i in range(int(skew_n/2))]
+            _push_chunked_json(pipeline, "tab_c", uniform_c)
+            pipeline.rebalance()
+
+            def cluster_policies() -> bool:
+                pvals = _balancer_policy_values(_fetch_circuit_json_profile(name))
+                print("cluster_policies: ", pvals)
+                if not pvals:
+                    return False
+                if "shard" in pvals:
+                    return False
+                if "balance" not in pvals or "broadcast" not in pvals:
+                    return False
+                # Extra probe input (tab_c) should stay on the broadcast side like tab_b.
+                return pvals.count("broadcast") == 2
+
+            wait_for_condition(
+                "three-way cluster: extra input stays broadcast with the other probe",
+                cluster_policies,
+                timeout_s=180.0,
+                poll_interval_s=0.5,
+            )
+
+            pipeline.stop(force=False)
+            pipeline.start()
+
+            print("Diluting skew with large uniform key ranges so sharding wins again.")
+            dilute_n = 80_000
+            base = 1_000_000
+            dilute_a = [{"k": base + i, "v": i} for i in range(dilute_n)]
+            dilute_b = [{"k": base + i, "w": i} for i in range(dilute_n)]
+            dilute_c = [{"k": base + i, "u": i} for i in range(dilute_n)]
+            _push_chunked_json(pipeline, "tab_a", dilute_a)
+            _push_chunked_json(pipeline, "tab_b", dilute_b)
+            _push_chunked_json(pipeline, "tab_c", dilute_c)
+            pipeline.rebalance()
+
+            wait_for_condition(
+                "all balancer_policy values return to shard after dilution",
+                all_sharded,
+                timeout_s=180.0,
+                poll_interval_s=0.5,
+            )
+
+        finally:
+            pipeline.stop(force=True)
+            pipeline.clear_storage()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/runtime/test_adaptive_joins.py
+++ b/python/tests/runtime/test_adaptive_joins.py
@@ -14,7 +14,12 @@ from feldera.enums import BootstrapPolicy
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 from tests import TEST_CLIENT, unique_pipeline_name
-from tests.platform.helper import API_PREFIX, http_request, wait_for_condition, wait_for_program_success
+from tests.platform.helper import (
+    API_PREFIX,
+    http_request,
+    wait_for_condition,
+    wait_for_program_success,
+)
 
 
 SQL_JOIN_AB = """
@@ -98,7 +103,9 @@ def _balancer_policy_values(profile: dict) -> list[str]:
     return out
 
 
-def _push_chunked_json(pipeline, table: str, rows: list[dict], chunk_size: int = 4000) -> None:
+def _push_chunked_json(
+    pipeline, table: str, rows: list[dict], chunk_size: int = 4000
+) -> None:
     for i in range(0, len(rows), chunk_size):
         pipeline.input_json(table, rows[i : i + chunk_size])
 
@@ -123,7 +130,9 @@ class TestAdaptiveJoins(unittest.TestCase):
         try:
             pipeline.start()
 
-            print("Single-join pipeline started; populating tables with balanced inputs")
+            print(
+                "Single-join pipeline started; populating tables with balanced inputs"
+            )
             # Uniform keys so both sides are ~evenly sharded (avoid k=0 used later for skew).
             n_uniform = 4000
             uniform_a = [{"k": i, "v": i} for i in range(1, n_uniform + 1)]
@@ -177,7 +186,7 @@ class TestAdaptiveJoins(unittest.TestCase):
             # with the existing skewed cluster.
             uniform_c = [{"k": i, "u": i} for i in range(1, n_uniform + 1)]
 
-            #skew_c = [{"k": 0, "u": i} for i in range(int(skew_n/2))]
+            # skew_c = [{"k": 0, "u": i} for i in range(int(skew_n/2))]
             _push_chunked_json(pipeline, "tab_c", uniform_c)
             pipeline.rebalance()
 


### PR DESCRIPTION
The balancer used to trigger a rebalancing on a restart from a checkpoint. This was a bad idea in hindsight. Not only it slowed down failover, it also caused the initial step executed before the pipeline transitioned to the RUNNING state potentially take a very long time. During this time none of the monitoring features are available, making this a potentially very long and awkward silence.

This commit disables this behavior. It also introduces a new DBSP-level API that disables automatic rebalancing altogether. The plan is to expose this API externally, allowing the user to control when rebalancings are allowed to happen, e.g., a latency-sensitive workload may disable rebalancing after initial backfill. This will be combined with an API to request a rebalancing on demand.

For now this API is only used to disable rebalancing during the initial step, making sure that a regular (non-forced) rebalancing doesn't trigger accidentally at that point.

This commit additionally skips the initial step when the pipeline is bootstrapping. The reason is similar to the above: bootstrapping steps can be expensive, so we don't want to perform them while the pipeline is initializing. This does mean that the pipeline won't initialize output snapshots until bootstrapping completes, but that was already the case previously.

----

The above fix revealed a bug in the implementation of adaptive joins during bootstrapping. The PR includes bug fix commits.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
