### PR TITLE
[SQL] Fix implementation of casts to structs

### DIFF
--- a/crates/dbsp/src/utils/is_none.rs
+++ b/crates/dbsp/src/utils/is_none.rs
@@ -16,6 +16,15 @@ pub trait IsNone {
     fn unwrap_or_self(&self) -> &Self::Inner;
 
     fn from_inner(inner: Self::Inner) -> Self;
+
+    /// If Self is `Option<T>` an `Err` is converted as `Ok(None)`.
+    /// For all other types the error is propagated unchanged.
+    fn result_to_field<E>(r: Result<Self, E>) -> Result<Self, E>
+    where
+        Self: Sized,
+    {
+        r
+    }
 }
 
 impl<T> IsNone for Option<T> {
@@ -32,6 +41,10 @@ impl<T> IsNone for Option<T> {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Some(inner)
+    }
+
+    fn result_to_field<E>(r: Result<Self, E>) -> Result<Self, E> {
+        Ok(r.unwrap_or(None))
     }
 }
 

--- a/crates/dbsp/src/utils/tuple.rs
+++ b/crates/dbsp/src/utils/tuple.rs
@@ -191,3 +191,38 @@ impl core::fmt::Debug for Tup0 {
 }
 
 impl Copy for Tup0 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_results_both_ok() {
+        let result = Tup2::<i32, Option<i32>>::from_results(
+            Ok::<i32, &str>(1),
+            Ok::<Option<i32>, &str>(Some(2)),
+        );
+        assert_eq!(result, Ok(Some(Tup2(1, Some(2)))));
+    }
+
+    #[test]
+    fn from_results_option_err_becomes_none() {
+        // The second field is Option<i32>: an Err should become None, not
+        // propagate.
+        let result = Tup2::<i32, Option<i32>>::from_results(
+            Ok::<i32, &str>(1),
+            Err::<Option<i32>, &str>("bad"),
+        );
+        assert_eq!(result, Ok(Some(Tup2(1, None))));
+    }
+
+    #[test]
+    fn from_results_non_option_err_propagates() {
+        // The first field is i32 (non-Option): an Err must propagate.
+        let result = Tup2::<i32, Option<i32>>::from_results(
+            Err::<i32, &str>("bad"),
+            Ok::<Option<i32>, &str>(Some(2)),
+        );
+        assert_eq!(result, Err("bad"));
+    }
+}

--- a/crates/feldera-macros/src/tuples.rs
+++ b/crates/feldera-macros/src/tuples.rs
@@ -85,6 +85,14 @@ pub(super) fn declare_tuple_impl(tuple: TupleDef) -> TokenStream2 {
         pub fn new(#(#fields: #generics),*) -> Self {
             Self(#(#fields),*)
         }
+
+        #[allow(clippy::too_many_arguments)]
+        pub fn from_results<E>(#(#fields: Result<#generics, E>),*) -> Result<Option<Self>, E>
+        where
+            #(#generics: ::dbsp::utils::IsNone,)*
+        {
+            Ok(Some(Self(#(<#generics as ::dbsp::utils::IsNone>::result_to_field(#fields)?,)*)))
+        }
     }
     };
 
@@ -1033,5 +1041,18 @@ mod tests {
         let formatted = prettyplease::unparse(&parsed_file);
         println!("{formatted}");
         assert!(formatted.contains("pub struct Tup8"));
+    }
+
+    #[test]
+    fn from_results_method() {
+        // Verify from_results is generated and has the right shape.
+        let tuple: TupleDef = syn::parse2(quote!(Tup2<T0, T1>)).expect("Failed to parse TupleDef");
+        let expanded = declare_tuple_impl(tuple);
+        let parsed_file: syn::File = syn::parse2(expanded).expect("Failed to parse output");
+        let formatted = prettyplease::unparse(&parsed_file);
+        assert!(formatted.contains("from_results"));
+        assert!(formatted.contains("-> Result<Option<Self>, E>"));
+        // Option fields absorb errors; non-Option fields propagate them.
+        assert!(formatted.contains("result_to_field"));
     }
 }

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -1023,10 +1023,6 @@ mod tests {
     use actix_web::http::Method;
     use actix_web::test;
 
-    async fn ok_handler() -> HttpResponse {
-        HttpResponse::Ok().body("ok")
-    }
-
     /// Content-hashed bundle paths get year-long immutable caching plus
     /// `ACAO: *` so SvelteKit's `crossorigin` script loads can be reused
     /// from cache.

--- a/crates/sqllib/src/lib.rs
+++ b/crates/sqllib/src/lib.rs
@@ -1522,7 +1522,7 @@ impl<T> Deref for StaticLazy<T> {
 }
 
 #[doc(hidden)]
-// If the data is Ok(None), convert it to Err, other leave it unchanged
+// If the data is Ok(None), convert it to Err, otherwise leave it unchanged
 pub fn unwrap_sql_result<T>(data: SqlResult<Option<T>>) -> SqlResult<T> {
     match data {
         Err(e) => Err(e),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -344,7 +344,7 @@ public class SqlToRelCompiler implements IWritesLogs {
                 // It is really an annotation attached to a rel node remembering the original AS alias
                 .hintStrategy(HINT_ALIAS, HintStrategy.builder(HintPredicates.JOIN).build())
                 .build();
-        this.cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory));
+        this.cluster = RelOptCluster.create(planner, new RexBuilder(this.typeFactory));
         this.cluster.setHintStrategies(hints);
         var metadataProvider = ChainedRelMetadataProvider.of(List.of(RelMdRowCount.SOURCE,
                 DefaultRelMetadataProvider.INSTANCE));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandSafeCasts.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/expandCasts/ExpandSafeCasts.java
@@ -16,7 +16,6 @@ import org.dbsp.sqlCompiler.ir.expression.DBSPFailExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPIfExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPOpcode;
 import org.dbsp.sqlCompiler.ir.expression.DBSPRawTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
@@ -35,7 +34,6 @@ import org.dbsp.util.Linq;
 import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -179,9 +177,8 @@ public class ExpandSafeCasts extends ExpressionTranslator {
     }
 
     // Can occur e.g., when converting a VARIANT to a ROW or user-defined type
-    DBSPExpression convertToStructOrTuple(
-            CalciteObject node, DBSPExpression source, DBSPTypeTuple type) {
-        List<DBSPExpression> fields = new ArrayList<>();
+    DBSPExpression convertToStructOrTuple(CalciteObject node, DBSPExpression source, DBSPTypeTuple type) {
+        DBSPExpression[] fields = new DBSPExpression[type.size()];
         DBSPTypeStruct struct = type.originalStruct;
         List<ProgramIdentifier> names = null;
         if (struct != null)
@@ -213,23 +210,25 @@ public class ExpandSafeCasts extends ExpressionTranslator {
             } else {
                 throw new InternalCompilerError("Unexpected source type " + sourceType);
             }
-            DBSPExpression expression = field.applyCloneIfNeeded().cast(node, fieldType, SAFE);
-            // Convert recursively
-            expression = this.analyze(expression).to(DBSPExpression.class);
-            fields.add(expression);
+
+            DBSPClosureExpression convertFunction = this.converterFunction(node, field.getType(), fieldType);
+            DBSPExpression expression = convertFunction.call(field.borrow()).reduce(this.compiler);
+            fields[i] = expression;
         }
 
-        DBSPExpression result = new DBSPTupleExpression(source.getNode(), type, fields);
+        DBSPType resultType = new DBSPTypeSqlResult(type);
+        DBSPExpression result = new DBSPApplyExpression("Tup" + type.size() + "::from_results", resultType, fields);
+        result = result.cast(node, type, UNWRAP);
         if (source.getType().mayBeNull) {
             if (type.mayBeNull) {
                 result = new DBSPIfExpression(node, source.is_null(), type.none(), result);
             } else {
                 result = new DBSPIfExpression(node, source.is_null(),
-                        new DBSPFailExpression(source.getNode(), type, "Cast to non-nullable value applied to NULL"),
+                        new DBSPFailExpression(source.getNode(), type,
+                                "Cast to non-nullable ROW applied to NULL"),
                         result);
             }
         }
-
         return result;
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPCastExpression.java
@@ -119,7 +119,8 @@ public final class DBSPCastExpression extends DBSPExpression {
         Utilities.enforce(!safe.isSafe() || to.mayBeNull);
         Utilities.enforce(source.getType().is(DBSPTypeNull.class)
                         || source.getType().is(DBSPTypeTupleBase.class) == to.is(DBSPTypeTupleBase.class)
-                        || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class),
+                        || source.getType().is(DBSPTypeVariant.class) || to.is(DBSPTypeVariant.class)
+                        || source.getType().is(DBSPTypeSqlResult.class),
                 () -> "Cast to/from tuple from/to non-tuple " + source.getType() + " to " + to);
         Utilities.enforce(to.code != DBSPTypeCode.INTERNED_STRING, () -> "Cast to INTERNED");
         Utilities.enforce(source.getType().code != DBSPTypeCode.INTERNED_STRING, () -> "Cast from INTERNED");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression2Tests.java
@@ -1623,4 +1623,52 @@ public class Regression2Tests extends SqlIoTest {
         this.statementsFailingInCompilation(program, """
                 OVER currently cannot sort on columns with type UUID NULL""");
     }
+
+    @Test
+    public void issue6255() {
+        this.getCCS("""
+                CREATE TABLE collection_events (
+                  row_id     BIGINT,
+                  grp        VARCHAR,
+                  nums       INT ARRAY,
+                  nums2      INT ARRAY,
+                  prices     DECIMAL(10,2) ARRAY,
+                  taxes      DECIMAL(10,2) ARRAY,
+                  tags       VARCHAR ARRAY,
+                  tags2      VARCHAR ARRAY,
+                  attrs      MAP<VARCHAR, VARCHAR>,
+                  attrs2     MAP<VARCHAR, VARCHAR>,
+                  raw_json   VARCHAR,
+                  start_date DATE,
+                  end_date   DATE
+                );
+                
+                CREATE VIEW v AS
+                SELECT j.row_id, e.sku, e.qty
+                FROM (
+                  SELECT row_id,
+                         CAST(PARSE_JSON(raw_json) AS ROW(sku VARCHAR, qty INT) ARRAY) AS items
+                  FROM collection_events
+                ) j
+                , UNNEST(j.items) AS e(sku, qty);""");
+    }
+
+    @Test @Ignore("https://issues.apache.org/jira/browse/CALCITE-7536")
+    public void issue6256() {
+        this.getCC("""
+                CREATE VIEW V AS SELECT col1
+                FROM (VALUES (1)) t1(col1)
+                GROUP BY col1
+                HAVING (
+                    SELECT MAX(t2.col1) != 0
+                    FROM (VALUES (1)) t2(col1)
+                    WHERE t2.col1 = t1.col1
+                    GROUP BY t2.col1
+                    HAVING (
+                        SELECT t3.col1 != 0
+                        FROM (VALUES (1)) t3(col1)
+                        WHERE t3.col1 = MAX(t2.col1)
+                    )
+                );""");
+    }
 }


### PR DESCRIPTION
This fixes casts that involve ROW types, including CAST(variant AS ROW). These casts are always "safe", they cannot panic, they should return NULL on failure. The way this is (now) implemented is using a new tuple method, which is generated by the tuple generator procedural macro:

```
TupN<T0, T1, ..., TN>::from_results(SqlResult<T0, E>, ... SqlResult<TN, E>) -> SqlResult<T0, ... TN>
```

This function returns a tuple if all arguments are Ok.
It will also return a tuple with some None fields if the corresponding arguments are Err, but the field has type `Option<>`
It will return Err(E) otherwise.

This method is invoked by the compiler to implement something like CAST(variant AS ROW). The result will be a ROW with as many fields possible filled from the VARIANT, and other fields NULL - or a NULL ROW if the fields that cannot be filled are not Option types.

This works for arbitrarily nested ROW/ARRAY/MAP types. A similar scheme is already used for ARRAY and MAP.

Fixes #6255

### Describe Manual Test Plan

Ran all Java tests 

## Checklist

- [x] Unit tests added/updated
