### PR TITLE
[web-console] Reconcile high-throughput stream parsing behavior

### DIFF
--- a/js-packages/web-console/src/lib/components/adhoc/Query.svelte
+++ b/js-packages/web-console/src/lib/components/adhoc/Query.svelte
@@ -185,7 +185,9 @@
                   {#if result.columns.length}
                     <thead>
                       <tr>
-                        <th class="bg-white-dark sticky top-0 z-10 pl-2 font-light {itemHeight}">#</th>
+                        <th class="bg-white-dark sticky top-0 z-10 pl-2 font-light {itemHeight}"
+                          >#</th
+                        >
                         {#each result.columns as column}
                           <SqlColumnHeader
                             {column}

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineMemoryGraph.svelte
@@ -40,7 +40,7 @@
 
   const pipelineName = $derived(pipeline.current.name)
 
-  const valueMax = $derived(metrics.length ? Math.max(...metrics.map((v) => v.m.toNumber())) : 0)
+  const valueMax = $derived(metrics.length ? Math.max(...metrics.map((v) => v.m)) : 0)
   const yMaxStep = $derived(2 ** Math.ceil(Math.log2(valueMax * 1.25)))
   const yMax = $derived(valueMax !== 0 ? yMaxStep : 1024 * 2048)
   const yMin = 0
@@ -61,8 +61,8 @@
       series: [
         {
           data: metrics.map((m) => ({
-            name: m.t.toString(),
-            value: tuple(m.t.toNumber(), m.m.toNumber() ?? 0)
+            id: m.t,
+            value: tuple(m.t, m.m ?? 0)
           }))
         }
       ],
@@ -159,8 +159,8 @@
           opacity: 0
         },
         data: metrics.map((m) => ({
-          name: m.t.toString(),
-          value: tuple(m.t.toNumber(), m.m.toNumber() ?? 0)
+          id: m.t,
+          value: tuple(m.t, m.m ?? 0)
         })),
         markLine: {
           animation: false,
@@ -201,7 +201,7 @@
 
 <div class="absolute h-full w-full py-4">
   <div class="px-4 pb-2">
-    Used memory: {humanSize(metrics.at(-1)?.m.toNumber() ?? 0)}
+    Used memory: {humanSize(metrics.at(-1)?.m ?? 0)}
   </div>
   {#key pipelineName}
     <Chart init={(dom, theme, opts) => (ref = init(dom, theme, opts))} {options} />

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineStorageGraph.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineStorageGraph.svelte
@@ -43,7 +43,7 @@
 
   const pipelineName = $derived(pipeline.current.name)
 
-  const valueMax = $derived(metrics.length ? Math.max(...metrics.map((v) => v.s.toNumber())) : 0)
+  const valueMax = $derived(metrics.length ? Math.max(...metrics.map((v) => v.s)) : 0)
   const yMaxStep = $derived(2 ** Math.ceil(Math.log2(valueMax * 1.25)))
   const yMax = $derived(valueMax !== 0 ? yMaxStep : 1024 * 2048)
   const yMin = 0
@@ -64,8 +64,8 @@
       series: [
         {
           data: metrics.map((m) => ({
-            name: m.t.toString(),
-            value: tuple(m.t.toNumber(), m.s.toNumber() ?? 0)
+            id: m.t,
+            value: tuple(m.t, m.s ?? 0)
           }))
         }
       ],
@@ -161,8 +161,8 @@
           opacity: 0
         },
         data: metrics.map((m) => ({
-          name: m.t.toString(),
-          value: tuple(m.t.toNumber(), m.s.toNumber() ?? 0)
+          id: m.t,
+          value: tuple(m.t, m.s ?? 0)
         })),
         markLine: {
           animation: false,
@@ -206,7 +206,7 @@
     <span>
       <span class="hidden sm:inline">Used storage:</span>
       <span class="inline sm:hidden">Storage:</span>
-      {humanSize(metrics.at(-1)?.s.toNumber() ?? 0)}
+      {humanSize(metrics.at(-1)?.s ?? 0)}
     </span>
     {@render headerAction?.()}
   </div>

--- a/js-packages/web-console/src/lib/components/layout/pipelines/PipelineThroughputGraph.svelte
+++ b/js-packages/web-console/src/lib/components/layout/pipelines/PipelineThroughputGraph.svelte
@@ -39,7 +39,10 @@
     ref.setOption({
       series: [
         {
-          data: throughput.series
+          data: throughput.series.map((p) => ({
+            id: p.value[0],
+            value: p.value
+          }))
         }
       ],
       xAxis: {
@@ -116,7 +119,10 @@
           opacity: 0
         },
         // svelte-ignore state_referenced_locally
-        data: throughput.series
+        data: throughput.series.map((p) => ({
+          id: p.value[0],
+          value: p.value
+        }))
       }
     ]
   }

--- a/js-packages/web-console/src/lib/components/pipelines/List.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/List.svelte.spec.ts
@@ -13,7 +13,11 @@ const pipelines = [thumb('orders'), thumb('payments'), thumb('fraud-detection')]
 
 // Each rendered pipeline is an <a>; the only other interactive elements are the
 // search box and the close button, so counting links counts visible pipelines.
-const visibleNames = () => page.getByRole('link').elements().map((el) => el.textContent?.trim())
+const visibleNames = () =>
+  page
+    .getByRole('link')
+    .elements()
+    .map((el) => el.textContent?.trim())
 
 describe('pipeline list search', () => {
   it('lists every pipeline before any search term is entered', async () => {

--- a/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/MonitoringPanel.svelte.spec.ts
@@ -12,8 +12,8 @@
  * file itself.
  */
 
-import { page, userEvent } from 'vitest/browser'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-svelte'
 
 // --- Mock the pipeline manager's log-stream fetch ----------------------------

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.test.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.test.ts
@@ -49,9 +49,9 @@ import { getExtendedPipeline, putPipeline } from '$lib/services/pipelineManager'
 import {
   cleanupPipeline,
   configureTestClient,
+  type ExtendedPipeline,
   startPipelineAndWaitForRunning,
-  waitForCompilation,
-  type ExtendedPipeline
+  waitForCompilation
 } from '$lib/services/testPipelineHelpers'
 import TabAdHocQuery from './TabAdHocQuery.svelte'
 

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabChangeStream.svelte
@@ -113,35 +113,37 @@
 
       const { cancel } = parseStream(
         result,
-        createBigNumberStreamParser<XgressEntry>({
-          paths: ['$.json_data.*'],
-          separator: ''
-        }),
+        newlineJsonDecoder<XgressEntry>(
+          createBigNumberStreamParser<XgressEntry>({
+            paths: ['$.json_data.*'],
+            separator: ''
+          }),
+          {
+            bufferSize: 4 * 1024 * 1024,
+            onBytesSkipped: (skippedBytes) => {
+              const cs = changeStream[tenantName][pipelineName]
+              // Coalesce consecutive skip markers for the same relation: if the row
+              // at the tail is already a skip marker tagged with this relation, just
+              // bump its byte count in place instead of pushing another row. Keeps
+              // the change-stream view from getting flooded with one-line "Skipped N bytes"
+              // entries when backpressure drops sustained traffic.
+              const lastRow = cs.rows.at(-1)
+              if (lastRow && 'skippedBytes' in lastRow && lastRow.relationName === relationName) {
+                lastRow.skippedBytes += skippedBytes
+              } else {
+                appendForRelation([{ relationName, skippedBytes }])
+              }
+              cs.totalSkippedBytes += skippedBytes
+            }
+          }
+        ),
         {
           pushChanges: (rows: XgressEntry[]) => {
             appendForRelation(rows as unknown as Row[], rows[0])
           },
-          onBytesSkipped: (skippedBytes) => {
-            const cs = changeStream[tenantName][pipelineName]
-            // Coalesce consecutive skip markers for the same relation: if the row at
-            // the tail is already a skip marker tagged with this relation, just bump
-            // its byte count in place instead of pushing another row. Keeps the
-            // change-stream view from getting flooded with one-line "Skipped N bytes"
-            // entries when backpressure drops sustained traffic.
-            const lastRow = cs.rows.at(-1)
-            if (lastRow && 'skippedBytes' in lastRow && lastRow.relationName === relationName) {
-              lastRow.skippedBytes += skippedBytes
-            } else {
-              appendForRelation([{ relationName, skippedBytes }])
-            }
-            cs.totalSkippedBytes += skippedBytes
-          },
           onParseEnded: () => {
             pipelinesRelations[tenantName][pipelineName][relationName].cancelStream = undefined
           }
-        },
-        {
-          bufferSize: 4 * 1024 * 1024
         }
       )
       return () => {
@@ -244,6 +246,7 @@
   import {
     appendRowsForRelation,
     createBigNumberStreamParser,
+    newlineJsonDecoder,
     parseStream
   } from '$lib/functions/pipelines/changeStream'
   import JSONbig from 'true-json-bigint'

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabLogs.svelte
@@ -28,9 +28,9 @@
   import { emptySearchState, type SearchState } from 'common-ui'
 
   import {
-    parseCancellable,
-    pushAsCircularBuffer,
-    SplitNewlineTransformStream
+    newlineTextDecoder,
+    parseStream,
+    pushAsCircularBuffer
   } from '$lib/functions/pipelines/changeStream'
   import { type ExtendedPipeline, type PipelineStatus } from '$lib/services/pipelineManager'
   import { usePipelineActionCallbacks } from '$lib/compositions/pipelines/usePipelineActionCallbacks.svelte'
@@ -159,8 +159,14 @@
         tryRestartStream(pipelineName, isServerOverloaded ? attempts + 1 : 0)
         return
       }
-      const { cancel } = parseCancellable(
+      const { cancel } = parseStream<string>(
         result,
+        newlineTextDecoder({
+          bufferSize: 16 * 1024 * 1024,
+          onBytesSkipped: (bytes) => {
+            streams[pipelineName].totalSkippedBytes += bytes
+          }
+        }),
         {
           pushChanges: (changes: string[]) => {
             const droppedNum = pushAsCircularBuffer(
@@ -179,14 +185,7 @@
               return
             }
             tryRestartStream(pipelineName, 0)
-          },
-          onBytesSkipped(bytes) {
-            streams[pipelineName].totalSkippedBytes += bytes
           }
-        },
-        new SplitNewlineTransformStream(),
-        {
-          bufferSize: 16 * 1024 * 1024
         }
       )
       streams[pipelineName] = {

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabPerformance.svelte
@@ -23,11 +23,9 @@
   import { formatDateTime, formatQty } from '$lib/functions/format'
   import { useElapsedTime } from '$lib/compositions/common/useElapsedTime'
   import type { PipelineMetrics } from '$lib/functions/pipelineMetrics'
-  import {
-    createBigNumberStreamParser,
-    parseStream,
-    pushAsCircularBuffer
-  } from '$lib/functions/pipelines/changeStream'
+  import { pushAsCircularBuffer } from '$lib/functions/pipelines/changeStream'
+  import { JSONParser } from '@streamparser/json-whatwg'
+  import type { ParsedElementInfo } from '@streamparser/json/utils/types/parsedElementInfo.js'
   import { getDeploymentStatusLabel, isMetricsAvailable } from '$lib/functions/pipelines/status'
   import type { CheckpointMetadata, CheckpointStatus } from '$lib/services/manager'
   import type { ExtendedPipeline } from '$lib/services/pipelineManager'
@@ -79,56 +77,62 @@
 
   let cancelStream: (() => void) | undefined
 
-  const endMetricsStream = (id?: string) => {
+  const endMetricsStream = () => {
     cancelStream?.()
     cancelStream = undefined
     timeSeries = []
   }
   const startMetricsStream = async (api: PipelineManagerApi, targetPipelineName: string) => {
-    const result = await api.pipelineTimeSeriesStream(pipelineName)
+    const result = await api.pipelineTimeSeriesStream(targetPipelineName)
     if (result instanceof Error) {
       cancelStream = undefined
-      return undefined
+      return
     }
-    const { cancel } = parseStream(
-      result,
-      createBigNumberStreamParser<TimeSeriesEntry>({
-        paths: ['$'],
-        separator: ''
-      }),
-      {
-        pushChanges: (rows: TimeSeriesEntry[]) => {
-          pushAsCircularBuffer(
-            () => timeSeries,
-            63,
-            (v: TimeSeriesEntry) => v
-          )(rows)
-        },
-        onBytesSkipped: (skippedBytes) => {},
-        onParseEnded: () => {
-          if (metricsAvailable && cancelStream) {
-            endMetricsStream()
-            if (pipelineName !== targetPipelineName) {
-              return
-            }
-            startMetricsStream(api, targetPipelineName)
-          }
-        },
-        onNetworkError: () => {
-          if (metricsAvailable && cancelStream) {
-            endMetricsStream()
-            if (pipelineName !== targetPipelineName) {
-              return
-            }
-            startMetricsStream(api, targetPipelineName)
-          }
-        }
-      },
-      {
-        bufferSize: 8 * 1024 * 1024
-      }
+    // Not routed through `parseStream` — the load shedding is unnecessary
+    // metrics stream. Metric values parsed as JS numbers —
+    // record counts and byte sizes sit well below `Number.MAX_SAFE_INTEGER`.
+    const appendRow = pushAsCircularBuffer(
+      () => timeSeries,
+      63,
+      (v: TimeSeriesEntry) => v
     )
-    cancelStream = cancel
+    const abortCtrl = new AbortController()
+    cancelStream = () => {
+      abortCtrl.abort()
+      result.cancel()
+    }
+    try {
+      await result.stream
+        .pipeThrough(new JSONParser({ paths: ['$'], separator: '' }))
+        .pipeTo(
+          new WritableStream<ParsedElementInfo>({
+            write(chunk) {
+              appendRow([chunk.value as TimeSeriesEntry])
+            }
+          }),
+          { signal: abortCtrl.signal }
+        )
+    } catch (e) {
+      // Only log unexpected failures — `AbortError` from `cancelStream` is intentional.
+      if (!abortCtrl.signal.aborted) {
+        console.warn('Pipeline metrics stream error:', e)
+      }
+    }
+    if (cancelStream) {
+      cancelStream = undefined
+    }
+    // Restart on natural EOS / transient errors only. Skip if cancelled, if
+    // metrics are no longer available, or if the user navigated away mid-stream.
+    if (abortCtrl.signal.aborted) {
+      return
+    }
+    if (!metricsAvailable) {
+      return
+    }
+    if (pipelineName !== targetPipelineName) {
+      return
+    }
+    startMetricsStream(api, targetPipelineName)
   }
 
   const pipelineName = $derived(pipeline.current.name)

--- a/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/logSearch.svelte.spec.ts
@@ -5,7 +5,6 @@
  * touches `window` — so the pure functions ride along here rather than in a node project.
  */
 
-import { afterEach, describe, expect, it } from 'vitest'
 import {
   advanceSearch,
   applySearchHighlight,
@@ -13,9 +12,10 @@ import {
   emptySearchState,
   findMatchOffsets,
   findOccurrence,
-  searchPatternsEqual,
-  type SearchPattern
+  type SearchPattern,
+  searchPatternsEqual
 } from 'common-ui'
+import { afterEach, describe, expect, it } from 'vitest'
 
 const substr = (query: string, caseSensitive = false): SearchPattern => ({
   kind: 'substring',
@@ -151,7 +151,9 @@ const mount = (html: string) => {
 
 const highlightedText = () => {
   const hl = CSS.highlights.get(NAME)
-  if (!hl) return []
+  if (!hl) {
+    return []
+  }
   return [...hl].map((range) => range.toString())
 }
 

--- a/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
+++ b/js-packages/web-console/src/lib/functions/pipelineMetrics.ts
@@ -203,12 +203,9 @@ export const accumulatePipelineMetrics =
  * @returns Time series of throughput with smoothing window over 3 data intervals
  */
 export const calcPipelineThroughput = (metrics: TimeSeriesEntry[]) => {
-  const series = discreteDerivative(metrics, (n1, n0) => {
-    return {
-      name: n1.t.toFixed(),
-      value: tuple(n1.t.toNumber(), n1.r.minus(n0.r).toNumber())
-    }
-  })
+  const series = discreteDerivative(metrics, (n1, n0) => ({
+    value: tuple(n1.t, n1.r - n0.r)
+  }))
 
   const avgN = Math.min(Math.ceil(series.length / 5), 4)
   const valueMax = series.length

--- a/js-packages/web-console/src/lib/functions/pipelines/changeStream.spec.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/changeStream.spec.ts
@@ -14,10 +14,11 @@
 import { BigNumber } from 'bignumber.js'
 import { describe, expect, it } from 'vitest'
 import type { ChangeStreamData, Row } from '$lib/components/pipelines/editor/ChangeStream.svelte'
-import type { XgressEntry } from '$lib/services/pipelineManager'
 import {
   appendRowsForRelation,
   createBigNumberStreamParser,
+  newlineJsonDecoder,
+  newlineTextDecoder,
   parseStream,
   type StreamingJsonParser
 } from './changeStream'
@@ -39,15 +40,16 @@ const makeMockStream = (chunks: (Uint8Array | string)[]): ReadableStream<Uint8Ar
   })
 }
 
-// Runs `parseStream` over `chunks` and resolves the returned Promise once the stream has ended and the
-// last flush has fired. Returns everything the consumer would have observed.
+// Runs `parseStream` over `chunks` with a JSON decoder and resolves once the
+// stream has ended and the last flush has fired. Returns everything the
+// consumer would have observed.
 const runParseStream = <T>(
   chunks: (Uint8Array | string)[],
   parserOpts: Parameters<typeof createBigNumberStreamParser<T>>[0] = {
     paths: ['$'],
     separator: ''
   },
-  options?: Parameters<typeof parseStream<T>>[3]
+  options?: { bufferSize?: number; flushIntervalMs?: number }
 ) =>
   new Promise<{
     values: T[]
@@ -59,17 +61,19 @@ const runParseStream = <T>(
     const parser = createBigNumberStreamParser<T>(parserOpts)
     parseStream<T>(
       { stream: makeMockStream(chunks), cancel: () => {} },
-      parser,
+      newlineJsonDecoder<T>(parser, {
+        bufferSize: options?.bufferSize,
+        onBytesSkipped: (n) => skipped.push(n)
+      }),
       {
         pushChanges: (vs) => {
           for (const v of vs) {
             values.push(v)
           }
         },
-        onBytesSkipped: (n) => skipped.push(n),
         onParseEnded: () => resolve({ values, skipped, parser })
       },
-      options
+      { flushIntervalMs: options?.flushIntervalMs }
     )
   })
 
@@ -160,6 +164,127 @@ describe('parseStream', () => {
     // JS Number would coerce this to 1e19; BigNumber preserves it verbatim.
     expect(values[0].v.toFixed()).toBe(huge)
   })
+})
+
+// Same shape as `runParseStream`, but drives `newlineTextDecoder` over the same
+// `parseStream` orchestrator and collects the emitted line strings.
+const runNewlineTextDecoder = (
+  chunks: (Uint8Array | string)[],
+  options?: { bufferSize?: number; bufferWindowMs?: number; flushIntervalMs?: number }
+) =>
+  new Promise<{ values: string[]; skipped: number[] }>((resolve) => {
+    const values: string[] = []
+    const skipped: number[] = []
+    parseStream<string>(
+      { stream: makeMockStream(chunks), cancel: () => {} },
+      newlineTextDecoder({
+        bufferSize: options?.bufferSize,
+        bufferWindowMs: options?.bufferWindowMs,
+        onBytesSkipped: (n) => skipped.push(n)
+      }),
+      {
+        pushChanges: (vs) => {
+          for (const v of vs) {
+            values.push(v)
+          }
+        },
+        onParseEnded: () => resolve({ values, skipped })
+      },
+      { flushIntervalMs: options?.flushIntervalMs ?? 10 }
+    )
+  })
+
+describe('newlineTextDecoder', () => {
+  it('emits each LF-terminated line with the trailing newline preserved', async () => {
+    const { values, skipped } = await runNewlineTextDecoder(['a\nb\nc\n'])
+    expect(values).toEqual(['a\n', 'b\n', 'c\n'])
+    expect(skipped).toEqual([])
+  })
+
+  it('reassembles a line that straddles two network chunks', async () => {
+    // `bar` arrives in chunk 1 with no terminator; it must be held as leftover
+    // and joined to `baz\n` from chunk 2 to form a single `barbaz\n` line.
+    const { values, skipped } = await runNewlineTextDecoder(['foo\nbar', 'baz\nqux\n'])
+    expect(values).toEqual(['foo\n', 'barbaz\n', 'qux\n'])
+    expect(skipped).toEqual([])
+  })
+
+  it('preserves CRLF line terminators on each emitted line', async () => {
+    // The docstring explicitly promises CRLF is preserved — log viewers rely on
+    // it so that copy-out round-trips byte-for-byte to the server's framing.
+    const { values, skipped } = await runNewlineTextDecoder(['one\r\ntwo\r\nthree\r\n'])
+    expect(values).toEqual(['one\r\n', 'two\r\n', 'three\r\n'])
+    expect(skipped).toEqual([])
+  })
+
+  it('does not emit a trailing partial line that lacks a newline', async () => {
+    const { values, skipped } = await runNewlineTextDecoder(['done\ndangling'])
+    expect(values).toEqual(['done\n'])
+    // Partial-tail-on-close is the connection-cut case, not a shedding event.
+    expect(skipped).toEqual([])
+  })
+
+  it('sheds a whole parser chunk and reports its byte count when the budget is exceeded', async () => {
+    // Each 21-byte line is its own network chunk → its own parser chunk. With a
+    // 25-byte budget, the first parser chunk fits (0+21≤25); the next two each
+    // overflow (21+21>25) and must be dropped wholesale, with their lengths
+    // reported via `onBytesSkipped`. `bufferWindowMs` is set well beyond the
+    // test's wall-clock so the budget never resets mid-test.
+    const lineA = 'A'.repeat(20) + '\n'
+    const lineB = 'B'.repeat(20) + '\n'
+    const lineC = 'C'.repeat(20) + '\n'
+    const { values, skipped } = await runNewlineTextDecoder([lineA, lineB, lineC], {
+      bufferSize: 25,
+      bufferWindowMs: 60_000
+    })
+    expect(values).toEqual([lineA])
+    expect(skipped).toEqual([lineB.length, lineC.length])
+  })
+
+  it("emits an empty line as just '\\n' (the line terminator is the whole record)", async () => {
+    // Blank lines are real records in log streams — the forward scan must not
+    // collapse them into a no-op.
+    const { values, skipped } = await runNewlineTextDecoder(['a\n\nb\n'])
+    expect(values).toEqual(['a\n', '\n', 'b\n'])
+    expect(skipped).toEqual([])
+  })
+
+  it('reassembles a CRLF whose CR and LF arrive in different network chunks', async () => {
+    // The text decoder scans for '\n', so a lone '\r' at the end of a network
+    // chunk must be held as leftover and merged with the leading '\n' of the
+    // next chunk; the resulting line must still end in '\r\n' (not '\n' with
+    // the '\r' eaten or stranded as a partial record).
+    const { values, skipped } = await runNewlineTextDecoder(['foo\r', '\nbar\r\n'])
+    expect(values).toEqual(['foo\r\n', 'bar\r\n'])
+    expect(skipped).toEqual([])
+  })
+
+  it('handles a line whose terminator lands exactly on the parser-chunk boundary', async () => {
+    // `PARSER_CHUNK_TARGET_BYTES` is private to the module; the value 16 KiB is
+    // fixed by the implementation. Construct an input whose '\n' sits at
+    // position `target - 1`, so the post-newline `scan` cursor equals `target`
+    // exactly — the boundary case for the `scan >= target` break. The next
+    // parser chunk must resume cleanly at the byte immediately after the
+    // boundary and emit the following line in full.
+    const PARSER_CHUNK_TARGET_BYTES = 16 * 1024
+    const bigLine = 'A'.repeat(PARSER_CHUNK_TARGET_BYTES - 1) + '\n'
+    const tail = 'tail\n'
+    const { values, skipped } = await runNewlineTextDecoder([bigLine + tail])
+    expect(values).toEqual([bigLine, tail])
+    expect(skipped).toEqual([])
+  })
+
+  it('purges a runaway record whose unterminated leftover exceeds MAX_LINE_SIZE', async () => {
+    // `MAX_LINE_SIZE` is private to the module; the value 16 MiB is fixed by the
+    // implementation. One byte over the cap, with no newline anywhere, must
+    // trigger the purge: nothing is emitted and the full leftover length is
+    // reported through `onBytesSkipped`.
+    const MAX_LINE_SIZE = 16 * 1024 * 1024
+    const runaway = new Uint8Array(MAX_LINE_SIZE + 1).fill(0x58) // 'X'
+    const { values, skipped } = await runNewlineTextDecoder([runaway])
+    expect(values).toEqual([])
+    expect(skipped).toEqual([MAX_LINE_SIZE + 1])
+  }, 30_000)
 })
 
 describe('appendRowsForRelation', () => {

--- a/js-packages/web-console/src/lib/functions/pipelines/changeStream.ts
+++ b/js-packages/web-console/src/lib/functions/pipelines/changeStream.ts
@@ -1,4 +1,4 @@
-import { type JSONParser, type JSONParserOptions, Tokenizer, TokenParser } from '@streamparser/json'
+import { type JSONParserOptions, Tokenizer, TokenParser } from '@streamparser/json'
 import { BigNumber } from 'bignumber.js'
 import invariant from 'tiny-invariant'
 import type { ChangeStreamData, Row } from '$lib/components/pipelines/editor/ChangeStream.svelte'
@@ -53,8 +53,6 @@ export const createBigNumberStreamParser = <T>(
   }
 }
 
-const NEWLINE = 0x0a
-
 /**
  * Soft cap on how many bytes a single not-yet-newline-terminated record may accumulate.
  * Anything beyond this is reported as skipped — accepting unbounded leftovers would let
@@ -63,11 +61,11 @@ const NEWLINE = 0x0a
 const MAX_LINE_SIZE = 16 * 1024 * 1024
 
 /**
- * Soft target for the size of each `parser.write` call. The reader splits each
- * line-aligned block at the nearest newline below this size and yields between pieces,
- * so a single big network chunk can't monopolize the main thread.
+ * Soft target for the size of each `parser.write` call. The decoder slices the
+ * accumulated buffer at the nearest newline below this size and yields between
+ * parser chunks, so a single big network chunk can't monopolize the main thread.
  */
-const PARSE_PIECE_TARGET_BYTES = 16 * 1024
+const PARSER_CHUNK_TARGET_BYTES = 16 * 1024
 
 /**
  * Yields control back to the event loop so the UI can render and respond to input.
@@ -97,154 +95,124 @@ const yieldToEventLoop = (): Promise<void> => {
 }
 
 /**
- * Streams newline-delimited JSON from `source` and dispatches parsed values via
- * `pushChanges` on a fixed cadence.
+ * Pluggable byte-stream decoder. The orchestrator (`parseStream`) owns the
+ * lifecycle (reader scheduling, flush cadence, cancel, end-of-stream); the
+ * decoder is responsible only for turning bytes into typed items.
  *
- * Single sequential reader loop (no `TransformStream` pipe). One `setInterval` drives UI
- * updates. Overflow shedding uses a single counter: when the bytes of unflushed values
- * exceed `bufferSize`, the next line-aligned block is dropped and reported via
- * `onBytesSkipped`. Between network chunks the reader yields to a macrotask so the flush
- * timer (and the rest of the page) keep ticking.
+ * Decoders are stateful and **single-use**: each call to `decode` allocates a
+ * fresh reader, accumulator, and (if shedding) per-window budget. To enforce
+ * that statically, decoders are obtained via a `StreamFormatDecoderFactory`
+ * rather than passed directly — the orchestrator calls the factory exactly
+ * once. Each decoder also owns its own shedding policy and skip-event
+ * reporting: NDJSON keeps a per-flush-window byte budget and reports
+ * `onBytesSkipped`; arrow IPC counts admitted rows and reports `onRowsSkipped`.
+ */
+export interface StreamFormatDecoder<T> {
+  /**
+   * Drive the read loop. Must call `ctx.admit(item)` for each parsed item and
+   * `ctx.nextTick()` at safe yield points so the flush timer keeps firing.
+   * Must return when the source is exhausted or `ctx.isCancelled()` becomes
+   * true. Thrown errors are routed through `cbs.onDecodeError`.
+   */
+  decode(ctx: DecodeContext<T>): Promise<void>
+  /**
+   * Release any reader-side state. Called on consumer cancel before the
+   * pipeline aborts the underlying source. Async errors are swallowed.
+   */
+  cancel?(): void | Promise<void>
+}
+
+/** Single-use factory that produces a fresh, configured decoder per call. */
+export type StreamFormatDecoderFactory<T> = () => StreamFormatDecoder<T>
+
+export interface DecodeContext<T> {
+  /** Raw source — the decoder may call `getReader()` or hand it to a library. */
+  source: ReadableStream<Uint8Array<ArrayBufferLike>>
+  /** Queue an item for the orchestrator to flush on its own UI cadence. */
+  admit: (value: T) => void
+  /** Cooperative cancel flag — decoders should poll this and return promptly. */
+  isCancelled: () => boolean
+  /** Yield to a macrotask so timers (and the rest of the page) keep ticking. */
+  nextTick: () => Promise<void>
+}
+
+/**
+ * Format-agnostic stream orchestrator. Drives one sequential reader loop and
+ * one `setInterval` flush — the abstraction is in the decoder boundary, not
+ * the runtime topology.
  *
- * The parser is `write`/`reset`-shaped on purpose: each network chunk is split into one
- * line-aligned block (everything up to the last `\n`) and passed straight to
- * `parser.write(block)`. The parser handles the multi-line block as a series of
- * concatenated documents in a single call, which is much cheaper than tokenizing one
- * line at a time. If `write` throws, the parser is `reset()` — its internal state is
- * discarded, the block is reported as skipped, and the next block starts on a clean
- * parser. Because we never feed the parser anything that isn't a complete document,
- * structurally-invalid-JSON corruption cannot occur.
+ * Two cadences are at play, and they are intentionally independent:
  *
- * @param parser Long-lived parser, typically allocated once per stream.
- * @param options.bufferSize **Main tuning knob.** Per-flush-window byte budget for
- *   pieces admitted into the parser. When the running total of admitted bytes in the
- *   current window exceeds this, the next piece (up to `PARSE_PIECE_TARGET_BYTES`) is dropped (and
- *   reported via `onBytesSkipped`) instead of being parsed. The budget resets on every
- *   `flushIntervalMs` tick, so in steady state the worst-case stream-to-UI latency is
- *   approximately `bufferSize / parse_rate`.
+ *   - **Parse cadence** — set by the decoder. The decoder yields between
+ *     parser chunks (so a single big read can't monopolize the main thread)
+ *     and sheds load on its own window when the input arrives faster than
+ *     the parser can keep up. None of this is visible at this layer.
+ *   - **UI flush cadence** — `flushIntervalMs`. How often `pushChanges` fires
+ *     for the consumer. Tuned for human perception (rendering is cheap
+ *     relative to parsing, so the flush rate can be set purely for how
+ *     "smooth" updates should feel), not for keeping parsing alive.
  *
- *   - **Too many skipped records?** Raise `bufferSize`. More bytes are admitted before
- *     dropping kicks in, but the visible data lags further behind real time.
- *   - **Updates feel too slow / stale?** Lower `bufferSize`. The window's worth of
- *     CPU/UI work is capped sooner, dropping the excess; perceived latency falls but
- *     the skipped-bytes counter climbs.
- * @param options.flushIntervalMs How often `pushChanges` fires and `bufferSize` is
- *   released. Lower → smoother UI cadence and a tighter latency cap, but more frequent
- *   Svelte/DOM updates per second. Default 100ms.
+ * Why not a `TransformStream` pipe? Web-streams transforms run back-to-back
+ * via microtasks; without explicit macrotask hops between chunks, the flush
+ * timer (and every other `setTimeout`/`setInterval` on the page) starves
+ * behind the microtask queue and the UI appears to update only every few
+ * seconds on busy streams. Owning the loop ourselves keeps the cadence
+ * predictable.
+ *
+ * @param decoderFactory Called once per `parseStream` invocation to obtain a
+ *   fresh, single-use decoder. Reusing a configured factory across multiple
+ *   `parseStream` calls is safe — each call gets its own decoder.
+ * @param options.flushIntervalMs UI flush cadence: how often `pushChanges`
+ *   fires for the consumer. Lower → smoother UI updates, more frequent DOM
+ *   work. Default 100ms. Does **not** affect parsing throughput or
+ *   shedding — those are configured per decoder.
  */
 export const parseStream = <T>(
   source: {
     stream: ReadableStream<Uint8Array<ArrayBufferLike>>
     cancel: () => void
   },
-  parser: StreamingJsonParser<T>,
+  decoderFactory: StreamFormatDecoderFactory<T>,
   cbs: {
     pushChanges: (changes: T[]) => void
-    onBytesSkipped?: (bytes: number) => void
     onParseEnded?: (reason: 'ended' | 'cancelled') => void
-    onNetworkError?: (e: TypeError, injectValue: (value: T) => void) => void
+    onDecodeError?: (e: Error) => void
   },
-  options?: { bufferSize?: number; flushIntervalMs?: number }
-) => {
+  options?: { flushIntervalMs?: number }
+): { cancel: () => void } => {
   invariant(
     source.stream instanceof ReadableStream,
     `parseStream(): stream is ${JSON.stringify(source.stream)}`
   )
-  const maxPendingBytes = options?.bufferSize ?? 1_000_000
   const flushIntervalMs = options?.flushIntervalMs ?? 100
+  const decoder = decoderFactory()
 
   let cancelled = false
   let closedReason: null | 'ended' | 'cancelled' = null
   let endedReported = false
 
   const outBuffer: T[] = []
-  let pendingBytes = 0
+  const admit = (v: T) => {
+    outBuffer.push(v)
+  }
 
-  const reader = source.stream.getReader()
-
-  const readLoop = async () => {
-    const decoder = new TextDecoder('utf-8')
-    let leftover = ''
-    while (!cancelled) {
-      let chunk
-      try {
-        chunk = await reader.read()
-      } catch (e) {
-        cbs.onNetworkError?.(e as TypeError, (v) => outBuffer.push(v))
-        return
-      }
-      if (chunk.done) {
-        return
-      }
-      const text = leftover + decoder.decode(chunk.value, { stream: true })
-      const lastNewline = text.lastIndexOf('\n')
-      if (lastNewline === -1) {
-        if (text.length > MAX_LINE_SIZE) {
-          cbs.onBytesSkipped?.(text.length)
-          leftover = ''
-        } else {
-          leftover = text
-        }
-        continue
-      }
-      const block = text.slice(0, lastNewline + 1)
-      leftover = text.slice(lastNewline + 1)
-
-      // Feed the parser line-aligned pieces of bounded size and yield between them.
-      // The parser is the same instance across all pieces (zero per-piece allocation),
-      // but bounding the size of each `parser.write` call caps how long the main
-      // thread is blocked at a stretch. The pending-bytes check is per-piece, not
-      // per-block: if we admitted/dropped at block granularity, a single network
-      // chunk larger than `bufferSize` would be dropped even though the
-      // flush timer resets `pendingBytes` to 0 between yields and most pieces would
-      // fit individually. Dropping per-piece (each piece is itself line-aligned)
-      // keeps as much data flowing as the flush rate allows.
-      let cursor = 0
-      while (cursor < block.length) {
-        let end = Math.min(cursor + PARSE_PIECE_TARGET_BYTES, block.length)
-        if (end < block.length) {
-          const nl = block.lastIndexOf('\n', end - 1)
-          end = nl > cursor ? nl + 1 : block.length
-        }
-        const pieceLen = end - cursor
-        if (pendingBytes + pieceLen > maxPendingBytes) {
-          cbs.onBytesSkipped?.(pieceLen)
-        } else {
-          const piece = block.slice(cursor, end)
-          try {
-            const items = parser.write(piece)
-            for (const item of items) {
-              outBuffer.push(item)
-            }
-            pendingBytes += pieceLen
-          } catch {
-            parser.reset()
-            cbs.onBytesSkipped?.(pieceLen)
-          }
-        }
-        cursor = end
-        await yieldToEventLoop()
-        if (cancelled) {
-          return
-        }
-      }
-    }
+  const ctx: DecodeContext<T> = {
+    source: source.stream,
+    admit,
+    isCancelled: () => cancelled,
+    nextTick: yieldToEventLoop
   }
 
   setTimeout(async () => {
-    await readLoop()
+    try {
+      await decoder.decode(ctx)
+    } catch (e) {
+      cbs.onDecodeError?.(e instanceof Error ? e : new Error(String(e)))
+    }
     closedReason ??= 'ended'
   })
 
   const flushHandle = setInterval(() => {
-    // Reset the per-window byte budget unconditionally. `pendingBytes` represents
-    // "CPU work admitted since the last window", not "bytes currently in outBuffer",
-    // so even pieces that parsed successfully but produced no values (heartbeat
-    // lines with no `json_data`, lines that don't match the parser's path filter,
-    // etc.) need to release their budget on each tick. If we only reset alongside
-    // pushChanges, a stream of no-output pieces would silently exhaust the cap
-    // and the read loop would drop everything from then on.
-    pendingBytes = 0
     if (outBuffer.length) {
       const batch = outBuffer.slice()
       outBuffer.length = 0
@@ -261,8 +229,7 @@ export const parseStream = <T>(
     cancel: () => {
       cancelled = true
       closedReason = 'cancelled'
-      reader
-        .cancel()
+      Promise.resolve(decoder.cancel?.())
         .catch(() => {})
         .finally(() => {
           try {
@@ -276,321 +243,267 @@ export const parseStream = <T>(
 }
 
 /**
+ * Decoder for newline-delimited JSON. Two granularities are at play here:
  *
- * @param stream
- * @param pushChanges
- * @param options.bufferSize Soft byte budget for the line queue between the network reader
- *   and the JSON parser. When the queue exceeds this, incoming complete lines are dropped
- *   instead of enqueued — see `splitByNewlineWithOverflowShedding` for why this is sound.
- * @returns
+ *   - **Network chunk:** whatever bytes one `reader.read()` call returns.
+ *     Sized by the network, unpredictable, can be very large.
+ *   - **Parser chunk:** a line-aligned slice the decoder hands to
+ *     `parser.write` — bounded by `PARSER_CHUNK_TARGET_BYTES` so a single
+ *     synchronous parse can't monopolize the main thread.
+ *
+ * After each read, the accumulated buffer (prior leftover + the new network
+ * chunk) is sliced into parser chunks; whatever sits past the last newline
+ * used becomes the leftover for the next read. The parser is fed each parser
+ * chunk via `parser.write` (multi-document mode); on a throw, `parser.reset()`
+ * clears its partial state and the parser chunk is reported as skipped — the
+ * next parser chunk starts on a clean parser. Because we never feed the
+ * parser anything that isn't a complete document, structurally invalid JSON
+ * corruption cannot occur.
+ *
+ * **Load shedding.** Independent of UI flush cadence. The decoder caps the
+ * bytes it admits to the orchestrator to `bufferSize` per `bufferWindowMs`;
+ * anything past the cap is dropped (and reported via `onBytesSkipped`)
+ * instead of parsed. The budget resets on the decoder's own `setInterval`
+ * so even parser chunks that produced no admitted items still release their
+ * reservation. Failed parses do **not** consume the budget. In steady state,
+ * worst-case parser-to-admit latency is roughly `bufferSize / parse_rate`.
+ *
+ *  - **Too many skipped records?** Raise `bufferSize` (or lengthen
+ *    `bufferWindowMs`). More bytes are admitted before dropping kicks in,
+ *    but visible data lags further behind real time.
+ *  - **Parse spikes feel heavy?** Lower `bufferSize`. The window's CPU work
+ *    is capped sooner and the excess is shed.
+ *
+ * @param parser Streaming JSON parser; the factory uses it as-is, so caller
+ *   must ensure that any single parser instance is not shared across parallel
+ *   parseStream invocations (its tokenizer state cannot be safely interleaved).
+ * @param opts.bufferSize Bytes admitted per `bufferWindowMs`; default 1 MB.
+ * @param opts.bufferWindowMs Budget reset period; default 100ms. Independent
+ *   of the orchestrator's UI flush cadence.
+ * @param opts.onBytesSkipped Called when a parser chunk is dropped.
  */
-export const parseCancellable = <T, Transformer extends TransformStream<Uint8Array, T>>(
-  source: {
-    stream: ReadableStream<Uint8Array<ArrayBufferLike>>
-    cancel: () => void
-  },
-  cbs: {
-    pushChanges: (changes: T[]) => void
+export const newlineJsonDecoder = <T>(
+  parser: StreamingJsonParser<T>,
+  opts?: {
+    bufferSize?: number
+    bufferWindowMs?: number
     onBytesSkipped?: (bytes: number) => void
-    onParseEnded?: (reason: 'ended' | 'cancelled') => void
-    onNetworkError?: (e: TypeError, injectValue: (value: T) => void) => void
-  },
-  transformer: Transformer,
-  options?: { bufferSize?: number }
-) => {
-  invariant(
-    source.stream instanceof ReadableStream,
-    `parseCancellable(): stream is ${JSON.stringify(source.stream)}`
-  )
-  const reader = source.stream
-    .pipeThrough(
-      splitByNewlineWithOverflowShedding(options?.bufferSize ?? 1_000_000, cbs.onBytesSkipped)
-    )
-    .pipeThrough(transformer)
-    .getReader()
-  const resultBuffer = [] as T[]
-  setTimeout(async () => {
-    while (true) {
-      try {
-        const { done, value } = await reader.read()
-        if (done || value === undefined) {
-          break
-        }
-        resultBuffer.push(value)
-      } catch (e) {
-        cbs.onNetworkError?.(e as TypeError, (value: T) => resultBuffer.push(value))
-        cbs.onParseEnded?.('ended')
-        break
-      }
-    }
-  })
-  const flush = () => {
-    if (resultBuffer.length) {
-      cbs.pushChanges?.(resultBuffer)
-      resultBuffer.length = 0
-    }
   }
-  let closedReason: null | 'ended' | 'cancelled' = null
-  setTimeout(async () => {
-    reader.closed.then(
-      () => {
-        closedReason ??= 'ended'
+): StreamFormatDecoderFactory<T> => {
+  const maxPendingBytes = opts?.bufferSize ?? 1_000_000
+  const bufferWindowMs = opts?.bufferWindowMs ?? 100
+  const onBytesSkipped = opts?.onBytesSkipped ?? (() => {})
+
+  return () => {
+    let pendingBytes = 0
+    let reader: ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>> | null = null
+    let budgetTimer: ReturnType<typeof setInterval> | null = null
+
+    return {
+      async cancel() {
+        try {
+          await reader?.cancel()
+        } catch {
+          /* reader may already be closed */
+        }
       },
-      (e) => {
-        closedReason = 'ended'
-        cbs.onNetworkError?.(e, (value: T) => resultBuffer.push(value))
+      async decode(ctx) {
+        // `pendingBytes` represents "CPU work admitted since the last window",
+        // not "bytes currently in outBuffer", so it must be released on a
+        // fixed cadence — even when no items were produced (heartbeat lines
+        // with no `json_data`, path-filtered lines, etc.). Resetting only
+        // alongside successful admits would let a stream of no-output parser
+        // chunks silently exhaust the cap and stall the reader.
+        budgetTimer = setInterval(() => {
+          pendingBytes = 0
+        }, bufferWindowMs)
+        try {
+          reader = ctx.source.getReader()
+          const textDecoder = new TextDecoder('utf-8')
+          let leftover = ''
+          while (!ctx.isCancelled()) {
+            const networkChunk = await reader.read()
+            if (networkChunk.done) {
+              return
+            }
+            const text = leftover + textDecoder.decode(networkChunk.value, { stream: true })
+
+            // One newline search per parser chunk, none per network chunk. For
+            // each parser chunk, snap the cut back to the last newline below
+            // the target; if none exists (a single record longer than
+            // `PARSER_CHUNK_TARGET_BYTES`), search forward to the next newline
+            // so the parser chunk is still a complete document; if no newline
+            // is found at all, stop and hold the rest as leftover for the next
+            // read. The pending-bytes check is per parser chunk: dropping at
+            // network-chunk granularity would shed a single network chunk
+            // larger than `bufferSize` wholesale even though the flush timer
+            // resets `pendingBytes` between yields and most parser chunks
+            // would fit individually.
+            let cursor = 0
+            while (cursor < text.length) {
+              const target = Math.min(cursor + PARSER_CHUNK_TARGET_BYTES, text.length)
+              let nl = text.lastIndexOf('\n', target - 1)
+              if (nl < cursor) {
+                nl = text.indexOf('\n', target)
+                if (nl === -1) {
+                  break
+                }
+              }
+              const end = nl + 1
+              const parserChunkLen = end - cursor
+              if (pendingBytes + parserChunkLen > maxPendingBytes) {
+                onBytesSkipped(parserChunkLen)
+              } else {
+                const parserChunk = text.slice(cursor, end)
+                try {
+                  const items = parser.write(parserChunk)
+                  for (const item of items) {
+                    ctx.admit(item)
+                  }
+                  pendingBytes += parserChunkLen
+                } catch {
+                  parser.reset()
+                  onBytesSkipped(parserChunkLen)
+                }
+              }
+              cursor = end
+              await ctx.nextTick()
+              if (ctx.isCancelled()) {
+                return
+              }
+            }
+            leftover = text.slice(cursor)
+            // Cap the leftover: accepting unbounded leftovers would let a
+            // runaway record without any terminator exhaust browser memory.
+            if (leftover.length > MAX_LINE_SIZE) {
+              onBytesSkipped(leftover.length)
+              leftover = ''
+            }
+          }
+        } finally {
+          if (budgetTimer !== null) {
+            clearInterval(budgetTimer)
+            budgetTimer = null
+          }
+        }
       }
-    )
-    while (true) {
-      flush()
-      if (closedReason) {
-        break
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    }
-    cbs.onParseEnded?.(closedReason)
-  })
-  return {
-    cancel: () => {
-      flush()
-      closedReason = 'cancelled'
-      reader.cancel().then(() => {
-        source.cancel()
-      })
     }
   }
 }
 
 /**
- * Trims each network chunk so what reaches the JSON parser starts and ends on a line
- * boundary, without emitting individual lines or scanning the interior. The trailing
- * partial line is held over to be prepended to the next chunk; everything before it —
- * including any prior leftover — is a contiguous run of complete top-level JSON
- * documents that the parser handles in one `write()` call. All current consumers
- * (pipeline egress, ad-hoc query results, time-series) emit newline-delimited JSON.
+ * Decoder for newline-delimited UTF-8 text. Same line-aligned chunking and
+ * per-window byte budget as `newlineJsonDecoder`, but each parser chunk is
+ * split into its constituent lines and admitted one string at a time (with
+ * the trailing `\n` or `\r\n` preserved on each line). Suitable for log
+ * viewers and other "byte stream → string[]" consumers.
  *
- * The line boundary is the overflow-drop granularity, not a parser requirement. The
- * parser accepts both multi-record blocks and blocks that span only part of what was
- * originally one network chunk — as long as every emit and every drop snaps to a
- * newline, the parser never receives a partial record.
+ * Shedding granularity is the parser chunk, not the individual line: when the
+ * budget is exhausted, the whole parser chunk's worth of lines is dropped and
+ * its byte count is reported via `onBytesSkipped`. Dropping at line
+ * granularity would be possible but produces visually scattered gaps; the
+ * parser-chunk strategy keeps dropped regions contiguous.
  *
- * Overflow shedding: when the readable side's queued bytes reach `maxBufferedBytes`
- * (`controller.desiredSize <= 0`), the line-aligned block is dropped wholesale instead
- * of enqueued, and its byte count is reported via `onBytesSkipped` so the UI can render
- * a gap marker.
- *
- * Line-aligned drops guarantee the parser's input is always a clean sequence of complete
- * documents — with gaps but never corruption — because drops and emits never split a
- * record mid-way.
- *
- * Records longer than `MAX_LINE_SIZE` while still being assembled are reported as
- * skipped and discarded, since accepting them would let a runaway record exhaust memory.
+ * @param opts.bufferSize Bytes admitted per `bufferWindowMs`; default 1 MB.
+ * @param opts.bufferWindowMs Budget reset period; default 100ms. Independent
+ *   of the orchestrator's UI flush cadence.
+ * @param opts.onBytesSkipped Called when a parser chunk is dropped, or when
+ *   a runaway record (no newline within `MAX_LINE_SIZE` bytes) is purged.
  */
-function splitByNewlineWithOverflowShedding(
-  maxBufferedBytes: number,
+export const newlineTextDecoder = (opts?: {
+  bufferSize?: number
+  bufferWindowMs?: number
   onBytesSkipped?: (bytes: number) => void
-): TransformStream<Uint8Array, Uint8Array> {
-  let leftover: Uint8Array | null = null
-  return new TransformStream<Uint8Array, Uint8Array>(
-    {
-      transform(chunk, controller) {
-        // Scan only backwards from the end of the chunk to find the last newline.
-        // The bytes before it (plus any prior leftover) form a contiguous run of complete
-        // lines; the bytes after it are the head of an incomplete record. We never need
-        // to find the newlines in between — the parser will walk them itself.
-        let lastNewline = -1
-        for (let i = chunk.length - 1; i >= 0; --i) {
-          if (chunk[i] === NEWLINE) {
-            lastNewline = i
-            break
-          }
-        }
+}): StreamFormatDecoderFactory<string> => {
+  const maxPendingBytes = opts?.bufferSize ?? 1_000_000
+  const bufferWindowMs = opts?.bufferWindowMs ?? 100
+  const onBytesSkipped = opts?.onBytesSkipped ?? (() => {})
 
-        if (lastNewline === -1) {
-          // No record terminator yet — extend the leftover.
-          const accumulated = (leftover?.length ?? 0) + chunk.length
-          if (accumulated > MAX_LINE_SIZE) {
-            onBytesSkipped?.(accumulated)
-            leftover = null
-            return
-          }
-          if (leftover) {
-            const merged = new Uint8Array(accumulated)
-            merged.set(leftover, 0)
-            merged.set(chunk, leftover.length)
-            leftover = merged
-          } else {
-            // Copy so we don't pin the network chunk's full backing buffer for one record.
-            leftover = chunk.slice()
-          }
-          return
-        }
+  return () => {
+    let pendingBytes = 0
+    let reader: ReadableStreamDefaultReader<Uint8Array<ArrayBufferLike>> | null = null
+    let budgetTimer: ReturnType<typeof setInterval> | null = null
 
-        const emitFromChunk = lastNewline + 1
-        const leftoverLen = leftover?.length ?? 0
-        const emitLen = leftoverLen + emitFromChunk
-
-        if (hasBackpressure(controller)) {
-          onBytesSkipped?.(emitLen)
-        } else if (leftoverLen === 0) {
-          // No prior leftover — enqueue a view into the chunk; saves an allocation.
-          // The view keeps the chunk's backing buffer alive only until the parser
-          // consumes it, which happens on the next transform tick.
-          controller.enqueue(chunk.subarray(0, emitFromChunk))
-        } else {
-          const merged = new Uint8Array(emitLen)
-          merged.set(leftover!, 0)
-          merged.set(chunk.subarray(0, emitFromChunk), leftoverLen)
-          controller.enqueue(merged)
-        }
-        leftover = null
-
-        const remainderLen = chunk.length - emitFromChunk
-        if (remainderLen === 0) {
-          return
-        }
-        if (remainderLen > MAX_LINE_SIZE) {
-          onBytesSkipped?.(remainderLen)
-        } else {
-          // Copy so leftover doesn't pin the (much larger) network chunk buffer.
-          leftover = chunk.slice(emitFromChunk)
+    return {
+      async cancel() {
+        try {
+          await reader?.cancel()
+        } catch {
+          /* reader may already be closed */
         }
       },
-      flush(controller) {
-        if (leftover && leftover.length > 0) {
-          if (hasBackpressure(controller)) {
-            onBytesSkipped?.(leftover.length)
-          } else {
-            controller.enqueue(leftover)
+      async decode(ctx) {
+        budgetTimer = setInterval(() => {
+          pendingBytes = 0
+        }, bufferWindowMs)
+        try {
+          reader = ctx.source.getReader()
+          const textDecoder = new TextDecoder('utf-8')
+          let leftover = ''
+          while (!ctx.isCancelled()) {
+            const networkChunk = await reader.read()
+            if (networkChunk.done) {
+              return
+            }
+            const text = leftover + textDecoder.decode(networkChunk.value, { stream: true })
+
+            // Forward-scan once, collecting line endings, until we've covered
+            // ~PARSER_CHUNK_TARGET_BYTES; that span is one parser chunk. Each
+            // byte is examined exactly once: the same scan that finds line
+            // boundaries for admit also finds the parser-chunk boundary used
+            // by the budget check.
+            let cursor = 0
+            while (cursor < text.length) {
+              const target = cursor + PARSER_CHUNK_TARGET_BYTES
+              const lineEnds: number[] = []
+              let scan = cursor
+              while (scan < text.length) {
+                const nl = text.indexOf('\n', scan)
+                if (nl === -1) {
+                  break
+                }
+                lineEnds.push(nl + 1)
+                scan = nl + 1
+                if (scan >= target) {
+                  break
+                }
+              }
+              if (lineEnds.length === 0) {
+                // No complete line in the remainder — stop and hold the rest
+                // as leftover for the next read.
+                break
+              }
+              const parserChunkEnd = lineEnds[lineEnds.length - 1]
+              const parserChunkLen = parserChunkEnd - cursor
+              if (pendingBytes + parserChunkLen > maxPendingBytes) {
+                onBytesSkipped(parserChunkLen)
+              } else {
+                let lineStart = cursor
+                for (const lineEnd of lineEnds) {
+                  ctx.admit(text.slice(lineStart, lineEnd))
+                  lineStart = lineEnd
+                }
+                pendingBytes += parserChunkLen
+              }
+              cursor = parserChunkEnd
+              await ctx.nextTick()
+              if (ctx.isCancelled()) {
+                return
+              }
+            }
+            leftover = text.slice(cursor)
+            if (leftover.length > MAX_LINE_SIZE) {
+              onBytesSkipped(leftover.length)
+              leftover = ''
+            }
           }
-          leftover = null
+        } finally {
+          if (budgetTimer !== null) {
+            clearInterval(budgetTimer)
+            budgetTimer = null
+          }
         }
       }
-    },
-    {},
-    { highWaterMark: maxBufferedBytes, size: (c) => c?.length ?? 0 }
-  )
-}
-
-const hasBackpressure = <T>(controller: TransformStreamDefaultController<T>) => {
-  return controller.desiredSize !== null && controller.desiredSize <= 0
-}
-
-const mkTransformerParser = <T>(
-  controller: TransformStreamDefaultController<T>,
-  opts?: JSONParserOptions
-) => {
-  const tokenizer = new BigNumberTokenizer()
-  const tokenParser = new TokenParser(opts)
-  tokenizer.onToken = tokenParser.write.bind(tokenParser)
-  tokenParser.onValue = (value) => {
-    controller.enqueue(value.value as T)
-  }
-
-  const parser = {
-    onToken: tokenizer.onToken.bind(tokenizer),
-    get isEnded() {
-      return tokenizer.isEnded
-    },
-    write: tokenizer.write.bind(tokenizer),
-    end: tokenizer.end.bind(tokenizer),
-    onError: tokenizer.onError.bind(tokenizer)
-  } as JSONParser
-  return parser
-}
-
-class JSONParserTransformer<T> implements Transformer<Uint8Array | string, T> {
-  // @ts-expect-error Controller always defined during start
-  private controller: TransformStreamDefaultController<T>
-  // @ts-expect-error Controller always defined during start
-  private parser: JSONParser
-  private opts?: JSONParserOptions
-
-  constructor(opts?: JSONParserOptions) {
-    this.opts = opts
-  }
-
-  start(controller: TransformStreamDefaultController<T>) {
-    this.controller = controller
-    this.parser = mkTransformerParser(this.controller, this.opts)
-  }
-
-  async transform(chunk: Uint8Array | string) {
-    try {
-      this.parser.write(chunk)
-    } catch {
-      // Every chunk arrives line-aligned from the upstream splitter, so a parse
-      // error means the source itself produced a malformed document. Reset the
-      // parser to drop its partial state and continue with the next chunk.
-      this.parser = mkTransformerParser(this.controller, this.opts)
-    }
-    // Yield to a macrotask between every chunk — not because the parser needs a
-    // break, but because the WebStreams pipe runs transforms back-to-back via
-    // microtasks. Without this hop, the 100ms flush timer (and any other
-    // setTimeout/setInterval) starves behind the microtask queue, which makes
-    // the UI appear to update only every few seconds on busy streams.
-    await yieldToEventLoop()
-  }
-
-  flush() {}
-}
-
-export class CustomJSONParserTransformStream<T> extends TransformStream<Uint8Array | string, T> {
-  constructor(
-    opts?: JSONParserOptions,
-    writableStrategy?: QueuingStrategy<Uint8Array | string>,
-    readableStrategy?: QueuingStrategy<T>
-  ) {
-    const transformer = new JSONParserTransformer(opts)
-    super(transformer, writableStrategy, readableStrategy)
-  }
-}
-
-export class SplitNewlineTransformStream extends TransformStream<Uint8Array, string> {
-  private decoder: TextDecoder
-  private buffer: string
-  private newlineRegex: RegExp
-
-  constructor(
-    writableStrategy?: QueuingStrategy<Uint8Array>,
-    readableStrategy?: QueuingStrategy<string>
-  ) {
-    super(
-      {
-        transform: (chunk, controller) => this.transform(chunk, controller),
-        flush: (controller) => this.flush(controller)
-      },
-      writableStrategy,
-      readableStrategy
-    )
-
-    this.decoder = new TextDecoder('utf-8')
-    this.buffer = ''
-    this.newlineRegex = /\r?\n/g // Matches both \n and \r\n
-  }
-
-  private async transform(chunk: Uint8Array, controller: TransformStreamDefaultController<string>) {
-    // Decode the chunk as a string and append it to the buffer
-    this.buffer += this.decoder.decode(chunk, { stream: true })
-    // Use RegExp.exec to find each newline
-    let match
-    while ((match = this.newlineRegex.exec(this.buffer)) !== null) {
-      // Extract the line from the start of the buffer up to the matched newline
-      const line = this.buffer.slice(0, match.index + match[0].length) // Include the newline character at the end of the line with `match[0].length`: '\n' => 1, '\r\n' => 2
-      controller.enqueue(line)
-
-      // Update buffer by removing the processed line and newline
-      this.buffer = this.buffer.slice(this.newlineRegex.lastIndex) // this.buffer.slice(match.index + match[0].length);
-      // Reset lastIndex for the regex to handle the modified buffer
-      this.newlineRegex.lastIndex = 0
-    }
-  }
-
-  private flush(controller: TransformStreamDefaultController<string>) {
-    // Enqueue any remaining buffered data
-    if (this.buffer) {
-      controller.enqueue(this.buffer)
-      this.buffer = ''
     }
   }
 }

--- a/js-packages/web-console/src/lib/types/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/types/pipelineManager.ts
@@ -10,19 +10,19 @@ export type TimeSeriesEntry = {
   /**
    * Timestamp ms
    */
-  t: BigNumber
+  t: number
   /**
    * Processed records
    */
-  r: BigNumber
+  r: number
   /**
    * Used memory bytes
    */
-  m: BigNumber
+  m: number
   /**
    * Used storage bytes
    */
-  s: BigNumber
+  s: number
 }
 
 export type PipelineDiff = {


### PR DESCRIPTION
Treat metrics stream values as simple numbers

Testing: manually make sure the metrics graphs, the change stream and logs behave as expected, in particular Change Stream is responsive when displaying a high-throughput stream.

The change removes a previous implementation for stream parsing, now Logs and Change Stream use the sam eload shedding mechanism; metrics parsing uses a simpler, off-the-shelf stream parsing without load shedding, and removes the unnecessary complication of using a BigNumber implementation to process the metrics values. The total code size and complexity is reduced.