### PR TITLE
[connectors] Add custom columns to PG output.

### DIFF
--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -727,6 +727,11 @@ pub enum ControllerError {
         error: AnyError,
     },
 
+    CommandError {
+        endpoint_name: String,
+        error: String,
+    },
+
     /// Error evaluating the DBSP circuit.
     DbspError {
         error: DbspError,
@@ -966,6 +971,7 @@ impl DbspDetailedError for ControllerError {
             Self::EncodeError { .. } => Cow::from("EncodeError"),
             Self::InputTransportError { .. } => Cow::from("InputTransportError"),
             Self::OutputTransportError { .. } => Cow::from("OutputTransportError"),
+            Self::CommandError { .. } => Cow::from("CommandError"),
             Self::PrometheusError { .. } => Cow::from("PrometheusError"),
             Self::DbspError { error } => error.error_code(),
             Self::DbspPanic => Cow::from("DbspPanic"),
@@ -1094,6 +1100,15 @@ impl Display for ControllerError {
                     "{}error on output endpoint '{endpoint_name}': {}",
                     if *fatal { "FATAL " } else { "" },
                     error.root_cause()
+                )
+            }
+            Self::CommandError {
+                endpoint_name,
+                error,
+            } => {
+                write!(
+                    f,
+                    "error executing command on output endpoint '{endpoint_name}': {error}"
                 )
             }
             Self::ParseError {
@@ -1482,6 +1497,13 @@ impl ControllerError {
         }
     }
 
+    pub fn command_error(endpoint_name: &str, error: &str) -> Self {
+        Self::CommandError {
+            endpoint_name: endpoint_name.to_owned(),
+            error: error.to_string(),
+        }
+    }
+
     pub fn parse_error(endpoint_name: &str, error: ParseError) -> Self {
         Self::ParseError {
             endpoint_name: endpoint_name.to_owned(),
@@ -1566,6 +1588,7 @@ impl ControllerError {
             | Self::EncodeError { .. }
             | Self::InputTransportError { .. }
             | Self::OutputTransportError { .. }
+            | Self::CommandError { .. }
             | Self::PrometheusError { .. }
             | Self::DbspPanic
             | Self::ControllerPanic

--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -942,6 +942,27 @@ where
 #[doc(hidden)]
 pub type AsyncErrorCallback = Box<dyn Fn(bool, AnyError, Option<&'static str>) + Send + Sync>;
 
+/// Command handler API exposed by connectors.
+///
+/// Connectors can support arbitrary connector-specific commands that can be
+/// invoked via the `/command` endpoint. These commands take and return arbitrary
+/// JSON values.
+///
+/// This API is not part of trait `Output[Input]Endpoint` because it can be invoked
+/// from any thread, and requires `Send + Sync`, while the `OutputEndpoint` API is
+/// not `Sync` and is meant to be called from the controller thread only.
+///
+/// The idea is that connectors that support custom commands create separate command
+/// handler objects that implement this trait and are returned by
+/// `OutputEndpoint::command_handler`.
+pub trait CommandHandler: Send + Sync {
+    /// Handle a command specified by the JSON objest.
+    ///
+    /// Fails if the connector does not support the command, the command is invalid,
+    /// or command execution fails.
+    fn command(&self, command: serde_json::Value) -> AnyResult<serde_json::Value>;
+}
+
 /// A configured output transport endpoint.
 ///
 /// Output endpoints come in two flavors:
@@ -959,6 +980,10 @@ pub type AsyncErrorCallback = Box<dyn Fn(bool, AnyError, Option<&'static str>) +
 /// * A non-fault-tolerant endpoint does not have a concept of steps and ignores
 ///   them.
 pub trait OutputEndpoint: Send {
+    fn command_handler(&self) -> Option<Arc<dyn CommandHandler>> {
+        None
+    }
+
     /// Finishes establishing the connection to the output endpoint.
     ///
     /// If the endpoint encounters any errors during output, now or later, it

--- a/crates/adapters/benches/postgres_output.rs
+++ b/crates/adapters/benches/postgres_output.rs
@@ -61,6 +61,7 @@ fn make_config(threads: usize) -> PostgresWriterConfig {
         mode: PostgresWriteMode::Materialized,
         cdc_op_column: "__feldera_op".to_string(),
         cdc_ts_column: "__feldera_ts".to_string(),
+        extra_columns: Vec::new(),
         tls: PostgresTlsConfig::default(),
         max_records_in_buffer: None,
         max_buffer_size_bytes: usize::pow(2, 20),

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -71,7 +71,7 @@ use dbsp::{Runtime, WeakRuntime};
 use enum_map::EnumMap;
 use feldera_adapterlib::format::BufferSize;
 use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
-use feldera_adapterlib::transport::{InputReader, Resume, Watermark};
+use feldera_adapterlib::transport::{CommandHandler, InputReader, Resume, Watermark};
 use feldera_ir::LirCircuit;
 use feldera_storage::fbuf::slab::FBufSlabsStats;
 use feldera_storage::histogram::{ExponentialHistogram, ExponentialHistogramSnapshot};
@@ -802,6 +802,15 @@ impl Controller {
         endpoint_name: &str,
     ) -> Result<ExternalOutputEndpointStatus, ControllerError> {
         self.inner.output_endpoint_status(endpoint_name)
+    }
+
+    /// Invoke a command on the output endpoint.
+    pub fn output_endpoint_command(
+        &self,
+        endpoint_name: &str,
+        command: serde_json::Value,
+    ) -> Result<serde_json::Value, ControllerError> {
+        self.inner.output_endpoint_command(endpoint_name, command)
     }
 
     /// Returns the current controller status.
@@ -4742,6 +4751,9 @@ struct OutputEndpointDescr {
     /// FIFO queue of batches read from the stream.
     queue: Arc<BatchQueue>,
 
+    /// Command handler for the endpoint.
+    command_handler: Option<Arc<dyn CommandHandler>>,
+
     /// Used to notify the endpoint thread that the endpoint is being
     /// disconnected.
     disconnect_flag: Arc<AtomicBool>,
@@ -4755,12 +4767,14 @@ impl OutputEndpointDescr {
         endpoint_name: &str,
         stream_name: &str,
         created_during_transaction_number: u64,
+        command_handler: Option<Arc<dyn CommandHandler>>,
         unparker: Unparker,
     ) -> Self {
         Self {
             endpoint_name: endpoint_name.to_string(),
             stream_name: canonical_identifier(stream_name),
             queue: Arc::new(SegQueue::new()),
+            command_handler,
             disconnect_flag: Arc::new(AtomicBool::new(false)),
             created_during_transaction_number,
             unparker,
@@ -6175,7 +6189,7 @@ impl ControllerInner {
             initial_statistics,
         );
 
-        let encoder = (|| -> Result<Box<dyn Encoder>, ControllerError> {
+        let (encoder, command_handler) = (|| {
             if let Some(mut endpoint) = endpoint {
                 endpoint
                     .connect(Box::new(
@@ -6192,6 +6206,8 @@ impl ControllerInner {
                         },
                     ))
                     .map_err(|e| ControllerError::output_transport_error(endpoint_name, true, e))?;
+
+                let command_handler = endpoint.command_handler();
 
                 // Create probe.
                 let probe = Box::new(OutputProbe::new(
@@ -6211,13 +6227,15 @@ impl ControllerInner {
                 let format = get_output_format(&format_config.name).ok_or_else(|| {
                     ControllerError::unknown_output_format(endpoint_name, &format_config.name)
                 })?;
-                Ok(format.new_encoder(
+                let encoder = format.new_encoder(
                     endpoint_name,
                     &resolved_connector_config,
                     &handles.key_schema,
                     &handles.value_schema,
                     probe,
-                )?)
+                )?;
+
+                Ok((encoder, command_handler))
             } else {
                 // `endpoint` is `None` - instantiate an integrated endpoint.
                 let endpoint = create_integrated_output_endpoint(
@@ -6229,10 +6247,12 @@ impl ControllerInner {
                     self_weak,
                 )?;
 
-                Ok(endpoint.into_encoder())
+                let command_handler = endpoint.command_handler();
+
+                Ok((endpoint.into_encoder(), command_handler))
             }
         })()
-        .inspect_err(|_e| {
+        .inspect_err(|_e: &ControllerError| {
             self.status.remove_output(&endpoint_id);
         })?;
 
@@ -6241,6 +6261,7 @@ impl ControllerInner {
             endpoint_name,
             &stream_name,
             self.get_transaction_number(),
+            command_handler,
             parker.unparker().clone(),
         );
         let queue = endpoint_descr.queue.clone();
@@ -6511,6 +6532,32 @@ impl ControllerInner {
     ) -> Result<ExternalOutputEndpointStatus, ControllerError> {
         let endpoint_id = self.output_endpoint_id_by_name(endpoint_name)?;
         Ok(self.status.output_status()[&endpoint_id].to_api_type(true))
+    }
+
+    fn output_endpoint_command(
+        &self,
+        endpoint_name: &str,
+        command: serde_json::Value,
+    ) -> Result<serde_json::Value, ControllerError> {
+        let command_handler = self
+            .outputs
+            .read()
+            .unwrap()
+            .lookup_by_name(endpoint_name)
+            .ok_or_else(|| ControllerError::unknown_output_endpoint(endpoint_name))?
+            .command_handler
+            .clone();
+
+        let Some(command_handler) = command_handler else {
+            return Err(ControllerError::command_error(
+                endpoint_name,
+                "this connector does not support custom commands",
+            ));
+        };
+
+        command_handler
+            .command(command)
+            .map_err(|e| ControllerError::command_error(endpoint_name, e.to_string().as_str()))
     }
 
     fn send_command(&self, command: Command) {

--- a/crates/adapters/src/integrated/postgres/output.rs
+++ b/crates/adapters/src/integrated/postgres/output.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::{io::Write, str::FromStr, sync::Weak, time::Duration};
 
@@ -16,13 +17,15 @@ use crate::{
 };
 use anyhow::{Context, Result as AnyResult, anyhow, bail};
 use feldera_adapterlib::catalog::SplitCursorBuilder;
-use feldera_adapterlib::transport::{AsyncErrorCallback, Step};
+use feldera_adapterlib::transport::{AsyncErrorCallback, CommandHandler, Step};
 use feldera_types::{
     format::json::JsonFlavor,
     program_schema::{Relation, SqlIdentifier},
     transport::postgres::{PostgresWriteMode, PostgresWriterConfig},
 };
+use parking_lot::RwLock;
 use postgres::{Client, NoTls, Statement};
+use serde::Deserialize;
 
 /// Commands sent to all workers at once.
 #[derive(Clone, Copy)]
@@ -50,6 +53,7 @@ struct PostgresWorker {
     table: String,
     client: postgres::Client,
     config: PostgresWriterConfig,
+    extra_columns: Arc<RwLock<BTreeMap<String, Option<String>>>>,
     transaction: Option<postgres::Transaction<'static>>,
     prepared_statements: PreparedStatements,
     insert_buf: Vec<u8>,
@@ -94,11 +98,13 @@ fn connect(config: &PostgresWriterConfig, endpoint_name: &str) -> Result<Client,
 }
 
 impl PostgresWorker {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         idx: usize,
         endpoint_id: EndpointId,
         endpoint_name: &str,
         config: &PostgresWriterConfig,
+        extra_columns: Arc<RwLock<BTreeMap<String, Option<String>>>>,
         key_schema: &Relation,
         value_schema: &Relation,
         controller: Weak<ControllerInner>,
@@ -116,6 +122,7 @@ impl PostgresWorker {
             controller,
             table,
             config: config.clone(),
+            extra_columns,
             client,
             transaction: None,
             prepared_statements,
@@ -392,7 +399,11 @@ These statements were successfully prepared before reconnecting. Does the table 
     }
 
     /// Encode records from the cursor into postgres within the current transaction.
-    fn encode_cursor(&mut self, cursor: &mut dyn SerCursor) -> anyhow::Result<()> {
+    fn encode_cursor(
+        &mut self,
+        cursor: &mut dyn SerCursor,
+        extra_columns: BTreeMap<String, Option<String>>,
+    ) -> anyhow::Result<()> {
         while cursor.key_valid() {
             if let Some(op) = indexed_operation_type(self.view_name(), self.index_name(), cursor)? {
                 cursor.rewind_vals();
@@ -400,6 +411,8 @@ These statements were successfully prepared before reconnecting. Does the table 
                     IndexedOperationType::Insert => {
                         let mut buf = Vec::new();
                         cursor.serialize_val(&mut buf)?;
+                        self.serialize_extra_columns(&mut buf, &extra_columns)?;
+
                         if self.is_cdc() {
                             self.serialize_cdc_fields(op, &mut buf)?;
                         }
@@ -410,6 +423,7 @@ These statements were successfully prepared before reconnecting. Does the table 
 
                         if self.is_cdc() {
                             cursor.serialize_val(&mut buf)?;
+                            self.serialize_extra_columns(&mut buf, &extra_columns)?;
                             self.serialize_cdc_fields(op, &mut buf)?;
                         } else {
                             cursor.serialize_key(&mut buf)?;
@@ -424,6 +438,7 @@ These statements were successfully prepared before reconnecting. Does the table 
 
                         let mut buf: Vec<u8> = Vec::new();
                         cursor.serialize_val(&mut buf)?;
+                        self.serialize_extra_columns(&mut buf, &extra_columns)?;
                         if self.is_cdc() {
                             self.serialize_cdc_fields(op, &mut buf)?;
                         }
@@ -468,6 +483,32 @@ These statements were successfully prepared before reconnecting. Does the table 
 
         Ok(())
     }
+
+    fn serialize_extra_columns(
+        &self,
+        buf: &mut Vec<u8>,
+        extra_columns: &BTreeMap<String, Option<String>>,
+    ) -> Result<(), anyhow::Error> {
+        if extra_columns.is_empty() {
+            return Ok(());
+        }
+
+        let brace = buf.pop(); // Remove the trailing '}'
+
+        debug_assert_eq!(brace, Some(b'}'));
+
+        for (key, value) in extra_columns {
+            write!(
+                buf,
+                r#",{}:{}"#,
+                serde_json::to_string(key).unwrap(),
+                serde_json::to_string(value).unwrap()
+            )
+            .context("failed when encoding extra columns")?;
+        }
+        buf.push(b'}'); // Re-add the trailing '}'
+        Ok(())
+    }
 }
 
 impl PostgresWorker {
@@ -503,7 +544,8 @@ impl PostgresWorker {
                 },
                 WorkerCommand::Encode(cursor_builder) => {
                     let mut cursor = cursor_builder.build();
-                    match self.encode_cursor(&mut cursor) {
+                    let extra_columns = self.extra_columns.read().clone();
+                    match self.encode_cursor(&mut cursor, extra_columns) {
                         Ok(()) => {
                             let _ = result_tx.send(WorkerResult::Ok {
                                 num_bytes: 0,
@@ -558,11 +600,72 @@ pub struct PostgresOutputEndpoint {
     endpoint_id: EndpointId,
     endpoint_name: String,
     config: PostgresWriterConfig,
+    extra_columns: Arc<RwLock<BTreeMap<String, Option<String>>>>,
     controller: Weak<ControllerInner>,
     handles: Vec<WorkerHandle>,
     txn_start: std::time::Instant,
     num_bytes: usize,
     num_rows: usize,
+}
+
+/// Commands supported by the Postgres output connector.
+#[derive(Deserialize)]
+enum PostgresOutputEndpointCommand {
+    /// Set the values of a subset of extra columns.
+    #[serde(rename = "set_extra_columns")]
+    SetExtraColumns(BTreeMap<String, Option<String>>),
+}
+
+struct PostgresOutputEndpointCommandHandler {
+    extra_columns: Arc<RwLock<BTreeMap<String, Option<String>>>>,
+    allowed_extra_column_names: HashSet<String>,
+}
+
+impl PostgresOutputEndpointCommandHandler {
+    fn new(
+        extra_columns: Arc<RwLock<BTreeMap<String, Option<String>>>>,
+        config: &PostgresWriterConfig,
+    ) -> Self {
+        Self {
+            extra_columns,
+            allowed_extra_column_names: config.extra_columns.iter().cloned().collect(),
+        }
+    }
+}
+
+impl CommandHandler for PostgresOutputEndpointCommandHandler {
+    fn command(&self, command: serde_json::Value) -> AnyResult<serde_json::Value> {
+        let command = serde_json::from_value::<PostgresOutputEndpointCommand>(command.clone())
+            .map_err(|e| anyhow!("Postgres output connector failed to parse command '{command}' with the following error: {e}"))?;
+
+        match command {
+            PostgresOutputEndpointCommand::SetExtraColumns(extra_columns) => {
+                let unknown: Vec<&str> = extra_columns
+                    .keys()
+                    .filter(|k| !self.allowed_extra_column_names.contains(*k))
+                    .map(|s| s.as_str())
+                    .collect();
+                if !unknown.is_empty() {
+                    let mut allowed: Vec<&str> = self
+                        .allowed_extra_column_names
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect();
+                    allowed.sort_unstable();
+                    bail!(
+                        "set_extra_columns: unknown column name(s) {unknown:?}; allowed names from connector config field `extra_columns` are {allowed:?}"
+                    );
+                }
+
+                let mut configured_extra_columns = self.extra_columns.write();
+                for (key, value) in extra_columns {
+                    configured_extra_columns.insert(key, value);
+                }
+                Ok(serde_json::to_value(&*configured_extra_columns)
+                    .expect("Postgres output connector failed to serialize response"))
+            }
+        }
+    }
 }
 
 impl Drop for PostgresOutputEndpoint {
@@ -580,6 +683,39 @@ impl Drop for PostgresOutputEndpoint {
     }
 }
 
+/// Ensures `config.extra_columns` has no duplicates and no name matches a column in `value_schema`.
+fn validate_extra_columns_against_value_schema(
+    endpoint_name: &str,
+    config: &PostgresWriterConfig,
+    value_schema: &Relation,
+) -> Result<(), ControllerError> {
+    let value_sql_names: HashSet<String> = value_schema
+        .fields
+        .iter()
+        .map(|f| f.name.name().to_lowercase())
+        .collect();
+
+    let mut seen = HashSet::new();
+    for name in &config.extra_columns {
+        if !seen.insert(name) {
+            return Err(ControllerError::invalid_transport_configuration(
+                endpoint_name,
+                &format!("duplicate name in connector config field 'extra_columns': {name:?}"),
+            ));
+        }
+        if value_sql_names.contains(&name.to_lowercase()) {
+            return Err(ControllerError::invalid_transport_configuration(
+                endpoint_name,
+                &format!(
+                    "connector config 'extra_columns' includes {name:?}, which is already a column in the output view; \
+                     extra columns must not duplicate view columns"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl PostgresOutputEndpoint {
     pub fn new(
         endpoint_id: EndpointId,
@@ -593,6 +729,8 @@ impl PostgresOutputEndpoint {
             ControllerError::invalid_transport_configuration(endpoint_name, &e.to_string())
         })?;
 
+        validate_extra_columns_against_value_schema(endpoint_name, config, value_schema)?;
+
         let key_schema = key_schema
             .to_owned()
             .ok_or(ControllerError::not_supported(
@@ -602,12 +740,16 @@ impl PostgresOutputEndpoint {
         let num_threads = config.threads;
         let mut handles = Vec::with_capacity(num_threads);
 
+        // Extra columns are not set initially.
+        let extra_columns = Arc::new(RwLock::new(BTreeMap::new()));
+
         for i in 0..num_threads {
             let worker = PostgresWorker::new(
                 i,
                 endpoint_id,
                 endpoint_name,
                 config,
+                extra_columns.clone(),
                 &key_schema,
                 value_schema,
                 controller.clone(),
@@ -640,6 +782,7 @@ impl PostgresOutputEndpoint {
             endpoint_id,
             endpoint_name: endpoint_name.to_owned(),
             config: config.clone(),
+            extra_columns,
             controller,
             handles,
             txn_start: std::time::Instant::now(),
@@ -820,6 +963,13 @@ impl Encoder for PostgresOutputEndpoint {
 }
 
 impl OutputEndpoint for PostgresOutputEndpoint {
+    fn command_handler(&self) -> Option<Arc<dyn CommandHandler>> {
+        Some(Arc::new(PostgresOutputEndpointCommandHandler::new(
+            self.extra_columns.clone(),
+            &self.config,
+        )))
+    }
+
     fn connect(&mut self, _: AsyncErrorCallback) -> anyhow::Result<()> {
         todo!()
     }
@@ -925,6 +1075,7 @@ mod tests {
             mode: PostgresWriteMode::Materialized,
             cdc_op_column: "__feldera_op".to_owned(),
             cdc_ts_column: "__feldera_ts".to_owned(),
+            extra_columns: Vec::new(),
             threads: 4,
         }
     }
@@ -1078,6 +1229,7 @@ mod tests {
 
         use dbsp::OrdIndexedZSet;
         use dbsp::utils::Tup2;
+        use feldera_adapterlib::transport::OutputEndpoint;
         use feldera_macros::IsNone;
         use feldera_types::program_schema::{ColumnType, Field, Relation, SqlIdentifier};
         use feldera_types::{deserialize_without_context, serialize_struct};
@@ -1158,6 +1310,36 @@ mod tests {
             id["id"]: i32
         });
 
+        #[derive(
+            Debug,
+            Default,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            serde::Serialize,
+            serde::Deserialize,
+            Clone,
+            Hash,
+            SizeOf,
+            rkyv::Archive,
+            rkyv::Serialize,
+            rkyv::Deserialize,
+            IsNone,
+        )]
+        #[archive_attr(derive(Ord, Eq, PartialEq, PartialOrd))]
+        struct TestRecordWithExtraColumns {
+            id: i32,
+            b: bool,
+            i: Option<i64>,
+            s: String,
+            #[serde(rename = "EXTRA.COLUMN1")]
+            extra_column1: Option<String>,
+            extra_column2: Option<String>,
+        }
+
+        deserialize_without_context!(TestRecordWithExtraColumns);
+
         // Helpers
 
         fn key_relation() -> Relation {
@@ -1214,7 +1396,33 @@ mod tests {
                 .expect("failed to truncate test table");
         }
 
-        fn make_config(threads: usize) -> PostgresWriterConfig {
+        fn setup_table_with_extra_columns(client: &mut postgres::Client) {
+            client
+                .execute(&format!(r#"DROP TABLE IF EXISTS "{TEST_TABLE}""#), &[])
+                .expect("failed to drop test table");
+
+            client
+                .execute(
+                    &format!(
+                        r#"
+                        CREATE TABLE "{TEST_TABLE}" (
+                            id int PRIMARY KEY,
+                            b bool NOT NULL,
+                            i int8,
+                            s varchar NOT NULL,
+                            "EXTRA.COLUMN1" varchar,
+                            extra_column2 varchar
+                        )"#
+                    ),
+                    &[],
+                )
+                .expect("failed to create test table");
+        }
+
+        fn make_config_with_extra_columns(
+            threads: usize,
+            extra_columns: Vec<String>,
+        ) -> PostgresWriterConfig {
             PostgresWriterConfig {
                 uri: postgres_url(),
                 table: TEST_TABLE.to_string(),
@@ -1226,19 +1434,27 @@ mod tests {
                 cdc_op_column: "__feldera_op".to_owned(),
                 cdc_ts_column: "__feldera_ts".to_owned(),
                 threads,
+                extra_columns,
             }
         }
 
-        fn make_endpoint(threads: usize) -> PostgresOutputEndpoint {
+        fn make_endpoint_with_extra_columns(
+            threads: usize,
+            extra_columns: Vec<String>,
+        ) -> PostgresOutputEndpoint {
             PostgresOutputEndpoint::new(
                 EndpointId::default(),
                 "test_endpoint",
-                &make_config(threads),
+                &make_config_with_extra_columns(threads, extra_columns),
                 &Some(key_relation()),
                 &value_relation(),
                 Weak::new(),
             )
             .expect("failed to create endpoint")
+        }
+
+        fn make_endpoint(threads: usize) -> PostgresOutputEndpoint {
+            make_endpoint_with_extra_columns(threads, Vec::new())
         }
 
         fn build_insert_batch(records: &[TestRecord]) -> Arc<dyn SerBatch> {
@@ -1292,6 +1508,27 @@ mod tests {
                     b: row.get(1),
                     i: row.get(2),
                     s: row.get(3),
+                })
+                .collect()
+        }
+
+        fn query_all_with_extra_columns(
+            client: &mut postgres::Client,
+        ) -> Vec<TestRecordWithExtraColumns> {
+            let rows = client
+                .query(
+                    &format!(r#"SELECT id, b, i, s, "EXTRA.COLUMN1", extra_column2 FROM "{TEST_TABLE}" ORDER BY id"#),
+                    &[],
+                )
+                .expect("failed to query");
+            rows.into_iter()
+                .map(|row| TestRecordWithExtraColumns {
+                    id: row.get(0),
+                    b: row.get(1),
+                    i: row.get(2),
+                    s: row.get(3),
+                    extra_column1: row.get(4),
+                    extra_column2: row.get(5),
                 })
                 .collect()
         }
@@ -1377,6 +1614,195 @@ mod tests {
                 })
                 .collect();
             assert_eq!(got, expected);
+        }
+
+        #[test]
+        #[serial_test::serial]
+        fn extra_columns_test() {
+            let mut client = pg_client();
+            setup_table_with_extra_columns(&mut client);
+
+            let records = make_records(100);
+            let batch1 = build_insert_batch(&records[..25]);
+            let batch2 = build_insert_batch(&records[25..50]);
+            let batch3 = build_insert_batch(&records[50..75]);
+            let batch4 = build_insert_batch(&records[75..100]);
+            let mut endpoint = make_endpoint_with_extra_columns(
+                2,
+                vec!["EXTRA.COLUMN1".to_string(), "extra_column2".to_string()],
+            );
+
+            encode_batch(&mut endpoint, &batch1);
+
+            endpoint
+                .command_handler()
+                .unwrap()
+                .command(serde_json::json!({
+                    "set_extra_columns": {
+                        "EXTRA.COLUMN1": "foo1",
+                        "extra_column2": "bar1",
+                    }
+                }))
+                .unwrap();
+
+            encode_batch(&mut endpoint, &batch2);
+
+            endpoint
+                .command_handler()
+                .unwrap()
+                .command(serde_json::json!({
+                    "set_extra_columns": {
+                        "EXTRA.COLUMN1": "foo2",
+                        "extra_column2": "bar2",
+                    }
+                }))
+                .unwrap();
+
+            encode_batch(&mut endpoint, &batch3);
+
+            endpoint
+                .command_handler()
+                .unwrap()
+                .command(serde_json::json!({
+                    "set_extra_columns": {
+                        "EXTRA.COLUMN1": null,
+                        "extra_column2": null,
+                    }
+                }))
+                .unwrap();
+
+            encode_batch(&mut endpoint, &batch4);
+
+            let got = query_all_with_extra_columns(&mut client);
+            let expected1: Vec<_> = records[..25]
+                .iter()
+                .map(|r| TestRecordWithExtraColumns {
+                    id: r.id,
+                    b: r.b,
+                    i: r.i,
+                    s: r.s.clone(),
+                    extra_column1: None,
+                    extra_column2: None,
+                })
+                .collect();
+            let expected2: Vec<_> = records[25..50]
+                .iter()
+                .map(|r| TestRecordWithExtraColumns {
+                    id: r.id,
+                    b: r.b,
+                    i: r.i,
+                    s: r.s.clone(),
+                    extra_column1: Some("foo1".to_string()),
+                    extra_column2: Some("bar1".to_string()),
+                })
+                .collect();
+            let expected3: Vec<_> = records[50..75]
+                .iter()
+                .map(|r| TestRecordWithExtraColumns {
+                    id: r.id,
+                    b: r.b,
+                    i: r.i,
+                    s: r.s.clone(),
+                    extra_column1: Some("foo2".to_string()),
+                    extra_column2: Some("bar2".to_string()),
+                })
+                .collect();
+            let expected4: Vec<_> = records[75..100]
+                .iter()
+                .map(|r| TestRecordWithExtraColumns {
+                    id: r.id,
+                    b: r.b,
+                    i: r.i,
+                    s: r.s.clone(),
+                    extra_column1: None,
+                    extra_column2: None,
+                })
+                .collect();
+            let expected: Vec<_> = expected1
+                .into_iter()
+                .chain(expected2)
+                .chain(expected3)
+                .chain(expected4)
+                .collect();
+            assert_eq!(got, expected);
+
+            // Update records
+            let updates: Vec<_> = records
+                .iter()
+                .map(|r| {
+                    let mut new = r.clone();
+                    new.s = format!("updated_{}", r.id);
+                    (r.clone(), new)
+                })
+                .collect();
+            let upsert_batch = build_upsert_batch(&updates);
+
+            endpoint
+                .command_handler()
+                .unwrap()
+                .command(serde_json::json!({
+                    "set_extra_columns": {
+                        "EXTRA.COLUMN1": "foo3",
+                        "extra_column2": "bar3",
+                    }
+                }))
+                .unwrap();
+
+            encode_batch(&mut endpoint, &upsert_batch);
+
+            let got = query_all_with_extra_columns(&mut client);
+            let expected: Vec<_> = expected
+                .into_iter()
+                .map(|r| {
+                    let mut new = r.clone();
+                    new.s = format!("updated_{}", r.id);
+                    new.extra_column1 = Some("foo3".to_string());
+                    new.extra_column2 = Some("bar3".to_string());
+                    new
+                })
+                .collect();
+            assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn extra_columns_duplicate_names_in_config_rejected() {
+            let cfg = make_config_with_extra_columns(1, vec!["a".into(), "a".into()]);
+            let err = match PostgresOutputEndpoint::new(
+                EndpointId::default(),
+                "test_endpoint",
+                &cfg,
+                &Some(key_relation()),
+                &value_relation(),
+                Weak::new(),
+            ) {
+                Ok(_) => panic!("expected duplicate extra_columns to be rejected"),
+                Err(e) => e,
+            };
+            assert!(
+                err.to_string().contains("duplicate"),
+                "unexpected error: {err:?}"
+            );
+        }
+
+        #[test]
+        fn extra_columns_clash_with_view_column_rejected() {
+            let cfg = make_config_with_extra_columns(1, vec!["id".into()]);
+            let err = match PostgresOutputEndpoint::new(
+                EndpointId::default(),
+                "test_endpoint",
+                &cfg,
+                &Some(key_relation()),
+                &value_relation(),
+                Weak::new(),
+            ) {
+                Ok(_) => panic!("expected extra column name clash with view to be rejected"),
+                Err(e) => e,
+            };
+            let msg = err.to_string();
+            assert!(
+                msg.contains("extra_columns") && msg.contains("output view"),
+                "unexpected error: {err:?}"
+            );
         }
 
         #[test]

--- a/crates/adapters/src/integrated/postgres/prepared_statements.rs
+++ b/crates/adapters/src/integrated/postgres/prepared_statements.rs
@@ -47,6 +47,12 @@ impl RawQueries {
                             let f = f.name.sql_name();
                             format!(r#" {f} = EXCLUDED.{f} "#)
                         })
+                        .chain(
+                            config
+                                .extra_columns
+                                .iter()
+                                .map(|k| format!(r#" "{k}" = EXCLUDED."{k}" "#)),
+                        )
                         .join(", ");
 
                     format!(" ({keys}) DO UPDATE SET {columns}")
@@ -87,6 +93,12 @@ impl RawQueries {
                         let f = f.name.sql_name();
                         format!("{f} = {new_alias}.{f}")
                     })
+                    .chain(
+                        config
+                            .extra_columns
+                            .iter()
+                            .map(|k| format!(r#""{k}" = {new_alias}."{k}""#)),
+                    )
                     .collect::<Vec<_>>()
                     .join(", ");
 

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -1226,6 +1226,7 @@ where
         .service(start_input_endpoint)
         .service(input_endpoint_status)
         .service(output_endpoint_status)
+        .service(output_endpoint_command)
         .service(reset_output_endpoint)
         .service(rebalance)
         .service(coordination_activate_handler)
@@ -2289,6 +2290,19 @@ async fn output_endpoint_status(
     path: web::Path<String>,
 ) -> Result<HttpResponse, PipelineError> {
     Ok(HttpResponse::Ok().json(state.controller()?.output_endpoint_status(&path)?))
+}
+
+#[post("/output_endpoints/{endpoint_name}/command")]
+async fn output_endpoint_command(
+    state: WebData<ServerState>,
+    path: web::Path<String>,
+    command: web::Json<serde_json::Value>,
+) -> Result<HttpResponse, PipelineError> {
+    Ok(HttpResponse::Ok().json(
+        state
+            .controller()?
+            .output_endpoint_command(&path, command.into_inner())?,
+    ))
 }
 
 #[post("/output_endpoints/{endpoint_name}/reset")]

--- a/crates/feldera-types/src/transport/postgres.rs
+++ b/crates/feldera-types/src/transport/postgres.rs
@@ -163,6 +163,13 @@ pub struct PostgresWriterConfig {
     #[serde(default = "default_writer_threads")]
     #[schema(default = default_writer_threads)]
     pub threads: usize,
+
+    /// The names of the extra columns in the Postgres table that are not part of the view schema.
+    ///
+    /// These connector can write user-defined values, configured using the `set_extra_columns` connector command,
+    /// to these columns.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_columns: Vec<String>,
 }
 
 fn default_max_buffer_size() -> usize {

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_interaction.rs
@@ -539,6 +539,75 @@ pub(crate) async fn post_pipeline_output_connector_reset(
     Ok(response)
 }
 
+/// Send command to an output connector.
+#[utoipa::path(
+    context_path = "/v0",
+    security(("JSON web token (JWT) or API key" = [])),
+    params(
+        ("pipeline_name" = String, Path, description = "Unique pipeline name"),
+        ("view_name" = String, Path, description = "SQL view name"),
+        ("connector_name" = String, Path, description = "Output connector name"),
+    ),
+    request_body(
+        content = Object,
+        content_type = "text/json",
+        description = "Command to send to the output connector"),
+    responses(
+        (status = OK
+            , body = Object
+            , description = "Command has been processed. Response contains the result of the command."),
+        (status = NOT_FOUND
+            , body = ErrorResponse
+            , description = "Pipeline, view and/or output connector with that name does not exist"
+            , examples(
+                ("Pipeline with that name does not exist" = (value = json!(examples::error_unknown_pipeline_name()))),
+            )
+        ),
+        (status = BAD_REQUEST
+            , body = ErrorResponse
+            , description = "Command is not supported by the output connector or the connector failed to execute the command"),
+        (status = SERVICE_UNAVAILABLE
+            , body = ErrorResponse
+            , examples(
+                ("Pipeline is not deployed" = (value = json!(examples::error_pipeline_interaction_not_deployed()))),
+                ("Pipeline is currently unavailable" = (value = json!(examples::error_pipeline_interaction_currently_unavailable()))),
+                ("Disconnected during response" = (value = json!(examples::error_pipeline_interaction_disconnected()))),
+                ("Response timeout" = (value = json!(examples::error_pipeline_interaction_timeout())))
+            )
+        ),
+        (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
+    ),
+    tag = "Output Connectors"
+)]
+#[post("/pipelines/{pipeline_name}/views/{view_name}/connectors/{connector_name}/command")]
+pub(crate) async fn post_pipeline_output_connector_command(
+    state: WebData<ServerState>,
+    client: WebData<awc::Client>,
+    tenant_id: ReqData<TenantId>,
+    path: web::Path<(String, String, String)>,
+    req: HttpRequest,
+    body: web::Payload,
+) -> Result<HttpResponse, ManagerError> {
+    let (pipeline_name, view_name, connector_name) = path.into_inner();
+
+    let actual_view_name = SqlIdentifier::from(&view_name).name();
+    let endpoint_name = format!("{actual_view_name}.{connector_name}");
+    let encoded_endpoint_name = urlencoding::encode(&endpoint_name).to_string();
+
+    state
+        .runner
+        .forward_streaming_http_request_to_pipeline_by_name(
+            client.as_ref(),
+            *tenant_id,
+            &pipeline_name,
+            &format!("output_endpoints/{encoded_endpoint_name}/command"),
+            req,
+            body,
+            None,
+        )
+        .await
+}
+
 /// Get Pipeline Stats
 ///
 /// Retrieve statistics (e.g., performance counters) of a running or paused pipeline.

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -573,6 +573,7 @@ fn api_scope() -> Scope {
         .service(endpoints::pipeline_interaction::get_pipeline_input_connector_status)
         .service(endpoints::pipeline_interaction::get_pipeline_output_connector_status)
         .service(endpoints::pipeline_interaction::post_pipeline_output_connector_reset)
+        .service(endpoints::pipeline_interaction::post_pipeline_output_connector_command)
         .service(endpoints::pipeline_interaction::get_pipeline_stats)
         .service(endpoints::pipeline_interaction::get_pipeline_metrics)
         .service(endpoints::pipeline_interaction::get_pipeline_time_series)

--- a/openapi.json
+++ b/openapi.json
@@ -11148,7 +11148,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "The names of the extra columns in the Postgres table that are not part of the view schema.\n\nThese connector can write user-defined values, configured using the `set_extra_columns` command,\nto these columns."
+                "description": "The names of the extra columns in the Postgres table that are not part of the view schema.\n\nThese connector can write user-defined values, configured using the `set_extra_columns` connector command,\nto these columns."
               },
               "max_buffer_size_bytes": {
                 "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -11143,6 +11143,13 @@
                 "description": "Name of the timestamp metadata column in CDC mode.\n\nOnly used when `mode = \"cdc\"`. This column will contain the timestamp\n(in RFC 3339 format) when the batch of updates was output\nby the pipeline.\n\nDefault: `\"__feldera_ts\"`",
                 "default": "__feldera_ts"
               },
+              "extra_columns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The names of the extra columns in the Postgres table that are not part of the view schema.\n\nThese connector can write user-defined values, configured using the `set_extra_columns` command,\nto these columns."
+              },
               "max_buffer_size_bytes": {
                 "type": "integer",
                 "description": "The maximum buffer size in for a single operation.\nNote that the buffers of `INSERT`, `UPDATE` and `DELETE` queries are\nseparate.\nDefault: 1 MiB",


### PR DESCRIPTION
This commit addresses a feature request from a user to have the Postgres connector write additional columns containing user-defined values to the destination Postgres table. The values can change at runtime.

It consists of:

- A new `extra_columns` connector config option that lists extra user-defined columns.  The columns are currently assumed to be of type `VARCHAR`.
- A mechanism to invoke custom connector-specific commands on output connectors: `POST /views/<view_name>/connectors/<connector_name>/command`. The command takes and returns arbitrary JSON objects. The semantics of the operation is determined by the connector.
- The `set_extra_columns` command for the Postgres output connector. The command updates values of a subset of extra columns. Outputs produced by the connector after receiving the command will contain the newly assigned values.

Example assigning an extra column value:

```
curl -X POST 'http://localhost:8080/v0/pipelines/extra_columns/views/v/connectors/unnamed-0/command' -H 'Content-Type: application/json' -d '{"set_extra_columns": {"extra_column1": "foo"}}'
```

Caveats:
- Until extra_columns are assigned values, the connector will write NULLs to these columns.
- The current values of extra_columns are not checkpointed, and need to be assigned afresh after a restart or failover.

My initial attempt at this added a mechanism to modify connector configuration at runtime, which has the advantage that the last values assigned to extra_columns get checkpointed. However the semantics of this became very messy, with two different sources of truth for connector config after a restart (SQL code and the checkpointed state).

This commit doesn't include docs. This isn't a particularly elegant feature and I'd like to see some user validation before we make it official.

### Describe Manual Test Plan

Checked that commands similar to the one listed above work for a simple local pipeline.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
