### PR TITLE
[dbsp] Improved set_balancer_hint API.

### DIFF
--- a/crates/dbsp/src/circuit/circuit_builder.rs
+++ b/crates/dbsp/src/circuit/circuit_builder.rs
@@ -23,7 +23,7 @@
 //! current thread.  To instead run the circuit in a collection of worker
 //! threads, use [`Runtime::init_circuit`].
 use crate::{
-    Error as DbspError, Position, Runtime,
+    Error as DbspError, Position, Runtime, RuntimeError,
     circuit::{
         cache::{CircuitCache, CircuitStoreMarker},
         fingerprinter::Fingerprinter,
@@ -1680,6 +1680,11 @@ pub trait CircuitBase: 'static {
     /// Returns vector of local node ids in the circuit.
     fn node_ids(&self) -> Vec<NodeId>;
 
+    fn lookup_local_node_by_persistent_id(
+        &self,
+        persistent_id: &str,
+    ) -> Result<GlobalNodeId, DbspError>;
+
     fn import_nodes(&self) -> Vec<NodeId>;
 
     fn clear(&mut self);
@@ -1814,14 +1819,21 @@ pub trait CircuitBase: 'static {
     ///
     /// Returns an error if the operator with the given global node id is not found
     /// or if the hint contradicts the current balancer policy.
-    fn set_balancer_hint(
+    fn set_balancer_hint_by_global_id(
         &self,
         global_node_id: &GlobalNodeId,
         hint: BalancerHint,
     ) -> Result<(), DbspError>;
 
+    fn set_balancer_hint(&self, persistent_id: &str, hint: BalancerHint) -> Result<(), DbspError>;
+
     /// Get the current balancer policy for all streams managed by the balancer.
-    fn get_current_balancer_policy(&self) -> BTreeMap<NodeId, PartitioningPolicy>;
+    fn get_current_balancer_policies(&self) -> BTreeMap<NodeId, PartitioningPolicy>;
+
+    fn get_current_balancer_policy(
+        &self,
+        persistent_id: &str,
+    ) -> Result<PartitioningPolicy, DbspError>;
 
     fn rebalance(&self);
 }
@@ -2844,6 +2856,25 @@ where
             node.borrow().fixedpoint(scope)
         })
     }
+
+    fn lookup_local_node_by_persistent_id(
+        &self,
+        persistent_id: &str,
+    ) -> Result<GlobalNodeId, DbspError> {
+        self.nodes
+            .borrow()
+            .iter()
+            .find_map(|node| {
+                if node.borrow().get_label(LABEL_PERSISTENT_OPERATOR_ID) == Some(persistent_id) {
+                    Some(node.borrow().global_id().clone())
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| {
+                DbspError::Runtime(RuntimeError::UnknownPersistentId(persistent_id.to_string()))
+            })
+    }
 }
 
 /// A circuit.
@@ -3382,6 +3413,14 @@ where
             .collect()
     }
 
+    fn lookup_local_node_by_persistent_id(
+        &self,
+        persistent_id: &str,
+    ) -> Result<GlobalNodeId, DbspError> {
+        self.inner()
+            .lookup_local_node_by_persistent_id(persistent_id)
+    }
+
     fn import_nodes(&self) -> Vec<NodeId> {
         self.inner().import_nodes()
     }
@@ -3425,7 +3464,7 @@ where
         self.inner().balancer.set_auto_rebalance(enable)
     }
 
-    fn set_balancer_hint(
+    fn set_balancer_hint_by_global_id(
         &self,
         global_node_id: &GlobalNodeId,
         hint: BalancerHint,
@@ -3441,8 +3480,27 @@ where
             .set_hint(global_node_id.local_node_id().unwrap(), hint)
     }
 
-    fn get_current_balancer_policy(&self) -> BTreeMap<NodeId, PartitioningPolicy> {
+    fn set_balancer_hint(&self, persistent_id: &str, hint: BalancerHint) -> Result<(), DbspError> {
+        let global_node_id = self.lookup_local_node_by_persistent_id(persistent_id)?;
+        self.set_balancer_hint_by_global_id(&global_node_id, hint)
+    }
+
+    fn get_current_balancer_policies(&self) -> BTreeMap<NodeId, PartitioningPolicy> {
         self.inner().balancer.get_policy()
+    }
+
+    fn get_current_balancer_policy(
+        &self,
+        persistent_id: &str,
+    ) -> Result<PartitioningPolicy, DbspError> {
+        let global_node_id = self.lookup_local_node_by_persistent_id(persistent_id)?;
+        let local_node_id = global_node_id.local_node_id().unwrap();
+        self.inner()
+            .balancer
+            .get_policy_for_stream(local_node_id)
+            .ok_or_else(|| {
+                DbspError::Balancer(BalancerError::NotRegisteredWithBalancer(local_node_id))
+            })
     }
 
     fn rebalance(&self) {
@@ -7576,20 +7634,36 @@ impl CircuitHandle {
         self.circuit.set_auto_rebalance(enable)
     }
 
-    pub fn set_balancer_hint(
+    pub fn set_balancer_hint_by_global_id(
         &self,
         global_node_id: &GlobalNodeId,
         hint: BalancerHint,
     ) -> Result<(), DbspError> {
-        self.circuit.set_balancer_hint(global_node_id, hint)
+        self.circuit
+            .set_balancer_hint_by_global_id(global_node_id, hint)
     }
 
-    pub fn get_current_balancer_policy(&self) -> BTreeMap<GlobalNodeId, PartitioningPolicy> {
+    pub fn set_balancer_hint(
+        &self,
+        persistent_id: &str,
+        hint: BalancerHint,
+    ) -> Result<(), DbspError> {
+        self.circuit.set_balancer_hint(persistent_id, hint)
+    }
+
+    pub fn get_current_balancer_policies(&self) -> BTreeMap<GlobalNodeId, PartitioningPolicy> {
         self.circuit
-            .get_current_balancer_policy()
+            .get_current_balancer_policies()
             .into_iter()
             .map(|(node_id, policy)| (GlobalNodeId::root().child(node_id), policy))
             .collect()
+    }
+
+    pub fn get_current_balancer_policy(
+        &self,
+        persistent_id: &str,
+    ) -> Result<PartitioningPolicy, DbspError> {
+        self.circuit.get_current_balancer_policy(persistent_id)
     }
 
     pub fn rebalance(&self) {

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -808,11 +808,11 @@ impl Runtime {
                             return;
                         }
                     }
-                    Ok(Command::SetBalancerHints(hints)) => {
+                    Ok(Command::SetBalancerHintsByGlobalId(hints)) => {
                         let results = hints
                             .into_iter()
                             .map(|(global_node_id, hint)| {
-                                circuit.set_balancer_hint(&global_node_id, hint)
+                                circuit.set_balancer_hint_by_global_id(&global_node_id, hint)
                             })
                             .collect::<Vec<Result<(), DbspError>>>();
                         if status_sender
@@ -822,8 +822,31 @@ impl Runtime {
                             return;
                         }
                     }
-                    Ok(Command::GetCurrentBalancerPolicy) => {
-                        let policy = circuit.get_current_balancer_policy();
+                    Ok(Command::SetBalancerHints(hints)) => {
+                        let results = hints
+                            .into_iter()
+                            .map(|(persistent_id, hint)| {
+                                circuit.set_balancer_hint(&persistent_id, hint)
+                            })
+                            .collect::<Vec<Result<(), DbspError>>>();
+                        if status_sender
+                            .send(Ok(Response::SetBalancerHints(results)))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Ok(Command::GetCurrentBalancerPolicies) => {
+                        let policy = circuit.get_current_balancer_policies();
+                        if status_sender
+                            .send(Ok(Response::CurrentBalancerPolicies(policy)))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Ok(Command::GetCurrentBalancerPolicy(persistent_id)) => {
+                        let policy = circuit.get_current_balancer_policy(&persistent_id);
                         if status_sender
                             .send(Ok(Response::CurrentBalancerPolicy(policy)))
                             .is_err()
@@ -924,8 +947,10 @@ enum Command {
     GetLir,
     Checkpoint(StoragePath),
     Restore(StoragePath),
-    SetBalancerHints(Vec<(GlobalNodeId, BalancerHint)>),
-    GetCurrentBalancerPolicy,
+    SetBalancerHintsByGlobalId(Vec<(GlobalNodeId, BalancerHint)>),
+    SetBalancerHints(Vec<(String, BalancerHint)>),
+    GetCurrentBalancerPolicies,
+    GetCurrentBalancerPolicy(String),
     Rebalance,
     SetAutoRebalance(bool),
 }
@@ -953,10 +978,18 @@ impl Debug for Command {
             Command::GetLir => write!(f, "GetLir"),
             Command::Checkpoint(path) => f.debug_tuple("Checkpoint").field(path).finish(),
             Command::Restore(path) => f.debug_tuple("Restore").field(path).finish(),
+            Command::SetBalancerHintsByGlobalId(hints) => f
+                .debug_tuple("SetBalancerHintsByGlobalId")
+                .field(hints)
+                .finish(),
             Command::SetBalancerHints(hints) => {
                 f.debug_tuple("SetBalancerHints").field(hints).finish()
             }
-            Command::GetCurrentBalancerPolicy => write!(f, "GetCurrentBalancerPolicy"),
+            Command::GetCurrentBalancerPolicies => write!(f, "GetCurrentBalancerPolicies"),
+            Command::GetCurrentBalancerPolicy(persistent_id) => f
+                .debug_tuple("GetCurrentBalancerPolicy")
+                .field(persistent_id)
+                .finish(),
             Command::Rebalance => write!(f, "Rebalance"),
             Command::SetAutoRebalance(enable) => {
                 f.debug_tuple("SetAutoRebalance").field(enable).finish()
@@ -977,7 +1010,8 @@ enum Response {
     CheckpointRestored(Option<BootstrapInfo>),
     Lir(LirCircuit),
     SetBalancerHints(Vec<Result<(), DbspError>>),
-    CurrentBalancerPolicy(BTreeMap<GlobalNodeId, PartitioningPolicy>),
+    CurrentBalancerPolicies(BTreeMap<GlobalNodeId, PartitioningPolicy>),
+    CurrentBalancerPolicy(Result<PartitioningPolicy, DbspError>),
 }
 
 /// A handle to control the execution of a circuit in a multithreaded runtime.
@@ -1606,18 +1640,58 @@ impl DBSPHandle {
         Ok(())
     }
 
-    pub fn set_balancer_hint(
+    pub fn set_balancer_hint_by_global_id(
         &mut self,
         global_node_id: &GlobalNodeId,
         hint: BalancerHint,
     ) -> Result<(), DbspError> {
-        let mut result = self.set_balancer_hints(vec![(global_node_id.clone(), hint)])?;
+        let mut result =
+            self.set_balancer_hints_by_global_id(vec![(global_node_id.clone(), hint)])?;
         result.pop().unwrap()
     }
 
-    pub fn set_balancer_hints(
+    /// Set the balancer hint for the stream with the given persistent id.
+    ///
+    /// - `persistent_id` must exist in the circuit and belong to an input stream of a
+    ///   balancing join operator. In practice, this means that the circuit should be running
+    ///   in `Persistent` mode and the stream should have a persistent id assigned using
+    ///   `set_persistent_id`.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the above requirements are not met or the hint cannot be enforced in the current state,
+    /// e.g., if the user is setting Broadcast policy on both inputs to a join.
+    pub fn set_balancer_hint(
+        &mut self,
+        persistent_id: &str,
+        hint: BalancerHint,
+    ) -> Result<(), DbspError> {
+        let mut result = self.set_balancer_hints(vec![(persistent_id.to_string(), hint)])?;
+        result.pop().unwrap()
+    }
+
+    pub fn set_balancer_hints_by_global_id(
         &mut self,
         hints: Vec<(GlobalNodeId, BalancerHint)>,
+    ) -> Result<Vec<Result<(), DbspError>>, DbspError> {
+        let mut results = Vec::new();
+
+        self.broadcast_command(Command::SetBalancerHintsByGlobalId(hints), |_, resp| {
+            let Response::SetBalancerHints(worker_results) = resp else {
+                panic!("Expected SetBalancerHints response, got {resp:?}");
+            };
+            results = worker_results;
+        })?;
+
+        Ok(results)
+    }
+
+    /// Set multiple balancer hints.
+    ///
+    /// Applies hints one by one.
+    pub fn set_balancer_hints(
+        &mut self,
+        hints: Vec<(String, BalancerHint)>,
     ) -> Result<Vec<Result<(), DbspError>>, DbspError> {
         let mut results = Vec::new();
 
@@ -1631,15 +1705,32 @@ impl DBSPHandle {
         Ok(results)
     }
 
-    pub fn get_current_balancer_policy(
+    /// Get the current balancer policies for all operators in the circuit.
+    pub fn get_current_balancer_policies(
         &mut self,
     ) -> Result<BTreeMap<GlobalNodeId, PartitioningPolicy>, DbspError> {
-        let resp = self.unicast_command(0, Command::GetCurrentBalancerPolicy)?;
+        let resp = self.unicast_command(0, Command::GetCurrentBalancerPolicies)?;
 
-        let Response::CurrentBalancerPolicy(policy) = resp else {
-            panic!("Expected GetCurrentBalancerPolicy policy response, got {resp:?}");
+        let Response::CurrentBalancerPolicies(policy) = resp else {
+            panic!("Expected GetCurrentBalancerPolicies response, got {resp:?}");
         };
         Ok(policy)
+    }
+
+    /// Get the current balancer policy for the operator with the given persistent id.
+    pub fn get_current_balancer_policy(
+        &mut self,
+        persistent_id: &str,
+    ) -> Result<PartitioningPolicy, DbspError> {
+        let resp = self.unicast_command(
+            0,
+            Command::GetCurrentBalancerPolicy(persistent_id.to_string()),
+        )?;
+
+        let Response::CurrentBalancerPolicy(policy) = resp else {
+            panic!("Expected GetCurrentBalancerPolicy response, got {resp:?}");
+        };
+        policy
     }
 
     pub fn rebalance(&mut self) -> Result<(), DbspError> {

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -69,6 +69,8 @@ pub const DEFAULT_REPLAY_STEP_SIZE: usize = 10000;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum Error {
+    /// Specified persistent id is not found in the circuit.
+    UnknownPersistentId(String),
     /// One of the worker threads terminated unexpectedly.
     WorkerPanic {
         // Detailed panic information from all threads that
@@ -85,6 +87,7 @@ pub enum Error {
 impl DetailedError for Error {
     fn error_code(&self) -> Cow<'static, str> {
         match self {
+            Self::UnknownPersistentId(_) => Cow::from("UnknownPersistentId"),
             Self::WorkerPanic { .. } => Cow::from("WorkerPanic"),
             Self::Terminated => Cow::from("Terminated"),
             Self::IncompatibleStorage => Cow::from("IncompatibleStorage"),
@@ -96,6 +99,9 @@ impl DetailedError for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         match self {
+            Self::UnknownPersistentId(persistent_id) => {
+                write!(f, "Unknown persistent node id: {persistent_id}")
+            }
             Self::WorkerPanic { panic_info } => {
                 writeln!(f, "One or more worker threads terminated unexpectedly")?;
 

--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -41,7 +41,7 @@ pub enum BalancerError {
     NotRegisteredWithBalancer(NodeId),
     /// Hint cannot be enforced in the current state.
     InvalidPolicyHint(PartitioningPolicy, String),
-    /// No solution found for .
+    /// No solution found for balancing constraints.
     NoSolution,
 }
 
@@ -1438,6 +1438,10 @@ impl Balancer {
         self.inner
             .borrow_mut()
             .set_policy_for_stream(stream, policy);
+    }
+
+    pub fn get_policy_for_stream(&self, node_id: NodeId) -> Option<PartitioningPolicy> {
+        self.inner.borrow().get_policy_for_stream(node_id)
     }
 
     pub fn key_distribtion_for_stream_local_worker(&self, stream: NodeId) -> Option<i64> {

--- a/crates/dbsp/src/operator/dynamic/balance/test.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/test.rs
@@ -7,7 +7,7 @@ use tempfile::tempdir;
 use crate::{
     Circuit, IndexedZSetHandle, OrdIndexedZSet, OrdZSet, OutputHandle, RootCircuit, Runtime,
     ZWeight,
-    circuit::{CircuitConfig, CircuitStorageConfig, GlobalNodeId},
+    circuit::{CircuitConfig, CircuitStorageConfig, Mode},
     default_hasher,
     dynamic::{Data, DowncastTrait as _},
     operator::{
@@ -58,12 +58,13 @@ fn accumulate_trace_with_balancer_test_circuit(
     circuit: &mut RootCircuit,
 ) -> AnyResult<(
     IndexedZSetHandle<u64, u64>,
-    GlobalNodeId,
+    String,
     OutputHandle<SpineSnapshot<OrdIndexedZSet<u64, u64>>>,
     OutputHandle<OrdIndexedZSet<u64, u64>>,
 )> {
     let (input, input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
-    let input_node_id = input.origin_node_id().clone();
+    input.set_persistent_id(Some("input"));
+    let input_node_id = "input".to_string();
 
     let (balanced_accumulator, balanced_trace) = input.accumulate_trace_balanced();
 
@@ -91,23 +92,27 @@ fn accumulate_trace_with_balancer_test_circuit(
 type JoinTestCircuitResult = (
     IndexedZSetHandle<u64, u64>,
     IndexedZSetHandle<u64, u64>,
-    GlobalNodeId,
-    GlobalNodeId,
+    String,
+    String,
     OutputHandle<OrdZSet<Tup3<u64, u64, Option<u64>>>>,
 );
 
 fn join_with_balancer_test_circuit(circuit: &mut RootCircuit) -> AnyResult<JoinTestCircuitResult> {
     let (left_input, left_input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
     let (right_input, right_input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
-    let left_input_node_id = left_input.origin_node_id().clone();
-    let right_input_node_id = right_input.origin_node_id().clone();
+    left_input.set_persistent_id(Some("left_input"));
+    let left_input_node_id = "left_input".to_string();
+
+    right_input.set_persistent_id(Some("right_input"));
+    let right_input_node_id = "right_input".to_string();
 
     // let balanced_stream_output = balanced_stream.accumulate_output();
     let join_output_handle = left_input
         .join_balanced_inner(&right_input, |key, v1, v2| Tup3(*key, *v1, Some(*v2)))
+        .set_persistent_id(Some("join_output"))
         .accumulate_integrate_trace()
         .apply(|trace| trace.ro_snapshot().consolidate())
-        .output();
+        .output_persistent(Some("output"));
 
     Ok((
         left_input_handle,
@@ -125,8 +130,8 @@ fn left_join_with_balancer_test_circuit(
 ) -> AnyResult<(
     IndexedZSetHandle<u64, u64>,
     IndexedZSetHandle<u64, u64>,
-    GlobalNodeId,
-    GlobalNodeId,
+    String,
+    String,
     OutputHandle<OrdZSet<Tup3<u64, u64, Option<u64>>>>,
 )> {
     let (left_input, left_input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
@@ -134,15 +139,19 @@ fn left_join_with_balancer_test_circuit(
 
     let right_input = right_input.map_index(|(k, v)| (k.clone(), Some(v.clone())));
 
-    let left_input_node_id = left_input.origin_node_id().clone();
-    let right_input_node_id = right_input.origin_node_id().clone();
+    left_input.set_persistent_id(Some("left_input"));
+    let left_input_node_id = "left_input".to_string();
+
+    right_input.set_persistent_id(Some("right_input"));
+    let right_input_node_id = "right_input".to_string();
 
     // let balanced_stream_output = balanced_stream.accumulate_output();
     let join_output_handle = left_input
         .left_join_balanced_inner(&right_input, |key, v1, v2| Tup3(*key, *v1, *v2))
+        .set_persistent_id(Some("join_output"))
         .accumulate_integrate_trace()
         .apply(|trace| trace.ro_snapshot().consolidate())
-        .output();
+        .output_persistent(Some("output"));
 
     Ok((
         left_input_handle,
@@ -194,39 +203,63 @@ fn circular_dependency_test_circuit(
     let (left_input, left_input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
     let (right_input, right_input_handle) = circuit.add_input_indexed_zset::<u64, u64>();
 
-    let s2 = left_input.map_index(|(k, v)| (k.clone(), v.clone()));
-    let s3 = right_input.map_index(|(k, v)| (k.clone(), v.clone()));
-    let s5 = left_input.map_index(|(k, v)| (k.clone(), v.clone()));
-    let s6 = right_input.map_index(|(k, v)| (k.clone(), v.clone()));
+    let s2 = left_input
+        .map_index(|(k, v)| (k.clone(), v.clone()))
+        .set_persistent_id(Some("s2"));
+    let s3 = right_input
+        .map_index(|(k, v)| (k.clone(), v.clone()))
+        .set_persistent_id(Some("s3"));
+    let s5 = left_input
+        .map_index(|(k, v)| (k.clone(), v.clone()))
+        .set_persistent_id(Some("s5"));
+    let s6 = right_input
+        .map_index(|(k, v)| (k.clone(), v.clone()))
+        .set_persistent_id(Some("s6"));
 
-    let s1 = s5.join_index_balanced_inner(&s6, |key, v1, v2| Some((*key, Tup2(*v1, *v2))));
-    let s4 = s2.join_index_balanced_inner(&s3, |key, v1, v2| Some((*key, Tup2(*v1, *v2))));
-    let s7 = s4.join_index_balanced_inner(&s5, |key, Tup2(v1, v2), v3| {
-        Some((*key, Tup3(*v1, *v2, *v3)))
-    });
-    let s8 = s2.join_index_balanced_inner(&s1, |key, v1, Tup2(v2, v3)| {
-        Some((*key, Tup3(*v1, *v2, *v3)))
-    });
+    let s1 = s5
+        .join_index_balanced_inner(&s6, |key, v1, v2| Some((*key, Tup2(*v1, *v2))))
+        .set_persistent_id(Some("s1"));
+    let s4 = s2
+        .join_index_balanced_inner(&s3, |key, v1, v2| Some((*key, Tup2(*v1, *v2))))
+        .set_persistent_id(Some("s4"));
+    let s7 = s4
+        .join_index_balanced_inner(&s5, |key, Tup2(v1, v2), v3| {
+            Some((*key, Tup3(*v1, *v2, *v3)))
+        })
+        .set_persistent_id(Some("s7"));
+    let s8 = s2
+        .join_index_balanced_inner(&s1, |key, v1, Tup2(v2, v3)| {
+            Some((*key, Tup3(*v1, *v2, *v3)))
+        })
+        .set_persistent_id(Some("s8"));
 
-    let output1 = s1.accumulate_output();
-    let output4 = s4.accumulate_output();
-    let output7 = s7.accumulate_output();
-    let output8 = s8.accumulate_output();
+    let output1 = s1.accumulate_output_persistent(Some("output1"));
+    let output4 = s4.accumulate_output_persistent(Some("output4"));
+    let output7 = s7.accumulate_output_persistent(Some("output7"));
+    let output8 = s8.accumulate_output_persistent(Some("output8"));
 
     // Reference outputs computed using regular joins.
-    let s1_ref = s5.join_index(&s6, |key, v1, v2| Some((*key, Tup2(*v1, *v2))));
-    let s4_ref = s2.join_index(&s3, |key, v1, v2| Some((*key, Tup2(*v1, *v2))));
-    let s7_ref = s4.join_index(&s5, |key, Tup2(v1, v2), v3| {
-        Some((*key, Tup3(*v1, *v2, *v3)))
-    });
-    let s8_ref = s2.join_index(&s1, |key, v1, Tup2(v2, v3)| {
-        Some((*key, Tup3(*v1, *v2, *v3)))
-    });
+    let s1_ref = s5
+        .join_index(&s6, |key, v1, v2| Some((*key, Tup2(*v1, *v2))))
+        .set_persistent_id(Some("s1_ref"));
+    let s4_ref = s2
+        .join_index(&s3, |key, v1, v2| Some((*key, Tup2(*v1, *v2))))
+        .set_persistent_id(Some("s4_ref"));
+    let s7_ref = s4
+        .join_index(&s5, |key, Tup2(v1, v2), v3| {
+            Some((*key, Tup3(*v1, *v2, *v3)))
+        })
+        .set_persistent_id(Some("s7_ref"));
+    let s8_ref = s2
+        .join_index(&s1, |key, v1, Tup2(v2, v3)| {
+            Some((*key, Tup3(*v1, *v2, *v3)))
+        })
+        .set_persistent_id(Some("s8_ref"));
 
-    let output1_ref = s1_ref.accumulate_output();
-    let output4_ref = s4_ref.accumulate_output();
-    let output7_ref = s7_ref.accumulate_output();
-    let output8_ref = s8_ref.accumulate_output();
+    let output1_ref = s1_ref.accumulate_output_persistent(Some("output1_ref"));
+    let output4_ref = s4_ref.accumulate_output_persistent(Some("output4_ref"));
+    let output7_ref = s7_ref.accumulate_output_persistent(Some("output7_ref"));
+    let output8_ref = s8_ref.accumulate_output_persistent(Some("output8_ref"));
 
     Ok((
         left_input_handle,
@@ -251,7 +284,8 @@ fn test_accumulate_trace_with_balancer(
         Runtime::init_circuit(
             CircuitConfig::from(workers)
                 .with_splitter_chunk_size_records(2)
-                .with_balancer_min_absolute_improvement_threshold(0),
+                .with_balancer_min_absolute_improvement_threshold(0)
+                .with_mode(Mode::Persistent),
             accumulate_trace_with_balancer_test_circuit,
         )
         .unwrap();
@@ -388,6 +422,7 @@ fn mkconfig(path: &Path, workers: usize) -> CircuitConfig {
             )
             .unwrap(),
         ))
+        .with_mode(Mode::Persistent)
 }
 
 fn test_join_with_balancer(
@@ -519,12 +554,15 @@ fn test_join_with_balancer(
                 .map(|worker| output_integral_handle.take_from_worker(worker).unwrap())
                 .collect();
 
-            let current_policies = circuit.get_current_balancer_policy().unwrap();
-            let current_left_policy = current_policies.get(&left_input_node_id).unwrap();
-            let current_right_policy = current_policies.get(&right_input_node_id).unwrap();
+            let current_left_policy = circuit
+                .get_current_balancer_policy(&left_input_node_id)
+                .unwrap();
+            let current_right_policy = circuit
+                .get_current_balancer_policy(&right_input_node_id)
+                .unwrap();
 
-            assert_eq!(current_left_policy, &expected_left_policy.unwrap());
-            assert_eq!(current_right_policy, &expected_right_policy.unwrap());
+            assert_eq!(current_left_policy, expected_left_policy.unwrap());
+            assert_eq!(current_right_policy, expected_right_policy.unwrap());
             assert_eq!(output_trace, expected_output);
 
             if checkpoints {


### PR DESCRIPTION
Partially fixes #6160 

Make the `set_balancer_hint` API more suited for use by the compiler. Instead of using global operator id's, which the compiler currently doesn't track (and which are internal to DBSP for most purposes), it now relies on compiler-assigned persistent id's. The old API still exists with a different name.