### PR TITLE
[SQL] New operator `AtomicSum`, implemented as `accumulate_concat_zsets().shard()`, for atomically computing global aggregates

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAtomicSumOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPAtomicSumOperator.java
@@ -1,0 +1,67 @@
+package org.dbsp.sqlCompiler.circuit.operator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.compiler.backend.JsonDecoder;
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteEmptyRel;
+import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
+import org.dbsp.sqlCompiler.compiler.visitors.VisitDecision;
+import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.util.Linq;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/** Semantically this operator is similar to a {@link DBSPSumOperator}, but the implementation is very
+ * different: it guarantees that successors will not see partial results within a transaction sub-step */
+public final class DBSPAtomicSumOperator extends DBSPSimpleOperator implements ILinear {
+    public DBSPAtomicSumOperator(CalciteRelNode node, List<OutputPort> inputs) {
+        super(node, "atomic_sum", null, inputs.get(0).outputType(), true);
+        for (OutputPort op: inputs) {
+            this.addInput(op);
+            if (!op.outputType().sameType(this.outputType)) {
+                throw new InternalCompilerError("Sum operator input type " + op.outputType() +
+                        " does not match output type " + this.outputType, this);
+            }
+        }
+    }
+
+    public DBSPAtomicSumOperator(CalciteRelNode node, OutputPort... inputs) {
+        this(node, Linq.list(inputs));
+    }
+
+    @Override
+    public void accept(CircuitVisitor visitor) {
+        visitor.push(this);
+        VisitDecision decision = visitor.preorder(this);
+        if (!decision.stop())
+            visitor.postorder(this);
+        visitor.pop(this);
+    }
+
+    @Override
+    public DBSPSimpleOperator with(
+            @Nullable DBSPExpression unused, DBSPType outputType,
+            List<OutputPort> newInputs, boolean force) {
+        boolean different = force;
+        if (newInputs.size() != this.inputs.size())
+            // Sum can have any number of inputs
+            different = true;
+        if (!different) {
+            different = this.inputsDiffer(newInputs);
+        }
+        if (different)
+            return new DBSPAtomicSumOperator(this.getRelNode(), newInputs).copyAnnotations(this);
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public static DBSPAtomicSumOperator fromJson(JsonNode node, JsonDecoder decoder) {
+        CommonInfo info = commonInfoFromJson(node, decoder);
+        return new DBSPAtomicSumOperator(CalciteEmptyRel.INSTANCE, info.inputs())
+                .addAnnotations(info.annotations(), DBSPAtomicSumOperator.class);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustVisitor.java
@@ -26,59 +26,11 @@ package org.dbsp.sqlCompiler.compiler.backend.rust;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyNOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPRankOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinBaseOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinIndexOperator;
-import org.dbsp.sqlCompiler.circuit.operator.IContainsIntegrator;
-import org.dbsp.sqlCompiler.circuit.operator.IInputMapOperator;
+import org.dbsp.sqlCompiler.circuit.operator.*;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.annotation.OperatorHash;
 import org.dbsp.sqlCompiler.circuit.annotation.Recursive;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPConcreteAsofJoinOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPControlledKeyFilterOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPInputMapWithWaterlineOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainNValuesOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPInternOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinIndexOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPLeftJoinOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.DBSPDeclaration;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPDeltaOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinBaseOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMultisetOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinIndexOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIndexedTopKOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainKeysOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinIndexOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPJoinOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPLagOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPNowOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPPartitionedRollingAggregateWithWaterlineOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSinkOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceBaseOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSourceMapOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPViewDeclarationOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPViewBaseOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPViewOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPWindowOperator;
-import org.dbsp.sqlCompiler.circuit.operator.IInputOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.InputColumnMetadata;
@@ -1653,6 +1605,36 @@ public class ToRustVisitor extends CircuitVisitor {
         this.builder.append(")")
                 .append(this.markDistinct(operator))
                 .append(";");
+        this.tagStream(operator);
+        this.innerVisitor.setOperatorContext(null);
+        return VisitDecision.STOP;
+    }
+
+    @Override
+    public VisitDecision preorder(DBSPAtomicSumOperator operator) {
+        // Implement as a pair of operators:
+        // - accumulate_concat_zsets
+        // - shard
+        this.computeHash(operator);
+        this.innerVisitor.setOperatorContext(operator);
+        DBSPType streamType = this.streamType(operator);
+        this.writeComments(operator)
+                .append("let ")
+                .append(operator.getNodeName(this.preferHash))
+                .append(": ");
+        streamType.accept(this.innerVisitor);
+        this.builder.append(" = circuit.accumulate_concat_zsets")
+                .append("(&[");
+        for (int i = 0; i < operator.inputs.size(); i++) {
+            if (i > 0)
+                this.builder.append(", ");
+            this.builder.append("(").append(this.getInputName(operator, i))
+                    .append(".clone(), true)");
+        }
+        this.builder.append("])")
+                .newline()
+                .append(this.markDistinct(operator))
+                .append(".shard();");
         this.tagStream(operator);
         this.innerVisitor.setOperatorContext(null);
         return VisitDecision.STOP;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/SingleOperatorWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/multi/SingleOperatorWriter.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler.backend.rust.multi;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.ICircuit;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPControlledKeyFilterOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeltaOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPInternOperator;
@@ -209,6 +210,21 @@ public final class SingleOperatorWriter extends BaseRustCodeGenerator {
             this.builder().append("])").append(";").newline();
             this.builder().newline()
                     .append(operator.getNodeName(true))
+                    .append(".set_persistent_id(hash);");
+        } else if (this.operator.is(DBSPAtomicSumOperator.class)) {
+            this.builder().append("let ")
+                    .append(name)
+                    .append(" = circuit.accumulate_concat_zsets")
+                    .append("(&[");
+            for (int i = 0; i < operator.inputs.size(); i++) {
+                if (i > 0)
+                    this.builder().append(", ");
+                this.builder().append("(").append(this.inputName(i))
+                        .append(".clone(), true)");
+            }
+            this.builder().append("])")
+                    .newline()
+                    .append(".shard()").newline()
                     .append(".set_persistent_id(hash);");
         } else {
             visitor.generateOperator(this.operator);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/AppendOnly.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
@@ -170,6 +171,11 @@ public class AppendOnly extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPSumOperator node) {
+        this.copy(node);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator node) {
         this.copy(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitCloneVisitor.java
@@ -379,6 +379,11 @@ public class CircuitCloneVisitor extends CircuitVisitor implements IWritesLogs, 
     }
 
     @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
+        this.replace(operator);
+    }
+
+    @Override
     public void postorder(DBSPStreamJoinOperator operator) {
         this.replace(operator);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/CircuitVisitor.java
@@ -214,6 +214,10 @@ public abstract class CircuitVisitor
         return this.preorder((DBSPSimpleOperator) node);
     }
 
+    public VisitDecision preorder(DBSPAtomicSumOperator node) {
+        return this.preorder((DBSPSimpleOperator) node);
+    }
+
     public VisitDecision preorder(DBSPJoinBaseOperator node) {
         return this.preorder((DBSPBinaryOperator) node);
     }
@@ -506,6 +510,10 @@ public abstract class CircuitVisitor
     }
 
     public void postorder(DBSPSumOperator node) {
+        this.postorder((DBSPSimpleOperator) node);
+    }
+
+    public void postorder(DBSPAtomicSumOperator node) {
         this.postorder((DBSPSimpleOperator) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandAggregateZero.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/ExpandAggregateZero.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateZeroOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeltaOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateOperator;
@@ -9,7 +10,6 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNestedOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
-import org.dbsp.sqlCompiler.circuit.operator.DBSPSumOperator;
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteRelNode;
@@ -104,7 +104,7 @@ public class ExpandAggregateZero extends Passes {
                         node.intermediate(), new DBSPZSetExpression(emptySetResult), false);
             }
             this.addOperator(constant);
-            DBSPSimpleOperator sum = new DBSPSumOperator(node, Linq.list(constant.outputPort(), neg.outputPort(), input));
+            DBSPSimpleOperator sum = new DBSPAtomicSumOperator(node, Linq.list(constant.outputPort(), neg.outputPort(), input));
             this.map(operator, sum);
         }
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Lineage.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/Lineage.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.OutputPort;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateZeroOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
@@ -548,6 +549,11 @@ public class Lineage extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPSumOperator node) {
+        this.intersect(node);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator node) {
         this.intersect(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeDistinctVisitor.java
@@ -47,7 +47,8 @@ public class OptimizeDistinctVisitor extends CircuitCloneVisitor {
         }
         if (input.node().is(DBSPStreamJoinOperator.class) ||
             input.node().is(DBSPMapOperator.class) ||
-            input.node().is(DBSPSumOperator.class)) {
+            input.node().is(DBSPSumOperator.class) ||
+            input.node().is(DBSPAtomicSumOperator.class)) {
             boolean allDistinct = Linq.all(input.node().inputs, i -> i.node().is(DBSPStreamDistinctOperator.class));
             if (allDistinct) {
                 // distinct(map(distinct)) = distinct(map)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeIncrementalVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeIncrementalVisitor.java
@@ -176,7 +176,23 @@ public class OptimizeIncrementalVisitor extends CircuitCloneVisitor {
         List<OutputPort> sources = Linq.map(operator.inputs, this::mapped);
         if (Linq.all(sources, s -> s.node().is(DBSPIntegrateOperator.class))) {
             List<OutputPort> sourceSource = Linq.map(sources, s -> s.node().inputs.get(0));
-            DBSPSimpleOperator replace = new DBSPSumOperator(operator.getRelNode(), sourceSource);
+            DBSPSimpleOperator replace = new DBSPSumOperator(operator.getRelNode(), sourceSource)
+                    .addAnnotations(operator.annotations, DBSPSimpleOperator.class);
+            this.addOperator(replace);
+            DBSPIntegrateOperator integral = new DBSPIntegrateOperator(operator.getRelNode(), replace.outputPort());
+            this.map(operator, integral);
+            return;
+        }
+        super.postorder(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
+        List<OutputPort> sources = Linq.map(operator.inputs, this::mapped);
+        if (Linq.all(sources, s -> s.node().is(DBSPIntegrateOperator.class))) {
+            List<OutputPort> sourceSource = Linq.map(sources, s -> s.node().inputs.get(0));
+            DBSPSimpleOperator replace = new DBSPAtomicSumOperator(operator.getRelNode(), sourceSource)
+                    .addAnnotations(operator.annotations, DBSPSimpleOperator.class);
             this.addOperator(replace);
             DBSPIntegrateOperator integral = new DBSPIntegrateOperator(operator.getRelNode(), replace.outputPort());
             this.map(operator, integral);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjections.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/OptimizeProjections.java
@@ -6,6 +6,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateZeroOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPApplyOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPBinaryOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayOperator;
@@ -645,12 +646,15 @@ public class OptimizeProjections extends CircuitCloneWithGraphsVisitor {
                 source.node().is(DBSPDelayOperator.class) ||
                 source.node().is(DBSPNegateOperator.class) ||
                 source.node().is(DBSPSumOperator.class) ||
+                source.node().is(DBSPAtomicSumOperator.class) ||
                 source.node().is(DBSPSubtractOperator.class) ||
                 source.node().is(DBSPNoopOperator.class)) {
             Logger.INSTANCE.belowLevel(this, 2)
                     .appendSupplier(() -> source.simpleNode().operation + " -> Map")
                     .newline();
-            if (source.node().is(DBSPSumOperator.class) || source.node().is(DBSPSubtractOperator.class)) {
+            if (source.node().is(DBSPSumOperator.class)
+                    || source.node().is(DBSPSubtractOperator.class)
+                    || source.node().is(DBSPAtomicSumOperator.class)) {
                 Projection projection = new Projection(this.compiler(), true, true);
                 projection.apply(operator.getFunction());
                 if (!projection.isProjection) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/PropagateEmptySources.java
@@ -2,6 +2,7 @@ package org.dbsp.sqlCompiler.compiler.visitors.outer;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPConstantOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDifferentiateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDistinctOperator;
@@ -16,6 +17,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPMapOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNegateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPNoopOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPSimpleOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinIndexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStarJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamAggregateOperator;
@@ -181,18 +183,45 @@ public class PropagateEmptySources extends CircuitCloneVisitor {
                 continue;
             newSources.add(source);
         }
+
         if (newSources.isEmpty()) {
             DBSPExpression value = emptySet(operator.getType());
             DBSPConstantOperator result = new DBSPConstantOperator(
                     operator.getRelNode(), value, operator.isMultiset);
             this.emptySources.add(result);
             this.map(operator, result);
-            return;
         } else if (newSources.size() == 1) {
             this.map(operator.outputPort(), newSources.get(0), false);
-            return;
+        } else if (newSources.size() < operator.inputs.size()) {
+            DBSPSimpleOperator result = operator.withInputs(newSources, false).to(DBSPSimpleOperator.class);
+            this.map(operator, result);
+        } else {
+            super.postorder(operator);
         }
-        super.postorder(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
+        List<OutputPort> newSources = new ArrayList<>();
+        for (OutputPort prev: operator.inputs) {
+            OutputPort source = this.mapped(prev);
+            if (this.emptySources.contains(source.node()))
+                continue;
+            newSources.add(source);
+        }
+        if (newSources.isEmpty()) {
+            DBSPExpression value = emptySet(operator.getType());
+            DBSPConstantOperator result = new DBSPConstantOperator(
+                    operator.getRelNode(), value, operator.isMultiset);
+            this.emptySources.add(result);
+            this.map(operator, result);
+        } else if (newSources.size() < operator.inputs.size()) {
+            // Keep the sum even for 1 input
+            DBSPSimpleOperator result = operator.withInputs(newSources, false).to(DBSPSimpleOperator.class);
+            this.map(operator, result);
+        } else {
+            super.postorder(operator);
+        }
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/DeltaExpandOperators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expansion/DeltaExpandOperators.java
@@ -5,6 +5,7 @@ import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOpera
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessRetainKeysOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
@@ -90,6 +91,11 @@ public class DeltaExpandOperators extends CircuitCloneVisitor {
 
     @Override
     public void postorder(DBSPSumOperator operator) {
+        this.identity(operator);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
         this.identity(operator);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/intern/RewriteInternedFields.java
@@ -493,12 +493,10 @@ public class RewriteInternedFields extends CircuitCloneVisitor {
         throw new InternalCompilerError("Unexpected type " + left);
     }
 
-    @Override
-    public void postorder(DBSPSumOperator operator) {
+    boolean processSum(DBSPSimpleOperator operator) {
         List<OutputPort> inputs = Linq.map(operator.inputs, this::mapped);
         if (!operator.inputsDiffer(inputs, false)) {
-            super.postorder(operator);
-            return;
+            return false;
         }
 
         DBSPType commonType = inputs.get(0).getOutputRowType();
@@ -527,8 +525,23 @@ public class RewriteInternedFields extends CircuitCloneVisitor {
             inputs.set(i, map.outputPort());
             this.addOperator(map);
         }
-        DBSPSumOperator result = new DBSPSumOperator(operator.getRelNode(), inputs);
+        DBSPSimpleOperator result = operator.withInputs(inputs, false).to(DBSPSimpleOperator.class);
         this.map(operator, result);
+        return true;
+    }
+
+    @Override
+    public void postorder(DBSPSumOperator operator) {
+        if (!this.processSum(operator)) {
+            super.postorder(operator);
+        }
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
+        if (!this.processSum(operator)) {
+            this.postorder(operator);
+        }
     }
 
     OutputPort uninternKey(OutputPort source, DBSPTypeIndexedZSet sourceType, DBSPTypeTuple commonKeyType) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -1842,6 +1842,20 @@ public class InsertLimiters extends CircuitCloneVisitor {
     }
 
     @Override
+    public void postorder(DBSPAtomicSumOperator operator) {
+        // Treat like an identity function (like the Sum operator)
+        ReplacementDeltaExpansion expanded = this.getReplacement(operator);
+        if (expanded != null) {
+            OutputPort bound = this.processSumOrDiff(expanded.replacement);
+            if (bound != null && expanded.replacement != operator)
+                this.markBound(operator.outputPort(), bound);
+        } else {
+            this.nonMonotone(operator);
+        }
+        super.postorder(operator);
+    }
+
+    @Override
     public void postorder(DBSPSubtractOperator operator) {
         // Similar to sum
         ReplacementDeltaExpansion expanded = this.getReplacement(operator);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/Monotonicity.java
@@ -4,6 +4,7 @@ import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAsofJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAggregateLinearPostprocessOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPAntiJoinOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPAtomicSumOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPChainAggregateOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDeindexOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPDelayedIntegralOperator;
@@ -522,6 +523,11 @@ public class Monotonicity extends CircuitVisitor {
 
     @Override
     public void postorder(DBSPSumOperator node) {
+        this.sumOrDifference(node);
+    }
+
+    @Override
+    public void postorder(DBSPAtomicSumOperator node) {
         this.sumOrDifference(node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/resources/metadataTests-generateDF.json
@@ -153,7 +153,7 @@
       "positions": [],
       "persistent_id": "bd39cf1159208fe39f804045bb097cac071084865503769ca862515fd35f1289"
     }, "s10": {
-      "operation": "sum",
+      "operation": "atomic_sum",
       "inputs": [
         { "node": "s9", "output": 0 },
         { "node": "s8", "output": 0 },
@@ -163,7 +163,7 @@
         "partial": 3
       },
       "positions": [],
-      "persistent_id": "5a531ea30f94f3cc3a4e724e1e9a72540d2a574be0d63565e5caa388c9f59221"
+      "persistent_id": "8fb479ab08f1915eb684200d6b26ff49a810ccaeb45c6a40b4f0ddebb1ec51a4"
     }, "s11": {
       "operation": "inspect",
       "inputs": [
@@ -177,7 +177,7 @@
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40},
         {"start_line_number":2,"start_column":1,"end_line_number":2,"end_column":40}
       ],
-      "persistent_id": "a5563f0944296ab7968e9015c9d8ced05a8e9955dec0aa1e727f76c2f4d05489"
+      "persistent_id": "cf472d4e3713ed0e8c91ebbf46cd813eaff94a440f8779390a9c96b745c19bab"
     }, "s12": {
       "operation": "constant",
       "inputs": [],


### PR DESCRIPTION
Fixes #6173

I have rerun the SLT tests that failed overnight and verified that they all pass.
