### PR TITLE
[adapters] Transactional bootstrapping postfix.

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3035,18 +3035,18 @@ impl CircuitThread {
         // processing; otherwise, there is a race for any code that runs a query
         // as soon as input has been processed.
         if transaction_state == TransactionState::None {
+            let bootstrapping = self.circuit.bootstrap_in_progress();
+
             // Don't update the snapshot until bootstrapping is complete (including the additional post-bootstrap transaction).
             // This guarantees that:
             // 1. Ad hoc queries observe a consistent view of the data.
             // 2. Ad hoc snapshots are up-to-date before the pipeline is marked as running.
-            if !self.controller.status.bootstrap_in_progress() {
+            if !bootstrapping && !self.bootstrapping {
                 Span::new("update")
                     .with_category("Step")
                     .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
                     .in_scope(|| self.update_snapshot());
             }
-
-            let bootstrapping = self.circuit.bootstrap_in_progress();
 
             // If bootstrapping has completed, clear self.bootstrapping, but don't update the status flag
             // until the circuit performs an extra transaction to initialize output snapshots


### PR DESCRIPTION
We delayed the creation of relation snapshots by one extra step, so the sequence was:

1. Commit bootstrapping transaction.
2. Commit the extra transaction we trigger post-bootstrapping.
3. For no reason: Wait for one extra transaction.

This commit fixes the logic to update the snapshot after step 2.

