### PR TITLE
ci: cancel run immediately when build-rust fails

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -183,3 +183,18 @@ jobs:
           name: fda-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.fda_artifact }}
           retention-days: 7
+
+  cancel-if-build-rust-failed:
+    name: Cancel if Rust Build Failed
+    needs: [build-rust]
+    if: failure()
+    runs-on: ubuntu-latest-amd64
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel workflow
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -138,19 +138,22 @@ jobs:
           retention-days: 7
 
   build-fda-native:
-    name: Build fda (Windows)
+    name: Build fda (native)
 
-    # Builds fda for Windows using GitHub-hosted larger runners.
-    # macOS arm64 will be added once self-hosted macOS runners are available.
+    # Builds fda for Windows and macOS using native runners.
     # Windows arm64 is skipped for now — the runner lacks Rust and MSVC.
     strategy:
       matrix:
         include:
+          - runner: macos-latest-arm64
+            target: aarch64-apple-darwin
+            fda_artifact: fda
           - runner: windows-latest-amd64
             target: x86_64-pc-windows-msvc
+            fda_artifact: fda.exe
     runs-on: ${{ matrix.runner }}
 
-    # sccache is not available on Windows GitHub-hosted runners
+    # sccache is not available on these runners
     env:
       RUSTC_WRAPPER: ""
 
@@ -178,5 +181,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: fda-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/fda.exe
+          path: target/${{ matrix.target }}/release/${{ matrix.fda_artifact }}
           retention-days: 7


### PR DESCRIPTION
build-rust.yml has two independent jobs: build-rust and build-fda-native. When build-rust fails, build-fda-native keeps running, delaying the cancel sentinel in ci.yml by 10-15 minutes. This adds a sentinel inside build-rust.yml to cancel the run as soon as build-rust fails.