### PR TITLE
pipeline-manager: fix refreshing of details

### DIFF
--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -194,10 +194,10 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
     /// `Initializing`. If it comes back one time something different, the grace period ends.
     const PROVISIONED_GRACE_PERIOD: Duration = Duration::from_secs(20);
 
-    /// The resources details can potentially change very frequently (especially if some counters or
+    /// The details can potentially change very frequently (especially if some counters or
     /// a timestamp is part of it). This is the minimum bound for them getting updated in the
     /// database, unless the status itself changed.
-    const RESOURCES_DETAILS_UPDATE_MIN_INTERVAL: Duration = Duration::from_secs(10);
+    const DETAILS_UPDATE_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
     /// If nothing changes, this will create the same event.
     const DETAILS_UPDATE_MAX_INTERVAL: Duration = Duration::from_secs(600);
@@ -1442,7 +1442,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 if Some(&details) != self.prev_resources_status_details.as_ref()
                     && self
                         .prev_details_update
-                        .is_none_or(|t| t.elapsed() >= Self::RESOURCES_DETAILS_UPDATE_MIN_INTERVAL)
+                        .is_none_or(|t| t.elapsed() >= Self::DETAILS_UPDATE_MIN_INTERVAL)
                 {
                     self.prev_details_update = Some(Instant::now());
                     self.prev_resources_status_details = Some(details.clone());
@@ -1710,12 +1710,12 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 false
             };
         if runtime_status_changed
-            || runtime_status_details_changed
-            || storage_status_details_changed
-            || (resources_status_details_changed
+            || ((resources_status_details_changed
+                || runtime_status_details_changed
+                || storage_status_details_changed)
                 && self
                     .prev_details_update
-                    .is_none_or(|t| t.elapsed() >= Self::RESOURCES_DETAILS_UPDATE_MIN_INTERVAL))
+                    .is_none_or(|t| t.elapsed() >= Self::DETAILS_UPDATE_MIN_INTERVAL))
             || self
                 .prev_details_update
                 .is_none_or(|t| t.elapsed() >= Self::DETAILS_UPDATE_MAX_INTERVAL)
@@ -1727,6 +1727,9 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                     .runtime_status_details
                     .clone(),
             );
+            self.prev_storage_status_details = latest_runtime_extended_status
+                .storage_status_details
+                .clone();
             Action::RemainProvisionedUpdateDetails {
                 deployment_resources_status_details: latest_resources_status_details,
                 extended_runtime_status: latest_runtime_extended_status.clone(),
@@ -1758,7 +1761,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             if (Some(&latest_details) != self.prev_resources_status_details.as_ref()
                 && self
                     .prev_details_update
-                    .is_none_or(|t| t.elapsed() >= Self::RESOURCES_DETAILS_UPDATE_MIN_INTERVAL))
+                    .is_none_or(|t| t.elapsed() >= Self::DETAILS_UPDATE_MIN_INTERVAL))
                 || self
                     .prev_details_update
                     .is_none_or(|t| t.elapsed() >= Self::DETAILS_UPDATE_MAX_INTERVAL)

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -620,7 +620,7 @@ def test_pipeline_storage_status_details_with_checkpoints(pipeline_name):
 
     # Check one checkpoint was created
     assert pipeline.storage_status() == StorageStatus.INUSE
-    time.sleep(5)
+    time.sleep(20)
     details = pipeline.storage_status_details()
     assert len(details["checkpoints"]) == 1
 
@@ -629,7 +629,7 @@ def test_pipeline_storage_status_details_with_checkpoints(pipeline_name):
 
     # Check another checkpoint was made
     assert pipeline.storage_status() == StorageStatus.INUSE
-    time.sleep(5)
+    time.sleep(20)
     details = pipeline.storage_status_details()
     assert len(details["checkpoints"]) == 2
 
@@ -650,3 +650,35 @@ def test_pipeline_storage_status_details_with_checkpoints(pipeline_name):
     pipeline.clear_storage()
     assert pipeline.storage_status() == StorageStatus.CLEARED
     assert pipeline.storage_status_details() is None
+
+
+@gen_pipeline_name
+def test_refresh_version(pipeline_name):
+    """
+    The `refresh_version` should only be sparingly incremented over the lifetime of a pipeline.
+    The refresh versions in this test are approximate as resources, runtime and storage status
+    details can be updated over time during deployment.
+    """
+    pipeline = PipelineBuilder(TEST_CLIENT, pipeline_name, "").create_or_replace()
+    assert (
+        TEST_CLIENT.http.get(f"/pipelines/{pipeline_name}?selector=status")[
+            "refresh_version"
+        ]
+        == 3
+    )
+    pipeline.start()
+    time.sleep(30.0)
+    assert (
+        TEST_CLIENT.http.get(f"/pipelines/{pipeline_name}?selector=status")[
+            "refresh_version"
+        ]
+        <= 10
+    )
+    pipeline.stop(force=True)
+    pipeline.clear_storage()
+    assert (
+        TEST_CLIENT.http.get(f"/pipelines/{pipeline_name}?selector=status")[
+            "refresh_version"
+        ]
+        <= 15
+    )


### PR DESCRIPTION
- The minimum update interval (10s) now applies to any of the three details (resources, runtime and status), rather than only on resources details.
- As a tradeoff, there is some additional latency before they will be reported (at most 10 seconds).
- Fix: the previous storage status details are now correctly updated, such that only when they change it triggers an update in the database instead of upon every check. Python regression test is included for this.