### PR TITLE
[SQL] Improve code generation for functions that use Regex and Timezone

### DIFF
--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -30,6 +30,7 @@ use std::{
     mem::{MaybeUninit, transmute},
     sync::Arc,
 };
+use tracing::warn;
 
 type StringRef = ArcStr;
 pub type InternedString = InternedStringId;
@@ -712,7 +713,7 @@ pub fn to_json_nullN(_value: Option<()>) -> Option<SqlString> {
 pub enum ParsedRegex {
     Regex(Regex),
     // The expression and the error produced while parsing
-    Invalid(String, String),
+    Invalid(SqlString, String),
 }
 
 #[doc(hidden)]
@@ -720,12 +721,12 @@ pub fn make_regex_(re: SqlString) -> ParsedRegex {
     match Regex::new(re.str()) {
         Ok(r) => ParsedRegex::Regex(r),
         Err(e) => {
-            tracing::warn!(
+            warn!(
                 "failed to parse '{}' as a regular expression: {}",
                 re,
                 e.to_string()
             );
-            ParsedRegex::Invalid(re.str().to_string(), e.to_string())
+            ParsedRegex::Invalid(re, e.to_string())
         }
     }
 }

--- a/crates/sqllib/src/string.rs
+++ b/crates/sqllib/src/string.rs
@@ -324,31 +324,17 @@ pub fn like2__(value: SqlString, pattern: SqlString) -> bool {
 
 some_function2!(like2, SqlString, SqlString, bool);
 
-// rlike with a Constant regular expression.
-// re is None when the regular expression expression is malformed,
-// In this case the result is false and not None.
-// The regular expression cannot be null - the compiler would detect that.
 #[doc(hidden)]
-pub fn rlikeC__(value: SqlString, re: &Option<Regex>) -> bool {
+pub fn rlike__(value: SqlString, re: ParsedRegex) -> bool {
     match re {
-        None => false,
-        Some(re) => re.is_match(value.str()),
+        ParsedRegex::Invalid(r, e) => {
+            panic!("Invalid regular expression in RLIKE '{}': {}", r, e);
+        }
+        ParsedRegex::Regex(re) => re.is_match(value.str()),
     }
 }
 
-#[doc(hidden)]
-pub fn rlikeCN_(value: Option<SqlString>, re: &Option<Regex>) -> Option<bool> {
-    let value = value?;
-    Some(rlikeC__(value, re))
-}
-
-#[doc(hidden)]
-pub fn rlike__(value: SqlString, pattern: SqlString) -> bool {
-    let re = Regex::new(pattern.str());
-    re.map_or_else(|_| false, |re| re.is_match(value.str()))
-}
-
-some_function2!(rlike, SqlString, SqlString, bool);
+some_function2!(rlike, SqlString, ParsedRegex, bool);
 
 #[doc(hidden)]
 pub fn like3___(value: SqlString, pattern: SqlString, escape: SqlString) -> bool {
@@ -722,69 +708,56 @@ pub fn to_json_nullN(_value: Option<()>) -> Option<SqlString> {
 }
 
 #[doc(hidden)]
-pub fn regexp_replace3___(str: SqlString, re: SqlString, repl: SqlString) -> SqlString {
-    let re = Regex::new(re.str()).ok();
-    regexp_replaceC3___(str, &re, repl)
+#[derive(Debug, Clone)]
+pub enum ParsedRegex {
+    Regex(Regex),
+    // The expression and the error produced while parsing
+    Invalid(String, String),
 }
 
-some_function3!(regexp_replace3, SqlString, SqlString, SqlString, SqlString);
-
 #[doc(hidden)]
-pub fn regexp_replace2__(str: SqlString, re: SqlString) -> SqlString {
-    regexp_replace3___(str, re, SqlString::new())
-}
-
-some_function2!(regexp_replace2, SqlString, SqlString, SqlString);
-
-#[doc(hidden)]
-pub fn regexp_replaceC3___(str: SqlString, re: &Option<Regex>, repl: SqlString) -> SqlString {
-    match re {
-        None => str,
-        Some(re) => SqlString::maybe_reuse(re.replace_all(str.str(), repl.str()).as_ref(), &str),
+pub fn make_regex_(re: SqlString) -> ParsedRegex {
+    match Regex::new(re.str()) {
+        Ok(r) => ParsedRegex::Regex(r),
+        Err(e) => {
+            tracing::warn!(
+                "failed to parse '{}' as a regular expression: {}",
+                re,
+                e.to_string()
+            );
+            ParsedRegex::Invalid(re.str().to_string(), e.to_string())
+        }
     }
 }
 
-#[doc(hidden)]
-pub fn regexp_replaceC3N__(
-    str: Option<SqlString>,
-    re: &Option<Regex>,
-    repl: SqlString,
-) -> Option<SqlString> {
-    let str = str?;
-    Some(regexp_replaceC3___(str, re, repl))
-}
+some_function1!(make_regex, SqlString, ParsedRegex);
 
 #[doc(hidden)]
-pub fn regexp_replaceC3__N(
-    str: SqlString,
-    re: &Option<Regex>,
-    repl: Option<SqlString>,
-) -> Option<SqlString> {
-    let repl = repl?;
-    Some(regexp_replaceC3___(str, re, repl))
+pub fn regexp_replace3___(str: SqlString, re: ParsedRegex, repl: SqlString) -> SqlString {
+    match re {
+        ParsedRegex::Invalid(r, e) => {
+            panic!("Invalid regular expression in REPLACE '{}': {}", r, e);
+        }
+        ParsedRegex::Regex(re) => {
+            SqlString::maybe_reuse(re.replace_all(str.str(), repl.str()).as_ref(), &str)
+        }
+    }
 }
 
-#[doc(hidden)]
-pub fn regexp_replaceC3N_N(
-    str: Option<SqlString>,
-    re: &Option<Regex>,
-    repl: Option<SqlString>,
-) -> Option<SqlString> {
-    let str = str?;
-    let repl = repl?;
-    Some(regexp_replaceC3___(str, re, repl))
-}
+some_function3!(
+    regexp_replace3,
+    SqlString,
+    ParsedRegex,
+    SqlString,
+    SqlString
+);
 
 #[doc(hidden)]
-pub fn regexp_replaceC2__(str: SqlString, re: &Option<Regex>) -> SqlString {
-    regexp_replaceC3___(str, re, SqlString::new())
+pub fn regexp_replace2__(str: SqlString, re: ParsedRegex) -> SqlString {
+    regexp_replace3___(str, re, SqlString::new())
 }
 
-#[doc(hidden)]
-pub fn regexp_replaceC2N_(str: Option<SqlString>, re: &Option<Regex>) -> Option<SqlString> {
-    let str = str?;
-    Some(regexp_replaceC3___(str, re, SqlString::new()))
-}
+some_function2!(regexp_replace2, SqlString, ParsedRegex, SqlString);
 
 #[doc(hidden)]
 pub fn concat_ws___(sep: SqlString, left: SqlString, right: SqlString) -> SqlString {

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -312,27 +312,29 @@ impl Timestamp {
 
 #[doc(hidden)]
 #[derive(Debug, Clone)]
-enum Zone {
+pub enum Zone {
     Iana(Tz),
     Offset(FixedOffset),
+    // Timezone string
+    Invalid(String),
 }
 
 impl Zone {
     #[doc(hidden)]
     /// Parse either an IANA timezone or a numeric offset like "+09:00".
-    fn parse(s: &str) -> Option<Self> {
+    fn parse(s: &str) -> Self {
         // Try IANA zone first
         if let Ok(tz) = s.parse::<Tz>() {
-            return Some(Zone::Iana(tz));
+            return Zone::Iana(tz);
         }
 
         // Try numeric offset: +HH, +HH:MM, +HH:MM:SS
         if let Some(offset) = Self::parse_fixed_offset(s) {
-            return Some(Zone::Offset(offset));
+            return Zone::Offset(offset);
         }
 
-        tracing::warn!("convert_timezone: failed to parse timezone '{}'", s);
-        None
+        tracing::warn!("failed to parse timezone '{}'", s);
+        Zone::Invalid(s.to_string())
     }
 
     #[doc(hidden)]
@@ -385,15 +387,21 @@ impl Zone {
                 })?;
                 Ok(dt.with_timezone(&Utc))
             }
+            Zone::Invalid(tz) => Err(SqlRuntimeError::from_string(format!(
+                "Cannot parse timezone {tz}"
+            ))),
         }
     }
 
     /// Convert a UTC datetime into this zone.
     #[doc(hidden)]
-    fn to_local(&self, utc: DateTime<Utc>) -> NaiveDateTime {
+    fn to_local(&self, utc: DateTime<Utc>) -> SqlResult<NaiveDateTime> {
         match self {
-            Zone::Iana(tz) => utc.with_timezone(tz).naive_local(),
-            Zone::Offset(off) => utc.with_timezone(off).naive_local(),
+            Zone::Iana(tz) => Ok(utc.with_timezone(tz).naive_local()),
+            Zone::Offset(off) => Ok(utc.with_timezone(off).naive_local()),
+            Zone::Invalid(tz) => Err(SqlRuntimeError::from_string(format!(
+                "Cannot parse timezone {tz}"
+            ))),
         }
     }
 }
@@ -490,54 +498,40 @@ mod tests {
 }
 
 #[doc(hidden)]
-pub fn convert_timezone___(
-    source: SqlString,
-    target: SqlString,
-    ts: Timestamp,
-) -> Option<Timestamp> {
-    // TODO: should we log the parse errors?
+pub fn parse_timezone_(tz: SqlString) -> Zone {
+    Zone::parse(tz.str())
+}
+
+#[doc(hidden)]
+pub fn parse_timezoneN(tz: Option<SqlString>) -> Option<Zone> {
+    let tz = tz?;
+    Some(parse_timezone_(tz))
+}
+
+#[doc(hidden)]
+pub fn convert_timezone___(src_tz: Zone, dst_tz: Zone, ts: Timestamp) -> Option<Timestamp> {
     let naive = ts.to_naiveDateTime();
-    let src_tz: Zone = Zone::parse(source.str())?;
-    let dst_tz: Zone = Zone::parse(target.str())?;
     let utc = src_tz.local_to_utc(naive).ok()?;
-    let result = dst_tz.to_local(utc);
+    let result = dst_tz.to_local(utc).ok()?;
     Some(Timestamp::from_naiveDateTime(result))
 }
 
 #[doc(hidden)]
-pub fn convert_timezoneN__(
-    source: Option<SqlString>,
-    target: SqlString,
-    ts: Timestamp,
-) -> Option<Timestamp> {
+pub fn convert_timezoneN__(source: Option<Zone>, target: Zone, ts: Timestamp) -> Option<Timestamp> {
     let source = source?;
     convert_timezone___(source, target, ts)
 }
 
 #[doc(hidden)]
-pub fn convert_timezone_N_(
-    source: SqlString,
-    target: Option<SqlString>,
-    ts: Timestamp,
-) -> Option<Timestamp> {
+pub fn convert_timezone_N_(source: Zone, target: Option<Zone>, ts: Timestamp) -> Option<Timestamp> {
     let target = target?;
     convert_timezone___(source, target, ts)
 }
 
 #[doc(hidden)]
-pub fn convert_timezone__N(
-    source: SqlString,
-    target: SqlString,
-    ts: Option<Timestamp>,
-) -> Option<Timestamp> {
-    let ts = ts?;
-    convert_timezone___(source, target, ts)
-}
-
-#[doc(hidden)]
 pub fn convert_timezoneNN_(
-    source: Option<SqlString>,
-    target: Option<SqlString>,
+    source: Option<Zone>,
+    target: Option<Zone>,
     ts: Timestamp,
 ) -> Option<Timestamp> {
     let source = source?;
@@ -547,8 +541,8 @@ pub fn convert_timezoneNN_(
 
 #[doc(hidden)]
 pub fn convert_timezoneN_N(
-    source: Option<SqlString>,
-    target: SqlString,
+    source: Option<Zone>,
+    target: Zone,
     ts: Option<Timestamp>,
 ) -> Option<Timestamp> {
     let source = source?;
@@ -558,8 +552,8 @@ pub fn convert_timezoneN_N(
 
 #[doc(hidden)]
 pub fn convert_timezone_NN(
-    source: SqlString,
-    target: Option<SqlString>,
+    source: Zone,
+    target: Option<Zone>,
     ts: Option<Timestamp>,
 ) -> Option<Timestamp> {
     let target = target?;
@@ -568,9 +562,15 @@ pub fn convert_timezone_NN(
 }
 
 #[doc(hidden)]
+pub fn convert_timezone__N(source: Zone, target: Zone, ts: Option<Timestamp>) -> Option<Timestamp> {
+    let ts = ts?;
+    convert_timezone___(source, target, ts)
+}
+
+#[doc(hidden)]
 pub fn convert_timezoneNNN(
-    source: Option<SqlString>,
-    target: Option<SqlString>,
+    source: Option<Zone>,
+    target: Option<Zone>,
     ts: Option<Timestamp>,
 ) -> Option<Timestamp> {
     let source = source?;

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -12,18 +12,25 @@ import TabItem from '@theme/TabItem';
     <TabItem className="changelogItem" value="enterprise"
         label="Enterprise">
 
-	## v0.288.0
+        ## Unreleased
 
-	Delta Lake input connector error handling behavior change:
+        Functions `RLIKE` and `REPLACE_REGEXP` will crash for invalid
+        regular expressions.  Previously they treated such as expressions
+        as expressions which never match.  The new behavior more closely
+        aligns with other databases.
 
-	In the past if the connector wasn't able to read a table version, it
-	signaled an error and moved to the next version. This could cause data loss.
-	With this change the connector will either retry forever or fail and stop
-	producing input after exhausting retry attempts.
+        ## v0.288.0
 
-	The second behavioral change is that the connector can now produce
-	duplicate inputs even without a pipeline restart as the connector retries
-	processing delta log entries.
+        Delta Lake input connector error handling behavior change:
+
+        In the past if the connector wasn't able to read a table version, it
+        signaled an error and moved to the next version. This could cause data loss.
+        With this change the connector will either retry forever or fail and stop
+        producing input after exhausting retry attempts.
+
+        The second behavioral change is that the connector can now produce
+        duplicate inputs even without a pipeline restart as the connector retries
+        processing delta log entries.
 
         ## v0.281.0
 

--- a/docs.feldera.com/docs/sql/datetime.md
+++ b/docs.feldera.com/docs/sql/datetime.md
@@ -335,9 +335,9 @@ The following arithmetic operations are supported:
 | Operation                         | Result Type        | Explanation                                                      |
 |-----------------------------------|--------------------|------------------------------------------------------------------|
 | _date_ `+` _interval_             | `DATE`             | Add an interval to a date                                        |
-| (_date_ `-` _date_) shortInterval | `INTERVAL`         | Compute the difference between two dates as a short interval     |
-| (_date_ `-` _date_) longInterval  | `INTERVAL`         | Compute the difference between two dates as a long interval      |
-| (_time_ `-` _time_) shortInterval | `INTERVAL`         | Compute the difference between two times as a short interval     |
+| (_date_ `-` _date_) UNIT          | `INTERVAL`         | Compute the difference between two dates as a short interval. E.g. `(d1 - d2) SECONDS` |
+| (_date_ `-` _date_) UNIT          | `INTERVAL`         | Compute the difference between two dates as a long interval. E.g. `(d1 - d2) MONTHS`   |
+| (_time_ `-` _time_) UNIT          | `INTERVAL`         | Compute the difference between two times as a short interval. E.g. (t1 - t2) HOURS`    |
 | _interval_ `+` _interval_         | `INTERVAL`         | Add two intervals; both must have the same type                  |
 | _timestamp_ `+` _interval_        | `TIMESTAMP`        | Add an interval to a timestamp                                   |
 | _time_ `+` _interval_             | `TIME`             | Add an interval to a time. Performs wrapping addition.           |
@@ -345,8 +345,8 @@ The following arithmetic operations are supported:
 | _date_ `-` _interval_             | `DATE`             | Subtract an interval from a date                                 |
 | _time_ `-` _interval_             | `TIME`             | Subtract an interval from a time. Performs wrapping subtraction. |
 | _timestamp_ `-` _interval_        | `TIMESTAMP`        | Subtract an interval from a timestamp                            |
-| (_timestamp_ `-` _timestamp_) shortInterval | `INTERVAL` | Compute the difference between two timestamps as a short interval|
-| (`TIMESTAMP` `-` `TIMESTAMP`) longInterval  | `INTERVAL` | Compute the difference between two timestamps as a long interval |
+| (_timestamp_ `-` _timestamp_) UNIT | `INTERVAL`        | Compute the difference between two timestamps as a short interval. E.g. `(ts1 - ts2) HOURS TO MINUTES` |
+| (`TIMESTAMP` `-` `TIMESTAMP`) UNIT | `INTERVAL`        | Compute the difference between two timestamps as a long interval. E.g. `(ts1 - ts2) YEARS TO MONTHS`   |
 | _interval_ `-` _interval_         | `INTERVAL`         | Subtract two intervals                                           |
 | _interval_ `*` _double_           | `INTERVAL`         | Multiply an interval by a scalar                                 |
 | _interval_ `/` _double_           | `INTERVAL`         | Divide an interval by a scalar                                   |

--- a/docs.feldera.com/docs/sql/string.md
+++ b/docs.feldera.com/docs/sql/string.md
@@ -211,7 +211,7 @@ example.
     <td>Produce an array of strings, by splitting <code>string</code> at each occurrence of <code>delimiter</code>.
         If <code>delimiter</code> is empty, return an array containing just <code>string</code>.  If
         <code>string</code> is empty, return an empty array.  If either argument is NULL, return NULL.
-        If <code>delimiter</code> is absent assume it is the string <code>','</code>.</td>
+        If <code>delimiter</code> is absent, a single quote is used <code>','</code>.</td>
     <td><code>SPLIT('a|b|c|', '|')</code> => <code>['a', 'b', 'c', '']</code></td>
   </tr>
   <tr>
@@ -222,7 +222,9 @@ example.
             <li><code>n = 1</code> refers to the first part of <code>string</code> after splitting.</li>
             <li><code>n = 2</code> refers to the second part, and so on.</li>
             <li>If <code>n</code> is negative, it returns the <code>abs(n)</code>'th part from the end of <code>string</code>.</li>
+            <li>If <code>delimiter</code> is empty there is only one part, the entire string.</li>
             <li>If <code>n</code> is out of bounds, it returns an empty string.</li>
+            <li>If any argument is <code>NULL</code>, the result is <code>NULL</code></li>
         </ul>
     </td>
     <td>

--- a/docs.feldera.com/docs/sql/string.md
+++ b/docs.feldera.com/docs/sql/string.md
@@ -111,7 +111,7 @@ example.
     <td><a id="rlike"></a><code>string RLIKE pattern</code> and
         <code>string NOT RLIKE pattern</code></td>
     <td>The RLIKE expression returns true if <code>string</code> matches <code>pattern</code>.
-        The pattern is a standard Rust regular expression.</td>
+        The pattern is a standard Rust regular expression.  If the regular expression is invalid the program will crash with an error.</td>
     <td><code>'string' RLIKE 's..i.*'</code> => <code>TRUE</code></td>
   </tr>
   <tr>
@@ -183,7 +183,7 @@ example.
         specified by the pattern `pat` with the replacement string `repl`, and returns
         the resulting string. If any one of `expr`, `pat`, or `repl` is `NULL`, the return value is `NULL`.
         If `repl` is missing, it is assumed to be the empty string.  If the regular
-        expression is invalid, the original string is returned.</td>
+        expression is invalid, the program will crash at runtime with an error.</td>
     <td></td>
   </tr>
   <tr>
@@ -211,7 +211,7 @@ example.
     <td>Produce an array of strings, by splitting <code>string</code> at each occurrence of <code>delimiter</code>.
         If <code>delimiter</code> is empty, return an array containing just <code>string</code>.  If
         <code>string</code> is empty, return an empty array.  If either argument is NULL, return NULL.
-        If <code>delimiter</code> is absent, a single quote is used <code>','</code>.</td>
+        If <code>delimiter</code> is absent, a single comma is used <code>','</code>.</td>
     <td><code>SPLIT('a|b|c|', '|')</code> => <code>['a', 'b', 'c', '']</code></td>
   </tr>
   <tr>
@@ -348,7 +348,7 @@ The description below uses fragments from the [Postgres
 documentation](https://www.postgresql.org/docs/15/functions-matching.html#FUNCTIONS-POSIX-REGEXP),
 where credit is given to Henry Spencer.
 
-Currently, our compiler does *not* support `SIMILAR TO` regular
+Currently, Feldera does *not* support `SIMILAR TO` regular
 expressions.
 
 A regular expression is a character sequence that is an abbreviated
@@ -574,7 +574,8 @@ If `repl` is missing, it is assumed to be the empty string.
 Replaces occurrences in the string `expr` that match the regular
 expression specified by the pattern `pat` with the replacement string
 `repl`, and returns the resulting string.  If any of `expr`, `pat`, or
-`repl` is `NULL`, the return value is `NULL`.
+`repl` is `NULL`, the return value is `NULL`.  If the pattern cannot
+be parsed as a valid regular expression the program will crash at runtime.
 
 #### Replacement string syntax
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -862,16 +862,36 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         operandCount + " arguments is unknown", node);
     }
 
-    /** Compile a string literal into a static Regex object and return it. */
     @Nullable
-    DBSPExpression makeRegex(DBSPStringLiteral lit) {
-        DBSPTypeUser user = new DBSPTypeUser(CalciteObject.EMPTY, USER, "Regex", true);
-        // Here we lie about the type: new does not return a Regex, but a Result<Regex, Error>.
-        // We lie again that ok returns an unchanged type.  These two lies cancel out.
-        DBSPExpression init = user.constructor("new", lit.toStr());
-        init = init.applyMethod("ok", init.getType());
-        String name = DBSPStaticExpression.generateName(init, this.compiler);
-        return new DBSPStaticExpression(lit.getNode(), init, name).borrow();
+    DBSPExpression makeRegex(DBSPExpression arg) {
+        DBSPType argType = arg.getType();
+        if (!argType.is(DBSPTypeString.class)) {
+            this.compiler.reportWarning(arg.getSourcePosition(),
+                    "Suspicious argument",
+                    "Regular expression argument expression should have type CHAR, but it has type " + argType.asSqlString());
+            arg = arg.cast(arg.getNode(), DBSPTypeString.varchar(arg.getType().mayBeNull),
+                    DBSPCastExpression.CastType.SqlUnsafe);
+        }
+        DBSPTypeUser user = new DBSPTypeUser(CalciteObject.EMPTY, USER, "ParsedRegex", argType.mayBeNull);
+        return new DBSPApplyExpression(CalciteObject.EMPTY,
+                "make_regex" + argType.nullableUnderlineSuffix(),
+                user, arg);
+    }
+
+    @Nullable
+    DBSPExpression makeTimezone(DBSPExpression arg) {
+        DBSPType argType = arg.getType();
+        if (!argType.is(DBSPTypeString.class)) {
+            this.compiler.reportWarning(arg.getSourcePosition(),
+                    "Suspicious argument",
+                    "Timezone expression should have type CHAR, but it has type " + argType.asSqlString());
+            arg = arg.cast(arg.getNode(), DBSPTypeString.varchar(arg.getType().mayBeNull),
+                    DBSPCastExpression.CastType.SqlUnsafe);
+        }
+        DBSPTypeUser user = new DBSPTypeUser(CalciteObject.EMPTY, USER, "Zone", argType.mayBeNull);
+        return new DBSPApplyExpression(CalciteObject.EMPTY,
+                "parse_timezone" + argType.nullableUnderlineSuffix(),
+                user, arg);
     }
 
     /** Check for polymorphic strict functions: if any operand is the NULL literal, replace with NULL */
@@ -1528,15 +1548,11 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                         return new DBSPApplyExpression(node, "blackbox", ops.get(0).type, ops.toArray(new DBSPExpression[0]));
                     case "regexp_replace": {
                         validateArgCount(node, operationName, ops.size(), 2, 3);
-                        for (int i = 0; i < ops.size(); i++)
-                            this.ensureString(ops, i);
-                        if (ops.get(1).is(DBSPStringLiteral.class)) {
-                            DBSPStringLiteral lit = ops.get(1).to(DBSPStringLiteral.class);
-                            if (lit.isNull())
-                                return type.none();
-                            ops.set(1, this.makeRegex(lit));
-                            return compileFunction("regexp_replaceC", node, type, ops, 2, 3);
+                        for (int i = 0; i < ops.size(); i++) {
+                            if (i != 1)
+                                this.ensureString(ops, i);
                         }
+                        ops.set(1, this.makeRegex(ops.get(1)));
                         return compileStrictFunction(call, node, type, ops, 2, 3);
                     }
                     case "parse_date":
@@ -1641,8 +1657,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                     }
                     case "convert_timezone": {
                         validateArgCount(node, operationName, ops.size(), 3);
-                        ensureString(ops, 0);
-                        ensureString(ops, 1);
+                        ops.set(0, this.makeTimezone(ops.get(0)));
+                        ops.set(1, this.makeTimezone(ops.get(1)));
                         return compileStrictFunction(call, node, type, ops, 3);
                     }
                 }
@@ -1670,19 +1686,10 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
             }
             case RLIKE: {
                 validateArgCount(node, operationName, ops.size(), 2);
-                for (int i = 0; i < 2; i++)
-                    // Calcite does not enforce the type of the arguments, why?
-                    this.ensureString(ops, i);
-                // if the second argument is a constant, compile it into a static
-                if (ops.get(1).is(DBSPStringLiteral.class)) {
-                    DBSPStringLiteral lit = ops.get(1).to(DBSPStringLiteral.class);
-                    if (lit.isNull())
-                        return type.none();
-                    ops.set(1, this.makeRegex(lit));
-                    return compileFunction("rlikeC", node, type, ops, 2);
-                } else {
-                    return compileFunction(call, node, type, ops, 2);
-                }
+                // Calcite does not enforce the type of the arguments, why?
+                this.ensureString(ops, 0);
+                ops.set(1, this.makeRegex(ops.get(1)));
+                return compileFunction(call, node, type, ops, 2);
             }
             case POSITION: {
                 validateArgCount(node, operationName, ops.size(), 2);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -437,11 +437,13 @@ public class Utilities {
         runProcess(directory, new HashMap<>(), commands);
     }
 
+    static HashMap<String, String> STACK = new HashMap<>() {{ put("RUST_MIN_STACK", "8388608"); }};
+
     static void compileAndTest(String directory, boolean quiet, String... extraArgs) throws IOException, InterruptedException {
         List<String> args = new ArrayList<>();
         args.add("cargo");
         args.add("test");
-        if (Utilities.inCI()) {
+        if (!Utilities.inCI()) {
             args.add("--jobs");
             args.add("6");
         }
@@ -452,7 +454,7 @@ public class Utilities {
             args.add("--");
             args.add("--show-output");
         }
-        runProcess(directory, args.toArray(new String[0]));
+        runProcess(directory, STACK, args.toArray(new String[0]));
     }
 
     static void addExtraArgs(List<String> args, String... packages) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/ComplexQueriesTest.java
@@ -61,7 +61,7 @@ public class ComplexQueriesTest extends BaseSQLTests {
                    AND b55=a31;
                 """;
         var ccs = this.getCCS(sql);
-        ccs.step("""
+        ccs.stepWeightOne("""
                 INSERT INTO t29 VALUES(1,4,'table t29 row 1');
                 INSERT INTO t29 VALUES(2,2,'table t29 row 2');
                 INSERT INTO t29 VALUES(3,9,'table t29 row 3');
@@ -106,9 +106,9 @@ public class ComplexQueriesTest extends BaseSQLTests {
                 INSERT INTO t55 VALUES(9,6,'table t55 row 9');
                 INSERT INTO t55 VALUES(10,2,'table t55 row 10');""",
                  """
-                 x29 | x31 | x51 | x55 | weight
+                 x29 | x31 | x51 | x55
                 ---------------------------------
-                 table t29 row 6| table t31 row 9| table t51 row 5| table t55 row 4| 1""");
+                 table t29 row 6| table t31 row 9| table t51 row 5| table t55 row 4""");
         InnerVisitor typeWidth = new InnerVisitor(ccs.compiler) {
             @Override
             public void postorder(DBSPTypeTupleBase type) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -722,39 +722,6 @@ public class MetadataTests extends BaseSQLTests {
         BaseSQLTests.compileAndTestRust(true);
     }
 
-    // Test that schema for a table can be retrieved from a JDBC data source
-    @Test @Ignore("Does not find system table")
-    public void jdbcSchemaTest() throws ClassNotFoundException, SQLException {
-        // Create a table in HSQLDB
-        Class.forName("org.hsqldb.jdbcDriver");
-        String jdbcUrl = "jdbc:hsqldb:mem:db";
-        Connection connection = DriverManager.getConnection(jdbcUrl, "", "");
-        try (Statement s = connection.createStatement()) {
-            s.execute("""
-                    create table mytable(
-                    id integer not null primary key,
-                    strcol varchar(25))
-                    """);
-        }
-
-        // Create a schema that retrieves data from HSQLDB
-        DataSource mockDataSource = JdbcSchema.dataSource(jdbcUrl, "org.hsqldb.jdbcDriver", "", "");
-        Connection executorConnection = DriverManager.getConnection("jdbc:calcite:");
-        CalciteConnection calciteConnection = executorConnection.unwrap(CalciteConnection.class);
-        SchemaPlus rootSchema = calciteConnection.getRootSchema();
-        JdbcSchema hsql = JdbcSchema.create(rootSchema, "schema", mockDataSource, null, null);
-
-        CompilerOptions options = new CompilerOptions();
-        options.languageOptions.throwOnError = true;
-        DBSPCompiler compiler = new DBSPCompiler(options);
-        compiler.addSchemaSource("schema", hsql);
-        compiler.submitStatementForCompilation("CREATE VIEW V AS SELECT * FROM mytable");
-        this.getCCS(compiler);
-        ObjectNode node = compiler.getIOMetadataAsJson();
-        String json = node.toPrettyString();
-        Assert.assertTrue(json.contains("MYTABLE"));
-    }
-
     @Test
     public void testUDFTypeError() throws IOException, SQLException {
         File file = createInputScript("""

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/WindowTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/WindowTests.java
@@ -234,18 +234,18 @@ public class WindowTests extends ScottBaseTests {
             query += tail;
 
             var ccs = this.getCCS(query);
-            ccs.step("""
+            ccs.stepWeightOne("""
                 INSERT INTO T VALUES('00', '2020-01-01 00:00:00', 100);
                 INSERT INTO T VALUES('00', '2020-01-01 00:10:00', 110);""", """
-                 daily_runtime_increment | account_id | weight
-                -----------------------------------------------
-                 100                     | 00|          1""");
-            ccs.step("""
+                 daily_runtime_increment | account_id
+                --------------------------------------
+                 100                     | 00""");
+            ccs.stepWeightOne("""
                 INSERT INTO T VALUES('01', '2020-01-01 00:00:00', 200);
                 INSERT INTO T VALUES('01', '2020-01-01 00:10:00', 210);""", """
-                 daily_runtime_increment | account_id | weight
-                -----------------------------------------------
-                 200                     | 01|          1""");
+                 daily_runtime_increment | account_id
+                --------------------------------------
+                 200                     | 01""");
         }
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -1990,6 +1990,13 @@ public class FunctionsTest extends SqlIoTest {
                 (1 row)
                 """
         );
+        var ccs = this.getCCS("""
+                CREATE TABLE T(x VARCHAR, r VARCHAR);
+                CREATE VIEW V AS SELECT RLIKE(x, r) FROM T;""");
+        ccs.stepWeightOne("INSERT INTO T VALUES('string', 's..i.*')", """
+                 r
+                ---
+                 true""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/functions/FunctionsTest.java
@@ -1997,6 +1997,9 @@ public class FunctionsTest extends SqlIoTest {
                  r
                 ---
                  true""");
+
+        this.runtimeConstantFail("SELECT 'x' RLIKE '('",
+                "Invalid regular expression in RLIKE '(': regex parse error:");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampDiffTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/mysql/TimestampDiffTests.java
@@ -561,6 +561,22 @@ public class TimestampDiffTests extends SqlIoTest {
                  r
                 ---
                  2008-03-05 09:25:29
+                (1 row)
+                
+                -- invalid timezone -> result is NULL
+                SELECT CONVERT_TIMEZONE('blah', 'blah', TIMESTAMP '2020-10-10 00:00:00');
+                 r
+                ---
+                NULL
                 (1 row)""");
+        // Test with non-constant values
+        var ccs = this.getCCS("""
+                CREATE TABLE T(x TIMESTAMP, y VARCHAR);
+                CREATE VIEW V AS SELECT CONVERT_TIMEZONE(y, 'America/Los_Angeles', x) FROM T;
+                """);
+        ccs.stepWeightOne("INSERT INTO T VALUES(TIMESTAMP '2008-03-05 12:25:29', 'America/New_York');", """
+                 ts
+                ----
+                 2008-03-05 09:25:29""");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
@@ -1113,6 +1113,24 @@ public class PostgresStringTests extends SqlIoTest {
             -------
              abc
             (1 row)
+            
+            SELECT split_part('abc', '', 1) AS result;
+             result
+            -------
+             abc
+            (1 row)
+            
+            SELECT split_part('abc', '', 2) AS result;
+             result
+            -------
+            \s
+            (1 row)
+            
+            SELECT split_part('abc', NULL, 2) AS result;
+             result
+            -------
+            NULL
+            (1 row)
             """);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresStringTests.java
@@ -485,151 +485,179 @@ public class PostgresStringTests extends SqlIoTest {
 
     @Test
     public void testLike2() {
-        this.q("""
+        this.qs("""
                 SELECT 'hawkeye' LIKE 'h%' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' NOT LIKE 'h%' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'hawkeye' LIKE 'H%' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'hawkeye' NOT LIKE 'H%' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' LIKE 'indio%' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'hawkeye' NOT LIKE 'indio%' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' LIKE 'h%eye' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' NOT LIKE 'h%eye' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' LIKE '_ndio' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'indio' NOT LIKE '_ndio' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' LIKE 'in__o' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'indio' NOT LIKE 'in__o' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' LIKE 'in_o' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' NOT LIKE 'in_o' AS "true";
                  true
                 ------
-                 t""");
+                 t
+                (1 row)""");
     }
 
     @Test
     public void testRlike() {
         // This is not a postgres operator
-        this.q("""
+        this.qs("""
                 SELECT 'hawkeye' RLIKE 'h.*' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' NOT RLIKE 'h.*' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'hawkeye' RLIKE 'H.*' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+                
                 SELECT 'hawkeye' NOT RLIKE 'H.*' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+                
                 SELECT 'hawkeye' RLIKE 'indio.*' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+                
                 SELECT 'hawkeye' NOT RLIKE 'indio.*' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' RLIKE 'h.*eye' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'hawkeye' NOT RLIKE 'h.*eye' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' RLIKE '.ndio' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'indio' NOT RLIKE '.ndio' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' RLIKE 'in..o' AS "true";
                  true
                 ------
-                 t""");
-        this.q("""
+                 t
+                (1 row)
+
                 SELECT 'indio' NOT RLIKE 'in..o' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+                
                 SELECT 'indio' RLIKE 'in.o' AS "false";
                  false
                 -------
-                 f""");
-        this.q("""
+                 f
+                (1 row)
+
                 SELECT 'indio' NOT RLIKE 'in.o' AS "true";
                  true
                 ------
-                 t""");
+                 t
+                (1 row)""");
     }
 
     @Test
@@ -1134,6 +1162,12 @@ public class PostgresStringTests extends SqlIoTest {
             """);
     }
 
+    @Test
+    public void invalidRegex() {
+        this.runtimeConstantFail(
+                "SELECT RLIKE('x', '(')",
+                "Invalid regular expression in RLIKE '(': regex parse error:");
+    }
 
     // TODO: sha, encode, decode
 
@@ -1193,9 +1227,7 @@ public class PostgresStringTests extends SqlIoTest {
     @Test
     public void testLikeTable() {
         String sql = """
-                CREATE TABLE example (
-                    name VARCHAR
-                );
+                CREATE TABLE example (name VARCHAR);
 
                 CREATE VIEW example_count AS
                 SELECT COUNT(*) FROM example WHERE name LIKE 'abc%' OR name LIKE name;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/PostgresTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/quidem/PostgresTests.java
@@ -78,12 +78,12 @@ public class PostgresTests extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE TABLE T(x INT, y INT NOT NULL, z DECIMAL(10, 2));
                 CREATE VIEW V AS SELECT GREATEST(x, y, z), LEAST(x, y, z) FROM T;""");
-        ccs.step("INSERT INTO T VALUES(0, 1, 2), (NULL, 1, 2), (2, 3, NULL)", """
-                 greatest | least | weight
-                ---------------------------
-                 2        | 0     | 1
-                          |       | 1
-                          |       | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(0, 1, 2), (NULL, 1, 2), (2, 3, NULL)", """
+                 greatest | least
+                ------------------
+                 2        | 0
+                          |
+                          |""");
     }
 
     @Test
@@ -91,11 +91,11 @@ public class PostgresTests extends SqlIoTest {
         var ccs = this.getCCS("""
                 CREATE TABLE T(x INT, y INT NOT NULL, z DECIMAL(10, 2));
                 CREATE VIEW V AS SELECT GREATEST_IGNORE_NULLS(x, y, z), LEAST_IGNORE_NULLS(x, y, z) FROM T;""");
-        ccs.step("INSERT INTO T VALUES(0, 1, 2), (NULL, 1, 2), (2, 3, NULL)", """
-                 greatest | least | weight
-                ---------------------------
-                 2        | 0     | 1
-                 2        | 1     | 1
-                 3        | 2     | 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(0, 1, 2), (NULL, 1, 2), (2, 3, NULL)", """
+                 greatest | least
+                ------------------
+                 2        | 0
+                 2        | 1
+                 3        | 2""");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/recursive/RecursiveTests.java
@@ -428,10 +428,10 @@ public class RecursiveTests extends BaseSQLTests {
                 DECLARE RECURSIVE VIEW V(v INT);
                 CREATE VIEW V AS SELECT v FROM V UNION SELECT 1;""";
         var ccs = this.getCCS(sql);
-        ccs.step("", """
-                 v | weight
-                ------------
-                 1 | 1""");
+        ccs.stepWeightOne("", """
+                 v
+                ---
+                 1""");
         CircuitVisitor visitor = new CircuitVisitor(ccs.compiler) {
             int recursive = 0;
             @Override
@@ -454,17 +454,17 @@ public class RecursiveTests extends BaseSQLTests {
                 CREATE TABLE T(v INT);
                 CREATE VIEW V AS SELECT v FROM V UNION SELECT * FROM T;""";
         var ccs = this.getCCS(sql);
-        ccs.step("", """
-                 v | weight
-                ------------""");
-        ccs.step("INSERT INTO T VALUES(1)", """
-                 v | weight
-                ------------
-                 1 | 1""");
-        ccs.step("INSERT INTO T VALUES(2)", """
-                 v | weight
-                ------------
-                 2 | 1""");
+        ccs.stepWeightOne("", """
+                 v
+                ---""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(1)", """
+                 v
+                ---
+                 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(2)", """
+                 v
+                ---
+                 2""");
     }
 
     @Test
@@ -478,17 +478,17 @@ public class RecursiveTests extends BaseSQLTests {
                 CREATE LOCAL VIEW V AS SELECT v FROM V UNION SELECT * FROM X;
                 CREATE VIEW O AS SELECT v+1 FROM V;""";
         var ccs = this.getCCS(sql);
-        ccs.step("", """
-                 v | weight
-                ------------""");
-        ccs.step("INSERT INTO T VALUES(1)", """
-                 v | weight
-                ------------
-                 1 | 1""");
-        ccs.step("INSERT INTO T VALUES(2)", """
-                 v | weight
-                ------------
-                 2 | 1""");
+        ccs.stepWeightOne("", """
+                 v
+                ---""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(1)", """
+                 v
+                ---
+                 1""");
+        ccs.stepWeightOne("INSERT INTO T VALUES(2)", """
+                 v
+                ---
+                 2""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -16,6 +16,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.dbsp.sqlCompiler.ir.aggregate.DBSPFold;
 import org.dbsp.sqlCompiler.ir.aggregate.DBSPMinMax;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPConstructorExpression;
 import org.dbsp.sqlCompiler.ir.statement.DBSPStaticItem;
 import org.dbsp.util.HashString;
@@ -496,15 +497,15 @@ public class Regression2Tests extends SqlIoTest {
 
     @Test
     public void issue2998() {
-        var cc = this.getCC("""
+        var cc = this.getCCS("""
                 CREATE TABLE T(x VARCHAR);
                 CREATE VIEW V AS SELECT regexp_replace(x, '1', '2') FROM T;""");
 
         boolean[] found = new boolean[1];
         InnerVisitor hasRegexConstructor = new InnerVisitor(cc.compiler) {
             @Override
-            public void postorder(DBSPConstructorExpression expression) {
-                if (expression.function.toString().equalsIgnoreCase("Regex::new")) {
+            public void postorder(DBSPApplyExpression expression) {
+                if (expression.function.toString().equalsIgnoreCase("make_regex_")) {
                     found[0] = true;
                 }
             }


### PR DESCRIPTION
Fixes #6039
Fixes #6035

There are a few other small commits.

The most important change is to change the generated code from:

```Rust
fn convert_timezone(tz: SqlString, ...) -> Option<Timestamp> {
  let t = parse_timezone(tz); 
  ...
}
```

to

```Rust
fn parse_timezone(tz: SqlString) -> Zone {
   ...
}

fn convert_timezone(t: Zone...) -> Option<Timestamp> {
  ...
}
```

The compiler already lifts constant expressions into lazy statics, so for the case when timezones are constant strings, this will parse each timezone only once. A similar adaptation has been made for functions that use `Regex`; these were hand-optimized previously for the case of constant regex patterns, but this way of doing things is simpler.

## Breaking changes

Regex functions (`RLIKE` and `REGEXP_REPLACE`) will now crash if the regex is not a legal Rust regex, matching the behavior of Postgres. Previously they were just ignoring malformed regexps and behaving as if there were no matches.
