### PR TITLE
[adapters] Fix completion status regression. 

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -1346,7 +1346,7 @@ impl Controller {
             "pipeline_complete",
             "Transitions from 0 to 1 when pipeline completes.",
             labels,
-            status.pipeline_complete() as u8,
+            self.pipeline_complete() as u8,
         );
         metrics.counter(
             "records_late_total",
@@ -2977,9 +2977,9 @@ impl CircuitThread {
 
         // Record that we've processed the records, unless there is a transaction in progress,
         // in which case records are ingested by the circuit but are not fully processed.
-        let processed_records = self.processed_records(total_consumed);
-        let processed_records = if self.controller.get_transaction_state() == TransactionState::None
-        {
+        let transaction_state = self.controller.get_transaction_state();
+        let processed_records = self.processed_records(total_consumed, Some(transaction_state));
+        let processed_records = if transaction_state == TransactionState::None {
             Some(ProcessedRecords {
                 total_processed_input_records: processed_records,
                 total_processed_steps: self.step,
@@ -3679,10 +3679,16 @@ impl CircuitThread {
     /// Reports that `total_consumed` has been consumed.
     ///
     /// Returns the total number of records processed.
-    fn processed_records(&mut self, total_consumed: BufferSize) -> u64 {
+    fn processed_records(
+        &mut self,
+        total_consumed: BufferSize,
+        transaction_state: Option<TransactionState>,
+    ) -> u64 {
         let processed_records = self.controller.status.processed_data(total_consumed);
         // If there are no output connectors, completed records can only get updated here.
-        self.controller.status.update_total_completed_records();
+        self.controller
+            .status
+            .update_total_completed_records(transaction_state);
         processed_records
     }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -808,12 +808,16 @@ impl ControllerStatus {
     /// Must be invoked any time this metric can change, i.e., after every output
     /// produced by an output connector as well as after each step.
     ///
+    /// The `transaction_state` parameter indicates the state of the current transaction when the
+    /// function is invoked after a step. Otherwise, if it is invoked by an output connector, it is None.
+    ///
     /// Computes `total_completed_records` as the minimum `total_processed_input_records` across
     /// all output connectors. In case there are no output connectors attached to the pipeline,
-    /// returns `total_processed_records`.
+    /// and the transaction state is None, it returns `total_processed_records`. Otherwise, it there
+    /// is currently a transaction in progress, it returns `total_completed_records`.
     ///
     /// Also updates watermark trackers in input endpoints.
-    pub fn update_total_completed_records(&self) {
+    pub fn update_total_completed_records(&self, transaction_state: Option<TransactionState>) {
         // Compute new `total_completed_records` atomically, protected by the output status lock.
         // However we don't want to call `watermarks_update_completed` while holding the lock, as that
         // will take the input status lock. This is not necessarily a bug, but it will complicate
@@ -825,8 +829,19 @@ impl ControllerStatus {
 
         let output_status = self.output_status();
 
-        let mut total_completed_records = self.global_metrics.num_total_processed_records();
-        let mut total_completed_steps = self.global_metrics.total_initiated_steps();
+        let (mut total_completed_records, mut total_completed_steps) =
+            if transaction_state == Some(TransactionState::None) || transaction_state.is_none() {
+                (
+                    self.num_total_processed_records(),
+                    self.global_metrics.total_initiated_steps(),
+                )
+            } else {
+                (
+                    self.num_total_completed_records(),
+                    self.global_metrics.total_completed_steps(),
+                )
+            };
+
         for output_ep in output_status.values() {
             total_completed_records =
                 total_completed_records.min(output_ep.num_total_processed_input_records());
@@ -1085,7 +1100,7 @@ impl ControllerStatus {
                 circuit_thread_unparker.unpark();
             }
         };
-        self.update_total_completed_records();
+        self.update_total_completed_records(None);
     }
 
     pub fn update_output_memory(&self, endpoint_id: EndpointId, memory: usize) {
@@ -1101,7 +1116,7 @@ impl ControllerStatus {
         if let Some(endpoint_stats) = self.output_status().get(&endpoint_id) {
             endpoint_stats.output_buffered_batches(processed);
         }
-        self.update_total_completed_records();
+        self.update_total_completed_records(None);
     }
 
     pub fn output_buffer(&self, endpoint_id: EndpointId, num_bytes: usize, num_records: usize) {
@@ -1193,14 +1208,7 @@ impl ControllerStatus {
         // All received records have been processed by the circuit.
         let total_input_records = self.num_total_input_records();
 
-        if self.num_total_processed_records() != total_input_records {
-            return false;
-        }
-
-        // Outputs have been pushed to their respective transport endpoints.
-        if !self.output_status().values().all(|endpoint_stats| {
-            endpoint_stats.num_total_processed_input_records() == total_input_records
-        }) {
+        if self.num_total_completed_records() != total_input_records {
             return false;
         }
 

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -94,7 +94,7 @@ where
         &json_file.path().display().to_string(),
     );
     input_pipeline.start();
-    wait(|| input_pipeline.status().pipeline_complete(), 400_000).expect("timeout");
+    wait(|| input_pipeline.pipeline_complete(), 400_000).expect("timeout");
     input_pipeline.stop().unwrap();
 
     info!("Read delta snapshot in {:?}", start.elapsed());
@@ -640,7 +640,7 @@ fn delta_table_output_test(
 
     controller.start();
 
-    wait(|| controller.status().pipeline_complete(), 100_000).unwrap();
+    wait(|| controller.pipeline_complete(), 100_000).unwrap();
 
     if verify {
         let parquet_files =

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -2892,6 +2892,66 @@ mod test_with_kafka {
         println!("{stats}")
     }
 
+    async fn start_test_server(config_str: &str, deployment_id: Uuid) -> TestServer {
+        let mut config_file = NamedTempFile::new().unwrap();
+        config_file.write_all(config_str.as_bytes()).unwrap();
+
+        println!("Creating HTTP server");
+
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Paused,
+            BootstrapPolicy::Allow,
+            deployment_id,
+            None,
+        ));
+        let state_clone = state.clone();
+
+        let args = ServerArgs {
+            config_file: config_file.path().display().to_string(),
+            metadata_file: None,
+            bind_address: "127.0.0.1".to_string(),
+            default_port: None,
+            storage_location: None,
+            enable_https: false,
+            https_tls_cert_path: None,
+            https_tls_key_path: None,
+            initial: RuntimeDesiredStatus::Paused,
+            bootstrap_policy: BootstrapPolicy::Allow,
+            deployment_id,
+            host_id: None,
+        };
+
+        let config = parse_config(&args.config_file).unwrap();
+        let builder = ControllerBuilder::new(&config).unwrap();
+        thread::spawn(move || {
+            bootstrap(
+                builder,
+                Box::new(|workers| {
+                    Ok(test_circuit::<TestStruct>(
+                        workers,
+                        &TestStruct::schema(),
+                        &[None],
+                    ))
+                }),
+                state_clone,
+            )
+        });
+
+        let server =
+            actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
+
+        let start = Instant::now();
+        while server.get("/stats").send().await.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE
+        {
+            assert!(start.elapsed() < Duration::from_millis(20_000));
+            sleep(Duration::from_millis(200));
+        }
+
+        server
+    }
+
     #[actix_web::test]
     async fn test_server() {
         ensure_default_crypto_provider();
@@ -2942,62 +3002,7 @@ outputs:
         format:
             name: csv
 "#;
-
-        let mut config_file = NamedTempFile::new().unwrap();
-        config_file.write_all(config_str.as_bytes()).unwrap();
-
-        println!("Creating HTTP server");
-
-        let state = WebData::new(ServerState::new(
-            PipelinePhase::Initializing(InitializationState::Starting),
-            String::new(),
-            RuntimeDesiredStatus::Paused,
-            BootstrapPolicy::Allow,
-            Uuid::new_v4(),
-            None,
-        ));
-        let state_clone = state.clone();
-
-        let args = ServerArgs {
-            config_file: config_file.path().display().to_string(),
-            metadata_file: None,
-            bind_address: "127.0.0.1".to_string(),
-            default_port: None,
-            storage_location: None,
-            enable_https: false,
-            https_tls_cert_path: None,
-            https_tls_key_path: None,
-            initial: RuntimeDesiredStatus::Paused,
-            bootstrap_policy: BootstrapPolicy::Allow,
-            deployment_id: uuid::Uuid::nil(),
-            host_id: None,
-        };
-
-        let config = parse_config(&args.config_file).unwrap();
-        let builder = ControllerBuilder::new(&config).unwrap();
-        thread::spawn(move || {
-            bootstrap(
-                builder,
-                Box::new(|workers| {
-                    Ok(test_circuit::<TestStruct>(
-                        workers,
-                        &TestStruct::schema(),
-                        &[None],
-                    ))
-                }),
-                state_clone,
-            )
-        });
-
-        let server =
-            actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
-
-        let start = Instant::now();
-        while server.get("/stats").send().await.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE
-        {
-            assert!(start.elapsed() < Duration::from_millis(20_000));
-            sleep(Duration::from_millis(200));
-        }
+        let server = start_test_server(config_str, Uuid::new_v4()).await;
 
         // Write data to Kafka.
         println!("Send test data");
@@ -3235,62 +3240,7 @@ name: test
 inputs:
 outputs:
 "#;
-
-        let mut config_file = NamedTempFile::new().unwrap();
-        config_file.write_all(config_str.as_bytes()).unwrap();
-
-        println!("Creating HTTP server");
-
-        let state = WebData::new(ServerState::new(
-            PipelinePhase::Initializing(InitializationState::Starting),
-            String::default(),
-            RuntimeDesiredStatus::Paused,
-            BootstrapPolicy::Allow,
-            Uuid::default(),
-            None,
-        ));
-        let state_clone = state.clone();
-
-        let args = ServerArgs {
-            config_file: config_file.path().display().to_string(),
-            metadata_file: None,
-            bind_address: "127.0.0.1".to_string(),
-            default_port: None,
-            storage_location: None,
-            enable_https: false,
-            https_tls_cert_path: None,
-            https_tls_key_path: None,
-            initial: RuntimeDesiredStatus::Paused,
-            bootstrap_policy: BootstrapPolicy::Allow,
-            deployment_id: Uuid::default(),
-            host_id: None,
-        };
-
-        let config = parse_config(&args.config_file).unwrap();
-        let builder = ControllerBuilder::new(&config).unwrap();
-        thread::spawn(move || {
-            bootstrap(
-                builder,
-                Box::new(|workers| {
-                    Ok(test_circuit::<TestStruct>(
-                        workers,
-                        &TestStruct::schema(),
-                        &[None],
-                    ))
-                }),
-                state_clone,
-            )
-        });
-
-        let server =
-            actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
-
-        let start = Instant::now();
-        while server.get("/stats").send().await.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE
-        {
-            assert!(start.elapsed() < Duration::from_millis(20_000));
-            sleep(Duration::from_millis(200));
-        }
+        let server = start_test_server(config_str, Uuid::default()).await;
 
         // Start pipeline.
         println!("/start");
@@ -3343,62 +3293,7 @@ name: test
 inputs:
 outputs:
 "#;
-
-        let mut config_file = NamedTempFile::new().unwrap();
-        config_file.write_all(config_str.as_bytes()).unwrap();
-
-        println!("Creating HTTP server");
-
-        let state = WebData::new(ServerState::new(
-            PipelinePhase::Initializing(InitializationState::Starting),
-            String::default(),
-            RuntimeDesiredStatus::Paused,
-            BootstrapPolicy::Allow,
-            Uuid::default(),
-            None,
-        ));
-        let state_clone = state.clone();
-
-        let args = ServerArgs {
-            config_file: config_file.path().display().to_string(),
-            metadata_file: None,
-            bind_address: "127.0.0.1".to_string(),
-            default_port: None,
-            storage_location: None,
-            enable_https: false,
-            https_tls_cert_path: None,
-            https_tls_key_path: None,
-            initial: RuntimeDesiredStatus::Paused,
-            bootstrap_policy: BootstrapPolicy::Allow,
-            deployment_id: Uuid::default(),
-            host_id: None,
-        };
-
-        let config = parse_config(&args.config_file).unwrap();
-        let builder = ControllerBuilder::new(&config).unwrap();
-        thread::spawn(move || {
-            bootstrap(
-                builder,
-                Box::new(|workers| {
-                    Ok(test_circuit::<TestStruct>(
-                        workers,
-                        &TestStruct::schema(),
-                        &[None],
-                    ))
-                }),
-                state_clone,
-            )
-        });
-
-        let server =
-            actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
-
-        let start = Instant::now();
-        while server.get("/stats").send().await.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE
-        {
-            assert!(start.elapsed() < Duration::from_millis(20_000));
-            sleep(Duration::from_millis(200));
-        }
+        let server = start_test_server(config_str, Uuid::default()).await;
 
         println!("/start");
         let resp = server.get("/start").send().await.unwrap();

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -2858,6 +2858,7 @@ mod test_with_kafka {
     use actix_web::{App, http::StatusCode, middleware::Logger, web::Data as WebData};
     use feldera_types::runtime_status::RuntimeDesiredStatus;
     use feldera_types::{
+        adapter_stats::{ExternalControllerStatus, TransactionStatus},
         completion_token::{CompletionStatus, CompletionStatusResponse, CompletionTokenResponse},
         runtime_status::BootstrapPolicy,
     };
@@ -3317,5 +3318,177 @@ outputs:
         assert!(resp.status().is_success());
 
         TestHttpReceiver::wait_for_output_unordered(&mut egress_resp, &data).await;
+    }
+
+    /// Regression test for issue #6231.
+    /// In a pipeline without output connectors, the number of completed records,
+    /// completed steps, and the `pipeline_complete` flag are updated before the current transaction
+    /// completes.
+    #[actix_web::test]
+    async fn test_transaction_completion_without_output_connectors() {
+        ensure_default_crypto_provider();
+
+        let data = vec![vec![
+            TestStruct::for_id(1),
+            TestStruct::for_id(2),
+            TestStruct::for_id(3),
+        ]];
+        let input_records = data.iter().map(Vec::len).sum::<usize>() as u64;
+
+        // Keep the controller free of configured output connectors.  This
+        // exercises the no-output path in completion accounting instead of
+        // waiting for any egress connector to report progress.
+        let config_str = r#"
+name: test
+inputs:
+outputs:
+"#;
+
+        let mut config_file = NamedTempFile::new().unwrap();
+        config_file.write_all(config_str.as_bytes()).unwrap();
+
+        println!("Creating HTTP server");
+
+        let state = WebData::new(ServerState::new(
+            PipelinePhase::Initializing(InitializationState::Starting),
+            String::default(),
+            RuntimeDesiredStatus::Paused,
+            BootstrapPolicy::Allow,
+            Uuid::default(),
+            None,
+        ));
+        let state_clone = state.clone();
+
+        let args = ServerArgs {
+            config_file: config_file.path().display().to_string(),
+            metadata_file: None,
+            bind_address: "127.0.0.1".to_string(),
+            default_port: None,
+            storage_location: None,
+            enable_https: false,
+            https_tls_cert_path: None,
+            https_tls_key_path: None,
+            initial: RuntimeDesiredStatus::Paused,
+            bootstrap_policy: BootstrapPolicy::Allow,
+            deployment_id: Uuid::default(),
+            host_id: None,
+        };
+
+        let config = parse_config(&args.config_file).unwrap();
+        let builder = ControllerBuilder::new(&config).unwrap();
+        thread::spawn(move || {
+            bootstrap(
+                builder,
+                Box::new(|workers| {
+                    Ok(test_circuit::<TestStruct>(
+                        workers,
+                        &TestStruct::schema(),
+                        &[None],
+                    ))
+                }),
+                state_clone,
+            )
+        });
+
+        let server =
+            actix_test::start(move || build_app(App::new().wrap(Logger::default()), state.clone()));
+
+        let start = Instant::now();
+        while server.get("/stats").send().await.unwrap().status() == StatusCode::SERVICE_UNAVAILABLE
+        {
+            assert!(start.elapsed() < Duration::from_millis(20_000));
+            sleep(Duration::from_millis(200));
+        }
+
+        println!("/start");
+        let resp = server.get("/start").send().await.unwrap();
+        assert!(resp.status().is_success());
+
+        println!("/start_transaction");
+        let resp = server.post("/start_transaction").send().await.unwrap();
+        assert!(resp.status().is_success());
+
+        // Push input through HTTP ingress while the transaction is open.  The
+        // endpoint returns a completion token for exactly the records that this
+        // request placed into the pipeline.
+        let req = server.post("/ingress/test_input1");
+        let CompletionTokenResponse { token } =
+            TestHttpSender::send_stream_deserialize_resp::<CompletionTokenResponse>(req, &data)
+                .await;
+        println!("completion token: {token}");
+
+        // Give the pipeline time to process the input inside the transaction.
+        // Before commit, records must not be reported as completed.
+        sleep(Duration::from_millis(5000));
+        let stats = server
+            .get("/stats")
+            .send()
+            .await
+            .unwrap()
+            .json::<ExternalControllerStatus>()
+            .await
+            .unwrap();
+        assert!(!stats.global_metrics.pipeline_complete);
+        assert_eq!(stats.global_metrics.total_completed_records, 0);
+
+        let CompletionStatusResponse { status, .. } = server
+            .get(format!("/completion_status?token={token}"))
+            .send()
+            .await
+            .unwrap()
+            .json::<CompletionStatusResponse>()
+            .await
+            .unwrap();
+        assert_eq!(status, CompletionStatus::InProgress);
+
+        println!("/commit_transaction");
+        let resp = server.post("/commit_transaction").send().await.unwrap();
+        assert!(resp.status().is_success());
+
+        // Wait for the transaction to commit.
+        async_wait(
+            || async {
+                let stats = server
+                    .get("/stats")
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<ExternalControllerStatus>()
+                    .await
+                    .unwrap();
+                stats.global_metrics.transaction_status == TransactionStatus::NoTransaction
+            },
+            20_000,
+        )
+        .await
+        .unwrap();
+
+        async_wait(
+            || async {
+                let CompletionStatusResponse { status, .. } = server
+                    .get(format!("/completion_status?token={token}"))
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<CompletionStatusResponse>()
+                    .await
+                    .unwrap();
+                status == CompletionStatus::Complete
+            },
+            20_000,
+        )
+        .await
+        .unwrap();
+
+        let stats = server
+            .get("/stats")
+            .send()
+            .await
+            .unwrap()
+            .json::<ExternalControllerStatus>()
+            .await
+            .unwrap();
+        assert!(stats.global_metrics.pipeline_complete);
+        assert_eq!(stats.global_metrics.total_completed_records, input_records,);
     }
 }


### PR DESCRIPTION
Fixes #6231.

This fixes a bug that existed for a while but became worse with the
introduction of automatic transactions. In a pipeline without output
connectors, the number of completed records, completed steps, and the
`pipeline_complete` flag are updated before the current transaction commits.
This used to only affect pipelines that used transactions, but now all
pipelines do.

The fix is to take transaction status into account when updating completed
record/step count.