### PR TITLE
dbsp: checkpointer: write empty checkpoint catalog on prepare

### DIFF
--- a/crates/dbsp/src/circuit/checkpointer.rs
+++ b/crates/dbsp/src/circuit/checkpointer.rs
@@ -203,6 +203,21 @@ impl Checkpointer {
         Ok(())
     }
 
+    /// Writes an empty `checkpoints.feldera` catalog if one does not yet exist.
+    ///
+    /// Call this before creating a new checkpoint UUID directory so that
+    /// `read_checkpoints` never observes UUID directories without a catalog
+    /// (which would trigger the "orphaned directory" error).
+    pub(super) fn ensure_catalog_exists(&self) -> Result<(), Error> {
+        if !self
+            .backend
+            .exists(&StoragePath::from(CHECKPOINT_FILE_NAME))?
+        {
+            self.update_checkpoint_file()?;
+        }
+        Ok(())
+    }
+
     pub(super) fn commit(
         &mut self,
         uuid: Uuid,

--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -1780,6 +1780,12 @@ impl<'a> CheckpointBuilder<'a> {
     /// commit it later.
     pub fn prepare(self) -> Result<CheckpointCommitter, DbspError> {
         let checkpointer = self.handle.checkpointer()?.clone();
+
+        // Write an empty catalog before the UUID directory is created by
+        // operators.  This prevents read_checkpoints from seeing orphaned UUID
+        // directories during the first checkpoint commit on fresh storage.
+        checkpointer.lock().unwrap().ensure_catalog_exists()?;
+
         let uuid = Uuid::now_v7();
         let checkpoint_dir = Checkpointer::checkpoint_dir(uuid);
         let mut readers = Vec::new();


### PR DESCRIPTION
When preparing to write a checkpoint, make an empty checkpoint catalog.

The `Checkpointer::read_checkpoints` method raises an error if there is a checkpoint UUID dir without a checkpoint catalog. This means when creating the first checkpoint, the operators start writing to the checkpoint dir, and the checkpoint catalog hasn't been created yet. When apps call `/checkpoints` or any code path that calls `read_checkpoints` is triggered, it will raise an error saying it found an unexpected checkpoint dir without a checkpoint catalog.

### Describe Manual Test Plan

Tested as part of sync tests, fixes the prior regression.

## Breaking Changes?

None
