### PR TITLE
[adapters] Always start a transaction before a step.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3028,82 +3028,92 @@ impl CircuitThread {
         }
 
         let transaction_state = self.controller.get_transaction_state();
-        assert_ne!(transaction_state, TransactionState::None);
 
-        debug!("circuit thread: calling 'circuit.step'");
+        if transaction_state != TransactionState::None {
+            debug!("circuit thread: calling 'circuit.step'");
 
-        let committed = Span::new("step")
-            .with_category("Step")
-            .with_tooltip(|| format!("step {}", self.step))
-            .in_scope(|| self.circuit.step())
-            .unwrap_or_else(|e| {
-                self.controller.error(Arc::new(e.into()), None);
-                false
-            });
+            let committed = Span::new("step")
+                .with_category("Step")
+                .with_tooltip(|| format!("step {}", self.step))
+                .in_scope(|| self.circuit.step())
+                .unwrap_or_else(|e| {
+                    self.controller.error(Arc::new(e.into()), None);
+                    false
+                });
 
-        debug!("circuit thread: 'circuit.step' returned");
+            debug!("circuit thread: 'circuit.step' returned");
 
-        if let TransactionState::Committing {
-            tid,
-            start,
-            processed_records,
-        } = transaction_state
-        {
-            let n = self
-                .controller
-                .status
-                .global_metrics
-                .num_total_processed_records()
-                - processed_records;
-            if !committed {
-                let commit_updates = self.commit_updates.get_or_insert_default();
-                if commit_updates.should_update_status() {
-                    match self.circuit.commit_progress() {
-                        Ok(progress) => {
-                            let summary = progress.summary();
-                            if commit_updates.should_display_status() {
-                                info!(
-                                    "Transaction {tid}: Commit of {n} records in progress ({summary})"
-                                );
-                            }
-                            self.controller
-                                .status
-                                .global_metrics
-                                .set_commit_progress(Some(summary));
-                        }
-                        Err(e) => {
-                            error!("Transaction {tid}: Error retrieving commit progress ({e})");
-                        }
-                    }
-                };
-            } else {
-                let duration = start.elapsed();
-                if duration >= COMMIT_DISPLAY_INTERVAL {
-                    info!(
-                        "Transaction {tid}: Finished committing {n} records in {:.1} seconds",
-                        duration.as_secs_f64()
-                    );
-                }
-
-                Span::new("commit")
-                    .with_category("Transaction")
-                    .with_tooltip(|| format!("transaction {tid} committed {n} records"))
-                    .with_start(start)
-                    .record();
-                TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
-
-                self.controller
-                    .transaction_info
-                    .lock()
-                    .unwrap()
-                    .transaction_state = TransactionState::None;
-
-                self.commit_updates = None;
-                self.controller
+            if let TransactionState::Committing {
+                tid,
+                start,
+                processed_records,
+            } = transaction_state
+            {
+                let n = self
+                    .controller
                     .status
                     .global_metrics
-                    .set_commit_progress(None);
+                    .num_total_processed_records()
+                    - processed_records;
+                if !committed {
+                    let commit_updates = self.commit_updates.get_or_insert_default();
+                    if commit_updates.should_update_status() {
+                        match self.circuit.commit_progress() {
+                            Ok(progress) => {
+                                let summary = progress.summary();
+                                if commit_updates.should_display_status() {
+                                    info!(
+                                        "Transaction {tid}: Commit of {n} records in progress ({summary})"
+                                    );
+                                }
+                                self.controller
+                                    .status
+                                    .global_metrics
+                                    .set_commit_progress(Some(summary));
+                            }
+                            Err(e) => {
+                                error!("Transaction {tid}: Error retrieving commit progress ({e})");
+                            }
+                        }
+                    };
+                } else {
+                    let duration = start.elapsed();
+                    if duration >= COMMIT_DISPLAY_INTERVAL {
+                        info!(
+                            "Transaction {tid}: Finished committing {n} records in {:.1} seconds",
+                            duration.as_secs_f64()
+                        );
+                    }
+
+                    Span::new("commit")
+                        .with_category("Transaction")
+                        .with_tooltip(|| format!("transaction {tid} committed {n} records"))
+                        .with_start(start)
+                        .record();
+                    TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
+
+                    self.controller
+                        .transaction_info
+                        .lock()
+                        .unwrap()
+                        .transaction_state = TransactionState::None;
+
+                    self.commit_updates = None;
+                    self.controller
+                        .status
+                        .global_metrics
+                        .set_commit_progress(None);
+                }
             }
+        } else {
+            debug!("circuit thread: calling 'circuit.transaction'");
+            self.controller.increment_transaction_number();
+            Span::new("step")
+                .with_category("Step")
+                .with_tooltip(|| format!("step {}", self.step))
+                .in_scope(|| self.circuit.transaction())
+                .unwrap_or_else(|e| self.controller.error(Arc::new(e.into()), None));
+            debug!("circuit thread: 'circuit.transaction' returned");
         }
     }
 
@@ -7172,15 +7182,28 @@ impl ControllerInner {
                     assert!(!transaction_info.initiators.is_active(is_multihost));
                     assert!(transaction_info.initiators.transaction_id.is_none());
 
-                    // Start and instantly commit a new transaction.
-                    transaction_info.last_transaction_id += 1;
+                    if self
+                        .status
+                        .pipeline_config
+                        .global
+                        .dev_tweaks
+                        .disable_auto_transaction()
+                    {
+                        None
+                    } else {
+                        // Start and instantly commit a new transaction.
+                        transaction_info.last_transaction_id += 1;
 
-                    transaction_info.transaction_state = TransactionState::Committing {
-                        tid: transaction_info.last_transaction_id,
-                        start: Instant::now(),
-                        processed_records: self.status.global_metrics.num_total_processed_records(),
-                    };
-                    Some(AdvanceTransaction::StartAndCommit)
+                        transaction_info.transaction_state = TransactionState::Committing {
+                            tid: transaction_info.last_transaction_id,
+                            start: Instant::now(),
+                            processed_records: self
+                                .status
+                                .global_metrics
+                                .num_total_processed_records(),
+                        };
+                        Some(AdvanceTransaction::StartAndCommit)
+                    }
                 }
             }
         };

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -7123,7 +7123,7 @@ impl ControllerInner {
                     // Nothing to do.
                     //
                     // We know that there must not be any active initiators
-                    // because we cleared them when we started the transaction
+                    // because we cleared them when we started committing the transaction
                     // (the previous case) and we reject requests to initiate a
                     // transaction while a transaction is committing.
                     assert!(!transaction_info.initiators.is_active(is_multihost));

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2660,7 +2660,7 @@ impl CircuitThread {
         };
 
         let (step_sender, step_receiver) =
-            tokio::sync::watch::channel(StepStatus::new(step, StepAction::Idle));
+            tokio::sync::watch::channel(StepStatus::new(step, StepAction::Idle, None));
         let (checkpoint_sender, checkpoint_receiver) = tokio::sync::watch::channel(None);
         let (parker, backpressure_thread, command_receiver, controller) = ControllerInner::new(
             pipeline_config,
@@ -2910,8 +2910,13 @@ impl CircuitThread {
             .total_initiated_steps
             .store(self.step + 1, Ordering::Release);
 
-        self.step_sender
-            .send_replace(StepStatus::new(self.step, StepAction::Step));
+        self.step_sender.send_replace(StepStatus::new(
+            self.step,
+            StepAction::Step,
+            self.controller
+                .get_transaction_state()
+                .into_coordination_status(),
+        ));
         let total_consumed = match Span::new("input")
             .with_category("Step")
             .with_tooltip(|| format!("supply input before step {}", self.step + 1))
@@ -2928,8 +2933,12 @@ impl CircuitThread {
         self.controller.unpark_backpressure();
         self.step_circuit();
 
-        self.step_sender
-            .send_replace(StepStatus::new(self.step, StepAction::Idle));
+        let transaction_state = self.controller.get_transaction_state();
+        self.step_sender.send_replace(StepStatus::new(
+            self.step,
+            StepAction::Idle,
+            transaction_state.into_coordination_status(),
+        ));
 
         // If bootstrapping has completed, update the status flag.
         self.controller
@@ -2942,7 +2951,7 @@ impl CircuitThread {
         // query results always reflect all data that we have reported
         // processing; otherwise, there is a race for any code that runs a query
         // as soon as input has been processed.
-        if self.controller.get_transaction_state() == TransactionState::None {
+        if transaction_state == TransactionState::None {
             Span::new("update")
                 .with_category("Step")
                 .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
@@ -3083,11 +3092,11 @@ impl CircuitThread {
                     .record();
                 TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
 
-                let mut transaction_info = self.controller.transaction_info.lock().unwrap();
-
-                transaction_info.transaction_state = TransactionState::None;
-                transaction_info.update_transaction_status();
-                drop(transaction_info);
+                self.controller
+                    .transaction_info
+                    .lock()
+                    .unwrap()
+                    .transaction_state = TransactionState::None;
 
                 self.commit_updates = None;
                 self.controller
@@ -3468,9 +3477,17 @@ impl CircuitThread {
         };
 
         for (&endpoint_id, status) in statuses.iter() {
-            if inputs == StepInputs::CheckpointBarriers && !status.is_barrier()
-                || committing.contains(&status.endpoint_name)
-            {
+            let poll_endpoint = if committing.contains(&status.endpoint_name) {
+                // Do not include connectors that have requested commit.
+                false
+            } else {
+                match inputs {
+                    StepInputs::All => true,
+                    StepInputs::CheckpointBarriers => status.is_barrier(),
+                    StepInputs::None => false,
+                }
+            };
+            if !poll_endpoint {
                 if let Some(resume) = self.input_metadata.remove(&status.endpoint_name) {
                     step_metadata.insert(
                         endpoint_id,
@@ -5176,6 +5193,16 @@ impl TransactionState {
             } => Some(*processed_records),
         }
     }
+
+    /// Returns this transaction status in the format used in [StepStatus] and
+    /// [TransactionCoordination].
+    pub fn into_coordination_status(self) -> Option<bool> {
+        match self {
+            TransactionState::None => None,
+            TransactionState::Started { .. } => Some(true),
+            TransactionState::Committing { .. } => Some(false),
+        }
+    }
 }
 
 enum AdvanceTransaction {
@@ -5558,21 +5585,6 @@ impl TransactionInfo {
     /// changed.
     fn update_transaction_status(&self) {
         let coordination = TransactionCoordination {
-            status: match (
-                self.transaction_state,
-                self.initiators.is_ongoing(self.is_multihost),
-            ) {
-                (TransactionState::None, false) => None,
-                (TransactionState::Started { .. } | TransactionState::Committing { .. }, false) => {
-                    Some(false)
-                }
-                (TransactionState::None | TransactionState::Started { .. }, true) => Some(true),
-                (TransactionState::Committing { .. }, true) => {
-                    // We can get here if a new transaction has been initiated via the API while the
-                    // prevous transaction is committing.
-                    return;
-                }
-            },
             requests: self
                 .initiators
                 .initiated_by_connectors
@@ -6970,10 +6982,7 @@ impl ControllerInner {
     pub fn start_transaction_from_api(&self) -> Result<TransactionId, ControllerError> {
         let transaction_info = &mut *self.transaction_info.lock().unwrap();
 
-        let transaction_id = transaction_info.start_transaction_from_api()?;
-        transaction_info.update_transaction_status();
-
-        Ok(transaction_id)
+        transaction_info.start_transaction_from_api()
     }
 
     /// Start committing the current transaction by setting desired state to None.

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2930,6 +2930,7 @@ impl CircuitThread {
 
         self.step_sender
             .send_replace(StepStatus::new(self.step, StepAction::Idle));
+
         // If bootstrapping has completed, update the status flag.
         self.controller
             .status
@@ -2943,8 +2944,8 @@ impl CircuitThread {
         // as soon as input has been processed.
         Span::new("update")
             .with_category("Step")
-            .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
-            .in_scope(|| self.update_snapshot());
+                .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
+                .in_scope(|| self.update_snapshot());
 
         // Record that we've processed the records, unless there is a transaction in progress,
         // in which case records are ingested by the circuit but are not fully processed.
@@ -3003,91 +3004,95 @@ impl CircuitThread {
                     .start_commit_transaction()
                     .expect("should have been able to start transaction commit");
             }
+            Some(AdvanceTransaction::StartAndCommit) => {
+                self.controller.increment_transaction_number();
+                self.circuit
+                    .start_transaction()
+                    .expect("should have been able to start transaction");
+                self.circuit
+                    .start_commit_transaction()
+                    .expect("should have been able to start transaction commit");
+            }
             None => (),
         }
 
         let transaction_state = self.controller.get_transaction_state();
-        if transaction_state != TransactionState::None {
-            debug!("circuit thread: calling 'circuit.step'");
+        assert_ne!(transaction_state, TransactionState::None);
 
-            let committed = Span::new("step")
-                .with_category("Step")
-                .with_tooltip(|| format!("step {}", self.step))
-                .in_scope(|| self.circuit.step())
-                .unwrap_or_else(|e| {
-                    self.controller.error(Arc::new(e.into()), None);
-                    false
-                });
+        debug!("circuit thread: calling 'circuit.step'");
 
-            debug!("circuit thread: 'circuit.step' returned");
+        let committed = Span::new("step")
+            .with_category("Step")
+            .with_tooltip(|| format!("step {}", self.step))
+            .in_scope(|| self.circuit.step())
+            .unwrap_or_else(|e| {
+                self.controller.error(Arc::new(e.into()), None);
+                false
+            });
 
-            if let TransactionState::Committing {
-                tid,
-                start,
-                processed_records,
-            } = transaction_state
-            {
-                let n = self
-                    .controller
-                    .status
-                    .global_metrics
-                    .num_total_processed_records()
-                    - processed_records;
-                if !committed {
-                    let commit_updates = self.commit_updates.get_or_insert_default();
-                    if commit_updates.should_update_status() {
-                        match self.circuit.commit_progress() {
-                            Ok(progress) => {
-                                let summary = progress.summary();
-                                if commit_updates.should_display_status() {
-                                    info!(
-                                        "Transaction {tid}: Commit of {n} records in progress ({summary})"
-                                    );
-                                }
-                                self.controller
-                                    .status
-                                    .global_metrics
-                                    .set_commit_progress(Some(summary));
+        debug!("circuit thread: 'circuit.step' returned");
+
+        if let TransactionState::Committing {
+            tid,
+            start,
+            processed_records,
+        } = transaction_state
+        {
+            let n = self
+                .controller
+                .status
+                .global_metrics
+                .num_total_processed_records()
+                - processed_records;
+            if !committed {
+                let commit_updates = self.commit_updates.get_or_insert_default();
+                if commit_updates.should_update_status() {
+                    match self.circuit.commit_progress() {
+                        Ok(progress) => {
+                            let summary = progress.summary();
+                            if commit_updates.should_display_status() {
+                                info!(
+                                    "Transaction {tid}: Commit of {n} records in progress ({summary})"
+                                );
                             }
-                            Err(e) => {
-                                error!("Transaction {tid}: Error retrieving commit progress ({e})");
-                            }
+                            self.controller
+                                .status
+                                .global_metrics
+                                .set_commit_progress(Some(summary));
                         }
-                    };
-                } else {
-                    let duration = start.elapsed();
+                        Err(e) => {
+                            error!("Transaction {tid}: Error retrieving commit progress ({e})");
+                        }
+                    }
+                };
+            } else {
+                let duration = start.elapsed();
+                if duration >= COMMIT_DISPLAY_INTERVAL {
                     info!(
                         "Transaction {tid}: Finished committing {n} records in {:.1} seconds",
                         duration.as_secs_f64()
                     );
-                    Span::new("commit")
-                        .with_category("Transaction")
-                        .with_tooltip(|| format!("transaction {tid} committed {n} records"))
-                        .with_start(start)
-                        .record();
-                    TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
-
-                    let mut transaction_info = self.controller.transaction_info.lock().unwrap();
-                    transaction_info.transaction_state = TransactionState::None;
-                    transaction_info.update_transaction_status();
-                    drop(transaction_info);
-
-                    self.commit_updates = None;
-                    self.controller
-                        .status
-                        .global_metrics
-                        .set_commit_progress(None);
                 }
+
+                Span::new("commit")
+                    .with_category("Transaction")
+                    .with_tooltip(|| format!("transaction {tid} committed {n} records"))
+                    .with_start(start)
+                    .record();
+                TRANSACTION_COMMIT_TIME_MICROSECONDS.record_duration(duration);
+
+                let mut transaction_info = self.controller.transaction_info.lock().unwrap();
+
+                transaction_info.transaction_state = TransactionState::None;
+                transaction_info.update_transaction_status();
+                drop(transaction_info);
+
+                self.commit_updates = None;
+                self.controller
+                    .status
+                    .global_metrics
+                    .set_commit_progress(None);
             }
-        } else {
-            debug!("circuit thread: calling 'circuit.transaction'");
-            self.controller.increment_transaction_number();
-            Span::new("step")
-                .with_category("Step")
-                .with_tooltip(|| format!("step {}", self.step))
-                .in_scope(|| self.circuit.transaction())
-                .unwrap_or_else(|e| self.controller.error(Arc::new(e.into()), None));
-            debug!("circuit thread: 'circuit.transaction' returned");
         }
     }
 
@@ -5135,6 +5140,10 @@ impl TransactionState {
         matches!(self, TransactionState::Committing { .. })
     }
 
+    fn is_started(&self) -> bool {
+        matches!(self, TransactionState::Started { .. })
+    }
+
     pub fn tid(&self) -> Option<TransactionId> {
         match self {
             TransactionState::None => None,
@@ -5168,8 +5177,14 @@ impl TransactionState {
 }
 
 enum AdvanceTransaction {
+    /// Start a new transaction.
     Start,
+
+    /// Commit the current transaction.
     Commit,
+
+    /// Start and instantly commit a new transaction.
+    StartAndCommit,
 }
 
 /// Phase of a transaction.
@@ -5258,7 +5273,7 @@ impl TransactionInitiators {
 
     /// Clear the transaction requested state.
     ///
-    /// Must be invoked when a transaction is committed.
+    /// Must be invoked when a transaction starts committing.
     fn clear(&mut self, is_multihost: bool) {
         self.transaction_id = None;
         self.initiated_by_api = None;
@@ -5369,7 +5384,7 @@ impl TransactionInfo {
 
     /// Start a new transaction from the API.
     fn start_transaction_from_api(&mut self) -> Result<TransactionId, ControllerError> {
-        if self.initiators.initiated_by_api.is_some() || self.transaction_state.is_committing() {
+        if self.initiators.initiated_by_api.is_some() {
             return Err(ControllerError::TransactionInProgress);
         }
 
@@ -5551,10 +5566,8 @@ impl TransactionInfo {
                 }
                 (TransactionState::None | TransactionState::Started { .. }, true) => Some(true),
                 (TransactionState::Committing { .. }, true) => {
-                    error!(
-                        "Invalid transaction state: actual state: {:?}; desired state {:?}",
-                        self.transaction_state, self.initiators
-                    );
+                    // We can get here if a new transaction has been initiated via the API while the
+                    // prevous transaction is committing.
                     return;
                 }
             },
@@ -6978,7 +6991,7 @@ impl ControllerInner {
         if transaction_info
             .initiators
             .is_ready_to_commit(transaction_info.is_multihost)
-            && transaction_info.transaction_state == TransactionState::None
+            && !transaction_info.transaction_state.is_started()
         {
             transaction_info.clear_initiators();
         }
@@ -7057,8 +7070,11 @@ impl ControllerInner {
             .is_committing()
     }
 
-    /// Advance transaction state from None to Started or from Started to committing in response
-    /// to desired state changes.
+    /// Advance transaction state before performing a step:
+    ///
+    /// - from None to Started if a transaction is requested by the API or a connector.
+    /// - from Started to Committing if transaction commit is requested
+    /// - from None to Committing if no transaction has been requested.
     ///
     /// Returns how the transaction is advancing (if it is).
     fn advance_transaction_state(&self) -> Option<AdvanceTransaction> {
@@ -7084,9 +7100,8 @@ impl ControllerInner {
                     // We are already in a transaction, so there is nothing to do.
                     None
                 }
-                TransactionState::Committing { .. } => unreachable!(
-                    "Requests to initiate a transaction are rejected while a transaction is committing but somehow one slipped through anyhow"
-                ),
+                // Don't start a new transaction until the current transaction has committed.
+                TransactionState::Committing { .. } => None,
             }
         } else {
             // The API and connectors want us to not be in a transaction, so
@@ -7130,8 +7145,6 @@ impl ControllerInner {
                     None
                 }
                 TransactionState::None => {
-                    // Nothing to do.
-                    //
                     // We know that there must not be any active initiators
                     // because:
                     //
@@ -7146,7 +7159,17 @@ impl ControllerInner {
                     //   clear all the initiators if they commit the last
                     //   initiator and no transaction has started.
                     assert!(!transaction_info.initiators.is_active(is_multihost));
-                    None
+                    assert!(transaction_info.initiators.transaction_id.is_none());
+
+                    // Start and instantly commit a new transaction.
+                    transaction_info.last_transaction_id += 1;
+
+                    transaction_info.transaction_state = TransactionState::Committing {
+                        tid: transaction_info.last_transaction_id,
+                        start: Instant::now(),
+                        processed_records: self.status.global_metrics.num_total_processed_records(),
+                    };
+                    Some(AdvanceTransaction::StartAndCommit)
                 }
             }
         };

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2942,10 +2942,12 @@ impl CircuitThread {
         // query results always reflect all data that we have reported
         // processing; otherwise, there is a race for any code that runs a query
         // as soon as input has been processed.
-        Span::new("update")
-            .with_category("Step")
+        if self.controller.get_transaction_state() == TransactionState::None {
+            Span::new("update")
+                .with_category("Step")
                 .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
                 .in_scope(|| self.update_snapshot());
+        }
 
         // Record that we've processed the records, unless there is a transaction in progress,
         // in which case records are ingested by the circuit but are not fully processed.

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -726,15 +726,10 @@ impl Runtime {
                             return;
                         }
                     }
-                    Ok(Command::BootstrapStep) => {
-                        if let Err(e) = circuit.transaction() {
-                            if status_sender.send(Err(e)).is_err() {
-                                return;
-                            }
-                        } else if status_sender
-                            .send(Ok(Response::BootstrapComplete(
-                                circuit.is_replay_complete(),
-                            )))
+                    Ok(Command::IsBootstrapComplete) => {
+                        let complete = circuit.is_replay_complete();
+                        if status_sender
+                            .send(Ok(Response::BootstrapComplete(complete)))
                             .is_err()
                         {
                             return;
@@ -932,8 +927,7 @@ enum Command {
     CommitTransaction,
     CommitProgress,
     Transaction,
-    /// Execute a step in bootstrap mode.
-    BootstrapStep,
+    IsBootstrapComplete,
     CompleteBootstrap,
     EnableProfiler,
     DumpProfile {
@@ -963,7 +957,7 @@ impl Debug for Command {
             Command::CommitTransaction => write!(f, "CommitTransaction"),
             Command::CommitProgress => write!(f, "CommitProgress"),
             Command::Transaction => write!(f, "Transaction"),
-            Command::BootstrapStep => write!(f, "BootstrapStep"),
+            Command::IsBootstrapComplete => write!(f, "IsBootstrapComplete"),
             Command::CompleteBootstrap => write!(f, "CompleteBootstrap"),
             Command::EnableProfiler => write!(f, "EnableProfiler"),
             Command::RetrieveGraph => write!(f, "RetrieveGraph"),
@@ -1245,13 +1239,49 @@ impl DBSPHandle {
         Ok(reply)
     }
 
+    /// Check if the bootstrap is complete and clear bootstrap info if it is.
+    ///
+    /// Should be called after a step or transaction is completed.
+    fn check_bootstrap_complete(&mut self) -> Result<(), DbspError> {
+        if self.bootstrap_in_progress() {
+            let mut replay_complete = Vec::with_capacity(self.status_receivers.len());
+
+            let result =
+                self.broadcast_command(Command::IsBootstrapComplete, |_worker, response| {
+                    let Response::BootstrapComplete(complete) = response else {
+                        panic!("Expected BootstrapComplete response, got {response:?}");
+                    };
+                    replay_complete.push(complete);
+                });
+
+            result?;
+
+            if replay_complete.iter().all(|complete| *complete) {
+                info!("Bootstrap complete");
+                self.send_complete_bootstrap()?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Start and instantly commit a transaction, waiting for the commit to complete.
     pub fn transaction(&mut self) -> Result<(), DbspError> {
-        if self.bootstrap_in_progress() {
-            self.step_bootstrap()
-        } else {
-            self.transaction_regular()
+        DBSP_STEP.fetch_add(1, Ordering::Relaxed);
+        let start = Instant::now();
+        let result = self.broadcast_command(Command::Transaction, |_, _| {});
+        DBSP_STEP_LATENCY_MICROSECONDS
+            .lock()
+            .unwrap()
+            .record_elapsed(start);
+        if let Some(handle) = self.runtime.as_ref() {
+            self.runtime_elapsed +=
+                start.elapsed() * handle.runtime().layout().local_workers().len() as u32 * 2;
         }
+
+        self.check_bootstrap_complete()?;
+
+        result
     }
 
     /// Start a transaction.
@@ -1312,6 +1342,7 @@ impl DBSPHandle {
 
         if commit_complete {
             debug!("Commit complete");
+            self.check_bootstrap_complete()?;
         }
 
         Ok(commit_complete)
@@ -1370,55 +1401,6 @@ impl DBSPHandle {
         } else {
             0
         }
-    }
-
-    fn transaction_regular(&mut self) -> Result<(), DbspError> {
-        DBSP_STEP.fetch_add(1, Ordering::Relaxed);
-        let start = Instant::now();
-        let result = self.broadcast_command(Command::Transaction, |_, _| {});
-        DBSP_STEP_LATENCY_MICROSECONDS
-            .lock()
-            .unwrap()
-            .record_elapsed(start);
-        if let Some(handle) = self.runtime.as_ref() {
-            self.runtime_elapsed +=
-                start.elapsed() * handle.runtime().layout().local_workers().len() as u32 * 2;
-        }
-        result
-    }
-
-    /// In the bootstrap mode, after performing a step, check if all workers have finished bootstrapping.
-    /// If so, notify all workers to exit the bootstrap phase and start normal operation.
-    fn step_bootstrap(&mut self) -> Result<(), DbspError> {
-        DBSP_STEP.fetch_add(1, Ordering::Relaxed);
-        let start = Instant::now();
-
-        let mut replay_complete = Vec::with_capacity(self.status_receivers.len());
-
-        let result = self.broadcast_command(Command::BootstrapStep, |_worker, response| {
-            let Response::BootstrapComplete(complete) = response else {
-                panic!("Expected BootstrapComplete response, got {response:?}");
-            };
-            replay_complete.push(complete);
-        });
-
-        DBSP_STEP_LATENCY_MICROSECONDS
-            .lock()
-            .unwrap()
-            .record_elapsed(start);
-        if let Some(handle) = self.runtime.as_ref() {
-            self.runtime_elapsed +=
-                start.elapsed() * handle.runtime().layout().local_workers().len() as u32 * 2;
-        }
-
-        result?;
-
-        if replay_complete.iter().all(|complete| *complete) {
-            info!("Bootstrap complete");
-            self.send_complete_bootstrap()?;
-        }
-
-        Ok(())
     }
 
     /// The circuit has been resumed from a checkpoint and is currently bootstrapping the modified part of the circuit.

--- a/crates/feldera-types/src/config/dev_tweaks.rs
+++ b/crates/feldera-types/src/config/dev_tweaks.rs
@@ -224,6 +224,10 @@ pub struct DevTweaks {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub negative_weight_multiplier: Option<u16>,
 
+    /// Don't automatically start a transaction for every step.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_auto_transaction: Option<bool>,
+
     /// Options not understood by this particular version.
     ///
     /// This allows the pipeline manager to take options that a custom or old
@@ -288,6 +292,10 @@ impl DevTweaks {
     }
     pub fn negative_weight_multiplier(&self) -> u16 {
         self.negative_weight_multiplier.unwrap_or(0)
+    }
+
+    pub fn disable_auto_transaction(&self) -> bool {
+        self.disable_auto_transaction.unwrap_or(false)
     }
 }
 

--- a/crates/feldera-types/src/coordination.rs
+++ b/crates/feldera-types/src/coordination.rs
@@ -116,31 +116,46 @@ pub type Step = u64;
 pub enum StepAction {
     /// Wait for instructions from the coordinator.
     Idle,
-    /// Wait for a triggering event to occur, such as arrival of a sufficient
-    /// amount of data on an input connector.  If one does, execute a step.
+    /// Wait for a triggering condition to occur, such as arrival of a
+    /// sufficient amount of data on an input connector or if a transaction is
+    /// committing.  If one does, execute a step.
     Trigger,
     /// Execute a step.
     Step,
 }
 
 /// `/coordination/step/status` update, streamed by pipeline to coordinator.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct StepStatus {
     /// The step that is running or will run next.
     pub step: Step,
     /// Current action.
     pub action: StepAction,
+    /// Whether a transaction is open:
+    ///
+    /// - `None`: No transaction open or committing.
+    ///
+    /// - `Some(true)`: Transaction is open.
+    ///
+    /// - `Some(false)`: Transaction is committing.  The coordinator needs to
+    ///   execute at least one more step to commit it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_status: Option<bool>,
 }
 
 impl StepStatus {
-    pub fn new(step: Step, action: StepAction) -> Self {
-        Self { step, action }
+    pub fn new(step: Step, action: StepAction, transaction_status: Option<bool>) -> Self {
+        Self {
+            step,
+            action,
+            transaction_status,
+        }
     }
     pub fn is_triggered(&self, step: Step) -> bool {
-        *self == Self::new(step, StepAction::Step) || self.is_idle(step + 1)
+        (self.step == step && self.action == StepAction::Step) || self.is_idle(step + 1)
     }
     pub fn is_idle(&self, step: Step) -> bool {
-        *self == Self::new(step, StepAction::Idle)
+        self.step == step && self.action == StepAction::Idle
     }
 }
 
@@ -152,7 +167,8 @@ pub struct StepRequest {
     ///
     /// - [Idle][]: Do not start a step.
     ///
-    /// - [Trigger][]: Start a step if input arrives on an input endpoint.
+    /// - [Trigger][]: Start a step if input arrives on an input endpoint or if
+    ///   a transaction is committing.
     ///
     /// - [Step][]: Start a step.
     ///
@@ -197,6 +213,12 @@ pub enum StepInputs {
     /// checkpoint to trigger a step.  For executing a step, use input only from
     /// input endpoints that are blocking a checkpoint.
     CheckpointBarriers,
+
+    /// Do not consider any input as triggering a step.  For executing a step,
+    /// do not use any input.
+    ///
+    /// This is for committing a transaction.
+    None,
 }
 
 /// `/coordination/checkpoint/status`, streamed by pipeline to coordinator.
@@ -228,19 +250,6 @@ pub enum CheckpointCoordination {
 /// `/coordination/transaction/status` update, streamed by pipeline to coordinator.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct TransactionCoordination {
-    /// Whether a transaction is open:
-    ///
-    /// - `None`: No transaction open or committing.
-    ///
-    /// - `Some(true)`: Transaction is open.
-    ///
-    /// - `Some(false)`: Transaction is committing.  The coordinator needs to
-    ///   execute at least one more step to commit it.
-    ///
-    /// Only the API can open and close a transaction when coordination is
-    /// enabled.
-    pub status: Option<bool>,
-
     /// Endpoints that want to join a transaction, with their optional labels.
     pub requests: HashMap<String, Option<String>>,
 }

--- a/openapi.json
+++ b/openapi.json
@@ -8692,6 +8692,12 @@
             "nullable": true,
             "minimum": 0
           },
+          "disable_auto_transaction": {
+            "type": "boolean",
+            "description": "Don't automatically start a transaction for every step.",
+            "default": null,
+            "nullable": true
+          },
           "eager_evict": {
             "type": "boolean",
             "description": "Evict eagerly from buffer caches as files get deleted.\n\nThis is an optimization that drops files from\nthe cache as soon as they are deleted.\n\nIt has unknown (no?) performance benefits from what I can tell.\n\nHistorically it made sense to do this for two reasons:\na) we know with 100% guarantee that the file won't ever be\nread again.\nb) we could do this in O(logn) time with the LRU cache.\nThis is no longer true for s3-fifo where it is O(n).\n\nIf the eviction is expensive, (many small objects in the cache)\nthis can cause a regression.\n\nNew default disables this behavior by making it false.\n\nIf this doesn't cause regression we will remove this option\nin the future.",


### PR DESCRIPTION
Need @blp 's help to get this to work with multihost.

----

The controller used to run the circuit in two different modes:

- When a transaction is explicitly requested via an API call
  or by a connector, the controller called `dbsp.start_transaction`
  followed by multiple calls to `dbsp.step()`.

- When no transaction was requested, the controller called
  `dbsp.transaction()`.

In the latter case, the circuit could internally perform a large number of
steps, taking a long time, before returning control to the controller. During
this time, the user didn't get any indication of progress, and wasn't able to
download a support bundle.

This commit addresses the issue by starting a transaction and instantly
initiating transaction commit before performing a step if the transaction was
not explicitly requested. This way, potentially long transactions are broken
down into short steps. The user can monitor progress in the WebConsole just
like during a normal transaction.