### PR TITLE
cargo: update `openssl` to `0.10.78`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7866,9 +7866,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -7898,9 +7898,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ num-format = "0.4.0"
 num-traits = "0.2.19"
 object_store = "0.11.2"
 once_cell = "1.20.2"
-openssl = "0.10.72"
+openssl = "0.10.78"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 ouroboros = "0.18.4"
 parquet = "57"


### PR DESCRIPTION
- `openssl`: `0.10.73` -> `0.10.78`
- `openssl-sys`: `0.9.109` -> `0.9.114`

Relevant CHANGELOG: https://github.com/rust-openssl/rust-openssl/blob/master/openssl/CHANGELOG.md