### PR TITLE
[python] Call `wait_for_idle()` before checking results in another test.

### DIFF
--- a/python/tests/platform/test_shared_pipeline.py
+++ b/python/tests/platform/test_shared_pipeline.py
@@ -779,6 +779,7 @@ class TestPipeline(SharedTestPipeline):
         )
 
         # Verify egress data includes both values with insert_delete markers
+        self.pipeline.wait_for_idle()
         egress_result = out.to_dict()
         expected_egress = [
             {"c1": "test_value", "insert_delete": 1},


### PR DESCRIPTION
This might have caused the test to fail occasionally.

Fixes: https://github.com/feldera/feldera/issues/6189

### Describe Manual Test Plan

I ran the test once manually and verified that it still passed for me.