### PR TITLE
[SQL] Add version information to SQL compiler

### DIFF
--- a/.github/workflows/ci-post-release.yml
+++ b/.github/workflows/ci-post-release.yml
@@ -113,6 +113,10 @@ jobs:
         run: |
           sed -i "s/version = \"${{ env.CURRENT_VERSION }}\"/version = \"${{ env.NEXT_VERSION }}\"/g" pyproject.toml
           sed -i "s/version: '${{ env.CURRENT_VERSION }}'/version: '${{ env.NEXT_VERSION }}'/g" dbt/include/feldera/dbt_project.yml
+      - name: Adjust sql compiler version
+        working-directory: ./sql-to-dbsp-compiler/SQL-compiler
+        run: |
+          sed -i "s|<project.version>${{ env.CURRENT_VERSION }}|<project.version>${{ env.NEXT_VERSION }}|g" pom.xml
       - name: List changes
         run: |
           git diff

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -19,6 +19,7 @@
         <calcite.version>1.42.0</calcite.version>
         <jackson.version>2.21.1</jackson.version>
         <janino.version>3.1.12</janino.version>
+        <project.version>0.288.0</project.version>
     </properties>
 
     <repositories>
@@ -188,6 +189,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <!-- This substitutes the program.version from pom.xml to the resource file version.properties -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <dependencies>

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/CompilerMain.java
@@ -57,6 +57,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Properties;
 
 /** Main entry point of the SQL compiler. */
 public class CompilerMain {
@@ -67,13 +68,33 @@ public class CompilerMain {
     }
 
     void usage(JCommander commander) {
-        // JCommander mistakenly prints this as default value
-        // if it manages to parse it partially.
-        // this.options.ioOptions.loggingLevel.clear();
         commander.usage();
     }
 
-    int parseOptions(String[] argv) {
+    String getVersion() {
+        Properties props = new Properties();
+        try (InputStream input = CompilerMain.class.getResourceAsStream("/version.properties")) {
+            props.load(input);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return props.getProperty("version", "unknown");
+    }
+
+    void showVersion() {
+        System.out.println("SQL to DBSP compiler version " + this.getVersion());
+    }
+
+    public enum ParseResult {
+        /** Error while parsing options */
+        Error,
+        /** Parsed options ok, continue compilation */
+        OkContinue,
+        /** Parsed options ok, stop compilation */
+        OkStop
+    }
+
+    ParseResult parseOptions(String[] argv) {
         JCommander commander = JCommander.newBuilder()
                 .addObject(this.options)
                 .build();
@@ -87,11 +108,15 @@ public class CompilerMain {
                 }
             }
             System.err.println(ex.getMessage());
-            return 1;
+            return ParseResult.Error;
         }
         if (this.options.help) {
             this.usage(commander);
-            return 1;
+            return ParseResult.OkStop;
+        }
+        if (this.options.ioOptions.showVersion) {
+            this.showVersion();
+            return ParseResult.OkStop;
         }
 
         for (Map.Entry<String, String> entry: options.ioOptions.loggingLevel.entrySet()) {
@@ -100,11 +125,11 @@ public class CompilerMain {
                 Logger.INSTANCE.setLoggingLevel(entry.getKey(), level);
             } catch (NumberFormatException ex) {
                 System.err.println("-T option must be followed by 'class=number'; could not parse " + entry);
-                return 1;
+                return ParseResult.Error;
             }
         }
 
-        return 0;
+        return ParseResult.OkContinue;
     }
 
     PrintStream getOutputStream() throws IOException {
@@ -277,15 +302,17 @@ public class CompilerMain {
 
     public static Pair<CompilerMessages, CompilerOptions> run(String... argv) throws SQLException {
         CompilerMain main = new CompilerMain();
-        int exitCode = main.parseOptions(argv);
+        var parseResult = main.parseOptions(argv);
         CompilerOptions options = main.options;
-        if (exitCode != 0) {
+        if (parseResult != ParseResult.OkContinue) {
             // return empty messages
             CompilerMessages result = new CompilerMessages(new DBSPCompiler(new CompilerOptions()));
+            int exitCode = parseResult == ParseResult.Error ? 1 : 0;
             result.setExitCode(exitCode);
             return new Pair<>(result, options);
         }
-        return new Pair<>(main.run(), options);
+        var messages = main.run();
+        return new Pair<>(messages, options);
     }
 
     public static CompilerMessages execute(String... argv) throws SQLException {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -226,6 +226,8 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
 
         // Used only for internal testing
         public boolean nowStream = true;
+        @Parameter(names = "--version", description = "Print compiler version", help = true)
+        public boolean showVersion = false;
 
         /** Only compare fields that matter. */
         public boolean same(IO other) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/resources/version.properties
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import javax.sql.DataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -150,6 +151,18 @@ public class MetadataTests extends BaseSQLTests {
         CompilerMain.runAndReportErrors("--noRust", file.getPath(), "--errors", errorFile.getPath());
         String str = Utilities.readFile(errorFile.getPath());
         Assert.assertTrue(str.contains("Error parsing SQL"));
+    }
+
+    @Test
+    public void issue4626() throws SQLException {
+        PrintStream savedOut = System.out;
+        ByteArrayOutputStream capture = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(capture));
+        var result = CompilerMain.run("--version");
+        System.setOut(savedOut);
+        Assert.assertEquals(0, result.left.exitCode);
+        String str = capture.toString();
+        Assert.assertTrue(str.contains("SQL to DBSP compiler version"));
     }
 
     @Test
@@ -1313,6 +1326,8 @@ public class MetadataTests extends BaseSQLTests {
                     --unaryPlusNoop
                       Compile unary plus into a no-operation; similar to sqlite
                       Default: false
+                    --version
+                      Print compiler version
                     -O
                       Optimization level (0, 1, or 2)
                       Default: 2

--- a/sql-to-dbsp-compiler/using.md
+++ b/sql-to-dbsp-compiler/using.md
@@ -115,6 +115,8 @@ Usage: sql-to-dbsp [options] Input file to compile
     --unaryPlusNoop
       Compile unary plus into a no-operation; similar to sqlite
       Default: false
+    --version
+      Print compiler version
     -O
       Optimization level (0, 1, or 2)
       Default: 2


### PR DESCRIPTION
Fixes #4626 

Until now the SQL compiler had no versioning information.
This PR brings it in line with the rest of the tools. A post-release script updates `pom.xml`, the maven build file. 
The Java maven build uses a resource rewriting plugin to insert the information in file version.properties
The Java program can read the version at runtime using standard Java properties access.
The current version of the Java compiler is 0.287.0, and it will track the other tools.

## Breaking changes

The compiler flag `-h` used to return an exit code of 1. Now it will return an exit code of 0.