### PR TITLE
[web-console] Fix compiler tab controls overlapping with tab labels in Monitoring Panel

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/editor/InteractionPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/InteractionPanel.svelte
@@ -5,7 +5,6 @@
   import TabsPanel from '$lib/components/pipelines/editor/TabsPanel.svelte'
   import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
   import { useLocalStorage } from '$lib/compositions/localStore.svelte'
-  import { tuple } from '$lib/functions/common/tuple'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import type { ExtendedPipeline } from '$lib/services/pipelineManager'
 
@@ -24,15 +23,33 @@
   const { showInteractionPanel } = useLayoutSettings()
 
   const tabs = $derived([
-    tuple('Ad-Hoc Queries' as const, TabControlAdhoc, PanelAdHocQuery, false),
-    tuple(TabProfileVisualizer.id, TabProfileVisualizer.Label, TabProfileVisualizer.default, true),
-    tuple('Samply' as const, TabSamplyProfile.Label, TabSamplyProfile.default, false)
+    {
+      id: 'Ad-Hoc Queries' as const,
+      label: TabControlAdhoc,
+      panel: PanelAdHocQuery,
+      keepAlive: false,
+      tabBarEnd: TabBarEndClose
+    },
+    {
+      id: TabProfileVisualizer.id,
+      label: TabProfileVisualizer.Label,
+      panel: TabProfileVisualizer.default,
+      keepAlive: true,
+      tabBarEnd: TabBarEndClose
+    },
+    {
+      id: 'Samply' as const,
+      label: TabSamplyProfile.Label,
+      panel: TabSamplyProfile.default,
+      keepAlive: false,
+      tabBarEnd: TabBarEndClose
+    }
   ])
 
   const currentTab = $derived(
-    useLocalStorage<(typeof tabs)[number][0]>(
+    useLocalStorage<(typeof tabs)[number]['id']>(
       'pipelines/' + pipelineName + '/currentInteractionTab',
-      tabs[0][0]
+      tabs[0].id
     )
   )
 
@@ -49,15 +66,15 @@
   <span class="hidden sm:inline"> Ad-Hoc Queries </span>
 {/snippet}
 
-<TabsPanel {tabs} bind:currentTab={currentTab.value} tabProps={{ pipeline, deleted }}>
-  {#snippet tabBarEnd()}
-    <button
-      class="fd fd-x ml-auto btn-icon text-[24px]"
-      onclick={() => {
-        _currentTab = null
-        showInteractionPanel.value = false
-      }}
-      aria-label="Close"
-    ></button>
-  {/snippet}
-</TabsPanel>
+{#snippet TabBarEndClose()}
+  <button
+    class="fd fd-x ml-auto btn-icon text-[24px]"
+    onclick={() => {
+      _currentTab = null
+      showInteractionPanel.value = false
+    }}
+    aria-label="Close"
+  ></button>
+{/snippet}
+
+<TabsPanel {tabs} bind:currentTab={currentTab.value} tabProps={{ pipeline, deleted }} />

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte
@@ -11,7 +11,9 @@
 
 <!-- svelte-ignore state_referenced_locally -->
 <script lang="ts">
+  import { Switch } from '@skeletonlabs/skeleton-svelte'
   import { useLocalStorage } from '$lib/compositions/localStore.svelte'
+  import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
   import PanelAdHocQuery from '$lib/components/pipelines/editor/TabAdHocQuery.svelte'
   import PanelChangeStream from '$lib/components/pipelines/editor/TabChangeStream.svelte'
   import * as TabPerformance from '$lib/components/pipelines/editor/TabPerformance.svelte'
@@ -19,7 +21,6 @@
   import * as TabProfileVisualizer from '$lib/components/pipelines/editor/TabProfileVisualizer.svelte'
   import * as TabSamplyProfile from '$lib/components/pipelines/editor/TabSamplyProfile.svelte'
   import PanelLogs from '$lib/components/pipelines/editor/TabLogs.svelte'
-  import { tuple } from '$lib/functions/common/tuple'
   import type { ExtendedPipeline } from '$lib/services/pipelineManager'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
   import { count } from '$lib/functions/common/array'
@@ -49,32 +50,70 @@
   } = $props()
 
   const pipelineName = $derived(pipeline.current.name)
+  const layoutSettings = useLayoutSettings()
 
   let tabs = $derived(
     [
-      tuple('Errors' as const, TabControlPipelineErrors, PanelPipelineErrors, false),
-      tuple(TabPerformance.id, TabControlPerformance, TabPerformance.default, false),
-      tuple('Ad-Hoc Queries' as const, TabControlAdhoc, PanelAdHocQuery, false),
-      tuple('Changes Stream' as const, TabControlChangeStream, PanelChangeStream, true),
-      tuple(
-        TabProfileVisualizer.id,
-        TabProfileVisualizer.Label,
-        TabProfileVisualizer.default,
-        true
-      ),
-      tuple('Samply' as const, TabSamplyProfile.Label, TabSamplyProfile.default, false),
-      tuple('Logs' as const, TabLogs, PanelLogs, true)
-    ].filter((tab) => !hiddenTabs.includes(tab[0]))
+      {
+        id: 'Errors' as const,
+        label: TabControlPipelineErrors,
+        panel: PanelPipelineErrors,
+        keepAlive: false,
+        tabBarEnd: TabBarEndCompiler
+      },
+      {
+        id: TabPerformance.id,
+        label: TabControlPerformance,
+        panel: TabPerformance.default,
+        keepAlive: false,
+        tabBarEnd: TabBarEndPipelineInfo
+      },
+      {
+        id: 'Ad-Hoc Queries' as const,
+        label: TabControlAdhoc,
+        panel: PanelAdHocQuery,
+        keepAlive: false,
+        tabBarEnd: TabBarEndPipelineInfo
+      },
+      {
+        id: 'Changes Stream' as const,
+        label: TabControlChangeStream,
+        panel: PanelChangeStream,
+        keepAlive: true,
+        tabBarEnd: TabBarEndPipelineInfo
+      },
+      {
+        id: TabProfileVisualizer.id,
+        label: TabProfileVisualizer.Label,
+        panel: TabProfileVisualizer.default,
+        keepAlive: true,
+        tabBarEnd: TabBarEndPipelineInfo
+      },
+      {
+        id: 'Samply' as const,
+        label: TabSamplyProfile.Label,
+        panel: TabSamplyProfile.default,
+        keepAlive: false,
+        tabBarEnd: TabBarEndPipelineInfo
+      },
+      {
+        id: 'Logs' as const,
+        label: TabLogs,
+        panel: PanelLogs,
+        keepAlive: true,
+        tabBarEnd: TabBarEndPipelineInfo
+      }
+    ].filter((tab) => !hiddenTabs.includes(tab.id))
   )
   const currentTabStorage = $derived(
     useLocalStorage<MonitoringTabs>('pipelines/' + pipelineName + '/currentMonitoringTab', 'Errors')
   )
   $effect.pre(() => {
     // Initialize from storage, or reset to first available tab if current is hidden
-    if (!tabs.some((t) => t[0] === currentTab)) {
-      currentTab = tabs.some((t) => t[0] === currentTabStorage.value)
+    if (!tabs.some((t) => t.id === currentTab)) {
+      currentTab = tabs.some((t) => t.id === currentTabStorage.value)
         ? currentTabStorage.value
-        : tabs[0][0]
+        : tabs[0].id
     }
   })
   $effect(() => {
@@ -156,21 +195,45 @@
   <span>Logs</span>
 {/snippet}
 
-<TabsPanel {tabs} bind:currentTab={currentTab!} {tabProps}>
-  {#snippet tabBarEnd()}
-    {#if currentTab !== 'Errors'}
-      <div class="ml-auto flex">
-        <ClipboardCopyButton
-          value={pipeline.current.id}
-          class="h-8 w-auto! gap-2 preset-tonal-surface px-4"
-        >
-          <span class="text-base font-normal text-surface-950-50"> Pipeline ID </span>
-        </ClipboardCopyButton>
-        <Tooltip placement="top">
-          {pipeline.current.id}
-        </Tooltip>
-        <DownloadSupportBundle {pipelineName} />
-      </div>
-    {/if}
-  {/snippet}
-</TabsPanel>
+{#snippet TabBarEndPipelineInfo()}
+  <div class="ml-auto flex">
+    <ClipboardCopyButton
+      value={pipeline.current.id}
+      class="h-8 w-auto! gap-2 preset-tonal-surface px-4"
+    >
+      <span class="text-base font-normal text-surface-950-50"> Pipeline ID </span>
+    </ClipboardCopyButton>
+    <Tooltip placement="top">
+      {pipeline.current.id}
+    </Tooltip>
+    <DownloadSupportBundle {pipelineName} />
+  </div>
+{/snippet}
+
+{#snippet TabBarEndCompiler()}
+  <div class="ml-auto flex flex-nowrap items-center gap-6 py-1">
+    <label
+      class="flex cursor-pointer items-center gap-2"
+      class:disabled={layoutSettings.verbatimErrors.value}
+    >
+      Hide warnings
+      <input class="checkbox" type="checkbox" bind:checked={layoutSettings.hideWarnings.value} />
+    </label>
+    <label class="flex cursor-pointer items-center gap-2 rounded">
+      Verbatim errors
+      <Switch
+        name="verbatimErrors"
+        checked={layoutSettings.verbatimErrors.value}
+        onCheckedChange={(e) => (layoutSettings.verbatimErrors.value = e.checked)}
+      >
+        <Switch.Control>
+          <Switch.Thumb />
+        </Switch.Control>
+        <Switch.Label />
+        <Switch.HiddenInput />
+      </Switch>
+    </label>
+  </div>
+{/snippet}
+
+<TabsPanel {tabs} bind:currentTab={currentTab!} {tabProps} />

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPipelineErrors.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Switch } from '@skeletonlabs/skeleton-svelte'
   import { selectScope } from '$lib/compositions/common/userSelect'
   import { extractProgramStderr, type SystemError } from '$lib/compositions/health/systemErrors'
   import { useLayoutSettings } from '$lib/compositions/layout/useLayoutSettings.svelte'
@@ -19,28 +18,6 @@
   const theme = useSkeletonTheme()
 </script>
 
-<div
-  class="flex w-full flex-nowrap justify-between gap-6 py-2 sm:pt-0 lg:absolute lg:right-0 lg:-mt-12 lg:w-auto"
->
-  <label class="flex cursor-pointer items-center gap-2" class:disabled={verbatimErrors.value}>
-    Hide warnings
-    <input class="checkbox" type="checkbox" bind:checked={hideWarnings.value} />
-  </label>
-  <label class="flex cursor-pointer items-center justify-end gap-2 rounded lg:justify-normal">
-    Verbatim errors
-    <Switch
-      name="verbatimErrors"
-      checked={verbatimErrors.value}
-      onCheckedChange={(e) => (verbatimErrors.value = e.checked)}
-    >
-      <Switch.Control>
-        <Switch.Thumb />
-      </Switch.Control>
-      <Switch.Label />
-      <Switch.HiddenInput />
-    </Switch>
-  </label>
-</div>
 <div class="scrollbar h-full w-full overflow-y-auto">
   <div
     class="flex min-h-full w-fit min-w-full flex-col gap-4 rounded"

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabsPanel.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabsPanel.svelte
@@ -1,20 +1,28 @@
-<script lang="ts" generics="T extends Record<string, unknown>  ">
+<script lang="ts" module>
   import type { Component } from 'svelte'
   import type { Snippet } from '$lib/types/svelte'
 
+  export type TabSpec<T extends Record<string, unknown>> = {
+    id: string
+    label: Snippet
+    panel: Component<T>
+    keepAlive: boolean
+    tabBarEnd?: Snippet
+  }
+</script>
+
+<script lang="ts" generics="T extends Record<string, unknown>  ">
   import { Tabs } from '@skeletonlabs/skeleton-svelte'
   import { SvelteSet } from 'svelte/reactivity'
 
   let {
     tabs,
-    tabBarEnd,
     tabProps,
     currentTab = $bindable(),
     tabContainer = defaultTabContainer
   }: {
-    tabs: [string, Snippet, Component<T>, boolean][]
+    tabs: TabSpec<T>[]
     tabContainer?: typeof defaultTabContainer
-    tabBarEnd?: Snippet
     tabProps: T
     currentTab: string
   } = $props()
@@ -23,6 +31,7 @@
   $effect.pre(() => {
     visited.add(currentTab)
   })
+  const activeTabBarEnd = $derived(tabs.find((t) => t.id === currentTab)?.tabBarEnd)
 </script>
 
 {#snippet defaultTabContainer(tab: Snippet, hidden: boolean)}
@@ -37,27 +46,27 @@
   class="flex flex-1 flex-col space-y-0! rounded-container bg-surface-50-950 p-4"
 >
   <Tabs.List class="flex w-full flex-wrap-reverse gap-0 pb-0 text-nowrap">
-    {#each tabs as [tabName, tabControl]}
+    {#each tabs as { id, label }}
       <Tabs.Trigger
-        value={tabName}
-        class="btn h-9 font-medium {tabName === currentTab
+        value={id}
+        class="btn h-9 font-medium {id === currentTab
           ? 'border-surface-950-50 '
           : 'rounded hover:bg-surface-100-900/50'}"
       >
-        {@render tabControl()}
+        {@render label()}
       </Tabs.Trigger>
     {/each}
-    {@render tabBarEnd?.()}
+    {@render activeTabBarEnd?.()}
     <Tabs.Indicator />
   </Tabs.List>
   <div class="relative h-full">
-    {#each tabs as [tabName, , TabComponent, keepAlive]}
+    {#each tabs as { id, panel: TabComponent, keepAlive }}
       {#snippet tab()}
         <TabComponent {...tabProps}></TabComponent>
       {/snippet}
-      {#if keepAlive && visited.has(tabName)}
-        {@render tabContainer(tab, currentTab !== tabName)}
-      {:else if currentTab === tabName}
+      {#if keepAlive && visited.has(id)}
+        {@render tabContainer(tab, currentTab !== id)}
+      {:else if currentTab === id}
         {@render tabContainer(tab, false)}
       {/if}
     {/each}


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/6159

Testing: manual. Playwright screenshot issue prevents a simple regression test, but it's not necessary here.

[Screencast from 2026-04-30 23-26-50.webm](https://github.com/user-attachments/assets/bf07b666-a762-4212-9b76-68f72700c8ef)
