### PR TITLE
pipeline-manager: reduce dependency of platform on the runtime

### DIFF
--- a/crates/adapters/src/controller/pipeline_diff.rs
+++ b/crates/adapters/src/controller/pipeline_diff.rs
@@ -2,6 +2,7 @@ use feldera_adapterlib::errors::journal::ControllerError;
 use feldera_types::{
     config::PipelineConfig,
     pipeline_diff::{PipelineDiff, ProgramDiff, program_diff},
+    program_schema::ProgramSchema,
 };
 use std::collections::BTreeMap;
 use std::fmt::Display;
@@ -53,17 +54,24 @@ fn compute_program_diff(
         return Err("Unable to compute the diff between the checkpointed and new pipeline configurations: the new configuration does not contain program information. It was likely created by an old version of Feldera.".to_owned());
     };
 
-    let new_relations_with_lateness = new_dataflow
-        .program_schema
+    // TODO: consider parsing only the necessary subset of schema fields to avoid compatibility issues
+    // with older runtime versions.
+    let new_program_schema: ProgramSchema =
+        serde_json::from_value(new_dataflow.program_schema.clone())
+            .map_err(|e| format!("Error parsing new program schema: {}", e))?;
+    let old_program_schema: ProgramSchema =
+        serde_json::from_value(old_dataflow.program_schema.clone())
+            .map_err(|e| format!("Error parsing old program schema: {}", e))?;
+
+    let new_relations_with_lateness = new_program_schema
         .relations_with_lateness()
         .into_iter()
-        .map(|s| s.name())
+        .map(|s| s.name().to_string())
         .collect::<Vec<_>>();
-    let old_relations_with_lateness = old_dataflow
-        .program_schema
+    let old_relations_with_lateness = old_program_schema
         .relations_with_lateness()
         .into_iter()
-        .map(|s| s.name())
+        .map(|s| s.name().to_string())
         .collect::<Vec<_>>();
 
     let blockers = BootstrapBlockers {

--- a/crates/feldera-types/src/config.rs
+++ b/crates/feldera-types/src/config.rs
@@ -6,7 +6,6 @@
 //! that the entire configuration tree can be deserialized from a JSON file.
 
 use crate::preprocess::PreprocessorConfig;
-use crate::program_schema::ProgramSchema;
 use crate::secret_resolver::default_secrets_directory;
 use crate::transport::adhoc::AdHocInputConfig;
 use crate::transport::clock::ClockConfig;
@@ -59,7 +58,7 @@ pub struct ProgramIr {
     /// The MIR of the program.
     pub mir: HashMap<MirNodeId, MirNode>,
     /// Program schema.
-    pub program_schema: ProgramSchema,
+    pub program_schema: serde_json::Value,
 }
 
 /// Pipeline deployment configuration.

--- a/crates/feldera-types/src/program_schema.rs
+++ b/crates/feldera-types/src/program_schema.rs
@@ -180,6 +180,18 @@ impl ProgramSchema {
     }
 }
 
+/// A version of `ProgramSchema` that contains only the name and properties of the relations
+/// by making use of `RelationPropertiesOnly` instead of `Relation` for its inputs and outputs.
+/// This is used to avoid parsing the entire `Relation` object, including SQL schema,
+/// which can change across runtime versions.
+#[derive(Debug, Deserialize)]
+pub struct ProgramSchemaPropertiesOnly {
+    #[serde(default)]
+    pub inputs: Vec<RelationPropertiesOnly>,
+    #[serde(default)]
+    pub outputs: Vec<RelationPropertiesOnly>,
+}
+
 #[derive(Serialize, Deserialize, ToSchema, Debug, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "testing", derive(proptest_derive::Arbitrary))]
 pub struct PropertyValue {
@@ -252,6 +264,17 @@ impl Relation {
         self.primary_key = Some(primary_key.into_iter().map(|id| id.name()).collect());
         self
     }
+}
+
+/// A version of `Relation` that only contains the name and properties.
+/// This is used to avoid parsing the entire `Relation` object, including
+/// SQL schema, which can change across runtime versions.
+#[derive(Debug, Deserialize)]
+pub struct RelationPropertiesOnly {
+    #[serde(flatten)]
+    pub name: SqlIdentifier,
+    #[serde(default)]
+    pub properties: BTreeMap<String, PropertyValue>,
 }
 
 /// A SQL field.

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -29,7 +29,6 @@ use chrono::{DateTime, Utc};
 use feldera_types::adapter_stats::PipelineStatsErrorsResponse;
 use feldera_types::config::{InputEndpointConfig, OutputEndpointConfig, RuntimeConfig};
 use feldera_types::error::ErrorResponse;
-use feldera_types::program_schema::ProgramSchema;
 use feldera_types::runtime_status::{
     BootstrapConfig, BootstrapPolicy, RuntimeDesiredStatus, RuntimeStatus,
 };
@@ -50,7 +49,7 @@ pub mod pipeline_events;
 #[derive(Deserialize, Serialize, ToSchema, Eq, PartialEq, Debug, Clone)]
 pub struct PartialProgramInfo {
     /// Schema of the compiled SQL.
-    pub schema: ProgramSchema,
+    pub schema: serde_json::Value,
 
     /// Generated user defined function (UDF) stubs Rust code: stubs.rs
     pub udf_stubs: String,

--- a/crates/pipeline-manager/src/compiler/sql_compiler.rs
+++ b/crates/pipeline-manager/src/compiler/sql_compiler.rs
@@ -20,7 +20,6 @@ use crate::error::source_error;
 use crate::has_unstable_feature;
 use feldera_ir::Dataflow;
 use feldera_observability::ReqwestTracingExt;
-use feldera_types::program_schema::ProgramSchema;
 use futures_util::StreamExt;
 use indoc::formatdoc;
 use std::fs::Metadata;
@@ -732,10 +731,10 @@ pub(crate) async fn perform_sql_compilation(
     if exit_status.success() {
         // Read schema.json
         let schema_str = read_file_content(&output_json_schema_file_path).await?;
-        let schema: ProgramSchema = serde_json::from_str(&schema_str).map_err(|e| {
+        let schema: serde_json::Value = serde_json::from_str(&schema_str).map_err(|e| {
             SqlCompilationError::SystemError(
                 CommonError::json_deserialization_error(
-                    "schema.json from SQL compiler into ProgramSchema".to_string(),
+                    "schema.json from SQL compiler".to_string(),
                     e,
                 )
                 .to_string(),
@@ -916,7 +915,9 @@ mod test {
     use crate::db::types::utils::validate_program_info;
     use crate::db::types::version::Version;
     use feldera_types::config::TransportConfig;
-    use feldera_types::program_schema::{SqlIdentifier, SqlType};
+    use feldera_types::program_schema::{
+        ProgramSchema, ProgramSchemaPropertiesOnly, SqlIdentifier, SqlType,
+    };
     use indoc::formatdoc;
 
     /// Tests the compilation of several of the most basic SQL programs succeeds.
@@ -1001,9 +1002,13 @@ mod test {
 
         // Check the types of the table and view
         let program_info = validate_program_info(&pipeline_descr.program_info.unwrap()).unwrap();
-        let table = program_info.schema.inputs.first().unwrap();
+
+        let program_schema: ProgramSchema =
+            serde_json::from_value(program_info.schema.clone()).unwrap();
+
+        let table = program_schema.inputs.first().unwrap();
         assert_eq!(table.name, SqlIdentifier::new("t_all", false));
-        let view = program_info.schema.outputs.get(1).unwrap();
+        let view = program_schema.outputs.get(1).unwrap();
         assert_eq!(view.name, SqlIdentifier::new("v_all", false));
         for relation in [table, view] {
             assert!(!relation.materialized);
@@ -1135,6 +1140,20 @@ mod test {
             assert!(subfields[1].columntype.nullable);
         }
 
+        // Program schema only with properties
+        let program_schema_properties_only: ProgramSchemaPropertiesOnly =
+            serde_json::from_value(program_info.schema.clone()).unwrap();
+
+        // Table
+        let table_properties_only = program_schema_properties_only.inputs.first().unwrap();
+        assert_eq!(table_properties_only.name, table.name);
+        assert_eq!(table_properties_only.properties, table.properties);
+
+        // View
+        let view_properties_only = program_schema_properties_only.outputs.get(1).unwrap();
+        assert_eq!(view_properties_only.name, view.name);
+        assert_eq!(view_properties_only.properties, view.properties);
+
         // Clean up
         test.delete_pipeline(tenant_id, pipeline_id, "p1").await;
         test.sql_compiler_tick().await;
@@ -1167,8 +1186,10 @@ mod test {
 
         // Check materialized outcome
         let program_info = validate_program_info(&pipeline_descr.program_info.unwrap()).unwrap();
-        assert_eq!(program_info.schema.inputs.len(), 3);
-        for table in program_info.schema.inputs {
+        let program_schema: ProgramSchema =
+            serde_json::from_value(program_info.schema.clone()).unwrap();
+        assert_eq!(program_schema.inputs.len(), 3);
+        for table in program_schema.inputs {
             match table.name.name().as_str() {
                 "t1" => assert!(!table.materialized),
                 "t2" => assert!(table.materialized),
@@ -1176,8 +1197,8 @@ mod test {
                 t => panic!("Unknown table: {t}"),
             }
         }
-        assert_eq!(program_info.schema.outputs.len(), 3);
-        for view in program_info.schema.outputs {
+        assert_eq!(program_schema.outputs.len(), 3);
+        for view in program_schema.outputs {
             match view.name.name().as_str() {
                 "v1" => assert!(!view.materialized),
                 // v2 is a LOCAL VIEW and should not be an output
@@ -1227,7 +1248,7 @@ mod test {
         let pipeline_descr = test
             .check_outcome_sql_compiled(tenant_id, pipeline_id, program_code)
             .await;
-        let input_connectors = validate_program_info(&pipeline_descr.program_info.unwrap())
+        let input_connectors = validate_program_info(&pipeline_descr.program_info.clone().unwrap())
             .unwrap()
             .clone()
             .input_connectors;
@@ -1241,6 +1262,17 @@ mod test {
             connector_config.transport,
             TransportConfig::Datagen(_)
         ));
+
+        // Program schema only with properties: check properties
+        let program_schema_properties_only: ProgramSchemaPropertiesOnly =
+            serde_json::from_value(pipeline_descr.program_info.unwrap()["schema"].clone()).unwrap();
+        let table_properties_only = program_schema_properties_only.inputs.first().unwrap();
+        assert_eq!(table_properties_only.name, "t1");
+        assert_eq!(table_properties_only.properties.len(), 1);
+        assert!(table_properties_only.properties.contains_key("connectors"));
+        assert!(table_properties_only.properties["connectors"]
+            .value
+            .contains("\"name\": \"c1\""));
     }
 
     /// Tests that SQL compiler recovers from an incorrect platform version.

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -363,10 +363,11 @@ fn map_val_to_limited_program_info(val: ProgramInfoPropVal) -> serde_json::Value
         json!({ "schema": 222 }) // An invalid program information
     } else {
         serde_json::to_value(ProgramInfo {
-            schema: ProgramSchema {
+            schema: serde_json::to_value(ProgramSchema {
                 inputs: vec![],
                 outputs: vec![],
-            },
+            })
+            .unwrap(),
             main_rust: format!("main-rust-{}", val.1),
             udf_stubs: format!("udf-stubs-{}", val.2),
             input_connectors: BTreeMap::new(),
@@ -1400,10 +1401,11 @@ async fn pipeline_program_compilation() {
                 messages: vec![],
             },
             &serde_json::to_value(ProgramInfo {
-                schema: ProgramSchema {
+                schema: serde_json::to_value(ProgramSchema {
                     inputs: vec![],
                     outputs: vec![],
-                },
+                })
+                .unwrap(),
                 main_rust: "".to_string(),
                 udf_stubs: "".to_string(),
                 input_connectors: BTreeMap::new(),
@@ -1563,10 +1565,11 @@ async fn pipeline_transition_after_quick_stop() {
                 messages: vec![],
             },
             &serde_json::to_value(ProgramInfo {
-                schema: ProgramSchema {
+                schema: serde_json::to_value(ProgramSchema {
                     inputs: vec![],
                     outputs: vec![],
-                },
+                })
+                .unwrap(),
                 main_rust: "".to_string(),
                 udf_stubs: "".to_string(),
                 input_connectors: BTreeMap::new(),
@@ -1678,7 +1681,6 @@ async fn pipeline_transition_after_quick_stop() {
                     pipeline1.id,
                     &pipeline1.name,
                     &serde_json::from_value(pipeline1.runtime_config.clone()).unwrap(),
-                    None,
                 ))
                 .unwrap(),
             )
@@ -1784,10 +1786,11 @@ async fn pipeline_deployment() {
                 messages: vec![],
             },
             &serde_json::to_value(ProgramInfo {
-                schema: ProgramSchema {
+                schema: serde_json::to_value(ProgramSchema {
                     inputs: vec![],
                     outputs: vec![],
-                },
+                })
+                .unwrap(),
                 main_rust: "".to_string(),
                 udf_stubs: "".to_string(),
                 input_connectors: BTreeMap::new(),
@@ -1871,7 +1874,6 @@ async fn pipeline_deployment() {
                 pipeline1.id,
                 &pipeline1.name,
                 &serde_json::from_value(pipeline1.runtime_config.clone()).unwrap(),
-                None,
             ))
             .unwrap(),
         )
@@ -2085,7 +2087,6 @@ async fn pipeline_deployment() {
                 pipeline1.id,
                 &pipeline1.name,
                 &serde_json::from_value(pipeline1.runtime_config.clone()).unwrap(),
-                Some(&ProgramInfo::default()),
             ))
             .unwrap(),
         )
@@ -2218,7 +2219,6 @@ async fn pipeline_deployment() {
                 pipeline1.id,
                 &pipeline1.name,
                 &serde_json::from_value(pipeline1.runtime_config).unwrap(),
-                Some(&ProgramInfo::default()),
             ))
             .unwrap(),
         )
@@ -2500,10 +2500,11 @@ async fn pipeline_provision_version_guard() {
                 messages: vec![],
             },
             &serde_json::to_value(ProgramInfo {
-                schema: ProgramSchema {
+                schema: serde_json::to_value(ProgramSchema {
                     inputs: vec![],
                     outputs: vec![],
-                },
+                })
+                .unwrap(),
                 main_rust: "".to_string(),
                 udf_stubs: "".to_string(),
                 input_connectors: BTreeMap::new(),
@@ -2629,7 +2630,6 @@ async fn pipeline_provision_version_guard() {
                       pipeline.id,
                       &pipeline.name,
                       &serde_json::from_value(pipeline.runtime_config.clone()).unwrap(),
-                      None,
                   )).unwrap(),
               )
               .await.unwrap_err(),
@@ -2700,7 +2700,6 @@ async fn pipeline_provision_version_guard() {
                 pipeline.id,
                 &pipeline.name,
                 &serde_json::from_value(pipeline.runtime_config.clone()).unwrap(),
-                Some(&ProgramInfo::default()),
             ))
             .unwrap(),
         )

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -9,7 +9,9 @@ use feldera_types::config::{
     ConnectorConfig, InputEndpointConfig, MultihostConfig, OutputEndpointConfig, PipelineConfig,
     PipelineConfigProgramInfo, ProgramIr, RuntimeConfig, TransportConfig,
 };
-use feldera_types::program_schema::{ProgramSchema, PropertyValue, SourcePosition, SqlIdentifier};
+use feldera_types::program_schema::{
+    ProgramSchemaPropertiesOnly, PropertyValue, SourcePosition, SqlIdentifier,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -132,6 +134,12 @@ impl SqlCompilerMessage {
             ConnectorGenerationError::ExpectedInputConnector { position, .. } => position,
             ConnectorGenerationError::ExpectedOutputConnector { position, .. } => position,
             ConnectorGenerationError::RelationConnectorNameCollision { position, .. } => position,
+            ConnectorGenerationError::InvalidProgramSchema { .. } => SourcePosition {
+                start_line_number: 0,
+                start_column: 0,
+                end_line_number: 0,
+                end_column: 0,
+            },
         };
         SqlCompilerMessage {
             start_line_number: position.start_line_number,
@@ -521,6 +529,8 @@ pub enum ConnectorGenerationError {
         relation: String,
         connector_name: String,
     },
+    #[error("error parsing program schema: {error}")]
+    InvalidProgramSchema { error: String },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
@@ -621,10 +631,10 @@ fn determine_connector_endpoint_names(
 ///
 /// It includes information needed for Rust compilation (e.g., generated Rust code)
 /// as well as only for runtime (e.g., schema, input/output connectors).
-#[derive(Default, Deserialize, Serialize, Eq, PartialEq, Debug, Clone, ToSchema)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, ToSchema)]
 pub struct ProgramInfo {
     /// Schema of the compiled SQL.
-    pub schema: ProgramSchema,
+    pub schema: serde_json::Value,
 
     /// Generated main program Rust code: main.rs
     #[serde(default)] // TODO: when a breaking migration can happen, remove this default
@@ -664,14 +674,19 @@ impl ProgramInfo {
 /// Generates the program info using the program schema.
 /// The info includes the schema and the input/output connectors derived from it.
 pub fn generate_program_info(
-    program_schema: ProgramSchema,
+    program_schema: serde_json::Value,
     main_rust: String,
     udf_stubs: String,
     dataflow: Option<Dataflow>,
 ) -> Result<ProgramInfo, ConnectorGenerationError> {
+    let program_schema_properties_only = ProgramSchemaPropertiesOnly::deserialize(&program_schema)
+        .map_err(|e| ConnectorGenerationError::InvalidProgramSchema {
+            error: e.to_string(),
+        })?;
+
     // Input connectors
     let mut input_connectors = vec![];
-    for input_relation in &program_schema.inputs {
+    for input_relation in program_schema_properties_only.inputs {
         let (connectors, origin_value) =
             parse_named_connectors(input_relation.name.clone(), &input_relation.properties)?;
         for connector in connectors {
@@ -724,7 +739,7 @@ pub fn generate_program_info(
 
     // Output connectors
     let mut output_connectors = vec![];
-    for output_relation in &program_schema.outputs {
+    for output_relation in &program_schema_properties_only.outputs {
         let (connectors, origin_value) =
             parse_named_connectors(output_relation.name.clone(), &output_relation.properties)?;
         for connector in connectors {
@@ -779,66 +794,21 @@ pub fn generate_program_info(
     })
 }
 
-/// Generates the pipeline configuration derived from the runtime configuration and the
-/// input/output connectors derived from the program schema.
+/// Generates the pipeline configuration derived from the runtime configuration.
 ///
-/// `program_info` is specified if the program was compiled by an older version of
-/// the runtime and its program info hasn't been uploaded to the compiler server.
-/// Such programs require the pipeline manager to provide program info via PipelineConfig.
-// TODO: remove the program_info parameter once we're allowed to stop supporting
-// platform versions <=0.199.0.
+/// The returned pipeline config leaves three fields empty (they will be populated later from
+/// `ProgramInfo`): `inputs`, `outputs`, `program_ir`.
+///
+/// These fields are populated when starting the pipeline: the local runner pulls program
+/// info from the compiler server and generates a config file itself. The k8s runner
+/// only distributes the subset of the pipeline config generated here via ConfigMap;
+/// the pipeline pulls the rest from the compiler server and merges the two in the startup
+/// shell script.
 pub fn generate_pipeline_config(
     pipeline_id: PipelineId,
     pipeline_name: &str,
     runtime_config: &RuntimeConfig,
-    program_info: Option<&ProgramInfo>,
 ) -> PipelineConfig {
-    let (inputs, outputs, program_ir) = if let Some(program_info) = program_info {
-        // Only keep tables and views, ignoring intermediate nodes.
-        // These are currently the only nodes used by the pipeline
-        // (to compute pipeline diffs). Including all nodes can cause the IR
-        // to exceed the maximum ConfigMap size supported by k8s (1MB).
-        let mir = program_info
-            .dataflow
-            .as_ref()
-            .map(|d| {
-                d.mir
-                    .iter()
-                    .filter_map(|(k, v)| {
-                        if v.is_relation() {
-                            Some((k.clone(), v.clone()))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // Remove inputs and outputs that do not have lateness.
-        // This field is currently only used for backfill avoidance, which only cares about
-        // relations with lateness. Including the entire schema would cause the IR to exceed the
-        // maximum ConfigMap size supported by k8s (1MB).
-        let mut program_schema = program_info.schema.clone();
-        program_schema.inputs.retain(|input| input.has_lateness());
-        program_schema
-            .outputs
-            .retain(|output| output.has_lateness());
-
-        let program_ir = ProgramIr {
-            mir,
-            program_schema,
-        };
-
-        (
-            program_info.input_connectors.clone(),
-            program_info.output_connectors.clone(),
-            Some(program_ir),
-        )
-    } else {
-        Default::default()
-    };
-
     PipelineConfig {
         name: Some(format!("pipeline-{pipeline_id}")),
         given_name: Some(pipeline_name.to_string()),
@@ -852,9 +822,9 @@ pub fn generate_pipeline_config(
         } else {
             None
         },
-        inputs,
-        outputs,
-        program_ir,
+        inputs: BTreeMap::new(),
+        outputs: BTreeMap::new(),
+        program_ir: None,
     }
 }
 

--- a/crates/pipeline-manager/src/db/types/utils.rs
+++ b/crates/pipeline-manager/src/db/types/utils.rs
@@ -271,10 +271,11 @@ mod tests {
     fn program_info_validation() {
         // ProgramInfo -> JSON -> ProgramInfo is the same as original
         let program_info = ProgramInfo {
-            schema: ProgramSchema {
+            schema: serde_json::to_value(ProgramSchema {
                 inputs: vec![],
                 outputs: vec![],
-            },
+            })
+            .unwrap(),
             main_rust: "".to_string(),
             udf_stubs: "".to_string(),
             input_connectors: Default::default(),

--- a/crates/pipeline-manager/src/runner/error.rs
+++ b/crates/pipeline-manager/src/runner/error.rs
@@ -19,6 +19,9 @@ pub enum RunnerError {
     AutomatonCannotConstructProgramBinaryUrl {
         error: String,
     },
+    AutomatonCannotConstructProgramInfoUrl {
+        error: String,
+    },
     AutomatonMissingDeploymentId,
     AutomatonMissingDeploymentConfig,
     AutomatonMissingDeploymentLocation,
@@ -119,6 +122,9 @@ impl DetailedError for RunnerError {
             RunnerError::AutomatonCannotConstructProgramBinaryUrl { .. } => {
                 Cow::from("AutomatonCannotConstructProgramBinaryUrl")
             }
+            RunnerError::AutomatonCannotConstructProgramInfoUrl { .. } => {
+                Cow::from("AutomatonCannotConstructProgramInfoUrl")
+            }
             RunnerError::AutomatonMissingDeploymentId => Cow::from("AutomatonMissingDeploymentId"),
             RunnerError::AutomatonMissingDeploymentConfig => {
                 Cow::from("AutomatonMissingDeploymentConfig")
@@ -199,6 +205,9 @@ impl Display for RunnerError {
             }
             Self::AutomatonCannotConstructProgramBinaryUrl { error } => {
                 write!(f, "Cannot construct program binary URL due to: {error}")
+            }
+            Self::AutomatonCannotConstructProgramInfoUrl { error } => {
+                write!(f, "Cannot construct program info URL due to: {error}")
             }
             Self::AutomatonMissingDeploymentId => {
                 write!(
@@ -407,6 +416,9 @@ impl ResponseError for RunnerError {
         match self {
             Self::AutomatonMissingProgramInfo => StatusCode::INTERNAL_SERVER_ERROR,
             Self::AutomatonCannotConstructProgramBinaryUrl { .. } => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::AutomatonCannotConstructProgramInfoUrl { .. } => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::AutomatonMissingDeploymentId => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/pipeline-manager/src/runner/local_runner.rs
+++ b/crates/pipeline-manager/src/runner/local_runner.rs
@@ -439,7 +439,7 @@ impl PipelineExecutor for LocalRunner {
         deployment_config: &PipelineConfig,
         _program_info: &serde_json::Value,
         program_binary_url: &str,
-        program_info_url: Option<&str>,
+        program_info_url: &str,
         program_version: Version,
         _runtime_config: &serde_json::Value,
     ) -> Result<(), ManagerError> {
@@ -485,47 +485,46 @@ impl PipelineExecutor for LocalRunner {
         // Going forward, we should be able to pass program info and deployment config files
         // as separate arguments to the pipeline instead of merging them into one JSON file.
         let mut deployment_config = deployment_config.clone();
-        if let Some(program_info_url) = program_info_url {
-            // Retrieve and store executable in pipeline working directory
-            let program_info_file_path = self.config.program_info_file_path(self.pipeline_id);
 
-            self.retrieve_pipeline_file(
-                program_info_url,
-                "program info",
-                &program_info_file_path,
-                0o660, // User: rw, Group: rw, Others: /
-            )
-            .await?;
+        // Retrieve and store program info in pipeline working directory
+        let program_info_file_path = self.config.program_info_file_path(self.pipeline_id);
 
-            // Read and parse the program info file
-            let program_info_contents =
-                fs::read_to_string(&program_info_file_path)
-                    .await
-                    .map_err(|e| {
-                        ManagerError::from(CommonError::io_error(
-                            format!(
-                                "read program info file '{}'",
-                                program_info_file_path.display()
-                            ),
-                            e,
-                        ))
-                    })?;
+        self.retrieve_pipeline_file(
+            program_info_url,
+            "program info",
+            &program_info_file_path,
+            0o660, // User: rw, Group: rw, Others: /
+        )
+        .await?;
 
-            let program_info: PipelineConfigProgramInfo =
-                serde_json::from_str(&program_info_contents).map_err(|e| {
-                    ManagerError::from(RunnerError::RunnerProvisionError {
-                        error: format!(
-                            "failed to parse program info file '{}': {e}",
+        // Read and parse the program info file
+        let program_info_contents =
+            fs::read_to_string(&program_info_file_path)
+                .await
+                .map_err(|e| {
+                    ManagerError::from(CommonError::io_error(
+                        format!(
+                            "read program info file '{}'",
                             program_info_file_path.display()
                         ),
-                    })
+                        e,
+                    ))
                 })?;
 
-            // Merge program info into deployment_config
-            deployment_config.inputs = program_info.inputs;
-            deployment_config.outputs = program_info.outputs;
-            deployment_config.program_ir = program_info.program_ir;
-        }
+        let program_info: PipelineConfigProgramInfo = serde_json::from_str(&program_info_contents)
+            .map_err(|e| {
+                ManagerError::from(RunnerError::RunnerProvisionError {
+                    error: format!(
+                        "failed to parse program info file '{}': {e}",
+                        program_info_file_path.display()
+                    ),
+                })
+            })?;
+
+        // Merge program info into deployment_config
+        deployment_config.inputs = program_info.inputs;
+        deployment_config.outputs = program_info.outputs;
+        deployment_config.program_ir = program_info.program_ir;
 
         // Write config as YAML and JSON
         //

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -951,8 +951,8 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             }
         };
 
-        // Input and output connectors from required program_info
-        let program_info = match &pipeline.program_info {
+        // Validate the required program_info which includes input and output connectors
+        let _program_info = match &pipeline.program_info {
             None => {
                 return Action::RemainStoppedUpdateError {
                     error: RunnerError::AutomatonMissingProgramInfo.into(),
@@ -976,16 +976,8 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
         let deployment_id = Uuid::now_v7();
 
         // Deployment configuration
-        let mut deployment_config = generate_pipeline_config(
-            pipeline.id,
-            &pipeline.name,
-            &runtime_config,
-            if pipeline.program_info_integrity_checksum.is_none() {
-                Some(&program_info)
-            } else {
-                None
-            },
-        );
+        let mut deployment_config =
+            generate_pipeline_config(pipeline.id, &pipeline.name, &runtime_config);
         deployment_config.storage_config =
             Some(self.pipeline_handle.generate_storage_config().await);
         let deployment_config_json = match serde_json::to_value(&deployment_config) {
@@ -1295,26 +1287,35 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
             },
         );
 
-        let program_info_url = if let Some(program_info_integrity_checksum) =
+        let Some(program_info_integrity_checksum) =
             pipeline.program_info_integrity_checksum.as_ref()
-        {
-            Some(format!(
-                "{}://{}:{}/program_info/{}/{}/{}/{}",
-                if self.common_config.enable_https {
-                    "https"
-                } else {
-                    "http"
-                },
-                self.common_config.compiler_host,
-                self.common_config.compiler_port,
-                self.pipeline_id,
-                pipeline.program_version,
-                source_checksum,
-                program_info_integrity_checksum,
-            ))
-        } else {
-            None
+        else {
+            return Action::TransitionToStopping {
+                error: Some(
+                    RunnerError::AutomatonCannotConstructProgramInfoUrl {
+                        error: "integrity checksum is missing".to_string(),
+                    }
+                    .into(),
+                ),
+                storage_status_details: None,
+            };
         };
+
+        // URL where the program info can be downloaded from
+        let program_info_url = format!(
+            "{}://{}:{}/program_info/{}/{}/{}/{}",
+            if self.common_config.enable_https {
+                "https"
+            } else {
+                "http"
+            },
+            self.common_config.compiler_host,
+            self.common_config.compiler_port,
+            self.pipeline_id,
+            pipeline.program_version,
+            source_checksum,
+            program_info_integrity_checksum,
+        );
 
         let bootstrap_config =
             if Self::platform_version_requires_bootstrap_policy(&pipeline.platform_version) {
@@ -1342,7 +1343,7 @@ impl<T: PipelineExecutor> PipelineAutomaton<T> {
                 &deployment_config,
                 program_info,
                 &program_binary_url,
-                program_info_url.as_deref(),
+                &program_info_url,
                 pipeline.program_version,
                 &pipeline.runtime_config,
             )
@@ -1916,7 +1917,7 @@ mod test {
             _: &PipelineConfig,
             _: &serde_json::Value,
             _: &str,
-            _: Option<&str>,
+            _: &str,
             _: Version,
             _: &serde_json::Value,
         ) -> Result<(), ManagerError> {
@@ -2081,10 +2082,11 @@ mod test {
                     messages: vec![],
                 },
                 &serde_json::to_value(ProgramInfo {
-                    schema: ProgramSchema {
+                    schema: serde_json::to_value(ProgramSchema {
                         inputs: vec![],
                         outputs: vec![],
-                    },
+                    })
+                    .unwrap(),
                     main_rust: "".to_string(),
                     udf_stubs: "".to_string(),
                     input_connectors: Default::default(),

--- a/crates/pipeline-manager/src/runner/pipeline_executor.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_executor.rs
@@ -76,7 +76,7 @@ pub trait PipelineExecutor: Sync + Send {
         deployment_config: &PipelineConfig,
         program_info: &serde_json::Value,
         program_binary_url: &str,
-        program_info_url: Option<&str>,
+        program_info_url: &str,
         program_version: Version,
         runtime_config: &serde_json::Value,
     ) -> Result<(), ManagerError>;

--- a/openapi.json
+++ b/openapi.json
@@ -10579,7 +10579,7 @@
             }
           },
           "schema": {
-            "$ref": "#/components/schemas/ProgramSchema"
+            "description": "Schema of the compiled SQL."
           },
           "udf_stubs": {
             "type": "string",
@@ -12003,7 +12003,7 @@
             }
           },
           "schema": {
-            "$ref": "#/components/schemas/ProgramSchema"
+            "description": "Schema of the compiled SQL."
           },
           "udf_stubs": {
             "type": "string",
@@ -12027,7 +12027,7 @@
             }
           },
           "program_schema": {
-            "$ref": "#/components/schemas/ProgramSchema"
+            "description": "Program schema."
           }
         }
       },

--- a/python/feldera/_helpers.py
+++ b/python/feldera/_helpers.py
@@ -81,7 +81,11 @@ def dataframe_from_response(
         column_name = column["name"]
         if not column["case_sensitive"]:
             column_name = column_name.lower()
-        column_type = column["columntype"]["type"]
+        if "type" in column["columntype"]:
+            column_type = column["columntype"]["type"]
+        else:
+            # default column type
+            column_type = "struct"
         if column_type == "DECIMAL":
             decimal_col.append(column_name)
         elif column_type == "UUID":


### PR DESCRIPTION
- Remove ConfigMap size workaround.

  We used to store a truncated version of program schema + connector configurations in the ConfigMap. This is only required for pre-v0.199 pipelines, since new pipelines receive this information from the compiler server instead of the ConfigMap. This backward compatibility code is removed, and eliminates the possibility of ConfigMaps growing beyond 1MB and reduces the dependency the platform has on the runtime.
  
- Don't parse relation schema in the manager.

  Pipeline manager needs to parse program schema in order to validate and name connectors. This introduces an unfortunate dependency between the platform and the runtime and we are hoping to eliminate it by moving connector validation into the compiler. For now, we reduce the surface of the dependency by having the pipeline manager parse only the properties field in each relation, ignoring the SQL schema info. This reduces the likelihood of runtime/platform compatibility issues.
  
- Require `program_info_url` as part of `provision()`.
  
  The `program_info_url` is now a mandatory parameter for a pipeline to be able to be started, as its absence has been long enough deprecated. An error is added in case it is missing. This makes it consistent with how program info is handled across runners.


**PR information**
- Once this patch is merged, the timestamp with timezone PR #2743 should be able to get through CI.
- Backward compatibility is discussed above including deprecation
- Unit tests