### PR TITLE
Added kwargs to input_json function

### DIFF
--- a/python/feldera/pipeline.py
+++ b/python/feldera/pipeline.py
@@ -167,6 +167,7 @@ class Pipeline:
         update_format: str = "raw",
         force: bool = False,
         wait: bool = True,
+        **kwargs,
     ) -> str:
         """
         Push this JSON data to the specified table of the pipeline.
@@ -181,6 +182,7 @@ class Pipeline:
             "raw", "insert_delete". https://docs.feldera.com/formats/json#the-insertdelete-format
         :param force: `True` to push data even if the pipeline is paused. `False` by default.
         :param wait: If True, blocks until this input has been processed by the pipeline
+        :param kwargs: Additional key word arguments forwarded to the Client push_to_pipeline method
 
         :returns: The completion token to this input.
 
@@ -206,6 +208,7 @@ class Pipeline:
             array=array,
             force=force,
             wait=wait,
+            **kwargs,
         )
 
     def pause_connector(self, table_name: str, connector_name: str):


### PR DESCRIPTION
forward additional key word arguments to the Client push_to_pipeline method from the Pipeline input_json method. Allows users to set important attributes, such as json_flavor when calling input_json.

closes: #6068

### Describe Manual Test Plan
Not required, just added **kwargs. 

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
