### PR TITLE
issues/6121: fix(postgres-cdc): When AtLeastOnce, ack slot on durable checkpoint, not step completion

### DIFF
--- a/crates/adapterlib/src/transport.rs
+++ b/crates/adapterlib/src/transport.rs
@@ -767,18 +767,34 @@ pub trait InputConsumer: Send + Sync + DynClone {
     /// so connectors that have no custom metrics need not override it.
     fn set_custom_metrics(&self, _metrics: Arc<dyn ConnectorMetrics>) {}
 
-    /// Returns a watch receiver that tracks completion of pipeline steps.
+    /// Returns a watch receiver that fires each time pipeline step processing
+    /// completes.  The value is the count of fully-processed steps
+    /// (`total_completed_steps`): a record ingested in step `n` is done when
+    /// the value exceeds `n`.
     ///
-    /// The receiver yields [`Completion`] values whose `total_completed_steps`
-    /// field indicates how many steps have been fully processed (circuit
-    /// execution + all output connectors).
+    /// Input adapters can use this to defer acknowledgment (e.g. a CDC
+    /// connector holding a replication slot) until their data has been
+    /// processed by the circuit and all output connectors.
     ///
-    /// Input adapters that need to defer acknowledgment until data is durably
-    /// processed (e.g., CDC adapters controlling a replication slot) can use
-    /// this to detect when their data has been consumed.
-    ///
-    /// Return `None` if the consumer does not support completion tracking.
+    /// Returns `None` if the consumer does not support completion tracking.
     fn completion_watcher(&self) -> Option<tokio::sync::watch::Receiver<Completion>>;
+
+    /// Returns a watch receiver that fires each time a durable checkpoint
+    /// completes.  The value is the count of checkpointed steps: a record
+    /// ingested in step `n` is durably stored when the value exceeds `n`.
+    ///
+    /// Input adapters that require at-least-once delivery stronger than step
+    /// completion (e.g. a CDC connector that must not advance its replication
+    /// slot past the last checkpoint) can wait on this rather than on
+    /// [`completion_watcher`][Self::completion_watcher].
+    ///
+    /// Returns `Some` only when fault tolerance is enabled for the pipeline
+    /// (which implies storage is configured and checkpoints are scheduled).
+    /// Returns `None` otherwise, in which case the connector should fall back
+    /// to [`completion_watcher`][Self::completion_watcher].
+    fn checkpoint_watcher(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        None
+    }
 
     /// Endpoint failed.
     ///

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3409,7 +3409,12 @@ impl CircuitThread {
             warn!("checkpoint failed: {error}");
         }
 
-        // Update the coordinator.
+        // Update the coordinator and, on success, advance the checkpointed-step
+        // counter so that connectors blocking on `checkpoint_watcher()` can
+        // release their pending acknowledgments.
+        if let Ok(checkpoint) = &result {
+            self.controller.status.notify_checkpoint(checkpoint.step);
+        }
         self.set_checkpoint_coordination(Some(match &result {
             Ok(_) => CheckpointCoordination::Done,
             Err(error) => CheckpointCoordination::Error(error.to_string()),
@@ -7684,6 +7689,21 @@ impl InputConsumer for InputProbe {
 
     fn completion_watcher(&self) -> Option<tokio::sync::watch::Receiver<Completion>> {
         Some(self.controller.status.completion_notifier.subscribe())
+    }
+
+    fn checkpoint_watcher(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        if self
+            .controller
+            .status
+            .pipeline_config
+            .global
+            .fault_tolerance
+            .is_enabled()
+        {
+            Some(self.controller.status.checkpoint_notifier.subscribe())
+        } else {
+            None
+        }
     }
 
     fn error(&self, fatal: bool, error: AnyError, tag: Option<&str>) {

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -452,6 +452,12 @@ pub struct ControllerStatus {
     /// Watch channel for notifying subscribers about [Completion] updates.
     pub completion_notifier: watch::Sender<Completion>,
 
+    /// Watch channel for notifying input adapters when a durable checkpoint
+    /// completes.  Carries the checkpointed step count (same semantics as
+    /// `total_completed_steps`: value `n` means steps `0..n` are durable).
+    /// Only fired when fault tolerance is enabled.
+    pub checkpoint_notifier: watch::Sender<u64>,
+
     /// Input endpoint configs and metrics.
     pub(crate) inputs: InputsStatus,
 
@@ -484,6 +490,7 @@ impl ControllerStatus {
     ) -> Self {
         let (time_series_notifier, _) = broadcast::channel(1024); // Buffer for up to 1024 time series updates
         let (completion_notifier, _) = watch::channel(Completion::default());
+        let (checkpoint_notifier, _) = watch::channel(0u64);
         Self {
             pipeline_config,
             global_metrics: GlobalControllerMetrics::new(
@@ -494,6 +501,7 @@ impl ControllerStatus {
             time_series: Mutex::new(VecDeque::with_capacity(60)),
             time_series_notifier,
             completion_notifier,
+            checkpoint_notifier,
             inputs: RwLock::new(BTreeMap::new()),
             outputs: RwLock::new(BTreeMap::new()),
         }
@@ -874,6 +882,21 @@ impl ControllerStatus {
                 }
             });
         }
+    }
+
+    /// Notify input adapters that a checkpoint covering `step` steps has
+    /// completed.  Wakes any watchers (e.g. the Postgres CDC connector when
+    /// fault tolerance is enabled) that are deferring slot advancement until
+    /// a durable checkpoint exists.
+    pub fn notify_checkpoint(&self, step: Step) {
+        self.checkpoint_notifier.send_if_modified(|current| {
+            if *current < step {
+                *current = step;
+                true
+            } else {
+                false
+            }
+        });
     }
 
     /// Notify all watermark trackers about a new value for `total_completed_records`.

--- a/crates/adapters/src/integrated/postgres/cdc_input.rs
+++ b/crates/adapters/src/integrated/postgres/cdc_input.rs
@@ -163,16 +163,19 @@ impl InputReader for PostgresCdcInputReader {
 
                 if !senders.is_empty() {
                     if let Some(tx) = self.inner.completion_tx.as_ref() {
-                        // Read completed steps AFTER flush — the step containing
-                        // our data hasn't completed yet, so waiting for this value
-                        // to increase guarantees our data was processed.
-                        let completed = self
+                        // Snapshot total_completed_steps AFTER flush.  The
+                        // data will land in the next step (>completed), so
+                        // this value is the correct lower bound for both
+                        // fast mode (fire when completed_steps > this) and
+                        // strict mode (fire when checkpointed_steps > this,
+                        // per the `total_checkpointed_steps >= n` semantics).
+                        let step_at_flush = self
                             .inner
                             .completion_rx
                             .as_ref()
                             .map(|rx| rx.borrow().total_completed_steps)
                             .unwrap_or(0);
-                        let _ = tx.send((completed, senders));
+                        let _ = tx.send((step_at_flush, senders));
                     } else {
                         // No completion tracking — fire immediately.
                         for sender in senders {
@@ -206,9 +209,14 @@ struct PostgresCdcInputInner {
     /// Deferred async result senders from `write_events`, waiting to be paired
     /// with a step number during the next `Queue` command.
     pending_senders: Arc<Mutex<DeferredSenders>>,
-    /// Watch receiver for step completion (cloned into the Queue handler).
+    /// Watch receiver for step completion — used to snapshot `step_at_flush`
+    /// in the Queue handler.  Always tracks `total_completed_steps`.
     completion_rx: Option<tokio::sync::watch::Receiver<Completion>>,
-    /// Sender for passing (completed_at_flush, senders) to the background task.
+    /// Watcher source for the background task.  Taken once by `worker_task_inner`.
+    /// `Strict` when fault tolerance is enabled (gates slot on checkpoint);
+    /// `Fast` otherwise (gates slot on step completion).
+    watcher_rx: Mutex<Option<WatcherReceiver>>,
+    /// Sender for passing (step_at_flush, senders) to the background task.
     /// Created once at construction time if completion tracking is available.
     completion_tx: Option<mpsc::UnboundedSender<(u64, DeferredSenders)>>,
     /// Receiver half, taken once by worker_task_inner to spawn the background task.
@@ -234,7 +242,14 @@ impl PostgresCdcInputInner {
             xxh3_64(identity.as_bytes())
         };
 
-        let (completion_tx, completion_task_rx) = if completion_rx.is_some() {
+        // Use strict mode (gate slot on checkpoint) when fault tolerance is enabled;
+        // fast mode (gate slot on step completion) otherwise.
+        let watcher_rx = match consumer.checkpoint_watcher() {
+            Some(rx) => Some(WatcherReceiver::Strict(rx)),
+            None => completion_rx.clone().map(WatcherReceiver::Fast),
+        };
+
+        let (completion_tx, completion_task_rx) = if watcher_rx.is_some() {
             let (tx, rx) = mpsc::unbounded_channel();
             (Some(tx), Some(rx))
         } else {
@@ -249,6 +264,7 @@ impl PostgresCdcInputInner {
             pipeline_id,
             pending_senders: Arc::new(Mutex::new(Vec::new())),
             completion_rx,
+            watcher_rx: Mutex::new(watcher_rx),
             completion_tx,
             completion_task_rx: Mutex::new(completion_task_rx),
         }
@@ -321,9 +337,9 @@ impl PostgresCdcInputInner {
         };
 
         // Spawn the completion watcher background task if tracking is available.
-        // The channel was created in new(); we take the receiver here.
+        // The watcher and the channel were created in new(); we take them here.
         let completion_handle = match (
-            self.consumer.completion_watcher(),
+            self.watcher_rx.lock().unwrap().take(),
             self.completion_task_rx.lock().unwrap().take(),
         ) {
             (Some(watcher), Some(rx)) => Some(tokio::spawn(completion_watcher_task(
@@ -828,14 +844,43 @@ fn array_cell_to_json(arr: &ArrayCell) -> Value {
     }
 }
 
-/// Background task that watches for Feldera step completion and fires deferred
-/// ETL async result senders when the step containing their data has completed.
+/// Typed watch receiver used by the completion watcher background task.
 ///
-/// Each entry is `(completed_at_flush, senders)` where `completed_at_flush` is
-/// the value of `total_completed_steps` at the time the data was flushed to the
-/// circuit. The data is processed once `total_completed_steps > completed_at_flush`.
+/// `Fast` waits for step completion (`total_completed_steps`); used when fault
+/// tolerance is not enabled.  `Strict` waits for checkpoint completion; used
+/// when fault tolerance is enabled so the replication slot only advances past
+/// the last durable checkpoint, preserving at-least-once correctness for
+/// stateful circuits after a crash.
+enum WatcherReceiver {
+    Fast(tokio::sync::watch::Receiver<Completion>),
+    Strict(tokio::sync::watch::Receiver<u64>),
+}
+
+impl WatcherReceiver {
+    async fn changed(&mut self) -> Result<(), tokio::sync::watch::error::RecvError> {
+        match self {
+            Self::Fast(rx) => rx.changed().await,
+            Self::Strict(rx) => rx.changed().await,
+        }
+    }
+
+    fn frontier(&self) -> u64 {
+        match self {
+            Self::Fast(rx) => rx.borrow().total_completed_steps,
+            Self::Strict(rx) => *rx.borrow(),
+        }
+    }
+}
+
+/// Background task that fires deferred ETL async result senders when the
+/// completion frontier passes the step recorded at Queue time.
+///
+/// Each entry is `(step_at_flush, senders)` where `step_at_flush` is the
+/// value of `total_completed_steps` at the time the data was flushed to the
+/// circuit.  The data lands in the next step, so we fire when the frontier
+/// strictly exceeds `step_at_flush`.
 async fn completion_watcher_task(
-    mut completion_rx: tokio::sync::watch::Receiver<Completion>,
+    mut watcher: WatcherReceiver,
     mut pending_rx: mpsc::UnboundedReceiver<(u64, DeferredSenders)>,
     endpoint_name: String,
 ) {
@@ -843,19 +888,19 @@ async fn completion_watcher_task(
 
     loop {
         tokio::select! {
-            result = completion_rx.changed() => {
+            result = watcher.changed() => {
                 if result.is_err() {
                     break; // Sender dropped (pipeline shutting down)
                 }
-                let completed = completion_rx.borrow().total_completed_steps;
-                fire_completed(&mut waiting, completed);
+                let f = watcher.frontier();
+                fire_completed(&mut waiting, f);
             }
             maybe_entry = pending_rx.recv() => {
                 match maybe_entry {
                     Some((step_at_flush, senders)) => {
-                        let completed = completion_rx.borrow().total_completed_steps;
-                        if completed > step_at_flush {
-                            // Already complete — fire immediately.
+                        let f = watcher.frontier();
+                        if f > step_at_flush {
+                            // Already past the threshold — fire immediately.
                             for sender in senders {
                                 sender.send(Ok(()));
                             }
@@ -1489,5 +1534,335 @@ mod tests {
         let cols = cache.get(&42).map(|info| info.column_names.clone());
         assert_eq!(cols, Some(vec!["id".to_string(), "amount".to_string()]));
         assert_eq!(cache.get(&99).map(|info| info.column_names.clone()), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // fire_completed unit tests
+    // -----------------------------------------------------------------------
+
+    /// Creates an `AsyncResult` sender and a future that resolves to `true` when
+    /// the sender is fired with `Ok(())`.  Works in both sync and async contexts
+    /// because the pending side is wrapped in a tokio oneshot that the caller
+    /// can `.await`.
+    fn make_async_sender() -> (
+        WriteEventsResult<()>,
+        impl std::future::Future<Output = bool>,
+    ) {
+        let (async_result, pending) = etl::destination::async_result::AsyncResult::<()>::new(());
+        let fut = async move { pending.await.into_result().is_ok() };
+        (async_result, fut)
+    }
+
+    /// Sync-only helper: spawns a background OS thread so `fire_completed`
+    /// (which is sync) can be tested without a tokio runtime on the test thread.
+    fn make_tracked_sender_sync() -> (WriteEventsResult<()>, std::sync::mpsc::Receiver<bool>) {
+        let (flag_tx, flag_rx) = std::sync::mpsc::channel();
+        let (async_result, pending) = etl::destination::async_result::AsyncResult::<()>::new(());
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    let result = pending.await;
+                    let _ = flag_tx.send(result.into_result().is_ok());
+                });
+        });
+        (async_result, flag_rx)
+    }
+
+    #[test]
+    fn test_fire_completed_fires_when_past_frontier() {
+        let (sender, flag_rx) = make_tracked_sender_sync();
+        let mut waiting: Vec<(u64, DeferredSenders)> = vec![(5, vec![sender])];
+
+        // completed_steps=5 is NOT strictly greater than step_at_flush=5 — should not fire.
+        fire_completed(&mut waiting, 5);
+        assert_eq!(waiting.len(), 1, "should still be waiting at step=5");
+
+        // completed_steps=6 is strictly greater — should fire.
+        fire_completed(&mut waiting, 6);
+        assert!(waiting.is_empty(), "entry should have been removed");
+
+        let fired = flag_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        assert!(fired, "sender should have been fired with Ok(())");
+    }
+
+    #[test]
+    fn test_fire_completed_does_not_fire_at_equal_frontier() {
+        let (sender, _flag_rx) = make_tracked_sender_sync();
+        let mut waiting: Vec<(u64, DeferredSenders)> = vec![(10, vec![sender])];
+        fire_completed(&mut waiting, 10);
+        assert_eq!(
+            waiting.len(),
+            1,
+            "step_at_flush==completed_steps must not fire"
+        );
+    }
+
+    #[test]
+    fn test_fire_completed_fires_only_ready_entries() {
+        let (s1, rx1) = make_tracked_sender_sync();
+        let (s2, _rx2) = make_tracked_sender_sync();
+        let mut waiting: Vec<(u64, DeferredSenders)> = vec![
+            (3, vec![s1]), // fires at completed=4
+            (7, vec![s2]), // stays waiting at completed=4
+        ];
+        fire_completed(&mut waiting, 4);
+        assert_eq!(waiting.len(), 1, "only the step=7 entry should remain");
+        assert_eq!(waiting[0].0, 7);
+        let fired = rx1.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
+        assert!(fired);
+    }
+
+    #[test]
+    fn test_fire_completed_empty_waiting() {
+        let mut waiting: Vec<(u64, DeferredSenders)> = vec![];
+        fire_completed(&mut waiting, 100);
+        assert!(waiting.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // completion_watcher_task unit tests
+    // -----------------------------------------------------------------------
+
+    fn make_completion(completed: u64) -> Completion {
+        Completion {
+            total_completed_steps: completed,
+        }
+    }
+
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+    #[tokio::test]
+    async fn test_watcher_fast_mode_fires_on_completed_steps() {
+        let (completion_tx, completion_rx) = tokio::sync::watch::channel(make_completion(0));
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Fast(completion_rx),
+            pending_rx,
+            "test-fast".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((2, vec![sender])).unwrap();
+
+        // Advance completed_steps past step_at_flush=2.
+        completion_tx.send(make_completion(3)).unwrap();
+
+        let fired = tokio::time::timeout(TIMEOUT, fired_fut)
+            .await
+            .expect("timed out waiting for fast-mode fire");
+        assert!(
+            fired,
+            "fast mode must fire when total_completed_steps > step_at_flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_strict_mode_does_not_fire_on_completed_steps_only() {
+        let (completion_tx, completion_rx) = tokio::sync::watch::channel(make_completion(0));
+        let (checkpoint_tx, checkpoint_rx) = tokio::sync::watch::channel(0u64);
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        // completion_rx is only used to read step_at_flush in Queue; the task
+        // uses checkpoint_rx for the strict-mode frontier.
+        let _ = completion_tx;
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Strict(checkpoint_rx),
+            pending_rx,
+            "test-strict".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((2, vec![sender])).unwrap();
+
+        // Only advance the checkpoint notifier to 0 (no change) — must not fire.
+        let _ = checkpoint_tx.send(0);
+        tokio::task::yield_now().await;
+
+        // The future must NOT resolve — a very short timeout should expire.
+        let did_fire = tokio::time::timeout(std::time::Duration::from_millis(50), fired_fut).await;
+        assert!(
+            did_fire.is_err(),
+            "strict mode must NOT fire when checkpoint frontier has not advanced past step_at_flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_strict_mode_fires_on_checkpointed_steps() {
+        let (checkpoint_tx, checkpoint_rx) = tokio::sync::watch::channel(0u64);
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Strict(checkpoint_rx),
+            pending_rx,
+            "test-strict-fires".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((2, vec![sender])).unwrap();
+
+        // Checkpoint step advances past step_at_flush=2 — must fire.
+        checkpoint_tx.send(3).unwrap();
+
+        let fired = tokio::time::timeout(TIMEOUT, fired_fut)
+            .await
+            .expect("timed out waiting for strict-mode fire");
+        assert!(
+            fired,
+            "strict mode must fire when checkpointed step > step_at_flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_fires_immediately_when_already_past_frontier() {
+        // completed_steps already beyond step_at_flush at task start.
+        let (_completion_tx, completion_rx) = tokio::sync::watch::channel(make_completion(10));
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Fast(completion_rx),
+            pending_rx,
+            "test-already-done".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((5, vec![sender])).unwrap();
+
+        let fired = tokio::time::timeout(TIMEOUT, fired_fut)
+            .await
+            .expect("timed out waiting for immediate fire");
+        assert!(
+            fired,
+            "must fire immediately when frontier already exceeds step_at_flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_strict_fires_immediately_when_checkpointed_past_frontier() {
+        let (_checkpoint_tx, checkpoint_rx) = tokio::sync::watch::channel(10u64);
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Strict(checkpoint_rx),
+            pending_rx,
+            "test-strict-already-done".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((5, vec![sender])).unwrap();
+
+        let fired = tokio::time::timeout(TIMEOUT, fired_fut)
+            .await
+            .expect("timed out waiting for immediate strict-mode fire");
+        assert!(
+            fired,
+            "strict mode must fire immediately when checkpointed step already exceeds step_at_flush"
+        );
+    }
+
+    /// Regression: at Queue time the checkpointed step (2) lags the flush
+    /// frontier (5).  A partial checkpoint advancing to 4 does not cover the
+    /// step containing the new data, so strict mode must NOT fire.
+    #[tokio::test]
+    async fn test_watcher_strict_does_not_fire_on_partial_checkpoint() {
+        let (checkpoint_tx, checkpoint_rx) = tokio::sync::watch::channel(2u64);
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Strict(checkpoint_rx),
+            pending_rx,
+            "test-strict-partial".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        // step_at_flush = 5.
+        pending_tx.send((5, vec![sender])).unwrap();
+
+        // Partial checkpoint advances to 4 — still below step_at_flush=5.
+        checkpoint_tx.send(4).unwrap();
+        tokio::task::yield_now().await;
+
+        let did_fire = tokio::time::timeout(std::time::Duration::from_millis(50), fired_fut).await;
+        assert!(
+            did_fire.is_err(),
+            "strict mode must NOT fire when checkpoint (4) does not exceed step_at_flush (5)"
+        );
+    }
+
+    /// Regression: after a partial checkpoint stalls, a full checkpoint that
+    /// passes step_at_flush must fire.
+    #[tokio::test]
+    async fn test_watcher_strict_fires_when_checkpoint_passes_step_at_flush() {
+        let (checkpoint_tx, checkpoint_rx) = tokio::sync::watch::channel(2u64);
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Strict(checkpoint_rx),
+            pending_rx,
+            "test-strict-passes".to_string(),
+        ));
+
+        let (sender, fired_fut) = make_async_sender();
+        pending_tx.send((5, vec![sender])).unwrap();
+
+        // Full checkpoint advances past step_at_flush=5 — must fire.
+        checkpoint_tx.send(6).unwrap();
+
+        let fired = tokio::time::timeout(TIMEOUT, fired_fut)
+            .await
+            .expect("timed out waiting for strict fire after lagging checkpoint");
+        assert!(
+            fired,
+            "strict mode must fire when checkpointed step (6) > step_at_flush (5)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_watcher_multiple_batches_different_thresholds() {
+        let (completion_tx, completion_rx) = tokio::sync::watch::channel(make_completion(0));
+        let (pending_tx, pending_rx) = mpsc::unbounded_channel::<(u64, DeferredSenders)>();
+
+        tokio::spawn(completion_watcher_task(
+            WatcherReceiver::Fast(completion_rx),
+            pending_rx,
+            "test-multi".to_string(),
+        ));
+
+        let (s1, f1) = make_async_sender(); // fires at completed > 1
+        let (s2, f2) = make_async_sender(); // fires at completed > 4
+        let (s3, f3) = make_async_sender(); // fires at completed > 7
+
+        pending_tx.send((1, vec![s1])).unwrap();
+        pending_tx.send((4, vec![s2])).unwrap();
+        pending_tx.send((7, vec![s3])).unwrap();
+
+        // Advance to 2 — only s1 fires.
+        completion_tx.send(make_completion(2)).unwrap();
+        assert!(
+            tokio::time::timeout(TIMEOUT, f1)
+                .await
+                .expect("s1 timed out")
+        );
+
+        // Advance to 5 — s2 fires.
+        completion_tx.send(make_completion(5)).unwrap();
+        assert!(
+            tokio::time::timeout(TIMEOUT, f2)
+                .await
+                .expect("s2 timed out")
+        );
+
+        // Advance to 8 — s3 fires.
+        completion_tx.send(make_completion(8)).unwrap();
+        assert!(
+            tokio::time::timeout(TIMEOUT, f3)
+                .await
+                .expect("s3 timed out")
+        );
     }
 }

--- a/crates/adapters/src/integrated/postgres/test.rs
+++ b/crates/adapters/src/integrated/postgres/test.rs
@@ -2131,6 +2131,7 @@ fn test_pg_input_tls() {
 mod cdc_tests {
     use super::*;
     use crate::test::wait;
+    use feldera_types::config::PipelineConfig;
     use pg::pg_connect;
 
     /// Helper: creates a table, publication, and sets REPLICA IDENTITY FULL.
@@ -2578,6 +2579,102 @@ mod cdc_tests {
                 let msg = format!("cdc_all_types_test: error: {e}");
                 println!("{msg}");
                 err_sender.send(msg).unwrap()
+            }),
+        )
+        .unwrap();
+
+        (controller, err_receiver)
+    }
+
+    /// Like `cdc_simple_test_circuit` but with fault tolerance enabled,
+    /// file storage at `storage_dir`, and a 3600-second checkpoint interval so
+    /// that no automatic checkpoint fires during the test.  With fault
+    /// tolerance enabled the connector uses strict mode: the replication slot
+    /// only advances after a durable checkpoint.
+    fn cdc_ft_test_circuit(
+        url: &str,
+        publication: &str,
+        source_table: &str,
+        storage_dir: &Path,
+        output_path: &Path,
+    ) -> (Controller, crossbeam::channel::Receiver<String>) {
+        let schema = TestStruct::schema();
+        let config: PipelineConfig = serde_json::from_value(json!({
+            "name": "cdc_ft_test",
+            "workers": 1,
+            "storage_config": { "path": storage_dir },
+            "storage": true,
+            "fault_tolerance": { "checkpoint_interval_secs": 3600 },
+            "inputs": {
+                "cdc_in": {
+                    "stream": "test_input1",
+                    "transport": {
+                        "name": "postgres_cdc_input",
+                        "config": {
+                            "uri": url,
+                            "publication": publication,
+                            "source_table": source_table,
+                        },
+                    },
+                },
+            },
+            "outputs": {
+                "test_output1": {
+                    "stream": "test_output1",
+                    "transport": {
+                        "name": "file_output",
+                        "config": { "path": output_path },
+                    },
+                    "format": {
+                        "name": "json",
+                        "config": { "update_format": "insert_delete", "array": false },
+                    },
+                },
+            },
+        }))
+        .unwrap();
+
+        let (err_sender, err_receiver) = crossbeam::channel::unbounded();
+        let controller = Controller::with_test_config(
+            move |workers| {
+                Ok({
+                    let (circuit, catalog) = Runtime::init_circuit(workers, move |circuit| {
+                        let mut catalog = Catalog::new();
+                        let (input, hinput) = circuit.add_input_zset::<TestStruct>();
+                        let input_schema = serde_json::to_string(&Relation::new(
+                            "test_input1".into(),
+                            schema.clone(),
+                            false,
+                            BTreeMap::new(),
+                        ))
+                        .unwrap();
+                        let output_schema = serde_json::to_string(&Relation::new(
+                            "test_output1".into(),
+                            schema,
+                            false,
+                            BTreeMap::new(),
+                        ))
+                        .unwrap();
+                        catalog.register_materialized_input_zset::<_, TestStruct>(
+                            input.clone(),
+                            hinput,
+                            &input_schema,
+                        );
+                        catalog.register_materialized_output_zset::<_, TestStruct>(
+                            input,
+                            &output_schema,
+                        );
+                        Ok(catalog)
+                    })
+                    .unwrap();
+                    (circuit, Box::new(catalog))
+                })
+            },
+            &config,
+            Box::new(move |e, _| {
+                let msg = format!("cdc_ft_test: error: {e}");
+                println!("{msg}");
+                err_sender.send(msg).unwrap();
             }),
         )
         .unwrap();
@@ -3085,5 +3182,111 @@ mod cdc_tests {
         );
 
         controller_2.stop().unwrap();
+    }
+
+    // -------------------------------------------------------------------
+    // Fault-tolerance / strict-mode tests
+    // -------------------------------------------------------------------
+
+    /// With fault tolerance enabled the replication slot LSN is not
+    /// advanced until a Feldera checkpoint completes.  When the pipeline is
+    /// stopped before any checkpoint occurs and then restarted with the same
+    /// connection identity (same slot), Postgres replays all events from the
+    /// original slot position — guaranteeing at-least-once delivery.
+    ///
+    /// Requires: wal_level=logical, user with REPLICATION privilege.
+    #[test]
+    #[serial]
+    #[ignore]
+    fn test_cdc_ft_mode_holds_slot() {
+        let url = postgres_url();
+        let table_name = "cdc_test_strict_hold";
+        let publication = "cdc_pub_strict_hold";
+
+        let mut table = CdcTestTable::new_simple(table_name, publication, &url);
+        table.execute(&format!(
+            "INSERT INTO {table_name} VALUES (1, true, NULL, 'first')"
+        ));
+        table.execute(&format!(
+            "INSERT INTO {table_name} VALUES (2, false, 42, 'second')"
+        ));
+
+        // --- Run 1: FT mode (strict), no checkpoint fires (interval = 3600 s) ---
+        let storage = tempfile::tempdir().unwrap();
+        let out_1 = NamedTempFile::new().unwrap();
+        let (ctrl_1, errs_1) = cdc_ft_test_circuit(
+            &url,
+            publication,
+            &format!("public.{table_name}"),
+            storage.path(),
+            out_1.path(),
+        );
+        ctrl_1.start();
+
+        wait(
+            || count_inserts(&read_output_json(out_1.path())) >= 2 || !errs_1.is_empty(),
+            60_000,
+        )
+        .expect("timeout: run 1 did not receive snapshot rows");
+        assert!(
+            errs_1.is_empty(),
+            "unexpected errors in run 1: {:?}",
+            errs_1.try_recv()
+        );
+
+        // Stop without a checkpoint — slot LSN is still at the snapshot position.
+        ctrl_1.stop().unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // --- Run 2: fresh output, same slot (same url/publication/source_table) ---
+        let out_2 = NamedTempFile::new().unwrap();
+        let storage_2 = tempfile::tempdir().unwrap();
+        let (ctrl_2, errs_2) = cdc_ft_test_circuit(
+            &url,
+            publication,
+            &format!("public.{table_name}"),
+            storage_2.path(),
+            out_2.path(),
+        );
+        ctrl_2.start();
+
+        // Insert a new row to confirm replication is flowing.
+        table.execute(&format!(
+            "INSERT INTO {table_name} VALUES (3, true, 99, 'third')"
+        ));
+
+        wait(
+            || count_inserts(&read_output_json(out_2.path())) >= 3 || !errs_2.is_empty(),
+            60_000,
+        )
+        .expect("timeout: run 2 did not receive expected rows");
+        assert!(
+            errs_2.is_empty(),
+            "unexpected errors in run 2: {:?}",
+            errs_2.try_recv()
+        );
+
+        let rows = read_output_json(out_2.path());
+        let ids: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| {
+                r.get("insert")
+                    .and_then(|v| v.get("id"))
+                    .and_then(|v| v.as_i64())
+            })
+            .collect();
+
+        // The slot was held back in run 1 — rows 1 and 2 must be redelivered.
+        assert!(
+            ids.contains(&1),
+            "row 1 must be redelivered (slot held); ids={ids:?}"
+        );
+        assert!(
+            ids.contains(&2),
+            "row 2 must be redelivered (slot held); ids={ids:?}"
+        );
+        assert!(ids.contains(&3), "row 3 (new) must appear; ids={ids:?}");
+
+        ctrl_2.stop().unwrap();
     }
 }


### PR DESCRIPTION
### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [x] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [x] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
