### PR TITLE
[web-console] Fix last checkpoint time derived incorrectly

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -71,17 +71,6 @@
   let openDrawer = $state<DrawerState | null>(null)
   let checkpoints = $state<CheckpointMetadata[]>([])
   let checkpointStatus = $state<CheckpointStatus | null>(null)
-  let lastCheckpointAt = $state<Date | null>(null)
-  let prevActivityStatus = $state<string | null>(null)
-
-  $effect(() => {
-    const status = metrics.current.checkpoint_activity.status
-    if (prevActivityStatus === 'in_progress' && status === 'idle') {
-      lastCheckpointAt = new Date()
-    }
-    prevActivityStatus = status
-  })
-
   const handleConnectorSelect = (
     relationName: string,
     connectorName: string,
@@ -353,7 +342,6 @@
           {checkpoints}
           {metrics}
           {checkpointStatus}
-          {lastCheckpointAt}
           onShowCheckpoints={() => (openDrawer = { kind: 'checkpoints' })}
         />
         <TransactionStatus {metrics} class="w-full"></TransactionStatus>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/performance/CheckpointsIndicator.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/performance/CheckpointsIndicator.svelte
@@ -4,6 +4,7 @@
   import { useGlobalDialog } from '$lib/compositions/layout/useGlobalDialog.svelte'
   import { usePipelineManager } from '$lib/compositions/usePipelineManager.svelte'
   import { usePremiumFeatures } from '$lib/compositions/usePremiumFeatures.svelte'
+  import { uuidV7Timestamp } from '$lib/functions/common/date'
   import { humanSize } from '$lib/functions/common/string'
   import { useElapsedTime } from '$lib/functions/format'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
@@ -18,16 +19,18 @@
     checkpoints,
     metrics,
     checkpointStatus,
-    lastCheckpointAt,
     onShowCheckpoints
   }: {
     pipelineName: string
     checkpoints: CheckpointMetadata[]
     metrics: { current: PipelineMetrics }
     checkpointStatus: CheckpointStatus | null
-    lastCheckpointAt: Date | null
     onShowCheckpoints: () => void
   } = $props()
+
+  const lastCheckpointAt = $derived(
+    uuidV7Timestamp(checkpoints.at(-1)?.uuid ?? '')?.toDate() ?? null
+  )
 
   const api = usePipelineManager()
   const isEnterprise = usePremiumFeatures()
@@ -54,15 +57,15 @@
   const lastCheckpointSuccess = $derived(checkpointStatus?.success)
   const showCheckpointFailure = $derived(
     checkpointFailure != null &&
-      (lastCheckpointSuccess == null ||
-        checkpointFailure.sequence_number > lastCheckpointSuccess)
+      (lastCheckpointSuccess == null || checkpointFailure.sequence_number > lastCheckpointSuccess)
   )
   const isPermanentlyUnavailable = $derived.by(() => {
     const errors = metrics.current.permanent_checkpoint_errors
-    return errors != null &&
+    return (
+      errors != null &&
       errors.length > 0 &&
-      !(errors.length === 1 &&
-        errors[0] === 'EnterpriseFeature')
+      !(errors.length === 1 && errors[0] === 'EnterpriseFeature')
+    )
   })
   const activityVisible = $derived(
     isPermanentlyUnavailable ||
@@ -80,7 +83,9 @@
     <div class="ml-auto flex items-center gap-4">
       <span class=""
         >{checkpoints.length}
-        {checkpoints.length === 1 ? 'checkpoint' : 'checkpoints'} using {humanSize(totalBytes)}</span
+        {checkpoints.length === 1 ? 'checkpoint' : 'checkpoints'} using {humanSize(
+          totalBytes
+        )}</span
       >
       <button class="btn preset-filled-surface-100-900" onclick={onShowCheckpoints}>
         All checkpoints

--- a/js-packages/web-console/src/lib/components/pipelines/editor/performance/CheckpointsIndicator.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/performance/CheckpointsIndicator.svelte.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-svelte'
+import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
+import type { CheckpointMetadata } from '$lib/services/manager'
+
+vi.mock('$lib/compositions/usePipelineManager.svelte', () => ({
+  usePipelineManager: () => ({ checkpointPipeline: vi.fn() })
+}))
+
+vi.mock('$lib/compositions/usePremiumFeatures.svelte', () => ({
+  usePremiumFeatures: () => ({
+    get value() {
+      return false
+    }
+  })
+}))
+
+vi.mock('$lib/compositions/layout/useGlobalDialog.svelte', () => ({
+  useGlobalDialog: () => ({
+    get dialog() {
+      return null
+    },
+    set dialog(_v: unknown) {},
+    get onClickAway() {
+      return null
+    },
+    set onClickAway(_v: unknown) {}
+  })
+}))
+
+import CheckpointsIndicator from './CheckpointsIndicator.svelte'
+
+function makeMetrics(): {
+  current: PipelineMetrics
+} {
+  return {
+    current: {
+      checkpoint_activity: { status: 'idle' } as PipelineMetrics['checkpoint_activity'],
+      permanent_checkpoint_errors: null
+    } as PipelineMetrics
+  }
+}
+
+function makeCheckpoint(): CheckpointMetadata {
+  return { uuid: '01900000-0000-7000-8000-000000000000', fingerprint: 0 }
+}
+
+describe('CheckpointsIndicator.svelte', () => {
+  it('shows elapsed time derived from the checkpoint UUID timestamp', async () => {
+    await render(CheckpointsIndicator, {
+      pipelineName: 'test',
+      checkpoints: [makeCheckpoint()],
+      metrics: makeMetrics(),
+      checkpointStatus: null,
+      onShowCheckpoints: vi.fn()
+    })
+    await expect.element(page.getByText(/Last checkpoint:.*ago/)).toBeInTheDocument()
+  })
+})

--- a/js-packages/web-console/src/lib/functions/common/date.spec.ts
+++ b/js-packages/web-console/src/lib/functions/common/date.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { uuidV7Timestamp } from './date'
+
+describe('uuidV7Timestamp', () => {
+  it('returns null for a non-v7 UUID', () => {
+    expect(uuidV7Timestamp('550e8400-e29b-41d4-a716-446655440000')).toBeNull()
+  })
+
+  it('extracts the correct timestamp from a v7 UUID', () => {
+    // 01900000-0000 encodes unix ms 0x019000000000 = 1717986918400
+    expect(uuidV7Timestamp('01900000-0000-7000-8000-000000000000')?.valueOf()).toBe(0x019000000000)
+  })
+})


### PR DESCRIPTION
The bug was the last checkpoint time was derived statefully during UI transitions, not from the API data, which caused incorrect results unless you actively observe the pipeline during checkpoint progress.

Testing: added unit test