### PR TITLE
ci: abort Docker build job when workflow is cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,6 @@ jobs:
   invoke-build-docker:
     name: Build Docker
     needs: [invoke-build-rust, invoke-build-java, invoke-tests-web-console-unit]
-    if: |
-      always() &&
-      (needs.invoke-build-rust.result == 'success' || needs.invoke-build-rust.result == 'skipped') &&
-      (needs.invoke-build-java.result == 'success' || needs.invoke-build-java.result == 'skipped') &&
-      (needs.invoke-tests-web-console-unit.result == 'success' || needs.invoke-tests-web-console-unit.result == 'skipped')
     uses: ./.github/workflows/build-docker.yml
     secrets: inherit
 


### PR DESCRIPTION
Remove always() and the result == 'skipped' conditions from invoke-build-docker. 

This is the same issue fixed for invoke-tests-web-console-e2e. The always() condition was added to allow Docker to build even when upstream jobs were "skipped", a scenario that only existed with the artifact-caching feature reverted in #5974. Without that feature, Rust/Java builds are never legitimately skipped, so always() causes Docker to keep running when the workflow is cancelled (upstream jobs get cancelled → skipped → Docker condition evaluates true).

Removing the if: entirely means Docker only builds when all upstream jobs actually succeed, and aborts with the rest of the workflow on cancellation.