### PR TITLE
[dbsp] Fix output buffering with multihost.

### DIFF
--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -1016,7 +1016,17 @@ impl Runtime {
         match current_thread_type() {
             Some(ThreadType::Foreground) => WORKER_INDEX.get(),
             Some(ThreadType::Background) => TOKIO_WORKER_INDEX.get(),
-            None => 0,
+            None => RUNTIME.with_borrow(|runtime| match runtime {
+                Some(runtime) => {
+                    // We are running in an auxiliary thread.  Treat it like the
+                    // first thread in the local runtime.
+                    runtime.layout().local_workers().start
+                }
+                None => {
+                    // We are not running in a runtime.
+                    0
+                }
+            }),
         }
     }
 


### PR DESCRIPTION
When output buffering is enablded, the output thread creates and operates on spines.  The output thread is created as an auxiliary thread for the DBSP runtime, which allows it to access storage and buffer caches, but it has no assigned worker index.  Before this commit, that meant that Runtime::worker_index returned 0.  That works OK on single-host deployments, but it led to a panic on hosts other than the first host in multihost deployments because those hosts cannot access the buffer cache (etc.) for worker 0.  This commit fixes the problem by assigning auxiliary threads to the first worker on their host, rather than to global worker 0.

### Describe Manual Test Plan

I tested that it worked with my pipeline that panicked without it.
