### PR TITLE
ci: fix runtime_aggtest test failures not failing CI

### DIFF
--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Python runtime_aggtest test
         if: ${{ vars.CI_DRY_RUN != 'true' && !contains(vars.CI_SKIP_JOBS, 'runtime-aggtest') }}
-        run: bash ./tests/runtime_aggtest/run.sh
+        run: uv run --locked ./tests/runtime_aggtest/run.sh
         working-directory: python
         env:
           RUNTIME_AGGTEST_JOBS: ${{ vars.RUNTIME_AGGTEST_JOBS }}

--- a/.github/workflows/test-integration-runtime.yml
+++ b/.github/workflows/test-integration-runtime.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Python runtime_aggtest test
         if: ${{ vars.CI_DRY_RUN != 'true' && !contains(vars.CI_SKIP_JOBS, 'runtime-aggtest') }}
-        run: uv run --locked ./tests/runtime_aggtest/run.sh
+        run: bash ./tests/runtime_aggtest/run.sh
         working-directory: python
         env:
           RUNTIME_AGGTEST_JOBS: ${{ vars.RUNTIME_AGGTEST_JOBS }}

--- a/python/tests/runtime_aggtest/run.sh
+++ b/python/tests/runtime_aggtest/run.sh
@@ -28,5 +28,5 @@ if [ "${RUNTIME_AGGTEST_JOBS:-1}" -le 1 ]; then
   for t in "${TESTS[@]}"; do run_one "$t"; done
 else
   echo "Running tests in parallel: ${RUNTIME_AGGTEST_JOBS} jobs"
-  printf '%s\n' "${TESTS[@]}" | xargs -P "${RUNTIME_AGGTEST_JOBS}" -I{} bash -e -c 'echo "Running: {}"; uv run --locked "$PYTHONPATH/tests/runtime_aggtest/{}"' || echo "{} failed"
+  printf '%s\n' "${TESTS[@]}" | xargs -P "${RUNTIME_AGGTEST_JOBS}" -I{} bash -e -c 'echo "Running: {}"; uv run --locked "$PYTHONPATH/tests/runtime_aggtest/{}"'
 fi


### PR DESCRIPTION
The runtime_aggtest step was running tests, logging failures, but still reporting success. CI was completely blind to these failures.
  
Two things were going wrong:

- In run.sh, the parallel path ends with || echo "{} failed". That || means bash never sees the failure from xargs, and since echo always succeeds, the script just exits 0 regardless of what happened. Removing it lets the failure propagate naturally.
- The workflow invoked run.sh via uv run --locked, which is meant for Python scripts. Running a shell script through it is fragile for exit code propagation, and unnecessary, since the script already calls uv run internally for each individual test. Switched to plain bash.