### PR TITLE
[fda] Log to stderr.

### DIFF
--- a/crates/fda/src/main.rs
+++ b/crates/fda/src/main.rs
@@ -2802,7 +2802,8 @@ fn init_logging(default_level: &str) {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
-                .without_time(),
+                .without_time()
+                .with_writer(std::io::stderr),
         )
         .try_init();
 }


### PR DESCRIPTION
Configure logger to write to stderr, so that log messages don't interfere with output.