### PR TITLE
python: fix logs test

### DIFF
--- a/python/tests/platform/test_metrics_logs.py
+++ b/python/tests/platform/test_metrics_logs.py
@@ -135,7 +135,14 @@ def test_pipeline_stats(pipeline_name):
     assert r_stats.status_code == HTTPStatus.OK, (r_stats.status_code, r_stats.text)
     r_stats_json = r_stats.json()
     keys = sorted(r_stats_json.keys())
-    assert keys == ["checkpoint_activity", "global_metrics", "inputs", "outputs", "permanent_checkpoint_errors", "suspend_error"]
+    assert keys == [
+        "checkpoint_activity",
+        "global_metrics",
+        "inputs",
+        "outputs",
+        "permanent_checkpoint_errors",
+        "suspend_error",
+    ]
     stats = PipelineStatistics.from_dict(r_stats_json)
 
     gm = stats.global_metrics

--- a/python/tests/platform/test_shared_pipeline_stress.py
+++ b/python/tests/platform/test_shared_pipeline_stress.py
@@ -17,7 +17,10 @@ class TestPipeline(SharedTestPipeline):
         for _ in range(200):
             logs = self.pipeline.logs()
             start = next(logs)
-            assert "Fresh start of pipeline log" in start
+            assert (
+                "Fresh start of pipeline log" in start
+                or "prior log lines were discarded due to buffer constraints" in start
+            )
         self.pipeline.pause()
         self.pipeline.stop(force=True)
 


### PR DESCRIPTION
Fixes logs test that could fail if too many log lines were produced.
