### PR TITLE
adapters: avoid empty steps when waiting for barrier inputs

### DIFF
--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -2975,6 +2975,7 @@ impl CircuitThread {
                 self.controller.status.bootstrap_in_progress(),
                 self.checkpoint_requested(),
                 self.sync_checkpoint_requested(),
+                self.next_step_inputs(coordination_request.as_ref()),
                 coordination_request,
                 self.step,
             ) {
@@ -3525,6 +3526,27 @@ impl CircuitThread {
         }
     }
 
+    fn next_step_inputs(&self, coordination_request: Option<&StepRequest>) -> StepInputs {
+        if let Some(coordination_request) = coordination_request {
+            coordination_request.inputs
+        } else if self.checkpoint_requested()
+            && self.ft.is_none()
+            && (self
+                .checkpoint_requests
+                .iter()
+                .any(|x| matches!(x, CheckpointRequest::SuspendCommand(_)))
+                || self.running_checkpoint.is_none())
+            && self.controller.get_transaction_state() == TransactionState::None
+        {
+            tracing::debug!(
+                "checkpoint requested: only CheckpointBarrier inputs will be processed"
+            );
+            StepInputs::CheckpointBarriers
+        } else {
+            StepInputs::All
+        }
+    }
+
     /// Requests all of the input adapters to flush their input to the circuit,
     /// and waits for them to finish doing it.
     ///
@@ -3606,24 +3628,7 @@ impl CircuitThread {
         // in the future is to remove the notion of barriers altogether, making input
         // connectors always checkpointable.
         let coordination_request = self.controller.coordination_request.lock().unwrap().clone();
-        let inputs = if self.checkpoint_requested()
-            && self.ft.is_none()
-            && (self
-                .checkpoint_requests
-                .iter()
-                .any(|x| matches!(x, CheckpointRequest::SuspendCommand(_)))
-                || self.running_checkpoint.is_none())
-            && self.controller.get_transaction_state() == TransactionState::None
-        {
-            tracing::debug!(
-                "checkpoint requested: only CheckpointBarrier inputs will be processed"
-            );
-            StepInputs::CheckpointBarriers
-        } else if let Some(coordination_request) = &coordination_request {
-            coordination_request.inputs
-        } else {
-            StepInputs::All
-        };
+        let inputs = self.next_step_inputs(coordination_request.as_ref());
 
         // Collect the ids of the endpoints that we'll flush to the circuit.
         //
@@ -4390,6 +4395,7 @@ impl StepTrigger {
         bootstrapping: bool,
         checkpoint_requested: bool,
         sync_checkpoint_requested: bool,
+        step_inputs: StepInputs,
         coordination_request: Option<StepRequest>,
         step: Step,
     ) -> Action {
@@ -4458,21 +4464,14 @@ impl StepTrigger {
             // deliberately ignored; counting them would trigger empty steps
             // because input_step() will not consume them.
             //
-            // If we're running under a coordinator, then we only consider input
-            // endpoints that the coordinator told us to.
-            let inputs = if let Some(coordination_request) = &coordination_request {
-                coordination_request.inputs
-            } else if checkpoint_requested {
-                StepInputs::CheckpointBarriers
-            } else {
-                StepInputs::All
-            };
+            // `step_inputs` matches the input selection that input_step() will
+            // use if this trigger decides to run a step.
             let buffered_records = self
                 .controller
                 .status
                 .input_status()
                 .values()
-                .filter(|status| match inputs {
+                .filter(|status| match step_inputs {
                     StepInputs::All => true,
                     StepInputs::CheckpointBarriers => status.is_barrier(),
                     StepInputs::None => false,

--- a/crates/adapters/src/controller.rs
+++ b/crates/adapters/src/controller.rs
@@ -68,7 +68,6 @@ use dbsp::{
     profile::{DbspProfile, GraphProfile},
 };
 use dbsp::{Runtime, WeakRuntime};
-use enum_map::EnumMap;
 use feldera_adapterlib::format::BufferSize;
 use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{
@@ -108,7 +107,7 @@ use nonzero_ext::nonzero;
 use rmpv::Value as RmpValue;
 use serde_json::Value as JsonValue;
 use size_of::HumanBytes;
-use stats::StepResults;
+use stats::{BufferedInput, StepResults};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -4454,10 +4453,10 @@ impl StepTrigger {
         } else {
             // Count buffered records.
             //
-            // If any input endpoints are blocking suspend, then those are the
-            // only ones that we count; otherwise, count all of them.  An input
-            // endpoint is blocking suspend if it has a barrier and a checkpoint
-            // has been requested.
+            // Count only the inputs that the next input step is allowed to poll.
+            // During checkpoint barrier handling, non-barrier inputs are
+            // deliberately ignored; counting them would trigger empty steps
+            // because input_step() will not consume them.
             //
             // If we're running under a coordinator, then we only consider input
             // endpoints that the coordinator told us to.
@@ -4468,17 +4467,18 @@ impl StepTrigger {
             } else {
                 StepInputs::All
             };
-            let mut buffered_records = EnumMap::<bool, u64>::default();
-            for status in self.controller.status.input_status().values() {
-                buffered_records
-                    [inputs == StepInputs::CheckpointBarriers && status.is_barrier()] +=
-                    status.metrics.buffered_records.load(Ordering::Relaxed);
-            }
-            let buffered_records = if buffered_records[true] > 0 {
-                buffered_records[true]
-            } else {
-                buffered_records[false]
-            };
+            let buffered_records = self
+                .controller
+                .status
+                .input_status()
+                .values()
+                .filter(|status| match inputs {
+                    StepInputs::All => true,
+                    StepInputs::CheckpointBarriers => status.is_barrier(),
+                    StepInputs::None => false,
+                })
+                .map(|status| status.metrics.buffered_records.load(Ordering::Relaxed))
+                .sum::<u64>();
 
             if buffered_records > self.min_batch_size_records
                 || timer_expired(self.buffer_timeout, now)
@@ -7246,17 +7246,19 @@ impl ControllerInner {
         // circuit thread, and the circuit thread reads the endpoint metrics.
         // Updating in the wrong order can cause the circuit thread to park
         // itself indefinitely.
-        if let Some(endpoint_id) = endpoint_id {
+        let buffered_input = if let Some(endpoint_id) = endpoint_id {
             self.status.input_batch_from_endpoint(
                 endpoint_id,
                 amt,
                 &self.backpressure_thread_unparker,
             )
-        }
+        } else {
+            BufferedInput::Normal
+        };
 
         if !amt.is_empty() {
             self.status
-                .input_batch_global(amt, &self.circuit_thread_unparker);
+                .input_batch_global(amt, buffered_input, &self.circuit_thread_unparker);
         }
     }
 

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -91,6 +91,20 @@ use utoipa::ToSchema;
 /// There are separate counters for parse and transport errors and for every tag.
 pub(crate) const MAX_CONNECTOR_ERRORS: usize = 100;
 
+/// Kind of input buffered by an endpoint.
+///
+/// Used by [ControllerStatus::input_batch_global] to decide whether input
+/// buffering should wake the circuit thread.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum BufferedInput {
+    /// Regular input buffering, with no special wakeup reason.
+    Normal,
+
+    /// Input was buffered for an endpoint currently blocking checkpoint or
+    /// suspend on a barrier.
+    Barrier,
+}
+
 /// Completion token.
 ///
 /// A completion token associated with an endpoint identifies a position in the endpoint's
@@ -957,9 +971,14 @@ impl ControllerStatus {
 
     /// Update the global counters after receiving a new input batch.
     ///
-    /// This method is used for inserts that don't belong to an endpoint, e.g.,
-    /// happen by executing an ad-hoc INSERT query.
-    pub(super) fn input_batch_global(&self, amt: BufferSize, circuit_thread_unparker: &Unparker) {
+    /// This method is used for all input batches, including inserts that don't
+    /// belong to an endpoint, e.g., happen by executing an ad-hoc INSERT query.
+    pub(super) fn input_batch_global(
+        &self,
+        amt: BufferSize,
+        buffered_input: BufferedInput,
+        circuit_thread_unparker: &Unparker,
+    ) {
         let num_records = amt.records as u64;
         // Increment buffered_records; unpark circuit thread once
         // `min_batch_size_records` is exceeded.
@@ -968,6 +987,7 @@ impl ControllerStatus {
         if old == 0
             || (old <= self.pipeline_config.global.min_batch_size_records
                 && old + num_records > self.pipeline_config.global.min_batch_size_records)
+            || buffered_input == BufferedInput::Barrier
         {
             circuit_thread_unparker.unpark();
         }
@@ -978,32 +998,38 @@ impl ControllerStatus {
     /// # Arguments
     ///
     /// * `endpoint_id` - id of the input endpoint.
-    /// * `num_bytes` - number of bytes received.
-    /// * `num_records` - number of records in the deserialized batch.
-    /// * `global_config` - global controller config.
-    /// * `circuit_thread_unparker` - unparker used to wake up the circuit
-    ///   thread if the total number of buffered records exceeds
-    ///   `min_batch_size_records`.
+    /// * `amt` - number of bytes and records in the batch.
     /// * `backpressure_thread_unparker` - unparker used to wake up the
     ///   backpressure thread if the endpoint is full.
+    ///
+    /// Returns the kind of input that was buffered, used by
+    /// [Self::input_batch_global] to decide whether to wake the circuit thread.
     pub(super) fn input_batch_from_endpoint(
         &self,
         endpoint_id: EndpointId,
         amt: BufferSize,
         backpressure_thread_unparker: &Unparker,
-    ) {
+    ) -> BufferedInput {
         // There is a potential race condition if the endpoint is currently
         // being removed. In this case, it's safe to ignore this operation.
         if !amt.is_empty() {
             let inputs = self.input_status();
             if let Some(endpoint_stats) = inputs.get(&endpoint_id) {
                 let old = endpoint_stats.add_buffered(amt);
+                let buffered_input = if old == 0 && endpoint_stats.is_barrier() {
+                    BufferedInput::Barrier
+                } else {
+                    BufferedInput::Normal
+                };
                 let threshold = endpoint_stats.config.connector_config.max_queued_records;
                 if old < threshold && old + amt.records as u64 >= threshold {
                     backpressure_thread_unparker.unpark();
                 }
+                return buffered_input;
             }
         }
+
+        BufferedInput::Normal
     }
 
     /// Update counters after receiving an end-of-input event on an input

--- a/crates/adapters/src/controller/stats.rs
+++ b/crates/adapters/src/controller/stats.rs
@@ -1016,7 +1016,11 @@ impl ControllerStatus {
             let inputs = self.input_status();
             if let Some(endpoint_stats) = inputs.get(&endpoint_id) {
                 let old = endpoint_stats.add_buffered(amt);
-                let buffered_input = if old == 0 && endpoint_stats.is_barrier() {
+                // Barrier endpoints must wake the circuit thread even if they
+                // already had buffered input. Otherwise the generic wake rules
+                // can ignore an old > 0 batch, leaving a suspend request parked
+                // even though this batch may make the endpoint checkpointable.
+                let buffered_input = if endpoint_stats.is_barrier() {
                     BufferedInput::Barrier
                 } else {
                     BufferedInput::Normal

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -460,6 +460,17 @@ fn wait_for_records(controller: &Controller, expect_n: &[usize]) {
     assert_eq!(&collect_endpoint_records(controller, n), expect_n);
 }
 
+fn assert_bounded_suspend_steps(controller: &Controller, suspend_request_step: u64) {
+    let suspend_complete_step = controller.status().global_metrics.total_initiated_steps();
+    let suspend_steps = suspend_complete_step.saturating_sub(suspend_request_step);
+
+    assert!(
+        suspend_steps <= 1000,
+        "suspend advanced {suspend_steps} steps while waiting for barriers \
+         ({suspend_request_step}..{suspend_complete_step})"
+    );
+}
+
 /// Runs a basic test of fault tolerance.
 ///
 /// The test proceeds in multiple rounds. For each element of `rounds`, the
@@ -1986,6 +1997,7 @@ fn suspend_barrier() {
     // Suspend.
     let (sender, receiver) = mpsc::channel();
     println!("start suspend");
+    let suspend_request_step = controller.status().global_metrics.total_initiated_steps();
     controller.start_suspend(Box::new(move |result| sender.send(result).unwrap()));
 
     // Suspend should not succeed, because of the barrier.
@@ -2003,6 +2015,7 @@ fn suspend_barrier() {
         .recv_timeout(Duration::from_millis(10000))
         .unwrap()
         .unwrap();
+    assert_bounded_suspend_steps(&controller, suspend_request_step);
 
     // Stop controller.
     println!("stop controller");
@@ -2125,6 +2138,7 @@ fn suspend_multiple_barriers(n_inputs: usize) {
     // barriers, since each input only has 1000 records so far.
     let (sender, receiver) = mpsc::channel();
     println!("start suspend");
+    let suspend_request_step = controller.status().global_metrics.total_initiated_steps();
     controller.start_suspend(Box::new(move |result| sender.send(result).unwrap()));
 
     // Iterate as long as we shouldn't have reached the barrier, adding records
@@ -2177,6 +2191,7 @@ fn suspend_multiple_barriers(n_inputs: usize) {
         .recv_timeout(Duration::from_millis(10000))
         .unwrap()
         .unwrap();
+    assert_bounded_suspend_steps(&controller, suspend_request_step);
 
     // Stop controller.
     println!("stop controller");

--- a/crates/adapters/src/controller/test.rs
+++ b/crates/adapters/src/controller/test.rs
@@ -1,4 +1,4 @@
-use super::OutputEndpointControl;
+use super::{OutputEndpointControl, stats::BufferedInput};
 use crate::{
     Controller, PipelineConfig,
     controller::{ControllerStatusContext, TransactionInfo},
@@ -9,7 +9,9 @@ use crate::{
     transport::set_barrier,
 };
 use anyhow::anyhow;
+use crossbeam::sync::Parker;
 use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
+use feldera_adapterlib::format::BufferSize;
 use feldera_types::{
     config::{InputEndpointConfig, OutputEndpointConfig},
     constants::STATE_FILE,
@@ -1861,6 +1863,54 @@ fn input_path(storage_dir: &Path, i: usize) -> PathBuf {
 
 fn output_path(storage_dir: &Path, i: usize) -> PathBuf {
     storage_dir.join(format!("output{}.csv", i + 1))
+}
+
+#[test]
+fn barrier_input_batch_wakes_when_endpoint_already_has_buffered_input() {
+    init_test_logger();
+
+    // During suspend, every new batch from a barrier endpoint can be the batch
+    // that clears the barrier.
+    //
+    // https://github.com/feldera/feldera/actions/runs/26535433930/job/78166265316
+    // That test likely failed because the endpoint already had buffered
+    // barrier input, so the old > 0 condition was not enough to wake the
+    // circuit thread.
+    let tempdir = TempDir::new().unwrap();
+    let storage_dir = tempdir.path().join("storage");
+    create_dir(&storage_dir).unwrap();
+    File::create(input_path(&storage_dir, 0)).unwrap();
+
+    let controller = start_controller(&storage_dir, &[0]);
+
+    let endpoint_id = {
+        let input_status = controller.status().input_status();
+        *input_status.keys().next().unwrap()
+    };
+    {
+        let input_status = controller.status().input_status();
+        let endpoint = input_status.get(&endpoint_id).unwrap();
+        endpoint.set_barrier(true);
+        endpoint
+            .metrics
+            .buffered_records
+            .store(1, Ordering::Relaxed);
+    }
+
+    let parker = Parker::new();
+    let unparker = parker.unparker().clone();
+    let buffered_input = controller.status().input_batch_from_endpoint(
+        endpoint_id,
+        BufferSize {
+            records: 1,
+            bytes: 1,
+        },
+        &unparker,
+    );
+
+    controller.stop().unwrap();
+
+    assert_eq!(buffered_input, BufferedInput::Barrier);
 }
 
 fn start_controller(storage_dir: &Path, barriers: &[usize]) -> Controller {


### PR DESCRIPTION
When checkpointing, or during suspend, we only process
`StepInputs::CheckpointBarriers`. However, the StepTrigger still
counts the non-barrier inputs if no records from barrier inputs were
buffered, which causes empty steps, as these inputs aren't consumed.

This meant when waiting for suspend with multiple barriers, there were a
lot of empty steps being made.

Now, we only count buffered records from inputs that the next input step
is allowed to consume. However, this means the circuit may not reliably
wake up on new input, as `ControllerStatus::input_batch_global` only
wakes up the circuit if:

- The number of buffered inputs goes up from zero.
- The number of buffered inputs crosses the min threshold.

However, as we're only consuming barrier inputs and ignoring non-barrier
input records, the number of buffered inputs may already be greater than
the threshold, and therefore doesn't wake the circuit thread.

This commit introduces an enum `BufferedInput` that specifies the type
of input that was buffered. If the records were buffered for a barrier
endpoint, then `input_batch_global` will wake the thread regardless.

After the fix, on my local machine, the checkpoints in `suspend_barrier`
tests are made at step ~9 instead of ~9000.


Fixes: #6300 

### Describe Manual Test Plan

Ran the existing suspend_barrier tests ~100 times locally, 
Ran the merge queue tasks once ([workflow](https://github.com/feldera/feldera/actions/runs/26401334620)), and then the adapters tests ([workflow](https://github.com/feldera/feldera/actions/runs/26402765509/job/77718841842)). 

## Breaking Changes?

There shouldn't be any breaking changes.

