### PR TITLE
pipeline-manager: fix serialization of `ManagerError`

### DIFF
--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -196,20 +196,34 @@ pub enum DBError {
     },
     PauseWhileNotProvisioned,
     ResumeWhileNotProvisioned,
-    InvalidResourcesStatus(String),
-    InvalidResourcesDesiredStatus(String),
-    InvalidRuntimeStatus(String),
-    InvalidRuntimeDesiredStatus(String),
-    InvalidBootstrap(String),
+    InvalidResourcesStatus {
+        value: String,
+    },
+    InvalidResourcesDesiredStatus {
+        value: String,
+    },
+    InvalidRuntimeStatus {
+        value: String,
+    },
+    InvalidRuntimeDesiredStatus {
+        value: String,
+    },
+    InvalidBootstrap {
+        value: String,
+    },
     NoRuntimeStatusWhileProvisioned,
-    PreconditionViolation(String),
+    PreconditionViolation {
+        precondition: String,
+    },
     CannotStartWithUndismissedError,
     CannotStartWhileClearingStorage,
     DismissErrorRestrictedToFullyStopped,
     InitialImmutableUnlessStopped,
     BootstrapPolicyImmutableUnlessStopped,
     InitialStandbyNotAllowed,
-    InvalidMonitorStatus(String),
+    InvalidMonitorStatus {
+        value: String,
+    },
     UnknownClusterMonitorEvent {
         event_id: ClusterMonitorEventId,
     },
@@ -642,20 +656,20 @@ impl Display for DBError {
                     "You can only call /resume when the pipeline is not Stopped, Provisioning or Stopping."
                 )
             }
-            DBError::InvalidResourcesStatus(s) => {
-                write!(f, "Invalid resources status: '{s}'")
+            DBError::InvalidResourcesStatus { value } => {
+                write!(f, "Invalid resources status: '{value}'")
             }
-            DBError::InvalidResourcesDesiredStatus(s) => {
-                write!(f, "Invalid resources desired status: '{s}'")
+            DBError::InvalidResourcesDesiredStatus { value } => {
+                write!(f, "Invalid resources desired status: '{value}'")
             }
-            DBError::InvalidRuntimeStatus(s) => {
-                write!(f, "Invalid runtime status: '{s}'")
+            DBError::InvalidRuntimeStatus { value } => {
+                write!(f, "Invalid runtime status: '{value}'")
             }
-            DBError::InvalidRuntimeDesiredStatus(s) => {
-                write!(f, "Invalid runtime desired status: '{s}'")
+            DBError::InvalidRuntimeDesiredStatus { value } => {
+                write!(f, "Invalid runtime desired status: '{value}'")
             }
-            DBError::InvalidBootstrap(s) => {
-                write!(f, "Invalid bootstrap policy: '{s}'")
+            DBError::InvalidBootstrap { value } => {
+                write!(f, "Invalid bootstrap configuration: '{value}'")
             }
             DBError::NoRuntimeStatusWhileProvisioned => {
                 write!(
@@ -663,8 +677,8 @@ impl Display for DBError {
                     "Runtime status is not set while the resources status is Provisioned"
                 )
             }
-            DBError::PreconditionViolation(s) => {
-                write!(f, "Operation precondition not met: '{s}'")
+            DBError::PreconditionViolation { precondition } => {
+                write!(f, "Operation precondition not met: '{precondition}'")
             }
             DBError::TlsConnection { hint, .. } => {
                 write!(f, "Unable to setup TLS connection to the database: {hint}")
@@ -716,8 +730,8 @@ impl Display for DBError {
                     (2) `runtime_config.storage.backend.config.sync` is configured."
                 )
             }
-            DBError::InvalidMonitorStatus(s) => {
-                write!(f, "Invalid monitor status: '{s}'")
+            DBError::InvalidMonitorStatus { value } => {
+                write!(f, "Invalid monitor status: '{value}'")
             }
             DBError::UnknownClusterMonitorEvent { event_id } => {
                 write!(f, "Cluster monitor event with identifier '{event_id}' does not exist -- it might have been deleted as monitor events are only retained for {}h and at most {}", MONITOR_RETENTION_HOURS, MONITOR_RETENTION_NUM)
@@ -825,13 +839,15 @@ impl DetailedError for DBError {
             Self::TlsConnection { .. } => Cow::from("TlsConnection"),
             Self::DeleteRestrictedToClearedStorage => Cow::from("DeleteRestrictedToClearedStorage"),
             Self::PauseWhileNotProvisioned => Cow::from("PauseWhileNotProvisioned"),
-            Self::InvalidResourcesStatus(..) => Cow::from("InvalidResourcesStatus"),
-            Self::InvalidResourcesDesiredStatus(..) => Cow::from("InvalidResourcesDesiredStatus"),
-            Self::InvalidRuntimeStatus(..) => Cow::from("InvalidRuntimeStatus"),
-            Self::InvalidRuntimeDesiredStatus(..) => Cow::from("InvalidRuntimeDesiredStatus"),
-            Self::InvalidBootstrap(..) => Cow::from("InvalidBootstrap"),
+            Self::InvalidResourcesStatus { .. } => Cow::from("InvalidResourcesStatus"),
+            Self::InvalidResourcesDesiredStatus { .. } => {
+                Cow::from("InvalidResourcesDesiredStatus")
+            }
+            Self::InvalidRuntimeStatus { .. } => Cow::from("InvalidRuntimeStatus"),
+            Self::InvalidRuntimeDesiredStatus { .. } => Cow::from("InvalidRuntimeDesiredStatus"),
+            Self::InvalidBootstrap { .. } => Cow::from("InvalidBootstrap"),
             Self::NoRuntimeStatusWhileProvisioned => Cow::from("NoRuntimeStatusWhileProvisioned"),
-            Self::PreconditionViolation(..) => Cow::from("PreconditionViolation"),
+            Self::PreconditionViolation { .. } => Cow::from("PreconditionViolation"),
             Self::ResumeWhileNotProvisioned => Cow::from("ResumeWhileNotProvisioned"),
             Self::CannotStartWithUndismissedError => Cow::from("CannotStartWithUndismissedError"),
             Self::CannotStartWhileClearingStorage => Cow::from("CannotStartWhileClearingStorage"),
@@ -843,7 +859,7 @@ impl DetailedError for DBError {
                 Cow::from("BootstrapPolicyImmutableUnlessStopped")
             }
             Self::InitialStandbyNotAllowed => Cow::from("InitialStandbyNotAllowed"),
-            Self::InvalidMonitorStatus(..) => Cow::from("InvalidMonitorStatus"),
+            Self::InvalidMonitorStatus { .. } => Cow::from("InvalidMonitorStatus"),
             Self::UnknownClusterMonitorEvent { .. } => Cow::from("UnknownClusterMonitorEvent"),
             Self::NoClusterMonitorEventsAvailable => Cow::from("NoClusterMonitorEventsAvailable"),
             Self::UnnecessaryResourcesStatusTransition { .. } => {
@@ -910,20 +926,20 @@ impl ResponseError for DBError {
             Self::InvalidStorageStatusTransition { .. } => StatusCode::BAD_REQUEST,
             Self::PauseWhileNotProvisioned => StatusCode::BAD_REQUEST,
             Self::ResumeWhileNotProvisioned => StatusCode::BAD_REQUEST,
-            Self::InvalidResourcesStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::InvalidResourcesDesiredStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::InvalidRuntimeStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::InvalidRuntimeDesiredStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::InvalidBootstrap(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidResourcesStatus { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidResourcesDesiredStatus { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidRuntimeStatus { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidRuntimeDesiredStatus { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidBootstrap { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NoRuntimeStatusWhileProvisioned => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::PreconditionViolation(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::PreconditionViolation { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::CannotStartWithUndismissedError => StatusCode::BAD_REQUEST,
             Self::CannotStartWhileClearingStorage => StatusCode::BAD_REQUEST,
             Self::DismissErrorRestrictedToFullyStopped => StatusCode::BAD_REQUEST,
             Self::InitialImmutableUnlessStopped => StatusCode::BAD_REQUEST,
             Self::BootstrapPolicyImmutableUnlessStopped => StatusCode::BAD_REQUEST,
             Self::InitialStandbyNotAllowed => StatusCode::BAD_REQUEST,
-            Self::InvalidMonitorStatus(..) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidMonitorStatus { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::UnknownClusterMonitorEvent { .. } => StatusCode::NOT_FOUND,
             Self::NoClusterMonitorEventsAvailable => StatusCode::NOT_FOUND,
             Self::UnnecessaryResourcesStatusTransition { .. } => StatusCode::BAD_REQUEST,
@@ -940,5 +956,40 @@ impl ResponseError for DBError {
 impl From<DBError> for ErrorResponse {
     fn from(val: DBError) -> Self {
         ErrorResponse::from_error_nolog(&val)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::db::error::DBError;
+    use crate::error::ManagerError;
+
+    #[test]
+    fn invalid_bootstrap_error_serialization() {
+        for db_error in [
+            DBError::InvalidResourcesStatus {
+                value: "abc".to_string(),
+            },
+            DBError::InvalidResourcesDesiredStatus {
+                value: "abc".to_string(),
+            },
+            DBError::InvalidRuntimeStatus {
+                value: "abc".to_string(),
+            },
+            DBError::InvalidRuntimeDesiredStatus {
+                value: "abc".to_string(),
+            },
+            DBError::InvalidBootstrap {
+                value: "abc".to_string(),
+            },
+            DBError::PreconditionViolation {
+                precondition: "abc".to_string(),
+            },
+            DBError::InvalidMonitorStatus {
+                value: "abc".to_string(),
+            },
+        ] {
+            serde_json::to_string_pretty(&ManagerError::DBError { db_error }).unwrap();
+        }
     }
 }

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -844,7 +844,9 @@ fn check_precondition(condition: bool, info: &str) -> Result<(), DBError> {
     if condition {
         Ok(())
     } else {
-        Err(DBError::PreconditionViolation(info.to_string()))
+        Err(DBError::PreconditionViolation {
+            precondition: info.to_string(),
+        })
     }
 }
 

--- a/crates/pipeline-manager/src/db/types/monitor.rs
+++ b/crates/pipeline-manager/src/db/types/monitor.rs
@@ -31,7 +31,7 @@ impl TryFrom<String> for MonitorStatus {
             "initial_unhealthy" => Ok(Self::InitialUnhealthy),
             "unhealthy" => Ok(Self::Unhealthy),
             "healthy" => Ok(Self::Healthy),
-            _ => Err(DBError::InvalidMonitorStatus(value)),
+            _ => Err(DBError::InvalidMonitorStatus { value }),
         }
     }
 }

--- a/crates/pipeline-manager/src/db/types/pipeline.rs
+++ b/crates/pipeline-manager/src/db/types/pipeline.rs
@@ -61,7 +61,7 @@ pub fn parse_string_as_runtime_status(s: String) -> Result<RuntimeStatus, DBErro
         "paused" => Ok(RuntimeStatus::Paused),
         "running" => Ok(RuntimeStatus::Running),
         "suspended" => Ok(RuntimeStatus::Suspended),
-        _ => Err(DBError::InvalidRuntimeStatus(s)),
+        _ => Err(DBError::InvalidRuntimeStatus { value: s }),
     }
 }
 
@@ -88,7 +88,7 @@ pub fn parse_string_as_runtime_desired_status(s: String) -> Result<RuntimeDesire
         "paused" => Ok(RuntimeDesiredStatus::Paused),
         "running" => Ok(RuntimeDesiredStatus::Running),
         "suspended" => Ok(RuntimeDesiredStatus::Suspended),
-        _ => Err(DBError::InvalidRuntimeDesiredStatus(s)),
+        _ => Err(DBError::InvalidRuntimeDesiredStatus { value: s }),
     }
 }
 
@@ -116,7 +116,7 @@ pub fn parse_string_as_bootstrap_config(s: String) -> Result<BootstrapConfig, DB
         "reject" => Ok(BootstrapConfig::from(BootstrapPolicy::Reject)),
         "await_approval" => Ok(BootstrapConfig::from(BootstrapPolicy::AwaitApproval)),
         _ => serde_json::from_str::<BootstrapConfig>(&s)
-            .map_err(|_| DBError::InvalidBootstrap(s.clone())),
+            .map_err(|_| DBError::InvalidBootstrap { value: s.clone() }),
     }
 }
 

--- a/crates/pipeline-manager/src/db/types/resources_status.rs
+++ b/crates/pipeline-manager/src/db/types/resources_status.rs
@@ -108,7 +108,7 @@ impl TryFrom<String> for ResourcesStatus {
             "provisioning" => Ok(Self::Provisioning),
             "provisioned" => Ok(Self::Provisioned),
             "stopping" => Ok(Self::Stopping),
-            _ => Err(DBError::InvalidResourcesStatus(value)),
+            _ => Err(DBError::InvalidResourcesStatus { value }),
         }
     }
 }
@@ -144,7 +144,7 @@ impl TryFrom<String> for ResourcesDesiredStatus {
         match value.as_str() {
             "stopped" => Ok(Self::Stopped),
             "provisioned" => Ok(Self::Provisioned),
-            _ => Err(DBError::InvalidResourcesDesiredStatus(value)),
+            _ => Err(DBError::InvalidResourcesDesiredStatus { value }),
         }
     }
 }


### PR DESCRIPTION
Some of the `DBError` variant of `ManagerError` were using a tuple for their content, which does not work with the `#[serde(flatten)]` getting applied during serialization. This changes them to use a struct instead and adds a test to check they can indeed be serialized now.

**PR information**
- Unit tests added
- Changelog not updated
- Backward incompatible changes: technically yes (the type changed of the `ManagerError`), however they were never able to be serialized properly, as such this is a fix such that the correct error is returned