### PR TITLE
fix partial_shuffle in distinct_count_test

### DIFF
--- a/crates/dbsp/src/operator/dynamic/count.rs
+++ b/crates/dbsp/src/operator/dynamic/count.rs
@@ -287,12 +287,12 @@ mod test {
             for k in K {
                 let mut v: Vec<u64> = V.collect();
                 let n = rng.gen_range(V);
-                v.partial_shuffle(&mut rng, n as usize);
+                let (shuffled, _) = v.partial_shuffle(&mut rng, n as usize);
 
                 let mut distinct_count = 0;
-                for &v in &v[0..n as usize] {
+                for v in shuffled {
                     let w = rng.gen_range(W);
-                    input_tuples.push(Tup2(k, Tup2(v as i64, w)));
+                    input_tuples.push(Tup2(k, Tup2(*v as i64, w)));
                     if w > 0 {
                         distinct_count += 1;
                     }


### PR DESCRIPTION
### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
~~- [ ] Integration tests added/updated~~ (N/A)
~~- [ ] Documentation updated~~ (N/A)
~~- [ ] Changelog updated~~ (N/A)

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

N/A

---

`partial_shuffle` actually currently puts the shuffled elements at the end of the original slice, but the more robust solution is to use the slices returned by the function directly. [(`partial_shuffle` docs here)](https://docs.rs/rand/0.8.5/rand/seq/trait.SliceRandom.html#tymethod.partial_shuffle)