### PR TITLE
[DBSP] Add a region for star_join

### DIFF
--- a/crates/dbsp/src/operator/dynamic/multijoin/star_join.rs
+++ b/crates/dbsp/src/operator/dynamic/multijoin/star_join.rs
@@ -658,8 +658,8 @@ where
                 })
                 .collect::<Vec<_>>();
 
-            // Delayed traces
-            let delayed_traces = traces
+            // Delayed traces; only n-1 are needed
+            let delayed_traces = &traces[..traces.len() - 1]
                 .iter()
                 .map(|(trace, batch_factories)| (trace.accumulate_delay_trace(), batch_factories))
                 .collect::<Vec<_>>();

--- a/crates/dbsp/src/operator/dynamic/multijoin/star_join.rs
+++ b/crates/dbsp/src/operator/dynamic/multijoin/star_join.rs
@@ -640,78 +640,80 @@ where
         assert_eq!(factories.input_factories.len(), others.len() + 1);
         assert_eq!(join_funcs.len(), others.len() + 1);
 
-        // Shard the input streams.
-        let streams = std::iter::once(self)
-            .chain(others.iter())
-            .zip(factories.input_factories.iter())
-            .collect::<Vec<_>>();
+        self.circuit().region("star_join", || {
+            // Shard the input streams.
+            let streams = std::iter::once(self)
+                .chain(others.iter())
+                .zip(factories.input_factories.iter())
+                .collect::<Vec<_>>();
 
-        // Traces
-        let traces = streams
-            .iter()
-            .map(|(stream, (batch_factories, trace_factories))| {
-                (
-                    stream.dyn_shard_accumulate_trace(trace_factories, batch_factories),
-                    batch_factories,
+            // Traces
+            let traces = streams
+                .iter()
+                .map(|(stream, (batch_factories, trace_factories))| {
+                    (
+                        stream.dyn_shard_accumulate_trace(trace_factories, batch_factories),
+                        batch_factories,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // Delayed traces
+            let delayed_traces = traces
+                .iter()
+                .map(|(trace, batch_factories)| (trace.accumulate_delay_trace(), batch_factories))
+                .collect::<Vec<_>>();
+
+            let mut output_streams = Vec::new();
+
+            for (i, (stream, (batch_factories, _trace_factories))) in streams.iter().enumerate() {
+                let delayed = &delayed_traces[..i];
+                let current = &traces[i + 1..];
+                let join_func = join_funcs[i].clone();
+
+                let match_factories = MatchFactories {
+                    prefix_factories: factories.input_factories[i].0.clone(),
+                    output_factories: factories.output_factories.clone(),
+                    timed_item_factory: factories.timed_item_factory,
+                    timed_items_factory: factories.timed_items_factory,
+                };
+
+                let output: Stream<C, O> = self.circuit().add_custom_node(
+                    format!("InnerStarJoin_{i}").into(),
+                    move |node_id| {
+                        let mut builder = MatchBuilder::new(
+                            &match_factories,
+                            self.circuit().global_node_id().child(node_id),
+                            self.circuit().clone(),
+                            stream.dyn_shard_accumulate(batch_factories),
+                            StarJoinMatchFunc::new(join_func, others.len()),
+                        );
+                        delayed.iter().for_each(|(trace, batch_factories)| {
+                            builder.add_input(trace.clone(), batch_factories.val_factory(), false);
+                        });
+                        current.iter().for_each(|(trace, batch_factories)| {
+                            builder.add_input(trace.clone(), batch_factories.val_factory(), false);
+                        });
+                        let join = builder.build();
+                        let output_stream = join.output_stream();
+
+                        (join, output_stream)
+                    },
+                );
+                output_streams.push(output);
+            }
+
+            // Merge outputs.
+            let output_factories = factories.output_factories.clone();
+
+            apply_n(self.circuit(), output_streams.iter(), move |batches| {
+                merge_batches_by_reference(
+                    &output_factories,
+                    batches.collect::<Vec<_>>().iter().map(|b| b.as_ref()),
+                    &None,
+                    &None,
                 )
             })
-            .collect::<Vec<_>>();
-
-        // Delayed traces
-        let delayed_traces = traces
-            .iter()
-            .map(|(trace, batch_factories)| (trace.accumulate_delay_trace(), batch_factories))
-            .collect::<Vec<_>>();
-
-        let mut output_streams = Vec::new();
-
-        for (i, (stream, (batch_factories, _trace_factories))) in streams.iter().enumerate() {
-            let delayed = &delayed_traces[..i];
-            let current = &traces[i + 1..];
-            let join_func = join_funcs[i].clone();
-
-            let match_factories = MatchFactories {
-                prefix_factories: factories.input_factories[i].0.clone(),
-                output_factories: factories.output_factories.clone(),
-                timed_item_factory: factories.timed_item_factory,
-                timed_items_factory: factories.timed_items_factory,
-            };
-
-            let output: Stream<C, O> = self.circuit().add_custom_node(
-                format!("InnerStarJoin_{i}").into(),
-                move |node_id| {
-                    let mut builder = MatchBuilder::new(
-                        &match_factories,
-                        self.circuit().global_node_id().child(node_id),
-                        self.circuit().clone(),
-                        stream.dyn_shard_accumulate(batch_factories),
-                        StarJoinMatchFunc::new(join_func, others.len()),
-                    );
-                    delayed.iter().for_each(|(trace, batch_factories)| {
-                        builder.add_input(trace.clone(), batch_factories.val_factory(), false);
-                    });
-                    current.iter().for_each(|(trace, batch_factories)| {
-                        builder.add_input(trace.clone(), batch_factories.val_factory(), false);
-                    });
-                    let join = builder.build();
-                    let output_stream = join.output_stream();
-
-                    (join, output_stream)
-                },
-            );
-            output_streams.push(output);
-        }
-
-        // Merge outputs.
-        let output_factories = factories.output_factories.clone();
-
-        apply_n(self.circuit(), output_streams.iter(), move |batches| {
-            merge_batches_by_reference(
-                &output_factories,
-                batches.collect::<Vec<_>>().iter().map(|b| b.as_ref()),
-                &None,
-                &None,
-            )
         })
     }
 }

--- a/js-packages/profiler-lib/src/cytograph.ts
+++ b/js-packages/profiler-lib/src/cytograph.ts
@@ -339,6 +339,10 @@ export class Cytograph {
             }
         }
 
+        // Keys are pairs (Simple node ID, target node ID), where target is simple or complex
+        // Used to avoid inserting the same edge twice between two complex nodes
+        // if the edge represents the same channel.
+        let insertedEdges: Set<string> = new Set();
         for (const edge of profile.edges) {
             let source = edge.source;
             let target = edge.target;
@@ -360,12 +364,24 @@ export class Cytograph {
             let sourceNode = inserted.get(source).expect(`Node ${source} not found in visible map`);
             let targetNode = inserted.get(target).expect(`Node ${target} not found in visible map`);
 
-            if (sourceNode !== targetNode) {
+            if (sourceNode === targetNode) {
                 // Induced edges can be self-edges; do not add these
-                let realEdge = result.createEdge(sourceNode.id, targetNode.id, edge.back);
-                result.edges.push(realEdge);
-                result.mapEdge(originalEdge, realEdge);
+                continue;
             }
+
+            // Detect whether an edge represents the same channel as a previous edge
+            // (only suppressed if the edge goes to a complex node)
+            if (!expandTarget) {
+                let pair = edge.source.toString() + "," + targetNode.id.toString();
+                if (insertedEdges.has(pair)) {
+                    continue;
+                }
+                insertedEdges.add(pair);
+            }
+
+            let realEdge = result.createEdge(sourceNode.id, targetNode.id, edge.back);
+            result.edges.push(realEdge);
+            result.mapEdge(originalEdge, realEdge);
         }
         return result;
     }


### PR DESCRIPTION
Three commits with three simple fixes
- make star_join a region
- skip generating one unused operator as part of star_join expansion
- improve profiler visualization for collapsed operators with many edges  

Related to #6285

### Describe Manual Test Plan

Ran profiler manually and inspected result

