### PR TITLE
Fix for #6243

### DIFF
--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -292,7 +292,7 @@ pub(crate) async fn execute_sql(
             .await
             .ok_or_else(|| PipelineError::Initializing)?,
     );
-    execute_sql_with_state(state, sql).await
+    execute_sql_with_state(state, sql, Some(controller)).await
 }
 
 /// Plan and translate `sql` against `state`, applying `PREPARE`/`EXECUTE`
@@ -300,10 +300,17 @@ pub(crate) async fn execute_sql(
 ///
 /// Only the final statement returns rows. Earlier statements may be
 /// `PREPARE`s or any non-result-producing statement (e.g. `INSERT`),
-/// executed for their side effect.
+/// executed for their side effect. After such an intermediate write
+/// runs, the per-request snapshot is refreshed so the trailing SELECT
+/// sees the just-written rows.
+///
+/// `controller` is optional so unit tests can drive this function
+/// without a running pipeline; in that case the post-write snapshot
+/// refresh is skipped.
 async fn execute_sql_with_state(
-    state: SessionState,
+    mut state: SessionState,
     sql: &str,
+    controller: Option<&Controller>,
 ) -> Result<DataFrame, PipelineError> {
     let mut statements = parse_sql_statements(&state, sql)?;
     if statements.is_empty() {
@@ -319,6 +326,13 @@ async fn execute_sql_with_state(
     let mut prepared: HashMap<String, LogicalPlan> = HashMap::new();
     let sql_options = SQLOptions::new().with_allow_ddl(false);
 
+    // Subscribe to `step_watcher` *before* any intermediate writes so the
+    // steps that drain those writes accumulate as unseen changes; calling
+    // `changed()` after the writes return then completes immediately
+    // instead of blocking on a step that may never be triggered.
+    let mut step_watcher = controller.map(|c| c.step_watcher());
+
+    let mut intermediate_wrote_data = false;
     while statements.len() > 1 {
         let stmt = statements.pop_front().unwrap();
         let plan = state.statement_to_plan(stmt).await?;
@@ -342,6 +356,7 @@ async fn execute_sql_with_state(
                 let values = execute_parameters_to_scalars(&parameters)?;
                 let bound = prepared_plan.replace_params_with_values(&ParamValues::List(values))?;
                 sql_options.verify_plan(&bound)?;
+                intermediate_wrote_data |= plan_writes_data(&bound);
                 drain_intermediate_plan(&state, bound).await?;
             }
             other if is_result_producing_plan(&other) => {
@@ -359,9 +374,21 @@ async fn execute_sql_with_state(
                 // UPDATE, DELETE, EXPLAIN, ...). Execute it for its side
                 // effects and discard the per-statement count row.
                 sql_options.verify_plan(&other)?;
+                intermediate_wrote_data |= plan_writes_data(&other);
                 drain_intermediate_plan(&state, other).await?;
             }
         }
+    }
+
+    // The snapshot pinned in `state` was captured at request start, before
+    // any intermediate INSERT ran. Refresh it so the trailing SELECT sees
+    // the just-written rows. Tracks
+    // https://github.com/feldera/feldera/issues/6243.
+    if intermediate_wrote_data
+        && let Some(controller) = controller
+        && let Some(watcher) = step_watcher.as_mut()
+    {
+        refresh_snapshot_after_writes(controller, watcher, &mut state).await?;
     }
 
     let stmt = statements.pop_front().unwrap();
@@ -418,6 +445,48 @@ async fn drain_intermediate_plan(
 ) -> Result<(), PipelineError> {
     let df = DataFrame::new(state.clone(), plan);
     let _ = df.collect().await?;
+    Ok(())
+}
+
+/// True if executing this plan mutates a table (and therefore needs the
+/// post-write snapshot refresh below). Today the only mutating plan our
+/// SQL options allow is a `LogicalPlan::Dml`.
+fn plan_writes_data(plan: &LogicalPlan) -> bool {
+    matches!(plan, LogicalPlan::Dml(_))
+}
+
+/// Wait for the controller to complete at least one full step after
+/// the intermediate writes returned, then update `state`'s pinned
+/// snapshot to the freshly produced one. The controller updates
+/// `trace_snapshots` at the end of every non-transactional step, so
+/// observing the next `Idle` transition is enough to guarantee that
+/// our writes are visible.
+///
+/// `watcher` must have been created before the intermediate writes
+/// happened so the steps that drain them are already buffered as
+/// unseen changes; otherwise this function would block waiting for
+/// a future step that may never be triggered on an idle pipeline.
+async fn refresh_snapshot_after_writes(
+    controller: &Controller,
+    watcher: &mut tokio::sync::watch::Receiver<feldera_types::coordination::StepStatus>,
+    state: &mut SessionState,
+) -> Result<(), PipelineError> {
+    use feldera_types::coordination::StepAction;
+
+    loop {
+        let status = *watcher.borrow_and_update();
+        if matches!(status.action, StepAction::Idle) {
+            break;
+        }
+        if watcher.changed().await.is_err() {
+            break;
+        }
+    }
+    let snapshot = controller
+        .latest_consistent_snapshot()
+        .await
+        .ok_or(PipelineError::Initializing)?;
+    set_snapshot(state, snapshot);
     Ok(())
 }
 
@@ -619,7 +688,7 @@ mod tests {
 
     /// A helper that executes a query and returns results.
     async fn collect_rows(state: SessionState, sql: &str) -> Vec<RecordBatch> {
-        execute_sql_with_state(state, sql)
+        execute_sql_with_state(state, sql, None)
             .await
             .unwrap()
             .collect()
@@ -644,7 +713,7 @@ mod tests {
     #[tokio::test]
     async fn execute_without_prepare_errors() {
         let state = test_state();
-        let err = execute_sql_with_state(state, "EXECUTE missing(1)")
+        let err = execute_sql_with_state(state, "EXECUTE missing(1)", None)
             .await
             .unwrap_err();
         assert!(
@@ -667,7 +736,7 @@ mod tests {
     #[tokio::test]
     async fn intermediate_select_is_rejected() {
         let state = test_state();
-        let err = execute_sql_with_state(state, "SELECT 1; SELECT 2")
+        let err = execute_sql_with_state(state, "SELECT 1; SELECT 2", None)
             .await
             .unwrap_err();
         let msg = format!("{err}");

--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -382,8 +382,7 @@ async fn execute_sql_with_state(
 
     // The snapshot pinned in `state` was captured at request start, before
     // any intermediate INSERT ran. Refresh it so the trailing SELECT sees
-    // the just-written rows. Tracks
-    // https://github.com/feldera/feldera/issues/6243.
+    // the just-written rows.
     if intermediate_wrote_data
         && let Some(controller) = controller
         && let Some(watcher) = step_watcher.as_mut()
@@ -455,17 +454,12 @@ fn plan_writes_data(plan: &LogicalPlan) -> bool {
     matches!(plan, LogicalPlan::Dml(_))
 }
 
-/// Wait for the controller to complete at least one full step after
-/// the intermediate writes returned, then update `state`'s pinned
-/// snapshot to the freshly produced one. The controller updates
-/// `trace_snapshots` at the end of every non-transactional step, so
-/// observing the next `Idle` transition is enough to guarantee that
-/// our writes are visible.
-///
-/// `watcher` must have been created before the intermediate writes
-/// happened so the steps that drain them are already buffered as
-/// unseen changes; otherwise this function would block waiting for
-/// a future step that may never be triggered on an idle pipeline.
+/// Wait for the controller to drain the intermediate writes, then pin the
+/// resulting snapshot in `state`. Relies on two controller invariants:
+/// `update_snapshot()` runs before each `Idle` notification (so any `Idle`
+/// observed after subscribing already reflects our writes), and `watcher`
+/// must be subscribed before the writes are submitted or we may sleep
+/// forever on an otherwise idle pipeline.
 async fn refresh_snapshot_after_writes(
     controller: &Controller,
     watcher: &mut tokio::sync::watch::Receiver<feldera_types::coordination::StepStatus>,

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3031,19 +3031,19 @@ impl CircuitThread {
         // We also keep this before updating `total_processed_records` so
         // that ad hoc query results always reflect all data that we have
         // reported processing.
+        // Keep `trace_snapshots` current on every step regardless of
+        // bootstrap or transaction state, so ad-hoc queries can read
+        // the freshest data including read-your-own-writes within one
+        // request. Connectors with `send_snapshot=true` still defer
+        // until bootstrap completes; that gate now lives in
+        // `enqueue_latest_snapshot`.
+        Span::new("update")
+            .with_category("Step")
+            .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
+            .in_scope(|| self.update_snapshot());
+
         if transaction_state == TransactionState::None {
             let bootstrapping = self.circuit.bootstrap_in_progress();
-
-            // Don't update the snapshot until bootstrapping is complete (including the additional post-bootstrap transaction).
-            // This guarantees that:
-            // 1. Ad hoc queries observe a consistent view of the data.
-            // 2. Ad hoc snapshots are up-to-date before the pipeline is marked as running.
-            if !bootstrapping && !self.bootstrapping {
-                Span::new("update")
-                    .with_category("Step")
-                    .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
-                    .in_scope(|| self.update_snapshot());
-            }
 
             // If bootstrapping has completed, clear self.bootstrapping, but don't update the status flag
             // until the circuit performs an extra transaction to initialize output snapshots
@@ -6707,6 +6707,17 @@ impl ControllerInner {
         processed_records: Option<ProcessedRecords>,
         step: Option<Step>,
     ) -> bool {
+        // Defer the initial snapshot delivery until bootstrap completes
+        // and no transaction is in flight; this is the gate that
+        // guarantees `send_snapshot=true` connectors receive a
+        // consistent, fully-formed view. Adhoc queries hit
+        // `trace_snapshots` directly and are not subject to this gate.
+        if self.status.bootstrap_in_progress()
+            || self.get_transaction_state() != TransactionState::None
+        {
+            return false;
+        }
+
         // Look up the most recent cached snapshot for this stream. Return early
         // if no snapshot has been produced yet (pipeline hasn't completed a step).
         // This method is only called from the circuit thread (via `push_output`),

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3022,18 +3022,15 @@ impl CircuitThread {
         self.step_circuit();
 
         let transaction_state = self.controller.get_transaction_state();
-        self.step_sender.send_replace(StepStatus::new(
-            self.step,
-            StepAction::Idle,
-            transaction_state.into_coordination_status(),
-        ));
 
-        // Update `trace_snapshot` to the latest traces.
+        // Update `trace_snapshot` to the latest traces *before* signaling
+        // `Idle` on the step watcher, so subscribers can rely on
+        // `latest_consistent_snapshot()` being current the moment they
+        // observe Idle.
         //
-        // We do this before updating `total_processed_records` so that ad hoc
-        // query results always reflect all data that we have reported
-        // processing; otherwise, there is a race for any code that runs a query
-        // as soon as input has been processed.
+        // We also keep this before updating `total_processed_records` so
+        // that ad hoc query results always reflect all data that we have
+        // reported processing.
         if transaction_state == TransactionState::None {
             let bootstrapping = self.circuit.bootstrap_in_progress();
 
@@ -3060,6 +3057,12 @@ impl CircuitThread {
                     .set_bootstrap_in_progress(bootstrapping);
             }
         }
+
+        self.step_sender.send_replace(StepStatus::new(
+            self.step,
+            StepAction::Idle,
+            transaction_state.into_coordination_status(),
+        ));
 
         // Record that we've processed the records, unless there is a transaction in progress,
         // in which case records are ingested by the circuit but are not fully processed.

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3223,15 +3223,40 @@ impl CircuitThread {
         }
     }
 
-    // Update `trace_snapshot` to the latest traces.
-    //
-    // This updates what ad hoc snapshots query.
+    /// Update `trace_snapshot` with the latest traces so ad hoc queries pick
+    /// up the freshest data.
+    ///
+    /// Tables refresh every step so an INSERT inside a transaction is visible
+    /// to a subsequent SELECT in the same request.  Views compute their
+    /// integral via `accumulate_integrate_trace`, which only advances on a
+    /// transaction boundary. We use the the previous snapshot instead.
     fn update_snapshot(&mut self) {
+        let bootstrapping = self.controller.status.bootstrap_in_progress();
+        let in_transaction =
+            !bootstrapping && self.controller.get_transaction_state() != TransactionState::None;
+
+        let previous_views: Option<ConsistentSnapshot> = if in_transaction {
+            let snapshots = self.controller.trace_snapshots.blocking_lock();
+            snapshots.iter().next_back().map(|(_, snap)| snap.clone())
+        } else {
+            None
+        };
+
         // Assemble a new snapshot.
         let mut snapshot = BTreeMap::new();
         for (name, clh) in self.controller.catalog.output_iter() {
             if let Some(ih) = &clh.integrate_handle {
-                let batches = ih.take_from_all();
+                let is_table = self
+                    .controller
+                    .catalog
+                    .input_collection_handle(name)
+                    .is_some();
+
+                let batches = match previous_views.as_ref().and_then(|s| s.get(name)) {
+                    Some(prev) if !is_table && in_transaction => prev.clone(),
+                    _ => ih.take_from_all(),
+                };
+
                 // The first index of a materialized view registers its
                 // integral under the view name with `alias_as_index =
                 // Some(index)` (see

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2277,6 +2277,11 @@ fn lir() {
       "to": "4"
     },
     {
+      "from": "3",
+      "stream_id": 3,
+      "to": "7"
+    },
+    {
       "from": "4",
       "stream_id": 4,
       "to": "5"
@@ -2284,12 +2289,12 @@ fn lir() {
     {
       "from": "4",
       "stream_id": 4,
-      "to": "7"
+      "to": "11"
     },
     {
       "from": "4",
       "stream_id": 4,
-      "to": "11"
+      "to": "13"
     },
     {
       "from": "6",
@@ -2312,11 +2317,6 @@ fn lir() {
       "to": "9"
     },
     {
-      "from": "7",
-      "stream_id": 8,
-      "to": "12"
-    },
-    {
       "from": "9",
       "stream_id": 9,
       "to": "10"
@@ -2325,6 +2325,26 @@ fn lir() {
       "from": "12",
       "stream_id": 10,
       "to": "13"
+    },
+    {
+      "from": "12",
+      "stream_id": null,
+      "to": "14"
+    },
+    {
+      "from": "13",
+      "stream_id": 13,
+      "to": "14"
+    },
+    {
+      "from": "13",
+      "stream_id": 13,
+      "to": "15"
+    },
+    {
+      "from": "15",
+      "stream_id": 14,
+      "to": "16"
     }
   ],
   "nodes": [
@@ -2374,24 +2394,21 @@ fn lir() {
     {
       "id": "6",
       "implements": [
-        "input.output",
-        "output"
+        "input.output"
       ],
       "operation": "Z1 (trace)"
     },
     {
       "id": "7",
       "implements": [
-        "input.output",
-        "output"
+        "input.output"
       ],
-      "operation": "AccumulateUntimedTraceAppend"
+      "operation": "UntimedTraceAppend"
     },
     {
       "id": "8",
       "implements": [
-        "input.output",
-        "output"
+        "input.output"
       ],
       "operation": "Z1 (trace)"
     },
@@ -2421,10 +2438,31 @@ fn lir() {
       "implements": [
         "output"
       ],
-      "operation": "Apply"
+      "operation": "Z1 (trace)"
     },
     {
       "id": "13",
+      "implements": [
+        "output"
+      ],
+      "operation": "AccumulateUntimedTraceAppend"
+    },
+    {
+      "id": "14",
+      "implements": [
+        "output"
+      ],
+      "operation": "Z1 (trace)"
+    },
+    {
+      "id": "15",
+      "implements": [
+        "output"
+      ],
+      "operation": "Apply"
+    },
+    {
+      "id": "16",
       "implements": [
         "output"
       ],

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -518,7 +518,7 @@ impl Catalog {
 
     /// `gather_integral` indicates whether the stream must be materialized on
     /// the host assigned to this stream. This is necessary in order to be able
-    /// to send a snapshot of the collection a connector attached to this stream.
+    /// to send a snapshot of the collection to a connector attached to this stream.
     pub fn register_materialized_output_zset_persistent_inner<Z, D>(
         &mut self,
         persistent_id: Option<&str>,
@@ -560,7 +560,11 @@ impl Catalog {
         let integral_stream = if gather_integral {
             gathered_stream.accumulate_integrate_trace()
         } else {
-            stream.accumulate_integrate_trace()
+            // Our transaction semantics currently promises to update table snapshots after every step,
+            // not just on commit, so that ad hoc queries that modify (INSERT) and instantly read (SELECT)
+            // the table see their own changes even when there is a transaction in progress.  Therefore,
+            // we use `integrate_trace` instead of `accumulate_integrate_trace` here.
+            stream.integrate_trace()
         };
 
         let (integrate_handle, integrate_gid) = integral_stream

--- a/docs.feldera.com/docs/sql/ad-hoc.md
+++ b/docs.feldera.com/docs/sql/ad-hoc.md
@@ -111,6 +111,22 @@ Ad-hoc queries can use CPU resources, memory and, to a lesser extent, storage (f
 especially if they are complex or involve scanning large datasets. Since these resources are shared with the
 Feldera SQL engine, such queries may reduce pipeline performance during ad-hoc query execution.
 
+### Read-after-write within a request
+
+Within a multi-statement request, the snapshot advances after each
+statement. A trailing `SELECT` observes the side effects of earlier
+`INSERT`s on tables in the same request:
+
+```sql
+INSERT INTO t VALUES (1);
+SELECT COUNT(*) FROM t;  -- returns 1
+```
+
+Materialized views derived from those inserts refresh when the
+surrounding transaction commits. While a transaction is open, a query
+against a view sees only the pre-transaction state, even if earlier
+statements in the same request inserted into the view's source tables.
+
 ## Examples
 
 ### Inserting Complex Data Types

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -160,7 +160,9 @@ _ROW_DIFF_LOG_LIMIT = 20
 def _log_row_diff(label: str, rows: list) -> None:
     if not rows:
         return
-    log(f"{label} ({len(rows)} rows; showing first {min(len(rows), _ROW_DIFF_LOG_LIMIT)}):")
+    log(
+        f"{label} ({len(rows)} rows; showing first {min(len(rows), _ROW_DIFF_LOG_LIMIT)}):"
+    )
     for row in rows[:_ROW_DIFF_LOG_LIMIT]:
         log(json.dumps(row, default=str))
 

--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -152,6 +152,19 @@ def log(*args, **kwargs):
     print(prefix, *args, **kwargs)
 
 
+# Cap on rows logged when a view validation fails. A failing TPC-H or test_now run
+# can otherwise emit tens of megabytes on a single line, which blows up CI log capture.
+_ROW_DIFF_LOG_LIMIT = 20
+
+
+def _log_row_diff(label: str, rows: list) -> None:
+    if not rows:
+        return
+    log(f"{label} ({len(rows)} rows; showing first {min(len(rows), _ROW_DIFF_LOG_LIMIT)}):")
+    for row in rows[:_ROW_DIFF_LOG_LIMIT]:
+        log(json.dumps(row, default=str))
+
+
 def unique_pipeline_name(base_name: str) -> str:
     """
     In CI, multiple tests of different runs can run against the same Feldera instance, we
@@ -231,13 +244,14 @@ def validate_view(pipeline: Pipeline, view: ViewSpec):
                 pipeline.query(f"({view_query}) except (select * from {view.name})")
             )
 
-            if extra_rows:
-                log("Extra rows in Feldera output, but not in the ad hoc query output")
-                log(json.dumps(extra_rows, default=str))
-
-            if missing_rows:
-                log("Extra rows in the ad hoc query output, but not in Feldera output")
-                log(json.dumps(missing_rows, default=str))
+            _log_row_diff(
+                "Extra rows in Feldera output, but not in the ad hoc query output",
+                extra_rows,
+            )
+            _log_row_diff(
+                "Extra rows in the ad hoc query output, but not in Feldera output",
+                missing_rows,
+            )
         except Exception as e:
             log(f"Error querying view '{view.name}': {e}")
             log(f"Ad-hoc Query: {view_query}")

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -235,6 +235,20 @@ class TestAdhocQueries(SharedTestPipeline):
         assert prepared_rows and prepared_rows[0].get("c") == 1
         assert self._count("SELECT COUNT(*) AS c FROM t1") == 7
 
+        # Multiple non-PREPARE statements in a single request: earlier
+        # INSERTs run for their side effect; the trailing SELECT returns
+        # its rows.
+        chain_rows = list(
+            self.pipeline.query(
+                "INSERT INTO t1 VALUES "
+                "(200,'2020-02-02','11111111-1111-1111-1111-111111111111');"
+                "INSERT INTO t1 VALUES "
+                "(201,'2020-02-02','22222222-2222-2222-2222-222222222222');"
+                "SELECT COUNT(*) AS c FROM t1 WHERE id BETWEEN 200 AND 201"
+            )
+        )
+        assert chain_rows and chain_rows[0].get("c") == 2
+
         # Non-materialized table via its materialized view
         assert self._count("SELECT COUNT(*) AS c FROM view_of_not_materialized") == 0
         ins_nm = list(

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -568,7 +568,7 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
           id INT NOT NULL PRIMARY KEY
         ) WITH ('materialized' = 'true');"""
     )
-    def test_multi_statement_query_during_open_transaction(self):
+    def test_multi_statement_query_during_open_transaction_pk(self):
         """An ad-hoc request running inside a user transaction must
         still see its own intermediate INSERTs in the trailing SELECT.
         Adhoc reads pull from `trace_snapshots`, which updates on every
@@ -598,6 +598,41 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
 
         # After commit, a fresh adhoc query still sees the same three rows.
         rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example2"))
+        assert rows_after and rows_after[0].get("c") == 3, (
+            f"after commit, all three inserts must be visible, got {rows_after!r}"
+        )
+
+    @sql(
+        """CREATE TABLE example3 (
+          id INT
+        ) WITH ('materialized' = 'true');"""
+    )
+    def test_multi_statement_query_during_open_transaction_no_pk(self):
+        """Same as test_multi_statement_query_during_open_transaction_pk, but for a table without a primary key."""
+        self.pipeline.start()
+
+        # Seed one row outside the transaction as the baseline.
+        self.pipeline.execute("INSERT INTO example3 VALUES (1)")
+
+        tid = self.pipeline.start_transaction()
+        rows_during = list(
+            self.pipeline.query(
+                "INSERT INTO example3 VALUES (2);"
+                " INSERT INTO example3 VALUES (3);"
+                " SELECT COUNT(*) AS c FROM example3"
+            )
+        )
+        self.pipeline.commit_transaction(transaction_id=tid, wait=True)
+
+        assert rows_during, "trailing SELECT must return a row"
+        count_during = rows_during[0].get("c")
+        assert count_during == 3, (
+            f"trailing SELECT inside the transaction must observe all "
+            f"three rows (baseline + two intermediate inserts), got {count_during}"
+        )
+
+        # After commit, a fresh adhoc query still sees the same three rows.
+        rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example3"))
         assert rows_after and rows_after[0].get("c") == 3, (
             f"after commit, all three inserts must be visible, got {rows_after!r}"
         )

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -569,9 +569,10 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
         ) WITH ('materialized' = 'true');"""
     )
     def test_multi_statement_query_during_open_transaction(self):
-        """While a user transaction is open, `update_snapshot()` is
-        skipped, so the trailing SELECT only sees the pre-transaction
-        baseline. Pin that shape so we notice if the gating changes.
+        """An ad-hoc request running inside a user transaction must
+        still see its own intermediate INSERTs in the trailing SELECT.
+        Adhoc reads pull from `trace_snapshots`, which updates on every
+        step regardless of transaction state.
         """
         self.pipeline.start()
 
@@ -590,12 +591,12 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
 
         assert rows_during, "trailing SELECT must return a row"
         count_during = rows_during[0].get("c")
-        assert count_during == 1, (
-            f"during the open transaction the SELECT must observe only "
-            f"the pre-transaction baseline, got {count_during}"
+        assert count_during == 3, (
+            f"trailing SELECT inside the transaction must observe all "
+            f"three rows (baseline + two intermediate inserts), got {count_during}"
         )
 
-        # After commit, a fresh adhoc query must see all three rows.
+        # After commit, a fresh adhoc query still sees the same three rows.
         rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example2"))
         assert rows_after and rows_after[0].get("c") == 3, (
             f"after commit, all three inserts must be visible, got {rows_after!r}"

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -235,20 +235,6 @@ class TestAdhocQueries(SharedTestPipeline):
         assert prepared_rows and prepared_rows[0].get("c") == 1
         assert self._count("SELECT COUNT(*) AS c FROM t1") == 7
 
-        # Multiple non-PREPARE statements in a single request: earlier
-        # INSERTs run for their side effect; the trailing SELECT returns
-        # its rows.
-        chain_rows = list(
-            self.pipeline.query(
-                "INSERT INTO t1 VALUES "
-                "(200,'2020-02-02','11111111-1111-1111-1111-111111111111');"
-                "INSERT INTO t1 VALUES "
-                "(201,'2020-02-02','22222222-2222-2222-2222-222222222222');"
-                "SELECT COUNT(*) AS c FROM t1 WHERE id BETWEEN 200 AND 201"
-            )
-        )
-        assert chain_rows and chain_rows[0].get("c") == 2
-
         # Non-materialized table via its materialized view
         assert self._count("SELECT COUNT(*) AS c FROM view_of_not_materialized") == 0
         ins_nm = list(
@@ -541,3 +527,76 @@ class TestAdhocQueriesArrow(SharedTestPipeline):
         assert math.isinf(rows["neg_inf"]["r"]) and rows["neg_inf"]["r"] < 0
         assert math.isnan(rows["nan"]["d"])
         assert math.isnan(rows["nan"]["r"])
+
+
+class TestAdhocReadAfterWrite(SharedTestPipeline):
+    """Regression tests for
+    https://github.com/feldera/feldera/issues/6243 .
+
+    A multi-statement adhoc request must see its own intermediate
+    INSERTs in the trailing SELECT. The earlier bug was that the SELECT
+    ran against the snapshot captured before the request started, so
+    inserts in the same request stayed invisible.
+    """
+
+    @property
+    def pipeline(self):
+        return self.p
+
+    @sql(
+        """CREATE TABLE example (
+          id INT NOT NULL PRIMARY KEY
+        ) WITH ('materialized' = 'true');"""
+    )
+    def test_insert_then_select_in_same_request_sees_inserts(self):
+        self.pipeline.start()
+
+        rows = list(
+            self.pipeline.query(
+                "INSERT INTO example VALUES (2222);"
+                " INSERT INTO example VALUES (3333);"
+                " SELECT COUNT(*) AS c FROM example"
+            )
+        )
+        assert rows, "trailing SELECT must return a row"
+        assert rows[0].get("c") == 2, (
+            f"trailing SELECT should see both intermediate inserts, got {rows!r}"
+        )
+
+    @sql(
+        """CREATE TABLE example2 (
+          id INT NOT NULL PRIMARY KEY
+        ) WITH ('materialized' = 'true');"""
+    )
+    def test_multi_statement_query_during_open_transaction(self):
+        """While a user transaction is open, `update_snapshot()` is
+        skipped, so the trailing SELECT only sees the pre-transaction
+        baseline. Pin that shape so we notice if the gating changes.
+        """
+        self.pipeline.start()
+
+        # Seed one row outside the transaction as the baseline.
+        self.pipeline.execute("INSERT INTO example2 VALUES (1)")
+
+        tid = self.pipeline.start_transaction()
+        rows_during = list(
+            self.pipeline.query(
+                "INSERT INTO example2 VALUES (2);"
+                " INSERT INTO example2 VALUES (3);"
+                " SELECT COUNT(*) AS c FROM example2"
+            )
+        )
+        self.pipeline.commit_transaction(transaction_id=tid, wait=True)
+
+        assert rows_during, "trailing SELECT must return a row"
+        count_during = rows_during[0].get("c")
+        assert count_during == 1, (
+            f"during the open transaction the SELECT must observe only "
+            f"the pre-transaction baseline, got {count_during}"
+        )
+
+        # After commit, a fresh adhoc query must see all three rows.
+        rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example2"))
+        assert rows_after and rows_after[0].get("c") == 3, (
+            f"after commit, all three inserts must be visible, got {rows_after!r}"
+        )


### PR DESCRIPTION
Adhoc queries now read state from the last consistent snapshot after inserts.

hence a `insert; select count();` returns 0 but should ideally return 1.
`insert; commit; select count();` returns 1

We fix this making sure we step after inserts and we update the snapshots.

Note that this works for tables, but while we execute in a transaction it does not necessarily make results computed from views visible to the query.

I guess this is similar to `REFRESH MATERIALIZED VIEW` in postgres or `ON COMMIT` refresh mode in oracle where the result of an update isn't immediately visible in a view.

Fixes https://github.com/feldera/feldera/issues/6243

## Checklist

- [x] Integration tests added/updated
- [x] Documentation updated

## Breaking Changes?

Bugfix, used to work like this before https://github.com/feldera/feldera/commit/6f5b81c903b1406be4c1b2700a898453dc894d46