### PR TITLE
Added instructions for installing dependencies on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ To run Feldera from sources, ensure at least 6 GB of free space in the sources d
 - [Bun](https://bun.sh/docs/installation)
 - [nodejs v20](https://github.com/nodesource/distributions/blob/master/DEV_README.md)
 
+On MacOS, after installing the Rust tool chain, the remaining dependencies can be installed with:
+```
+xcode-select --install
+```
+for Xcode tools that includes clang, and
+```
+brew install cmake openssl cyrus-sasl go pkg-config zstd openjdk@21 maven oven-sh/bun/bun node@20
+```
+for the rest.
+
 After that, the first step is to build the SQL compiler:
 
 ```


### PR DESCRIPTION
I tried to install Feldera locally on MacOS, after talking with Mihai, and noticed that some of the dependencies have different names vs. Linux (for which the existing instructions seem to be for), so I added some instructions for MacOS to the README.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
