### PR TITLE
[connectors] Fix delta lake test.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -1588,7 +1588,8 @@ async fn test_follow(
         .await;
     }
 
-    if test_end_version && suspend {
+    // If the table has reached the end_version, make sure the eoi status survives the suspend.
+    if test_end_version && suspend && input_table.version().unwrap() >= end_version {
         suspend_pipeline(pipeline).await;
 
         pipeline = start_pipeline(
@@ -1604,6 +1605,7 @@ async fn test_follow(
 
         let status = pipeline.input_endpoint_status("test_input1").unwrap();
         assert!(status.metrics.end_of_input);
+        println!("eoi status survived suspend");
     }
 
     // TODO: this does not currently work because our output delta connector doesn't support
@@ -1905,7 +1907,7 @@ async fn test_cdc(
 
 /// Generate up to `max_records` _unique_ records.
 fn delta_data(max_records: usize) -> impl Strategy<Value = Vec<DeltaTestStruct>> {
-    vec(DeltaTestStruct::arbitrary(), 0..max_records).prop_map(|vec| {
+    vec(DeltaTestStruct::arbitrary(), 10..max_records).prop_map(|vec| {
         let mut idx = 0;
         vec.into_iter()
             .map(|mut x| {


### PR DESCRIPTION
The `test_follow` function checked that the end_of_input status set by the connector upon reaching the end_version survives across suspend and resume. However this check only make sense for tests that generate >=5 versions of the table, since end_version is set to 5. In the unlikely case that the test generates <5 test records, the table never reaches version 5.

For good measure, we also increase the minimum number of generated records to 10.
