### PR TITLE
[webconsole] Refine definition of 'paused' connector

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/editor/performance/MetricsTables.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/performance/MetricsTables.svelte
@@ -502,7 +502,7 @@
 {/snippet}
 
 {#snippet tableMultiConnectorCell(data: AggregatedInputEndpointMetrics, isExpanded: boolean)}
-  {@const runningCount = data.connectors.filter((c) => c.paused === false).length}
+  {@const runningCount = data.connectors.filter((c) => c.paused === false && c.metrics.end_of_input === false).length}
   {@const anyErrors = data.connectors.some(inputHasErrors)}
   {@const anyFatalError = data.connectors.some((c) => c.fatal_error != null)}
   {@const anyBarrier = data.connectors.some((c) => c.barrier === true)}

--- a/js-packages/web-console/src/lib/components/pipelines/editor/performance/MetricsTables.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/performance/MetricsTables.svelte.spec.ts
@@ -421,6 +421,26 @@ describe('MetricsTables.svelte', () => {
       await renderComponent(buildMetrics(status))
       await expect.element(page.getByText('3 connectors')).toBeInTheDocument()
     })
+
+    it('combined row shows paused icon (not running) when one connector is end-of-input and the other is paused', async () => {
+      const status = makeStatus(
+        [],
+        [
+          makeInputStatus('t1', {
+            endpoint_name: 'c1',
+            paused: false,
+            metrics: makeInputMetrics({ end_of_input: true })
+          }),
+          makeInputStatus('t1', {
+            endpoint_name: 'c2',
+            paused: true
+          })
+        ]
+      )
+      await renderComponent(buildMetrics(status))
+      await expect.element(page.getByTestId('box-icon-paused')).toBeInTheDocument()
+      await expect.element(page.getByTestId('box-icon-running')).not.toBeInTheDocument()
+    })
   })
 
   describe('F. Error count buttons & callbacks', () => {


### PR DESCRIPTION
I hope this fixes #6206, but I don't have a complex enough pipeline handy to test