### PR TITLE
[connectors] configure storage for datafusion instances used by connectors

### DIFF
--- a/crates/adapterlib/src/errors/controller.rs
+++ b/crates/adapterlib/src/errors/controller.rs
@@ -168,6 +168,14 @@ pub enum ConfigError {
     FtRequiresStorage,
     FtRequiresFtInput,
 
+    /// `datafusion_memory_mb` was set to a value greater than or equal to
+    /// the pipeline's effective memory budget, which would leave no memory
+    /// for the DBSP circuit.
+    DatafusionMemoryExceedsBudget {
+        datafusion_memory_mb: u64,
+        max_rss_mb: u64,
+    },
+
     InvalidLayout(LayoutError),
 }
 
@@ -203,6 +211,9 @@ impl DbspDetailedError for ConfigError {
             Self::FtRequiresFtInput => Cow::from("FtWithNonFtInput"),
             Self::CyclicDependency { .. } => Cow::from("CyclicDependency"),
             Self::EmptyStartAfter { .. } => Cow::from("EmptyStartAfter"),
+            Self::DatafusionMemoryExceedsBudget { .. } => {
+                Cow::from("DatafusionMemoryExceedsBudget")
+            }
             Self::InvalidLayout(_) => Cow::from("LayoutError"),
         }
     }
@@ -416,6 +427,13 @@ impl Display for ConfigError {
             Self::FtRequiresFtInput => write!(
                 f,
                 "Fault tolerance is configured, but it cannot be enabled because the pipeline has at least one non-fault-tolerant input adapter"
+            ),
+            Self::DatafusionMemoryExceedsBudget {
+                datafusion_memory_mb,
+                max_rss_mb,
+            } => write!(
+                f,
+                "'datafusion_memory_mb' ({datafusion_memory_mb} MB) must be less than the pipeline's memory budget ({max_rss_mb} MB); the difference is the budget available to the DBSP circuit"
             ),
             Self::InvalidLayout(e) => write!(f, "Multihost layout error: {e}"),
         }

--- a/crates/adapterlib/src/utils/datafusion.rs
+++ b/crates/adapterlib/src/utils/datafusion.rs
@@ -1,12 +1,227 @@
 use crate::errors::journal::ControllerError;
 use anyhow::{Error as AnyError, anyhow};
 use arrow::array::Array;
+use datafusion::common::ScalarValue;
 use datafusion::common::arrow::array::{AsArray, RecordBatch};
+use datafusion::execution::SessionStateBuilder;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::logical_expr::sqlparser::parser::ParserError;
-use datafusion::prelude::{SQLOptions, SessionContext};
+use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion::sql::sqlparser::dialect::GenericDialect;
 use datafusion::sql::sqlparser::parser::Parser;
+use feldera_types::config::PipelineConfig;
+use feldera_types::constants::DATAFUSION_TEMP_DIR;
 use feldera_types::program_schema::{ColumnType, Field, Relation, SqlType};
+use std::ffi::OsStr;
+use std::fs::{create_dir_all, read_dir, remove_dir_all, remove_file};
+use std::io::Error as IoError;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tracing::warn;
+
+/// In-memory sort threshold; above this, sorts spill to disk. 64 MiB.
+///
+/// Powers of two align with page sizes (4 KiB / 2 MiB) the allocator
+/// hands back, so a `1 << 26` budget matches what the OS actually
+/// reserves rather than a round decimal value the OS rounds up anyway.
+const SORT_IN_PLACE_THRESHOLD_BYTES: usize = 1 << 26;
+
+/// Memory withheld from the sort phase for the merge phase to use. 64 MiB.
+///
+/// Reserved per partition: a sort with N partitions pre-allocates
+/// `N * SORT_SPILL_RESERVATION_BYTES` from the pool.
+/// If the pool can't satisfy that, the query fails immediately
+/// with `Resources exhausted`. `create_runtime_env` emits a startup warning
+/// when the configured pool is below `workers * SORT_SPILL_RESERVATION_BYTES`.
+///
+/// Note: DataFusion 52.x emits noisy `WARN datafusion_physical_plan::spill:
+/// Record batch memory usage ... exceeds the expected limit ... by more
+/// than the allowed tolerance` lines during spilled sorts. The overage is
+/// typically a handful of bytes over a 4 KB tolerance -- upstream
+/// accounting drift, tracked at
+/// <https://github.com/apache/datafusion/issues/17340> Not a query failure
+const SORT_SPILL_RESERVATION_BYTES: usize = 1 << 26;
+
+/// Build the shared datafusion [`RuntimeEnv`] for a pipeline.
+///
+/// Build once per pipeline and share the `Arc` across every
+/// `SessionContext`. A separate `RuntimeEnv` per context would give each its
+/// own pool, multiplying the effective memory budget by `(1 + #connectors)`.
+pub fn create_runtime_env(
+    pipeline_config: &PipelineConfig,
+) -> Result<Arc<RuntimeEnv>, ControllerError> {
+    let mut builder = RuntimeEnvBuilder::new();
+    if let Some(datafusion_memory_mb) = pipeline_config.global.resolved_datafusion_memory_mb() {
+        let memory_bytes_max = datafusion_memory_mb * 1_000_000;
+        builder = builder.with_memory_pool(Arc::new(FairSpillPool::new(memory_bytes_max as usize)));
+        warn_if_pool_too_small_for_adhoc_sort(pipeline_config, datafusion_memory_mb);
+    }
+    if let Some(storage) = &pipeline_config.storage_config {
+        let path = PathBuf::from(storage.path.clone()).join(DATAFUSION_TEMP_DIR);
+        create_dir_all(&path).map_err(|error| {
+            ControllerError::io_error(
+                format!(
+                    "unable to create datafusion scratch space directory '{}'",
+                    path.display()
+                ),
+                error,
+            )
+        })?;
+        clean_stale_scratch_entries(&path);
+        builder = builder.with_temp_file_path(path);
+    }
+    builder.build_arc().map_err(|error| {
+        ControllerError::io_error(
+            "unable to build datafusion runtime environment",
+            IoError::other(error.to_string()),
+        )
+    })
+}
+
+/// Minimum DataFusion pool size, in MB, that can satisfy the ad-hoc
+/// engine's per-partition sort reservation given `workers`.
+///
+/// Ad-hoc sessions set `target_partitions = workers`
+/// (see [`create_session_context`]), so an `ORDER BY` (or any other
+/// sort-based operator) reserves `workers * SORT_SPILL_RESERVATION_BYTES`
+/// from the pool *before* sorting any rows. The reservation is in
+/// binary MiB (`1 << 26`); the pool is sized from the user-facing
+/// `datafusion_memory_mb` (decimal MB). Compare in bytes, then
+/// ceil-divide to MB so the warning's threshold is never lower than
+/// the actual byte requirement.
+fn min_pool_mb_for_adhoc_sort(workers: u64) -> u64 {
+    let needed_bytes = (SORT_SPILL_RESERVATION_BYTES as u64).saturating_mul(workers);
+    needed_bytes.div_ceil(1_000_000)
+}
+
+/// Warn at startup when the DataFusion pool is too small to satisfy the
+/// per-partition sort reservation for the ad-hoc query engine.
+///
+/// If the pool can't satisfy that, the query fails on the first reservation
+/// attempt with `Resources exhausted`. Surface this as a single startup
+/// warning so the failure mode isn't silent. Connector sessions can override
+/// `target_partitions`; their reservation budget is not checked here.
+fn warn_if_pool_too_small_for_adhoc_sort(pipeline_config: &PipelineConfig, pool_mb: u64) {
+    let workers = pipeline_config.global.workers as u64;
+    // Degenerate configs (tests / synthetic) report `workers == 0`; nothing
+    // useful to say in that case and the message would print "0 MB".
+    if workers == 0 {
+        return;
+    }
+    let min_pool_mb = min_pool_mb_for_adhoc_sort(workers);
+    // `<=` not `<`: at exact equality every partition's reservation sums to
+    // the full pool with zero headroom. FairSpillPool's internal accounting
+    // takes a few bytes of overhead, so the last partition's reservation
+    // fails by a fraction of a MB. Empirically: pool=256 / workers=4
+    // fails; 257 succeeds.
+    if pool_mb <= min_pool_mb {
+        let per_worker_mb = min_pool_mb_for_adhoc_sort(1);
+        warn!(
+            "DataFusion memory pool is {pool_mb} MB; sort-heavy ad-hoc \
+             queries (ORDER BY, EXCEPT, hash joins) need at least \
+             {min_pool_mb} MB ({workers} workers x {per_worker_mb} MB \
+             reservation per worker). Such queries may fail at first \
+             allocation with 'Resources exhausted'. Increase \
+             'datafusion_memory_mb' or reduce 'workers'."
+        );
+    }
+}
+
+/// Remove leftovers from a previous process inside the scratch directory.
+///
+/// DataFusion's `DiskManager` leaks its `datafusion-XXXXXX/` subdir if the
+/// process is killed before `tempfile::TempDir::drop` runs. The previous
+/// process is gone by the time we get here, so anything still in the dir is
+/// orphaned. Spill files are per-query and never need to survive a restart.
+/// Errors only logged: a stuck file should not block startup.
+fn clean_stale_scratch_entries(scratch_dir: &Path) {
+    // Tripwire: refuse to recursively delete anything whose final
+    // component isn't the well-known scratch dir name. Defends against a
+    // future caller accidentally passing `/`, `~`, or the storage root.
+    if scratch_dir.file_name() != Some(OsStr::new(DATAFUSION_TEMP_DIR)) {
+        warn!(
+            "refusing to clean unexpected scratch directory '{}'; expected final component '{DATAFUSION_TEMP_DIR}'",
+            scratch_dir.display(),
+        );
+        return;
+    }
+    let entries = match read_dir(scratch_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(
+                "unable to read datafusion scratch directory '{}' for startup cleanup: {error}",
+                scratch_dir.display(),
+            );
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(error) => {
+                warn!(
+                    "unable to stat stale datafusion scratch entry '{}': {error}",
+                    path.display(),
+                );
+                continue;
+            }
+        };
+        let result = if file_type.is_dir() {
+            remove_dir_all(&path)
+        } else {
+            remove_file(&path)
+        };
+        if let Err(error) = result {
+            warn!(
+                "unable to remove stale datafusion scratch entry '{}': {error}",
+                path.display(),
+            );
+        }
+    }
+}
+
+/// `SessionContext` bound to the shared [`RuntimeEnv`], configured with the
+/// pipeline's worker count and feldera's sort-spill thresholds.
+pub fn create_session_context(
+    pipeline_config: &PipelineConfig,
+    runtime_env: Arc<RuntimeEnv>,
+) -> SessionContext {
+    create_session_context_with(pipeline_config, runtime_env, |cfg| cfg)
+}
+
+/// Like [`create_session_context`], with a hook to override individual
+/// datafusion settings (e.g. parquet decoding) before the context is built.
+pub fn create_session_context_with<F>(
+    pipeline_config: &PipelineConfig,
+    runtime_env: Arc<RuntimeEnv>,
+    customize_config: F,
+) -> SessionContext
+where
+    F: FnOnce(SessionConfig) -> SessionConfig,
+{
+    let workers = pipeline_config
+        .global
+        .io_workers
+        .unwrap_or(pipeline_config.global.workers as u64);
+    let session_config = SessionConfig::new()
+        .with_target_partitions(workers as usize)
+        .with_sort_in_place_threshold_bytes(SORT_IN_PLACE_THRESHOLD_BYTES)
+        .with_sort_spill_reservation_bytes(SORT_SPILL_RESERVATION_BYTES)
+        .set(
+            "datafusion.execution.planning_concurrency",
+            &ScalarValue::UInt64(Some(workers)),
+        );
+    let session_config = customize_config(session_config);
+
+    let state = SessionStateBuilder::new()
+        .with_config(session_config)
+        .with_runtime_env(runtime_env)
+        .with_default_features()
+        .build();
+    SessionContext::from(state)
+}
 
 /// Execute a SQL query and collect all results in a vector of `RecordBatch`'s.
 pub async fn execute_query_collect(
@@ -171,4 +386,282 @@ pub async fn validate_timestamp_column(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_runtime_env, create_session_context};
+    use datafusion::execution::memory_pool::MemoryLimit;
+    use feldera_types::config::{PipelineConfig, ResourceConfig, RuntimeConfig, StorageConfig};
+    use feldera_types::constants::DATAFUSION_TEMP_DIR;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    /// Drop guard so a failing test does not leak temp directories.
+    struct TempStorage {
+        path: PathBuf,
+    }
+
+    impl TempStorage {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(name);
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempStorage {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn pipeline_config(global: RuntimeConfig, storage: Option<&Path>) -> PipelineConfig {
+        PipelineConfig {
+            global,
+            multihost: None,
+            name: None,
+            given_name: None,
+            storage_config: storage.map(|p| StorageConfig {
+                path: p.to_string_lossy().into(),
+                cache: Default::default(),
+            }),
+            secrets_dir: None,
+            inputs: Default::default(),
+            outputs: Default::default(),
+            program_ir: None,
+        }
+    }
+
+    #[test]
+    fn create_runtime_env_creates_tmp_dir_under_storage() {
+        let storage = TempStorage::new("feldera-datafusion-create-runtime-env-tmp-dir-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+
+        create_runtime_env(&cfg).unwrap();
+
+        let expected = storage.path().join(DATAFUSION_TEMP_DIR);
+        assert!(
+            expected.is_dir(),
+            "expected scratch directory at {}",
+            expected.display(),
+        );
+    }
+
+    /// Must match the value `checkpointer::gc_startup` allowlists, or the
+    /// scratch dir is wiped on every restart.
+    #[test]
+    fn scratch_dir_name_matches_gc_allowlist_constant() {
+        assert_eq!(DATAFUSION_TEMP_DIR, "datafusion-tmp");
+    }
+
+    #[test]
+    fn create_runtime_env_without_storage_succeeds() {
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                ..Default::default()
+            },
+            None,
+        );
+        create_runtime_env(&cfg).unwrap();
+    }
+
+    #[test]
+    fn create_runtime_env_applies_memory_pool_when_budget_set() {
+        // 5% of 16 GB = 800 MB; below the 2 GB ceiling.
+        let storage = TempStorage::new("feldera-datafusion-create-runtime-env-pool-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                max_rss_mb: Some(16_000),
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+
+        let env = create_runtime_env(&cfg).unwrap();
+        match env.memory_pool.memory_limit() {
+            MemoryLimit::Finite(bytes) => assert_eq!(bytes, 800 * 1_000_000),
+            MemoryLimit::Infinite => panic!("expected a bounded memory pool, got Infinite"),
+            MemoryLimit::Unknown => panic!("expected a bounded memory pool, got Unknown"),
+        }
+    }
+
+    #[test]
+    fn create_runtime_env_no_memory_limit_when_budget_unset() {
+        let storage = TempStorage::new("feldera-datafusion-create-runtime-env-unbounded-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+
+        let env = create_runtime_env(&cfg).unwrap();
+        // Anything other than `Finite(_)` proves no FairSpillPool was wired in.
+        match env.memory_pool.memory_limit() {
+            MemoryLimit::Finite(bytes) => {
+                panic!("expected an unbounded pool, got finite limit of {bytes} bytes");
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn create_runtime_env_uses_resources_memory_mb_max_fallback() {
+        let storage = TempStorage::new("feldera-datafusion-create-runtime-env-resources-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                max_rss_mb: None,
+                resources: ResourceConfig {
+                    memory_mb_max: Some(16_000),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+
+        let env = create_runtime_env(&cfg).unwrap();
+        match env.memory_pool.memory_limit() {
+            MemoryLimit::Finite(bytes) => assert_eq!(bytes, 800 * 1_000_000),
+            MemoryLimit::Infinite => panic!("expected a bounded memory pool, got Infinite"),
+            MemoryLimit::Unknown => panic!("expected a bounded memory pool, got Unknown"),
+        }
+    }
+
+    #[test]
+    fn create_runtime_env_wipes_stale_scratch_entries() {
+        let storage = TempStorage::new("feldera-datafusion-create-runtime-env-wipe-test");
+        let scratch = storage.path().join(DATAFUSION_TEMP_DIR);
+        fs::create_dir_all(&scratch).unwrap();
+
+        // Simulate leftovers from a prior crashed process.
+        let stale_subdir = scratch.join("datafusion-stale1");
+        fs::create_dir_all(&stale_subdir).unwrap();
+        fs::write(stale_subdir.join("orphan.arrow"), b"stale").unwrap();
+        let stale_file = scratch.join("loose.tmp");
+        fs::write(&stale_file, b"stale").unwrap();
+
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 1,
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+        create_runtime_env(&cfg).unwrap();
+
+        assert!(
+            scratch.is_dir(),
+            "scratch root must survive cleanup; gc_startup keeps it on the allowlist",
+        );
+        assert!(
+            !stale_subdir.exists(),
+            "stale per-DiskManager subdir should be removed on startup",
+        );
+        assert!(
+            !stale_file.exists(),
+            "stale loose file should be removed on startup",
+        );
+    }
+
+    #[test]
+    fn create_session_context_target_partitions_match_workers() {
+        let storage = TempStorage::new("feldera-datafusion-create-session-context-workers-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 7,
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+        let env = create_runtime_env(&cfg).unwrap();
+        let ctx = create_session_context(&cfg, env);
+        assert_eq!(ctx.copied_config().target_partitions(), 7);
+    }
+
+    #[test]
+    fn create_session_context_target_partitions_prefer_io_workers() {
+        let storage = TempStorage::new("feldera-datafusion-create-session-context-io-workers-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 4,
+                io_workers: Some(12),
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+        let env = create_runtime_env(&cfg).unwrap();
+        let ctx = create_session_context(&cfg, env);
+        assert_eq!(ctx.copied_config().target_partitions(), 12);
+    }
+
+    #[test]
+    fn create_session_context_with_customise_overrides_defaults() {
+        use super::create_session_context_with;
+        let storage = TempStorage::new("feldera-datafusion-create-session-context-override-test");
+        let cfg = pipeline_config(
+            RuntimeConfig {
+                workers: 4,
+                ..Default::default()
+            },
+            Some(storage.path()),
+        );
+        let env = create_runtime_env(&cfg).unwrap();
+        // Customise hook must win over the worker-derived defaults.
+        let ctx = create_session_context_with(&cfg, env, |c| {
+            c.set_usize("datafusion.execution.target_partitions", 99)
+        });
+        assert_eq!(ctx.copied_config().target_partitions(), 99);
+    }
+
+    /// Tripwire: `clean_stale_scratch_entries` refuses to walk a directory
+    /// whose final component isn't `DATAFUSION_TEMP_DIR`, so a misuse can't
+    /// recursively wipe an arbitrary path.
+    #[test]
+    fn clean_stale_scratch_entries_refuses_unexpected_paths() {
+        use super::clean_stale_scratch_entries;
+        let storage = TempStorage::new("feldera-datafusion-clean-scratch-guard-test");
+        let bogus = storage.path().join("not-the-scratch-dir");
+        fs::create_dir_all(&bogus).unwrap();
+        let canary = bogus.join("canary.txt");
+        fs::write(&canary, b"do not delete").unwrap();
+
+        clean_stale_scratch_entries(&bogus);
+
+        assert!(
+            canary.exists(),
+            "guard must not delete contents of a directory whose name != DATAFUSION_TEMP_DIR",
+        );
+    }
+
+    /// Pins the boundary that drives the `warn_if_pool_too_small_for_adhoc_sort`
+    /// log line. If `SORT_SPILL_RESERVATION_BYTES` changes, the warning
+    /// threshold changes with it
+    #[test]
+    fn min_pool_mb_for_adhoc_sort_matches_reservation_times_workers() {
+        use super::min_pool_mb_for_adhoc_sort;
+        // SORT_SPILL_RESERVATION_BYTES is 64 MiB = 67_108_864 B; the
+        // resolved pool size is reported in decimal MB, so each worker's
+        // requirement ceil-divides to 68 MB.
+        assert_eq!(min_pool_mb_for_adhoc_sort(0), 0);
+        assert_eq!(min_pool_mb_for_adhoc_sort(1), 68);
+        assert_eq!(min_pool_mb_for_adhoc_sort(2), 135);
+        assert_eq!(min_pool_mb_for_adhoc_sort(8), 537);
+    }
 }

--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -3,10 +3,8 @@ use crate::{Controller, PipelineError};
 use actix_web::{HttpRequest, HttpResponse, http::header, web::Payload};
 use actix_ws::{AggregatedMessage, CloseCode, CloseReason, Closed, Session as WsSession};
 use datafusion::common::metadata::ScalarAndMetadata;
-use datafusion::common::{DFSchema, ParamValues, ScalarValue};
-use datafusion::execution::memory_pool::FairSpillPool;
-use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion::common::{DFSchema, ParamValues};
+use datafusion::execution::SessionState;
 use datafusion::logical_expr::{EmptyRelation, Execute, LogicalPlan, Prepare, Statement};
 use datafusion::prelude::*;
 use datafusion::sql::parser::{DFParserBuilder, Statement as DFStatement};
@@ -15,64 +13,17 @@ use executor::{
     hash_query_result, infallible_from_bytestring, stream_arrow_query, stream_json_query,
     stream_parquet_query, stream_text_query,
 };
-use feldera_adapterlib::errors::journal::ControllerError;
-use feldera_types::config::PipelineConfig;
 use feldera_types::query::{AdHocResultFormat, AdhocQueryArgs, MAX_WS_FRAME_SIZE};
 use futures_util::StreamExt;
 use serde_json::json;
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
-use std::fs::create_dir_all;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::warn;
 
 mod executor;
 mod format;
 pub(crate) mod table;
-
-pub(crate) fn create_session_context(
-    config: &PipelineConfig,
-) -> Result<SessionContext, ControllerError> {
-    const SORT_IN_PLACE_THRESHOLD_BYTES: usize = 64 * 1024 * 1024;
-    const SORT_SPILL_RESERVATION_BYTES: usize = 64 * 1024 * 1024;
-    let session_config = SessionConfig::new()
-        .with_target_partitions(config.global.workers as usize)
-        .with_sort_in_place_threshold_bytes(SORT_IN_PLACE_THRESHOLD_BYTES)
-        .with_sort_spill_reservation_bytes(SORT_SPILL_RESERVATION_BYTES)
-        .set(
-            "datafusion.execution.planning_concurrency",
-            &ScalarValue::UInt64(Some(config.global.workers as u64)),
-        );
-    // Initialize datafusion memory limits
-    let mut runtime_env_builder = RuntimeEnvBuilder::new();
-    if let Some(memory_mb_max) = config.global.resources.memory_mb_max {
-        let memory_bytes_max = memory_mb_max * 1_000_000;
-        runtime_env_builder = runtime_env_builder
-            .with_memory_pool(Arc::new(FairSpillPool::new(memory_bytes_max as usize)));
-    }
-    // Initialize datafusion spill-to-disk directory
-    if let Some(storage) = &config.storage_config {
-        let path = PathBuf::from(storage.path.clone()).join("adhoc-tmp");
-        if !path.exists() {
-            create_dir_all(&path).map_err(|error| {
-                ControllerError::io_error(
-                    "unable to create ad-hoc scratch space directory during startup",
-                    error,
-                )
-            })?;
-        }
-        runtime_env_builder = runtime_env_builder.with_temp_file_path(path);
-    }
-
-    let runtime_env = runtime_env_builder.build_arc().unwrap();
-    let state = SessionStateBuilder::new()
-        .with_config(session_config)
-        .with_runtime_env(runtime_env)
-        .with_default_features()
-        .build();
-    Ok(SessionContext::from(state))
-}
 
 /// Helper for for closing the websocket session
 ///
@@ -537,6 +488,8 @@ mod tests {
     use super::*;
     use datafusion::arrow;
     use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::common::ScalarValue;
+    use datafusion::execution::SessionStateBuilder;
 
     fn test_state() -> SessionState {
         SessionStateBuilder::new().with_default_features().build()

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -73,6 +73,7 @@ use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{
     CommandHandler, InputReader, OutputBatchType, Resume, Watermark,
 };
+use feldera_adapterlib::utils::datafusion::{create_runtime_env, create_session_context};
 use feldera_ir::LirCircuit;
 use feldera_samply::{AnnotationOptions, CaptureOptions, Span};
 use feldera_storage::fbuf::slab::FBufSlabsStats;
@@ -148,8 +149,8 @@ mod stats;
 mod sync;
 mod validate;
 
+use crate::adhoc::execute_sql;
 use crate::adhoc::table::AdHocTable;
-use crate::adhoc::{create_session_context, execute_sql};
 use crate::catalog::{SerBatch, SerBatchReader, SerTrace};
 use crate::format::parquet::relation_to_arrow_fields;
 use crate::format::{MessageOrientedPreprocessedParser, StreamingPreprocessedParser};
@@ -4720,6 +4721,7 @@ impl ControllerInit {
                 hosts: checkpoint_config.global.hosts,
                 workers: checkpoint_config.global.workers,
                 max_rss_mb: config.global.max_rss_mb,
+                datafusion_memory_mb: checkpoint_config.global.datafusion_memory_mb,
 
                 // The checkpoint determines the fault tolerance model, but the
                 // pipeline manager can override the details of the
@@ -4844,10 +4846,37 @@ Using the Kubernetes limit as the RSS memory limit."
             );
         }
 
+        // Carve out a slice of the pipeline's memory budget for DataFusion's
+        // memory pool (see `RuntimeConfig::datafusion_memory_mb`) and pass
+        // only the remainder to the DBSP circuit. Without this, the circuit
+        // and DataFusion would each independently grow to the full budget,
+        // which would double-book RAM.
+        let datafusion_memory_mb = pipeline_config.global.resolved_datafusion_memory_mb();
+        let circuit_max_rss_mb = match (max_rss_mb, datafusion_memory_mb) {
+            (Some(rss), Some(df)) => {
+                if df >= rss {
+                    return Err(ControllerError::Config {
+                        config_error: Box::new(ConfigError::DatafusionMemoryExceedsBudget {
+                            datafusion_memory_mb: df,
+                            max_rss_mb: rss,
+                        }),
+                    });
+                }
+                let remainder = rss - df;
+                info!(
+                    "memory budget split: circuit RSS {remainder} MB, datafusion {df} MB \
+(total {rss} MB)"
+                );
+                Some(remainder)
+            }
+            (Some(rss), None) => Some(rss),
+            (None, _) => None,
+        };
+
         let layout =
             layout.unwrap_or_else(|| Layout::new_solo(pipeline_config.global.workers as usize));
         Ok(CircuitConfig::from(layout)
-            .with_max_rss_bytes(max_rss_mb.map(|mb| mb * 1_000_000))
+            .with_max_rss_bytes(circuit_max_rss_mb.map(|mb| mb * 1_000_000))
             .with_pin_cpus(pipeline_config.global.pin_cpus.clone())
             .with_storage(storage)
             .with_mode(Mode::Persistent)
@@ -5858,6 +5887,10 @@ pub struct ControllerInner {
     backpressure_thread_unparker: Unparker,
     error_cb: Box<dyn Fn(Arc<ControllerError>, Option<String>) + Send + Sync>,
     session_ctxt: SessionContext,
+    /// Shared datafusion runtime environment. Owns the pipeline-wide
+    /// `FairSpillPool` and spill-to-disk path so that every `SessionContext`
+    /// (ad-hoc + integrated connectors) draws from a single bounded budget.
+    datafusion_runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
     adhoc_tables: HashMap<SqlIdentifier, Arc<AdHocTable>>,
     fault_tolerance: Option<FtModel>,
     step_receiver: tokio::sync::watch::Receiver<StepStatus>,
@@ -5939,7 +5972,8 @@ impl ControllerInner {
         let (command_sender, command_receiver) = channel();
         let (transaction_sender, transaction_receiver) =
             tokio::sync::watch::channel(TransactionCoordination::default());
-        let session_ctxt = create_session_context(&config)?;
+        let datafusion_runtime_env = create_runtime_env(&config)?;
+        let session_ctxt = create_session_context(&config, datafusion_runtime_env.clone());
         let controller = Arc::new_cyclic(|weak| {
             let adhoc_tables = Self::initialize_adhoc_queries(&session_ctxt, &*catalog, weak);
             Self {
@@ -5961,6 +5995,7 @@ impl ControllerInner {
                 backpressure_thread_unparker: backpressure_thread_parker.unparker().clone(),
                 error_cb,
                 session_ctxt,
+                datafusion_runtime_env,
                 adhoc_tables,
                 fault_tolerance: config.global.fault_tolerance.model,
                 transaction_info: Mutex::new(TransactionInfo::new(
@@ -6372,6 +6407,8 @@ impl ControllerInner {
                 let endpoint = create_integrated_input_endpoint(
                     endpoint_name,
                     &resolved_connector_config,
+                    &self.status.pipeline_config,
+                    self.datafusion_runtime_env.clone(),
                     probe,
                 )?;
 
@@ -8190,4 +8227,75 @@ impl CheckpointThread {
 }
 
 #[cfg(test)]
-mod test;
+mod controller_init_tests {
+    use super::ControllerInit;
+    use crate::ControllerError;
+    use feldera_adapterlib::errors::controller::ConfigError;
+    use feldera_types::config::{PipelineConfig, RuntimeConfig};
+
+    fn pipeline_config(global: RuntimeConfig) -> PipelineConfig {
+        PipelineConfig {
+            global,
+            multihost: None,
+            name: None,
+            given_name: None,
+            storage_config: None,
+            secrets_dir: None,
+            inputs: Default::default(),
+            outputs: Default::default(),
+            program_ir: None,
+        }
+    }
+
+    /// `circuit_config` must reject an explicit `datafusion_memory_mb`
+    /// that meets or exceeds the pipeline's RSS budget — otherwise the
+    /// DBSP circuit would be carved down to zero.
+    #[test]
+    fn circuit_config_rejects_datafusion_memory_equal_to_rss() {
+        let config = pipeline_config(RuntimeConfig {
+            workers: 1,
+            max_rss_mb: Some(2_000),
+            datafusion_memory_mb: Some(2_000),
+            ..Default::default()
+        });
+        let result = ControllerInit::circuit_config(None, &config, None);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("config with df==max_rss should fail"),
+        };
+        match err {
+            ControllerError::Config { config_error } => match *config_error {
+                ConfigError::DatafusionMemoryExceedsBudget {
+                    datafusion_memory_mb,
+                    max_rss_mb,
+                } => {
+                    assert_eq!(datafusion_memory_mb, 2_000);
+                    assert_eq!(max_rss_mb, 2_000);
+                }
+                other => panic!("expected DatafusionMemoryExceedsBudget, got {other:?}"),
+            },
+            other => panic!("expected ControllerError::Config, got {other:?}"),
+        }
+    }
+
+    /// `df > rss` must also error; the resolver doesn't silently shrink
+    /// the user's explicit value.
+    #[test]
+    fn circuit_config_rejects_datafusion_memory_above_rss() {
+        let config = pipeline_config(RuntimeConfig {
+            workers: 1,
+            max_rss_mb: Some(1_000),
+            datafusion_memory_mb: Some(4_000),
+            ..Default::default()
+        });
+        let result = ControllerInit::circuit_config(None, &config, None);
+        assert!(matches!(
+            result,
+            Err(ControllerError::Config { config_error })
+                if matches!(
+                    *config_error,
+                    ConfigError::DatafusionMemoryExceedsBudget { .. },
+                ),
+        ));
+    }
+}

--- a/crates/adapters/src/integrated.rs
+++ b/crates/adapters/src/integrated.rs
@@ -1,9 +1,10 @@
 use crate::controller::{ControllerInner, EndpointId};
 use crate::transport::IntegratedInputEndpoint;
 use crate::{ControllerError, Encoder, InputConsumer, OutputEndpoint};
-use feldera_types::config::{ConnectorConfig, TransportConfig};
+use datafusion::execution::runtime_env::RuntimeEnv;
+use feldera_types::config::{ConnectorConfig, PipelineConfig, TransportConfig};
 use feldera_types::program_schema::Relation;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 
 #[cfg(feature = "with-deltalake")]
 pub mod delta_table;
@@ -93,17 +94,31 @@ pub fn create_integrated_output_endpoint(
 pub fn create_integrated_input_endpoint(
     endpoint_name: &str,
     config: &ConnectorConfig,
+    pipeline_config: &PipelineConfig,
+    runtime_env: Arc<RuntimeEnv>,
     consumer: Box<dyn InputConsumer>,
 ) -> Result<Box<dyn IntegratedInputEndpoint>, ControllerError> {
     let ep: Box<dyn IntegratedInputEndpoint> = match &config.transport {
         #[cfg(feature = "with-deltalake")]
-        TransportConfig::DeltaTableInput(config) => Box::new(
-            delta_table::DeltaTableInputEndpoint::new(endpoint_name, config, consumer),
-        ),
+        TransportConfig::DeltaTableInput(config) => {
+            Box::new(delta_table::DeltaTableInputEndpoint::new(
+                endpoint_name,
+                config,
+                pipeline_config,
+                runtime_env,
+                consumer,
+            ))
+        }
         #[cfg(feature = "with-iceberg")]
-        TransportConfig::IcebergInput(config) => Box::new(
-            feldera_iceberg::IcebergInputEndpoint::new(endpoint_name, config, consumer),
-        ),
+        TransportConfig::IcebergInput(config) => {
+            Box::new(feldera_iceberg::IcebergInputEndpoint::new(
+                endpoint_name,
+                config,
+                pipeline_config,
+                runtime_env,
+                consumer,
+            ))
+        }
         TransportConfig::PostgresInput(config) => {
             Box::new(PostgresInputEndpoint::new(endpoint_name, config, consumer))
         }

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -7,6 +7,7 @@ use crate::{ControllerError, InputConsumer, InputReader, PipelineState};
 use anyhow::{Error as AnyError, Result as AnyResult, anyhow, bail};
 use arrow::array::BooleanArray;
 use chrono::{DateTime, Utc};
+use datafusion::common::DataFusionError;
 use datafusion::common::arrow::array::RecordBatch;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
@@ -14,7 +15,6 @@ use datafusion::datasource::listing::{
 };
 use datafusion::physical_plan::{PhysicalExpr, displayable};
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
-use datafusion::prelude::SessionConfig;
 use dbsp::circuit::tokio::TOKIO;
 use deltalake::datafusion::dataframe::DataFrame;
 use deltalake::datafusion::execution::context::SQLOptions;
@@ -27,12 +27,12 @@ use feldera_adapterlib::format::{ParseError, StagedInputBuffer};
 use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{InputQueueEntry, Resume, Watermark, parse_resume_info};
 use feldera_adapterlib::utils::datafusion::{
-    array_to_string, execute_query_collect, execute_singleton_query, timestamp_to_sql_expression,
-    validate_sql_expression, validate_timestamp_column,
+    array_to_string, create_session_context_with, execute_query_collect, execute_singleton_query,
+    timestamp_to_sql_expression, validate_sql_expression, validate_timestamp_column,
 };
 use feldera_storage::tokio::TOKIO_DEDICATED_IO;
 use feldera_types::adapter_stats::ConnectorHealth;
-use feldera_types::config::FtModel;
+use feldera_types::config::{FtModel, PipelineConfig};
 use feldera_types::program_schema::Relation;
 use feldera_types::transport::delta_table::{DeltaTableReaderConfig, DeltaTableTransactionMode};
 use futures_util::StreamExt;
@@ -101,6 +101,26 @@ static MAX_CONCURRENT_READERS: AtomicUsize = AtomicUsize::new(0);
 /// that can be used in datafusion queries like `select "foo""bar" from my_table`.
 fn quote_sql_identifier<S: AsRef<str>>(ident: S) -> String {
     format!("\"{}\"", ident.as_ref().replace("\"", "\"\""))
+}
+
+/// Format a DataFusion error, appending actionable guidance when the
+/// underlying variant is `ResourcesExhausted` (the shared memory pool ran
+/// out). `find_root` walks past `Context(...)` / `ArrowError(...)` wrappers
+/// so the check is robust to the deeply nested errors DataFusion typically
+/// produces during sort/merge.
+fn format_datafusion_error(prefix: &str, e: &DataFusionError) -> String {
+    let base = format!("{prefix}: {e:?}");
+    if matches!(e.find_root(), DataFusionError::ResourcesExhausted(_)) {
+        format!(
+            "{base}\n\
+             DataFusion memory pool is exhausted. \
+             Consider increasing 'datafusion_memory_mb' in the pipeline runtime config. \
+             If raising the budget is not an option, reduce 'io_workers' / 'workers' or \
+             set the env var 'DELTA_DF_TARGET_PARTITIONS=1' to lower per-scan parallelism.\n"
+        )
+    } else {
+        base
+    }
 }
 
 /// Build the `DataFrame` that streams a CDC transaction to the circuit.
@@ -191,6 +211,7 @@ pub(super) fn build_cdc_dataframe(
 pub struct DeltaTableInputEndpoint {
     endpoint_name: String,
     config: DeltaTableReaderConfig,
+    datafusion: SessionContext,
     consumer: Box<dyn InputConsumer>,
 }
 
@@ -198,13 +219,75 @@ impl DeltaTableInputEndpoint {
     pub fn new(
         endpoint_name: &str,
         config: &DeltaTableReaderConfig,
+        pipeline_config: &PipelineConfig,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
         consumer: Box<dyn InputConsumer>,
     ) -> Self {
         register_storage_handlers();
 
+        // if `DELTA_DF_TARGET_PARTITIONS` env var (process-wide override) is set,
+        // override default target partitions with that value. Target partitions
+        // controls the number of parallel tasks DataFusion uses for scanning during the
+        // snapshot phase.
+        let env_target_partitions = match std::env::var("DELTA_DF_TARGET_PARTITIONS").ok() {
+            None => None,
+            Some(s) => match s.parse::<usize>() {
+                Ok(n) if n > 0 => Some(n),
+                _ => {
+                    warn!(
+                        "delta_table {endpoint_name}: ignoring DELTA_DF_TARGET_PARTITIONS={s:?}; expected a positive integer"
+                    );
+                    None
+                }
+            },
+        };
+        if let Some(n) = env_target_partitions {
+            info!("delta_table {endpoint_name}: DELTA_DF_TARGET_PARTITIONS={n} overriding default");
+        }
+
+        let env_batch_size = match std::env::var("DELTA_DF_BATCH_SIZE").ok() {
+            None => None,
+            Some(s) => match s.parse::<usize>() {
+                Ok(n) if n > 0 => {
+                    info!("delta_table {endpoint_name}: applying DELTA_DF_BATCH_SIZE={n}");
+                    Some(n)
+                }
+                _ => {
+                    warn!(
+                        "delta_table {endpoint_name}: ignoring DELTA_DF_BATCH_SIZE={s:?}; expected a positive integer"
+                    );
+                    None
+                }
+            },
+        };
+
+        // Configure datafusion not to generate Utf8View arrow types, which are
+        // not yet supported by the `serde_arrow` crate. The `SessionContext`
+        // shares the pipeline-wide `RuntimeEnv` so that the CDC-mode ORDER BY
+        // query spills to the same bounded memory pool and on-disk scratch
+        // dir as every other datafusion user in the pipeline.
+        //
+        // `target_partitions` inherits `create_session_context_with`'s
+        // worker-derived default; only override if `DELTA_DF_TARGET_PARTITIONS`
+        // was set explicitly. Same for `batch_size`.
+        let datafusion = create_session_context_with(pipeline_config, runtime_env, |cfg| {
+            let mut cfg = cfg.set_bool(
+                "datafusion.execution.parquet.schema_force_view_types",
+                false,
+            );
+            if let Some(n) = env_target_partitions {
+                cfg = cfg.set_usize("datafusion.execution.target_partitions", n);
+            }
+            if let Some(n) = env_batch_size {
+                cfg = cfg.set_usize("datafusion.execution.batch_size", n);
+            }
+            cfg
+        });
+
         Self {
             endpoint_name: endpoint_name.to_string(),
             config: config.clone(),
+            datafusion,
             consumer,
         }
     }
@@ -224,6 +307,7 @@ impl IntegratedInputEndpoint for DeltaTableInputEndpoint {
         Ok(Box::new(DeltaTableInputReader::new(
             self.endpoint_name,
             self.config,
+            self.datafusion,
             self.consumer,
             input_handle,
             resume_info,
@@ -240,6 +324,7 @@ impl DeltaTableInputReader {
     fn new(
         endpoint_name: String,
         mut config: DeltaTableReaderConfig,
+        datafusion: SessionContext,
         consumer: Box<dyn InputConsumer>,
         input_handle: &InputCollectionHandle,
         resume_info: Option<JsonValue>,
@@ -372,6 +457,7 @@ impl DeltaTableInputReader {
         let endpoint = Arc::new(DeltaTableInputEndpointInner::new(
             &endpoint_name,
             config,
+            datafusion,
             consumer,
             schema,
             resume_info.clone(),
@@ -787,62 +873,12 @@ impl DeltaTableInputEndpointInner {
     fn new(
         endpoint_name: &str,
         config: DeltaTableReaderConfig,
+        datafusion: SessionContext,
         consumer: Box<dyn InputConsumer>,
         schema: Relation,
         resume_info: Option<DeltaResumeInfo>,
     ) -> Self {
         let queue = Arc::new(InputQueue::new(consumer.clone()));
-        // Configure datafusion not to generate Utf8View arrow types, which are not yet
-        // supported by the `serde_arrow` crate.
-        let mut session_config = SessionConfig::new().set_bool(
-            "datafusion.execution.parquet.schema_force_view_types",
-            false,
-        );
-        // Number of parallel scan partitions DataFusion plans for the
-        // snapshot read. Resolution order:
-        //
-        //   1. `DELTA_DF_TARGET_PARTITIONS` env var (process-wide override).
-        //   2. `max_concurrent_readers` from the connector config (which
-        //      also drives the global `DELTA_READER_SEMAPHORE`); using the
-        //      same value here keeps the per-connector parallelism aligned
-        //      with the process-wide concurrent-reader cap.
-        //   3. `DEFAULT_MAX_CONCURRENT_READERS` (6), matching the semaphore
-        //      default.
-        let env_target_partitions = match std::env::var("DELTA_DF_TARGET_PARTITIONS").ok() {
-            None => None,
-            Some(s) => match s.parse::<usize>() {
-                Ok(n) if n > 0 => Some(n),
-                _ => {
-                    warn!(
-                        "delta_table {endpoint_name}: ignoring DELTA_DF_TARGET_PARTITIONS={s:?}; expected a positive integer"
-                    );
-                    None
-                }
-            },
-        };
-        let target_partitions = env_target_partitions
-            .or_else(|| {
-                config
-                    .max_concurrent_readers
-                    .map(|n| n as usize)
-                    .filter(|n| *n > 0)
-            })
-            .unwrap_or(DEFAULT_MAX_CONCURRENT_READERS);
-        session_config =
-            session_config.set_usize("datafusion.execution.target_partitions", target_partitions);
-        info!("delta_table {endpoint_name}: target_partitions={target_partitions}");
-
-        if let Ok(s) = std::env::var("DELTA_DF_BATCH_SIZE") {
-            match s.parse::<usize>() {
-                Ok(n) if n > 0 => {
-                    session_config = session_config.set_usize("datafusion.execution.batch_size", n);
-                    info!("delta_table {endpoint_name}: applying DELTA_DF_BATCH_SIZE={n}");
-                }
-                _ => warn!(
-                    "delta_table {endpoint_name}: ignoring DELTA_DF_BATCH_SIZE={s:?}; expected a positive integer"
-                ),
-            }
-        }
 
         let metrics = Arc::new(DeltaTableMetrics::new());
         consumer.set_custom_metrics(Arc::clone(&metrics) as Arc<dyn ConnectorMetrics>);
@@ -854,7 +890,7 @@ impl DeltaTableInputEndpointInner {
             schema,
             config,
             consumer,
-            datafusion: SessionContext::new_with_config(session_config),
+            datafusion,
             transaction_index: AtomicUsize::new(0),
 
             // Set version to None by default so that the connector is checkpointable in the initial state.
@@ -2343,7 +2379,10 @@ impl DeltaTableInputEndpointInner {
                         Vec::new(),
                     );
 
-                    return Err(format!("error retrieving batch {num_batches}: {e:?}"));
+                    return Err(format_datafusion_error(
+                        &format!("error retrieving batch {num_batches}"),
+                        &e,
+                    ));
                 }
             };
             // info!("schema: {}", batch.schema());
@@ -2819,4 +2858,41 @@ async fn wait_running(receiver: &mut Receiver<PipelineState>) {
     let _ = receiver
         .wait_for(|state| state == &PipelineState::Running)
         .await;
+}
+
+#[cfg(test)]
+mod format_datafusion_error_tests {
+    use super::format_datafusion_error;
+    use datafusion::common::DataFusionError;
+
+    #[test]
+    fn appends_pool_hint_for_resources_exhausted() {
+        let inner = DataFusionError::ResourcesExhausted(
+            "Failed to allocate additional 64.0 MB ...".to_string(),
+        );
+        let wrapped = DataFusionError::Context("external sort".to_string(), Box::new(inner));
+        let msg = format_datafusion_error("error retrieving batch 0", &wrapped);
+        assert!(
+            msg.contains("DataFusion memory pool is exhausted"),
+            "missing actionable hint; got: {msg}"
+        );
+        assert!(
+            msg.contains("datafusion_memory_mb"),
+            "missing knob name; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn passes_through_unrelated_errors() {
+        let other = DataFusionError::Plan("bad column reference".to_string());
+        let msg = format_datafusion_error("error retrieving batch 0", &other);
+        assert!(
+            !msg.contains("memory pool"),
+            "spurious pool hint on non-exhaustion error; got: {msg}"
+        );
+        assert!(
+            msg.contains("bad column reference"),
+            "lost the original error text; got: {msg}"
+        );
+    }
 }

--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -8,7 +8,7 @@ use feldera_types::checkpoint::{
     CheckpointDependencies, CheckpointDependenciesWrite, CheckpointMetadata,
 };
 use feldera_types::constants::{
-    ACTIVATION_MARKER_FILE, ADHOC_TEMP_DIR, CHECKPOINT_DEPENDENCIES, CHECKPOINT_FILE_NAME,
+    ACTIVATION_MARKER_FILE, CHECKPOINT_DEPENDENCIES, CHECKPOINT_FILE_NAME, DATAFUSION_TEMP_DIR,
     DBSP_FILE_EXTENSION, STATE_FILE, STATUS_FILE, STEPS_FILE,
 };
 use itertools::Itertools;
@@ -118,7 +118,7 @@ impl Checkpointer {
         // it.
         in_use_paths.insert(STATUS_FILE.into(), SmallVec::new());
         in_use_paths.insert(format!("{}.mut", STATUS_FILE).into(), SmallVec::new());
-        in_use_paths.insert(ADHOC_TEMP_DIR.into(), SmallVec::new());
+        in_use_paths.insert(DATAFUSION_TEMP_DIR.into(), SmallVec::new());
         in_use_paths.insert(ACTIVATION_MARKER_FILE.into(), SmallVec::new());
         for (checkpoint_index, cpm) in self.checkpoint_list.iter().enumerate() {
             in_use_paths

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -803,6 +803,28 @@ pub struct RuntimeConfig {
     /// for more details.
     pub max_rss_mb: Option<u64>,
 
+    /// DataFusion memory pool size, in MB, shared by the ad-hoc query
+    /// engine and the Delta Lake / Iceberg connectors.
+    ///
+    /// Carved out of `max_rss_mb` (falling back to
+    /// `resources.memory_mb_max`); the remainder goes to the DBSP circuit,
+    /// so the two do not double-book RAM.
+    ///
+    /// Unset: defaults to 5% of the effective budget, capped at 2 GB.
+    /// Pipelines that don't run heavy ad-hoc / Delta / Iceberg workloads
+    /// can leave this unset.
+    ///
+    /// Sort/aggregate-heavy ad-hoc queries (especially at high `workers`
+    /// counts) should set this explicitly. An under-sized pool surfaces as
+    /// `ResourcesExhausted` on the failing query — the pipeline keeps
+    /// running and only that query fails.
+    ///
+    /// No pool limit applied if no overall budget is configured.
+    ///
+    /// See [documentation on the pipeline's memory usage](https://docs.feldera.com/operations/memory)
+    /// for more details.
+    pub datafusion_memory_mb: Option<u64>,
+
     /// Number of DBSP hosts.
     ///
     /// The worker threads are evenly divided among the hosts.  For single-host
@@ -1065,6 +1087,7 @@ impl Default for RuntimeConfig {
         Self {
             workers: 8,
             max_rss_mb: None,
+            datafusion_memory_mb: None,
             hosts: 1,
             storage: Some(StorageOptions::default()),
             fault_tolerance: FtConfig::default(),
@@ -1091,6 +1114,36 @@ impl Default for RuntimeConfig {
             logging: None,
             pipeline_template_configmap: None,
         }
+    }
+}
+
+/// Upper bound on the default DataFusion pool size, in MB.
+///
+/// Spill-to-disk handles overflow; reserving more starves the circuit.
+pub const DEFAULT_DATAFUSION_MEMORY_MB_CEILING: u64 = 2048;
+
+/// Default DataFusion pool size as a percentage of the pipeline's
+/// effective memory budget. The remainder is left for the DBSP circuit.
+pub const DEFAULT_DATAFUSION_MEMORY_PERCENT: u64 = 5;
+
+impl RuntimeConfig {
+    /// Pipeline's effective memory budget in MB: `max_rss_mb`, falling back
+    /// to `resources.memory_mb_max` (the k8s pod limit).
+    pub fn effective_memory_mb(&self) -> Option<u64> {
+        self.max_rss_mb.or(self.resources.memory_mb_max)
+    }
+
+    /// Resolved DataFusion pool size in MB: explicit `datafusion_memory_mb`
+    /// if set, else 5% of the effective budget capped at
+    /// `DEFAULT_DATAFUSION_MEMORY_MB_CEILING`. `None` if no budget is
+    /// configured.
+    pub fn resolved_datafusion_memory_mb(&self) -> Option<u64> {
+        if let Some(explicit) = self.datafusion_memory_mb {
+            return Some(explicit);
+        }
+        let effective = self.effective_memory_mb()?;
+        let fraction = effective * DEFAULT_DATAFUSION_MEMORY_PERCENT / 100;
+        Some(fraction.min(DEFAULT_DATAFUSION_MEMORY_MB_CEILING))
     }
 }
 
@@ -1143,8 +1196,81 @@ impl Default for FtConfig {
 #[cfg(test)]
 mod test {
     use super::deserialize_fault_tolerance;
-    use crate::config::{FtConfig, FtModel};
+    use crate::config::{
+        DEFAULT_DATAFUSION_MEMORY_MB_CEILING, FtConfig, FtModel, ResourceConfig, RuntimeConfig,
+    };
     use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn resolved_datafusion_memory_explicit_passes_through() {
+        let config = RuntimeConfig {
+            max_rss_mb: Some(8_000),
+            datafusion_memory_mb: Some(1_500),
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_datafusion_memory_mb(), Some(1_500));
+    }
+
+    #[test]
+    fn resolved_datafusion_memory_unconfigured_returns_none() {
+        let config = RuntimeConfig::default();
+        assert!(config.max_rss_mb.is_none());
+        assert!(config.resources.memory_mb_max.is_none());
+        assert_eq!(config.resolved_datafusion_memory_mb(), None);
+    }
+
+    #[test]
+    fn resolved_datafusion_memory_small_budget_scales_down() {
+        // Small pipelines must provision cleanly; the default just shrinks.
+        let config = RuntimeConfig {
+            max_rss_mb: Some(256),
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_datafusion_memory_mb(), Some(12));
+
+        let config = RuntimeConfig {
+            max_rss_mb: Some(512),
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_datafusion_memory_mb(), Some(25));
+    }
+
+    #[test]
+    fn resolved_datafusion_memory_clamps_to_ceiling_for_large_budgets() {
+        // 5% of 64 GB = 3.2 GB, above the 2 GB ceiling.
+        let config = RuntimeConfig {
+            max_rss_mb: Some(64_000),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.resolved_datafusion_memory_mb(),
+            Some(DEFAULT_DATAFUSION_MEMORY_MB_CEILING),
+        );
+    }
+
+    #[test]
+    fn resolved_datafusion_memory_midrange_uses_five_percent() {
+        // 5% of 16 GB = 800 MB, inside the clamp range.
+        let config = RuntimeConfig {
+            max_rss_mb: Some(16_000),
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_datafusion_memory_mb(), Some(800));
+    }
+
+    #[test]
+    fn resolved_datafusion_memory_falls_back_to_resources() {
+        // No max_rss_mb, but resources.memory_mb_max is set.
+        let config = RuntimeConfig {
+            max_rss_mb: None,
+            resources: ResourceConfig {
+                memory_mb_max: Some(16_000),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(config.resolved_datafusion_memory_mb(), Some(800));
+    }
 
     #[test]
     fn ft_config() {

--- a/crates/feldera-types/src/constants.rs
+++ b/crates/feldera-types/src/constants.rs
@@ -18,7 +18,16 @@ pub const STEPS_FILE: &str = "steps.bin";
 /// `CheckpointDependencies` for the on-disk shape.
 pub const CHECKPOINT_DEPENDENCIES: &str = "dependencies.json";
 
-pub const ADHOC_TEMP_DIR: &str = "adhoc-tmp";
+/// Subdirectory under the pipeline's storage path where DataFusion writes
+/// spill files for the ad-hoc query engine and every integrated connector
+/// that uses DataFusion (Delta Lake, Iceberg).
+///
+/// One pipeline-wide directory keeps the on-disk layout discoverable in a
+/// single place and lets `gc_startup` allowlist it as a single entry. If
+/// you change this value, audit `gc_startup` in `dbsp::circuit::checkpointer`
+/// — the GC's allowlist must keep matching the directory the runtime
+/// actually creates.
+pub const DATAFUSION_TEMP_DIR: &str = "datafusion-tmp";
 
 /// A slice of all file-extension the system can create.
 pub const DBSP_FILE_EXTENSION: &[&str] = &["mut", "feldera"];

--- a/crates/iceberg/src/input.rs
+++ b/crates/iceberg/src/input.rs
@@ -12,13 +12,13 @@ use feldera_adapterlib::{
         IntegratedInputEndpoint, NonFtInputReaderCommand,
     },
     utils::datafusion::{
-        array_to_string, execute_query_collect, execute_singleton_query,
+        array_to_string, create_session_context, execute_query_collect, execute_singleton_query,
         timestamp_to_sql_expression, validate_sql_expression, validate_timestamp_column,
     },
     PipelineState,
 };
 use feldera_types::{
-    config::FtModel,
+    config::{FtModel, PipelineConfig},
     program_schema::Relation,
     transport::iceberg::{IcebergCatalogType, IcebergReaderConfig},
 };
@@ -125,12 +125,16 @@ impl IcebergInputEndpoint {
     pub fn new(
         endpoint_name: &str,
         config: &IcebergReaderConfig,
+        pipeline_config: &PipelineConfig,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
         consumer: Box<dyn InputConsumer>,
     ) -> Self {
         Self {
             inner: Arc::new(IcebergInputEndpointInner::new(
                 endpoint_name,
                 config.clone(),
+                pipeline_config,
+                runtime_env,
                 consumer,
             )),
         }
@@ -246,14 +250,20 @@ impl IcebergInputEndpointInner {
     fn new(
         endpoint_name: &str,
         config: IcebergReaderConfig,
+        pipeline_config: &PipelineConfig,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
         consumer: Box<dyn InputConsumer>,
     ) -> Self {
         let queue = InputQueue::new(consumer.clone());
+        // Share the pipeline-wide `RuntimeEnv` so that scans against the
+        // iceberg table spill to the bounded memory pool and on-disk scratch
+        // dir alongside every other datafusion user in the pipeline.
+        let datafusion = create_session_context(pipeline_config, runtime_env);
         Self {
             endpoint_name: endpoint_name.to_string(),
             config,
             consumer,
-            datafusion: SessionContext::new(),
+            datafusion,
             queue,
         }
     }

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -96,6 +96,7 @@ fn extended_pipeline_2() -> ExtendedPipelineDescr {
         runtime_config: serde_json::to_value(RuntimeConfig {
             workers: 10,
             max_rss_mb: None,
+            datafusion_memory_mb: None,
             hosts: 1,
             storage: Some(StorageOptions::default()),
             fault_tolerance: FtConfig::default(),

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -300,6 +300,7 @@ fn map_val_to_limited_runtime_config(val: RuntimeConfigPropVal) -> serde_json::V
         serde_json::to_value(RuntimeConfig {
             workers: val.val0,
             max_rss_mb: val.val21,
+            datafusion_memory_mb: None,
             hosts: val.val20,
             cpu_profiler: val.val1,
             min_batch_size_records: val.val2,
@@ -1192,6 +1193,7 @@ async fn pipeline_versioning() {
     let new_runtime_config = serde_json::to_value(RuntimeConfig {
         workers: 100,
         max_rss_mb: None,
+        datafusion_memory_mb: None,
         hosts: 1,
         storage: None,
         fault_tolerance: FtConfig::default(),
@@ -2484,6 +2486,7 @@ async fn pipeline_provision_version_guard() {
                 serde_json::to_value(RuntimeConfig {
                     workers: 10,
                     max_rss_mb: None,
+                    datafusion_memory_mb: None,
                     hosts: 1,
                     storage: None,
                     fault_tolerance: FtConfig::default(),

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
-        Delta Lake output connector:
+        - Delta Lake output connector:
 
         `log_retention_duration` and
         `enable_expired_log_cleanup` config options to control transaction-log retention on newly created
@@ -26,6 +26,12 @@ import TabItem from '@theme/TabItem';
         The connector now logs a warning at startup when `checkpoint_interval`,
         `log_retention_duration`, or `enable_expired_log_cleanup` in the connector config
         differs from the existing table's metadata.
+
+        - Large Delta Lake, Iceberg scans (e.g. Delta CDC `ORDER BY`) and ad-hoc queries now share a bounded memory pool
+        and spill to disk under `<storage>/datafusion-tmp/`.
+
+        A new `runtime_config.datafusion_memory_mb` setting controls the pool size
+        (defaults to 5% of the pipeline's memory budget, capped at 2 GB).
 
         ## v0.294.0
 

--- a/openapi.json
+++ b/openapi.json
@@ -584,6 +584,7 @@
                     "runtime_config": {
                       "workers": 16,
                       "max_rss_mb": null,
+                      "datafusion_memory_mb": null,
                       "hosts": 1,
                       "storage": {
                         "backend": {
@@ -674,6 +675,7 @@
                     "runtime_config": {
                       "workers": 10,
                       "max_rss_mb": null,
+                      "datafusion_memory_mb": null,
                       "hosts": 1,
                       "storage": {
                         "backend": {
@@ -794,6 +796,7 @@
                 "runtime_config": {
                   "workers": 16,
                   "max_rss_mb": null,
+                  "datafusion_memory_mb": null,
                   "hosts": 1,
                   "storage": {
                     "backend": {
@@ -867,6 +870,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -1050,6 +1054,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -1197,6 +1202,7 @@
                 "runtime_config": {
                   "workers": 16,
                   "max_rss_mb": null,
+                  "datafusion_memory_mb": null,
                   "hosts": 1,
                   "storage": {
                     "backend": {
@@ -1270,6 +1276,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -1370,6 +1377,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -1639,6 +1647,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -6542,6 +6551,7 @@
                   "runtime_config": {
                     "workers": 16,
                     "max_rss_mb": null,
+                    "datafusion_memory_mb": null,
                     "hosts": 1,
                     "storage": {
                       "backend": {
@@ -10634,6 +10644,14 @@
                 "description": "Enable CPU profiler.\n\nThe default value is `true`.",
                 "default": true
               },
+              "datafusion_memory_mb": {
+                "type": "integer",
+                "format": "int64",
+                "description": "DataFusion memory pool size, in MB, shared by the ad-hoc query\nengine and the Delta Lake / Iceberg connectors.\n\nCarved out of `max_rss_mb` (falling back to\n`resources.memory_mb_max`); the remainder goes to the DBSP circuit,\nso the two do not double-book RAM.\n\nUnset: defaults to 5% of the effective budget, capped at 2 GB.\nPipelines that don't run heavy ad-hoc / Delta / Iceberg workloads\ncan leave this unset.\n\nSort/aggregate-heavy ad-hoc queries (especially at high `workers`\ncounts) should set this explicitly. An under-sized pool surfaces as\n`ResourcesExhausted` on the failing query — the pipeline keeps\nrunning and only that query fails.\n\nNo pool limit applied if no overall budget is configured.\n\nSee [documentation on the pipeline's memory usage](https://docs.feldera.com/operations/memory)\nfor more details.",
+                "default": null,
+                "nullable": true,
+                "minimum": 0
+              },
               "dev_tweaks": {
                 "allOf": [
                   {
@@ -12514,6 +12532,14 @@
             "type": "boolean",
             "description": "Enable CPU profiler.\n\nThe default value is `true`.",
             "default": true
+          },
+          "datafusion_memory_mb": {
+            "type": "integer",
+            "format": "int64",
+            "description": "DataFusion memory pool size, in MB, shared by the ad-hoc query\nengine and the Delta Lake / Iceberg connectors.\n\nCarved out of `max_rss_mb` (falling back to\n`resources.memory_mb_max`); the remainder goes to the DBSP circuit,\nso the two do not double-book RAM.\n\nUnset: defaults to 5% of the effective budget, capped at 2 GB.\nPipelines that don't run heavy ad-hoc / Delta / Iceberg workloads\ncan leave this unset.\n\nSort/aggregate-heavy ad-hoc queries (especially at high `workers`\ncounts) should set this explicitly. An under-sized pool surfaces as\n`ResourcesExhausted` on the failing query — the pipeline keeps\nrunning and only that query fails.\n\nNo pool limit applied if no overall budget is configured.\n\nSee [documentation on the pipeline's memory usage](https://docs.feldera.com/operations/memory)\nfor more details.",
+            "default": null,
+            "nullable": true,
+            "minimum": 0
           },
           "dev_tweaks": {
             "allOf": [


### PR DESCRIPTION
see commit

Fix #6153 

### Describe Manual Test Plan

Created big ( ~15M rows ) CDC Delta table and verified that delta connector cdc mode spillds to disk.

on main branch it uses over 8GB memory where as with this fix we use only about 2GB ( / around what we configure )


Verified there are datafusion session files on disk, if we configure pipeline with low memory we get:
```
Not enough memory to continue external sort. Consider increasing the memory limit, or decreasing sort_spill_reservation_bytes caused by Resources exhausted: Failed to allocate additional 64.0 MB for ExternalSorterMerge[0] with 0.0 B already allocated for this reservation - 5.7 MB remain available for the total pool
```

though this was same behavior prev ig, but now we log warning if allocated memory is too low like:
```
=WARN feldera_adapterlib::utils::datafusion:  DataFusion memory pool is 64 MB; sort-heavy ad-hoc queries (ORDER BY, EXCEPT, hash joins) need at least 256 MB (4 workers x 64 MB reservation per worker). Such queries may fail at first allocation with 'Resources exhausted'. Increase 'datafusion_memory_mb' or reduce 'workers'.
``` 

pipeline sql:
```sql
CREATE TABLE seeds (
    id BIGINT NOT NULL
) WITH (
    'materialized' = 'true',
    'connectors' = '[{
        "transport": {
            "name": "datagen",
            "config": {
                "plan": [
                    {
                        "limit": 5000000,
                        "rate": 10000,
                        "fields": {
                            "id": {
                                "strategy": "increment"
                            }
                        }
                    }
                ]
            }
        }
    }]'
);
```

run `select * from seeds order by id;`.

 for delta cdc:
```sql
CREATE TABLE big_cdc (
    id BIGINT NOT NULL,
    payload VARCHAR,
    "__feldera_op" VARCHAR,
    "__feldera_ts" BIGINT
) WITH (
    'connectors' = '[{
        "transport": {
            "name": "delta_table_input",
            "config": {
                "uri": "/tmp/pr6170-validation/cdc_table",
                "mode": "cdc",
                "version": 0,
                "cdc_delete_filter": "__feldera_op = ''d''",
                "cdc_order_by": "__feldera_ts",
                "max_concurrent_readers": 1
            }
        }
    }]'
);
```

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?
not a breaking change
