### PR TITLE
[py] skip delta output truncate test on aarch64

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -1,6 +1,7 @@
 "Utility functions for writing tests against a Feldera instance."
 
 import os
+import platform
 import re
 import time
 import json
@@ -174,6 +175,21 @@ def single_host_only(fn):
     return unittest.skipUnless(
         FELDERA_TEST_NUM_HOSTS == 1,
         f"multihost not yet supported for {fn.__name__}, skipping",
+    )(fn)
+
+
+def skip_on_arm64(fn):
+    """Skip the test on Linux aarch64.
+
+    Some native Python wheels (e.g. `deltalake`) bundle a jemalloc built
+    for 4 KB pages and abort on import on Ubuntu's 64 KB-page aarch64
+    kernel used by some CI runners. Tests that depend on such wheels can
+    use this decorator to opt out of running there.
+    """
+    fn._skip_on_arm64 = True
+    return unittest.skipIf(
+        platform.machine() == "aarch64",
+        f"{fn.__name__} skipped on aarch64 (incompatible native wheel)",
     )(fn)
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "sphinx==7.3.7",
     "simplejson==3.20.1",
     "confluent-kafka>=2.2.0",
-    "deltalake>=0.18"
+    "deltalake>=1.5.0"
 ]
 
 [tool.pytest.ini_options]

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -7,6 +7,7 @@ from feldera.testutils import (
     FELDERA_REQUESTS_VERIFY,
     TEST_CLIENT,
     enterprise_only,
+    skip_on_arm64,
     unique_pipeline_name,
 )
 
@@ -17,6 +18,7 @@ __all__ = [
     "TEST_CLIENT",
     "unique_pipeline_name",
     "enterprise_only",
+    "skip_on_arm64",
     "API_KEY",
     "BASE_URL",
     "FELDERA_REQUESTS_VERIFY",

--- a/python/tests/platform/test_delta_output_restart.py
+++ b/python/tests/platform/test_delta_output_restart.py
@@ -21,8 +21,6 @@ The delta table backend toggles automatically via `DeltaTestLocation`:
 
 import json
 
-import pytest
-
 from feldera import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import (
@@ -30,11 +28,8 @@ from feldera.testutils import (
     FELDERA_TEST_NUM_WORKERS,
     unique_pipeline_name,
 )
-from tests import TEST_CLIENT, enterprise_only
-
-pytest.importorskip("deltalake")
-
-from tests.utils import DeltaTestLocation  # noqa: E402
+from tests import TEST_CLIENT, enterprise_only, skip_on_arm64
+from tests.utils import DeltaTestLocation
 
 
 # ─── helpers ───────────────────────────────────────────────────────────
@@ -96,6 +91,7 @@ def _seed_50_rows_and_suspend(name: str, loc: DeltaTestLocation):
 
 
 @enterprise_only
+@skip_on_arm64
 def test_clean_resume_preserves_table():
     """Restarting an unchanged pipeline keeps the delta table contents."""
     name = unique_pipeline_name("delta_restart_clean")
@@ -117,6 +113,7 @@ def test_clean_resume_preserves_table():
 
 
 @enterprise_only
+@skip_on_arm64
 def test_modified_connector_re_truncates_on_resume():
     """Changing the connector config on resume makes it a new incarnation that re-truncates."""
     name = unique_pipeline_name("delta_restart_conn_modified")
@@ -142,6 +139,7 @@ def test_modified_connector_re_truncates_on_resume():
 
 
 @enterprise_only
+@skip_on_arm64
 def test_modified_view_re_truncates_on_resume():
     """Changing the view's schema on resume forces a rebuild from scratch."""
     name = unique_pipeline_name("delta_restart_view_modified")

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -6,8 +6,6 @@ import uuid
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
-from deltalake import DeltaTable
-
 
 MINIO_BUCKET = os.environ.get("CI_MINIO_BUCKET", "ci-tests")
 MINIO_ENDPOINT = os.environ.get(
@@ -106,7 +104,14 @@ class DeltaTestLocation:
 
         Uses the per-file `numRecords` stats recorded in the delta log, so
         we never need to scan parquet (and never need pyarrow).
+
+        The `deltalake` import is deferred to here so that module-level
+        test collection does not crash on aarch64 hosts where the wheel
+        aborts on import; tests that need this method gate themselves
+        with `@skip_on_arm64`.
         """
+        from deltalake import DeltaTable
+
         dt = DeltaTable(self.uri, storage_options=self._delta_storage_options())
         return dt.count()
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-19T17:01:59.573641Z"
+exclude-newer = "2026-04-21T06:47:07.2353Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -366,7 +366,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "confluent-kafka", specifier = ">=2.2.0" },
-    { name = "deltalake", specifier = ">=0.18" },
+    { name = "deltalake", specifier = ">=1.5.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },


### PR DESCRIPTION
Some native Python wheels (e.g. `deltalake`) bundle a jemalloc built for 4 KB pages. Our CI machines use default Ubuntu's 64 KB-page aarch64 ker, which leads to crash.

Hence, we're skipping these tests for now
