### PR TITLE
Fix confusing message when pipeline name edit is disabled on a deleted pipeline

### DIFF
--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineEditLayout.svelte
@@ -116,7 +116,7 @@
     if (deleted) {
       return {
         header: 'This pipeline has been deleted',
-        message: 'The pipeline was deleted. All editing and monitoring has been disabled.',
+        message: 'All editing and monitoring has been disabled.',
         style: 'error' as const
       }
     }
@@ -257,7 +257,13 @@
               </span>
             </DoubleClickInput>
             {#if editNameDisabled}
-              <Tooltip class="">Cannot edit the pipeline's name while it's running</Tooltip>
+              <Tooltip class="">
+                {#if deleted}
+                  Cannot edit the deleted pipeline's name
+                {:else}
+                  Cannot edit the pipeline's name while it's running
+                {/if}
+              </Tooltip>
             {/if}
           {/snippet}
         </PipelineBreadcrumbs>

--- a/js-packages/web-console/tests/pipelineNameTooltip.e2e.ts
+++ b/js-packages/web-console/tests/pipelineNameTooltip.e2e.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+import { deletePipeline, putPipeline } from '$lib/services/pipelineManager'
+import {
+  cleanupPipeline,
+  configureTestClient,
+  killPipelineAndWaitForStopped,
+  startPipelineAndWaitForRunning,
+  waitForCompilation,
+  waitForPipeline
+} from '$lib/services/testPipelineHelpers'
+
+configureTestClient()
+
+const PREFIX = `test-name-tooltip-${Date.now()}`
+const PIPELINE_NAME = `${PREFIX}`
+
+test.describe('Pipeline name edit tooltip', () => {
+  test.setTimeout(120_000)
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(60_000)
+    await putPipeline(PIPELINE_NAME, {
+      name: PIPELINE_NAME,
+      description: 'E2E test pipeline for name-edit tooltip',
+      program_code: 'create view v as (select 1)',
+      program_config: { profile: 'unoptimized' }
+    })
+    await waitForPipeline(PIPELINE_NAME, (p) => p.status === 'Stopped', 60_000)
+  })
+
+  test.afterAll(async () => {
+    await cleanupPipeline(PIPELINE_NAME)
+  })
+
+  test('shows no tooltip when stopped, running tooltip when running, deleted tooltip after out-of-band delete', async ({
+    page
+  }) => {
+    await page.goto(`/pipelines/${PIPELINE_NAME}`)
+
+    const editButton = page.getByRole('button', { name: 'Edit pipeline name', exact: true })
+    const statusChip = page.getByTestId('box-pipeline-status')
+    // The pipeline name display in the header breadcrumb (the tooltip trigger element).
+    const pipelineNameTrigger = page
+      .locator('span[role="button"]')
+      .filter({ hasText: PIPELINE_NAME })
+
+    // Stopped: edit is enabled, no tooltip on hover.
+    await expect(editButton).not.toBeDisabled()
+    await pipelineNameTrigger.hover()
+    await expect(
+      page.getByText("Cannot edit the pipeline's name while it's running")
+    ).not.toBeVisible()
+    await expect(page.getByText("Cannot edit the deleted pipeline's name")).not.toBeVisible()
+
+    // Start the pipeline and wait for Running.
+    await waitForCompilation(PIPELINE_NAME, 60_000)
+    await startPipelineAndWaitForRunning(PIPELINE_NAME, 20_000)
+    await expect(statusChip).toHaveText(/running/i, { timeout: 2_000 })
+
+    // Running: edit is disabled, "running" tooltip appears on hover.
+    await expect(editButton).toBeDisabled()
+    await pipelineNameTrigger.hover()
+    await expect(page.getByText("Cannot edit the pipeline's name while it's running")).toBeVisible({
+      timeout: 5_000
+    })
+
+    // Kill the pipeline and wait for Stopped.
+    await killPipelineAndWaitForStopped(PIPELINE_NAME)
+    await expect(statusChip).not.toHaveText(/running/i, { timeout: 2_000 })
+
+    // Delete the pipeline out-of-band (simulates another tab / API client).
+    await deletePipeline(PIPELINE_NAME)
+
+    // Wait for the page to enter the frozen "Deleted" state.
+    await expect(statusChip).toHaveText(/deleted/i, { timeout: 10_000 })
+
+    // Deleted: edit is disabled, "deleted" tooltip appears on hover.
+    await expect(editButton).toBeDisabled()
+    await pipelineNameTrigger.hover()
+    await expect(page.getByText("Cannot edit the deleted pipeline's name")).toBeVisible({
+      timeout: 5_000
+    })
+  })
+})


### PR DESCRIPTION
Fix https://github.com/feldera/feldera/issues/6233

Testing: manual, added e2e test
<img width="762" height="216" alt="image" src="https://github.com/user-attachments/assets/962e3bb6-dae8-4f72-976a-ef7cfcabcf8a" />
