### PR TITLE
[web-console] Make status polling resilient to hiding the page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,7 +207,7 @@
         "vite-plugin-virtual": "0.5.0",
         "vitest": "^4.0.18",
         "vitest-browser-svelte": "^2.0.2",
-        "worker-timers": "8.0.30",
+        "worker-timers": "^8.0.31",
       },
     },
   },
@@ -228,7 +228,7 @@
 
     "@axa-fr/oidc-client-service-worker": ["@axa-fr/oidc-client-service-worker@7.26.4", "", {}, "sha512-II7gtBn/vbNlvSbocNNYHfQW9RZ1CaVxHyF+pkgj9OVxFstsCntR41J12sRrxcfOS08H/H56cbZ6UXX37uDDag=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
 
@@ -1036,7 +1036,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "broker-factory": ["broker-factory@3.1.13", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-unique-numbers": "^9.0.26", "tslib": "^2.8.1", "worker-factory": "^7.0.48" } }, "sha512-H2VALe31mEtO/SRcNp4cUU5BAm1biwhc/JaF77AigUuni/1YT0FLCJfbUxwIEs9y6Kssjk2fmXgf+Y9ALvmKlw=="],
+    "broker-factory": ["broker-factory@3.1.14", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1", "worker-factory": "^7.0.49" } }, "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
@@ -1264,7 +1264,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-unique-numbers": ["fast-unique-numbers@9.0.26", "", { "dependencies": { "@babel/runtime": "^7.28.6", "tslib": "^2.8.1" } }, "sha512-3Mtq8p1zQinjGyWfKeuBunbuFoixG72AUkk4VvzbX4ykCW9Q4FzRaNyIlfQhUjnKw2ARVP+/CKnoyr6wfHftig=="],
+    "fast-unique-numbers": ["fast-unique-numbers@9.0.27", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1" } }, "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -2010,13 +2010,13 @@
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
-    "worker-factory": ["worker-factory@7.0.48", "", { "dependencies": { "@babel/runtime": "^7.28.6", "fast-unique-numbers": "^9.0.26", "tslib": "^2.8.1" } }, "sha512-CGmBy3tJvpBPjUvb0t4PrpKubUsfkI1Ohg0/GGFU2RvA9j/tiVYwKU8O7yu7gH06YtzbeJLzdUR29lmZKn5pag=="],
+    "worker-factory": ["worker-factory@7.0.49", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1" } }, "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw=="],
 
-    "worker-timers": ["worker-timers@8.0.30", "", { "dependencies": { "@babel/runtime": "^7.28.6", "tslib": "^2.8.1", "worker-timers-broker": "^8.0.15", "worker-timers-worker": "^9.0.13" } }, "sha512-8P7YoMHWN0Tz7mg+9oEhuZdjBIn2z6gfjlJqFcHiDd9no/oLnMGCARCDkV1LR3ccQus62ZdtIp7t3aTKrMLHOg=="],
+    "worker-timers": ["worker-timers@8.0.31", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1", "worker-timers-broker": "^8.0.16", "worker-timers-worker": "^9.0.14" } }, "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA=="],
 
-    "worker-timers-broker": ["worker-timers-broker@8.0.15", "", { "dependencies": { "@babel/runtime": "^7.28.6", "broker-factory": "^3.1.13", "fast-unique-numbers": "^9.0.26", "tslib": "^2.8.1", "worker-timers-worker": "^9.0.13" } }, "sha512-Te+EiVUMzG5TtHdmaBZvBrZSFNauym6ImDaCAnzQUxvjnw+oGjMT2idmAOgDy30vOZMLejd0bcsc90Axu6XPWA=="],
+    "worker-timers-broker": ["worker-timers-broker@8.0.16", "", { "dependencies": { "@babel/runtime": "^7.29.2", "broker-factory": "^3.1.14", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1", "worker-timers-worker": "^9.0.14" } }, "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA=="],
 
-    "worker-timers-worker": ["worker-timers-worker@9.0.13", "", { "dependencies": { "@babel/runtime": "^7.28.6", "tslib": "^2.8.1", "worker-factory": "^7.0.48" } }, "sha512-qjn18szGb1kjcmh2traAdki1eiIS5ikFo+L90nfMOvSRpuDw1hAcR1nzkP2+Hkdqz5thIRnfuWx7QSpsEUsA6Q=="],
+    "worker-timers-worker": ["worker-timers-worker@9.0.14", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1", "worker-factory": "^7.0.49" } }, "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -2133,6 +2133,8 @@
     "glob/minimatch": ["minimatch@3.1.3", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA=="],
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
+
+    "json-schema-to-ts/@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/js-packages/web-console/package.json
+++ b/js-packages/web-console/package.json
@@ -102,7 +102,7 @@
     "vite-plugin-virtual": "0.5.0",
     "vitest": "^4.0.18",
     "vitest-browser-svelte": "^2.0.2",
-    "worker-timers": "8.0.30"
+    "worker-timers": "8.0.31"
   },
   "overrides": {
     "vite": "npm:rolldown-vite@7.3.1",

--- a/js-packages/web-console/src/lib/compositions/common/useInterval.svelte.ts
+++ b/js-packages/web-console/src/lib/compositions/common/useInterval.svelte.ts
@@ -1,23 +1,26 @@
+import { closedIntervalAction } from '$lib/functions/common/promise'
+
 /**
- * Runs the function on initial call
- * @param f
- * @param durationMs
- * @param offsetMs
- * @returns
+ * Runs `f` immediately, then repeatedly on an interval, exposing the latest return value
+ * as reactive `.current`.
+ *
+ * Built on {@link closedIntervalAction}, so polling is paused while the document is
+ * hidden and async callbacks are awaited before the next tick is scheduled.
  */
 export const useInterval = <T>(f: () => T, durationMs: number, offsetMs?: number) => {
   let state = $state(f())
-  let interval: Timer
-  $effect.pre(() => {
-    if (offsetMs) {
-      setTimeout(() => (interval = setInterval(() => (state = f()), durationMs)), offsetMs)
+
+  const action = async () => {
+    const result = f()
+    if (result && typeof (result as { then?: unknown }).then === 'function') {
+      state = await (result as unknown as Promise<T>)
     } else {
-      interval = setInterval(() => (state = f()), durationMs)
+      state = result
     }
-    return () => {
-      clearInterval(interval)
-    }
-  })
+  }
+
+  $effect.pre(() => closedIntervalAction(action, durationMs, { initialDelayMs: offsetMs }))
+
   return {
     get current() {
       return state

--- a/js-packages/web-console/src/lib/functions/common/promise.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/functions/common/promise.svelte.spec.ts
@@ -1,0 +1,185 @@
+// Named `.svelte.spec.ts` so it runs under the `client` project (real browser via
+// Playwright) — the test needs `document`, `visibilitychange` events, and worker-timers'
+// Web Worker. No Svelte component is rendered here.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Replace worker-timers with thin wrappers over the global timer API so that
+// `vi.useFakeTimers()` can deterministically drive time in the test.
+vi.mock('worker-timers', () => ({
+  setTimeout: (fn: () => void, ms: number) =>
+    globalThis.setTimeout(fn, ms) as unknown as number,
+  clearTimeout: (id: number) => globalThis.clearTimeout(id as unknown as ReturnType<typeof setTimeout>)
+}))
+
+import { closedIntervalAction } from './promise'
+
+const setHidden = (hidden: boolean) => {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible')
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('closedIntervalAction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setHidden(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    setHidden(false)
+  })
+
+  it('calls the action every period while the tab is visible', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000)
+
+    expect(action).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('respects `initialDelayMs` for the first tick', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000, { initialDelayMs: 50 })
+
+    await vi.advanceTimersByTimeAsync(49)
+    expect(action).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(action).toHaveBeenCalledTimes(1)
+
+    cancel()
+  })
+
+  it('does not call the action while the tab is hidden', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000)
+
+    setHidden(true)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(action).not.toHaveBeenCalled()
+
+    cancel()
+  })
+
+  it('pauses an already-armed timer when the tab is hidden mid-period', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000)
+
+    await vi.advanceTimersByTimeAsync(500) // half-way through the first period
+    setHidden(true)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(action).not.toHaveBeenCalled()
+
+    cancel()
+  })
+
+  it('fires a single tick on visibility return — never a burst of catch-up ticks', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000)
+
+    setHidden(true)
+    await vi.advanceTimersByTimeAsync(60_000) // tab hidden for 60 periods
+    expect(action).not.toHaveBeenCalled()
+
+    setHidden(false)
+    await vi.advanceTimersByTimeAsync(0) // flush the scheduled(0) tick
+    expect(action).toHaveBeenCalledTimes(1) // exactly one, not 60
+
+    // And the cadence resumes relative to now, not the original t0.
+    await vi.advanceTimersByTimeAsync(999)
+    expect(action).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(action).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('awaits the previous invocation before scheduling the next', async () => {
+    let resolveFirst!: () => void
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r
+    })
+    let calls = 0
+    const action = vi.fn(async () => {
+      calls++
+      if (calls === 1) await firstDone
+    })
+
+    const cancel = closedIntervalAction(action, 1000)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(1)
+
+    // Even after multiple periods pass, the next tick is not scheduled
+    // until the first action resolves.
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(action).toHaveBeenCalledTimes(1)
+
+    resolveFirst()
+    // Microtask + one full period for the next scheduled tick.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('a rejection in the action does not break the loop', async () => {
+    let calls = 0
+    const action = vi.fn(async () => {
+      calls++
+      if (calls === 1) throw new Error('boom')
+    })
+
+    const cancel = closedIntervalAction(action, 1000)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(2)
+
+    cancel()
+  })
+
+  it('cancel while hidden prevents a tick when the tab later becomes visible', async () => {
+    const action = vi.fn(async () => {})
+    const cancel = closedIntervalAction(action, 1000)
+
+    setHidden(true)
+    await vi.advanceTimersByTimeAsync(2000)
+    cancel()
+
+    setHidden(false)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  it('cancel mid-flight prevents the next tick from scheduling', async () => {
+    let resolveAction!: () => void
+    const blocking = new Promise<void>((r) => {
+      resolveAction = r
+    })
+    const action = vi.fn(async () => {
+      await blocking
+    })
+
+    const cancel = closedIntervalAction(action, 1000)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(action).toHaveBeenCalledTimes(1) // running
+
+    cancel()
+    resolveAction()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(action).toHaveBeenCalledTimes(1) // never re-scheduled
+  })
+})

--- a/js-packages/web-console/src/lib/functions/common/promise.ts
+++ b/js-packages/web-console/src/lib/functions/common/promise.ts
@@ -1,38 +1,126 @@
+import { clearTimeout as clearWorkerTimeout, setTimeout as setWorkerTimeout } from 'worker-timers'
+
 export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
-/**
- * Start calling an action in a loop with an interval while waiting for the previous invocation to resolve
- * Does not perform the action on the initial call
- * Does not handle rejection
- * @returns A function to cancel the action loop
- */
-export const closedIntervalAction = (action: () => Promise<void>, periodMs: number) => {
-  let cancelled = false
-  let t0 = Date.now()
-  let timeout: Timer
+const hasDocument = typeof document !== 'undefined'
+const isHidden = () => hasDocument && document.hidden
+const clearWorkerTimeoutSafely = (timeout: number) => {
+  try {
+    clearWorkerTimeout(timeout)
+  } catch {
+    // timer may have already fired
+  }
+}
 
-  function execute() {
-    if (cancelled) {
+export type ClosedIntervalOptions = {
+  /** Delay before the first invocation. Defaults to `periodMs`. */
+  initialDelayMs?: number
+}
+
+/**
+ * Start calling an action in a loop with an interval while waiting for the previous
+ * invocation to resolve. A sync action's return value is ignored; a rejected promise is
+ * swallowed (same semantics the callers relied on before).
+ *
+ * Polling is paused while the document is hidden (Page Visibility API) to prevent
+ * browser throttling from queueing up missed ticks that would then fire as a burst when
+ * the tab regains focus. When the tab becomes visible again the action runs immediately
+ * and the cadence resumes relative to that moment.
+ *
+ * Uses `worker-timers` so the scheduler ticks in a dedicated Web Worker and is not
+ * subject to main-thread throttling while the tab is visible but resource-starved.
+ *
+ * @returns A function to cancel the action loop.
+ */
+export const closedIntervalAction = (
+  action: () => void | Promise<void>,
+  periodMs: number,
+  options: ClosedIntervalOptions = {}
+) => {
+  // Lifecycle state machine. Transitions:
+  //   idle      → scheduled (schedule while visible)
+  //   idle      → paused    (schedule while hidden)
+  //   scheduled → running   (timer fires)
+  //   running   → idle      (action resolved — then re-schedules)
+  //   scheduled → paused    (visibility → hidden)
+  //   paused    → scheduled (visibility → visible)
+  //   any       → cancelled (caller disposed)
+  type State =
+    | { name: 'idle' }
+    | { name: 'scheduled'; timeout: number }
+    | { name: 'running' }
+    | { name: 'paused' }
+    | { name: 'cancelled' }
+
+  let state: State = { name: 'idle' }
+  let nextAt = Date.now() + periodMs
+
+  const schedule = (delay: number) => {
+    if (state.name !== 'idle' && state.name !== 'paused') {
       return
     }
-
-    action().finally(() => {
-      if (cancelled) {
-        return
-      }
-
-      const now = Date.now()
-      t0 += periodMs
-      const nextDelay = Math.max(t0 - now, 0)
-
-      timeout = setTimeout(execute, nextDelay)
-    })
+    if (isHidden()) {
+      state = { name: 'paused' }
+      return
+    }
+    state = { name: 'scheduled', timeout: setWorkerTimeout(tick, delay) }
   }
 
-  timeout = setTimeout(execute, periodMs)
+  const tick = () => {
+    if (state.name !== 'scheduled') return
+    state = { name: 'running' }
+    Promise.resolve()
+      .then(action)
+      .catch(() => {
+        /* swallow — rejection handling is the caller's responsibility */
+      })
+      .finally(afterTick)
+  }
+
+  const afterTick = () => {
+    if (state.name !== 'running') return
+    const now = Date.now()
+    nextAt += periodMs
+    // If we fell far behind (e.g. action took longer than one period), reset cadence
+    // to `now` instead of firing a burst of catch-up ticks.
+    if (now - nextAt > periodMs) {
+      nextAt = now + periodMs
+    }
+    state = { name: 'idle' }
+    schedule(Math.max(nextAt - now, 0))
+  }
+
+  const onVisibilityChange = () => {
+    if (isHidden()) {
+      if (state.name === 'scheduled') {
+        clearWorkerTimeoutSafely(state.timeout)
+        state = { name: 'paused' }
+      }
+      // In `running`, afterTick will observe isHidden() via schedule() and park in paused.
+      return
+    }
+    if (state.name === 'paused') {
+      // Anchor cadence to `now` so that after the immediate resume tick advances
+      // `nextAt` by one period in afterTick, the next tick fires one period later
+      // (not two).
+      nextAt = Date.now()
+      state = { name: 'idle' }
+      schedule(0)
+    }
+  }
+
+  schedule(options.initialDelayMs ?? periodMs)
+  if (hasDocument) {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+  }
 
   return () => {
-    cancelled = true
-    clearTimeout(timeout)
+    if (state.name === 'scheduled') {
+      clearWorkerTimeoutSafely(state.timeout)
+    }
+    state = { name: 'cancelled' }
+    if (hasDocument) {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
   }
 }

--- a/js-packages/web-console/vite.config.ts
+++ b/js-packages/web-console/vite.config.ts
@@ -65,7 +65,13 @@ const testOptimizeDepsInclude = [
   'true-json-bigint',
   'ts-pattern',
   'valibot',
-  'virtua/svelte'
+  'virtua/svelte',
+  // worker-timers and its transitive fast-unique-numbers ship UMD bundles
+  // via their `browser` package.json field. Without pre-bundling, Vite
+  // serves the raw UMD file and ESM named imports (generateUniqueNumber, …)
+  // fail. Pre-bundling rewraps them into ESM with real named exports.
+  'worker-timers',
+  'worker-timers > fast-unique-numbers'
 ]
 
 const browserTestProject = ({


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/5913

The problem was the default browser polling mechanism (setTimeout and setInterval) gets severely throttled when the page is hidden (e.g. user switches to another tab), or when it simply goes out of focus (if the action was requested on a certain timeout the browser can trigger the callback later than requested). When page was hidden for a long time a lot of polling requests got queued by the browser and then executed in quick succession when the user returned to the page; causing some requests to fail and causing toast errors and unexpected program state corruption.

The fix is two-fold:
- Use the package `worker-timers` to make sure the requested timeouts used for polling logic get executed on schedule and do not get throttled by browsers in some scenarios;
- Stop polling altogether when the browser window is hidden.

All uses of useInterval and closedIntervalAction play nicely with the changed semantics of not running the updates when the browser tab is hidden (not if it's simply out of focus)

Since they only fundamentally differ in the way they are used, `useInterval()` now re-uses the more generic `closedIntervalAction()`.

Tested: manually tested some features that require polling: pipeline performance metrics updates, checked periodic health, license and config requests are being sent; tested that the page behaves normally after leaving it for a long time and coming back. Added unit tests for the `closedIntervalAction` primitive that validate the behavior when the browser tab is returned to, and the cadence of callbacks after it