### PR TITLE
[web-console] Fix page reload loop when feldera version upgraded in background

### DIFF
--- a/js-packages/web-console/src/lib/components/layout/LineBanner.svelte
+++ b/js-packages/web-console/src/lib/components/layout/LineBanner.svelte
@@ -17,13 +17,15 @@
     center,
     end,
     variant = 'formal',
-    dismiss
+    dismiss,
+    testid
   }: {
     start?: Snippet
     center?: Snippet
     end?: Snippet
     variant?: keyof typeof variants
     dismiss?: () => void
+    testid?: string
   } = $props()
 </script>
 
@@ -64,6 +66,7 @@
   class="{variants[
     variant
   ]} flex min-h-9 flex-nowrap items-center gap-1 px-2 py-2 text-base font-medium sm:px-8"
+  data-testid={testid}
 >
   <div class="flex flex-nowrap items-center gap-2 sm:gap-6">
     {@render start?.()}

--- a/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
+++ b/js-packages/web-console/src/routes/(system)/(authenticated)/+layout.svelte
@@ -23,8 +23,8 @@
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { useSystemMessages } from '$lib/compositions/useSystemMessages.svelte'
   import { useToast } from '$lib/compositions/useToastNotification'
+  import { fetchConfigs } from '$lib/compositions/configCache'
   import { closedIntervalAction } from '$lib/functions/common/promise'
-  import { getConfig } from '$lib/services/pipelineManager'
   import type { Snippet } from '$lib/types/svelte'
   import type { LayoutData } from './$types'
 
@@ -45,10 +45,14 @@
 
   // Check for backend version changes every 10 seconds, starting 10 seconds
   // after layout load (first tick is delayed by `periodMs`).
+  // Calls `fetchConfigs()` to both get the latest config and update the cache,
+  // otherwise `invalidateAll()` would re-render the root layout from a stale cache
+  // and trigger the version mismatch in a loop.
+  let dismissTimeout: ReturnType<typeof setTimeout> | undefined
   $effect.pre(() =>
     closedIntervalAction(async () => {
       try {
-        const config = await getConfig()
+        const { config } = await fetchConfigs()
         const currentVersion = data.feldera?.version
         const currentRevision = data.feldera?.revision
         if (
@@ -62,7 +66,9 @@
           // Show a notification that the backend was updated
           const msgId = `backend_version_changed`
 
-          const dismissTimeout = setTimeout(() => systemMessages.dismiss(msgId), 30000) // Auto-dismiss after 30 seconds
+          // Auto-dismiss after 30 seconds; clear any prior pending timer.
+          clearTimeout(dismissTimeout)
+          dismissTimeout = setTimeout(() => systemMessages.dismiss(msgId), 30000)
           systemMessages.upsert(msgId, {
             id: msgId,
             text: `Feldera was updated from version ${currentVersion} to ${config.version}.`,
@@ -178,6 +184,7 @@
         dismiss={message.dismissable !== 'never'
           ? () => systemMessages.dismiss(message.id)
           : undefined}
+        testid={`box-system-message-${message.id}`}
       >
         {#snippet start()}
           <span>{@html message.text}</span>

--- a/js-packages/web-console/tests/backendVersionBanner.e2e.ts
+++ b/js-packages/web-console/tests/backendVersionBanner.e2e.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test'
+import { configureTestClient } from '$lib/services/testPipelineHelpers'
+
+configureTestClient()
+
+test.describe('Backend version banner', () => {
+  test.setTimeout(60_000)
+
+  test('polling refreshes feldera_config_cache when backend version changes', async ({
+    page
+  }) => {
+    // Intercept /v0/config and overwrite version/revision. Direct localStorage
+    // poisoning does not work — `lazyUpdateConfig()` is scheduled ~2s after
+    // any warm-cache load() and calls `fetchConfigs()`, which overwrites the
+    // cache from the real backend. Mocking the response means every cache
+    // write — boot, lazyUpdate, and polling — sees the version we control.
+    const OLD_VERSION = '99.99.0-banner-e2e-old'
+    const NEW_VERSION = '99.99.1-banner-e2e-new'
+    let currentVersion = OLD_VERSION
+
+    const configRequests: { url: string; status: number; intercepted: boolean }[] = []
+
+    let configIntercepts = 0
+    await page.route(/\/v0\/config(?:\?|$)/, async (route) => {
+      configIntercepts++
+      const url = route.request().url()
+      try {
+        const response = await route.fetch()
+        const body = await response.json()
+        body.version = currentVersion
+        body.revision = `rev-${currentVersion}`
+        // Strip headers that don't survive body rewriting: Content-Encoding
+        // (the original may be gzip; our new body is plain) and Content-Length
+        // (now wrong). Leaving them in causes the browser to fail decompression
+        // or truncate the response, which surfaces as an empty `data.feldera`
+        // and silently suppresses the banner.
+        const headers = { ...response.headers() }
+        delete headers['content-encoding']
+        delete headers['content-length']
+        configRequests.push({ url, status: response.status(), intercepted: true })
+        console.log('sending value', body.version)
+        await route.fulfill({
+          status: response.status(),
+          headers,
+          body: JSON.stringify(body)
+        })
+      } catch (e) {
+        configRequests.push({ url, status: -1, intercepted: false })
+        await route.abort()
+      }
+    })
+
+    // Cold-cache boot: load() calls fetchConfigs() → intercepted → writes
+    // OLD into feldera_config_cache and into data.feldera.version.
+    await page.goto('/demos')
+    await page.waitForFunction(
+      () => !!localStorage.getItem('feldera_config_cache'),
+      null,
+      { timeout: 3_000 }
+    )
+
+    // Sanity check: the boot fetch wrote OLD. If this is wrong the route
+    // mock isn't intercepting, and every later assertion is a false positive.
+    const bootCachedVersion = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('feldera_config_cache')!).version
+    )
+    expect(bootCachedVersion).toBe(OLD_VERSION)
+
+    // Flip the live response. The next 10s polling tick must call
+    // `fetchConfigs()` and rewrite the cache to NEW — that's the fix's whole
+    // mechanism. The buggy code path called bare `getConfig()`, which never
+    // wrote the cache, so `feldera_config_cache.version` would stay at OLD
+    // forever and `data.feldera.version` would keep mismatching the live
+    // response, re-firing `invalidateAll()` every 10s.
+    currentVersion = NEW_VERSION
+    const tFlip = Date.now()
+
+    await page.waitForFunction(
+      (newVer) => {
+        const raw = localStorage.getItem('feldera_config_cache')
+        return raw ? JSON.parse(raw).version === newVer : false
+      },
+      NEW_VERSION,
+      { timeout: 12_000 }
+    )
+    console.log(`[banner] cache updated to NEW after ${Date.now() - tFlip}ms`)
+  })
+})


### PR DESCRIPTION
The issue was that now the Feldera version is cached, but when the web-console polls /v0/config to detect version upgrade it didn't update the cache - so the page was reloaded without resolving the conflict. With this fix the polling also updates the cache, so the data is fresh after reload and there is no more mismatch with the remote version.

Testing: manual, added e2e regression test