### PR TITLE
[dbsp] Gate streaming exchange with a DevTweak.

### DIFF
--- a/crates/dbsp/src/circuit/dbsp_handle.rs
+++ b/crates/dbsp/src/circuit/dbsp_handle.rs
@@ -502,6 +502,11 @@ impl CircuitConfig {
         self
     }
 
+    pub fn with_streaming_exchange(mut self, enabled: bool) -> Self {
+        self.dev_tweaks.streaming_exchange = Some(enabled);
+        self
+    }
+
     pub fn with_splitter_chunk_size_records(mut self, records: u64) -> Self {
         self.dev_tweaks.splitter_chunk_size_records = Some(records);
         self

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -484,6 +484,12 @@ impl RuntimeInner {
             );
         }
 
+        if config.dev_tweaks.streaming_exchange() {
+            info!("dev_tweaks.streaming_exchange enabled");
+        } else {
+            info!("dev_tweaks.streaming_exchange disabled");
+        }
+
         Ok(Self {
             pin_cpus_fg,
             pin_cpus_bg,

--- a/crates/dbsp/src/operator/dynamic/sharded_accumulator.rs
+++ b/crates/dbsp/src/operator/dynamic/sharded_accumulator.rs
@@ -55,6 +55,8 @@ where
             sharded.dyn_accumulate(factories)
         } else if Runtime::num_workers() == 1 {
             self.dyn_accumulate(factories)
+        } else if Runtime::with_dev_tweaks(|d| !d.streaming_exchange()) {
+            self.dyn_shard(factories).dyn_accumulate(factories)
         } else {
             self.circuit()
                 .cache_get_or_insert_with(ShardedAccumulatorId::new(self.stream_id()), || {
@@ -677,12 +679,17 @@ mod tests {
     /// `n` steps and exchanges `O(n**2)` data.
     const STREAMING_ROUNDS: usize = 64;
 
+    fn test_config(workers: usize) -> CircuitConfig {
+        CircuitConfig::with_workers(workers).with_streaming_exchange(true)
+    }
+
     fn test_circuit(workers: usize, hosts: usize) {
         let (mut dbsp_handles, input_handles, output_handles) = match hosts {
             0 => unreachable!(),
             1 => {
                 let (dbsp_handle, (input_handle, output_handle)) =
-                    Runtime::init_circuit(workers, circuit).expect("failed to start runtime");
+                    Runtime::init_circuit(test_config(workers), circuit)
+                        .expect("failed to start runtime");
                 (vec![dbsp_handle], vec![input_handle], vec![output_handle])
             }
             _ => {
@@ -719,7 +726,8 @@ mod tests {
                     let cconf = CircuitConfig::from(
                         Layout::new_multihost(&params, *local_address).unwrap(),
                     )
-                    .with_exchange_listener(exchange_listener);
+                    .with_exchange_listener(exchange_listener)
+                    .with_streaming_exchange(true);
 
                     let (dbsp_handle, (input_handle, output_handle)) =
                         Runtime::init_circuit(cconf, circuit).expect("failed to start runtime");

--- a/crates/feldera-types/src/config/dev_tweaks.rs
+++ b/crates/feldera-types/src/config/dev_tweaks.rs
@@ -262,6 +262,12 @@ pub struct DevTweaks {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub now_http_driven: Option<bool>,
 
+    /// Enable streaming exchange.
+    ///
+    /// `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming_exchange: Option<bool>,
+
     /// Options not understood by this particular version.
     ///
     /// This allows the pipeline manager to take options that a custom or old
@@ -340,6 +346,10 @@ impl DevTweaks {
 
     pub fn now_http_driven(&self) -> bool {
         self.now_http_driven.unwrap_or(false)
+    }
+
+    pub fn streaming_exchange(&self) -> bool {
+        self.streaming_exchange.unwrap_or(true)
     }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -8748,6 +8748,12 @@
             "default": null,
             "nullable": true,
             "minimum": 0
+          },
+          "streaming_exchange": {
+            "type": "boolean",
+            "description": "Enable streaming exchange.\n\n`false`",
+            "default": null,
+            "nullable": true
           }
         },
         "additionalProperties": {


### PR DESCRIPTION
It looks like the streaming exchange operator may need more tuning. This commit puts it behind a `streaming_exchange` dev tweak.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

This change will affect multihost performance.