### PR TITLE
[adapters] Revert read-after-write semantics in ad hoc queries.

### DIFF
--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -292,7 +292,7 @@ pub(crate) async fn execute_sql(
             .await
             .ok_or_else(|| PipelineError::Initializing)?,
     );
-    execute_sql_with_state(state, sql, Some(controller)).await
+    execute_sql_with_state(state, sql).await
 }
 
 /// Plan and translate `sql` against `state`, applying `PREPARE`/`EXECUTE`
@@ -300,17 +300,10 @@ pub(crate) async fn execute_sql(
 ///
 /// Only the final statement returns rows. Earlier statements may be
 /// `PREPARE`s or any non-result-producing statement (e.g. `INSERT`),
-/// executed for their side effect. After such an intermediate write
-/// runs, the per-request snapshot is refreshed so the trailing SELECT
-/// sees the just-written rows.
-///
-/// `controller` is optional so unit tests can drive this function
-/// without a running pipeline; in that case the post-write snapshot
-/// refresh is skipped.
+/// executed for their side effect.
 async fn execute_sql_with_state(
-    mut state: SessionState,
+    state: SessionState,
     sql: &str,
-    controller: Option<&Controller>,
 ) -> Result<DataFrame, PipelineError> {
     let mut statements = parse_sql_statements(&state, sql)?;
     if statements.is_empty() {
@@ -326,13 +319,6 @@ async fn execute_sql_with_state(
     let mut prepared: HashMap<String, LogicalPlan> = HashMap::new();
     let sql_options = SQLOptions::new().with_allow_ddl(false);
 
-    // Subscribe to `step_watcher` *before* any intermediate writes so the
-    // steps that drain those writes accumulate as unseen changes; calling
-    // `changed()` after the writes return then completes immediately
-    // instead of blocking on a step that may never be triggered.
-    let mut step_watcher = controller.map(|c| c.step_watcher());
-
-    let mut intermediate_wrote_data = false;
     while statements.len() > 1 {
         let stmt = statements.pop_front().unwrap();
         let plan = state.statement_to_plan(stmt).await?;
@@ -356,7 +342,6 @@ async fn execute_sql_with_state(
                 let values = execute_parameters_to_scalars(&parameters)?;
                 let bound = prepared_plan.replace_params_with_values(&ParamValues::List(values))?;
                 sql_options.verify_plan(&bound)?;
-                intermediate_wrote_data |= plan_writes_data(&bound);
                 drain_intermediate_plan(&state, bound).await?;
             }
             other if is_result_producing_plan(&other) => {
@@ -374,20 +359,9 @@ async fn execute_sql_with_state(
                 // UPDATE, DELETE, EXPLAIN, ...). Execute it for its side
                 // effects and discard the per-statement count row.
                 sql_options.verify_plan(&other)?;
-                intermediate_wrote_data |= plan_writes_data(&other);
                 drain_intermediate_plan(&state, other).await?;
             }
         }
-    }
-
-    // The snapshot pinned in `state` was captured at request start, before
-    // any intermediate INSERT ran. Refresh it so the trailing SELECT sees
-    // the just-written rows.
-    if intermediate_wrote_data
-        && let Some(controller) = controller
-        && let Some(watcher) = step_watcher.as_mut()
-    {
-        refresh_snapshot_after_writes(controller, watcher, &mut state).await?;
     }
 
     let stmt = statements.pop_front().unwrap();
@@ -444,43 +418,6 @@ async fn drain_intermediate_plan(
 ) -> Result<(), PipelineError> {
     let df = DataFrame::new(state.clone(), plan);
     let _ = df.collect().await?;
-    Ok(())
-}
-
-/// True if executing this plan mutates a table (and therefore needs the
-/// post-write snapshot refresh below). Today the only mutating plan our
-/// SQL options allow is a `LogicalPlan::Dml`.
-fn plan_writes_data(plan: &LogicalPlan) -> bool {
-    matches!(plan, LogicalPlan::Dml(_))
-}
-
-/// Wait for the controller to drain the intermediate writes, then pin the
-/// resulting snapshot in `state`. Relies on two controller invariants:
-/// `update_snapshot()` runs before each `Idle` notification (so any `Idle`
-/// observed after subscribing already reflects our writes), and `watcher`
-/// must be subscribed before the writes are submitted or we may sleep
-/// forever on an otherwise idle pipeline.
-async fn refresh_snapshot_after_writes(
-    controller: &Controller,
-    watcher: &mut tokio::sync::watch::Receiver<feldera_types::coordination::StepStatus>,
-    state: &mut SessionState,
-) -> Result<(), PipelineError> {
-    use feldera_types::coordination::StepAction;
-
-    loop {
-        let status = *watcher.borrow_and_update();
-        if matches!(status.action, StepAction::Idle) {
-            break;
-        }
-        if watcher.changed().await.is_err() {
-            break;
-        }
-    }
-    let snapshot = controller
-        .latest_consistent_snapshot()
-        .await
-        .ok_or(PipelineError::Initializing)?;
-    set_snapshot(state, snapshot);
     Ok(())
 }
 
@@ -682,7 +619,7 @@ mod tests {
 
     /// A helper that executes a query and returns results.
     async fn collect_rows(state: SessionState, sql: &str) -> Vec<RecordBatch> {
-        execute_sql_with_state(state, sql, None)
+        execute_sql_with_state(state, sql)
             .await
             .unwrap()
             .collect()
@@ -707,7 +644,7 @@ mod tests {
     #[tokio::test]
     async fn execute_without_prepare_errors() {
         let state = test_state();
-        let err = execute_sql_with_state(state, "EXECUTE missing(1)", None)
+        let err = execute_sql_with_state(state, "EXECUTE missing(1)")
             .await
             .unwrap_err();
         assert!(
@@ -730,7 +667,7 @@ mod tests {
     #[tokio::test]
     async fn intermediate_select_is_rejected() {
         let state = test_state();
-        let err = execute_sql_with_state(state, "SELECT 1; SELECT 2", None)
+        let err = execute_sql_with_state(state, "SELECT 1; SELECT 2")
             .await
             .unwrap_err();
         let msg = format!("{err}");

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -3023,27 +3023,24 @@ impl CircuitThread {
 
         let transaction_state = self.controller.get_transaction_state();
 
-        // Update `trace_snapshot` to the latest traces *before* signaling
-        // `Idle` on the step watcher, so subscribers can rely on
-        // `latest_consistent_snapshot()` being current the moment they
-        // observe Idle.
-        //
-        // We also keep this before updating `total_processed_records` so
-        // that ad hoc query results always reflect all data that we have
-        // reported processing.
-        // Keep `trace_snapshots` current on every step regardless of
-        // bootstrap or transaction state, so ad-hoc queries can read
-        // the freshest data including read-your-own-writes within one
-        // request. Connectors with `send_snapshot=true` still defer
-        // until bootstrap completes; that gate now lives in
-        // `enqueue_latest_snapshot`.
-        Span::new("update")
-            .with_category("Step")
-            .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
-            .in_scope(|| self.update_snapshot());
-
         if transaction_state == TransactionState::None {
             let bootstrapping = self.circuit.bootstrap_in_progress();
+
+            // Don't update the snapshot until bootstrapping is complete (including the additional post-bootstrap transaction).
+            // This guarantees that:
+            // 1. Ad hoc queries observe a consistent view of the data.
+            // 2. Ad hoc snapshots are up-to-date before the pipeline is marked as running.
+            if !bootstrapping && !self.bootstrapping {
+                // Update `trace_snapshot` to the latest traces.
+                //
+                // We do this before updating `total_processed_records` so
+                // that ad hoc query results always reflect all data that we have
+                // reported processing.
+                Span::new("update")
+                    .with_category("Step")
+                    .with_tooltip(|| format!("update ad-hoc tables after step {}", self.step))
+                    .in_scope(|| self.update_snapshot());
+            }
 
             // If bootstrapping has completed, clear self.bootstrapping, but don't update the status flag
             // until the circuit performs an extra transaction to initialize output snapshots
@@ -3225,37 +3222,18 @@ impl CircuitThread {
 
     /// Update `trace_snapshot` with the latest traces so ad hoc queries pick
     /// up the freshest data.
-    ///
-    /// Tables refresh every step so an INSERT inside a transaction is visible
-    /// to a subsequent SELECT in the same request.  Views compute their
-    /// integral via `accumulate_integrate_trace`, which only advances on a
-    /// transaction boundary. We use the the previous snapshot instead.
     fn update_snapshot(&mut self) {
-        let bootstrapping = self.controller.status.bootstrap_in_progress();
-        let in_transaction =
-            !bootstrapping && self.controller.get_transaction_state() != TransactionState::None;
-
-        let previous_views: Option<ConsistentSnapshot> = if in_transaction {
-            let snapshots = self.controller.trace_snapshots.blocking_lock();
-            snapshots.iter().next_back().map(|(_, snap)| snap.clone())
-        } else {
-            None
-        };
+        assert_eq!(
+            self.controller.get_transaction_state(),
+            TransactionState::None,
+            "update_snapshot must be called when no transaction is in progress"
+        );
 
         // Assemble a new snapshot.
         let mut snapshot = BTreeMap::new();
         for (name, clh) in self.controller.catalog.output_iter() {
             if let Some(ih) = &clh.integrate_handle {
-                let is_table = self
-                    .controller
-                    .catalog
-                    .input_collection_handle(name)
-                    .is_some();
-
-                let batches = match previous_views.as_ref().and_then(|s| s.get(name)) {
-                    Some(prev) if !is_table && in_transaction => prev.clone(),
-                    _ => ih.take_from_all(),
-                };
+                let batches = ih.take_from_all();
 
                 // The first index of a materialized view registers its
                 // integral under the view name with `alias_as_index =
@@ -6746,17 +6724,6 @@ impl ControllerInner {
         processed_records: Option<ProcessedRecords>,
         step: Option<Step>,
     ) -> bool {
-        // Defer the initial snapshot delivery until bootstrap completes
-        // and no transaction is in flight; this is the gate that
-        // guarantees `send_snapshot=true` connectors receive a
-        // consistent, fully-formed view. Adhoc queries hit
-        // `trace_snapshots` directly and are not subject to this gate.
-        if self.status.bootstrap_in_progress()
-            || self.get_transaction_state() != TransactionState::None
-        {
-            return false;
-        }
-
         // Look up the most recent cached snapshot for this stream. Return early
         // if no snapshot has been produced yet (pipeline hasn't completed a step).
         // This method is only called from the circuit thread (via `push_output`),
@@ -6769,7 +6736,7 @@ impl ControllerInner {
         };
 
         let Some(snapshot_batches) = snapshot_batches else {
-            // No cached snapshot yet (pipeline hasn't completed a step).
+            // No cached snapshot yet (pipeline hasn't completed a step or bootstrapping is in progress).
             // Leave the state as `Pending` and let the next step retry.
             return false;
         };

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -2277,11 +2277,6 @@ fn lir() {
       "to": "4"
     },
     {
-      "from": "3",
-      "stream_id": 3,
-      "to": "7"
-    },
-    {
       "from": "4",
       "stream_id": 4,
       "to": "5"
@@ -2289,12 +2284,12 @@ fn lir() {
     {
       "from": "4",
       "stream_id": 4,
-      "to": "11"
+      "to": "7"
     },
     {
       "from": "4",
       "stream_id": 4,
-      "to": "13"
+      "to": "11"
     },
     {
       "from": "6",
@@ -2317,6 +2312,11 @@ fn lir() {
       "to": "9"
     },
     {
+      "from": "7",
+      "stream_id": 8,
+      "to": "12"
+    },
+    {
       "from": "9",
       "stream_id": 9,
       "to": "10"
@@ -2325,26 +2325,6 @@ fn lir() {
       "from": "12",
       "stream_id": 10,
       "to": "13"
-    },
-    {
-      "from": "12",
-      "stream_id": null,
-      "to": "14"
-    },
-    {
-      "from": "13",
-      "stream_id": 13,
-      "to": "14"
-    },
-    {
-      "from": "13",
-      "stream_id": 13,
-      "to": "15"
-    },
-    {
-      "from": "15",
-      "stream_id": 14,
-      "to": "16"
     }
   ],
   "nodes": [
@@ -2394,21 +2374,24 @@ fn lir() {
     {
       "id": "6",
       "implements": [
-        "input.output"
+        "input.output",
+        "output"
       ],
       "operation": "Z1 (trace)"
     },
     {
       "id": "7",
       "implements": [
-        "input.output"
+        "input.output",
+        "output"
       ],
-      "operation": "UntimedTraceAppend"
+      "operation": "AccumulateUntimedTraceAppend"
     },
     {
       "id": "8",
       "implements": [
-        "input.output"
+        "input.output",
+        "output"
       ],
       "operation": "Z1 (trace)"
     },
@@ -2438,31 +2421,10 @@ fn lir() {
       "implements": [
         "output"
       ],
-      "operation": "Z1 (trace)"
-    },
-    {
-      "id": "13",
-      "implements": [
-        "output"
-      ],
-      "operation": "AccumulateUntimedTraceAppend"
-    },
-    {
-      "id": "14",
-      "implements": [
-        "output"
-      ],
-      "operation": "Z1 (trace)"
-    },
-    {
-      "id": "15",
-      "implements": [
-        "output"
-      ],
       "operation": "Apply"
     },
     {
-      "id": "16",
+      "id": "13",
       "implements": [
         "output"
       ],

--- a/crates/adapters/src/static_compile/catalog.rs
+++ b/crates/adapters/src/static_compile/catalog.rs
@@ -560,11 +560,7 @@ impl Catalog {
         let integral_stream = if gather_integral {
             gathered_stream.accumulate_integrate_trace()
         } else {
-            // Our transaction semantics currently promises to update table snapshots after every step,
-            // not just on commit, so that ad hoc queries that modify (INSERT) and instantly read (SELECT)
-            // the table see their own changes even when there is a transaction in progress.  Therefore,
-            // we use `integrate_trace` instead of `accumulate_integrate_trace` here.
-            stream.integrate_trace()
+            stream.accumulate_integrate_trace()
         };
 
         let (integrate_handle, integrate_gid) = integral_stream

--- a/docs.feldera.com/docs/sql/ad-hoc.md
+++ b/docs.feldera.com/docs/sql/ad-hoc.md
@@ -111,21 +111,22 @@ Ad-hoc queries can use CPU resources, memory and, to a lesser extent, storage (f
 especially if they are complex or involve scanning large datasets. Since these resources are shared with the
 Feldera SQL engine, such queries may reduce pipeline performance during ad-hoc query execution.
 
-### Read-after-write within a request
+### Read-after-write within a multi-statement ad-hoc query
 
-Within a multi-statement request, the snapshot advances after each
-statement. A trailing `SELECT` observes the side effects of earlier
-`INSERT`s on tables in the same request:
+A multi-statement ad-hoc request reads from a single consistent snapshot
+captured at the start of the request. Intermediate `INSERT`s in the same
+request are applied to the pipeline, but a trailing `SELECT` does not
+observe them:
 
 ```sql
 INSERT INTO t VALUES (1);
-SELECT COUNT(*) FROM t;  -- returns 1
+SELECT COUNT(*) FROM t;  -- returns the count before the INSERT
 ```
 
-Materialized views derived from those inserts refresh when the
-surrounding transaction commits. While a transaction is open, a query
-against a view sees only the pre-transaction state, even if earlier
-statements in the same request inserted into the view's source tables.
+The same rule applies inside a user transaction: the request observes the
+state of all tables and materialized views as of the start of that
+transaction, even when earlier statements in the same request inserted
+into source tables.
 
 ## Examples
 

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -530,13 +530,20 @@ class TestAdhocQueriesArrow(SharedTestPipeline):
 
 
 class TestAdhocReadAfterWrite(SharedTestPipeline):
-    """Regression tests for
-    https://github.com/feldera/feldera/issues/6243 .
+    """
+    The read-after-write behavior of ad-hoc queries differs depending on whether they are running inside a user transaction.
 
-    A multi-statement adhoc request must see its own intermediate
-    INSERTs in the trailing SELECT. The earlier bug was that the SELECT
-    ran against the snapshot captured before the request started, so
-    inserts in the same request stayed invisible.
+    When running inside a user transaction, the request must observe the state before the transaction started.
+    When not running inside a user transaction, the request must observe the state before the multi-statement request started.
+
+    In all cases, a SELECT following an INSERT in the same request must not observe the INSERT.
+
+    FIXME: This may not be the most user-friendly behavior. We have considered exposing changes to tables
+    immediately after each statement, while exposing view changes after the transaction is committed,
+    but that change introduced backward incompatibilities. For now this test validates the current expected 
+    behavior.
+
+    See https://github.com/feldera/feldera/issues/6243.
     """
 
     @property
@@ -548,7 +555,7 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
           id INT NOT NULL PRIMARY KEY
         ) WITH ('materialized' = 'true');"""
     )
-    def test_insert_then_select_in_same_request_sees_inserts(self):
+    def test_multi_statement_query_no_transaction(self):
         self.pipeline.start()
 
         rows = list(
@@ -559,8 +566,8 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
             )
         )
         assert rows, "trailing SELECT must return a row"
-        assert rows[0].get("c") == 2, (
-            f"trailing SELECT should see both intermediate inserts, got {rows!r}"
+        assert rows[0].get("c") == 0, (
+            f"trailing SELECT should see previous state, got {rows!r}"
         )
 
     @sql(
@@ -569,10 +576,7 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
         ) WITH ('materialized' = 'true');"""
     )
     def test_multi_statement_query_during_open_transaction_pk(self):
-        """An ad-hoc request running inside a user transaction must
-        still see its own intermediate INSERTs in the trailing SELECT.
-        Adhoc reads pull from `trace_snapshots`, which updates on every
-        step regardless of transaction state.
+        """An ad-hoc request running inside a user transaction must observe the state before the transaction started.
         """
         self.pipeline.start()
 
@@ -591,12 +595,11 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
 
         assert rows_during, "trailing SELECT must return a row"
         count_during = rows_during[0].get("c")
-        assert count_during == 3, (
-            f"trailing SELECT inside the transaction must observe all "
-            f"three rows (baseline + two intermediate inserts), got {count_during}"
+        assert count_during == 1, (
+            f"trailing SELECT inside the transaction should see pre-transaction state, got {count_during}"
         )
 
-        # After commit, a fresh adhoc query still sees the same three rows.
+        # After commit, a fresh adhoc query sees all three rows.
         rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example2"))
         assert rows_after and rows_after[0].get("c") == 3, (
             f"after commit, all three inserts must be visible, got {rows_after!r}"
@@ -626,12 +629,11 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
 
         assert rows_during, "trailing SELECT must return a row"
         count_during = rows_during[0].get("c")
-        assert count_during == 3, (
-            f"trailing SELECT inside the transaction must observe all "
-            f"three rows (baseline + two intermediate inserts), got {count_during}"
+        assert count_during == 1, (
+            f"trailing SELECT inside the transaction should see pre-transaction state, got {count_during}"
         )
 
-        # After commit, a fresh adhoc query still sees the same three rows.
+        # After commit, a fresh adhoc query sees all three rows.
         rows_after = list(self.pipeline.query("SELECT COUNT(*) AS c FROM example3"))
         assert rows_after and rows_after[0].get("c") == 3, (
             f"after commit, all three inserts must be visible, got {rows_after!r}"

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -540,7 +540,7 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
 
     FIXME: This may not be the most user-friendly behavior. We have considered exposing changes to tables
     immediately after each statement, while exposing view changes after the transaction is committed,
-    but that change introduced backward incompatibilities. For now this test validates the current expected 
+    but that change introduced backward incompatibilities. For now this test validates the current expected
     behavior.
 
     See https://github.com/feldera/feldera/issues/6243.
@@ -576,8 +576,7 @@ class TestAdhocReadAfterWrite(SharedTestPipeline):
         ) WITH ('materialized' = 'true');"""
     )
     def test_multi_statement_query_during_open_transaction_pk(self):
-        """An ad-hoc request running inside a user transaction must observe the state before the transaction started.
-        """
+        """An ad-hoc request running inside a user transaction must observe the state before the transaction started."""
         self.pipeline.start()
 
         # Seed one row outside the transaction as the baseline.


### PR DESCRIPTION
A recent change that enabled ad hoc queries to observe their own changes to input tables (but not views) introduced a regression that prevented bootstrapping state from materialized tables. We rollback that change here.