### PR TITLE
[adapters] Delta input: revamp error handling and retry logic.

### DIFF
--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -1,6 +1,7 @@
 use anyhow::{Error as AnyError, Result as AnyResult};
 use chrono::{DateTime, Utc};
 use dyn_clone::DynClone;
+use feldera_types::adapter_stats::ConnectorHealth;
 use feldera_types::config::FtModel;
 use feldera_types::program_schema::Relation;
 use rmpv::{Value as RmpValue, ext::Error as RmpDecodeError};
@@ -773,6 +774,9 @@ pub trait InputConsumer: Send + Sync + DynClone {
     /// Optional tag that can be used for additional context
     /// e.g. for rate limiting
     fn error(&self, fatal: bool, error: AnyError, tag: Option<&'static str>);
+
+    /// Updates the health status of the connector.
+    fn update_connector_health(&self, health: ConnectorHealth);
 }
 
 /// Information needed to restart after or replay input.

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -7096,6 +7096,11 @@ impl InputConsumer for InputProbe {
             .status
             .set_custom_metrics(self.endpoint_id, metrics);
     }
+
+    fn update_connector_health(&self, health: ConnectorHealth) {
+        self.controller
+            .update_input_connector_health(self.endpoint_id, health);
+    }
 }
 
 /// An output probe inserted between the encoder and the output transport

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -33,14 +33,18 @@ use feldera_adapterlib::utils::datafusion::{
     validate_sql_expression, validate_timestamp_column,
 };
 use feldera_storage::tokio::TOKIO_DEDICATED_IO;
+use feldera_types::adapter_stats::ConnectorHealth;
 use feldera_types::config::FtModel;
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::delta_table::{DeltaTableReaderConfig, DeltaTableTransactionMode};
 use futures_util::StreamExt;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::cmp::min;
 use std::collections::{BTreeSet, HashMap};
+use std::fmt::Display;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -56,12 +60,18 @@ use url::Url;
 const POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 /// Calculate exponential backoff delay for retrying delta log reads.
-/// Starts at 0.5s, doubles each retry, caps at 32s.
+/// Starts at 0.5s, doubles each retry, caps at 32s, plus uniform jitter up to 25% of that delay
+/// (capped at `max_delay_ms`) to reduce synchronized retries.
 fn calculate_backoff_delay(retry_count: u32) -> Duration {
-    let base_delay_ms = 500; // 0.5 seconds
-    let max_delay_ms = 32_000; // 32 seconds
-    let delay_ms = std::cmp::min(base_delay_ms << retry_count, max_delay_ms);
-    Duration::from_millis(delay_ms)
+    let base_delay_ms: u64 = 500; // 0.5 seconds
+    let max_delay_ms: u64 = 32_000; // 32 seconds
+    let delay_ms = min(
+        base_delay_ms.checked_shl(retry_count).unwrap_or(u64::MAX),
+        max_delay_ms,
+    );
+    let jitter_span = (delay_ms / 4).max(1);
+    let jitter_ms = rand::thread_rng().gen_range(0..jitter_span);
+    Duration::from_millis(min(delay_ms + jitter_ms, max_delay_ms))
 }
 
 /// Default object store timeout. When not explicitly set by the user,
@@ -83,7 +93,7 @@ static DELTA_READER_SEMAPHORE: std::sync::LazyLock<Semaphore> =
 /// Used to detect conflicting values of `max_concurrent_readers`.
 static MAX_CONCURRENT_READERS_SET: AtomicBool = AtomicBool::new(false);
 
-/// Takes a column name from a DeltaLake schema and returns a qouted string
+/// Takes a column name from a DeltaLake schema and returns a quoted string
 /// that can be used in datafusion queries like `select "foo""bar" from my_table`.
 fn quote_sql_identifier<S: AsRef<str>>(ident: S) -> String {
     format!("\"{}\"", ident.as_ref().replace("\"", "\"\""))
@@ -274,9 +284,11 @@ impl DeltaTableInputReader {
         // status for the frontier will be set to the current time instead of whenever the table version in resume_info
         // was actually processed. The right solution is to checkpoint the frontier with the connector.
         if resume_info.is_some() {
-            endpoint
-                .queue
-                .push_with_aux((None, Vec::new()), Utc::now(), resume_info);
+            endpoint.queue.push_with_aux(
+                (None, Vec::new()),
+                Utc::now(),
+                QueueEntry::ResumeInfo(resume_info),
+            );
         }
 
         if eoi {
@@ -347,18 +359,34 @@ impl InputReader for DeltaTableInputReader {
                 checkpoint_requested,
             } => {
                 // When initiating a checkpoint, try to stop at a delta table transaction boundary.
-                let stop_at: &dyn Fn(&Option<DeltaResumeInfo>) -> bool = if checkpoint_requested {
-                    &|resume_info: &Option<DeltaResumeInfo>| resume_info.is_some()
+                let stop_at: &dyn Fn(&QueueEntry) -> bool = if checkpoint_requested {
+                    &|entry: &QueueEntry| {
+                        matches!(
+                            entry,
+                            QueueEntry::ResumeInfo(Some(_)) | QueueEntry::Rollback
+                        )
+                    }
                 } else {
-                    &|_: &Option<DeltaResumeInfo>| false
+                    &|_: &QueueEntry| false
                 };
 
                 let (total, _, resume_info) = self.inner.queue.flush_with_aux_until(stop_at);
-                let resume_status = resume_info
-                    .last()
-                    .map(|(_ts, resume_info)| resume_info.clone())
-                    .unwrap_or_else(|| self.inner.last_resume_status.lock().unwrap().clone());
+                let resume_status = match resume_info.last() {
+                    None => self.inner.last_resume_status.lock().unwrap().clone(),
+                    Some((_ts, QueueEntry::ResumeInfo(resume_info))) => resume_info.clone(),
+                    Some((_ts, QueueEntry::Rollback)) => Some(
+                        self.inner
+                            .last_checkpointable_status
+                            .lock()
+                            .unwrap()
+                            .clone(),
+                    ),
+                };
+
                 *self.inner.last_resume_status.lock().unwrap() = resume_status.clone();
+                if let Some(resume_status) = &resume_status {
+                    *self.inner.last_checkpointable_status.lock().unwrap() = resume_status.clone();
+                }
 
                 let resume = match resume_status {
                     None => Resume::Barrier,
@@ -371,11 +399,12 @@ impl InputReader for DeltaTableInputReader {
                     Some(resume),
                     resume_info
                         .into_iter()
-                        .map(|(timestamp, metadata)| {
-                            Watermark::new(
+                        .filter_map(|(timestamp, metadata)| match metadata {
+                            QueueEntry::ResumeInfo(resume_info) => Some(Watermark::new(
                                 timestamp,
-                                metadata.map(|m| serde_json::to_value(m).unwrap()),
-                            )
+                                resume_info.map(|m| serde_json::to_value(m).unwrap()),
+                            )),
+                            QueueEntry::Rollback => None,
                         })
                         .collect(),
                 );
@@ -550,8 +579,26 @@ struct DeltaTableInputEndpointInner {
     /// * Updated to `Some(new_version)` after advancing to the next table version in the transaction log
     ///   in follow mode or after ingesting the initial snapshot.
     last_resume_status: Mutex<Option<DeltaResumeInfo>>,
-    queue: Arc<InputQueue<Option<DeltaResumeInfo>, StagedInputBuffer>>,
+
+    /// The latest checkpointable status of this endpoint.
+    last_checkpointable_status: Mutex<DeltaResumeInfo>,
+
+    queue: Arc<InputQueue<QueueEntry, StagedInputBuffer>>,
     metrics: Arc<DeltaTableMetrics>,
+}
+
+#[derive(Debug, Clone)]
+enum QueueEntry {
+    /// Resume info for the connector after processing this queue entry.
+    ResumeInfo(Option<DeltaResumeInfo>),
+
+    /// Sent after failing to read a delta log entry, before retrying or
+    /// declaring a fatal error. Makes sure that the connector can be checkpointed
+    /// between retries.
+    ///
+    /// Note: this is not the actual transaction rollback: the current transaction,
+    /// if any, will be committed.
+    Rollback,
 }
 
 impl DeltaTableInputEndpointInner {
@@ -573,6 +620,8 @@ impl DeltaTableInputEndpointInner {
         let metrics = Arc::new(DeltaTableMetrics::new());
         consumer.set_custom_metrics(Arc::clone(&metrics) as Arc<dyn ConnectorMetrics>);
 
+        let resume_status = resume_info.unwrap_or_else(DeltaResumeInfo::initial);
+
         Self {
             endpoint_name: endpoint_name.to_string(),
             schema,
@@ -582,9 +631,9 @@ impl DeltaTableInputEndpointInner {
             transaction_index: AtomicUsize::new(0),
 
             // Set version to None by default so that the connector is checkpointable in the initial state.
-            last_resume_status: Mutex::new(Some(
-                resume_info.unwrap_or_else(DeltaResumeInfo::initial),
-            )),
+            last_resume_status: Mutex::new(Some(resume_status.clone())),
+
+            last_checkpointable_status: Mutex::new(resume_status),
             queue,
             metrics,
         }
@@ -737,12 +786,16 @@ impl DeltaTableInputEndpointInner {
 
     /// Load the entire table snapshot as a single "select * where <filter>" query.
     /// Returns the total number of records processed.
+    ///
+    /// Fails with an error if the function fails to read the snapshot.  This function
+    /// doesn't retry (the idea being that the snapshot can be large, and it's better to
+    /// fail fast and give the user a chance to restart the pipeline).
     async fn read_unordered_snapshot(
         &self,
         table: &DeltaTable,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
-    ) -> usize {
+    ) -> AnyResult<usize> {
         let column_names = self.used_column_list(table);
 
         let mut snapshot_query = format!("select {column_names} from snapshot");
@@ -759,8 +812,14 @@ impl DeltaTableInputEndpointInner {
         let timestamp = Utc::now();
 
         let record_count = self
-            .execute_snapshot_query(&snapshot_query, "initial snapshot", input_stream, receiver)
-            .await;
+            .execute_snapshot_query(
+                &snapshot_query,
+                "initial snapshot",
+                input_stream,
+                receiver,
+                self.config.max_retries(),
+            )
+            .await?;
         self.metrics
             .snapshot_records_total
             .fetch_add(record_count as u64, Ordering::Relaxed);
@@ -769,11 +828,11 @@ impl DeltaTableInputEndpointInner {
         self.queue.push_entry(
             InputQueueEntry::new_with_aux(
                 timestamp,
-                Some(DeltaResumeInfo::follow_mode(
+                QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(
                     // We verified that the table version is not None in the open_table method.
                     table.version().unwrap(),
                     !self.config.follow(),
-                )),
+                ))),
             )
             // If we started a transaction while processing the snapshot, commit it now.
             .with_commit_transaction(true),
@@ -787,38 +846,37 @@ impl DeltaTableInputEndpointInner {
             record_count,
             table.version().unwrap()
         );
-        record_count
+        Ok(record_count)
     }
 
     /// Load the initial snapshot by issuing a sequence of queries for monotonically
     /// increasing timestamp ranges.
     /// Returns the total number of records processed.
+    ///
+    /// Fails with an error if the function fails to complete one of the range queries
+    /// after retrying `self.config.max_retries` times.
     async fn read_ordered_snapshot(
         &self,
         table: &DeltaTable,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
-    ) -> usize {
+    ) -> AnyResult<usize> {
         // Use the time when we started reading the snapshot as the ingestion timestamp for the snapshot.
         let timestamp = Utc::now();
 
         let total_records = self
             .read_ordered_snapshot_inner(table, input_stream, receiver)
-            .await
-            .unwrap_or_else(|e| {
-                self.consumer.error(true, e, None);
-                0
-            });
+            .await?;
 
         // Empty buffer to indicate checkpointable state.
         self.queue.push_entry(
             InputQueueEntry::new_with_aux(
                 timestamp,
-                Some(DeltaResumeInfo::follow_mode(
+                QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(
                     // We verified that the table version is not None in the open_table method.
                     table.version().unwrap(),
                     !self.config.follow(),
-                )),
+                ))),
             )
             // If we started a transaction while processing the snapshot, commit it now.
             .with_commit_transaction(true),
@@ -831,7 +889,7 @@ impl DeltaTableInputEndpointInner {
             total_records,
             table.version().unwrap()
         );
-        total_records
+        Ok(total_records)
     }
 
     async fn read_ordered_snapshot_inner(
@@ -940,8 +998,14 @@ impl DeltaTableInputEndpointInner {
             }
 
             let range_record_count = self
-                .execute_snapshot_query(&range_query, "range", input_stream, receiver)
-                .await;
+                .execute_snapshot_query(
+                    &range_query,
+                    "range",
+                    input_stream,
+                    receiver,
+                    self.config.max_retries(),
+                )
+                .await?;
             self.metrics
                 .snapshot_records_total
                 .fetch_add(range_record_count as u64, Ordering::Relaxed);
@@ -962,11 +1026,11 @@ impl DeltaTableInputEndpointInner {
             self.queue.push_entry(
                 InputQueueEntry::new_with_aux(
                     Utc::now(),
-                    Some(DeltaResumeInfo::snapshot_mode(
+                    QueueEntry::ResumeInfo(Some(DeltaResumeInfo::snapshot_mode(
                         // We verified that the table version is not None in the open_table method.
                         table.version().unwrap(),
                         &start,
-                    )),
+                    ))),
                 )
                 // If we started a transaction while processing the range query, commit it now.
                 .with_commit_transaction(true),
@@ -975,6 +1039,55 @@ impl DeltaTableInputEndpointInner {
         }
 
         Ok(total_records)
+    }
+
+    /// Runs `operation` until it succeeds or [`DeltaTableReaderConfig::max_retries`] is exhausted.
+    ///
+    /// On failure before the limit: sets connector health to unhealthy, logs a warning with
+    /// `description` as the message prefix, sleeps using [`calculate_backoff_delay`], then retries.
+    /// On final failure: updates health, invokes [`InputConsumer::error`], and returns `Err`.
+    async fn retry<F, Fut, T, E>(
+        &self,
+        description: &str,
+        error_tag: Option<&'static str>,
+        mut operation: F,
+    ) -> Result<T, AnyError>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+        E: Display,
+    {
+        let max_retries = self.config.max_retries();
+        let mut retry_count = 0u32;
+        loop {
+            match operation().await {
+                Ok(value) => {
+                    self.consumer
+                        .update_connector_health(ConnectorHealth::healthy());
+                    return Ok(value);
+                }
+                Err(e) => {
+                    retry_count += 1;
+                    if retry_count - 1 == max_retries {
+                        let message = format!("{description} after {retry_count} attempts: {e}");
+                        self.consumer
+                            .update_connector_health(ConnectorHealth::unhealthy(&message));
+                        self.consumer
+                            .error(true, anyhow!(message.clone()), error_tag);
+                        return Err(anyhow!(message));
+                    }
+                    let backoff_delay = calculate_backoff_delay(retry_count - 1);
+                    let message = format!(
+                        "{description} after {retry_count} attempts: {e}; retrying in {:?}",
+                        backoff_delay
+                    );
+                    self.consumer
+                        .update_connector_health(ConnectorHealth::unhealthy(&message));
+                    warn!("delta_table {}: {message}", &self.endpoint_name);
+                    sleep(backoff_delay).await;
+                }
+            }
+        }
     }
 
     async fn worker_task_inner(
@@ -1032,19 +1145,28 @@ impl DeltaTableInputEndpointInner {
                 })
         );
 
-        let mut snapshot_record_count = 0usize;
-
-        if snapshot_incomplete && self.config.snapshot() && self.config.timestamp_column.is_none() {
+        let snapshot_record_count = if snapshot_incomplete
+            && self.config.snapshot()
+            && self.config.timestamp_column.is_none()
+        {
             // Read snapshot chunk-by-chunk.
-            snapshot_record_count = self
-                .read_unordered_snapshot(&table, input_stream.as_mut(), &mut receiver)
-                .await;
+            self.read_unordered_snapshot(&table, input_stream.as_mut(), &mut receiver)
+                .await
         } else if snapshot_incomplete && self.config.snapshot() {
             // Read the entire snapshot in one query.
-            snapshot_record_count = self
-                .read_ordered_snapshot(&table, input_stream.as_mut(), &mut receiver)
-                .await;
-        }
+            self.read_ordered_snapshot(&table, input_stream.as_mut(), &mut receiver)
+                .await
+        } else {
+            Ok(0)
+        };
+
+        let snapshot_record_count = match snapshot_record_count {
+            Ok(snapshot_record_count) => snapshot_record_count,
+            Err(e) => {
+                self.consumer.error(true, e, None);
+                return;
+            }
+        };
 
         // Start following the table if required by the configuration.
         if self.config.follow() {
@@ -1074,8 +1196,6 @@ impl DeltaTableInputEndpointInner {
             // Note: If self.config.snapshot() && !snapshot_incomplete, we're resuming from a checkpoint
             // where the snapshot was already completed, so no special log needed
 
-            let mut retry_count = 0;
-
             // If we haven't previously read a snapshot of the table, report initial frontier.
             // This makes sure that even if the current version of the table is the final version,
             // we will report the frontier.
@@ -1083,7 +1203,7 @@ impl DeltaTableInputEndpointInner {
                 self.queue.push_with_aux(
                     (None, Vec::new()),
                     Utc::now(),
-                    Some(DeltaResumeInfo::follow_mode(version, false)),
+                    QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(version, false))),
                 );
             }
 
@@ -1091,36 +1211,59 @@ impl DeltaTableInputEndpointInner {
                 wait_running(&mut receiver).await;
                 let new_version = version + 1;
 
-                match table.log_store().read_commit_entry(new_version).await {
-                    Ok(None) => sleep(POLL_INTERVAL).await,
-                    Ok(Some(bytes))
+                let table_for_retry = Arc::clone(&table);
+                let entry = match self
+                    .retry(
+                        &format!(
+                            "error reading the next log entry (current table version: {version})"
+                        ),
+                        Some("delta-next-log"),
+                        move || {
+                            let table = Arc::clone(&table_for_retry);
+                            async move { table.log_store().read_commit_entry(new_version).await }
+                        },
+                    )
+                    .await
+                {
+                    Ok(entry) => entry,
+                    Err(_) => break,
+                };
+
+                match entry {
+                    None => sleep(POLL_INTERVAL).await,
+                    Some(bytes)
                         if self.config.end_version.is_none()
                             || self.config.end_version.unwrap() >= new_version =>
                     {
-                        retry_count = 0;
-
                         let actions = match logstore::get_actions(new_version, &bytes) {
                             Ok(actions) => actions,
                             Err(e) => {
                                 self.consumer.error(
                                     true,
-                                    anyhow!("error parsing log entry for table version {new_version}: {e}"),
-                                    Some("delta-parse-log")
+                                    anyhow!(
+                                        "error parsing log entry for table version {new_version}: {e}"
+                                    ),
+                                    None,
                                 );
                                 break;
                             }
                         };
 
                         version = new_version;
-                        self.process_log_entry(
-                            new_version,
-                            &actions,
-                            &table,
-                            cdc_delete_filter.clone(),
-                            input_stream.as_mut(),
-                            &mut receiver,
-                        )
-                        .await;
+                        if let Err(e) = self
+                            .process_log_entry(
+                                new_version,
+                                &actions,
+                                &table,
+                                cdc_delete_filter.clone(),
+                                input_stream.as_mut(),
+                                &mut receiver,
+                            )
+                            .await
+                        {
+                            self.consumer.error(true, e, None);
+                            break;
+                        };
 
                         if let Some(end_version) = self.config.end_version
                             && end_version <= new_version
@@ -1136,7 +1279,7 @@ impl DeltaTableInputEndpointInner {
                             break;
                         }
                     }
-                    Ok(Some(_bytes)) => {
+                    Some(_bytes) => {
                         info!(
                             "delta_table {}: reached table version {new_version}, which is greater than the 'end_version' {} specified in connector config: stopping the connector",
                             &self.endpoint_name,
@@ -1151,30 +1294,10 @@ impl DeltaTableInputEndpointInner {
                         self.queue.push_with_aux(
                             (None, Vec::new()),
                             Utc::now(),
-                            Some(DeltaResumeInfo::eoi()),
+                            QueueEntry::ResumeInfo(Some(DeltaResumeInfo::eoi())),
                         );
 
                         break;
-                    }
-                    Err(e) => {
-                        // Transient timeouts are common when reading the next log entry from S3.
-                        retry_count += 1;
-
-                        if retry_count == 20 {
-                            self.consumer.error(
-                                true,
-                                anyhow!("error reading the next log entry after {retry_count} attempts (current table version: {version}): {e}"),
-                                Some("delta-next-log")
-                            );
-                            break;
-                        } else {
-                            let backoff_delay = calculate_backoff_delay(retry_count - 1);
-                            warn!(
-                                "delta_table {}: error reading the next log entry after {retry_count} attempts (current table version: {version}): {e}; retrying in {:?}",
-                                &self.endpoint_name, backoff_delay
-                            );
-                            sleep(backoff_delay).await;
-                        }
                     }
                 }
             }
@@ -1209,6 +1332,7 @@ impl DeltaTableInputEndpointInner {
 
         let delta_table: DeltaTable = {
             let mut retry_count = 0;
+            // We don't use config.max_retries here. Do we want unlimited retries opening the table?
             const MAX_RETRIES: u32 = 10;
 
             // We've seen the table builder get stuck forever in S3 authentication for some configurations
@@ -1338,6 +1462,8 @@ impl DeltaTableInputEndpointInner {
         if !self.config.snapshot() {
             *self.last_resume_status.lock().unwrap() =
                 Some(DeltaResumeInfo::follow_mode(version, false));
+            *self.last_checkpointable_status.lock().unwrap() =
+                DeltaResumeInfo::follow_mode(version, false);
         }
 
         // Register object store with datafusion, so it will recognize individual parquet
@@ -1582,13 +1708,17 @@ impl DeltaTableInputEndpointInner {
 
     /// Execute a SQL query to load a complete or partial snapshot of the DeltaTable.
     /// Returns the total number of records processed.
+    ///
+    /// Fails with an error if the function fails to read the snapshot after retrying
+    /// `num_retries` times.
     async fn execute_snapshot_query(
         &self,
         query: &str,
         descr: &str,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
-    ) -> usize {
+        num_retries: u32,
+    ) -> Result<usize, AnyError> {
         let descr = format!("{descr} query '{query}'");
         debug!(
             "delta_table {}: retrieving data from the Delta table snapshot using {descr}",
@@ -1602,9 +1732,7 @@ impl DeltaTableInputEndpointInner {
         let df = match self.datafusion.sql_with_options(query, options).await {
             Ok(df) => df,
             Err(e) => {
-                self.consumer
-                    .error(true, anyhow!("error compiling query '{query}': {e}"), None);
-                return 0;
+                return Err(anyhow!("error compiling query '{query}': {e}"));
             }
         };
 
@@ -1616,6 +1744,8 @@ impl DeltaTableInputEndpointInner {
             input_stream,
             receiver,
             self.allocate_snapshot_transaction_label(),
+            num_retries,
+            None,
         )
         .await
     }
@@ -1633,7 +1763,19 @@ impl DeltaTableInputEndpointInner {
     ///
     /// * `transaction` - execute the dataframe as part of a transaction with the given label (is `Some`).
     ///
+    /// * `max_retries` - the maximum number of retries to attempt if the function fails to read the log entry.
+    ///
     /// Returns the total number of records processed.
+    ///
+    /// Returns an error if the function fails to read the log entry after performing the configured
+    /// number of retries. Note that errors parsing table records are not reported here; they are
+    /// reported by calling `consumer.error`.
+    ///
+    /// On error, the function commits the current transaction if any. It is possible that some of the
+    /// records have been processed and pushed to the circuit before the error.
+    ///
+    /// If `max_retries` is >0, the function can push duplicate inputs to the circuit as part of the
+    /// retry loop.
     #[allow(clippy::too_many_arguments)]
     async fn execute_df(
         &self,
@@ -1644,20 +1786,88 @@ impl DeltaTableInputEndpointInner {
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         transaction: Option<Option<String>>,
-    ) -> usize {
+        max_retries: u32,
+        current_table_version: Option<i64>,
+    ) -> Result<usize, AnyError> {
+        let mut retry_count = 0;
+        loop {
+            match self
+                .execute_df_inner(
+                    dataframe.clone(),
+                    polarity,
+                    cdc_delete_filter.clone(),
+                    input_stream,
+                    receiver,
+                    &transaction,
+                )
+                .await
+            {
+                Ok(total_records) => {
+                    self.consumer
+                        .update_connector_health(ConnectorHealth::healthy());
+                    return Ok(total_records);
+                }
+                Err(e) => {
+                    retry_count += 1;
+                    if retry_count - 1 == max_retries {
+                        let message = format!(
+                            "error retrieving {descr} after {retry_count} attempts{}: {e}",
+                            if let Some(version) = current_table_version {
+                                format!(" (current table version: {version})")
+                            } else {
+                                String::new()
+                            }
+                        );
+                        self.consumer
+                            .update_connector_health(ConnectorHealth::unhealthy(&message));
+                        return Err(anyhow!(message));
+                    }
+                    let backoff_delay = calculate_backoff_delay(retry_count - 1);
+
+                    let message = format!(
+                        "error retrieving {descr} after {retry_count} attempts{}: {e}; retrying in {backoff_delay:?}",
+                        if let Some(version) = current_table_version {
+                            format!(" (current table version: {version})")
+                        } else {
+                            String::new()
+                        }
+                    );
+                    self.consumer
+                        .update_connector_health(ConnectorHealth::unhealthy(&message));
+                    warn!("delta_table {}: {message}", &self.endpoint_name);
+                    sleep(backoff_delay).await;
+                }
+            }
+        }
+    }
+
+    // A single attempt of the `execute_df` retry loop.
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_df_inner(
+        &self,
+        dataframe: DataFrame,
+        polarity: bool,
+        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
+        input_stream: &mut dyn ArrowStream,
+        receiver: &mut Receiver<PipelineState>,
+        transaction: &Option<Option<String>>,
+    ) -> Result<usize, String> {
         wait_running(receiver).await;
+        let transaction = transaction.clone();
 
         // Limit the number of connectors simultaneously reading from Delta Lake.
         let _token = DELTA_READER_SEMAPHORE.acquire().await.unwrap();
 
         let mut stream = match dataframe.execute_stream().await {
             Err(e) => {
-                self.consumer
-                    .error(true, anyhow!("error retrieving {descr}: {e:?}"), None);
-                return 0;
+                return Err(format!("{e:?}"));
             }
             Ok(stream) => stream,
         };
+
+        // We declare the connector healthy at this point.
+        self.consumer
+            .update_connector_health(ConnectorHealth::healthy());
 
         let mut num_batches = 0;
         let mut total_records = 0usize;
@@ -1701,7 +1911,7 @@ impl DeltaTableInputEndpointInner {
             },
             move |(buffer, errors, timestamp)| {
                 queue.push_entry(
-                    InputQueueEntry::new_with_aux(timestamp, None)
+                    InputQueueEntry::new_with_aux(timestamp, QueueEntry::ResumeInfo(None))
                         .with_buffer(buffer)
                         .with_start_transaction(transaction.clone()),
                     errors,
@@ -1717,13 +1927,18 @@ impl DeltaTableInputEndpointInner {
             let batch = match batch {
                 Ok(batch) => batch,
                 Err(e) => {
-                    self.consumer.error(
-                        false,
-                        anyhow!("error retrieving batch {num_batches} of {descr}: {e:?}"),
-                        Some("delta-batch"),
+                    drop(job_queue);
+                    // We don't have a way to rollback the transaction at this point. The best
+                    // we can do is commit the transaction so it doesn't block the pipeline.
+                    // This means that the connector will generate duplicate inputs on a retry.
+                    self.queue.push_entry(
+                        InputQueueEntry::new_with_aux(timestamp, QueueEntry::Rollback)
+                            // If we started a transaction while processing the log entry, commit it now.
+                            .with_commit_transaction(true),
+                        Vec::new(),
                     );
 
-                    continue;
+                    return Err(format!("error retrieving batch {num_batches}: {e:?}"));
                 }
             };
             // info!("schema: {}", batch.schema());
@@ -1736,7 +1951,7 @@ impl DeltaTableInputEndpointInner {
         }
 
         job_queue.flush().await;
-        total_records
+        Ok(total_records)
     }
 
     async fn parse_record_batch(
@@ -1786,6 +2001,16 @@ impl DeltaTableInputEndpointInner {
     /// Apply actions from a transaction log entry.
     ///
     /// Only `Add` and `Remove` actions are picked up.
+    ///
+    /// Returns an error if the connector failed to read the log entry after performing the `self.config.max_retries`
+    /// number of retries. Note that errors parsing table records are not reported here; they are
+    /// reported in the `execute_df` method by calling `consumer.error`.
+    ///
+    /// On error, the function commits the current transaction if any. It is possible that some of the
+    /// records have been processed and pushed to the circuit before the error.
+    ///
+    /// If `self.config.max_retries` is >0, the function can push duplicate inputs to the circuit as part of the
+    /// retry loop.
     async fn process_log_entry(
         &self,
         new_version: i64,
@@ -1794,7 +2019,7 @@ impl DeltaTableInputEndpointInner {
         cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
-    ) {
+    ) -> AnyResult<()> {
         if self.config.verbose > 0 {
             // Don't log actions we ignore to limit spurious logging. E.g., delta lake
             // optimization passes can generate thousand of noop actions.
@@ -1825,7 +2050,7 @@ impl DeltaTableInputEndpointInner {
 
         if self.config.is_cdc() {
             self.process_cdc_transaction(actions, table, cdc_delete_filter, input_stream, receiver)
-                .await;
+                .await?;
         } else {
             let column_names = self.used_column_list(table);
 
@@ -1849,7 +2074,7 @@ impl DeltaTableInputEndpointInner {
                         receiver,
                         start_transaction.clone(),
                     )
-                    .await;
+                    .await?;
                 }
             }
 
@@ -1863,7 +2088,7 @@ impl DeltaTableInputEndpointInner {
                         receiver,
                         start_transaction.clone(),
                     )
-                    .await;
+                    .await?;
                 }
             }
         }
@@ -1872,15 +2097,17 @@ impl DeltaTableInputEndpointInner {
         self.queue.push_entry(
             InputQueueEntry::new_with_aux(
                 timestamp,
-                Some(DeltaResumeInfo::follow_mode(
+                QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(
                     new_version,
                     self.config.end_version == Some(new_version),
-                )),
+                ))),
             )
             // If we started a transaction while processing the log entry, commit it now.
             .with_commit_transaction(true),
             Vec::new(),
         );
+
+        Ok(())
     }
 
     /// Process a DeltaLake transaction in CDC mode:
@@ -1897,7 +2124,7 @@ impl DeltaTableInputEndpointInner {
         cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
-    ) {
+    ) -> AnyResult<()> {
         let result = self
             .do_process_cdc_transaction(actions, table, cdc_delete_filter, input_stream, receiver)
             .await;
@@ -1906,9 +2133,7 @@ impl DeltaTableInputEndpointInner {
         // If the table does not exist, there's no harm.
         let _ = self.datafusion.deregister_table("tmp_table");
 
-        if let Err(e) = result {
-            self.consumer.error(false, e, Some("delta-cdc"));
-        }
+        result
     }
 
     async fn do_process_cdc_transaction(
@@ -1939,12 +2164,12 @@ impl DeltaTableInputEndpointInner {
         );
 
         // Create a datafusion table backed by these files.
-        let table = Arc::new(
+        let parquet_table = Arc::new(
             self.create_parquet_table(table, files, &description)
                 .await?,
         );
 
-        self.datafusion.register_table("tmp_table", table).map_err(|e| {
+        self.datafusion.register_table("tmp_table", parquet_table).map_err(|e| {
             anyhow!("internal error processing {description}; {REPORT_ERROR}; error registering Parquet table: {e}")
         })?;
 
@@ -1973,8 +2198,10 @@ impl DeltaTableInputEndpointInner {
                 input_stream,
                 receiver,
                 self.allocate_follow_transaction_label(),
+                self.config.max_retries(),
+                table.version(),
             )
-            .await;
+            .await?;
 
         Ok(())
     }
@@ -2013,7 +2240,7 @@ impl DeltaTableInputEndpointInner {
         input_stream: &mut dyn ArrowStream,
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
-    ) {
+    ) -> AnyResult<()> {
         let result = match action {
             Action::Add(add) if add.data_change => {
                 self.add_with_polarity(
@@ -2041,16 +2268,14 @@ impl DeltaTableInputEndpointInner {
                 )
                 .await
             }
-            _ => return,
+            _ => return Ok(()),
         };
 
         // Deregister the table registered by `add_with_polarity`.
         // If the table does not exist, there's no harm.
         let _ = self.datafusion.deregister_table("tmp_table");
 
-        if let Err(e) = result {
-            self.consumer.error(false, e, Some("delta-action"));
-        }
+        result
     }
 
     // TODO: here, as well as in `process_cdc_transaction`, we can get some potential speedup by only reading a subset
@@ -2074,12 +2299,12 @@ impl DeltaTableInputEndpointInner {
         let full_path = format!("{}{}", table.log_store().object_store_url().as_str(), path);
 
         // Create a datafusion table backed by these files.
-        let table = Arc::new(
+        let parquet_table = Arc::new(
             self.create_parquet_table(table, vec![full_path.clone()], &description)
                 .await?,
         );
 
-        self.datafusion.register_table("tmp_table", table).map_err(|e| {
+        self.datafusion.register_table("tmp_table", parquet_table).map_err(|e| {
             anyhow!("internal error processing file {full_path}; {REPORT_ERROR}; error registering Parquet table: {e}")
         })?;
 
@@ -2104,8 +2329,10 @@ impl DeltaTableInputEndpointInner {
                 input_stream,
                 receiver,
                 start_transaction,
+                self.config.max_retries(),
+                table.version(),
             )
-            .await;
+            .await?;
 
         Ok(())
     }

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -45,8 +45,8 @@ use std::fs::File;
 use std::io::Write;
 use std::mem::forget;
 use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, TempDir};
 use tokio::sync::mpsc;
@@ -108,6 +108,7 @@ async fn wait_for_output_records<T>(
     expected_output: &[T],
     datafusion: &SessionContext,
     timeout_ms: u64,
+    dedup: bool,
 ) where
     T: for<'a> DeserializeWithContext<'a, SqlSerdeConfig, Variant> + DBData,
 {
@@ -144,8 +145,12 @@ async fn wait_for_output_records<T>(
             result.len()
         );
 
+        result.sort();
+        if dedup {
+            result.dedup();
+        }
+
         if result.len() == expected_output.len() {
-            result.sort();
             let mut expected_output = expected_output.to_vec();
             expected_output.sort();
             assert_eq!(result, expected_output);
@@ -713,6 +718,8 @@ async fn test_follow(
     test_end_version: bool,
     buffer_size: u64,
     buffer_timeout_ms: u64,
+    inject_failure: Option<Box<dyn Fn()>>,
+    clear_failure: Option<Box<dyn Fn()>>,
 ) {
     async fn suspend_pipeline(pipeline: Controller) {
         println!("start suspend");
@@ -897,6 +904,7 @@ async fn test_follow(
         &expected_output,
         &datafusion,
         20_000,
+        false,
     )
     .await;
 
@@ -948,6 +956,58 @@ async fn test_follow(
                 .collect::<Vec<_>>();
         };
 
+        // Run after the write so the test process can still update the table; the pipeline
+        // then fails to read the new snapshot until permissions are restored.
+        if let Some(inject_failure) = &inject_failure {
+            inject_failure();
+        }
+
+        if inject_failure.is_some() {
+            wait(
+                || {
+                    pipeline
+                        .input_endpoint_status("test_input1")
+                        .ok()
+                        .and_then(|s| s.health)
+                        .is_some_and(|h| {
+                            let unhealthy = matches!(
+                                h.status,
+                                feldera_types::adapter_stats::ConnectorHealthStatus::Unhealthy
+                            );
+                            if unhealthy {
+                                println!("unhealthy: {:?}", h);
+                            }
+                            unhealthy
+                        })
+                },
+                20_000,
+            )
+            .expect("timeout waiting for input connector health to become unhealthy");
+        }
+
+        if let Some(clear_failure) = &clear_failure {
+            clear_failure();
+        }
+
+        if clear_failure.is_some() {
+            wait(
+                || {
+                    pipeline
+                        .input_endpoint_status("test_input1")
+                        .ok()
+                        .and_then(|s| s.health)
+                        .is_some_and(|h| {
+                            matches!(
+                                h.status,
+                                feldera_types::adapter_stats::ConnectorHealthStatus::Healthy
+                            )
+                        })
+                },
+                20_000,
+            )
+            .expect("timeout waiting for input connector health to become healthy");
+        }
+
         if suspend {
             suspend_pipeline(pipeline).await;
 
@@ -995,6 +1055,7 @@ async fn test_follow(
             &expected_output,
             &datafusion,
             if suspend { 200_000 } else { 0 },
+            inject_failure.is_some(),
         )
         .await;
     }
@@ -1319,6 +1380,48 @@ fn delta_data(max_records: usize) -> impl Strategy<Value = Vec<DeltaTestStruct>>
     })
 }
 
+/// Remove owner read and execute on the delta table **root directory only**, and push that path
+/// and its original mode onto `saved` for [`restore_delta_input_table_read_permission`].
+///
+/// Without `r` and `x` on the root, the process cannot traverse into `_delta_log` or data paths
+/// even if inner files still have permissive modes.
+#[cfg(unix)]
+fn strip_delta_input_table_read_permission(
+    table_root: &Path,
+    saved: &mut Vec<(PathBuf, u32)>,
+) -> std::io::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = fs::metadata(table_root)?;
+    if !meta.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "delta input table path must be a directory",
+        ));
+    }
+
+    let mode = meta.permissions().mode();
+    saved.push((table_root.to_path_buf(), mode));
+
+    let new_mode = mode & !0o500;
+    let mut perms = meta.permissions();
+    perms.set_mode(new_mode);
+    fs::set_permissions(table_root, perms)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restore_delta_input_table_read_permission(saved: Vec<(PathBuf, u32)>) -> std::io::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    for (path, mode) in saved.into_iter().rev() {
+        fs::set_permissions(&path, fs::Permissions::from_mode(mode))?;
+    }
+    Ok(())
+}
+
 async fn delta_table_follow_file_test_common(
     snapshot: bool,
     transaction_mode: DeltaTableTransactionMode,
@@ -1338,6 +1441,45 @@ async fn delta_table_follow_file_test_common(
     let output_table_dir: TempDir = TempDir::new().unwrap();
     let output_table_uri = output_table_dir.path().display().to_string();
 
+    // With `end_version`, the connector stops tailing the log before new versions appear, so
+    // stripping read permission would not drive the connector unhealthy (wait would time out).
+    #[cfg(unix)]
+    let (inject_failure, clear_failure): (Option<Box<dyn Fn()>>, Option<Box<dyn Fn()>>) =
+        if end_version {
+            (None, None)
+        } else {
+            let saved_modes: Arc<Mutex<Vec<(PathBuf, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+            let input_root = input_table_dir.path().to_path_buf();
+
+            let inject_failure: Box<dyn Fn()> = {
+                let saved_modes = Arc::clone(&saved_modes);
+                let input_root = input_root.clone();
+                Box::new(move || {
+                    let mut guard = saved_modes.lock().unwrap();
+                    guard.clear();
+                    strip_delta_input_table_read_permission(&input_root, &mut *guard)
+                        .unwrap_or_else(|e| {
+                            panic!("inject_failure (strip read permission on input table): {e}")
+                        });
+                })
+            };
+
+            let clear_failure: Box<dyn Fn()> = {
+                let saved_modes = Arc::clone(&saved_modes);
+                Box::new(move || {
+                    let entries = std::mem::take(&mut *saved_modes.lock().unwrap());
+                    restore_delta_input_table_read_permission(entries).unwrap_or_else(|e| {
+                        panic!("clear_failure (restore read permission on input table): {e}")
+                    });
+                })
+            };
+
+            (Some(inject_failure), Some(clear_failure))
+        };
+
+    #[cfg(not(unix))]
+    let (inject_failure, clear_failure) = (None, None);
+
     test_follow(
         &relation_schema,
         &input_table_uri,
@@ -1350,6 +1492,8 @@ async fn delta_table_follow_file_test_common(
         end_version,
         1000,
         100,
+        inject_failure,
+        clear_failure,
     )
     .await;
 }
@@ -1565,6 +1709,8 @@ async fn delta_table_follow_s3_test_common(snapshot: bool, suspend: bool) {
         false,
         1000,
         100,
+        None,
+        None,
     )
     .await;
 }

--- a/crates/adapters/src/test/mock_input_consumer.rs
+++ b/crates/adapters/src/test/mock_input_consumer.rs
@@ -6,6 +6,7 @@ use dbsp::operator::StagedBuffers;
 use feldera_adapterlib::ConnectorMetadata;
 use feldera_adapterlib::format::BufferSize;
 use feldera_adapterlib::transport::{Resume, Watermark};
+use feldera_types::adapter_stats::ConnectorHealth;
 use feldera_types::config::FtModel;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -129,6 +130,8 @@ impl InputConsumer for MockInputConsumer {
     fn commit_transaction(&self) {
         self.state().transaction_in_progress = false;
     }
+
+    fn update_connector_health(&self, _health: ConnectorHealth) {}
 }
 
 pub struct MockInputParserState {

--- a/crates/adapters/src/transport/kafka/ft/test.rs
+++ b/crates/adapters/src/transport/kafka/ft/test.rs
@@ -25,6 +25,7 @@ use feldera_adapterlib::format::{BufferSize, flatten_nested};
 use feldera_adapterlib::transport::{Resume, Watermark};
 use feldera_macros::IsNone;
 use feldera_sqllib::{ByteArray, SqlString, Variant};
+use feldera_types::adapter_stats::ConnectorHealth;
 use feldera_types::config::{
     ConnectorConfig, FormatConfig, FtModel, InputEndpointConfig, OutputBufferConfig,
     TransportConfig, default_max_queued_records,
@@ -763,6 +764,8 @@ impl InputConsumer for DummyInputConsumer {
     fn start_transaction(&self, _label: Option<&str>) {}
 
     fn commit_transaction(&self) {}
+
+    fn update_connector_health(&self, _health: ConnectorHealth) {}
 }
 
 #[test]

--- a/crates/feldera-types/src/transport/delta_table.rs
+++ b/crates/feldera-types/src/transport/delta_table.rs
@@ -354,6 +354,20 @@ pub struct DeltaTableReaderConfig {
     #[serde(default)]
     pub verbose: u32,
 
+    /// Maximum number of retries for failed object store operations.
+    ///
+    /// Controls how many times the connector retries high-level storage operations,
+    /// such as reading a Delta log entry or a Parquet file.
+    ///
+    /// This is in addition to lower-level retries (e.g., individual S3 operation retries governed
+    /// by storage options like `retry_timeout`). If those retries are exhausted
+    /// or the failure is otherwise unrecoverable at the storage layer, the
+    /// connector retries the entire operation.
+    ///
+    /// Defaults to unlimited retries. Set to 0 to disable retries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_retries: Option<u32>,
+
     /// Storage options for configuring backend object store.
     ///
     /// For specific options available for different storage backends, see:
@@ -362,6 +376,12 @@ pub struct DeltaTableReaderConfig {
     /// * [Google Cloud Storage options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html)
     #[serde(flatten)]
     pub object_store_config: HashMap<String, String>,
+}
+
+impl DeltaTableReaderConfig {
+    pub fn max_retries(&self) -> u32 {
+        self.max_retries.unwrap_or(u32::MAX)
+    }
 }
 
 #[cfg(test)]

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -12,7 +12,20 @@ import TabItem from '@theme/TabItem';
     <TabItem className="changelogItem" value="enterprise"
         label="Enterprise">
 
-        ## Unreleased
+	## v0.288.0
+
+	Delta Lake input connector error handling behavior change:
+
+	In the past if the connector wasn't able to read a table version, it
+	signaled an error and moved to the next version. This could cause data loss.
+	With this change the connector will either retry forever or fail and stop
+	producing input after exhausting retry attempts.
+
+	The second behavioral change is that the connector can now produce
+	duplicate inputs even without a pipeline restart as the connector retries
+	processing delta log entries.
+
+        ## v0.281.0
 
         Starting a pipeline while storage is still clearing (`storage_status=Clearing`) now returns
         `CannotStartWhileClearingStorage` instead of succeeding. Clearing storage while a start

--- a/docs.feldera.com/docs/connectors/sources/delta.md
+++ b/docs.feldera.com/docs/connectors/sources/delta.md
@@ -36,6 +36,7 @@ exactly once fault tolerance.
 | `cdc_delete_filer`          | string |            | <p>A predicate that determines whether the record represents a deletion.</p><p>This setting is only valid in the `cdc` mode. It specifies a predicate applied to each row in the Delta table to determine whether the row represents a deletion event. Its value must be a valid Boolean SQL expression that can be used in a query of the form `SELECT * from <table> WHERE <cdc_delete_filter>`.</p>|
 | `cdc_order_by`              | string |            | <p>An expression that determines the ordering of updates in the Delta table.</p><p>This setting is only valid in the `cdc` mode. It specifies a predicate applied to each row in the Delta table to determine the order in which updates in the table should be applied. Its value must be a valid SQL expression that can be used in a query of the form `SELECT * from <table> ORDER BY <cdc_order_by>`.</p>|
 | `num_parsers`               | string |            | The number of parallel parsing tasks the connector uses to process data read from the table. Increasing this value can enhance performance by allowing more concurrent processing. Recommended range: 1–10. The default is 4.|
+| `max_retries`               | integer| unlimited retries| <p>Maximum number of retries for failed object store operations.</p><p>Controls how many times the connector retries high-level storage operations, such as reading a Delta log entry or a Parquet file.</p><p>This is in addition to lower-level retries (e.g., individual S3 operation retries governed by storage options like `retry_timeout`). If those retries are exhausted or the failure is otherwise unrecoverable at the storage layer, the connector retries the entire operation.</p><p>Defaults to unlimited retries. Set to 0 to disable retries.</p><p>See [retries and at-least-once delivery](#retries-and-at-least-once-delivery)</p>|
 | `skip_unused_columns` (<b>DEPRECATED</b>) | bool   | false | <p>This property is deprecated. Use the [table-level `skip_unused_columns` property](/sql/grammar#ignoring-unused-columns) instead.</p><p>Don't read unused columns from the Delta table.  When set to `true`, this option instructs the connector to avoid reading columns from the Delta table that are not used in any view definitions. To be skipped, the columns must be either nullable or have default values. This can improve ingestion performance, especially for wide tables.</p><p>Note: The simplest way to exclude unused columns is to omit them from the Feldera SQL table declaration. The connector never reads columns that aren't declared in the SQL schema. Additionally, the SQL compiler emits warnings for declared but unused columns—use these as a guide to optimize your schema.</p>|
 | `max_concurrent_readers`    | integer| 6          | <p>Maximum number of concurrent object store reads performed by all Delta Lake connectors.</p><p>This setting is used to limit the number of concurrent reads of the object store in a pipeline with a large number of Delta Lake connectors. When multiple connectors are simultaneously reading from the object store, this can lead to transport timeouts.</p><p>When enabled, this setting limits the number of concurrent reads across all connectors. This is a global setting that affects all Delta Lake connectors, and not just the connector where it is specified. It should therefore be used at most once in a pipeline.  If multiple connectors specify this setting, they must all use the same value.</p><p>The default value is 6.</p>|
 
@@ -167,6 +168,8 @@ Additional configuration options to configure HTTP client for remote object stor
 | `proxy_excludes`              | List of hosts that bypass proxy.                                                                                                                               |
 | `randomize_addresses`         | Randomize order addresses that the DNS resolution yields. This will spread the connections across more servers.                                                |
 | `timeout`                     | Request timeout. The timeout is applied from when the request starts connecting until the response body has finished. Format: `<number><units>`, e.g., `30s`, `1.5m`.|
+| `retry_timeout`               | The maximum length of time from the initial request after which no further retries will be attempted. This not only bounds the length of time before a server error will be surfaced to the application, but also bounds the length of time a request’s credentials must remain valid. As requests are retried without renewing credentials or regenerating request payloads, this number should be kept below 5 minutes to avoid errors due to expired credentials and/or request payloads|
+| `connect_timeout`             | Set a timeout for only the connect phase of a client. This is the time allowed for the client to establish a connection and if the connection is not established within this time, the client returns a timeout error.|
 | `user_agent`                  | User-Agent header to be used by this client.                                                                                                                   |
 
 ## Data type mapping
@@ -302,6 +305,39 @@ CREATE TABLE transaction(
   }
 ]');
 ```
+
+## Retries and at-least-once delivery
+
+When interacting with an object store such as Amazon S3, the Delta Lake connector must handle
+transient failures, including timeouts and expired authentication tokens.
+
+These errors are first handled at the level of individual object store operations, which are
+automatically retried when possible. This behavior is controlled by the
+[HTTP client configuration](#http-client-configuration) settings: `connect_timeout`,
+`timeout`, and `retry_timeout`.
+
+If these lower-level retries are exhausted—or if the error cannot be recovered at the storage
+layer—the connector retries the entire operation (for example, re-reading a Delta log entry).
+This behavior is controlled by the `max_retries` setting:
+
+* By default, the connector performs unbounded retries.
+* Set `max_retries = N` to limit the number of attempts.
+* Set `max_retries = 0` to disable retries entirely.
+
+If the connector cannot recover after `N` attempts, it fails with a fatal error and stops
+ingesting inputs.
+
+Because retries may occur after partial progress (e.g., after partially processing a Delta log entry),
+the same data may be ingested more than once. This is consistent with the connector’s **at-least-once delivery**
+guarantee.
+
+To ensure idempotent ingestion, we recommend defining [primary keys](/connectors/unique_keys).
+
+Retry activity is reflected in the connector’s [health status](https://docs.feldera.com/api/get-input-status/):
+it is marked **UNHEALTHY** while retrying failed operations.
+
+If the pipeline is stopped and restarted during a retry, the connector resumes from the last successfully
+ingested table version. This guarantees that no data loss occurs due to object store read errors.
 
 ## Additional examples
 

--- a/openapi.json
+++ b/openapi.json
@@ -7924,6 +7924,13 @@
             "nullable": true,
             "minimum": 0
           },
+          "max_retries": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of retries for failed object store operations.\n\nControls how many times the connector retries high-level storage operations,\nsuch as reading a Delta log entry or a Parquet file.\n\nThis is in addition to lower-level retries (e.g., individual S3 operation retries governed\nby storage options like `retry_timeout`). If those retries are exhausted\nor the failure is otherwise unrecoverable at the storage layer, the\nconnector retries the entire operation.\n\nDefaults to unlimited retries. Set to 0 to disable retries.",
+            "nullable": true,
+            "minimum": 0
+          },
           "mode": {
             "$ref": "#/components/schemas/DeltaTableIngestMode"
           },


### PR DESCRIPTION
The connector already had retry logic in some places, but mostly relied on delta-rs for retries. This wasn't always enough and we saw timeouts and expired token errors bubbling up.

This commit adds retry loops around all object store accesses. The loops are controlled by the new `max_retries` setting, similar to the output connector. By default, it will retry forever. The retry loops set health status to UNHEALTHY while retrying.

If the pipeline is stopped and restarted during a retry, the connector resumes from the last successfully ingested table version.  After exhausting retry attempts the connector fails permanently with a fatal error, which eliminates the possibility of data loss.

There is an important caveat:

Because retries may occur after partial progress (e.g., after partially processing a Delta log entry), the same data may be ingested more than once. This is consistent with the connector’s at-least-once delivery guarantee.

### Describe Manual Test Plan

Tested using @anandbraman 's e-commerce demo pipeline.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [x] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

In the past if the connector wasn't able to read a table version, it signaled an error and moved to the next version. This could cause data loss. With this change the connector will either retry forever or fail and stop producing input after exhausting retry attempts.

The second behavioral change is that the connector can now produce duplicate inputs even without a pipeline restart.