### PR TITLE
[SQL] Warn about `INSERT`/`REMOVE` (undocumented) statements used in pipeline definitions as having no effect

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/CompilerOptions.java
@@ -196,33 +196,34 @@ public class CompilerOptions implements IDiff<CompilerOptions>, IValidate {
         @Parameter(names = "--handles",
                 description = "Use handles (true) or Catalog (false) in the emitted Rust code")
         public boolean emitHandles = false;
-        // This option is ignored; it is here just for backward compatibility, and it will be removed.
-        @Parameter(names = "--nowstream", hidden = true,
-                description = "Implement NOW as a stream (true) or as an internal operator (false)")
-        public boolean ignored = true;
-        @Parameter(names = "--sqlnames", hidden = true,
-                description = "Use the table names as identifiers in the generated code")
-        public boolean sqlNames = false;
         @Parameter(names = "--trimInputs", description = "Do not ingest unused fields of input tables")
         public boolean trimInputs = false;
-        @Parameter(names = "--raw", hidden = true,
-                description = "Do not generate any internal tables (ERROR, NOW, etc).")
-        public boolean raw = false;
         @Parameter(names = "--crates", description = "Followed by a program name. Generates code using multiple crates; " +
                 "`outputFile` is interpreted as a directory.")
         public String crates = "";
         @Parameter(names = "--runtime", description = "Followed by a path.  Path to the runtime to use.  " +
                 "Used in conjunction with '--crates'.")
         public String runtimePath = "";
+        @Parameter(names = "--correlatedColumns",
+                description = "Dump information about the columns that are used in join equality comparisons")
+        public boolean correlatedColumns = false;
+
+        // Hidden options used for testing
+        @Parameter(names = "--sqlnames", hidden = true,
+                description = "Use the table names as identifiers in the generated code")
+        public boolean sqlNames = false;
+        @Parameter(names = "--raw", hidden = true,
+                description = "Do not generate any internal tables (ERROR, NOW, etc).")
+        public boolean raw = false;
         @Parameter(hidden = true, names = "--input_circuit",
                 description = "Do not process the circuit, return immediately after creation.  Used for testing")
         public boolean inputCircuit = false;
         @Parameter(hidden = true, names = "--skip_calcite_optimization",
                 description = "Calcite optimizer steps whose names match this regex are not applied.  Used for testing")
         public String skipCalciteOptimizations = "";
-        @Parameter(names = "--correlatedColumns",
-                description = "Dump information about the columns that are used in join equality comparisons")
-        public boolean correlatedColumns = false;
+        @Parameter(hidden = true, names = "--testing",
+                description = "Signals that compiler is invoked from a testing path: disables some warnings")
+        public boolean testing = false;
 
         // Used only for internal testing
         public boolean nowStream = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -2329,9 +2329,13 @@ public class CalciteToDBSPCompiler extends RelVisitor
         DBSPTypeTuple resultType;
         if (this.modifyTableTranslation != null) {
             resultType = this.modifyTableTranslation.getResultType();
-            if (sourceType.size() != resultType.size())
-                throw new InternalCompilerError("Expected a tuple with " + resultType.size() +
-                        " values but got " + values, node);
+            if (sourceType.size() != resultType.size()) {
+                this.compiler.reportError(this.modifyTableTranslation.getPosition(),
+                        "Schema error",
+                        "VALUES has " + sourceType.size() + " columns but " + resultType.size() + " are expected");
+                // Ignore value
+                return;
+            }
         } else {
             resultType = sourceType;
         }
@@ -3076,6 +3080,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
         return o;
     }
 
+    @Nullable
     DBSPNode compileModifyTable(TableModifyStatement modify) {
         // The type of the data must be extracted from the modified table
         boolean isInsert = modify.insert;
@@ -3086,6 +3091,10 @@ public class CalciteToDBSPCompiler extends RelVisitor
         } else {
             SqlRemove remove = (SqlRemove) modify.parsedStatement.statement();
             targetColumnList = remove.getTargetColumnList();
+        }
+        if (!this.options.ioOptions.testing) {
+            this.compiler.reportWarning(modify.getPosition(), "Statement ignored",
+                    modify.getSqlOperationName() + " has no effect in a pipeline definition");
         }
         CreateTableStatement def = this.tableContents.getTableDefinition(modify.tableName);
         this.modifyTableTranslation = new ModifyTableTranslation(
@@ -3123,9 +3132,11 @@ public class CalciteToDBSPCompiler extends RelVisitor
             throw new UnimplementedException("statement of this form not supported",
                     modify.getCalciteObject());
         }
+        this.modifyTableTranslation = null;
+        if (result == null)
+            return result;
         if (!isInsert)
             result = result.negate();
-        this.modifyTableTranslation = null;
         this.tableContents.addToTable(modify.tableName, result, this.compiler);
         return result;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ModifyTableTranslation.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.dbsp.sqlCompiler.compiler.errors.CompilationError;
+import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
 import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.CreateTableStatement;
@@ -46,6 +47,7 @@ import java.util.Objects;
 
 /** Information used to translate INSERT or DELETE SQL statements */
 class ModifyTableTranslation {
+    private final TableModifyStatement statement;
     /** Result of the VALUES expression. */
     @Nullable
     private DBSPZSetExpression valuesTranslation;
@@ -63,6 +65,7 @@ class ModifyTableTranslation {
                                   CreateTableStatement tableDefinition,
                                   @Nullable SqlNodeList columnList,
                                   TypeCompiler compiler) {
+        this.statement = statement;
         this.valuesTranslation = null;
         this.columnPermutation = null;
         DBSPTypeTuple sourceType = tableDefinition.getRowTypeAsTuple(compiler);
@@ -97,12 +100,17 @@ class ModifyTableTranslation {
         }
     }
 
+    @Nullable
     public DBSPZSetExpression getTranslation() {
-        return Objects.requireNonNull(this.valuesTranslation);
+        return this.valuesTranslation;
     }
 
     public DBSPTypeTuple getResultType() {
         return Objects.requireNonNull(this.resultType);
+    }
+
+    public SourcePositionRange getPosition() {
+        return this.statement.getPosition();
     }
 
     DBSPExpression permuteColumns(DBSPExpression expression) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/statements/TableModifyStatement.java
@@ -40,8 +40,7 @@ public class TableModifyStatement extends RelStatement {
     /** True for insert, false for remove */
     public final boolean insert;
 
-    public TableModifyStatement(
-            ParsedStatement node, boolean insert, ProgramIdentifier tableName, SqlNode data) {
+    public TableModifyStatement(ParsedStatement node, boolean insert, ProgramIdentifier tableName, SqlNode data) {
         super(node);
         this.insert = insert;
         this.tableName = tableName;
@@ -51,5 +50,9 @@ public class TableModifyStatement extends RelStatement {
 
     public void setTranslation(RelNode rel) {
         this.rel = rel;
+    }
+
+    public String getSqlOperationName() {
+        return this.insert ? "INSERT" : "REMOVE";
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/suites/nexmark/NexmarkTest.java
@@ -565,6 +565,7 @@ SELECT
     @Override
     public CompilerOptions testOptions() {
         CompilerOptions options = new CompilerOptions();
+        options.ioOptions.testing = true;
         options.languageOptions.streaming = true;
         options.languageOptions.throwOnError = true;
         options.languageOptions.incrementalize = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -413,6 +413,7 @@ public class BaseSQLTests {
         if (Utilities.inCI())
             // Set to compile to multiple crates
             options.ioOptions.crates = "x";
+        options.ioOptions.testing = true;
         options.languageOptions.throwOnError = true;
         options.languageOptions.generateInputForEveryTable = true;
         options.ioOptions.quiet = true;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/SqlIoTest.java
@@ -52,6 +52,7 @@ public abstract class SqlIoTest extends BaseSQLTests {
 
     public CompilerOptions testOptions() {
         CompilerOptions options = new CompilerOptions();
+        options.ioOptions.testing = true;
         options.ioOptions.quiet = true;
         options.ioOptions.emitHandles = true;
         options.languageOptions.throwOnError = true;


### PR DESCRIPTION
Fixes #6158 

We heuristically detect if the compiler is invoked from the pipeline manager and we give a warning for INSERT statements.
(These statements have legitimate uses in testing, so the compiler supports them.)

Eventually we may want to support these (using a special constant connector?), but right now they have no effect.


