### PR TITLE
[dbsp] Adaptive joins fix.

### DIFF
--- a/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/accumulate_trace_balanced.rs
@@ -296,6 +296,10 @@ struct RebalanceState<B: Batch<Time = ()>> {
     /// The policy that was used to accumulate the integral before the rebalancing.
     /// This is the policy used during the previous transaction.
     trace_policy: PartitioningPolicy,
+
+    /// True if `trace_policy` differs from the current policy, i.e., the integral
+    /// must be retracted and redistributed before the transaction commits.
+    rebalance_trace: bool,
 }
 
 /// Information about the key distribution of the input stream.
@@ -571,14 +575,17 @@ where
                 retractions
                     .accumulator
                     .extend_with_batches(accumulator_batches);
+                retractions.rebalance_trace = retractions.trace_policy != new_policy;
             }
             retractions @ None => {
+                let trace_policy = old_policy.unwrap_or(PartitioningPolicy::Shard);
                 *retractions = Some(RebalanceState {
                     accumulator: SpineSnapshot::with_batches(
                         &self.batch_factories,
                         accumulator_batches,
                     ),
-                    trace_policy: old_policy.unwrap_or(PartitioningPolicy::Shard),
+                    trace_policy,
+                    rebalance_trace: trace_policy != new_policy,
                 });
             }
         }
@@ -1354,10 +1361,18 @@ where
             // Used to measure step duration and add it to the total rebalancing time.
             let mut step_start_time = Instant::now();
 
-            let RebalanceState { mut accumulator, trace_policy } = self.rebalance_state.borrow_mut().take().unwrap();
+            let RebalanceState {
+                mut accumulator,
+                trace_policy,
+                rebalance_trace,
+            } = self.rebalance_state.borrow_mut().take().unwrap();
 
             self.rebalance_accumulator_size.set(accumulator.len());
-            self.rebalance_integral_size.set(delayed_trace.len());
+            self.rebalance_integral_size.set(if rebalance_trace {
+                delayed_trace.len()
+            } else {
+                0
+            });
 
             let mut integral_cursor = delayed_trace.cursor();
 
@@ -1365,15 +1380,28 @@ where
 
             // Retract the contents of the integral by sending it with negated weights to the accumulator
             // in the same worker.
-            while integral_cursor.key_valid() {
-                self.process_retractions(&mut integral_cursor, &mut builders[self.worker_index], chunk_size);
+            if rebalance_trace {
+                while integral_cursor.key_valid() {
+                    self.process_retractions(
+                        &mut integral_cursor,
+                        &mut builders[self.worker_index],
+                        chunk_size,
+                    );
 
-                // println!("{}: integral retractions: {:?}", Runtime::worker_index(), batches);
-                builders = self.send_builders(builders, &mut builder_capacity, false, &mut serializer_inner).await;
-                self.update_exchange_metadata();
-                self.update_total_rebalancing_time(&step_start_time);
-                yield (false, None);
-                step_start_time = Instant::now();
+                    // println!("{}: integral retractions: {:?}", Runtime::worker_index(), batches);
+                    builders = self
+                        .send_builders(
+                            builders,
+                            &mut builder_capacity,
+                            false,
+                            &mut serializer_inner,
+                        )
+                        .await;
+                    self.update_exchange_metadata();
+                    self.update_total_rebalancing_time(&step_start_time);
+                    yield (false, None);
+                    step_start_time = Instant::now();
+                }
             }
 
             // Start new cursors.
@@ -1393,31 +1421,40 @@ where
             }
 
             // Repartition integral.
-            while integral_cursor.key_valid() {
-                self.repartition(trace_policy, &mut integral_cursor, &mut builders, chunk_size);
+            if rebalance_trace {
+                while integral_cursor.key_valid() {
+                    self.repartition(trace_policy, &mut integral_cursor, &mut builders, chunk_size);
 
-                // println!("{}: integral insertions: {:?}", Runtime::worker_index(), batches);
-                builders = self.send_builders(builders, &mut builder_capacity, !integral_cursor.key_valid(), &mut serializer_inner).await;
-                self.update_exchange_metadata();
-
-                if integral_cursor.key_valid(){
+                    // println!("{}: integral insertions: {:?}", Runtime::worker_index(), batches);
+                    builders = self
+                        .send_builders(
+                            builders,
+                            &mut builder_capacity,
+                            !integral_cursor.key_valid(),
+                            &mut serializer_inner,
+                        )
+                        .await;
                     self.update_exchange_metadata();
-                    self.update_total_rebalancing_time(&step_start_time);
-                    yield (false, None);
-                    step_start_time = Instant::now();
-                } else {
-                    // if Runtime::worker_index() == 0 {
-                    //     println!("{}: flush complete 2 ({:?})", self.input_node_id, *self.current_policy.borrow());
-                    // }
 
-                    self.flush_state.set(FlushState::FlushCompleted);
-                    self.update_exchange_metadata();
-                    self.rebalance_accumulator_size.set(0);
-                    self.rebalance_integral_size.set(0);
-                    self.update_total_rebalancing_time(&step_start_time);
-                    self.rebalance_start_time.set(None);
-                    yield (true, None);
-                    return;
+                    if integral_cursor.key_valid() {
+                        self.update_exchange_metadata();
+                        self.update_total_rebalancing_time(&step_start_time);
+                        yield (false, None);
+                        step_start_time = Instant::now();
+                    } else {
+                        // if Runtime::worker_index() == 0 {
+                        //     println!("{}: flush complete 2 ({:?})", self.input_node_id, *self.current_policy.borrow());
+                        // }
+
+                        self.flush_state.set(FlushState::FlushCompleted);
+                        self.update_exchange_metadata();
+                        self.rebalance_accumulator_size.set(0);
+                        self.rebalance_integral_size.set(0);
+                        self.update_total_rebalancing_time(&step_start_time);
+                        self.rebalance_start_time.set(None);
+                        yield (true, None);
+                        return;
+                    }
                 }
             }
 

--- a/crates/dbsp/src/operator/dynamic/balance/test.rs
+++ b/crates/dbsp/src/operator/dynamic/balance/test.rs
@@ -1062,6 +1062,91 @@ fn test_accumulate_trace_with_balancer_round_robin_big_step() {
     test_accumulate_trace_with_balancer(4, true, round_robin_integrate_workload());
 }
 
+#[test]
+fn test_accumulate_trace_with_balancer_policy_returns_to_trace_policy() {
+    // The integral is rebalanced at commit using the policy captured on the first
+    // policy change in the transaction. A long transaction can still see later
+    // policy changes before commit; if the policy changes Shard -> Broadcast -> Shard,
+    // the final policy matches the original trace policy. This used to panic when
+    // the sender assumed that the saved trace policy and current policy must differ.
+    let workers = 4;
+    let (mut circuit, (input_handle, input_node_id, output_delta, output_trace)) =
+        Runtime::init_circuit(
+            CircuitConfig::from(workers)
+                .with_splitter_chunk_size_records(2)
+                .with_balancer_min_absolute_improvement_threshold(0)
+                .with_mode(Mode::Persistent),
+            accumulate_trace_with_balancer_test_circuit,
+        )
+        .unwrap();
+
+    circuit
+        .set_balancer_hint(
+            &input_node_id,
+            BalancerHint::Policy(Some(PartitioningPolicy::Shard)),
+        )
+        .unwrap();
+    input_handle.push(0, (0, 1));
+    circuit.transaction().unwrap();
+    for worker in 0..workers {
+        output_delta.take_from_worker(worker).unwrap();
+        output_trace.take_from_worker(worker).unwrap();
+    }
+
+    circuit.start_transaction().unwrap();
+
+    circuit
+        .set_balancer_hint(
+            &input_node_id,
+            BalancerHint::Policy(Some(PartitioningPolicy::Broadcast)),
+        )
+        .unwrap();
+    input_handle.push(1, (0, 1));
+    circuit.step().unwrap();
+
+    circuit
+        .set_balancer_hint(
+            &input_node_id,
+            BalancerHint::Policy(Some(PartitioningPolicy::Shard)),
+        )
+        .unwrap();
+    input_handle.push(2, (0, 1));
+    circuit.step().unwrap();
+
+    circuit.commit_transaction().unwrap();
+
+    let expected_output_delta = balance_batch(
+        &OrdIndexedZSet::from_tuples((), vec![Tup2(Tup2(1, 0), 1), Tup2(Tup2(2, 0), 1)]),
+        PartitioningPolicy::Shard,
+        workers,
+    );
+    let expected_output_trace = balance_batch(
+        &OrdIndexedZSet::from_tuples(
+            (),
+            vec![
+                Tup2(Tup2(0, 0), 1),
+                Tup2(Tup2(1, 0), 1),
+                Tup2(Tup2(2, 0), 1),
+            ],
+        ),
+        PartitioningPolicy::Shard,
+        workers,
+    );
+    let output_delta: Vec<_> = (0..workers)
+        .map(|worker| output_delta.take_from_worker(worker).unwrap().consolidate())
+        .collect();
+    let output_trace: Vec<_> = (0..workers)
+        .map(|worker| output_trace.take_from_worker(worker).unwrap())
+        .collect();
+
+    assert_eq!(
+        circuit.get_current_balancer_policy(&input_node_id).unwrap(),
+        PartitioningPolicy::Shard
+    );
+    assert_eq!(output_delta, expected_output_delta);
+    assert_eq!(output_trace, expected_output_trace);
+}
+
 /// Join a large left collection with a small right collection. Both are skewed.
 /// The balancer should balance the left collection using Policy::Balance and the
 /// right collection using Policy::Broadcast.


### PR DESCRIPTION
Correctly handle the corner case where the balancing policy changes twice during the transaction and returns back to the pre-transaction policy. In this case, we don't need to rebalance the integral, but we may need to rebalance the accumulator. This caused an assertion failure.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

