### PR TITLE
retries with tenacity for python sdk

### DIFF
--- a/python/feldera/__init__.py
+++ b/python/feldera/__init__.py
@@ -1,4 +1,5 @@
 from feldera.rest.feldera_client import FelderaClient as FelderaClient
+from feldera.rest.retry import RetryConfig as RetryConfig
 from feldera.pipeline import Pipeline as Pipeline
 from feldera.pipeline_builder import PipelineBuilder as PipelineBuilder
 from feldera.rest._helpers import determine_client_version

--- a/python/feldera/rest/__init__.py
+++ b/python/feldera/rest/__init__.py
@@ -9,3 +9,4 @@ instead of using the REST client directly.
 """
 
 from feldera.rest.feldera_client import FelderaClient as FelderaClient
+from feldera.rest.retry import RetryConfig as RetryConfig

--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -1,10 +1,27 @@
+from __future__ import annotations
+
 import json
 import logging
-import time
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Union
+import random
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import requests
 from requests.packages import urllib3
+from tenacity import (
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from feldera.rest.config import Config
 from feldera.rest.errors import (
@@ -13,10 +30,17 @@ from feldera.rest.errors import (
     FelderaTimeoutError,
 )
 
+if TYPE_CHECKING:
+    from tenacity import RetryCallState
+
 
 def json_serialize(body: Any) -> str:
     # serialize as string if this object cannot be serialized (e.g. UUID)
     return json.dumps(body, default=str) if body else "" if body == "" else "null"
+
+
+def _is_502(exc: BaseException) -> bool:
+    return isinstance(exc, FelderaAPIError) and exc.status_code == 502
 
 
 class HttpRequests:
@@ -32,11 +56,7 @@ class HttpRequests:
             self.headers["Authorization"] = f"Bearer {self.config.api_key}"
 
     def _check_cluster_health(self) -> bool:
-        """Check cluster health via /cluster_healthz endpoint.
-
-        Returns:
-            bool: True if both runner and compiler services are healthy, False otherwise
-        """
+        """Check `/cluster_healthz`; return True iff `all_healthy` is reported."""
         try:
             health_path = (
                 self.config.url + "/" + self.config.version + "/cluster_healthz"
@@ -49,98 +69,80 @@ class HttpRequests:
             )
 
             if response.status_code == 200:
-                health_data = response.json()
-                all_healthy = health_data.get("all_healthy", False)
-                return all_healthy
-            else:
-                logging.warning(
-                    f"Health check returned status {response.status_code}. The instance might be in the process of being upgraded. Waiting to see if it recovers."
-                )
-                return False
+                return bool(response.json().get("all_healthy", False))
+            logging.warning(
+                "Health check returned status %d; instance may be upgrading",
+                response.status_code,
+            )
+            return False
         except Exception as e:
-            logging.error(f"Health check failed: {e}")
+            logging.error("Health check failed: %s", e)
             return False
 
-    def _wait_for_health_recovery(self, max_wait_seconds: int = 300) -> bool:
-        """
-        Wait for cluster to become healthy after detecting upgrade/restart.
-
-        Args:
-            max_wait_seconds: Maximum time to wait for health recovery (default 5 minutes)
-
-        Returns:
-            bool: True if cluster became healthy within timeout, False otherwise
-        """
-        start_time = time.monotonic()
-        check_interval = 5
-
-        logging.info(
-            f"Waiting for cluster health recovery (max {max_wait_seconds}s)..."
-        )
-
-        while time.monotonic() - start_time < max_wait_seconds:
-            if self._check_cluster_health():
-                elapsed = time.monotonic() - start_time
-                logging.info(f"Instance health recovered after {elapsed:.1f}s")
-                return True
-
-            time.sleep(check_interval)
-            elapsed = time.monotonic() - start_time
-            logging.debug(
-                f"Still waiting for health recovery ({elapsed:.1f}s elapsed)..."
-            )
-
-        logging.warning(f"Instance did not recover within {max_wait_seconds}s timeout")
+    def _is_retryable(self, exc: BaseException) -> bool:
+        """Define which exceptions are worth retrying."""
+        if isinstance(exc, requests.exceptions.Timeout):
+            return True
+        if isinstance(exc, FelderaAPIError):
+            return exc.status_code in self.config.retry_config.retryable_status_codes
         return False
 
-    def _handle_502_with_health_check(
-        self, path: str, attempt: int, max_retries: int
-    ) -> bool:
+    def _custom_wait(self, retry_state: "RetryCallState") -> float:
         """
-        Handles 502 errors with health monitoring.
-
-        Args:
-            path: The request path that failed
-            attempt: Current attempt number (0-based)
-            max_retries: Maximum number of retries allowed
-
-        Returns:
-            bool: True if should retry, False if should give up
+        Compute the wait between retries. Branches by exception type:
+          - `Retry-After` header (if any) wins, capped at `max_backoff`.
+          - 502: probe `/cluster_healthz`. If the cluster is healthy the 502
+            is treated as spurious — return 0 so the retry runs immediately.
+            Otherwise return the configured `unhealthy_backoff` (a flat wait
+            while an upgrade or restart completes).
+          - Everything else: exponential backoff plus optional jitter.
         """
-        if attempt >= max_retries:
-            return False
+        cfg = self.config.retry_config
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
 
-        logging.warning(
-            f"HTTP 502 received for {path} (attempt {attempt + 1}/{max_retries + 1}), checking cluster health..."
+        retry_after = getattr(exc, "retry_after", None)
+        if retry_after is not None:
+            return min(float(retry_after), cfg.max_backoff)
+
+        if _is_502(exc):
+            if self._check_cluster_health():
+                logging.info("Cluster healthy — treating 502 as spurious")
+                return 0.0
+            logging.info(
+                "Cluster unhealthy; backing off %.1fs before retrying 502",
+                cfg.unhealthy_backoff,
+            )
+            return cfg.unhealthy_backoff
+
+        backoff = wait_exponential(
+            multiplier=cfg.initial_backoff,
+            exp_base=cfg.multiplier,
+            max=cfg.max_backoff,
+        )(retry_state)
+        if cfg.jitter > 0:
+            backoff += random.uniform(0, cfg.jitter)
+        return backoff
+
+    def _do_single_request(
+        self,
+        http_method: Callable,
+        request_path: str,
+        data: Any,
+        params: Optional[Mapping[str, Any]],
+        stream: bool,
+    ) -> Any:
+        response = http_method(
+            request_path,
+            data=data,
+            timeout=(self.config.connection_timeout, self.config.timeout),
+            headers=self.headers,
+            params=params,
+            stream=stream,
+            verify=self.requests_verify,
         )
-
-        # Do a short backoff and retry
-        time.sleep(min(2 << attempt, 64))
-
-        # First, check if cluster is currently healthy
-        if self._check_cluster_health():
-            # Instance appears healthy, this might be a spurious 502
-            logging.info(
-                f"Instance appears healthy, treating 502 for {path} as spurious - retrying"
-            )
-            return True
-        else:
-            # Instance is unhealthy, likely an upgrade/restart scenario
-            logging.info(
-                f"Instance unhealthy for request to {path}, likely upgrade in progress - waiting for recovery..."
-            )
-
-            # Wait for cluster to recover (up to 5 minutes)
-            recovery_timeout = self.config.health_recovery_timeout
-            if self._wait_for_health_recovery(max_wait_seconds=recovery_timeout):
-                logging.info(f"Instance health recovered, can now retry {path}...")
-                return True
-            else:
-                # Health didn't recover within timeout
-                logging.error(
-                    f"Instance health did not recover within {recovery_timeout}s timeout for {path}, giving up"
-                )
-                return False
+        resp = self.__validate(response, stream=stream)
+        logging.debug("got response: %s", str(resp))
+        return resp
 
     def send_request(
         self,
@@ -153,21 +155,8 @@ class HttpRequests:
         params: Optional[Mapping[str, Any]] = None,
         stream: bool = False,
         serialize: bool = True,
-        max_retries: int = 3,
     ) -> Any:
         """
-        Send HTTP request with intelligent retry logic.
-
-        Handles different error conditions with appropriate retry strategies:
-        - 502 errors: Checks cluster health and waits for recovery during upgrades
-        - 503/408 errors: Standard retry with backoff
-        - Timeout errors: Standard retry with backoff
-
-        For 502 errors, the method distinguishes between:
-        1. Spurious 502s (cluster healthy): Quick retry with short backoff
-        2. Upgrade scenarios (cluster unhealthy): Waits up to health_recovery_timeout
-           for cluster to become healthy, then retries
-
         :param http_method: The HTTP method to use. Takes the equivalent `requests.*` module. (Example: `requests.get`)
         :param path: The path to send the request to.
         :param body: The HTTP request body.
@@ -175,104 +164,58 @@ class HttpRequests:
         :param params: The query parameters part of this request.
         :param stream: True if the response is expected to be a HTTP stream.
         :param serialize: True if the body needs to be serialized to JSON.
-        :param max_retries: Maximum number of retry attempts.
+
+        Send an HTTP request, retrying transient failures per the client's
+        `RetryConfig`.
+
+        Retry policy:
+        - Status codes in `retry_config.retryable_status_codes` (default
+          408, 429, 502, 503, 504) and connection/read timeouts retry.
+        - 502 probes `/cluster_healthz` to distinguish a spurious gateway
+          error (cluster healthy → retry immediately) from a real outage
+          (cluster unhealthy → wait `unhealthy_backoff` seconds before
+          retrying).
+        - Other retryable failures use exponential backoff with optional
+          jitter; a server-supplied `Retry-After` header overrides it
+          (capped at `max_backoff`).
+        - All other errors are raised immediately.
         """
         self.headers["Content-Type"] = content_type
+        request_path = self.config.url + "/" + self.config.version + path
 
-        prev_resp: requests.Response | None = None
+        # Serialize the body once, not per retry. None / bytes / `serialize=False`
+        # all pass through unchanged.
+        if body is None or isinstance(body, bytes) or not serialize:
+            data = body
+        else:
+            data = json_serialize(body)
+
+        logging.debug(
+            "sending %s request to: %s with headers: %s, and params: %s",
+            http_method.__name__,
+            request_path,
+            str(self.headers),
+            str(params),
+        )
+
+        cfg = self.config.retry_config
+        retryer = Retrying(
+            retry=retry_if_exception(self._is_retryable),
+            wait=self._custom_wait,
+            stop=stop_after_attempt(cfg.max_retries + 1),
+            reraise=True,
+        )
 
         try:
-            conn_timeout = self.config.connection_timeout
-            timeout = self.config.timeout
-            headers = self.headers
-
-            request_path = self.config.url + "/" + self.config.version + path
-
-            logging.debug(
-                "sending %s request to: %s with headers: %s, and params: %s",
-                http_method.__name__,
-                request_path,
-                str(headers),
-                str(params),
-            )
-
-            for attempt in range(max_retries):
-                if http_method.__name__ == "get":
-                    request = http_method(
-                        request_path,
-                        timeout=(conn_timeout, timeout),
-                        headers=headers,
-                        params=params,
-                        stream=stream,
-                        verify=self.requests_verify,
+            for attempt in retryer:
+                with attempt:
+                    return self._do_single_request(
+                        http_method, request_path, data, params, stream
                     )
-                elif isinstance(body, bytes):
-                    request = http_method(
-                        request_path,
-                        timeout=(conn_timeout, timeout),
-                        headers=headers,
-                        data=body,
-                        params=params,
-                        stream=stream,
-                        verify=self.requests_verify,
-                    )
-                else:
-                    request = http_method(
-                        request_path,
-                        timeout=(conn_timeout, timeout),
-                        headers=headers,
-                        data=json_serialize(body) if serialize else body,
-                        params=params,
-                        stream=stream,
-                        verify=self.requests_verify,
-                    )
-
-                prev_resp = request
-
-                try:
-                    resp = self.__validate(request, stream=stream)
-                    logging.debug("got response: %s", str(resp))
-                    return resp
-                except FelderaAPIError as err:
-                    # Handle 502 with intelligent health monitoring
-                    if err.status_code == 502:
-                        if self._handle_502_with_health_check(
-                            path, attempt, max_retries
-                        ):
-                            continue
-                        else:
-                            raise
-                    # Handle other retryable errors
-                    elif err.status_code in [408, 503, 504]:
-                        if attempt < max_retries:
-                            logging.warning(
-                                "HTTP %d received for %s, retrying (%d/%d)...",
-                                err.status_code,
-                                path,
-                                attempt + 1,
-                                max_retries,
-                            )
-                            time.sleep(min(2 << attempt, 64))
-                            continue
-                    raise  # re-raise for all other errors or if out of retries
-                except requests.exceptions.Timeout as err:
-                    if attempt < max_retries:
-                        logging.warning(
-                            "HTTP Connection Timeout for %s, retrying (%d/%d)...",
-                            path,
-                            attempt + 1,
-                            max_retries,
-                        )
-                        time.sleep(2)
-                        continue
-                    raise FelderaTimeoutError(str(err)) from err
-
+        except requests.exceptions.Timeout as err:
+            raise FelderaTimeoutError(str(err)) from err
         except requests.exceptions.ConnectionError as err:
             raise FelderaCommunicationError(str(err)) from err
-
-        raise FelderaAPIError(
-            "Max retries exceeded, couldn't successfully connect to Feldera", prev_resp
-        )
 
     def get(
         self,

--- a/python/feldera/rest/config.py
+++ b/python/feldera/rest/config.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 from feldera.rest._helpers import requests_verify_from_env
+from feldera.rest.retry import RetryConfig
 
 
 class Config:
@@ -19,22 +20,22 @@ class Config:
         timeout: Optional[float] = None,
         connection_timeout: Optional[float] = None,
         requests_verify: Optional[bool | str] = None,
-        health_recovery_timeout: Optional[int] = None,
+        retry_config: Optional[RetryConfig] = None,
     ) -> None:
         """
         See documentation of the `FelderaClient` constructor for the other arguments.
 
         :param version: (Optional) Version of the API to use.
             Default: `v0`.
-        :param health_recovery_timeout: (Optional) Maximum time in seconds to wait for cluster health recovery after a 502 error.
-            Default: `300` (5 minutes).
+        :param retry_config: (Optional) Retry behavior for transient HTTP failures.
+            Default: `RetryConfig()` — 3 retries with exponential backoff starting at 2 seconds.
         """
         self.url: str = url or os.environ.get("FELDERA_HOST") or "http://localhost:8080"
         self.api_key: Optional[str] = api_key or os.environ.get("FELDERA_API_KEY")
         self.version: str = version or "v0"
         self.timeout: Optional[float] = timeout
         self.connection_timeout: Optional[float] = connection_timeout
-        self.health_recovery_timeout: int = health_recovery_timeout or 300
+        self.retry_config: RetryConfig = retry_config or RetryConfig()
         env_verify = requests_verify_from_env()
         self.requests_verify: bool | str = (
             requests_verify if requests_verify is not None else env_verify

--- a/python/feldera/rest/errors.py
+++ b/python/feldera/rest/errors.py
@@ -1,6 +1,32 @@
 from requests import Response
 import json
+from datetime import datetime, timezone
+from typing import Optional
 from urllib.parse import urlparse
+
+
+# RFC 9110 §5.6.7: HTTP-date "IMF-fixdate" format used by `Retry-After`.
+_HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """
+    Parse an HTTP `Retry-After` header into a delay in seconds.
+
+    Returns `None` if missing or unparseable. Per RFC 9110, the value is
+    either a non-negative integer of seconds or an IMF-fixdate HTTP-date.
+    """
+    if not value:
+        return None
+    try:
+        return max(float(value), 0.0)
+    except ValueError:
+        pass
+    try:
+        retry_at = datetime.strptime(value, _HTTP_DATE_FMT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    return max((retry_at - datetime.now(timezone.utc)).total_seconds(), 0.0)
 
 
 class FelderaError(Exception):
@@ -25,6 +51,9 @@ class FelderaAPIError(FelderaError):
         self.error_code = None
         self.message = None
         self.details = None
+        self.retry_after: Optional[float] = _parse_retry_after(
+            request.headers.get("Retry-After")
+        )
 
         err_msg = ""
 

--- a/python/feldera/rest/feldera_client.py
+++ b/python/feldera/rest/feldera_client.py
@@ -15,6 +15,7 @@ from feldera.rest.config import Config
 from feldera.rest.errors import FelderaAPIError, FelderaTimeoutError
 from feldera.rest.feldera_config import FelderaConfig
 from feldera.rest.pipeline import Pipeline
+from feldera.rest.retry import RetryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,7 @@ class FelderaClient:
         timeout: Optional[float] = None,
         connection_timeout: Optional[float] = None,
         requests_verify: Optional[bool | str] = None,
+        retry_config: Optional[RetryConfig] = None,
     ) -> None:
         """
         Constructs a Feldera client.
@@ -80,6 +82,9 @@ class FelderaClient:
             By setting `FELDERA_TLS_INSECURE` to `"1"`, `"true"` or `"yes"` (all case-insensitive), the default becomes
             `False` which means to disable TLS verification by default. If both variables are set, the former takes
             priority over the latter. If neither variable is set, the default is `True`.
+        :param retry_config: (Optional) Retry behavior for transient HTTP failures
+            (408, 502, 503, 504, timeouts). The default is `RetryConfig()` — 3 retries
+            with exponential backoff starting at 2 seconds.
         """
 
         self.config = Config(
@@ -88,6 +93,7 @@ class FelderaClient:
             timeout=timeout,
             connection_timeout=connection_timeout,
             requests_verify=requests_verify,
+            retry_config=retry_config,
         )
         self.http = HttpRequests(self.config)
 

--- a/python/feldera/rest/retry.py
+++ b/python/feldera/rest/retry.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass, field
+from typing import FrozenSet
+
+
+_DEFAULT_RETRYABLE_STATUS_CODES: FrozenSet[int] = frozenset({408, 429, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """
+    Configures retry behavior for the Feldera HTTP client.
+
+    Retries are attempted on transient failures: connection/read timeouts and
+    the HTTP statuses listed in `retryable_status_codes` (408, 429, 502, 503,
+    504 by default).
+
+    Wait strategies:
+      - 408, 429, 503, 504 and connection/read timeouts use exponential
+        backoff: `min(initial_backoff * (multiplier ** n), max_backoff)`,
+        plus a uniform random `[0, jitter)` term, where `n` is the
+        zero-based retry index.
+      - 502 uses cluster-aware backoff: the client probes
+        `/cluster_healthz`; if the cluster is healthy, the 502 is treated as
+        spurious and the next retry runs immediately (wait = 0). If the
+        cluster reports unhealthy (e.g. an upgrade is in progress), the next
+        retry waits `unhealthy_backoff` seconds.
+      - A server-supplied `Retry-After` header always overrides the computed
+        wait (capped at `max_backoff`).
+
+    :param max_retries: Number of retries to attempt after the initial request.
+        A value of `3` means up to `4` total attempts. Must be `>= 0`.
+        Default: `3`.
+    :param initial_backoff: Base wait in seconds before the first retry.
+        Default: `2.0`.
+    :param max_backoff: Maximum wait in seconds between retries. The computed
+        exponential wait is clamped to this value. Default: `64.0`.
+    :param multiplier: Exponential base applied to `initial_backoff` for each
+        successive retry. Default: `2.0`.
+    :param jitter: Maximum random extra wait in seconds added to each
+        exponential backoff (drawn uniformly from `[0, jitter)`). Helps avoid
+        thundering-herd retries when many clients fail at once.
+        Default: `0.0` (no jitter).
+    :param unhealthy_backoff: Flat wait in seconds between 502 retries when
+        the cluster reports unhealthy on `/cluster_healthz`. The cluster is
+        likely upgrading/restarting, so a flat pause is preferable to an
+        exponential ramp. Default: `90.0`.
+    :param retryable_status_codes: HTTP status codes that should trigger a
+        retry. Default: `{408, 429, 502, 503, 504}`.
+    """
+
+    max_retries: int = 3
+    initial_backoff: float = 2.0
+    max_backoff: float = 64.0
+    multiplier: float = 2.0
+    jitter: float = 0.0
+    unhealthy_backoff: float = 90.0
+    retryable_status_codes: FrozenSet[int] = field(
+        default_factory=lambda: _DEFAULT_RETRYABLE_STATUS_CODES
+    )
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if self.initial_backoff < 0:
+            raise ValueError("initial_backoff must be >= 0")
+        if self.max_backoff < 0:
+            raise ValueError("max_backoff must be >= 0")
+        if self.multiplier <= 0:
+            raise ValueError("multiplier must be > 0")
+        if self.jitter < 0:
+            raise ValueError("jitter must be >= 0")
+        if self.unhealthy_backoff < 0:
+            raise ValueError("unhealthy_backoff must be >= 0")
+        # Coerce to frozenset so callers can pass a set/list without surprises,
+        # and so equality comparisons against the default behave intuitively.
+        if not isinstance(self.retryable_status_codes, frozenset):
+            object.__setattr__(
+                self, "retryable_status_codes", frozenset(self.retryable_status_codes)
+            )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pretty-errors",
     "ruff>=0.6.9",
     "PyJWT>=2.12.0",
+    "tenacity>=9.1.4",
 ]
 [project.urls]
 Homepage = "https://www.feldera.com"

--- a/python/tests/unit/test_httprequests_retry.py
+++ b/python/tests/unit/test_httprequests_retry.py
@@ -1,0 +1,398 @@
+"""Tests for the tenacity-based retry behavior in HttpRequests."""
+
+from __future__ import annotations
+
+import dataclasses
+from contextlib import contextmanager
+from typing import Iterable, List, Optional
+from unittest import mock
+
+import pytest
+import requests
+
+from feldera.rest._httprequests import HttpRequests
+from feldera.rest.config import Config
+from feldera.rest.errors import (
+    FelderaAPIError,
+    FelderaCommunicationError,
+    FelderaTimeoutError,
+)
+from feldera.rest.retry import RetryConfig
+
+
+def _make_response(
+    status_code: int,
+    body: bytes = b"{}",
+    content_type: str = "application/json",
+    headers: Optional[dict] = None,
+) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = body
+    resp.headers["content-type"] = content_type
+    if headers:
+        for k, v in headers.items():
+            resp.headers[k] = v
+    # __validate uses request.request.url when formatting 401 messages — supply
+    # a harmless PreparedRequest so attribute access does not fail elsewhere.
+    prepared = requests.PreparedRequest()
+    prepared.prepare(method="GET", url="http://example.test/v0/x")
+    resp.request = prepared
+    return resp
+
+
+def _fast_retry(max_retries: int = 3, **overrides) -> RetryConfig:
+    # Near-zero backoff so tests finish quickly.
+    base = dict(
+        max_retries=max_retries,
+        initial_backoff=0.0,
+        max_backoff=0.0,
+        multiplier=1.0,
+        unhealthy_backoff=0.0,
+    )
+    base.update(overrides)
+    return RetryConfig(**base)
+
+
+def _make_client(retry_config: Optional[RetryConfig] = None) -> HttpRequests:
+    cfg = Config(
+        url="http://example.test",
+        retry_config=retry_config or _fast_retry(),
+    )
+    return HttpRequests(cfg)
+
+
+def _sequence(responses: Iterable[object]):
+    """Return a side_effect callable producing the given responses/exceptions."""
+    items = list(responses)
+    calls: List[int] = []
+
+    def _call(*args, **kwargs):
+        calls.append(1)
+        if not items:
+            raise AssertionError("exhausted mock responses")
+        nxt = items.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    _call.remaining = items
+    _call.call_count_list = calls
+    return _call
+
+
+@contextmanager
+def patch_requests(method: str, responses: Iterable[object]):
+    """Patch `requests.<method>` with a mock that carries `__name__`.
+
+    `HttpRequests.send_request` dispatches on `http_method.__name__`, so the
+    MagicMock replacement must expose that attribute.
+    """
+    with mock.patch(f"requests.{method}") as m:
+        m.__name__ = method
+        m.side_effect = _sequence(responses)
+        yield m
+
+
+class TestRetryConfig:
+    def test_defaults(self):
+        cfg = RetryConfig()
+        assert cfg.max_retries == 3
+        assert cfg.initial_backoff == 2.0
+        assert cfg.max_backoff == 64.0
+        assert cfg.multiplier == 2.0
+        assert cfg.jitter == 0.0
+        assert cfg.unhealthy_backoff == 90.0
+        assert cfg.retryable_status_codes == frozenset({408, 429, 502, 503, 504})
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            RetryConfig(max_retries=-1)
+        with pytest.raises(ValueError):
+            RetryConfig(initial_backoff=-0.5)
+        with pytest.raises(ValueError):
+            RetryConfig(max_backoff=-1.0)
+        with pytest.raises(ValueError):
+            RetryConfig(multiplier=0)
+        with pytest.raises(ValueError):
+            RetryConfig(jitter=-0.1)
+        with pytest.raises(ValueError):
+            RetryConfig(unhealthy_backoff=-1.0)
+
+    def test_is_frozen(self):
+        cfg = RetryConfig()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.max_retries = 99  # type: ignore[misc]
+
+    def test_status_codes_are_coerced_to_frozenset(self):
+        cfg = RetryConfig(retryable_status_codes={500, 502})  # plain set
+        assert isinstance(cfg.retryable_status_codes, frozenset)
+        assert cfg.retryable_status_codes == frozenset({500, 502})
+
+    def test_config_default_retry_config(self):
+        assert Config().retry_config == RetryConfig()
+
+    def test_config_uses_custom_retry_config(self):
+        rc = RetryConfig(max_retries=7)
+        assert Config(retry_config=rc).retry_config is rc
+
+
+class TestRetryBehavior:
+    def test_success_no_retry(self):
+        client = _make_client()
+        with patch_requests("get", [_make_response(200, b'{"ok": true}')]) as m:
+            result = client.get("/foo")
+        assert result == {"ok": True}
+        assert m.call_count == 1
+
+    def test_503_then_success(self):
+        client = _make_client()
+        with patch_requests(
+            "get",
+            [_make_response(503), _make_response(503), _make_response(200, b"{}")],
+        ) as m:
+            assert client.get("/foo") == {}
+        assert m.call_count == 3
+
+    def test_503_exhausts_raises(self):
+        client = _make_client(_fast_retry(max_retries=2))
+        with patch_requests("get", [_make_response(503)] * 3) as m:
+            with pytest.raises(FelderaAPIError) as exc_info:
+                client.get("/foo")
+        assert exc_info.value.status_code == 503
+        # max_retries=2 → 1 initial + 2 retries == 3 total calls.
+        assert m.call_count == 3
+
+    @pytest.mark.parametrize("status", [408, 429, 504])
+    def test_other_retryable_statuses(self, status):
+        client = _make_client()
+        with patch_requests(
+            "get", [_make_response(status), _make_response(200, b"{}")]
+        ) as m:
+            client.get("/foo")
+        assert m.call_count == 2
+
+    def test_404_is_not_retried(self):
+        client = _make_client()
+        with patch_requests(
+            "get", [_make_response(404, b'{"error":"not found"}')]
+        ) as m:
+            with pytest.raises(FelderaAPIError) as exc_info:
+                client.get("/foo")
+        assert exc_info.value.status_code == 404
+        assert m.call_count == 1
+
+    def test_500_is_not_retried_by_default(self):
+        client = _make_client()
+        with patch_requests("get", [_make_response(500, b'{"error":"boom"}')]) as m:
+            with pytest.raises(FelderaAPIError) as exc_info:
+                client.get("/foo")
+        assert exc_info.value.status_code == 500
+        assert m.call_count == 1
+
+    def test_custom_retryable_status_codes_includes_500(self):
+        client = _make_client(_fast_retry(retryable_status_codes=frozenset({500})))
+        with patch_requests(
+            "get", [_make_response(500), _make_response(200, b"{}")]
+        ) as m:
+            client.get("/foo")
+        assert m.call_count == 2
+
+    def test_timeout_then_success(self):
+        client = _make_client()
+        with patch_requests(
+            "get",
+            [requests.exceptions.ReadTimeout("boom"), _make_response(200, b"{}")],
+        ) as m:
+            client.get("/foo")
+        assert m.call_count == 2
+
+    def test_connect_timeout_is_retried(self):
+        # ConnectTimeout inherits from BOTH ConnectionError and Timeout — make
+        # sure we treat it as retryable (Timeout branch wins) and surface the
+        # final failure as FelderaTimeoutError.
+        client = _make_client(_fast_retry(max_retries=1))
+        with patch_requests(
+            "get", [requests.exceptions.ConnectTimeout("conn")] * 2
+        ) as m:
+            with pytest.raises(FelderaTimeoutError):
+                client.get("/foo")
+        assert m.call_count == 2
+
+    def test_timeout_exhausts_raises_timeout_error(self):
+        client = _make_client(_fast_retry(max_retries=1))
+        with patch_requests("get", [requests.exceptions.ReadTimeout("boom")] * 2) as m:
+            with pytest.raises(FelderaTimeoutError):
+                client.get("/foo")
+        assert m.call_count == 2
+
+    def test_connection_error_wrapped(self):
+        client = _make_client()
+        # ConnectionError isn't retryable — the first raise should propagate
+        # and be wrapped as FelderaCommunicationError.
+        with patch_requests("get", [requests.exceptions.ConnectionError("down")]):
+            with pytest.raises(FelderaCommunicationError):
+                client.get("/foo")
+
+    def test_no_retries_when_max_retries_zero(self):
+        client = _make_client(_fast_retry(max_retries=0))
+        with patch_requests("get", [_make_response(503)]) as m:
+            with pytest.raises(FelderaAPIError):
+                client.get("/foo")
+        assert m.call_count == 1
+
+    def test_custom_retry_config_uses_its_limit(self):
+        client = _make_client(_fast_retry(max_retries=5))
+        with patch_requests("get", [_make_response(503)] * 6) as m:
+            with pytest.raises(FelderaAPIError):
+                client.get("/foo")
+        assert m.call_count == 6  # 1 initial + 5 retries
+
+
+class TestRetryAfter:
+    def test_retry_after_header_is_honored(self):
+        client = _make_client(_fast_retry(max_backoff=0.0))
+        with patch_requests(
+            "get",
+            [
+                _make_response(503, headers={"Retry-After": "0"}),
+                _make_response(200, b"{}"),
+            ],
+        ) as m:
+            with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                client.get("/foo")
+        assert m.call_count == 2
+        # Server asked for 0s; jitter and exp backoff are also 0 in _fast_retry.
+        sleeper.assert_called_once_with(0.0)
+
+    def test_retry_after_capped_at_max_backoff(self):
+        # Server asks for 9999s; we should cap at our local max_backoff.
+        client = _make_client(
+            _fast_retry(initial_backoff=0.0, max_backoff=2.5, multiplier=1.0)
+        )
+        with patch_requests(
+            "get",
+            [
+                _make_response(503, headers={"Retry-After": "9999"}),
+                _make_response(200, b"{}"),
+            ],
+        ):
+            with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                client.get("/foo")
+        sleeper.assert_called_once_with(2.5)
+
+    def test_retry_after_http_date_is_parsed(self):
+        from datetime import datetime, timezone, timedelta
+
+        future = datetime.now(timezone.utc) + timedelta(seconds=1)
+        header = {"Retry-After": future.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+        client = _make_client(_fast_retry(max_backoff=10.0))
+        with patch_requests(
+            "get", [_make_response(503, headers=header), _make_response(200, b"{}")]
+        ):
+            with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                client.get("/foo")
+        # Should sleep ~1s (minus a few ms of test overhead). Just assert the
+        # call happened with a reasonable positive value capped at max_backoff.
+        sleeper.assert_called_once()
+        (slept,), _ = sleeper.call_args
+        assert 0.0 <= slept <= 10.0
+
+
+class TestExponentialBackoff:
+    def test_backoff_grows_as_documented(self):
+        """The first retry waits initial_backoff, then * multiplier, capped."""
+        cfg = RetryConfig(
+            max_retries=4,
+            initial_backoff=1.0,
+            max_backoff=8.0,
+            multiplier=2.0,
+            jitter=0.0,
+        )
+        client = _make_client(cfg)
+        with patch_requests("get", [_make_response(503)] * 5):
+            with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                with pytest.raises(FelderaAPIError):
+                    client.get("/foo")
+        # 4 retries → 4 sleeps. Schedule: 1, 2, 4, 8 (capped).
+        slept = [call.args[0] for call in sleeper.call_args_list]
+        assert slept == [1.0, 2.0, 4.0, 8.0]
+
+    def test_jitter_adds_uniform_extra(self):
+        cfg = RetryConfig(
+            max_retries=2,
+            initial_backoff=1.0,
+            max_backoff=10.0,
+            multiplier=1.0,
+            jitter=0.5,
+        )
+        client = _make_client(cfg)
+        with patch_requests("get", [_make_response(503)] * 3):
+            with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                with pytest.raises(FelderaAPIError):
+                    client.get("/foo")
+        slept = [call.args[0] for call in sleeper.call_args_list]
+        assert all(1.0 <= s < 1.5 for s in slept), slept
+
+
+class Test502HealthHandling:
+    def test_spurious_502_retries_immediately(self):
+        """Healthy cluster + 502 → wait function returns 0 (no backoff)."""
+        client = _make_client(_fast_retry(unhealthy_backoff=99.0))
+        with patch_requests(
+            "get", [_make_response(502), _make_response(200, b"{}")]
+        ) as m:
+            with mock.patch.object(
+                client, "_check_cluster_health", return_value=True
+            ) as health:
+                with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                    client.get("/foo")
+        assert m.call_count == 2
+        assert health.call_count == 1
+        sleeper.assert_called_once_with(0.0)
+
+    def test_unhealthy_502_uses_unhealthy_backoff(self):
+        """Unhealthy cluster + 502 → wait function returns unhealthy_backoff."""
+        cfg = RetryConfig(
+            max_retries=1,
+            initial_backoff=0.0,
+            max_backoff=0.0,
+            multiplier=1.0,
+            unhealthy_backoff=5.0,
+        )
+        client = _make_client(cfg)
+        with patch_requests(
+            "get", [_make_response(502), _make_response(200, b"{}")]
+        ) as m:
+            with mock.patch.object(
+                client, "_check_cluster_health", return_value=False
+            ) as health:
+                with mock.patch("tenacity.nap.time.sleep") as sleeper:
+                    client.get("/foo")
+        assert m.call_count == 2
+        assert health.call_count == 1
+        sleeper.assert_called_once_with(5.0)
+
+    def test_unhealthy_502_exhausts_retries(self):
+        """If the cluster stays unhealthy, retries proceed until max_retries."""
+        client = _make_client(_fast_retry(max_retries=2))
+        with patch_requests("get", [_make_response(502)] * 3) as m:
+            with mock.patch.object(client, "_check_cluster_health", return_value=False):
+                with pytest.raises(FelderaAPIError) as exc_info:
+                    client.get("/foo")
+        assert exc_info.value.status_code == 502
+        assert m.call_count == 3
+
+
+class TestFelderaClientAcceptsRetryConfig:
+    def test_passes_retry_config_through(self):
+        from feldera.rest.feldera_client import FelderaClient
+
+        rc = RetryConfig(max_retries=9, initial_backoff=0.1)
+        # Skip the server-version handshake performed in __init__.
+        with mock.patch.object(
+            FelderaClient, "get_config", return_value=mock.Mock(version="x")
+        ):
+            client = FelderaClient(url="http://example.test", retry_config=rc)
+        assert client.config.retry_config is rc
+        assert client.http.config.retry_config is rc

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -337,6 +337,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "tenacity" },
     { name = "typing-extensions" },
 ]
 
@@ -360,6 +361,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "requests" },
     { name = "ruff", specifier = ">=0.6.9" },
+    { name = "tenacity", specifier = ">=9.1.4" },
     { name = "typing-extensions" },
 ]
 
@@ -1123,6 +1125,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Currently retry loop is done by hand and does not expose all required configuration args to the user i.e., for customizing health check backoffs, custom wait times, etc. This has resulted in issues where an error is raised even though it would have succeeded with a longer backoff. This PR introduces tenacity for more granular retry control, introduces a standard exponential backoff pattern, and retains logic that captures spurious 502s as well as real 502s where the cluster is upgrading.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
