### PR TITLE
Disable eager file eviction.

### DIFF
--- a/crates/dbsp/src/storage/buffer_cache/cache.rs
+++ b/crates/dbsp/src/storage/buffer_cache/cache.rs
@@ -13,6 +13,7 @@ use feldera_types::config::dev_tweaks::{BufferCacheAllocationStrategy, BufferCac
 use serde::{Deserialize, Serialize};
 use size_of::SizeOf;
 
+use crate::Runtime;
 use crate::circuit::metadata::{
     CACHE_BACKGROUND_HIT_RATE_PERCENT, CACHE_BACKGROUND_HITS, CACHE_BACKGROUND_MISSES,
     CACHE_FOREGROUND_HIT_RATE_PERCENT, CACHE_FOREGROUND_HITS, CACHE_FOREGROUND_MISSES, MetaItem,
@@ -92,6 +93,11 @@ impl BufferCache {
     }
 
     pub fn evict(&self, file: &dyn FileReader) {
+        let eager_evict = Runtime::with_dev_tweaks(|d| d.eager_evict.unwrap_or(false));
+        if !eager_evict {
+            return;
+        }
+
         let file_id = file.file_id();
         if let Some(lru) = self
             .inner

--- a/crates/feldera-types/src/config/dev_tweaks.rs
+++ b/crates/feldera-types/src/config/dev_tweaks.rs
@@ -91,6 +91,29 @@ pub struct DevTweaks {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adaptive_joins: Option<bool>,
 
+    /// Evict eagerly from buffer caches as files get deleted.
+    ///
+    /// This is an optimization that drops files from
+    /// the cache as soon as they are deleted.
+    ///
+    /// It has unknown (no?) performance benefits from what I can tell.
+    ///
+    /// Historically it made sense to do this for two reasons:
+    /// a) we know with 100% guarantee that the file won't ever be
+    ///    read again.
+    /// b) we could do this in O(logn) time with the LRU cache.
+    ///    This is no longer true for s3-fifo where it is O(n).
+    ///
+    /// If the eviction is expensive, (many small objects in the cache)
+    /// this can cause a regression.
+    ///
+    /// New default disables this behavior by making it false.
+    ///
+    /// If this doesn't cause regression we will remove this option
+    /// in the future.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eager_evict: Option<bool>,
+
     /// The minimum relative improvement threshold for the join balancer.
     ///
     /// The join balancer is a component that dynamically chooses an optimal

--- a/openapi.json
+++ b/openapi.json
@@ -8393,6 +8393,12 @@
             "nullable": true,
             "minimum": 0
           },
+          "eager_evict": {
+            "type": "boolean",
+            "description": "Evict eagerly from buffer caches as files get deleted.\n\nThis is an optimization that drops files from\nthe cache as soon as they are deleted.\n\nIt has unknown (no?) performance benefits from what I can tell.\n\nHistorically it made sense to do this for two reasons:\na) we know with 100% guarantee that the file won't ever be\nread again.\nb) we could do this in O(logn) time with the LRU cache.\nThis is no longer true for s3-fifo where it is O(n).\n\nIf the eviction is expensive, (many small objects in the cache)\nthis can cause a regression.\n\nNew default disables this behavior by making it false.\n\nIf this doesn't cause regression we will remove this option\nin the future.",
+            "default": null,
+            "nullable": true
+          },
           "fbuf_slab_bytes_per_class": {
             "type": "integer",
             "description": "Target number of cached bytes retained in each `FBuf` slab size class.\n\nThe default is 16 MiB.",


### PR DESCRIPTION
We have this optimization that drops files from the cache as soon as they are deleted.

It has unknown (no?) performance benefits from what I can tell.

Historically it made sense to do this for two reasons: 

a) we know with 100% guarantee that the file won't ever be
   read again.
b) we could do this in O(logn) time with the LRU cache.
   This is no longer true for s3-fifo where it is O(n).

If the eviction is expensive, (many small objects in the cache) this can cause a regression for users.

New default disables this behavior by making it false.

### Describe Manual Test Plan

I ran a multi-hour workload and didn't find it negatively impacts anything (it actually improved perf by a few percent but it could also be just noise).
We did get reports that not disabling the eager eviction causes regressions.