### PR TITLE
docs: fix broken warning blocks

### DIFF
--- a/docs.feldera.com/docs/sql/aggregates.md
+++ b/docs.feldera.com/docs/sql/aggregates.md
@@ -221,7 +221,7 @@ The following window aggregate functions are supported:
   </tr>
 </table>
 
-::: warning Potential inefficiency
+:::warning Potential inefficiency
 
 The window aggregate functions `RANK`, `DENSE_RANK`, and `ROW_NUMBER`
 may be very expensive to evaluate incrementally, because it's possible

--- a/docs.feldera.com/docs/sql/system.md
+++ b/docs.feldera.com/docs/sql/system.md
@@ -5,7 +5,7 @@ built-in.  Their contents is pre-populated by the runtime.
 
 ## `ERROR_VIEW`
 
-::: Warning
+:::warning
 
 The `ERROR_VIEW` is still experimental; the schema and name of this
 view may change.


### PR DESCRIPTION
They currently show up like this:
<img width="727" height="117" alt="image" src="https://github.com/user-attachments/assets/cd30e160-8b94-4f6d-a90d-d48575836ffc" />


### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
