### PR TITLE
[SQL] Increase the macro expansion recursion size for operators with wide star joins

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -68,11 +68,11 @@ public class RustFileWriter extends RustWriter {
 
     void generatePreamble() {
         this.builder().append(COMMON_PREAMBLE);
-        long max = this.used.getMaxTupleSize();
-        if (max > 120) {
+        long limit = this.used.getRecursionLimit();
+        if (limit > 240) {
             // this is just a guess
             this.builder().append("#![recursion_limit = \"")
-                    .append(max * 2)
+                    .append(limit)
                     .append("\"]")
                     .newline();
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustWriter.java
@@ -50,6 +50,19 @@ public abstract class RustWriter extends BaseRustCodeGenerator {
                     max = s;
             return max;
         }
+
+        int getMaxJoinSize() {
+            int max = 0;
+            for (StarJoin join: this.starJoinsUsed) {
+                if (join.inputs > max)
+                    max = join.inputs;
+            }
+            return max;
+        }
+
+        public int getRecursionLimit() {
+            return Math.max(this.getMaxJoinSize(), this.getMaxTupleSize()) * 2;
+        }
     }
 
     /** Visitor which discovers some data structures used.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/SingleOperatorWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/SingleOperatorWriter.java
@@ -88,6 +88,16 @@ public final class SingleOperatorWriter extends BaseRustCodeGenerator {
         this.operator.accept(findOuterResources);
 
         boolean useHandles = compiler.options.ioOptions.emitHandles;
+
+        long limit = used.getRecursionLimit();
+        if (limit > 240) {
+            // this is just a guess
+            this.builder().append("#![recursion_limit = \"")
+                    .append(limit)
+                    .append("\"]")
+                    .newline();
+        }
+
         this.builder()
                 .append(RustWriter.COMMON_PREAMBLE)
                 .append(RustWriter.STANDARD_PREAMBLE);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MultiCrateTests.java
@@ -439,4 +439,19 @@ public class MultiCrateTests extends BaseSQLTests {
         Utilities.deleteFile(udf, false);
         udf.deleteOnExit();
     }
+
+    @Test
+    public void issue6150() throws IOException, SQLException, InterruptedException {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CREATE TABLE T(x INT, y INT, z INT);\n");
+        builder.append("CREATE LOCAL VIEW V AS SELECT z, y, COUNT(X)");
+        for (int i = 0; i < 140; i++) {
+            builder.append(",\n");
+            builder.append("  MAX(x + ").append(i).append(") AS a").append(i);
+        }
+        builder.append(" FROM T GROUP BY y, z;\n");
+        builder.append("CREATE VIEW W AS SELECT * FROM V JOIN T ON V.y = T.y;");
+        File file = createInputScript(builder.toString());
+        compileToMultiCrate(file.getAbsolutePath(), true, true);
+    }
 }


### PR DESCRIPTION
Fixes #6150

### Describe Manual Test Plan

There is a unit test.
I have also tested this with the web-ui.

This fix is not the one suggested in the issue: it does not break wide joins into multiple joins. It just increases the macro expansion limit for Rust. We already do that for wide tuples, so the same procedure is followed for wide joins.