### PR TITLE
Redact sensitive request headers in logs

### DIFF
--- a/python/feldera/rest/_httprequests.py
+++ b/python/feldera/rest/_httprequests.py
@@ -43,6 +43,16 @@ def _is_502(exc: BaseException) -> bool:
     return isinstance(exc, FelderaAPIError) and exc.status_code == 502
 
 
+_SENSITIVE_HEADERS = {"authorization", "cookie", "proxy-authorization", "x-api-key"}
+
+
+def _redact_headers(headers: dict) -> dict:
+    return {
+        key: "[REDACTED]" if key.lower() in _SENSITIVE_HEADERS else value
+        for key, value in headers.items()
+    }
+
+
 class HttpRequests:
     def __init__(self, config: Config) -> None:
         self.config = config
@@ -194,7 +204,7 @@ class HttpRequests:
             "sending %s request to: %s with headers: %s, and params: %s",
             http_method.__name__,
             request_path,
-            str(self.headers),
+            _redact_headers(self.headers),
             str(params),
         )
 


### PR DESCRIPTION
Fixes feldera/feldera-qa#171

## Describe Manual Test Plan

I reviewed the HTTP request debug logging path and confirmed that request headers were being logged directly.

This change adds redaction for sensitive headers before logging request details. Headers like `Authorization`, `Cookie`, `Proxy-Authorization`, and `X-API-Key` are now shown as `[REDACTED]` instead of exposing raw values.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

No breaking changes.

## Describe Incompatible Changes

No incompatible changes. This only changes debug logging output to avoid leaking sensitive request headers.