### PR TITLE
[SQL] Cast of a VARIANT to string should work for most variant types

### DIFF
--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -17,7 +17,7 @@ use crate::{
     variant::*,
 };
 
-use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use dbsp::algebra::{F32, F64, HasOne, HasZero};
 use num::{One, Zero};
 use num_traits::cast::NumCast;
@@ -551,6 +551,7 @@ pub fn cast_to_SqlDecimalN_V<const P: usize, const S: usize>(
     value: Variant,
 ) -> SqlResult<Option<SqlDecimal<P, S>>> {
     match value {
+        Variant::String(x) => r2o(cast_to_SqlDecimal_s::<P, S>(x)),
         Variant::TinyInt(i) => r2o(cast_to_SqlDecimal_i8::<P, S>(i)),
         Variant::SmallInt(i) => r2o(cast_to_SqlDecimal_i16::<P, S>(i)),
         Variant::Int(i) => r2o(cast_to_SqlDecimal_i32::<P, S>(i)),
@@ -1147,37 +1148,19 @@ pub fn cast_to_s_s(value: SqlString, n_chars: i32, fixed: bool) -> SqlResult<Sql
 
 #[doc(hidden)]
 pub fn cast_to_s_Timestamp(value: Timestamp, size: i32, fixed: bool) -> SqlResult<SqlString> {
-    let dt = value.to_dateTime();
-    let month = dt.month();
-    let day = dt.day();
-    let year = dt.year();
-    let hr = dt.hour();
-    let min = dt.minute();
-    let sec = dt.second();
-    let result = format!(
-        "{}-{:02}-{:02} {:02}:{:02}:{:02}",
-        year, month, day, hr, min, sec
-    );
+    let result = value.to_string();
     limit_or_size_string(&result, size, fixed)
 }
 
 #[doc(hidden)]
 pub fn cast_to_s_Date(value: Date, size: i32, fixed: bool) -> SqlResult<SqlString> {
-    let dt = value.to_date();
-    let month = dt.month();
-    let day = dt.day();
-    let year = dt.year();
-    let result = format!("{}-{:02}-{:02}", year, month, day);
+    let result = value.to_string();
     limit_or_size_string(&result, size, fixed)
 }
 
 #[doc(hidden)]
 pub fn cast_to_s_Time(value: Time, size: i32, fixed: bool) -> SqlResult<SqlString> {
-    let dt = value.to_time();
-    let hr = dt.hour();
-    let min = dt.minute();
-    let sec = dt.second();
-    let result = format!("{:02}:{:02}:{:02}", hr, min, sec);
+    let result = value.to_string();
     limit_or_size_string(&result, size, fixed)
 }
 
@@ -1329,7 +1312,7 @@ pub fn cast_to_s_LongInterval_YEARS(
 }
 
 #[doc(hidden)]
-const fn sign(negative: bool) -> &'static str {
+pub(crate) const fn sign(negative: bool) -> &'static str {
     if negative { "-" } else { "+" }
 }
 
@@ -1358,7 +1341,8 @@ pub fn cast_to_s_LongInterval_YEARS_TO_MONTHS(
 }
 
 impl ShortInterval {
-    fn into_sign_and_magnitude(self) -> (&'static str, Self) {
+    #[doc(hidden)]
+    pub(crate) fn into_sign_and_magnitude(self) -> (&'static str, Self) {
         if self.microseconds() < 0 {
             ("-", Self::from_microseconds(-self.microseconds()))
         } else {
@@ -1450,8 +1434,10 @@ pub fn cast_to_s_ShortInterval_SECONDS(
     size: i32,
     fixed: bool,
 ) -> SqlResult<SqlString> {
+    let (sign, interval) = interval.into_sign_and_magnitude();
     let seconds = interval.microseconds() / 1_000_000;
-    let result = format_args!("{seconds:+}.{:06}", 0).to_small_string::<32>();
+    let micros = interval.microseconds() % 1_000_000;
+    let result = format_args!("{sign}{seconds}.{:06}", micros).to_small_string::<32>();
     limit_or_size_string(&result, size, fixed)
 }
 
@@ -1461,16 +1447,7 @@ pub fn cast_to_s_ShortInterval_DAYS_TO_SECONDS(
     size: i32,
     fixed: bool,
 ) -> SqlResult<SqlString> {
-    let (sign, interval) = interval.into_sign_and_magnitude();
-    let days = extract_day_ShortInterval(interval);
-    let hours = extract_hour_ShortInterval(interval);
-    let minutes = extract_minute_ShortInterval(interval);
-    let seconds = extract_second_ShortInterval(interval);
-    let result = format_args!(
-        "{sign}{} {:02}:{:02}:{:02}.{:06}",
-        days, hours, minutes, seconds, 0
-    )
-    .to_small_string::<32>();
+    let result = interval.to_string();
     limit_or_size_string(&result, size, fixed)
 }
 
@@ -1485,12 +1462,13 @@ pub fn cast_to_s_ShortInterval_HOURS_TO_SECONDS(
     let hours = extract_hour_ShortInterval(interval);
     let minutes = extract_minute_ShortInterval(interval);
     let seconds = extract_second_ShortInterval(interval);
+    let micros = interval.microseconds() % 1_000_000;
     let result = format_args!(
         "{sign}{}:{:02}:{:02}.{:06}",
         days * 24 + hours,
         minutes,
         seconds,
-        0
+        micros
     )
     .to_small_string::<32>();
     limit_or_size_string(&result, size, fixed)
@@ -1507,11 +1485,12 @@ pub fn cast_to_s_ShortInterval_MINUTES_TO_SECONDS(
     let hours = extract_hour_ShortInterval(interval);
     let minutes = extract_minute_ShortInterval(interval);
     let seconds = extract_second_ShortInterval(interval);
+    let micros = interval.microseconds() % 1_000_000;
     let result = format_args!(
         "{sign}{:02}:{:02}.{:06}",
         (days * 24 + hours) * 60 + minutes,
         seconds,
-        0
+        micros
     )
     .to_small_string::<32>();
     limit_or_size_string(&result, size, fixed)
@@ -2548,6 +2527,15 @@ pub fn cast_to_ShortInterval_DAYS_TO_MINUTES_s(value: SqlString) -> SqlResult<Sh
 }
 
 #[doc(hidden)]
+pub fn cast_to_GeoPoint_s(_value: SqlString) -> SqlResult<GeoPoint> {
+    Err(SqlRuntimeError::from_strng(
+        "String cannot be cast to ST_POINT",
+    ))
+}
+
+cast_function!(GeoPoint, GeoPoint, s, SqlString);
+
+#[doc(hidden)]
 pub fn cast_to_ShortInterval_HOURS_TO_MINUTES_s(value: SqlString) -> SqlResult<ShortInterval> {
     if let Some(captures) = HOURS_TO_MINUTES.captures(value.str()) {
         let negative = negative(&captures);
@@ -3370,8 +3358,9 @@ macro_rules! cast_from_variant {
             #[doc(hidden)]
             pub fn [< cast_to_ $result_name N _V >](value: Variant) -> SqlResult<Option<$result_type>> {
                 match value {
+                    Variant::String(x) => r2o([< cast_to_ $result_name _s>](x)),
                     Variant::$enum(value) => Ok(Some(value)),
-                    _            => Ok(None),
+                    _ => Ok(None),
                 }
             }
 
@@ -3401,6 +3390,7 @@ macro_rules! cast_from_variant_numeric {
             #[doc(hidden)]
             pub fn [< cast_to_ $result_name N _V >](value: Variant) -> SqlResult<Option<$result_type>> {
                 match value {
+                    Variant::String(x) => r2o([< cast_to_ $result_name _s>](x)),
                     Variant::TinyInt(value) => r2o([< cast_to_ $result_name _i8 >](value)),
                     Variant::SmallInt(value) => r2o([< cast_to_ $result_name _i16 >](value)),
                     Variant::Int(value) => r2o([< cast_to_ $result_name _i32 >](value)),
@@ -3901,7 +3891,7 @@ mod tests {
         assert_eq!(
             cast_to_s_ShortInterval_SECONDS(ShortInterval::from_milliseconds(123456789), -1, false)
                 .unwrap(),
-            SqlString::from_ref("+123456.000000")
+            SqlString::from_ref("+123456.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_SECONDS(
@@ -3910,7 +3900,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("-123456.000000")
+            SqlString::from_ref("-123456.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_DAYS_TO_SECONDS(
@@ -3919,7 +3909,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("+1 10:17:36.000000")
+            SqlString::from_ref("+1 10:17:36.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_DAYS_TO_SECONDS(
@@ -3928,7 +3918,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("-1 10:17:36.000000")
+            SqlString::from_ref("-1 10:17:36.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_HOURS_TO_SECONDS(
@@ -3937,7 +3927,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("+34:17:36.000000")
+            SqlString::from_ref("+34:17:36.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_HOURS_TO_SECONDS(
@@ -3946,7 +3936,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("-34:17:36.000000")
+            SqlString::from_ref("-34:17:36.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_MINUTES_TO_SECONDS(
@@ -3955,7 +3945,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("+2057:36.000000")
+            SqlString::from_ref("+2057:36.789000")
         );
         assert_eq!(
             cast_to_s_ShortInterval_MINUTES_TO_SECONDS(
@@ -3964,7 +3954,7 @@ mod tests {
                 false
             )
             .unwrap(),
-            SqlString::from_ref("-2057:36.000000")
+            SqlString::from_ref("-2057:36.789000")
         );
     }
 

--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -4,7 +4,7 @@
 use crate::{
     Date, SqlDecimal,
     operators::{eq, gt, gte, lt, lte, neq},
-    plus_Date_Date_LongInterval__, some_existing_operator, some_function2, some_operator,
+    plus_Date_Date_LongInterval__, sign, some_existing_operator, some_function2, some_operator,
     some_polymorphic_function1, some_polymorphic_function2,
     timestamp::{extract_epoch_Date, extract_quarter_Date},
 };
@@ -15,10 +15,8 @@ use feldera_types::serde_with_context::{
 };
 use serde::{Deserialize, Serialize, de::Error as _, ser::Error as _};
 use size_of::SizeOf;
-use std::{
-    fmt::Debug,
-    ops::{Add, Div, Mul, Neg, Sub},
-};
+use std::fmt;
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 #[cfg(doc)]
 use crate::{Time, Timestamp};
@@ -231,6 +229,30 @@ impl Div<i64> for ShortInterval {
     fn div(self, rhs: i64) -> Self {
         Self {
             microseconds: self.microseconds / rhs,
+        }
+    }
+}
+
+impl fmt::Display for ShortInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (sign, interval) = self.into_sign_and_magnitude();
+        let days = extract_day_ShortInterval(interval);
+        let hours = extract_hour_ShortInterval(interval);
+        let minutes = extract_minute_ShortInterval(interval);
+        let seconds = extract_second_ShortInterval(interval);
+        let micro = interval.microseconds % 1_000_000;
+        if micro == 0 {
+            write!(
+                f,
+                "{sign}{} {:02}:{:02}:{:02}",
+                days, hours, minutes, seconds
+            )
+        } else {
+            write!(
+                f,
+                "{sign}{} {:02}:{:02}:{:02}.{:06}",
+                days, hours, minutes, seconds, micro
+            )
         }
     }
 }
@@ -489,6 +511,16 @@ impl LongInterval {
             (1, self.months())
         };
         (months / 12) * mul
+    }
+}
+
+impl fmt::Display for LongInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let months = self.months();
+        let sign = sign(months < 0);
+        let years = months.unsigned_abs() / 12;
+        let months = months.unsigned_abs() % 12;
+        write!(f, "{sign}{years}-{months:02}")
     }
 }
 

--- a/crates/sqllib/src/timestamp.rs
+++ b/crates/sqllib/src/timestamp.rs
@@ -98,7 +98,27 @@ impl Debug for Timestamp {
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <Self as Debug>::fmt(self, f)
+        let dt = self.to_dateTime();
+        let month = dt.month();
+        let day = dt.day();
+        let year = dt.year();
+        let hr = dt.hour();
+        let min = dt.minute();
+        let sec = dt.second();
+        let micro = dt.nanosecond() / 1000;
+        if micro == 0 {
+            write!(
+                f,
+                "{}-{:02}-{:02} {:02}:{:02}:{:02}",
+                year, month, day, hr, min, sec
+            )
+        } else {
+            write!(
+                f,
+                "{}-{:02}-{:02} {:02}:{:02}:{:02}.{:06}",
+                year, month, day, hr, min, sec, micro
+            )
+        }
     }
 }
 
@@ -1509,6 +1529,16 @@ impl fmt::Debug for Date {
     }
 }
 
+impl fmt::Display for Date {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let dt = self.to_date();
+        let month = dt.month();
+        let day = dt.day();
+        let year = dt.year();
+        write!(f, "{}-{:02}-{:02}", year, month, day)
+    }
+}
+
 #[doc(hidden)]
 impl ToInteger<i32> for Date {
     #[doc(hidden)]
@@ -2340,6 +2370,21 @@ some_polymorphic_function1!(date_trunc_day, Date, Date, Date);
 #[serde(transparent)]
 pub struct Time {
     nanoseconds: u64,
+}
+
+impl fmt::Display for Time {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let dt = self.to_time();
+        let hr = dt.hour();
+        let min = dt.minute();
+        let sec = dt.second();
+        let nanos = dt.nanosecond();
+        if nanos != 0 {
+            write!(f, "{:02}:{:02}:{:02}.{:09}", hr, min, sec, nanos)
+        } else {
+            write!(f, "{:02}:{:02}:{:02}", hr, min, sec)
+        }
+    }
 }
 
 #[doc(hidden)]

--- a/crates/sqllib/src/variant.rs
+++ b/crates/sqllib/src/variant.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     Date, GeoPoint, LongInterval, ShortInterval, SqlDecimal, SqlString, Time, Timestamp, Uuid,
-    array::Array, binary::ByteArray, casts::*, error::*, map::Map, tn, ttn,
+    array::Array, binary::ByteArray, casts::*, error::*, map::Map, tn, to_hex_, ttn,
 };
 use dbsp::algebra::{F32, F64};
 use feldera_fxp::DynamicDecimal;
@@ -71,6 +71,7 @@ pub enum Variant {
     ShortInterval(ShortInterval),
     LongInterval(LongInterval),
     Binary(ByteArray),
+    // TODO: this should be called GeoPoint, not Geometry.
     Geometry(GeoPoint),
     Uuid(Uuid),
     #[size_of(skip, skip_bounds)]
@@ -609,11 +610,54 @@ where
 
 //////////////////// Reverse conversions Variant -> T
 
+// Conversion from Variant to a specific type
 macro_rules! into {
-    ($variant:ident, $type:ty) => {
+    ($variant:ident, $type:ty, $type_name: ident) => {
+        ::paste::paste! {
+            #[doc(hidden)]
+            impl TryFrom<Variant> for $type {
+                type Error = Box<SqlRuntimeError>;
+
+                #[doc(hidden)]
+                fn try_from(value: Variant) -> Result<Self, Self::Error> {
+                    match value {
+                        Variant::String(x) => [< cast_to_ $type_name _s>](x),
+                        Variant::$variant(x) => Ok(x),
+                        _ => Err(SqlRuntimeError::from_string(format!(
+                            "variant is {}, which cannot be converted to {}",
+                            typeof_(value),
+                            ttn!($type),
+                        ))),
+                    }
+                }
+            }
+
+            #[doc(hidden)]
+            impl TryFrom<Variant> for Option<$type> {
+                type Error = Box<SqlRuntimeError>;
+
+                #[doc(hidden)]
+                fn try_from(value: Variant) -> Result<Self, Self::Error> {
+                    match value {
+                        Variant::SqlNull => Ok(None),
+                        Variant::VariantNull => Ok(None),
+                        _ => match <$type>::try_from(value) {
+                            Ok(result) => Ok(Some(result)),
+                            Err(e) => Err(SqlRuntimeError::from_string(e.to_string())),
+                        },
+                    }
+                }
+            }
+        }
+    };
+}
+
+// Like into! but no string conversion
+macro_rules! into_no_string {
+    ($variant:ident, $type:ty, $type_name: ident) => {
         #[doc(hidden)]
         impl TryFrom<Variant> for $type {
-            type Error = Box<dyn Error>;
+            type Error = Box<SqlRuntimeError>;
 
             #[doc(hidden)]
             fn try_from(value: Variant) -> Result<Self, Self::Error> {
@@ -630,7 +674,7 @@ macro_rules! into {
 
         #[doc(hidden)]
         impl TryFrom<Variant> for Option<$type> {
-            type Error = Box<dyn Error>;
+            type Error = Box<SqlRuntimeError>;
 
             #[doc(hidden)]
             fn try_from(value: Variant) -> Result<Self, Self::Error> {
@@ -647,16 +691,16 @@ macro_rules! into {
     };
 }
 
-into!(Boolean, bool);
-into!(String, SqlString);
-into!(Date, Date);
-into!(Time, Time);
-into!(Timestamp, Timestamp);
-into!(ShortInterval, ShortInterval);
-into!(LongInterval, LongInterval);
-into!(Geometry, GeoPoint);
-into!(Binary, ByteArray);
-into!(Uuid, Uuid);
+into!(Boolean, bool, b);
+into!(Date, Date, Date);
+into!(Time, Time, Time);
+into!(Timestamp, Timestamp, Timestamp);
+into!(ShortInterval, ShortInterval, ShortInterval_DAYS_TO_MINUTES);
+into!(LongInterval, LongInterval, LongInterval_YEARS_TO_MONTHS);
+into!(Uuid, Uuid, Uuid);
+
+into_no_string!(Geometry, GeoPoint, GeoPoint);
+into_no_string!(Binary, ByteArray, bytes);
 
 macro_rules! into_numeric {
     ($type:ty, $type_name: ident) => {
@@ -668,6 +712,7 @@ macro_rules! into_numeric {
                 #[doc(hidden)]
                 fn try_from(value: Variant) -> Result<Self, Self::Error> {
                     match value {
+                        Variant::String(x) => [< cast_to_ $type_name _s>](x),
                         Variant::TinyInt(x) => [< cast_to_ $type_name _i8>](x),
                         Variant::SmallInt(x) => [< cast_to_ $type_name _i16>](x),
                         Variant::Int(x) => [< cast_to_ $type_name _i32 >](x),
@@ -725,6 +770,72 @@ into_numeric!(u32, u32);
 into_numeric!(u64, u64);
 into_numeric!(F32, f);
 into_numeric!(F64, d);
+
+#[doc(hidden)]
+impl TryFrom<Variant> for SqlString {
+    type Error = Box<SqlRuntimeError>;
+
+    #[doc(hidden)]
+    fn try_from(value: Variant) -> Result<Self, Self::Error> {
+        match value {
+            Variant::Boolean(x) => Ok(SqlString::from(if x { "true" } else { "false" })),
+            Variant::TinyInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::SmallInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::Int(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::BigInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::UTinyInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::USmallInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::UInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::UBigInt(x) => Ok(SqlString::from(format!("{x}"))),
+            Variant::SqlDecimal(x) => Ok(SqlString::from(format!(
+                "{}",
+                DynamicDecimal::new(x.0, x.1)
+            ))),
+            Variant::Real(x) => {
+                let mut buffer = ryu::Buffer::new();
+                let result = buffer.format(x.into_inner());
+                Ok(SqlString::from(result))
+            }
+            Variant::Double(x) => {
+                let mut buffer = ryu::Buffer::new();
+                let result = buffer.format(x.into_inner());
+                Ok(SqlString::from(result))
+            }
+            Variant::String(x) => Ok(x),
+            Variant::Date(x) => Ok(SqlString::from(x.to_string())),
+            Variant::Time(x) => Ok(SqlString::from(x.to_string())),
+            Variant::Timestamp(x) => Ok(SqlString::from(x.to_string())),
+            Variant::ShortInterval(x) => Ok(SqlString::from(x.to_string())),
+            Variant::LongInterval(x) => Ok(SqlString::from(x.to_string())),
+            Variant::Binary(x) => Ok(to_hex_(x)),
+            Variant::Uuid(x) => Ok(SqlString::from(format!("{x}"))),
+            // GeoPoint does not have a cast to string
+            // Map does not have a cast to string
+            // Array does not have a cast to string
+            _ => Err(SqlRuntimeError::from_string(format!(
+                "variant is {}, which cannot be converted to CHAR",
+                typeof_(value),
+            ))),
+        }
+    }
+}
+
+#[doc(hidden)]
+impl TryFrom<Variant> for Option<SqlString> {
+    type Error = Box<dyn Error>;
+
+    #[doc(hidden)]
+    fn try_from(value: Variant) -> Result<Self, Self::Error> {
+        match value {
+            Variant::SqlNull => Ok(None),
+            Variant::VariantNull => Ok(None),
+            _ => match SqlString::try_from(value) {
+                Ok(result) => Ok(Some(result)),
+                Err(e) => Err(SqlRuntimeError::from_string(e.to_string())),
+            },
+        }
+    }
+}
 
 #[doc(hidden)]
 impl<const P: usize, const S: usize> TryFrom<Variant> for SqlDecimal<P, S> {

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -25,6 +25,17 @@ import TabItem from '@theme/TabItem';
         as expressions which never match.  The new behavior more closely
         aligns with other databases.
 
+        `CAST(variant AS VARCHAR)` will return a meaningful value for all
+        scalar variant values, and not just for `VARIANT` objects with a
+        string value.  In the past this cast used to return `NULL`.
+
+        `(CAST(string AS VARIANT) AS type)` will now behave like
+        `CAST(string AS type)`.  Previously the result was `NULL`.
+
+        Conversion of short intervals including seconds to strings will
+        now include the fractional seconds as well.  Previously the
+        fractional seconds were ignored.
+
         ## v0.288.0
 
         Delta Lake input connector error handling behavior change:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -67,7 +67,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPPathExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPStaticExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTimeAddSub;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPUnaryExpression;
@@ -950,6 +949,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
         return false;
     }
 
+    @SuppressWarnings("SameParameterValue")
     void checkFormatArg(List<DBSPExpression> args, int formatPosition) {
         if (formatPosition >= args.size())
             return;
@@ -1012,11 +1012,6 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 .appendSupplier(finalCall::toString)
                 .append(" ")
                 .appendSupplier(() -> finalCall.getType().toString());
-        if (call.op.kind == SqlKind.SEARCH) {
-            // TODO: Ideally the optimizer should do this before handing the expression to us.
-            // Then the rexBuilder won't be needed.
-            call = (RexCall) RexUtil.expandSearch(this.rexBuilder, null, call);
-        }
         List<DBSPExpression> ops = Linq.map(call.operands, e -> e.accept(this));
         String operationName = call.op.kind.sql;
         switch (call.op.kind) {
@@ -1103,6 +1098,9 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 }
                 DBSPCastExpression.CastType safe = call.op.kind == SqlKind.SAFE_CAST ?
                         DBSPCastExpression.CastType.SqlSafe : DBSPCastExpression.CastType.SqlUnsafe;
+                if (ops.get(0).getType().is(DBSPTypeVariant.class))
+                    // Casts from variant types are always safe
+                    safe = DBSPCastExpression.CastType.SqlSafe;
                 return ops.get(0).applyCloneIfNeeded().cast(node, type, safe);
             case IS_NULL:
             case IS_NOT_NULL: {
@@ -2040,7 +2038,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 for (int i = 0; i < tuple.size(); i++) {
                     converted.add(ops.get(i).cast(node, tuple.getFieldType(i), DBSPCastExpression.CastType.SqlUnsafe));
                 }
-                return new DBSPTupleExpression(node, converted);
+                return new DBSPTupleExpression(node, tuple, converted);
             }
             case COALESCE: {
                 if (ops.isEmpty()) {
@@ -2270,6 +2268,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression>
                 .append("Compiling ")
                 .appendSupplier(expression::toString)
                 .newline();
+        expression = RexUtil.expandSearch(this.rexBuilder, null, expression);
         DBSPExpression result = expression.accept(this);
         if (result == null)
             throw new InternalCompilerError("Unexpected Calcite expression " + expression,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/optimizer/ReduceExpressionsRule.java
@@ -964,15 +964,19 @@ public abstract class ReduceExpressionsRule<C extends org.apache.calcite.rel.rul
             // https://github.com/feldera/feldera/issues/4700:
             // Disable all expression evaluations for TIME and TIMESTAMP values, since they are broken in Calcite:
             // Calcite does not support TIMESTAMP with precisions above 3
+            // Disable optimizations for VARIANT values, the evaluation rules are different
             SqlTypeName resultType = call.getType().getSqlTypeName();
             if (resultType == SqlTypeName.TIMESTAMP ||
                     resultType == SqlTypeName.TIME ||
+                    resultType == SqlTypeName.VARIANT ||
                     SqlTypeName.INTERVAL_TYPES.contains(resultType))
                 callConstancy = Constancy.NON_CONSTANT;
             for (int iOperand = 0; iOperand < operandCount; ++iOperand) {
                 RexNode operand = call.getOperands().get(iOperand);
                 SqlTypeName operandType = operand.getType().getSqlTypeName();
-                if (operandType == SqlTypeName.TIMESTAMP || operandType == SqlTypeName.TIME) {
+                if (operandType == SqlTypeName.TIMESTAMP
+                        || operandType == SqlTypeName.TIME
+                        || operandType == SqlTypeName.VARIANT) {
                     callConstancy = Constancy.NON_CONSTANT;
                 }
             }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandSafeCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandSafeCasts.java
@@ -2,7 +2,8 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer.expandCasts;
 
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
-import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteCompiler.ProgramIdentifier;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.visitors.inner.ExpressionTranslator;
 import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
@@ -11,11 +12,18 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPBinaryExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPCastExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPClosureExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPFailExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeStruct;
 import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.derived.DBSPTypeTupleBase;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeAny;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeNull;
@@ -23,9 +31,12 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVariant;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeArray;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeMap;
 import org.dbsp.sqlCompiler.ir.type.user.DBSPTypeSqlResult;
+import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Expand SAFE_CAST invocations that convert complex types to simpler invocations
@@ -167,6 +178,61 @@ public class ExpandSafeCasts extends ExpressionTranslator {
         return source.cast(node, type, UNWRAP);
     }
 
+    // Can occur e.g., when converting a VARIANT to a ROW or user-defined type
+    DBSPExpression convertToStructOrTuple(
+            CalciteObject node, DBSPExpression source, DBSPTypeTuple type) {
+        List<DBSPExpression> fields = new ArrayList<>();
+        DBSPTypeStruct struct = type.originalStruct;
+        List<ProgramIdentifier> names = null;
+        if (struct != null)
+            names = Linq.list(type.originalStruct.getFieldNames());
+
+        DBSPType sourceType = source.getType();
+        for (int i = 0; i < type.size(); i++) {
+            DBSPType fieldType = type.getFieldType(i);
+            DBSPExpression field;
+            if (sourceType.is(DBSPTypeNull.class)) {
+                field = fieldType.none();
+            } else if (sourceType.is(DBSPTypeTupleBase.class)) {
+                field = source.field(i);
+            } else if (sourceType.is(DBSPTypeVariant.class)) {
+                if (struct == null) {
+                    field = new DBSPBinaryExpression(
+                            // Result of index is always nullable
+                            node, DBSPTypeVariant.create(true),
+                            DBSPOpcode.RUST_INDEX, source.applyCloneIfNeeded(),
+                            new DBSPUSizeLiteral(i));
+                } else {
+                    ProgramIdentifier fieldName = names.get(i);
+                    field = new DBSPBinaryExpression(
+                            // Result of index is always nullable
+                            node, DBSPTypeVariant.create(true),
+                            DBSPOpcode.VARIANT_INDEX, source.applyCloneIfNeeded(),
+                            new DBSPStringLiteral(fieldName.toString()));
+                }
+            } else {
+                throw new InternalCompilerError("Unexpected source type " + sourceType);
+            }
+            DBSPExpression expression = field.applyCloneIfNeeded().cast(node, fieldType, SAFE);
+            // Convert recursively
+            expression = this.analyze(expression).to(DBSPExpression.class);
+            fields.add(expression);
+        }
+
+        DBSPExpression result = new DBSPTupleExpression(source.getNode(), type, fields);
+        if (source.getType().mayBeNull) {
+            if (type.mayBeNull) {
+                result = new DBSPIfExpression(node, source.is_null(), type.none(), result);
+            } else {
+                result = new DBSPIfExpression(node, source.is_null(),
+                        new DBSPFailExpression(source.getNode(), type, "Cast to non-nullable value applied to NULL"),
+                        result);
+            }
+        }
+
+        return result;
+    }
+
     @Override
     public void postorder(DBSPCastExpression expression) {
         if (this.getEN(expression) != null) {
@@ -205,9 +271,7 @@ public class ExpandSafeCasts extends ExpressionTranslator {
         } else if (type.is(DBSPTypeArray.class)) {
             result = this.convertToArray(node, source, type.to(DBSPTypeArray.class));
         } else if (type.is(DBSPTypeTuple.class)) {
-            // These should be rejected in the front-end; they are documented as not supported
-            // We may support them someday if there is demand.
-            throw new UnimplementedException("SAFE_CAST to tuple type");
+            result = this.convertToStructOrTuple(node, source, type.to(DBSPTypeTuple.class));
         } else if (type.is(DBSPTypeMap.class)) {
             result = this.convertToMap(node, source, type.to(DBSPTypeMap.class));
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandUnsafeCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandUnsafeCasts.java
@@ -67,14 +67,16 @@ public class ExpandUnsafeCasts extends ExpressionTranslator {
         return expanded.closure(var);
     }
 
-    @Nullable DBSPExpression convertToVariant(CalciteObject node, DBSPExpression source, boolean mayBeNull) {
+    @Nullable
+    DBSPExpression convertToVariant(CalciteObject node, DBSPExpression source, boolean mayBeNull) {
         DBSPExpression expression;
+        DBSPTypeVariant variantType = DBSPTypeVariant.create(false);
         if (source.type.is(DBSPTypeTuple.class)) {
             // Convert a tuple to a VARIANT MAP indexed by the field names
             DBSPTypeTuple tuple = source.getType().to(DBSPTypeTuple.class);
             DBSPTypeMap type = new DBSPTypeMap(
                     DBSPTypeString.varchar(false),
-                    DBSPTypeVariant.create(false),
+                    variantType,
                     source.getType().mayBeNull);
 
             if (tuple.originalStruct == null) {
@@ -91,7 +93,7 @@ public class ExpandUnsafeCasts extends ExpressionTranslator {
                 DBSPExpression field = source.field(i);
                 if (!field.getType().hasCopy())
                     field = field.applyCloneIfNeeded();
-                DBSPExpression rec = field.cast(node, DBSPTypeVariant.create(false), UNSAFE);
+                DBSPExpression rec = field.cast(node, variantType, UNSAFE);
                 values.add(rec);
             }
             expression = new DBSPMapExpression(type, keys, values);
@@ -109,7 +111,7 @@ public class ExpandUnsafeCasts extends ExpressionTranslator {
                     .applyCloneIfNeeded().cast(node, DBSPTypeVariant.create(false), UNSAFE)
                     .closure(var);
             expression = new DBSPBinaryExpression(node,
-                    new DBSPTypeArray(DBSPTypeVariant.create(false), vecType.mayBeNull),
+                    new DBSPTypeArray(variantType, vecType.mayBeNull),
                     DBSPOpcode.ARRAY_CONVERT, source, converter);
         } else {
             return null;
@@ -117,7 +119,7 @@ public class ExpandUnsafeCasts extends ExpressionTranslator {
         return new DBSPCastExpression(node, expression, DBSPTypeVariant.create(mayBeNull), UNSAFE);
     }
 
-    public DBSPExpression convertToStructOrTuple(
+    DBSPExpression convertToStructOrTuple(
             CalciteObject node, DBSPExpression source, DBSPTypeTuple type) {
         List<DBSPExpression> fields = new ArrayList<>();
         DBSPTypeStruct struct = type.originalStruct;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -155,10 +155,13 @@ public final class DBSPCastExpression extends DBSPExpression {
 
     @Override
     public IIndentStream toString(IIndentStream builder) {
-        return builder.append("((")
+        return builder
+                .append("((")
                 .append(this.type)
                 .append(")")
                 .append(this.source)
+                //.append(", ")
+                //.append(this.safe.name())
                 .append(")");
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresIntervalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/postgres/PostgresIntervalTests.java
@@ -574,7 +574,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL DAYS TO SECONDS) AS VARCHAR);
                  x
                 ---
-                 +1 02:03:04.000000
+                 +1 02:03:04.500000
                 (1 row)
 
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL HOURS) AS VARCHAR);
@@ -592,7 +592,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL HOURS TO SECONDS) AS VARCHAR);
                  x
                 ---
-                 +26:03:04.000000
+                 +26:03:04.500000
                 (1 row)
                 
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL MINUTES) AS VARCHAR);
@@ -604,13 +604,13 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL MINUTES TO SECONDS) AS VARCHAR);
                  x
                 ---
-                 +1563:04.000000
+                 +1563:04.500000
                 (1 row)
                 
                 SELECT CAST(CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS INTERVAL SECONDS) AS VARCHAR);
                  x
                 ---
-                 +93784.000000
+                 +93784.500000
                 (1 row)""");
     }
 
@@ -620,7 +620,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(INTERVAL '1 02:03:04.5' DAYS TO SECONDS AS VARCHAR);
                  x
                 ---
-                 +1 02:03:04.000000
+                 +1 02:03:04.500000
                 (1 row)
                 
                 SELECT CAST(INTERVAL '1' DAYS AS VARCHAR);
@@ -644,7 +644,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(INTERVAL '02:03:04.5' HOURS TO SECONDS AS VARCHAR);
                  x
                 ---
-                 +2:03:04.000000
+                 +2:03:04.500000
                 (1 row)
                 
                 SELECT CAST(INTERVAL '02:03' HOURS TO MINUTES AS VARCHAR);
@@ -674,7 +674,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(INTERVAL '-1 02:03:04.5' DAYS TO SECONDS AS VARCHAR);
                  x
                 ---
-                 -1 02:03:04.000000
+                 -1 02:03:04.500000
                 (1 row)
                 
                 SELECT CAST(INTERVAL '-1' DAYS AS VARCHAR);
@@ -716,7 +716,7 @@ public class PostgresIntervalTests extends SqlIoTest {
                 SELECT CAST(INTERVAL '-02:03:04.5' HOURS TO SECONDS AS VARCHAR);
                  x
                 ---
-                 -2:03:04.000000
+                 -2:03:04.500000
                 (1 row)
                 
                 SELECT CAST(INTERVAL '-4.000' SECONDS AS VARCHAR);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
@@ -729,11 +729,10 @@ public class CastTests extends SqlIoTest {
 
     @Test
     public void issue5895() {
-        this.qs("""
+        this.q("""
                 SELECT CAST(INTERVAL '1000' MONTH AS INT);
                  r
                 -----
-                 1000
-                (1 row)""");
+                 1000""");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/TimeTests.java
@@ -156,13 +156,13 @@ public class TimeTests extends BaseSQLTests {
     @Test
     public void castTimestampToString() {
         String query = "SELECT CAST(T.COL1 AS STRING) FROM T";
-        this.testQuery(query, new DBSPStringLiteral("1970-01-01 00:00:00"));
+        this.testQuery(query, new DBSPStringLiteral("1970-01-01 00:00:00.100000"));
     }
 
     @Test
     public void castTimestampToStringToTimestamp() {
         String query = "SELECT CAST(CAST(T.COL1 AS STRING) AS Timestamp) FROM T";
-        this.testQuery(query, DBSPTimestampLiteral.fromMilliseconds(0));
+        this.testQuery(query, DBSPTimestampLiteral.fromMilliseconds(100));
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/VariantTests.java
@@ -6,10 +6,10 @@ import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.TableData;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
-import org.dbsp.sqlCompiler.compiler.sql.tools.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.sql.tools.Change;
 import org.dbsp.sqlCompiler.compiler.sql.tools.CompilerCircuitStream;
 import org.dbsp.sqlCompiler.compiler.sql.tools.InputOutputChange;
+import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBinaryLiteral;
@@ -48,7 +48,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-public class VariantTests extends BaseSQLTests {
+public class VariantTests extends SqlIoTest {
     /** Return the default compiler used for testing. */
     @Override
     public CompilerOptions testOptions() {
@@ -280,17 +280,21 @@ public class VariantTests extends BaseSQLTests {
 
     @Test
     public void testCastVec() {
-        // This is a bug in Calcite, the array should be nullable, and the elements should be nullable too
+        this.testQuery("""
+                SELECT CAST(PARSE_JSON('["10:10:10"]') AS TIME ARRAY)""",
+                new DBSPArrayExpression(true,
+                        new DBSPTimeLiteral(
+                                CalciteObject.EMPTY, DBSPTypeTime.NULLABLE_INSTANCE, new TimeString("10:10:10"))));
         this.testQuery("""
                 SELECT CAST(ARRAY[NULL, 1] AS INT ARRAY)""",
                 new DBSPArrayExpression(false,
                         new DBSPTypeInteger(CalciteObject.EMPTY, 32, true, true).none(),
                         new DBSPI32Literal(1, true)));
-        // result is null, since 1 cannot be converted to a string
+        // result is null, since 1 cannot be converted to a TIME
         this.testQuery("""
-                SELECT CAST(PARSE_JSON('["a", 1]') AS STRING ARRAY)""",
+                SELECT CAST(PARSE_JSON('["10:10:10", 1]') AS TIME ARRAY)""",
                 new DBSPArrayExpression(
-                        new DBSPTypeArray(DBSPTypeString.varchar(true), true),
+                        new DBSPTypeArray(DBSPTypeTime.NULLABLE_INSTANCE, true),
                         true));
         this.testQuery("""
                 SELECT CAST(PARSE_JSON('["a", 1.0]') AS VARIANT ARRAY)""",
@@ -486,11 +490,142 @@ public class VariantTests extends BaseSQLTests {
                 -- extract and flatten the arrays from the DECODE view
                 CREATE VIEW OUT(name, "uuid") AS SELECT x.name, x."uuid" FROM DECODE, UNNEST(DECODE.rec.steps) AS x;
                 """);
-        ccs.step("INSERT INTO DATA VALUES (" + data + ")",
+        ccs.stepWeightOne("INSERT INTO DATA VALUES (" + data + ")",
                 """
-                         name | uuid| weight
-                        ---------------------
-                         blah| uuid0| 1
-                         boo|NULL   | 1""");
+                         name | uuid
+                        -------------
+                         blah| uuid0
+                         boo|NULL""");
+    }
+
+    @Test
+    public void issue5938() {
+        // type -> Variant -> string
+        this.qs("""
+                SELECT CAST(CAST(1 AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 1
+                (1 row)
+                
+                SELECT CAST(CAST('a' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 a
+                (1 row)
+                
+                SELECT CAST(CAST(1.5 AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 1.5
+                (1 row)
+                
+                 SELECT CAST(CAST(1.5e0 AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 1.5
+                (1 row)
+                
+                SELECT CAST(CAST(TRUE AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 true
+                (1 row)
+                
+                SELECT CAST(CAST(UUID '123e4567-e89b-12d3-a456-426655440000' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 123e4567-e89b-12d3-a456-426655440000
+                (1 row)
+                
+                SELECT CAST(CAST(INTERVAL '+1 10:10:10.123' DAYS TO SECONDS AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 +1 10:10:10.123000
+                (1 row)
+
+                SELECT CAST(CAST(x'0abc' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 0abc
+                (1 row)
+                
+                SELECT CAST(CAST(TIME '10:00:00.123' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 10:00:00.123000000
+                (1 row)
+                
+                SELECT CAST(CAST(TIMESTAMP '2024-02-02 10:00:00.123' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 2024-02-02 10:00:00.123000
+                (1 row)
+
+                SELECT CAST(CAST(DATE '2024-02-02' AS VARIANT) AS VARCHAR);
+                 r
+                ---
+                 2024-02-02
+                (1 row)
+                """);
+    }
+
+    @Test
+    public void issue5938a() {
+        // String -> Variant -> type
+        this.qs("""
+                SELECT CAST(CAST('1' AS VARIANT) AS INT);
+                 r
+                ---
+                 1
+                (1 row)
+                
+                SELECT CAST(CAST('1.5' AS VARIANT) AS DECIMAL(10, 1));
+                 r
+                ---
+                 1.5
+                (1 row)
+                
+                SELECT CAST(CAST('1.5e0' AS VARIANT) AS DOUBLE);
+                 r
+                ---
+                 1.5
+                (1 row)
+                
+                SELECT CAST(CAST('TRUE' AS VARIANT) AS BOOLEAN);
+                 r
+                ---
+                 true
+                (1 row)
+                
+                SELECT CAST(CAST('123e4567-e89b-12d3-a456-426655440000' AS VARIANT) AS UUID);
+                 r
+                ---
+                 123e4567-e89b-12d3-a456-426655440000
+                (1 row)
+                
+                SELECT CAST(CAST('+1 10:10:10.123' AS VARIANT) AS INTERVAL DAYS TO SECONDS);
+                 r
+                ---
+                 1 days 10 hours 10 mins 10.123000 secs
+                (1 row)
+
+                SELECT CAST(CAST('10:00:00.123' AS VARIANT) AS TIME);
+                 r
+                ---
+                 10:00:00.123000000
+                (1 row)
+                
+                SELECT CAST(CAST('2024-02-02 10:00:00.123' AS VARIANT) AS TIMESTAMP);
+                 r
+                ---
+                 2024-02-02 10:00:00.123000
+                (1 row)
+
+                SELECT CAST(CAST('2024-02-02' AS VARIANT) AS DATE);
+                 r
+                ---
+                 2024-02-02
+                (1 row)""");
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/TableParser.java
@@ -87,7 +87,7 @@ public class TableParser {
     static final DateTimeFormatter DATE_OUTPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ENGLISH);
     static final Pattern YEAR = Pattern.compile("^(\\d+) years?(.*)");
     static final Pattern MONTHS = Pattern.compile("^\\s*(\\d+) months?(.*)");
-    static final Pattern MINUS = Pattern.compile("^-\\s*(.*)");
+    static final Pattern MINUS = Pattern.compile("^([-+])\\s*(.*)");
     static final Pattern DAYS = Pattern.compile("^(\\d+) days?(.*)");
     static final Pattern HOURS = Pattern.compile("^\\s*(\\d+) hours?(.*)");
     static final Pattern MINUTES = Pattern.compile("\\s*(\\d+) mins?(.*)");
@@ -196,8 +196,10 @@ public class TableParser {
         } else {
             Matcher m = MINUS.matcher(interval);
             if (m.matches()) {
-                negate = true;
-                interval = m.group(1);
+                if (m.group(1).equals("-"))
+                    // Do not negate for +
+                    negate = true;
+                interval = m.group(2);
             }
 
             m = DAYS.matcher(interval);


### PR DESCRIPTION
Fixes #5938

### Describe Manual Test Plan

Implemented conversion of VARIANT to CHAR types. Previously this conversion would return NULL for all values except Variant::String values. Now it will behave roughly as a CAST of the underlying value to the CHAR type.

E.g. `CAST(CAST(TRUE AS VARIANT) AS VARCHAR)` used to return `NULL` and now will return `true`.

## Checklist

- [x] Unit tests added/updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] Feldera SQL (Syntax, Semantics)

### Describe Incompatible Changes

See first paragraph above and changelog.
