### PR TITLE
[dbsp] Fix adaptive join heuristic.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -1430,10 +1430,6 @@ impl Balancer {
         self.inner.borrow().get_policy()
     }
 
-    pub fn set_policy(&self, solution: &BTreeMap<NodeId, PartitioningPolicy>) {
-        self.inner.borrow_mut().set_policy(solution);
-    }
-
     pub fn set_policy_for_stream(&self, stream: NodeId, policy: PartitioningPolicy) {
         self.inner
             .borrow_mut()

--- a/crates/dbsp/src/operator/dynamic/balance/balancer.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/balancer.rs
@@ -674,7 +674,6 @@ impl BalancerInner {
         for i in 0..num_clusters {
             //let cluster = &mut self.clusters[cluster_index];
             if !self.cluster_needs_refresh(i, self.auto_rebalance_enabled) {
-                solutions.extend(self.clusters[i].solution.clone());
                 continue;
             }
 
@@ -828,13 +827,20 @@ impl BalancerInner {
         ])
     }
 
-    // Get current policy for a stream.
+    /// Get current policy for a stream.
     fn get_policy_for_stream(&self, node_id: NodeId) -> Option<PartitioningPolicy> {
         //println!("stream_to_cluster({node_id}): {:?}", self.stream_to_cluster);
         let cluster_index = *self.stream_to_cluster.get(&node_id).unwrap();
         self.clusters[cluster_index].solution.get(&node_id).cloned()
     }
 
+    /// Set policy for a subset of streams.
+    ///
+    /// Policies for streams that are not listed in `solution` are not changed.
+    ///
+    /// Updates `last_distribution` for each stream in `solution`, so that the solution
+    /// is not reevaluated until the distribution changes by more than
+    /// `balancer_key_distribution_refresh_threshold()`.
     fn set_policy(&mut self, solution: &BTreeMap<NodeId, PartitioningPolicy>) {
         for (stream, policy) in solution.iter() {
             self.set_policy_for_stream(*stream, *policy);

--- a/crates/dbsp/src/operator/dynamic/balance/test.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/test.rs
@@ -1121,6 +1121,51 @@ fn test_skewed_join_left(left_join: bool, auto_rebalance: bool) {
 }
 
 #[test]
+fn test_slow_skew() {
+    let num_partitions = 4;
+
+    let mut test_steps = vec![];
+
+    // Several evenly distributed batches. Expected policy: (Shard, Shard)
+    for _ in 0..10 {
+        let left_batch = generate_skewed_batch(num_partitions, 20, 1);
+        let right_batch = generate_skewed_batch(num_partitions, 10, 1);
+        test_steps.push(JoinTestStep {
+            left: left_batch,
+            right: right_batch,
+            left_policy_hint: None,
+            right_policy_hint: None,
+            expected_left_policy: Some(PartitioningPolicy::Shard),
+            expected_right_policy: Some(PartitioningPolicy::Shard),
+        });
+    }
+
+    // Introduce skew. Expected policy: (Balance, Broadcast)
+
+    for i in 0..100 {
+        let left_batch = generate_skewed_batch(num_partitions, 5, 5);
+        let right_batch = generate_skewed_batch(num_partitions, 1, 1);
+        test_steps.push(JoinTestStep {
+            left: left_batch,
+            right: right_batch,
+            left_policy_hint: None,
+            right_policy_hint: None,
+            expected_left_policy: if i >= 80 {
+                Some(PartitioningPolicy::Balance)
+            } else {
+                None
+            },
+            expected_right_policy: if i >= 80 {
+                Some(PartitioningPolicy::Broadcast)
+            } else {
+                None
+            },
+        });
+    }
+    test_join_with_balancer(num_partitions, false, false, test_steps, false, true);
+}
+
+#[test]
 fn test_skewed_inner_join_left() {
     test_skewed_join_left(false, true);
 }


### PR DESCRIPTION
We use a heuristic to decide when the balancer should check for a better
balancing policy for a stream. Since doing this on every step can be expensive,
we memoize the key distribution when the current solution was computed and only
re-compute it when the distribution has changes by more than a pre-defined
threshold. The implementation of the heuristic was incorrect, updating the
distribution even when the solution wasn't recomputed. This meant that we would
only recompute if the distribution has changed significantly between
consecutive steps, and would ignore slow drift over time. In practice, we never
recomputed the distribution once the stream has processed a large number of
updates, since relative change from step to step are always below the threshold
at this point.