### PR TITLE
python: fix test `nowstream` and `update stop_force_after_start`

### DIFF
--- a/python/tests/platform/test_nowstream.py
+++ b/python/tests/platform/test_nowstream.py
@@ -14,7 +14,10 @@ from feldera.enums import PipelineStatus
 
 def get_result(pipeline) -> str:
     result = list(pipeline.query("SELECT * FROM v;"))
-    assert len(result) == 1
+    assert len(result) == 1, f"result length was not 1; result: {result}"
+    assert "x" in result[0], (
+        f"first entry of result did not contain column 'x'; result: {result}"
+    )
     return result[0]["x"]
 
 
@@ -45,8 +48,9 @@ class TestNowStream(PipelineTestCase):
 
         pipeline.start()
         assert pipeline.status() == PipelineStatus.RUNNING
+        time.sleep(2)
         time0 = get_result(pipeline)
-        time.sleep(1)
+        time.sleep(2)
         time1 = get_result(pipeline)
         # Time has increased; this works on string time representations too
         # due to the standard format, which looks like `2025-10-20T20:55:16.350`

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -184,17 +184,22 @@ def test_pipeline_stop_force_after_start(pipeline_name):
     """
     Start and then force stop after varying short delays.
     """
-    create_pipeline(pipeline_name, "CREATE TABLE t1(c1 INTEGER);")
+    pipeline = PipelineBuilder(
+        TEST_CLIENT, pipeline_name, "CREATE TABLE t1(c1 INTEGER);"
+    ).create_or_replace()
 
     for delay_sec in [0, 0.1, 0.5, 1, 3, 10, 20]:
         print(f"Testing with {delay_sec} second delay")
+
         # Issue non-blocking start
-        start_pipeline(pipeline_name, wait=False)
+        pipeline.start(wait=False)
+
         # Shortly wait for the pipeline to transition to next state(s)
         time.sleep(delay_sec)
+
         # Stop force and clear the pipeline
-        stop_pipeline(pipeline_name, force=True)
-        clear_pipeline(pipeline_name)
+        pipeline.stop(force=True)
+        pipeline.clear_storage()
 
 
 @gen_pipeline_name


### PR DESCRIPTION
The `nowstream` test assumed that there immediately is a value present in the view when selecting from `NOW()`, but it can be it has not yet processed a step. This adds two delays, one before getting the first value, and one before getting the second value.

Use the `Pipeline` API for the `stop_force_after_start` test. This is a possible fix for the case where it cannot start because the pipeline is still stopping.