### PR TITLE
[connectors] persist recent connector error messages across restarts

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -820,7 +820,11 @@ impl Controller {
 
     /// Returns the current controller status in the form used by the external
     /// API.
-    pub fn api_status(&self) -> ExternalControllerStatus {
+    ///
+    /// When `include_connector_errors` is `true`, the response carries the
+    /// recent error messages stored on each endpoint. Pollers should pass
+    /// `false`; the selector is intended for the support-bundle collector.
+    pub fn api_status(&self, include_connector_errors: bool) -> ExternalControllerStatus {
         let runtime = self.inner.runtime.upgrade();
         let memory_pressure = runtime
             .as_ref()
@@ -842,6 +846,7 @@ impl Controller {
             transaction_info: self.inner.transaction_info.lock().unwrap().clone(),
             memory_pressure,
             memory_pressure_epoch,
+            include_connector_errors,
         })
     }
 
@@ -7521,7 +7526,7 @@ impl RunningCheckpoint {
             .map(|endpoint| {
                 (
                     endpoint.endpoint_name.clone(),
-                    CheckpointInputEndpointMetrics::from(&endpoint.metrics),
+                    CheckpointInputEndpointMetrics::from_endpoint_status(endpoint),
                 )
             })
             .collect();
@@ -7533,7 +7538,7 @@ impl RunningCheckpoint {
             .map(|endpoint| {
                 (
                     endpoint.endpoint_name.clone(),
-                    CheckpointOutputEndpointMetrics::from(&endpoint.metrics),
+                    CheckpointOutputEndpointMetrics::from_endpoint_status(endpoint),
                 )
             })
             .collect();

--- a/crates/adapters/src/controller/checkpoint.rs
+++ b/crates/adapters/src/controller/checkpoint.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use dbsp::storage::backend::{StorageBackend, StoragePath};
-use feldera_types::{checkpoint::CheckpointMetadata, config::PipelineConfig};
+use feldera_types::{
+    adapter_stats::ConnectorError, checkpoint::CheckpointMetadata, config::PipelineConfig,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::{
@@ -13,7 +15,7 @@ use std::{
 
 use crate::{
     ControllerError,
-    controller::stats::{InputEndpointMetrics, OutputEndpointMetrics},
+    controller::stats::{InputEndpointMetrics, InputEndpointStatus, OutputEndpointStatus},
     transport::Step,
 };
 
@@ -123,7 +125,8 @@ impl Checkpoint {
 
 /// Checkpoint for the statistics for an input endpoint.
 ///
-/// This is the checkpointed form of [InputEndpointMetrics].
+/// This is the checkpointed form of [InputEndpointMetrics] and of the
+/// recent error messages associated with the endpoint.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CheckpointInputEndpointMetrics {
     /// Number of records pushed from the endpoint's queue to the circuit.
@@ -137,15 +140,25 @@ pub struct CheckpointInputEndpointMetrics {
 
     /// Number of parse errors.
     pub num_parse_errors: u64,
+
+    /// Recent transport error messages captured at checkpoint time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transport_errors: Vec<ConnectorError>,
+
+    /// Recent parse error messages captured at checkpoint time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parse_errors: Vec<ConnectorError>,
 }
 
-impl From<&InputEndpointMetrics> for CheckpointInputEndpointMetrics {
-    fn from(value: &InputEndpointMetrics) -> Self {
+impl CheckpointInputEndpointMetrics {
+    pub fn from_endpoint_status(status: &InputEndpointStatus) -> Self {
         Self {
-            circuit_input_records: value.circuit_input_records.load(Ordering::Relaxed),
-            circuit_input_bytes: value.circuit_input_bytes.load(Ordering::Relaxed),
-            num_transport_errors: value.num_transport_errors.load(Ordering::Relaxed),
-            num_parse_errors: value.num_parse_errors.load(Ordering::Relaxed),
+            circuit_input_records: status.metrics.circuit_input_records.load(Ordering::Relaxed),
+            circuit_input_bytes: status.metrics.circuit_input_bytes.load(Ordering::Relaxed),
+            num_transport_errors: status.metrics.num_transport_errors.load(Ordering::Relaxed),
+            num_parse_errors: status.metrics.num_parse_errors.load(Ordering::Relaxed),
+            transport_errors: status.transport_errors.lock().unwrap().to_api_type(),
+            parse_errors: status.parse_errors.lock().unwrap().to_api_type(),
         }
     }
 }
@@ -174,7 +187,8 @@ impl From<&CheckpointInputEndpointMetrics> for InputEndpointMetrics {
 
 /// Checkpoint for the statistics for an output endpoint.
 ///
-/// This is the checkpointed form of [OutputEndpointMetrics].
+/// This is the checkpointed form of [OutputEndpointMetrics] and of the
+/// recent error messages associated with the endpoint.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CheckpointOutputEndpointMetrics {
     /// Records sent on the underlying transport (HTTP, Kafka, etc.)  to the
@@ -190,11 +204,20 @@ pub struct CheckpointOutputEndpointMetrics {
 
     /// Number of transport errors.
     pub num_transport_errors: u64,
+
+    /// Recent encode error messages captured at checkpoint time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub encode_errors: Vec<ConnectorError>,
+
+    /// Recent transport error messages captured at checkpoint time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transport_errors: Vec<ConnectorError>,
 }
 
-impl From<&OutputEndpointMetrics> for CheckpointOutputEndpointMetrics {
-    fn from(value: &OutputEndpointMetrics) -> Self {
-        let snapshot = value.snapshot();
+impl CheckpointOutputEndpointMetrics {
+    /// Build the checkpoint form from the live endpoint status.
+    pub fn from_endpoint_status(status: &OutputEndpointStatus) -> Self {
+        let snapshot = status.metrics.snapshot();
         Self {
             // This includes all the records that have been transmitted plus all
             // of the records that will be transmitted by the time we commit the
@@ -212,6 +235,9 @@ impl From<&OutputEndpointMetrics> for CheckpointOutputEndpointMetrics {
             // commit.
             num_encode_errors: snapshot.num_encode_errors,
             num_transport_errors: snapshot.num_transport_errors,
+
+            encode_errors: status.encode_errors.lock().unwrap().to_api_type(),
+            transport_errors: status.transport_errors.lock().unwrap().to_api_type(),
         }
     }
 }
@@ -255,5 +281,149 @@ impl Checkpoint {
                     error,
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckpointInputEndpointMetrics, CheckpointOutputEndpointMetrics};
+    use crate::controller::stats::{ConnectorErrorList, MAX_CONNECTOR_ERRORS};
+    use chrono::{TimeZone, Utc};
+    use feldera_types::adapter_stats::ConnectorError;
+
+    fn mk_error(index: u64, tag: Option<&str>, msg: &str) -> ConnectorError {
+        ConnectorError {
+            timestamp: Utc.with_ymd_and_hms(2026, 4, 22, 12, 0, 0).unwrap(),
+            index,
+            tag: tag.map(str::to_string),
+            message: msg.to_string(),
+        }
+    }
+
+    /// A checkpoint containing error messages round-trips through JSON
+    /// serialization, and replaying the errors into a fresh
+    /// `ConnectorErrorList` yields the same flat form.
+    #[test]
+    fn input_checkpoint_roundtrip_preserves_errors() {
+        let original = CheckpointInputEndpointMetrics {
+            circuit_input_records: 42,
+            circuit_input_bytes: 1024,
+            num_transport_errors: 2,
+            num_parse_errors: 1,
+            transport_errors: vec![
+                mk_error(0, Some("kafka"), "broker unavailable"),
+                mk_error(1, Some("kafka"), "offset out of range"),
+            ],
+            parse_errors: vec![mk_error(0, None, "bad JSON: unexpected token")],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: CheckpointInputEndpointMetrics = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.num_transport_errors, 2);
+        assert_eq!(restored.num_parse_errors, 1);
+
+        // Replay into a ConnectorErrorList (what InputEndpointStatus::new does).
+        let transport = ConnectorErrorList::from_api_type(restored.transport_errors.clone());
+        let parse = ConnectorErrorList::from_api_type(restored.parse_errors.clone());
+
+        assert_eq!(transport.to_api_type(), original.transport_errors);
+        assert_eq!(parse.to_api_type(), original.parse_errors);
+    }
+
+    #[test]
+    fn output_checkpoint_roundtrip_preserves_errors() {
+        let original = CheckpointOutputEndpointMetrics {
+            transmitted_records: 99,
+            transmitted_bytes: 2048,
+            num_encode_errors: 3,
+            num_transport_errors: 0,
+            encode_errors: vec![
+                mk_error(0, Some("avro"), "schema mismatch"),
+                mk_error(1, Some("avro"), "null field"),
+                mk_error(2, None, "unknown"),
+            ],
+            transport_errors: vec![],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: CheckpointOutputEndpointMetrics = serde_json::from_str(&json).unwrap();
+        let encode = ConnectorErrorList::from_api_type(restored.encode_errors.clone());
+
+        assert_eq!(encode.to_api_type(), original.encode_errors);
+        assert!(restored.transport_errors.is_empty());
+    }
+
+    /// Old-format checkpoint (written before the error-list fields existed)
+    /// must still deserialize — missing fields default to empty vectors
+    /// which produce empty `ConnectorErrorList`s on restore, matching the
+    /// behavior the pipeline had before this change.
+    #[test]
+    fn input_checkpoint_backcompat_accepts_missing_error_fields() {
+        let old_format = r#"{
+            "circuit_input_records": 7,
+            "circuit_input_bytes": 128,
+            "num_transport_errors": 0,
+            "num_parse_errors": 0
+        }"#;
+        let m: CheckpointInputEndpointMetrics = serde_json::from_str(old_format).unwrap();
+
+        assert_eq!(m.circuit_input_records, 7);
+        assert!(m.transport_errors.is_empty());
+        assert!(m.parse_errors.is_empty());
+        assert!(
+            ConnectorErrorList::from_api_type(m.transport_errors)
+                .to_api_type()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn output_checkpoint_backcompat_accepts_missing_error_fields() {
+        let old_format = r#"{
+            "transmitted_records": 3,
+            "transmitted_bytes": 64,
+            "num_encode_errors": 0,
+            "num_transport_errors": 0
+        }"#;
+        let m: CheckpointOutputEndpointMetrics = serde_json::from_str(old_format).unwrap();
+
+        assert!(m.encode_errors.is_empty());
+        assert!(m.transport_errors.is_empty());
+    }
+
+    /// Serializing a checkpoint whose error lists are empty must not emit
+    /// the new fields as JSON keys, so checkpoint files written in the
+    /// common case stay as compact as before. (Substring check uses
+    /// quoted field names to avoid matching `num_transport_errors`.)
+    #[test]
+    fn input_checkpoint_omits_empty_error_fields_in_json() {
+        let m = CheckpointInputEndpointMetrics::default();
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(!json.contains("\"transport_errors\""));
+        assert!(!json.contains("\"parse_errors\""));
+    }
+
+    /// A malformed checkpoint could hold more errors for a single tag than
+    /// `MAX_CONNECTOR_ERRORS` (e.g. written by a build with a higher cap).
+    /// `from_api_type` must drop the oldest excess so the in-memory list
+    /// stays bounded; the newest entries are the ones kept.
+    #[test]
+    fn from_api_type_truncates_excess_per_tag() {
+        let overflow = 5usize;
+        let errors: Vec<ConnectorError> = (0..(MAX_CONNECTOR_ERRORS + overflow) as u64)
+            .map(|i| mk_error(i, Some("kafka"), &format!("err {i}")))
+            .collect();
+
+        let restored = ConnectorErrorList::from_api_type(errors).to_api_type();
+
+        assert_eq!(restored.len(), MAX_CONNECTOR_ERRORS);
+        // The first `overflow` entries must have been dropped; the oldest
+        // retained entry has index == overflow.
+        assert_eq!(restored.first().unwrap().index, overflow as u64);
+        assert_eq!(
+            restored.last().unwrap().index,
+            (MAX_CONNECTOR_ERRORS + overflow - 1) as u64
+        );
     }
 }

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -89,7 +89,7 @@ use utoipa::ToSchema;
 
 /// The number of the most recent errors stored for each endpoint as part of the endpoint status.
 /// There are separate counters for parse and transport errors and for every tag.
-const MAX_CONNECTOR_ERRORS: usize = 100;
+pub(crate) const MAX_CONNECTOR_ERRORS: usize = 100;
 
 /// Completion token.
 ///
@@ -469,6 +469,10 @@ pub struct ControllerStatusContext {
     pub transaction_info: TransactionInfo,
     pub memory_pressure: MemoryPressure,
     pub memory_pressure_epoch: u64,
+    /// When `true`, per-endpoint error messages are serialized alongside
+    /// the counters. Set by the support-bundle collector via the
+    /// `?include_connector_errors=true` query parameter on `/stats`.
+    pub include_connector_errors: bool,
 }
 
 impl ControllerStatus {
@@ -1327,7 +1331,7 @@ impl ControllerStatus {
         let mut inputs: Vec<_> = self
             .input_status()
             .values()
-            .map(|input| input.to_api_type(false))
+            .map(|input| input.to_api_type(ctx.include_connector_errors))
             .collect();
         inputs.sort_by(|ep1, ep2| ep1.endpoint_name.cmp(&ep2.endpoint_name));
 
@@ -1335,7 +1339,7 @@ impl ControllerStatus {
         let mut outputs: Vec<_> = self
             .output_status()
             .values()
-            .map(|output| output.to_api_type(false))
+            .map(|output| output.to_api_type(ctx.include_connector_errors))
             .collect();
         outputs.sort_by(|ep1, ep2| ep1.endpoint_name.cmp(&ep2.endpoint_name));
 
@@ -2007,6 +2011,15 @@ impl InputEndpointStatus {
         let paused_by_user =
             config.connector_config.paused || config.connector_config.start_after.is_some();
 
+        // When resuming from a checkpoint, restore the recent error messages
+        // alongside the counters.
+        let transport_errors = initial_statistics
+            .map(|s| ConnectorErrorList::from_api_type(s.transport_errors.clone()))
+            .unwrap_or_default();
+        let parse_errors = initial_statistics
+            .map(|s| ConnectorErrorList::from_api_type(s.parse_errors.clone()))
+            .unwrap_or_default();
+
         Self {
             endpoint_name: endpoint_name.to_string(),
             config,
@@ -2015,8 +2028,8 @@ impl InputEndpointStatus {
                     initial_statistics.into()
                 }),
             fatal_error: Mutex::new(None),
-            transport_errors: Mutex::new(ConnectorErrorList::new()),
-            parse_errors: Mutex::new(ConnectorErrorList::new()),
+            transport_errors: Mutex::new(transport_errors),
+            parse_errors: Mutex::new(parse_errors),
             health: Mutex::new(None),
             progress: Mutex::new(None),
             paused: AtomicBool::new(paused_by_user),
@@ -2421,6 +2434,45 @@ impl ConnectorErrorList {
         errors.sort_by_key(|error| error.index);
         errors
     }
+
+    /// Reconstruct a list from the flat representation produced by
+    /// [`Self::to_api_type`]. Used when restoring from a checkpoint.
+    ///
+    /// Restored errors keep their pre-restart `index`; the sequence
+    /// counter itself lives on [`InputEndpointMetrics`] /
+    /// [`OutputEndpointMetrics`] and is restored separately, so new
+    /// errors resume numbering from `counter + 1` (see
+    /// `InputEndpointStatus::parse_error` and
+    /// `OutputEndpointStatus::encode_error` / `transport_error`). Do not
+    /// renumber on restore.
+    ///
+    /// The per-tag [`MAX_CONNECTOR_ERRORS`] bound is re-enforced so that
+    /// a malformed checkpoint cannot make a list grow unbounded. If the
+    /// input exceeds the bound for any tag, the excess oldest entries
+    /// are dropped and a warning is logged.
+    pub fn from_api_type(errors: Vec<ConnectorError>) -> Self {
+        let mut list = Self::new();
+        let mut dropped: usize = 0;
+        for error in errors {
+            let entry: &mut VecDeque<ConnectorError> =
+                list.errors.entry(error.tag.clone()).or_default();
+            entry.push_back(error);
+            if entry.len() > MAX_CONNECTOR_ERRORS {
+                entry.pop_front();
+                dropped += 1;
+            }
+        }
+        if dropped > 0 {
+            warn!(
+                "restored connector error list exceeded per-tag cap of \
+                 {MAX_CONNECTOR_ERRORS}; dropped {dropped} oldest \
+                 entr{} — checkpoint may be malformed or written by a \
+                 build with a higher cap",
+                if dropped == 1 { "y" } else { "ies" }
+            );
+        }
+        list
+    }
 }
 
 /// Output endpoint status information.
@@ -2507,13 +2559,21 @@ impl OutputEndpointStatus {
         total_processed_records: u64,
         initial_statistics: Option<&CheckpointOutputEndpointMetrics>,
     ) -> Self {
+        // error lists are restored from the checkpoint if present, empty otherwise
+        let encode_errors = initial_statistics
+            .map(|s| ConnectorErrorList::from_api_type(s.encode_errors.clone()))
+            .unwrap_or_default();
+        let transport_errors = initial_statistics
+            .map(|s| ConnectorErrorList::from_api_type(s.transport_errors.clone()))
+            .unwrap_or_default();
+
         Self {
             endpoint_name: endpoint_name.to_string(),
             config: config.clone(),
             metrics: OutputEndpointMetrics::new(total_processed_records, initial_statistics),
             fatal_error: Mutex::new(None),
-            encode_errors: Mutex::new(ConnectorErrorList::new()),
-            transport_errors: Mutex::new(ConnectorErrorList::new()),
+            encode_errors: Mutex::new(encode_errors),
+            transport_errors: Mutex::new(transport_errors),
             health: Mutex::new(None),
         }
     }

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2310,6 +2310,7 @@ fn test_external_controller_status_serialization() {
         transaction_info: TransactionInfo::default(),
         memory_pressure: MemoryPressure::default(),
         memory_pressure_epoch: 0,
+        include_connector_errors: false,
     });
     external_status.global_metrics.rss_bytes = 1024 * 1024 * 512; // 512 MB
     external_status.global_metrics.cpu_msecs = 45_000;

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -1557,9 +1557,23 @@ async fn query(
     }
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct StatsParams {
+    /// When `true`, include the most recent error messages for each endpoint
+    /// in the response (up to `MAX_CONNECTOR_ERRORS` per list). Default is
+    /// `false` so that callers polling `/stats` keep getting a lightweight
+    /// response. This selector is intended for the support-bundle collector.
+    #[serde(default)]
+    include_connector_errors: bool,
+}
+
 #[get("/stats")]
-async fn stats(state: WebData<ServerState>) -> Result<HttpResponse, PipelineError> {
-    Ok(HttpResponse::Ok().json(state.controller()?.api_status()))
+async fn stats(
+    state: WebData<ServerState>,
+    params: Query<StatsParams>,
+) -> Result<HttpResponse, PipelineError> {
+    let include_connector_errors = params.into_inner().include_connector_errors;
+    Ok(HttpResponse::Ok().json(state.controller()?.api_status(include_connector_errors)))
 }
 
 /// This endpoint returns a subset of stats that don't need updating and so is more performant than /stats

--- a/crates/adapters/src/transport/nats/input/test/controller_framework.rs
+++ b/crates/adapters/src/transport/nats/input/test/controller_framework.rs
@@ -274,6 +274,7 @@ outputs:
                         transaction_info: TransactionInfo::default(),
                         memory_pressure: MemoryPressure::default(),
                         memory_pressure_epoch: 0,
+                        include_connector_errors: false,
                     },
                 ))
                 .unwrap()

--- a/crates/feldera-types/src/adapter_stats.rs
+++ b/crates/feldera-types/src/adapter_stats.rs
@@ -175,7 +175,7 @@ impl ConnectorHealth {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, ToSchema, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, ToSchema, Clone, PartialEq, Eq)]
 pub struct ConnectorError {
     /// Timestamp when the error occurred, serialized as RFC3339 with microseconds.
     #[serde(serialize_with = "serialize_timestamp_micros")]

--- a/crates/pipeline-manager/src/api/support_data_collector.rs
+++ b/crates/pipeline-manager/src/api/support_data_collector.rs
@@ -99,13 +99,18 @@ impl Default for SupportBundleParameters {
     }
 }
 
-/// Fetch data from a pipeline endpoint
+/// Fetch data from a pipeline endpoint.
+///
+/// `query_string` is appended verbatim after `?` and must already be URL-encoded
+/// (e.g., `"include_connector_errors=true"`). Pass `""` for endpoints that take no query.
+#[allow(clippy::too_many_arguments)]
 async fn fetch_pipeline_data(
     state: &ServerState,
     client: &awc::Client,
     tenant_id: TenantId,
     pipeline_name: &str,
     endpoint: &str,
+    query_string: &str,
     timeout_duration: Option<Duration>,
     body_size_limit: Option<usize>,
 ) -> Result<HttpResponse, ManagerError> {
@@ -117,7 +122,7 @@ async fn fetch_pipeline_data(
             pipeline_name,
             Method::GET,
             endpoint,
-            "",
+            query_string,
             timeout_duration,
             body_size_limit,
         )
@@ -481,6 +486,7 @@ impl SupportBundleData {
             tenant_id,
             pipeline_name,
             "dump_profile",
+            "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
         )
@@ -501,6 +507,7 @@ impl SupportBundleData {
             tenant_id,
             pipeline_name,
             "dump_json_profile",
+            "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
         )
@@ -534,6 +541,7 @@ impl SupportBundleData {
             tenant_id,
             pipeline_name,
             "heap_profile",
+            "",
             Some(COLLECTION_TIMEOUT),
             Some(EXTENDED_RESPONSE_SIZE_LIMIT),
         )
@@ -554,6 +562,7 @@ impl SupportBundleData {
             tenant_id,
             pipeline_name,
             "metrics",
+            "",
             Some(COLLECTION_TIMEOUT),
             None,
         )
@@ -573,6 +582,11 @@ impl SupportBundleData {
             .map_err(|e| e.to_string())
     }
 
+    /// Fetch `/stats` from the running pipeline, requesting
+    /// `?include_connector_errors=true` so the response carries the recent
+    /// per-endpoint error message arrays alongside the counters. Connector
+    /// error messages survive pipeline restarts via the checkpoint, so
+    /// post-resume bundles still capture them.
     async fn collect_stats(
         state: &ServerState,
         client: &awc::Client,
@@ -585,6 +599,7 @@ impl SupportBundleData {
             tenant_id,
             pipeline_name,
             "stats",
+            "include_connector_errors=true",
             Some(COLLECTION_TIMEOUT),
             None,
         )

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -19,6 +19,15 @@ import TabItem from '@theme/TabItem';
           It does not get get cleared when the pipeline stops, only when the storage is cleared.
         - (Fix) Dedicated error `BootstrapPolicyImmutableUnlessStopped` for repeated `/start` of a
           pipeline but with a different bootstrap policy.
+        - (New) Recent per-endpoint connector error messages are now persisted in the pipeline
+          checkpoint and restored on resume, so debugging information survives a restart. The
+          `/stats` endpoint gains an opt-in `?include_connector_errors=true` selector that inlines
+          these messages alongside the counters; the default response is unchanged so hot pollers
+          stay lightweight. The support bundle collector uses the selector automatically.
+        - (Checkpoint format) Backwards-compatible extension: `CheckpointInputEndpointMetrics` and
+          `CheckpointOutputEndpointMetrics` gain optional `parse_errors` / `transport_errors` /
+          `encode_errors` fields. Old checkpoints load as empty lists; checkpoints with no errors
+          still serialize without the new keys, so unaffected files stay byte-identical.
 
         Functions `RLIKE` and `REPLACE_REGEXP` will crash for invalid
         regular expressions.  Previously they treated such as expressions

--- a/docs.feldera.com/docs/operations/guide.md
+++ b/docs.feldera.com/docs/operations/guide.md
@@ -62,11 +62,18 @@ The support bundle has the following content:
 
 3. **Pipeline Metrics**: from the [pipeline metrics](/api/get-pipeline-metrics) endpoint.
 
-3. **Endpoint Stats**: from the [stats](/api/get-pipeline-stats) endpoint.
+4. **Endpoint Stats**: from the [stats](/api/get-pipeline-stats) endpoint.
+   The bundle collector calls this endpoint with
+   `?include_connector_errors=true` so the saved `stats.json` contains the
+   most recent per-endpoint error messages alongside the counters. These
+   error messages are persisted in the pipeline's checkpoint, so a bundle
+   taken after a restart still contains errors recorded before the restart.
+   The selector is intended for the bundle collector; regular callers
+   polling `/stats` keep getting a lightweight, count-only response.
 
-4. **Circuit Profile**: from the [circuit profile](/api/get-performance-profile) endpoint.
+5. **Circuit Profile**: from the [circuit profile](/api/get-performance-profile) endpoint.
 
-5. **Heap Profile**: from [heap usage](/api/get-heap-profile) endpoint.
+6. **Heap Profile**: from [heap usage](/api/get-heap-profile) endpoint.
 
 ## Common Error Messages
 

--- a/python/tests/platform/test_connector_status.py
+++ b/python/tests/platform/test_connector_status.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any
 
 from feldera import Pipeline
@@ -6,7 +7,7 @@ from feldera.pipeline_builder import PipelineBuilder
 from feldera.rest.errors import FelderaAPIError
 from tests import TEST_CLIENT, enterprise_only
 
-from .helper import gen_pipeline_name, wait_for_condition
+from .helper import api_url, gen_pipeline_name, get, wait_for_condition
 
 
 def _http_connector_stats(pipeline: Pipeline) -> tuple[list[Any], list[Any]]:
@@ -201,3 +202,125 @@ def test_http_connector_status_across_restart_and_sql_changes(pipeline_name):
         timeout_s=60.0,
         poll_interval_s=1.0,
     )
+
+
+def _fetch_stats_with_errors(name: str) -> dict:
+    """Call `/stats?include_connector_errors=true` and return the parsed JSON."""
+    resp = get(api_url(f"/pipelines/{name}/stats?include_connector_errors=true"))
+    assert resp.status_code == HTTPStatus.OK, (
+        f"/stats returned {resp.status_code}: {resp.text}"
+    )
+    return resp.json()
+
+
+def _input_parse_error_messages(stats_json: dict, table_name: str) -> list[str]:
+    """Pluck parse-error messages for any input connector targeting `table_name`.
+
+    The bundle selector returns error arrays inline on each endpoint; counts
+    without the selector would instead leave the arrays absent. Sorted for
+    order-independent comparison.
+    """
+    messages: list[str] = []
+    for entry in stats_json.get("inputs", []):
+        config = entry.get("config") or {}
+        if config.get("stream", "").split(".")[-1].lower() != table_name.lower():
+            continue
+        for err in entry.get("parse_errors") or []:
+            messages.append(err.get("message", ""))
+    return sorted(messages)
+
+
+@enterprise_only
+@gen_pipeline_name
+def test_parse_error_messages_survive_restart(pipeline_name):
+    """
+    Recent parse-error messages are persisted in the checkpoint and exposed
+    through /stats?include_connector_errors=true after a stop+start cycle.
+
+    Covers the core behaviour guarded by the checkpoint-persistence change:
+    not only the parse-error *count* but the message payload must be recovered.
+    """
+
+    sql = "CREATE TABLE input_t(c1 INT); CREATE MATERIALIZED VIEW v AS SELECT * FROM input_t;"
+    pipeline: Pipeline = PipelineBuilder(
+        TEST_CLIENT,
+        pipeline_name,
+        sql=sql,
+    ).create_or_replace()
+    pipeline.start()
+
+    # Seed one valid record so the input connector exists, then two distinct
+    # malformed records so we produce two parse errors with different messages.
+    pipeline.input_json("input_t", [{"c1": 1}])
+
+    for bad in ([{"c1": "not_an_int"}], [{"c1": [1, 2, 3]}]):
+        try:
+            TEST_CLIENT.push_to_pipeline(
+                pipeline.name,
+                "input_t",
+                "json",
+                bad,
+                array=True,
+                update_format="raw",
+            )
+        except FelderaAPIError:
+            # HTTP ingress surfaces 400 for parse failures; the connector
+            # still records the error, which is what we assert below.
+            pass
+
+    def two_parse_errors_with_messages() -> bool:
+        status = _single_input_status(pipeline, "input_t")
+        if status is None or status.metrics.num_parse_errors < 2:
+            return False
+        stats_json = _fetch_stats_with_errors(pipeline.name)
+        return len(_input_parse_error_messages(stats_json, "input_t")) >= 2
+
+    wait_for_condition(
+        "two parse errors with messages recorded before restart",
+        two_parse_errors_with_messages,
+        timeout_s=60.0,
+        poll_interval_s=1.0,
+    )
+
+    # Snapshot messages before restart so we can assert exact-match survival.
+    before = _input_parse_error_messages(
+        _fetch_stats_with_errors(pipeline.name), "input_t"
+    )
+    assert len(before) >= 2, (
+        f"expected >=2 parse-error messages pre-restart, got {before}"
+    )
+
+    # Stop with checkpoint, then start again; the restored endpoint status
+    # must carry the same error messages, not just the counts.
+    pipeline.stop(force=False)
+    pipeline.start()
+
+    def errors_restored() -> bool:
+        status = _single_input_status(pipeline, "input_t")
+        if status is None or status.metrics.num_parse_errors < 2:
+            return False
+        after = _input_parse_error_messages(
+            _fetch_stats_with_errors(pipeline.name), "input_t"
+        )
+        return after == before
+
+    wait_for_condition(
+        "parse-error messages restored from checkpoint after restart",
+        errors_restored,
+        timeout_s=60.0,
+        poll_interval_s=1.0,
+    )
+
+    # Guardrail for the non-selector path: without the query param, the
+    # error-message arrays must not appear in the /stats response — this keeps
+    # the hot polling endpoint lightweight for the web console.
+    plain = get(api_url(f"/pipelines/{pipeline.name}/stats")).json()
+    for entry in plain.get("inputs", []):
+        assert entry.get("parse_errors") is None, (
+            f"/stats without selector leaked parse_errors: {entry}"
+        )
+        assert entry.get("transport_errors") is None, (
+            f"/stats without selector leaked transport_errors: {entry}"
+        )
+
+    pipeline.stop(force=True)


### PR DESCRIPTION
Previously only error *counts* survived a pipeline restart via the
checkpoint; the actual messages were lost, which made post-restart
debugging hard.

The pipeline now stores per-endpoint connector errors in the checkpoint
and restores them on resume. Backwards compatible: old checkpoints
missing the new fields are parsed as empty error lists, and empty
lists are omitted on serialization so unaffected checkpoints stay
byte-identical.

InputEndpointStatus::new / OutputEndpointStatus::new seed their
ConnectorErrorList from the checkpoint via a new
ConnectorErrorList::from_api_type, which re-enforces
MAX_CONNECTOR_ERRORS per tag against a malformed checkpoint.

To expose the restored messages, /stats gains an opt-in
?include_connector_errors=true selector that populates each
endpoint's parse_errors / transport_errors / encode_errors arrays
alongside the counters. The default /stats response stays lightweight
for web-console polling. The selector is intended for the
support-bundle collector, which calls /stats with it so the
bundle's stats.json carries the messages.

Tests cover checkpoint round-trip, pre-field backwards compatibility,
the empty-list-omitted invariant, and an enterprise integration
test that restarts a pipeline after producing parse errors and
asserts the messages reappear via the selector on /stats.

Fixes #5968 #5969

### Describe Manual Test Plan

Tested manually by restarting pipeline and checking error counts and messages in support bundle 

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [x] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] Adapters (including configuration)
- [x] Storage Format / Checkpoints
- [x] Others (specify)

### Describe Incompatible Changes

This shouldn't _break_ anything and be backwards compatible. But still marked as breaking change to be explicit
