### PR TITLE
ci+py: clean up tests after failure

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -423,39 +423,46 @@ def run_workload(
 
     pipeline = build_pipeline(pipeline_name, tables, views, resources)
 
-    pipeline.start()
-    start_time = time.monotonic()
-
-    if transaction:
-        try:
-            pipeline.start_transaction()
-        except Exception as e:
-            log(f"Error starting transaction: {e}")
-
-    if transaction:
-        wait_end_of_input(pipeline, timeout_s=3600)
-    else:
-        pipeline.wait_for_completion(force_stop=False, timeout_s=3600)
-
-    elapsed = time.monotonic() - start_time
-    log(f"Data ingested in {elapsed}")
-
-    if transaction:
+    try:
+        pipeline.start()
         start_time = time.monotonic()
-        try:
-            pipeline.commit_transaction(transaction_id=None, wait=True, timeout_s=None)
-            log(f"Commit took {time.monotonic() - start_time}")
-        except Exception as e:
-            log(f"Error committing transaction: {e}")
 
-        log("Waiting for outputs to flush")
-        start_time = time.monotonic()
-        pipeline.wait_for_completion(force_stop=False, timeout_s=3600)
-        log(f"Flushing outputs took {time.monotonic() - start_time}")
+        if transaction:
+            try:
+                pipeline.start_transaction()
+            except Exception as e:
+                log(f"Error starting transaction: {e}")
 
-    validate_outputs(pipeline, tables, views)
+        if transaction:
+            wait_end_of_input(pipeline, timeout_s=3600)
+        else:
+            pipeline.wait_for_completion(force_stop=False, timeout_s=3600)
 
-    if stop:
-        pipeline.stop(force=True)
+        elapsed = time.monotonic() - start_time
+        log(f"Data ingested in {elapsed}")
+
+        if transaction:
+            start_time = time.monotonic()
+            try:
+                pipeline.commit_transaction(
+                    transaction_id=None, wait=True, timeout_s=None
+                )
+                log(f"Commit took {time.monotonic() - start_time}")
+            except Exception as e:
+                log(f"Error committing transaction: {e}")
+
+            log("Waiting for outputs to flush")
+            start_time = time.monotonic()
+            pipeline.wait_for_completion(force_stop=False, timeout_s=3600)
+            log(f"Flushing outputs took {time.monotonic() - start_time}")
+
+        validate_outputs(pipeline, tables, views)
+    finally:
+        if stop:
+            try:
+                pipeline.stop(force=True)
+                pipeline.clear_storage()
+            except Exception as e:
+                log(f"Error during pipeline cleanup: {e}")
 
     return pipeline

--- a/python/tests/platform/helper.py
+++ b/python/tests/platform/helper.py
@@ -14,15 +14,16 @@ from __future__ import annotations
 
 import json
 import os
+import unittest
 from http import HTTPStatus
 from typing import Any, Dict, Iterable
 from urllib.parse import quote, quote_plus
 
 import pytest
 import requests
-
 from feldera.testutils import FELDERA_TEST_NUM_HOSTS, FELDERA_TEST_NUM_WORKERS
 from feldera.testutils_oidc import get_oidc_test_helper
+
 from tests import (
     API_KEY,
     BASE_URL,
@@ -270,6 +271,25 @@ def gen_pipeline_name(func):
     return pytest.mark.usefixtures("pipeline_name")(func)
 
 
+class PipelineTestCase(unittest.TestCase):
+    """Base class for unittest tests that own pipelines on a shared instance.
+
+    Subclasses call ``self.register_for_cleanup(base)`` to get a unique
+    pipeline name. Each call cleans any leftover named pipeline and
+    registers an ``addCleanup`` that stops the pipeline and clears its
+    storage when the test finishes, regardless of pass or fail.
+
+    This mirrors the ``pipeline_name`` pytest fixture in ``conftest.py``
+    for code that still uses ``unittest.TestCase``.
+    """
+
+    def register_for_cleanup(self, base: str) -> str:
+        name = unique_pipeline_name(base)
+        cleanup_pipeline(name)
+        self.addCleanup(reset_pipeline, name)
+        return name
+
+
 __all__ = [
     "API_PREFIX",
     "HTTPStatus",
@@ -285,4 +305,5 @@ __all__ = [
     "extract_object_by_name",
     "gen_pipeline_name",
     "connector_action",
+    "PipelineTestCase",
 ]

--- a/python/tests/platform/negative_test.py
+++ b/python/tests/platform/negative_test.py
@@ -1,17 +1,17 @@
 import unittest
 from feldera import PipelineBuilder, Pipeline
 from feldera.testutils import (
-    unique_pipeline_name,
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
 from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 
 
-class NegativeCompilationTests(unittest.TestCase):
+class NegativeCompilationTests(PipelineTestCase):
     def test_sql_error(self):
-        pipeline_name = unique_pipeline_name("sql_error")
+        pipeline_name = self.register_for_cleanup("sql_error")
         sql = """
 CREATE TABLE student(
     id INT,
@@ -43,7 +43,7 @@ Code snippet:
         pipeline.clear_storage()
 
     def test_rust_error(self):
-        pipeline_name = unique_pipeline_name("rust_error")
+        pipeline_name = self.register_for_cleanup("rust_error")
         sql = ""
 
         with self.assertRaises(Exception) as err:
@@ -62,7 +62,7 @@ Code snippet:
 
     def test_program_error0(self):
         sql = "create taabl;"
-        name = unique_pipeline_name("test_program_error0")
+        name = self.register_for_cleanup("test_program_error0")
         try:
             _ = PipelineBuilder(
                 TEST_CLIENT,
@@ -83,7 +83,7 @@ Code snippet:
 
     def test_program_error1(self):
         sql = ""
-        name = unique_pipeline_name("test_program_error1")
+        name = self.register_for_cleanup("test_program_error1")
         _ = PipelineBuilder(
             TEST_CLIENT,
             name,
@@ -102,7 +102,7 @@ Code snippet:
 
     def test_errors0(self):
         sql = "SELECT invalid"
-        name = unique_pipeline_name("test_errors0")
+        name = self.register_for_cleanup("test_errors0")
         try:
             _ = PipelineBuilder(
                 TEST_CLIENT,
@@ -139,7 +139,7 @@ Code snippet:
         """
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_initialization_error"),
+            name=self.register_for_cleanup("test_initialization_error"),
             sql=sql,
             runtime_config=RuntimeConfig(
                 workers=FELDERA_TEST_NUM_WORKERS,

--- a/python/tests/platform/test_delta_output_restart.py
+++ b/python/tests/platform/test_delta_output_restart.py
@@ -26,7 +26,6 @@ from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import (
     FELDERA_TEST_NUM_HOSTS,
     FELDERA_TEST_NUM_WORKERS,
-    unique_pipeline_name,
 )
 from tests import TEST_CLIENT, enterprise_only, skip_on_arm64
 from tests.utils import DeltaTestLocation
@@ -91,12 +90,11 @@ def _seed_50_rows_and_suspend(name: str, loc: DeltaTestLocation):
 
 @enterprise_only
 @skip_on_arm64  # https://github.com/delta-io/delta-rs/issues/4413
-def test_clean_resume_preserves_table():
+def test_clean_resume_preserves_table(pipeline_name):
     """Restarting an unchanged pipeline keeps the delta table contents."""
-    name = unique_pipeline_name("delta_restart_clean")
-    loc = DeltaTestLocation.create(name)
+    loc = DeltaTestLocation.create(pipeline_name)
     try:
-        pipeline = _seed_50_rows_and_suspend(name, loc)
+        pipeline = _seed_50_rows_and_suspend(pipeline_name, loc)
 
         # Resume the SAME pipeline object — connector identity is preserved.
         pipeline.start()
@@ -104,25 +102,21 @@ def test_clean_resume_preserves_table():
 
         pipeline.input_json("t", [{"id": i} for i in range(50, 80)], wait=True)
         assert loc.row_count() == 80
-
-        pipeline.stop(force=True)
-        pipeline.clear_storage()
     finally:
         loc.cleanup()
 
 
 @enterprise_only
 @skip_on_arm64  # https://github.com/delta-io/delta-rs/issues/4413
-def test_modified_connector_re_truncates_on_resume():
+def test_modified_connector_re_truncates_on_resume(pipeline_name):
     """Changing the connector config on resume makes it a new incarnation that re-truncates."""
-    name = unique_pipeline_name("delta_restart_conn_modified")
-    loc = DeltaTestLocation.create(name)
+    loc = DeltaTestLocation.create(pipeline_name)
     try:
-        _seed_50_rows_and_suspend(name, loc)
+        _seed_50_rows_and_suspend(pipeline_name, loc)
 
         # Resume with a MODIFIED connector config (extra `checkpoint_interval` field).
         pipeline = _build_pipeline(
-            name,
+            pipeline_name,
             _sql(loc, extra_connector_options={"checkpoint_interval": 60}),
         )
         pipeline.start()
@@ -130,31 +124,24 @@ def test_modified_connector_re_truncates_on_resume():
 
         pipeline.input_json("t", [{"id": i} for i in range(50, 80)], wait=True)
         assert loc.row_count() == 30
-
-        pipeline.stop(force=True)
-        pipeline.clear_storage()
     finally:
         loc.cleanup()
 
 
 @enterprise_only
 @skip_on_arm64  # https://github.com/delta-io/delta-rs/issues/4413
-def test_modified_view_re_truncates_on_resume():
+def test_modified_view_re_truncates_on_resume(pipeline_name):
     """Changing the view's schema on resume forces a rebuild from scratch."""
-    name = unique_pipeline_name("delta_restart_view_modified")
-    loc = DeltaTestLocation.create(name)
+    loc = DeltaTestLocation.create(pipeline_name)
     try:
-        _seed_50_rows_and_suspend(name, loc)
+        _seed_50_rows_and_suspend(pipeline_name, loc)
 
         # Resume with a MODIFIED view (adds an `extra` column).
-        pipeline = _build_pipeline(name, _sql(loc, extra_view_column=True))
+        pipeline = _build_pipeline(pipeline_name, _sql(loc, extra_view_column=True))
         pipeline.start()
         assert loc.row_count() == 0  # rebuilt empty
 
         pipeline.input_json("t", [{"id": i} for i in range(50, 80)], wait=True)
         assert loc.row_count() == 30
-
-        pipeline.stop(force=True)
-        pipeline.clear_storage()
     finally:
         loc.cleanup()

--- a/python/tests/platform/test_nowstream.py
+++ b/python/tests/platform/test_nowstream.py
@@ -4,11 +4,11 @@ import time
 from feldera.pipeline_builder import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import (
-    unique_pipeline_name,
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
 from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.enums import PipelineStatus
 
 
@@ -18,14 +18,14 @@ def get_result(pipeline) -> str:
     return result[0]["x"]
 
 
-class TestNowStream(unittest.TestCase):
+class TestNowStream(PipelineTestCase):
     def test_nowstream(self):
         """
         Test the now() function:
         pipeline should produce outputs even if no new inputs are supplied.
         """
 
-        pipeline_name = unique_pipeline_name("test_now")
+        pipeline_name = self.register_for_cleanup("test_now")
 
         sql = """
         CREATE MATERIALIZED VIEW v AS SELECT NOW() as X;

--- a/python/tests/platform/test_pipeline_builder.py
+++ b/python/tests/platform/test_pipeline_builder.py
@@ -1,15 +1,15 @@
 import unittest
 from feldera.testutils import (
-    unique_pipeline_name,
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
 from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
 
 
-class TestPipelineBuilder(unittest.TestCase):
+class TestPipelineBuilder(PipelineTestCase):
     def test_connector_orchestration(self):
         sql = """
         CREATE TABLE numbers (
@@ -28,7 +28,7 @@ class TestPipelineBuilder(unittest.TestCase):
         );
         """
 
-        pipeline_name = unique_pipeline_name("test_connector_orchestration")
+        pipeline_name = self.register_for_cleanup("test_connector_orchestration")
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,

--- a/python/tests/platform/test_update_runtime.py
+++ b/python/tests/platform/test_update_runtime.py
@@ -3,15 +3,15 @@ import unittest
 from feldera.pipeline_builder import PipelineBuilder
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import (
-    unique_pipeline_name,
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
 from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.enums import PipelineStatus
 
 
-class TestPipeline(unittest.TestCase):
+class TestPipeline(PipelineTestCase):
     def test_update_runtime(self):
         """
         Test the /update_runtime API.
@@ -20,7 +20,7 @@ class TestPipeline(unittest.TestCase):
         (by calling /update_runtime) or when updating the pipeline code.
         """
 
-        pipeline_name = unique_pipeline_name("test_update_runtime")
+        pipeline_name = self.register_for_cleanup("test_update_runtime")
 
         sql = """
         CREATE TABLE tbl(id INT) WITH ('materialized' = 'true');

--- a/python/tests/runtime/lateness/test_issue4457.py
+++ b/python/tests/runtime/lateness/test_issue4457.py
@@ -2,12 +2,13 @@ import unittest
 
 from pandas import Timestamp
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
-class TestIssue_4457(unittest.TestCase):
+class TestIssue_4457(PipelineTestCase):
     def test_local(self):
         sql = """
         CREATE TABLE test_events (
@@ -21,7 +22,7 @@ class TestIssue_4457(unittest.TestCase):
         # Make sure the pipelines are unique if we have concurrent runs
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_issue4457"),
+            name=self.register_for_cleanup("test_issue4457"),
             sql=sql,
             runtime_config=RuntimeConfig(
                 workers=FELDERA_TEST_NUM_WORKERS,

--- a/python/tests/runtime/lateness/test_issue4895.py
+++ b/python/tests/runtime/lateness/test_issue4895.py
@@ -2,22 +2,22 @@ import unittest
 
 from feldera.pipeline_builder import PipelineBuilder
 from feldera.testutils import (
-    unique_pipeline_name,
     FELDERA_TEST_NUM_WORKERS,
     FELDERA_TEST_NUM_HOSTS,
 )
 from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.enums import PipelineStatus
 from feldera.runtime_config import RuntimeConfig
 
 
-class TestIssue4895(unittest.TestCase):
+class TestIssue4895(PipelineTestCase):
     def test_issue4895(self):
         """
         LATENESS is applied correctly to materialized tables
         """
 
-        pipeline_name = unique_pipeline_name("test_issue4895")
+        pipeline_name = self.register_for_cleanup("test_issue4895")
 
         sql = """
         create table t (x int lateness 0) with

--- a/python/tests/runtime/test_doubles.py
+++ b/python/tests/runtime/test_doubles.py
@@ -2,13 +2,14 @@ import unittest
 
 import math
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 # Test serialization of doubles
-class TestDouble(unittest.TestCase):
+class TestDouble(PipelineTestCase):
     def test_local(self):
         sql = """
 CREATE TABLE t (
@@ -35,7 +36,7 @@ SELECT 1/d as one, 0/d as zero FROM t;
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_doubles"),
+            name=self.register_for_cleanup("test_doubles"),
             sql=sql,
             runtime_config=RuntimeConfig(
                 workers=FELDERA_TEST_NUM_WORKERS,

--- a/python/tests/runtime/test_output_snapshot.py
+++ b/python/tests/runtime/test_output_snapshot.py
@@ -5,7 +5,7 @@ from feldera.enums import BootstrapPolicy
 from feldera.pipeline import Pipeline
 from feldera.runtime_config import RuntimeConfig, Storage
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, skip_on_arm64
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
 from tests.utils import DeltaTestLocation, wait_for_condition
 
 
@@ -40,8 +40,7 @@ def collect_output_chunks(stream, expected_rows: int) -> tuple[list[dict], list[
     return chunks, rows
 
 
-def test_egress_send_snapshot():
-    pipeline_name = unique_pipeline_name("test_egress_send_snapshot")
+def test_egress_send_snapshot(pipeline_name):
     sql = """
     CREATE TABLE t1(id INT) WITH ('materialized' = 'true');
     CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1;
@@ -239,7 +238,7 @@ def _build_sql_round3(
 
 
 @skip_on_arm64  # https://github.com/delta-io/delta-rs/issues/4413
-def test_delta_output_send_snapshot_after_flag_flip():
+def test_delta_output_send_snapshot_after_flag_flip(pipeline_name):
     """Verify snapshot delivery to delta sinks across a connector
     modification (`send_snapshot: false` → `send_snapshot: true`).
 
@@ -276,9 +275,6 @@ def test_delta_output_send_snapshot_after_flag_flip():
     ``delta2`` should be populated during startup, while ``delta3``
     should remain empty until future deltas arrive.
     """
-    pipeline_name = unique_pipeline_name(
-        "test_delta_output_send_snapshot_after_flag_flip"
-    )
     locations = [
         DeltaTestLocation.create(f"{pipeline_name}_{label}") for label, *_ in _VIEWS
     ]

--- a/python/tests/runtime/test_spreadsheet.py
+++ b/python/tests/runtime/test_spreadsheet.py
@@ -4,7 +4,8 @@ import unittest
 
 import time
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 
 
 def make_value(id: int, raw: str, computed: str) -> dict:
@@ -17,7 +18,7 @@ def make_value(id: int, raw: str, computed: str) -> dict:
     }
 
 
-class TestUDF(unittest.TestCase):
+class TestUDF(PipelineTestCase):
     def test_local(self):
         dir = "../crates/pipeline-manager/demos/sql/"
         # Read the file ../crates/pipeline-manager/demos/sql/10-spreadsheet.sql
@@ -30,7 +31,7 @@ class TestUDF(unittest.TestCase):
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_spreadsheet"),
+            name=self.register_for_cleanup("test_spreadsheet"),
             sql=sql,
             udf_rust=udfs,
             udf_toml=toml,

--- a/python/tests/runtime/test_transactions.py
+++ b/python/tests/runtime/test_transactions.py
@@ -1,12 +1,13 @@
 import unittest
 
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
-class TestTransactions(unittest.TestCase):
+class TestTransactions(PipelineTestCase):
     def test_dynamic_output_connector(self):
         # When an output connector is created during a transaction, it should not receive any outputs until the next transaction.
 
@@ -18,7 +19,7 @@ class TestTransactions(unittest.TestCase):
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_dynamic_output_connector"),
+            name=self.register_for_cleanup("test_dynamic_output_connector"),
             sql=sql,
             runtime_config=RuntimeConfig(
                 workers=FELDERA_TEST_NUM_WORKERS,

--- a/python/tests/runtime/test_udf.py
+++ b/python/tests/runtime/test_udf.py
@@ -3,12 +3,13 @@ import unittest
 
 from pandas import Timedelta, Timestamp
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
-class TestUDF(unittest.TestCase):
+class TestUDF(PipelineTestCase):
     def test_local(self):
         sql = """
 CREATE TYPE my_struct AS (
@@ -235,7 +236,7 @@ pub fn nstruct2nstruct(i: Tup2<Option<i32>, Option<SqlString>>) -> Result<Tup2<O
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_udfs"),
+            name=self.register_for_cleanup("test_udfs"),
             sql=sql,
             udf_rust=udfs,
             runtime_config=RuntimeConfig(

--- a/python/tests/runtime/test_udp.py
+++ b/python/tests/runtime/test_udp.py
@@ -1,13 +1,14 @@
 import unittest
 
 from feldera import PipelineBuilder
-from tests import TEST_CLIENT, unique_pipeline_name
+from tests import TEST_CLIENT
+from tests.platform.helper import PipelineTestCase
 from feldera.runtime_config import RuntimeConfig
 from feldera.testutils import FELDERA_TEST_NUM_WORKERS, FELDERA_TEST_NUM_HOSTS
 
 
 # Test user-defined preprocessor
-class TestUDP(unittest.TestCase):
+class TestUDP(PipelineTestCase):
     def test_local(self):
         sql = """
 CREATE TABLE t (
@@ -98,7 +99,7 @@ tracing = { version = "0.1.40" }
 
         pipeline = PipelineBuilder(
             TEST_CLIENT,
-            name=unique_pipeline_name("test_udps"),
+            name=self.register_for_cleanup("test_udps"),
             sql=sql,
             udf_rust=udfs,
             udf_toml=toml,


### PR DESCRIPTION
We have some test that do not get cleaned up automatically when they end or some when they fail.

Not incredibly problematic because we clean them up anyways after 24h but it's also unnecessary to keep them running longer than they have to.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Integration tests added/updated