### PR TITLE
[SQL] Emit a warning if DECIMAL is used without precision and scale

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -543,6 +543,13 @@ public class SqlToRelCompiler implements IWritesLogs {
                                 "Illegal type",
                                 "Maximum precision supported for DECIMAL is " + DBSPTypeDecimal.MAX_PRECISION);
                     }
+                    if (basic.getScale() == RelDataType.SCALE_NOT_SPECIFIED &&
+                            basic.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED) {
+                        SourcePositionRange position = new SourcePositionRange(typeNameSpec.getParserPos());
+                        this.errorReporter.reportWarning(position, "DECIMAL precision and scale unspecified",
+                                "DECIMAL/NUMERIC type used without specifying precision and scale.\n" +
+                                        "This is interpreted as DECIMAL(" + DBSPTypeDecimal.MAX_PRECISION + ", 0)");
+                    }
                 } else if (relDataType.getSqlTypeName() == SqlTypeName.FLOAT) {
                     SourcePositionRange position = new SourcePositionRange(typeNameSpec.getParserPos());
                     this.errorReporter.reportError(position,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/NegativeParserTests.java
@@ -19,6 +19,7 @@ public class NegativeParserTests extends BaseSQLTests {
     public CompilerOptions testOptions() {
         CompilerOptions options = super.testOptions();
         options.languageOptions.throwOnError = false;
+        options.ioOptions.quiet = false;
         return options;
     }
 
@@ -181,6 +182,26 @@ public class NegativeParserTests extends BaseSQLTests {
         TestUtil.assertMessagesContain(messages,
                 "cannot convert GEOMETRY literal to class org.locationtech.jts.geom.Point\n" +
                 "'LINESTRING (0 0, 0 0)'");
+    }
+
+    @Test
+    public void issue6069() {
+        var cc = this.getCC("""
+                CREATE TABLE T(x DECIMAL);
+                CREATE VIEW V AS SELECT CAST(x AS DECIMAL) FROM T;""");
+        TestUtil.assertMessagesContain(cc.compiler.messages, """
+                (no input file): DECIMAL precision and scale unspecified
+                (no input file):1:18: warning: DECIMAL precision and scale unspecified: DECIMAL/NUMERIC type used without specifying precision and scale.
+                This is interpreted as DECIMAL(38, 0)
+                    1|CREATE TABLE T(x DECIMAL);
+                                       ^^^^^^^
+                    2|CREATE VIEW V AS SELECT CAST(x AS DECIMAL) FROM T;
+                (no input file): DECIMAL precision and scale unspecified
+                (no input file):2:35: warning: DECIMAL precision and scale unspecified: DECIMAL/NUMERIC type used without specifying precision and scale.
+                This is interpreted as DECIMAL(38, 0)
+                    1|CREATE TABLE T(x DECIMAL);
+                    2|CREATE VIEW V AS SELECT CAST(x AS DECIMAL) FROM T;
+                                                        ^^^^^^^""");
     }
 
     @Test


### PR DESCRIPTION
Fixes #6069 

In other SQL dialects `CAST(x AS DECIMAL)` may have a different interpretation.
In Feldera SQL `DECIMAL` is the same as `DECIMAL(38, 0)`. So any use of `DECIMAL` without precision and scale is probably a bug - thus we emit a warning.