### PR TITLE
[SQL] Add missing CAST function implementations for INTERVALs

### DIFF
--- a/crates/fxp/src/dynamic.rs
+++ b/crates/fxp/src/dynamic.rs
@@ -12,6 +12,7 @@ use crate::{
     parse_decimal, pow10, u256::I256,
 };
 
+use num_traits::CheckedDiv;
 use rand::Rng;
 use rand::distributions::uniform::{UniformInt, UniformSampler};
 
@@ -163,6 +164,18 @@ impl DynamicDecimal {
     pub const fn abs(self) -> Self {
         Self::new(self.sig.abs(), self.exponent)
     }
+
+    /// Deserializes [DynamicDecimal] into `Fixed`.  If successful, returns the
+    /// original value from before serialization.  If `S < value.exponent`, then
+    /// some trailing decimals are lost, by rounding toward even.  Returns an
+    /// error` if the value is out of range for this type.
+    #[doc(hidden)]
+    pub fn into_fixed_round_even<const P: usize, const S: usize>(
+        self,
+    ) -> Result<Fixed<P, S>, OutOfRange> {
+        Fixed::<P, S>::try_new_with_exponent_round_even(self.sig, S as i32 - self.exponent as i32)
+            .ok_or(OutOfRange)
+    }
 }
 
 impl<const P: usize, const S: usize> From<Fixed<P, S>> for DynamicDecimal {
@@ -236,12 +249,10 @@ impl Mul<DynamicDecimal> for DynamicDecimal {
     }
 }
 
-impl Div<DynamicDecimal> for DynamicDecimal {
-    type Output = Self;
-
-    fn div(self, other: DynamicDecimal) -> DynamicDecimal {
+impl CheckedDiv for DynamicDecimal {
+    fn checked_div(&self, other: &DynamicDecimal) -> Option<DynamicDecimal> {
         if other.sig == 0i128 {
-            panic!("Division by zero");
+            None
         } else {
             // We have to choose an arbitrary number of digits after the decimal
             // point where we stop.
@@ -253,14 +264,25 @@ impl Div<DynamicDecimal> for DynamicDecimal {
                 // A shift this big would exceed the range of I256, so we can't
                 // calculate it, but the ultimate result would also overflow, so
                 // we don't have to.
-                panic!("Division overflow");
+                None
             } else {
                 let scaled = I256::from_product(self.sig, pow10(shift_left as usize));
                 let div = scaled.narrowing_div(other.sig).unwrap();
                 let exp = self.exponent.saturating_sub(other.exponent + digits);
                 let adjust = div * pow10(exp as usize);
-                DynamicDecimal::new(adjust, digits)
+                Some(DynamicDecimal::new(adjust, digits))
             }
+        }
+    }
+}
+
+impl Div<DynamicDecimal> for DynamicDecimal {
+    type Output = Self;
+
+    fn div(self, other: DynamicDecimal) -> DynamicDecimal {
+        match self.checked_div(&other) {
+            None => panic!("Overflow dividing {} / {}", self, other),
+            Some(v) => v,
         }
     }
 }

--- a/crates/fxp/src/fixed.rs
+++ b/crates/fxp/src/fixed.rs
@@ -300,7 +300,7 @@ impl<const P: usize, const S: usize> Fixed<P, S> {
 
     /// Returns `Self(value * 10**exponent)`, rounding to even if `exponent` is
     /// negative, if the computed value is in the correct range for the type.
-    fn try_new_with_exponent_round_even(value: i128, exponent: i32) -> Option<Self> {
+    pub(super) fn try_new_with_exponent_round_even(value: i128, exponent: i32) -> Option<Self> {
         i128_mul_pow10_round_even(value, exponent).and_then(Self::try_new)
     }
 

--- a/crates/sqllib/src/casts.rs
+++ b/crates/sqllib/src/casts.rs
@@ -20,12 +20,19 @@ use crate::{
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use dbsp::algebra::{F32, F64, HasOne, HasZero};
 use num::{One, Zero};
-use num_traits::cast::NumCast;
+use num_traits::{CheckedDiv, cast::NumCast};
 use regex::{Captures, Regex};
 use smallstr::SmallString;
-use std::{error::Error, fmt::Display, iter::once, ops::Div};
-use std::{fmt::Write, str::FromStr};
-use std::{marker::PhantomData, sync::LazyLock};
+use std::{
+    error::Error,
+    fmt::Display,
+    fmt::Write,
+    iter::once,
+    marker::PhantomData,
+    ops::{Div, Mul},
+    str::FromStr,
+    sync::LazyLock,
+};
 
 trait ToSmallString: Display {
     fn to_small_string<const N: usize>(&self) -> SmallString<[u8; N]>;
@@ -1717,103 +1724,143 @@ pub fn cast_to_i64_Weight(w: Weight) -> SqlResult<i64> {
     Ok(w as i64)
 }
 
+// Creates a cast function from an interval to an integer
+macro_rules! cast_interval_to_integer {
+    ($result_type: ty, $type_name: ident, $arg_type: ty, $intermediate_type: ty, $method: ident) => {
+        ::paste::paste! {
+            #[doc(hidden)]
+            pub fn [<cast_to_ $result_type _ $type_name >](value: $arg_type) -> SqlResult<$result_type> {
+                [< cast_to_ $result_type _ $intermediate_type >]( value. $method() )
+            }
+
+            cast_function!($result_type, $result_type, $type_name, $arg_type);
+        }
+    }
+}
+
+cast_interval_to_integer!(i8, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(i16, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(i32, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(i64, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(u8, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(u16, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(u32, LongInterval_YEARS, LongInterval, i32, years);
+cast_interval_to_integer!(u64, LongInterval_YEARS, LongInterval, i32, years);
+
+cast_interval_to_integer!(i8, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(i16, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(i32, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(i64, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(u8, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(u16, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(u32, LongInterval_MONTHS, LongInterval, i32, months);
+cast_interval_to_integer!(u64, LongInterval_MONTHS, LongInterval, i32, months);
+
+cast_interval_to_integer!(i8, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(i16, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(i32, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(i64, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(u8, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(u16, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(u32, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+cast_interval_to_integer!(u64, ShortInterval_SECONDS, ShortInterval, i64, seconds);
+
+cast_interval_to_integer!(i8, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(i16, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(i32, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(i64, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(u8, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(u16, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(u32, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+cast_interval_to_integer!(u64, ShortInterval_MINUTES, ShortInterval, i64, minutes);
+
+cast_interval_to_integer!(i8, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(i16, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(i32, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(i64, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(u8, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(u16, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(u32, ShortInterval_HOURS, ShortInterval, i64, hours);
+cast_interval_to_integer!(u64, ShortInterval_HOURS, ShortInterval, i64, hours);
+
+cast_interval_to_integer!(i8, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(i16, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(i32, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(i64, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(u8, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(u16, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(u32, ShortInterval_DAYS, ShortInterval, i64, days);
+cast_interval_to_integer!(u64, ShortInterval_DAYS, ShortInterval, i64, days);
+
 #[doc(hidden)]
-pub fn cast_to_i8_LongInterval_YEARS(value: LongInterval) -> SqlResult<i8> {
-    cast_to_i8_i32(value.years())
+pub fn cast_to_SqlDecimal_LongInterval_YEARS<const P: usize, const S: usize>(
+    value: LongInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    cast_to_SqlDecimal_i32::<P, S>(value.years())
 }
 
 #[doc(hidden)]
-pub fn cast_to_i8_LongInterval_MONTHS(value: LongInterval) -> SqlResult<i8> {
-    cast_to_i8_i32(value.months())
+pub fn cast_to_SqlDecimal_LongInterval_MONTHS<const P: usize, const S: usize>(
+    value: LongInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    cast_to_SqlDecimal_i32::<P, S>(value.months())
+}
+
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, LongInterval_YEARS, LongInterval);
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, LongInterval_MONTHS, LongInterval);
+
+fn convert_to_SqlDecimal_ShortInterval<const P: usize, const S: usize>(
+    value: ShortInterval,
+    divider: i64,
+) -> SqlResult<SqlDecimal<P, S>> {
+    let v = DynamicDecimal::from(value.microseconds());
+    let num = DynamicDecimal::from(divider);
+    let div = match v.checked_div(&num) {
+        None => Err(SqlRuntimeError::from_string(format!(
+            "Error converting {value} to DECIMAL",
+        )))?,
+        Some(result) => result,
+    };
+    feldera_fxp::Fixed::<P, S>::try_from(div).map_err(|e| {
+        SqlRuntimeError::from_string(format!(
+            "Overflow during conversion of {value} to DECIMAL: {}",
+            e
+        ))
+    })
 }
 
 #[doc(hidden)]
-pub fn cast_to_i16_LongInterval_YEARS(value: LongInterval) -> SqlResult<i16> {
-    cast_to_i16_i32(value.years())
+pub fn cast_to_SqlDecimal_ShortInterval_SECONDS<const P: usize, const S: usize>(
+    value: ShortInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    convert_to_SqlDecimal_ShortInterval::<P, S>(value, 1_000_000)
 }
 
 #[doc(hidden)]
-pub fn cast_to_i16_LongInterval_MONTHS(value: LongInterval) -> SqlResult<i16> {
-    cast_to_i16_i32(value.months())
+pub fn cast_to_SqlDecimal_ShortInterval_MINUTES<const P: usize, const S: usize>(
+    value: ShortInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    convert_to_SqlDecimal_ShortInterval::<P, S>(value, 60 * 1_000_000)
 }
 
 #[doc(hidden)]
-pub fn cast_to_i32_LongInterval_YEARS(value: LongInterval) -> SqlResult<i32> {
-    Ok(value.years())
+pub fn cast_to_SqlDecimal_ShortInterval_HOURS<const P: usize, const S: usize>(
+    value: ShortInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    convert_to_SqlDecimal_ShortInterval::<P, S>(value, 60 * 60 * 1_000_000i64)
 }
 
 #[doc(hidden)]
-pub fn cast_to_i32_LongInterval_MONTHS(value: LongInterval) -> SqlResult<i32> {
-    Ok(value.months())
+pub fn cast_to_SqlDecimal_ShortInterval_DAYS<const P: usize, const S: usize>(
+    value: ShortInterval,
+) -> SqlResult<SqlDecimal<P, S>> {
+    convert_to_SqlDecimal_ShortInterval::<P, S>(value, 24 * 60 * 60 * 1_000_000i64)
 }
 
-#[doc(hidden)]
-pub fn cast_to_i64_LongInterval_YEARS(value: LongInterval) -> SqlResult<i64> {
-    Ok(value.years() as i64)
-}
-
-#[doc(hidden)]
-pub fn cast_to_i64_LongInterval_MONTHS(value: LongInterval) -> SqlResult<i64> {
-    Ok(value.months() as i64)
-}
-
-#[doc(hidden)]
-pub fn cast_to_u8_LongInterval_YEARS(value: LongInterval) -> SqlResult<u8> {
-    cast_to_u8_i32(value.years())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u8_LongInterval_MONTHS(value: LongInterval) -> SqlResult<u8> {
-    cast_to_u8_i32(value.months())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u16_LongInterval_YEARS(value: LongInterval) -> SqlResult<u16> {
-    cast_to_u16_i32(value.years())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u16_LongInterval_MONTHS(value: LongInterval) -> SqlResult<u16> {
-    cast_to_u16_i32(value.months())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u32_LongInterval_YEARS(value: LongInterval) -> SqlResult<u32> {
-    cast_to_u32_i32(value.years())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u32_LongInterval_MONTHS(value: LongInterval) -> SqlResult<u32> {
-    cast_to_u32_i32(value.months())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u64_LongInterval_YEARS(value: LongInterval) -> SqlResult<u64> {
-    cast_to_u64_i32(value.years())
-}
-
-#[doc(hidden)]
-pub fn cast_to_u64_LongInterval_MONTHS(value: LongInterval) -> SqlResult<u64> {
-    cast_to_u64_i32(value.months())
-}
-
-cast_function!(i8, i8, LongInterval_MONTHS, LongInterval);
-cast_function!(i8, i8, LongInterval_YEARS, LongInterval);
-cast_function!(i16, i16, LongInterval_MONTHS, LongInterval);
-cast_function!(i16, i16, LongInterval_YEARS, LongInterval);
-cast_function!(i32, i32, LongInterval_MONTHS, LongInterval);
-cast_function!(i32, i32, LongInterval_YEARS, LongInterval);
-cast_function!(i64, i64, LongInterval_MONTHS, LongInterval);
-cast_function!(i64, i64, LongInterval_YEARS, LongInterval);
-
-cast_function!(u8, u8, LongInterval_MONTHS, LongInterval);
-cast_function!(u8, u8, LongInterval_YEARS, LongInterval);
-cast_function!(u16, u16, LongInterval_MONTHS, LongInterval);
-cast_function!(u16, u16, LongInterval_YEARS, LongInterval);
-cast_function!(u32, u32, LongInterval_MONTHS, LongInterval);
-cast_function!(u32, u32, LongInterval_YEARS, LongInterval);
-cast_function!(u64, u64, LongInterval_MONTHS, LongInterval);
-cast_function!(u64, u64, LongInterval_YEARS, LongInterval);
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, ShortInterval_SECONDS, ShortInterval);
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, ShortInterval_MINUTES, ShortInterval);
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, ShortInterval_HOURS, ShortInterval);
+cast_function!(SqlDecimal <const P: usize, const S: usize>, SqlDecimal<P, S>, ShortInterval_DAYS, ShortInterval);
 
 //////// casts to Short interval
 
@@ -1834,13 +1881,38 @@ pub fn cast_to_ShortInterval_DAYS_i32(value: i32) -> SqlResult<ShortInterval> {
 
 #[doc(hidden)]
 pub fn cast_to_ShortInterval_DAYS_i64(value: i64) -> SqlResult<ShortInterval> {
-    let val = value.checked_mul(86400 * 1000);
+    let val = value.checked_mul(86400 * 1000 * 1000);
     match val {
         None => Err(SqlRuntimeError::from_string(format!(
             "Overflow during conversion of {value} to INTERVAL DAYS"
         ))),
-        Some(value) => Ok(ShortInterval::from_milliseconds(value)),
+        Some(value) => Ok(ShortInterval::from_microseconds(value)),
     }
+}
+
+fn convert_to_ShortInterval_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+    multiplier: i64,
+    kind: &'static str,
+) -> SqlResult<ShortInterval> {
+    let dd = DynamicDecimal::from(value);
+    let mul = DynamicDecimal::from(multiplier);
+    let val = dd.mul(mul);
+    i64::try_from(val)
+        .map(ShortInterval::from_microseconds)
+        .map_err(|e| {
+            SqlRuntimeError::from_string(format!(
+                "Overflow during conversion of {value} to INTERVAL {}: {}",
+                kind, e
+            ))
+        })
+}
+
+#[doc(hidden)]
+pub fn cast_to_ShortInterval_DAYS_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<ShortInterval> {
+    convert_to_ShortInterval_SqlDecimal::<P, S>(value, 86400i64 * 1000 * 1000, "DAYS")
 }
 
 #[doc(hidden)]
@@ -1873,6 +1945,13 @@ pub fn cast_to_ShortInterval_HOURS_i64(value: i64) -> SqlResult<ShortInterval> {
 }
 
 #[doc(hidden)]
+pub fn cast_to_ShortInterval_HOURS_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<ShortInterval> {
+    convert_to_ShortInterval_SqlDecimal::<P, S>(value, 3600i64 * 1000 * 1000, "DAYS")
+}
+
+#[doc(hidden)]
 #[inline]
 pub fn cast_to_ShortInterval_MINUTES_i8(value: i8) -> SqlResult<ShortInterval> {
     cast_to_ShortInterval_MINUTES_i64(value as i64)
@@ -1902,6 +1981,13 @@ pub fn cast_to_ShortInterval_MINUTES_i64(value: i64) -> SqlResult<ShortInterval>
 }
 
 #[doc(hidden)]
+pub fn cast_to_ShortInterval_MINUTES_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<ShortInterval> {
+    convert_to_ShortInterval_SqlDecimal::<P, S>(value, 60 * 1_000_000, "MINUTES")
+}
+
+#[doc(hidden)]
 #[inline]
 pub fn cast_to_ShortInterval_SECONDS_i8(value: i8) -> SqlResult<ShortInterval> {
     cast_to_ShortInterval_SECONDS_i64(value as i64)
@@ -1928,6 +2014,13 @@ pub fn cast_to_ShortInterval_SECONDS_i64(value: i64) -> SqlResult<ShortInterval>
         ))),
         Some(value) => Ok(ShortInterval::from_milliseconds(value)),
     }
+}
+
+#[doc(hidden)]
+pub fn cast_to_ShortInterval_SECONDS_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<ShortInterval> {
+    convert_to_ShortInterval_SqlDecimal::<P, S>(value, 1_000_000, "SECONDS")
 }
 
 #[doc(hidden)]
@@ -2082,35 +2175,41 @@ cast_function!(ShortInterval_DAYS, ShortInterval, i8, i8);
 cast_function!(ShortInterval_DAYS, ShortInterval, i16, i16);
 cast_function!(ShortInterval_DAYS, ShortInterval, i32, i32);
 cast_function!(ShortInterval_DAYS, ShortInterval, i64, i64);
-cast_function!(ShortInterval_HOURS, ShortInterval, i8, i8);
-cast_function!(ShortInterval_HOURS, ShortInterval, i16, i16);
-cast_function!(ShortInterval_HOURS, ShortInterval, i32, i32);
-cast_function!(ShortInterval_HOURS, ShortInterval, i64, i64);
-cast_function!(ShortInterval_MINUTES, ShortInterval, i8, i8);
-cast_function!(ShortInterval_MINUTES, ShortInterval, i16, i16);
-cast_function!(ShortInterval_MINUTES, ShortInterval, i32, i32);
-cast_function!(ShortInterval_MINUTES, ShortInterval, i64, i64);
-cast_function!(ShortInterval_SECONDS, ShortInterval, i8, i8);
-cast_function!(ShortInterval_SECONDS, ShortInterval, i16, i16);
-cast_function!(ShortInterval_SECONDS, ShortInterval, i32, i32);
-cast_function!(ShortInterval_SECONDS, ShortInterval, i64, i64);
-
 cast_function!(ShortInterval_DAYS, ShortInterval, u8, u8);
 cast_function!(ShortInterval_DAYS, ShortInterval, u16, u16);
 cast_function!(ShortInterval_DAYS, ShortInterval, u32, u32);
 cast_function!(ShortInterval_DAYS, ShortInterval, u64, u64);
+cast_function!(ShortInterval_DAYS <const P: usize, const S: usize>, ShortInterval, SqlDecimal, SqlDecimal<P, S>);
+
+cast_function!(ShortInterval_HOURS, ShortInterval, i8, i8);
+cast_function!(ShortInterval_HOURS, ShortInterval, i16, i16);
+cast_function!(ShortInterval_HOURS, ShortInterval, i32, i32);
+cast_function!(ShortInterval_HOURS, ShortInterval, i64, i64);
 cast_function!(ShortInterval_HOURS, ShortInterval, u8, u8);
 cast_function!(ShortInterval_HOURS, ShortInterval, u16, u16);
 cast_function!(ShortInterval_HOURS, ShortInterval, u32, u32);
 cast_function!(ShortInterval_HOURS, ShortInterval, u64, u64);
+cast_function!(ShortInterval_HOURS <const P: usize, const S: usize>, ShortInterval, SqlDecimal, SqlDecimal<P, S>);
+
+cast_function!(ShortInterval_MINUTES, ShortInterval, i8, i8);
+cast_function!(ShortInterval_MINUTES, ShortInterval, i16, i16);
+cast_function!(ShortInterval_MINUTES, ShortInterval, i32, i32);
+cast_function!(ShortInterval_MINUTES, ShortInterval, i64, i64);
 cast_function!(ShortInterval_MINUTES, ShortInterval, u8, u8);
 cast_function!(ShortInterval_MINUTES, ShortInterval, u16, u16);
 cast_function!(ShortInterval_MINUTES, ShortInterval, u32, u32);
 cast_function!(ShortInterval_MINUTES, ShortInterval, u64, u64);
+cast_function!(ShortInterval_MINUTES <const P: usize, const S: usize>, ShortInterval, SqlDecimal, SqlDecimal<P, S>);
+
+cast_function!(ShortInterval_SECONDS, ShortInterval, i8, i8);
+cast_function!(ShortInterval_SECONDS, ShortInterval, i16, i16);
+cast_function!(ShortInterval_SECONDS, ShortInterval, i32, i32);
+cast_function!(ShortInterval_SECONDS, ShortInterval, i64, i64);
 cast_function!(ShortInterval_SECONDS, ShortInterval, u8, u8);
 cast_function!(ShortInterval_SECONDS, ShortInterval, u16, u16);
 cast_function!(ShortInterval_SECONDS, ShortInterval, u32, u32);
 cast_function!(ShortInterval_SECONDS, ShortInterval, u64, u64);
+cast_function!(ShortInterval_SECONDS <const P: usize, const S: usize>, ShortInterval, SqlDecimal, SqlDecimal<P, S>);
 
 //////// casts to ShortIntervalN
 
@@ -2159,6 +2258,14 @@ pub fn cast_to_LongInterval_YEARS_i64(value: i64) -> SqlResult<LongInterval> {
 }
 
 #[doc(hidden)]
+pub fn cast_to_LongInterval_YEARS_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<LongInterval> {
+    let value = cast_to_i32_SqlDecimal::<P, S>(value)?;
+    cast_to_LongInterval_YEARS_i32(value)
+}
+
+#[doc(hidden)]
 #[inline]
 pub fn cast_to_LongInterval_MONTHS_i8(value: i8) -> SqlResult<LongInterval> {
     cast_to_LongInterval_MONTHS_i32(value as i32)
@@ -2186,6 +2293,14 @@ pub fn cast_to_LongInterval_MONTHS_i64(value: i64) -> SqlResult<LongInterval> {
             )));
         }
     };
+    cast_to_LongInterval_MONTHS_i32(value)
+}
+
+#[doc(hidden)]
+pub fn cast_to_LongInterval_MONTHS_SqlDecimal<const P: usize, const S: usize>(
+    value: SqlDecimal<P, S>,
+) -> SqlResult<LongInterval> {
+    let value = cast_to_i32_SqlDecimal::<P, S>(value)?;
     cast_to_LongInterval_MONTHS_i32(value)
 }
 
@@ -2269,19 +2384,21 @@ cast_function!(LongInterval_YEARS, LongInterval, i8, i8);
 cast_function!(LongInterval_YEARS, LongInterval, i16, i16);
 cast_function!(LongInterval_YEARS, LongInterval, i32, i32);
 cast_function!(LongInterval_YEARS, LongInterval, i64, i64);
-cast_function!(LongInterval_MONTHS, LongInterval, i8, i8);
-cast_function!(LongInterval_MONTHS, LongInterval, i16, i16);
-cast_function!(LongInterval_MONTHS, LongInterval, i32, i32);
-cast_function!(LongInterval_MONTHS, LongInterval, i64, i64);
-
 cast_function!(LongInterval_YEARS, LongInterval, u8, u8);
 cast_function!(LongInterval_YEARS, LongInterval, u16, u16);
 cast_function!(LongInterval_YEARS, LongInterval, u32, u32);
 cast_function!(LongInterval_YEARS, LongInterval, u64, u64);
+cast_function!(LongInterval_YEARS <const P: usize, const S: usize>, LongInterval, SqlDecimal, SqlDecimal<P, S>);
+
+cast_function!(LongInterval_MONTHS, LongInterval, i8, i8);
+cast_function!(LongInterval_MONTHS, LongInterval, i16, i16);
+cast_function!(LongInterval_MONTHS, LongInterval, i32, i32);
+cast_function!(LongInterval_MONTHS, LongInterval, i64, i64);
 cast_function!(LongInterval_MONTHS, LongInterval, u8, u8);
 cast_function!(LongInterval_MONTHS, LongInterval, u16, u16);
 cast_function!(LongInterval_MONTHS, LongInterval, u32, u32);
 cast_function!(LongInterval_MONTHS, LongInterval, u64, u64);
+cast_function!(LongInterval_MONTHS <const P: usize, const S: usize>, LongInterval, SqlDecimal, SqlDecimal<P, S>);
 
 #[doc(hidden)]
 pub fn cast_to_LongInterval_YEARS_s(value: SqlString) -> SqlResult<LongInterval> {

--- a/crates/sqllib/src/interval.rs
+++ b/crates/sqllib/src/interval.rs
@@ -23,10 +23,10 @@ use crate::{Time, Timestamp};
 
 /// A ShortInterval can express a difference between two [Time]
 /// values, two [Date] values, or two [Timestamp] values.  The
-/// representation is a (positive or negative) number of milliseconds.
+/// representation is a (positive or negative) number of microseconds.
 /// While there are functions that can extract nanosecond-precision
 /// values from a ShortInterval, the precision is always limited to
-/// milliseconds.
+/// microseconds.
 #[derive(
     Debug,
     Default,
@@ -111,10 +111,34 @@ impl ShortInterval {
 
     /// Extract the length of the interval in nanoseconds.  The result
     /// can be negative.  The granularity of the representation is
-    /// actually milliseconds, so this function will always return a
-    /// number that is a multiple of 1 million.
+    /// actually microseconds, so this function will always return a
+    /// number that is a multiple of 1000.
     pub fn nanoseconds(&self) -> i64 {
         self.microseconds * 1_000
+    }
+
+    /// Extract the length of the interval in milliseconds.  The
+    /// result can be negative.
+    pub fn seconds(&self) -> i64 {
+        self.microseconds / 1_000_000
+    }
+
+    /// Extract the length of the interval in minutes.  The
+    /// result can be negative.
+    pub fn minutes(&self) -> i64 {
+        self.microseconds / (60 * 1_000_000)
+    }
+
+    /// Extract the length of the interval in minutes.  The
+    /// result can be negative.
+    pub fn hours(&self) -> i64 {
+        self.microseconds / (60 * 60 * 1_000_000i64)
+    }
+
+    /// Extract the length of the interval in minutes.  The
+    /// result can be negative.
+    pub fn days(&self) -> i64 {
+        self.microseconds / (24 * 60 * 60 * 1_000_000i64)
     }
 }
 
@@ -152,7 +176,6 @@ pub fn to_bound_ShortInterval_Date_u64(value: &ShortInterval) -> u64 {
 /// This function is used in rolling window computations, to compute a window bound.
 /// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Timestamp_u128(value: &ShortInterval) -> u128 {
-    // express value in milliseconds
     value.microseconds as u128
 }
 
@@ -160,7 +183,6 @@ pub fn to_bound_ShortInterval_Timestamp_u128(value: &ShortInterval) -> u128 {
 /// This function is used in rolling window computations, to compute a window bound.
 /// Window bounds are always positive.
 pub fn to_bound_ShortInterval_Timestamp_u64(value: &ShortInterval) -> u64 {
-    // express value in milliseconds
     value.microseconds as u64
 }
 

--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -77,12 +77,107 @@ use dbsp::{
     typed_batch::{SpineSnapshot, TypedBatch},
     utils::*,
 };
-use num::PrimInt;
+use num::{PrimInt, Signed};
 use num_traits::Pow;
 use std::marker::PhantomData;
 use std::ops::{Deref, Neg};
 use std::sync::OnceLock;
 use std::{fmt::Debug, sync::atomic::Ordering};
+
+#[allow(dead_code)]
+#[doc(hidden)]
+pub(crate) fn div_round_nearest<T>(a: T, b: T) -> T
+where
+    T: PrimInt + Signed,
+{
+    // Code tries to avoid overflows
+    debug_assert!(b > T::zero());
+    let q = a / b;
+    let r = (a % b).abs();
+    if r.is_zero() {
+        return q;
+    }
+
+    if r > b - r {
+        q + a.signum()
+    } else if r < b - r {
+        q
+    } else {
+        // Tie
+        let two = T::one() + T::one();
+        if (q % two).is_zero() {
+            q
+        } else {
+            q + a.signum()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------
+    // divisor = 1000
+    // -----------------------------
+    #[test]
+    fn test_rounding_1000() {
+        assert_eq!(div_round_nearest(0, 1000), 0);
+        assert_eq!(div_round_nearest(1, 1000), 0);
+        assert_eq!(div_round_nearest(499, 1000), 0);
+        assert_eq!(div_round_nearest(500, 1000), 0);
+        assert_eq!(div_round_nearest(501, 1000), 1);
+        assert_eq!(div_round_nearest(999, 1000), 1);
+        assert_eq!(div_round_nearest(1000, 1000), 1);
+        assert_eq!(div_round_nearest(1499, 1000), 1);
+        assert_eq!(div_round_nearest(1500, 1000), 2);
+        assert_eq!(div_round_nearest(1501, 1000), 2);
+
+        assert_eq!(div_round_nearest(-1, 1000), 0);
+        assert_eq!(div_round_nearest(-499, 1000), 0);
+        assert_eq!(div_round_nearest(-500, 1000), 0);
+        assert_eq!(div_round_nearest(-501, 1000), -1);
+        assert_eq!(div_round_nearest(-999, 1000), -1);
+        assert_eq!(div_round_nearest(-1000, 1000), -1);
+        assert_eq!(div_round_nearest(-1499, 1000), -1);
+        assert_eq!(div_round_nearest(-1500, 1000), -2);
+        assert_eq!(div_round_nearest(-1501, 1000), -2);
+    }
+
+    #[test]
+    fn test_extremes() {
+        assert_eq!(div_round_nearest(i64::MAX, 1000), 9_223_372_036_854_776);
+        assert_eq!(div_round_nearest(i64::MIN, 1000), -9_223_372_036_854_776);
+    }
+
+    #[test]
+    fn test_rounding_7() {
+        assert_eq!(div_round_nearest(0, 7), 0);
+        assert_eq!(div_round_nearest(1, 7), 0);
+        assert_eq!(div_round_nearest(2, 7), 0);
+        assert_eq!(div_round_nearest(3, 7), 0);
+        assert_eq!(div_round_nearest(4, 7), 1);
+        assert_eq!(div_round_nearest(5, 7), 1);
+        assert_eq!(div_round_nearest(6, 7), 1);
+        assert_eq!(div_round_nearest(7, 7), 1);
+        assert_eq!(div_round_nearest(8, 7), 1);
+        assert_eq!(div_round_nearest(9, 7), 1);
+        assert_eq!(div_round_nearest(10, 7), 1);
+        assert_eq!(div_round_nearest(11, 7), 2);
+
+        assert_eq!(div_round_nearest(-1, 7), 0);
+        assert_eq!(div_round_nearest(-2, 7), 0);
+        assert_eq!(div_round_nearest(-3, 7), 0);
+        assert_eq!(div_round_nearest(-4, 7), -1);
+        assert_eq!(div_round_nearest(-5, 7), -1);
+        assert_eq!(div_round_nearest(-6, 7), -1);
+        assert_eq!(div_round_nearest(-7, 7), -1);
+        assert_eq!(div_round_nearest(-8, 7), -1);
+        assert_eq!(div_round_nearest(-9, 7), -1);
+        assert_eq!(div_round_nearest(-10, 7), -1);
+        assert_eq!(div_round_nearest(-11, 7), -2);
+    }
+}
 
 /// Convert a value of a SQL data type to an integer
 /// that preserves ordering.  Used for partitioned_rolling_aggregates

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/CastTests.java
@@ -592,6 +592,7 @@ public class CastTests extends SqlIoTest {
 
         // Rows and columns match the array of types above.
         final CanConvert[][] legal = {
+//             <--integers----------->                      <-Long-> <---short------------------->
 // To:   N, B, I8,16,32,64,U8,U6,U3,U6,De,r, d, c, v, b, vb,ym,y, m, d, h, dh,m,dm,hm, s, ds,hs,ms,t, ts,dt,ro,a, m, V, U
 /*From                                                                                                                    */
 /* N */{ F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, F },
@@ -638,10 +639,25 @@ public class CastTests extends SqlIoTest {
         Assert.assertEquals(types.length, legal[0].length);
         StringBuilder program = new StringBuilder();
         boolean first = true;
+        program.append("CREATE LOCAL VIEW T AS SELECT ");
+        for (int i = 0; i < types.length; i++) {
+            if (!first)
+                program.append(", ");
+            first = false;
+            if (i > 0)
+                program.append("CAST(");
+            program.append(values[i]);
+            if (i > 0)
+                program.append(" AS ").append(types[i]).append(")");
+            program.append(" AS col").append(i).append("\n");
+        }
+        program.append(";\n");
+
+        first = true;
         program.append("CREATE VIEW V AS SELECT ");
         for (int i = 0; i < types.length; i++) {
             String type = types[i];
-            String value = values[i];
+            String value = "col" + i;
             if (legal[i][i] == CanConvert.F)
                 continue;
             if (!first)
@@ -649,10 +665,11 @@ public class CastTests extends SqlIoTest {
             first = false;
             program.append("CAST(").append(value).append(" AS ").append(type).append(")\n");
         }
-        program.append(";\n");
+        program.append(" FROM T;\n");
 
         for (int i = 0; i < types.length; i++) {
             String value = values[i];
+            String coli = "col" + i;
             String from = types[i];
             if (!Linq.any(legal[i], p -> p == T)) continue;
             program.append("CREATE VIEW V").append(i).append(" AS SELECT ");
@@ -679,13 +696,16 @@ public class CastTests extends SqlIoTest {
                     // Special case
                     program.append(value);
                 else
-                    program.append("CAST(").append(value).append(" AS ").append(from).append(")");
+                    program.append("CAST(").append(coli).append(" AS ").append(from).append(")");
                 program.append(" AS ").append(to).append(")");
                 program.append("\n");
             }
-            program.append(";\n");
+            program.append(" FROM T;\n");
         }
         // Disable Calcite optimizations so it doesn't do constant-folding
+        // Despite this, this program still does not generate all possible cast com
+        // binations:
+        // for some interval casts it generates reinterpret casts.
         CompilerOptions options = this.testOptions();
         options.languageOptions.optimizationLevel = 0;
         DBSPCompiler compiler = new DBSPCompiler(options);
@@ -734,5 +754,50 @@ public class CastTests extends SqlIoTest {
                  r
                 -----
                  1000""");
+    }
+
+    @Test
+    public void issue6257() {
+        // Calcite rounds by truncating, so we are tied to that behavior
+        this.qs("""
+                SELECT CAST(INTERVAL '10' DAY AS BIGINT);
+                 r
+                ---
+                 10
+                (1 row)
+                
+                SELECT SAFE_CAST(INTERVAL '1000' DAY AS TINYINT);
+                 r
+                ---
+                NULL
+                (1 row)
+                
+                SELECT CAST(INTERVAL '10.6' SECONDS AS INT);
+                 r
+                ---
+                 10
+                (1 row)
+                
+                SELECT CAST(INTERVAL '10.135' SECONDS AS DECIMAL(10, 2));
+                 r
+                ---
+                 10.13
+                (1 row)
+                
+                SELECT CAST(INTERVAL '-10.135' SECONDS AS DECIMAL(10, 2));
+                 r
+                ---
+                 -10.13
+                (1 row)
+                
+                SELECT SAFE_CAST(INTERVAL '1000.123' SECONDS AS DECIMAL(2, 2));
+                 r
+                ---
+                NULL
+                (1 row)""");
+        this.statementsFailingInCompilation("CREATE VIEW V AS SELECT CAST(INTERVAL '10' MONTHS AS DOUBLE)",
+                "Cast function cannot convert value of type INTERVAL MONTH NOT NULL to type DOUBLE NOT NULL");
+        this.statementsFailingInCompilation("CREATE VIEW V AS SELECT CAST(INTERVAL '10' SECONDS AS REAL)",
+                "Cast function cannot convert value of type INTERVAL SECOND NOT NULL to type REAL NOT NULL");
     }
 }


### PR DESCRIPTION
We were still missing some cast functions. Our test cases would never generated these calls, because Calcite desugars them to something else, so I thought they are not necessary, but it turns out that writing code differently does need these functions.

Fixes #6257

### Describe Incompatible Changes

Converting Intervals to seconds now rounds instead of truncating. This was not documented, so I don't think we can call it officially a breaking change.
