### PR TITLE
Move from jdk to jdk-headless

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update --fix-missing && \
 
 ## Setup Java and Python
 
-RUN apt-get install -y \
+RUN apt-get install --no-install-recommends -y \
    gcc clang libclang-dev python3-pip python3-plumbum \
-   hub numactl openjdk-21-jdk maven
+   hub numactl openjdk-21-jdk-headless maven
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ## Install nodejs

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ playwright/.cache/
 
 # Claude Code
 /.claude/settings.local.json
+
+# Devcontainers - the lock file should be committed when more people use them
+.devcontainer/devcontainer-lock.json

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update --fix-missing && apt-get install -y \
     # To download tools
     curl  \
     # For running the SQL compiler
-    openjdk-21-jdk -y \
+    openjdk-21-jdk-headless -y \
     # Install locale-gen
     locales \
     # To add the nodesource debian repository


### PR DESCRIPTION
As a part of https://github.com/feldera/feldera/commit/1b247fe1e48e33235fed6762918dbc82bc38fc70 `jre-headless` Java installation was replaced with `jdk`. It contains the JDK toolchain apparently needed to compile the latest version of Calcite, but also includes unnecessary X11/AWT/audio/font dependencies. This does not affect the build-image, but conflicts in a local workflow that uses Playwright-managed browser instances for UI testing. Since the full `jdk` is not needed anyway, it is cleaner to use `jdk-headless`.
There is no need to switch to the new build-image right away.

Testing: sql-to-dbsp-compiler/build.sh runs successfully after a clean ubuntu 24 install with openjdk-21-jdk-headless