### PR TITLE
feat(pytest): add read_table() and log_files() to DeltaTestLocation (#6135)

### DIFF
--- a/python/tests/unit/test_delta_test_location.py
+++ b/python/tests/unit/test_delta_test_location.py
@@ -1,0 +1,104 @@
+"""Unit tests for DeltaTestLocation helper methods."""
+
+import pytest
+from tests import skip_on_arm64
+from tests.utils import DeltaTestLocation
+
+
+@skip_on_arm64
+def test_read_table_missing_ok():
+    """read_table with missing_ok=True returns None for non-existent table."""
+    loc = DeltaTestLocation.create("test_read_table_missing", mode="snapshot")
+    try:
+        result = loc.read_table(missing_ok=True)
+        assert result is None
+    finally:
+        loc.cleanup()
+
+
+@skip_on_arm64
+def test_read_table_raises_on_missing():
+    """read_table raises TableNotFoundError when table doesn't exist."""
+    from deltalake.exceptions import TableNotFoundError
+
+    loc = DeltaTestLocation.create("test_read_table_raises", mode="snapshot")
+    try:
+        with pytest.raises(TableNotFoundError):
+            loc.read_table(missing_ok=False)
+    finally:
+        loc.cleanup()
+
+
+@skip_on_arm64
+def test_log_files_missing_ok():
+    """log_files with missing_ok=True returns empty list for non-existent table."""
+    loc = DeltaTestLocation.create("test_log_files_missing", mode="snapshot")
+    try:
+        result = loc.log_files(missing_ok=True)
+        assert result == []
+    finally:
+        loc.cleanup()
+
+
+@skip_on_arm64
+def test_log_files_raises_on_missing():
+    """log_files raises TableNotFoundError when table doesn't exist."""
+    from deltalake.exceptions import TableNotFoundError
+
+    loc = DeltaTestLocation.create("test_log_files_raises", mode="snapshot")
+    try:
+        with pytest.raises(TableNotFoundError):
+            loc.log_files(missing_ok=False)
+    finally:
+        loc.cleanup()
+
+
+@skip_on_arm64
+def test_read_table_returns_pyarrow():
+    """read_table returns a pyarrow Table when table exists."""
+    from deltalake import write_deltalake
+    import pyarrow as pa
+
+    loc = DeltaTestLocation.create("test_read_table_pyarrow", mode="snapshot")
+    try:
+        # Create a simple delta table
+        data = pa.table({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+        write_deltalake(
+            loc.uri, data, mode="overwrite", storage_options=loc.delta_storage_options()
+        )
+
+        # Read it back
+        result = loc.read_table()
+        assert result is not None
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 3
+        assert "id" in result.column_names
+        assert "value" in result.column_names
+    finally:
+        loc.cleanup()
+
+
+@skip_on_arm64
+def test_log_files_returns_file_list():
+    """log_files returns a list of file URIs when table exists."""
+    from deltalake import write_deltalake
+    import pyarrow as pa
+
+    loc = DeltaTestLocation.create("test_log_files_list", mode="snapshot")
+    try:
+        # Create a simple delta table
+        data = pa.table({"id": [1, 2, 3]})
+        write_deltalake(
+            loc.uri, data, mode="overwrite", storage_options=loc.delta_storage_options()
+        )
+
+        # Get file list
+        result = loc.log_files()
+        assert isinstance(result, list)
+        assert len(result) > 0
+        # Each entry should be a file URI
+        for file_uri in result:
+            assert isinstance(file_uri, str)
+            assert ".parquet" in file_uri.lower()
+    finally:
+        loc.cleanup()

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -146,6 +146,50 @@ class DeltaTestLocation:
             raise
         return dt.count()
 
+    def read_table(self, missing_ok: bool = False):
+        """Return the Delta table as a pyarrow Table.
+
+        The `deltalake` import is deferred to here so that module-level
+        test collection does not crash on aarch64 hosts where the wheel
+        aborts on import; tests that need this method gate themselves
+        with `@skip_on_arm64`.
+
+        :param missing_ok: When True, return ``None`` if the table does not
+            exist instead of raising.
+        """
+        from deltalake import DeltaTable
+        from deltalake.exceptions import TableNotFoundError
+
+        try:
+            dt = DeltaTable(self.uri, storage_options=self.delta_storage_options())
+        except TableNotFoundError:
+            if missing_ok:
+                return None
+            raise
+        return dt.to_pyarrow_table()
+
+    def log_files(self, missing_ok: bool = False) -> list[str]:
+        """Return the list of data files in the current Delta snapshot.
+
+        The `deltalake` import is deferred to here so that module-level
+        test collection does not crash on aarch64 hosts where the wheel
+        aborts on import; tests that need this method gate themselves
+        with `@skip_on_arm64`.
+
+        :param missing_ok: When True, return an empty list if the table does
+            not exist instead of raising.
+        """
+        from deltalake import DeltaTable
+        from deltalake.exceptions import TableNotFoundError
+
+        try:
+            dt = DeltaTable(self.uri, storage_options=self.delta_storage_options())
+        except TableNotFoundError:
+            if missing_ok:
+                return []
+            raise
+        return dt.file_uris()
+
     def cleanup(self) -> None:
         """Remove the local temp directory, if any.
 


### PR DESCRIPTION
## Summary

- Add `read_table()` method to `DeltaTestLocation` that returns the Delta table as a PyArrow Table, with `missing_ok` parameter for graceful handling of non-existent tables
- Add `log_files()` method that returns the list of data file URIs in the current Delta snapshot, also with `missing_ok` support
- Both methods use deferred imports (matching the existing `row_count` pattern) to avoid crashes on aarch64 hosts

Fixes #6135

## Test plan

- 6 new unit tests covering: missing table with `missing_ok=True/False`, reading existing tables, listing files
- All 37 total unit tests pass with no regressions
- Tests gated with `@skip_on_arm64` matching repo conventions