### PR TITLE
ci: add fda-aarch64-apple-darwin to release artifacts

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -113,6 +113,7 @@ jobs:
             fda-x86_64-unknown-linux-gnu.zip
             fda-aarch64-unknown-linux-gnu.zip
             fda-x86_64-pc-windows-msvc.zip
+            fda-aarch64-apple-darwin.zip
             sql2dbsp-jar-with-dependencies-v${{ env.CURRENT_VERSION }}.jar
             feldera-sbom-source.spdx.json
             feldera-sbom-image.spdx.json


### PR DESCRIPTION
Add fda-aarch64-apple-darwin.zip to the release artifacts in ci-release.yml. The artifact is already built by the build-fda-native job and downloaded via the fda-* wildcard, this just adds it to the GitHub release files list. 

Closes #6063 