### PR TITLE
[web-console] Fix cursor misplaced in SQL editor on Windows

### DIFF
--- a/js-packages/web-console/src/lib/components/MonacoEditorRunes.svelte
+++ b/js-packages/web-console/src/lib/components/MonacoEditorRunes.svelte
@@ -104,6 +104,21 @@
     }
     monaco = await loader.init()
     editor = monaco.editor.create(container, {
+      // TODO: Workaround for Windows-only cursor mis-positioning on mouse click
+      // (cursor lands progressively further off the clicked glyph along the line;
+      // a line that contains an emoji renders correctly because Monaco's
+      // monospace fast path is disabled per-line for complex characters).
+      // Suspected cause: at editor-create time the configured webfont has not
+      // finished loading, so Monaco measures `typicalHalfwidthCharacterWidth`
+      // against a fallback font; on Windows this fallback's advance width
+      // differs from the real font, on Linux it happens to match — hence the
+      // OS asymmetry. Forcing the variable-width path globally avoids the bad
+      // cached measurement at the cost of a small per-render measurement.
+      // Proper fix to try once a Windows test machine is available: drop this
+      // option and instead `await document.fonts.ready` before
+      // `monaco.editor.create`, plus call `monaco.editor.remeasureFonts()`
+      // after any subsequent webfont swap.
+      disableMonospaceOptimizations: true,
       ...options,
       model: null
     })


### PR DESCRIPTION
[web-console] Fix cursor misplaced in SQL editor on Windows

####  Symptom

  In the Monaco-based SQL editor, clicking on a character with the mouse on Windows lands the caret to the side of the intended glyph. The offset grows the further along the line the click lands — column 1 is roughly correct, by column 60 the caret is several characters off.
  Reproduces in multiple browsers on Windows; not reproducible on Linux. A line that contains an emoji (or any non-BMP / complex character) renders and clicks correctly even before the emoji on the same line.

####  Cause

  Monaco has two text-measurement paths. The fast path caches a single typicalHalfwidthCharacterWidth and computes cursorX = column * charWidth. The slow path measures the painted run via the DOM. Monaco uses the fast path for "simple" lines and falls back to the slow path the 
  moment a line contains a complex character — which is why an emoji on the line "heals" cursor placement.

  Two plausible explanations for why only Windows is affected:
  
  1. Fractional glyph advances from DirectWrite + DPI scaling. Windows' text stack returns sub-pixel per-glyph advances and rounds them per-glyph during paint; combined with non-100% display scaling (125%/150% is the Windows default), the painted run length is not exactly n ×  charWidth. Linux/macOS pipelines happen to hand back advances that match Monaco's integer assumption for true monospace fonts, so the fast path agrees with the painter there. Under this hypothesis no single cached width is correct at every column — only switching to per-run measurement fixes it.
  2. Font-loading race against the cached width. At monaco.editor.create time the configured webfont may not have finished loading, so Monaco measures typicalHalfwidthCharacterWidth against a fallback. Once the real font swaps in, every cursor click is off by the cached-vs-real width delta, accumulating with column. The OS asymmetry would arise because the fallback's advance happens to match the real font on Linux but not on Windows. Under this hypothesis the proper fix is to await document.fonts.ready before creating the editor and call monaco.editor.remeasureFonts() after any subsequent webfont swap — leaving the fast path enabled.

I do not have a Windows setup handy to confirm one or the other, so this PR takes the conservative route of disabling the optimization and dynamically calculating the cursor position based on the actual glyphs as a reasonable temporary measure.