### PR TITLE
deps: use iceberg fork and upgrade delta-rs to 0.32.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +408,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -677,9 +701,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -698,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -712,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -723,7 +747,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -731,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -743,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -765,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -780,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -793,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -809,15 +833,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap 2.13.0",
@@ -833,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -846,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -859,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.10.0",
  "serde",
@@ -871,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -885,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1420,14 +1445,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -1520,13 +1545,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -1561,7 +1586,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1 0.10.6",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -2130,6 +2155,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "buoyant_kernel"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2235eb320cd7178862a32dd111bd0c0f71a368e393add4914c50129add478eab"
+dependencies = [
+ "arrow",
+ "buoyant_kernel_derive",
+ "bytes",
+ "chrono",
+ "crc",
+ "futures",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "object_store 0.13.2",
+ "parquet",
+ "percent-encoding",
+ "rand 0.9.4",
+ "reqwest 0.13.4",
+ "roaring",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+ "z85",
+]
+
+[[package]]
+name = "buoyant_kernel_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3448e05bba811d98c73a466843abd8c16d0416dc083f92b66847693fcb0714f4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,6 +2581,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -2952,6 +3027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2991,8 +3067,19 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "ctor-proc-macro 0.0.7",
+ "dtor 0.1.1",
+]
+
+[[package]]
+name = "ctor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "ctor-proc-macro 0.0.13",
+ "dtor 0.8.1",
+ "link-section",
 ]
 
 [[package]]
@@ -3000,6 +3087,30 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
 
 [[package]]
 name = "cty"
@@ -3138,9 +3249,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datafusion"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7541353e77dc7262b71ca27be07d8393661737e3a73b5d1b1c6f7d814c64fa2a"
+checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3178,7 +3289,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.4",
  "parquet",
  "rand 0.9.4",
@@ -3193,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9997731f90fa5398ef831ad0e69600f92c861b79c0d38bd1a29b6f0e3a0ce4c8"
+checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3211,16 +3322,16 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.4",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b30a3dd50dec860c9559275c8d97d9de602e611237a6ecfbda0b3b63b872352"
+checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3236,14 +3347,14 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
+checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3252,9 +3363,10 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
+ "itertools 0.14.0",
  "libc",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parquet",
  "paste",
  "recursive",
@@ -3265,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567d40e285f5b79f8737b576605721cd6c1133b5d2b00bdbd5d9838d90d0812f"
+checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
 dependencies = [
  "futures",
  "log",
@@ -3276,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d2668f51b3b30befae2207472569e37807fdedd1d14da58acc6f8ca6257eae"
+checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
 dependencies = [
  "arrow",
  "async-compression",
@@ -3301,7 +3413,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "rand 0.9.4",
  "tokio",
  "tokio-util",
@@ -3311,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e1b3e3a8ec55f1f62de4252b0407c8567363d056078769a197e24fc834a0f"
+checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3329,15 +3441,15 @@ dependencies = [
  "datafusion-session",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b559d7bf87d4f900f847baba8509634f838d9718695389e903604cdcccdb01f3"
+checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3351,16 +3463,16 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250e2d7591ba8b638f063854650faa40bca4e8bd4059b2ece8836f6388d02db4"
+checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3374,15 +3486,17 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "object_store",
+ "object_store 0.13.2",
+ "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b043149f2c3557ca94abc58de40f68a8d412ff53365c06126ed234f8596399d"
+checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3402,7 +3516,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.4",
  "parquet",
  "tokio",
@@ -3410,25 +3524,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9496cb0db222dbb9a3735760ceca7fc56f35e1d5502c38d0caa77a81e9c1f6a"
+checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-execution"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc45d23c516ed8d3637751e44e09e21b45b3f58b473c802dddd1f1ad4fe435ff"
+checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
 dependencies = [
  "arrow",
+ "arrow-buffer",
  "async-trait",
  "chrono",
  "dashmap 6.1.0",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr-common",
  "futures",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.4",
  "rand 0.9.4",
  "tempfile",
@@ -3437,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd30526d2db4fda6440806a41e4676334a94bc0596cc9cc2a0efed20ef2c44"
+checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3460,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b486b5f6255d40976b88bb83813b0d035a8333e0ec39864824e78068cf42fa6"
+checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3473,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07356c94118d881130dd0ffbff127540407d969c8978736e324edcd6c41cd48f"
+checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -3494,19 +3610,20 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "md-5",
+ "memchr",
  "num-traits",
  "rand 0.9.4",
  "regex",
- "sha2",
+ "sha2 0.10.9",
  "unicode-segmentation",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
+checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3520,14 +3637,15 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "log",
+ "num-traits",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
+checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3538,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552f8d92e4331ee91d23c02d12bb6acf32cbfd5215117e01c0fb63cd4b15af1a"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -3554,16 +3672,18 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
+ "itoa",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970fd0cdd3df8802b9a9975ff600998289ba9d46682a4f7285cba4820c9ada78"
+checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3577,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b4c21a7c8a986a1866c0a87ab756d0bbf7b5f41f306009fa2d9af79c52ed31"
+checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3595,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1210ad73b8b3211aeaf4a42bef9bd7a2b7fce3ec119a478831f18c6ff7f7b93"
+checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -3605,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa566a963013a38681ad82a727a654bc7feb19632426aea8c3412d415d200c5"
+checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -3616,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9aa82b240252a88dee118372f9b9757c545ab9e53c0736bebab2e7da0ef1f2"
+checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
 dependencies = [
  "arrow",
  "chrono",
@@ -3636,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
+checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3660,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7a8abc0b4fe624000972a9b145b30b7f1b680bffaa950ea53f78d9b21c27c3"
+checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3675,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
+checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3692,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689156bb2282107b6239db8d7ef44b4dab10a9b33d3491a0c74acac5e4fedd72"
+checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3711,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
+checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3735,6 +3855,7 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "log",
+ "num-traits",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "tokio",
@@ -3742,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5ab57d0b5a368258fff1d828f1619a10541fa5c4ec4930a383deb3a23204c8"
+checksum = "6a387aaef949dc16bb6abc81bd1af850ec7449183aef011214f9724957495738"
 dependencies = [
  "arrow",
  "chrono",
@@ -3763,15 +3884,16 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
- "object_store",
+ "object_store 0.13.2",
  "prost 0.14.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
 name = "datafusion-proto-common"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd21d2c804802ca4b1719191dfe8e3d0860686649de6375ddc9237f85beb82b3"
+checksum = "16e614c7c53a9c304c6a850b821010bb492e57300311835f1180613f9d2c63d9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3780,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcad240a54d0b1d3e8f668398900260a53122d522b2102ab57218590decacd6"
+checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -3797,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e83a68bb67007a8fcbf005c44cefe441270c7ee7f6dee10c0e0109b556f6d"
+checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -3811,15 +3933,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "52.5.0"
+version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be53e9eb55db0fbb8980bb6d87f2435b0524acf4c718ed54a57cabbb299b2ab3"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-nested",
  "indexmap 2.13.0",
  "log",
  "recursive",
@@ -3947,6 +4070,7 @@ dependencies = [
  "backtrace",
  "base64 0.22.1",
  "bstr",
+ "buoyant_kernel",
  "bytemuck",
  "bytes",
  "bytestring",
@@ -3964,7 +4088,6 @@ dependencies = [
  "datafusion",
  "dbsp",
  "dbsp_nexmark",
- "delta_kernel",
  "deltalake",
  "deltalake-catalog-unity",
  "dyn-clone",
@@ -4038,7 +4161,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "smallstr",
  "smallvec",
  "tempfile",
@@ -4154,54 +4277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
-name = "delta_kernel"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f7fc164b1557731fcc68a198e813811a000efade0f112d4f0a002e65042b83"
-dependencies = [
- "arrow",
- "bytes",
- "chrono",
- "comfy-table",
- "crc",
- "delta_kernel_derive",
- "futures",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "object_store",
- "parquet",
- "reqwest 0.12.24",
- "roaring",
- "rustc_version",
- "serde",
- "serde_json",
- "strum",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "z85",
-]
-
-[[package]]
-name = "delta_kernel_derive"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86815a2c475835751ffa9b8d9ac8ed86cf86294304c42bedd1103d54f25ecbfe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "deltalake"
-version = "0.31.1"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.32.3"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
- "ctor",
- "delta_kernel",
+ "buoyant_kernel",
+ "ctor 0.10.1",
  "deltalake-aws",
  "deltalake-azure",
  "deltalake-catalog-unity",
@@ -4211,8 +4292,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-aws"
-version = "0.14.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.15.0"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4225,7 +4306,7 @@ dependencies = [
  "chrono",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "regex",
  "thiserror 2.0.17",
  "tokio",
@@ -4237,12 +4318,12 @@ dependencies = [
 
 [[package]]
 name = "deltalake-azure"
-version = "0.14.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.15.0"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "bytes",
  "deltalake-core",
- "object_store",
+ "object_store 0.13.2",
  "thiserror 2.0.17",
  "tokio",
  "url",
@@ -4250,8 +4331,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-catalog-unity"
-version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.16.0"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4263,7 +4344,7 @@ dependencies = [
  "deltalake-gcp",
  "futures",
  "moka",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.12.24",
  "reqwest-middleware",
  "reqwest-retry",
@@ -4277,8 +4358,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-core"
-version = "0.31.1"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.32.3"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4292,6 +4373,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "async-trait",
+ "buoyant_kernel",
  "bytes",
  "cfg-if",
  "chrono",
@@ -4300,7 +4382,6 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-physical-expr-adapter",
  "datafusion-proto",
- "delta_kernel",
  "deltalake-derive",
  "dirs 6.0.0",
  "either",
@@ -4309,13 +4390,13 @@ dependencies = [
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot 0.12.4",
  "parquet",
  "percent-encoding",
  "percent-encoding-rfc3986",
  "pin-project-lite",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "serde",
  "serde_json",
@@ -4331,8 +4412,8 @@ dependencies = [
 
 [[package]]
 name = "deltalake-derive"
-version = "0.31.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "1.0.0"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "convert_case 0.9.0",
  "itertools 0.14.0",
@@ -4343,14 +4424,14 @@ dependencies = [
 
 [[package]]
 name = "deltalake-gcp"
-version = "0.15.0"
-source = "git+https://github.com/feldera/delta-rs.git?rev=93d94dc66976788a378313af7eff3312ad0d294c#93d94dc66976788a378313af7eff3312ad0d294c"
+version = "0.16.0"
+source = "git+https://github.com/feldera/delta-rs.git?rev=5b35c0988b07ab921d5eee5b8da8da55e4d65945#5b35c0988b07ab921d5eee5b8da8da55e4d65945"
 dependencies = [
  "async-trait",
  "bytes",
  "deltalake-core",
  "futures",
- "object_store",
+ "object_store 0.13.2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4531,6 +4612,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -4634,7 +4716,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.6",
+]
+
+[[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+dependencies = [
+ "dtor-proc-macro 0.0.13",
 ]
 
 [[package]]
@@ -4642,6 +4733,12 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "duct"
@@ -4706,7 +4803,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "subtle",
 ]
@@ -5384,7 +5481,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "nix 0.27.1",
- "object_store",
+ "object_store 0.12.5",
  "once_cell",
  "rkyv",
  "serde",
@@ -5732,7 +5829,7 @@ dependencies = [
  "base64 0.22.1",
  "gcloud-metadata",
  "home",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "reqwest 0.12.24",
  "serde",
  "serde_json",
@@ -5913,6 +6010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6079,6 +6186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6151,7 +6264,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -6161,6 +6274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -6416,10 +6538,10 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9c3fc1f55c84ff64645c0d2ee35159f5574d33f729fc0860783bc247c8b8c5"
+version = "0.9.0"
+source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306bd80d11d03f232670feec3#28c4800f198686f306bd80d11d03f232670feec3"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "apache-avro 0.21.0",
  "array-init",
@@ -6461,18 +6583,19 @@ dependencies = [
  "serde_with",
  "strum",
  "tokio",
+ "tracing",
  "typed-builder 0.20.1",
  "typetag",
  "url",
  "uuid",
+ "zeroize",
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "iceberg-catalog-glue"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c510ae5f666202151bd24728a2cb569af04694d04e67788ba5ec00770314301"
+version = "0.9.0"
+source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306bd80d11d03f232670feec3#28c4800f198686f306bd80d11d03f232670feec3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6482,14 +6605,12 @@ dependencies = [
  "iceberg-storage-opendal",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49dfef578060c3a2a3f619522dcb25382a7ce85336dcb500495d4b8d72ae714"
+version = "0.9.0"
+source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306bd80d11d03f232670feec3#28c4800f198686f306bd80d11d03f232670feec3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6501,16 +6622,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
- "tracing",
  "typed-builder 0.20.1",
  "uuid",
 ]
 
 [[package]]
 name = "iceberg-datafusion"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f668954750597310308ba6ce3a6d3a6874196e64a8a3197e3d1c5017977ba6"
+version = "0.9.0"
+source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306bd80d11d03f232670feec3#28c4800f198686f306bd80d11d03f232670feec3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6525,18 +6644,18 @@ dependencies = [
 
 [[package]]
 name = "iceberg-storage-opendal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30acae4698949eea6cfbd3e64ddf1c3ec39e6b7191acb0b0da2dcd1a25dfa842"
+version = "0.9.0"
+source = "git+https://github.com/feldera/iceberg-rust.git?rev=28c4800f198686f306bd80d11d03f232670feec3#28c4800f198686f306bd80d11d03f232670feec3"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "cfg-if",
+ "futures",
  "iceberg",
  "opendal",
- "reqsign",
- "reqwest 0.12.24",
+ "reqsign-aws-v4",
+ "reqsign-core",
  "serde",
  "typetag",
  "url",
@@ -6782,16 +6901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6884,10 +6993,12 @@ checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-sys 0.61.2",
 ]
 
@@ -6918,6 +7029,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6929,10 +7089,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6949,24 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -6977,6 +7124,7 @@ dependencies = [
  "serde_json",
  "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -7172,6 +7320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7281e4b2b1a1fae03463a7c49dd21464de50251a450f6da9715c40c7b21a70"
 
 [[package]]
+name = "link-section"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7255,9 +7409,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -7269,7 +7423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
 dependencies = [
  "crc",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7341,10 +7495,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.4"
+name = "mea"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -7864,6 +8027,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper 1.6.0",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot 0.12.4",
+ "percent-encoding",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
+ "reqwest 0.12.24",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7882,6 +8085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openapiv3"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7894,31 +8103,146 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+dependencies = [
+ "ctor 0.6.3",
+ "opendal-core",
+ "opendal-layer-concurrent-limit",
+ "opendal-layer-logging",
+ "opendal-layer-retry",
+ "opendal-layer-timeout",
+ "opendal-service-fs",
+ "opendal-service-gcs",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
 dependencies = [
  "anyhow",
- "backon",
  "base64 0.22.1",
  "bytes",
- "crc32c",
  "futures",
- "getrandom 0.2.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "jiff",
  "log",
  "md-5",
+ "mea",
  "percent-encoding",
  "quick-xml 0.38.3",
- "reqsign",
- "reqwest 0.12.24",
+ "reqsign-core",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
  "url",
  "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048b1b29c503263bdd80a9afe46a68cd02ea9bd361185b1feab4b151078998e9"
+dependencies = [
+ "futures",
+ "http 1.3.1",
+ "mea",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2645adc988b12eda106e2679ae529facfbbaa868ceb706f6f8125c6af15c47b"
+dependencies = [
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619586ab7480c2e3009f6d18eabab18957bc094778fd130bcc38924970a90f4c"
+dependencies = [
+ "opendal-core",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0be0417abeeb0053376d816b90fceb9ca98f20dfb54ebf1f2a282729f83663"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
+]
+
+[[package]]
+name = "opendal-service-gcs"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a49477a10163431896d106136117f5670717f9c9e49cf6f710528800c6633a"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "log",
+ "opendal-core",
+ "percent-encoding",
+ "quick-xml 0.38.3",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-google",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "http 1.3.1",
+ "log",
+ "md-5",
+ "opendal-core",
+ "quick-xml 0.38.3",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -8121,7 +8445,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8193,14 +8517,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -8212,13 +8535,14 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "paste",
+ "ring",
  "seq-macro",
  "serde_json",
  "simdutf8",
@@ -8263,7 +8587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -8467,7 +8791,7 @@ dependencies = [
  "hex",
  "indoc",
  "itertools 0.14.0",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "nix 0.29.0",
  "openssl",
  "pg-client-config",
@@ -8487,7 +8811,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "static-files",
  "static_assertions",
  "tar",
@@ -8543,7 +8867,7 @@ dependencies = [
  "der 0.7.10",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki 0.7.3",
 ]
 
@@ -8632,6 +8956,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8705,11 +9041,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "memchr",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
 ]
 
@@ -8723,11 +9059,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "memchr",
  "rand 0.9.4",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
 ]
 
@@ -8795,7 +9131,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "target-triple",
  "tempfile",
@@ -9311,9 +9647,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
  "serde",
@@ -9321,9 +9657,19 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -9367,6 +9713,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -9818,33 +10165,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqsign"
-version = "0.16.5"
+name = "reqsign-aws-v4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
+checksum = "7b75624bd8a466e37ddc0a7b6c33ac859a85347c153a916e1dd9d0b68338f74a"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
+ "bytes",
  "form_urlencoded",
- "getrandom 0.2.16",
  "hex",
- "hmac",
- "home",
  "http 1.3.1",
- "jsonwebtoken 9.3.1",
  "log",
  "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.6",
- "reqwest 0.12.24",
- "rsa",
+ "quick-xml 0.40.1",
+ "reqsign-core",
  "rust-ini 0.21.1",
  "serde",
  "serde_json",
- "sha1 0.10.6",
- "sha2",
+ "serde_urlencoded",
+ "sha1 0.11.0",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5fa5cb48808693614d1701fcd3db0b30fa292e0f18e122ae068b6d32eaeed3f"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures",
+ "hex",
+ "hmac 0.13.0",
+ "http 1.3.1",
+ "jiff",
+ "log",
+ "percent-encoding",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a4b6f3a3fd29ffcc99a90aec585a65217783badfd73acddf847b63ae683bda9"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
+ "tokio",
+]
+
+[[package]]
+name = "reqsign-google"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb215d0876a18b6bd9cdd380b589e5292aaa638ca15266de794b1122d898b6b2"
+dependencies = [
+ "form_urlencoded",
+ "http 1.3.1",
+ "log",
+ "percent-encoding",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -9881,7 +10273,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "winreg",
 ]
@@ -9930,9 +10322,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.13",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -10022,7 +10455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -10152,7 +10585,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -10225,7 +10658,7 @@ version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -10341,7 +10774,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.6.0",
 ]
 
 [[package]]
@@ -10362,6 +10795,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.1",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.6.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -10539,7 +10999,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10593,9 +11053,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
@@ -10606,9 +11066,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -10786,9 +11246,9 @@ dependencies = [
 
 [[package]]
 name = "serde_arrow"
-version = "0.13.7"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038967a6dda16f5c6ca5b6e1afec9cd2361d39f0db681ca338ac5f0ccece6469"
+checksum = "26e4ac1bef72720318e2c67bd19b972d17084840f3188a585021828122c43c2c"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -11036,6 +11496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11129,6 +11600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11165,12 +11646,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sltsqlvalue"
@@ -11279,9 +11757,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "recursive",
@@ -11290,9 +11768,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11339,7 +11817,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.17",
  "tokio",
@@ -11377,7 +11855,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -11409,7 +11887,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -11420,7 +11898,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1 0.10.6",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -11447,7 +11925,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -11457,7 +11935,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -12369,20 +12847,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -12744,6 +13222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13101,48 +13589,32 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13150,22 +13622,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -13206,6 +13678,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13234,9 +13719,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14157,9 +14642,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -14238,7 +14723,7 @@ dependencies = [
  "deflate64",
  "flate2",
  "getrandom 0.3.3",
- "hmac",
+ "hmac 0.12.1",
  "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ anyhow = "1.0.91"
 apache-avro = "0.18.0"
 arc-swap = "1.5.1"
 arcstr = "1.2.0"
-arrow = "57"
-arrow-json = "57"
-arrow-schema = "57"
+arrow = "58"
+arrow-json = "58"
+arrow-schema = "58"
 ascii_table = "=4.0.2"
 async-channel = "2.3.1"
 async-nats = "0.47.0"
@@ -102,26 +102,23 @@ crossbeam-utils = "0.8.6"
 csv = "1.2.2"
 csv-core = "0.1.10"
 dashmap = "6.1.0"
-datafusion = "52.2"
+datafusion = "53.1"
 dbsp = { path = "crates/dbsp", version = "0.305.0" }
 dbsp_nexmark = { path = "crates/nexmark" }
 deadpool-postgres = "0.14.1"
-# Feldera fork of delta-rs: upstream tag `rust-v0.31.1` + 3 patches, on branch
-# `v0.31.1-feldera`. When bumping the pinned revision, preserve these patches:
-#   - 71d185e5 "Initialize unity from environment." — let the unity catalog
-#     pick up credentials/host from process env, matching how we configure
-#     other connectors.
-#   - d2c12edd "Disable unsupported feature check." — relax the writer-side
+# Feldera fork of delta-rs: upstream tag `rust-v0.32.3` + 2 patches, on branch
+# `v0.32.3-feldera`. When bumping the pinned revision, preserve these patches:
+#   - 7f8bb445 "Disable unsupported feature check." — relax the writer-side
 #     protocol-feature gate so we can write tables produced by newer clients.
-#   - 93d94dc6 "delta-rs: round-robin pre-split unpartitioned scans into
+#   - 5b35c098 "delta-rs: round-robin pre-split unpartitioned scans into
 #     target_partitions FileGroups" — improves snapshot read parallelism for
 #     unpartitioned tables; pairs with the DataFusion knobs we tune in adapters.
 # Diff vs. upstream:
-#   https://github.com/delta-io/delta-rs/compare/rust-v0.31.1...feldera:delta-rs:v0.31.1-feldera
-deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "93d94dc66976788a378313af7eff3312ad0d294c" }
-deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "93d94dc66976788a378313af7eff3312ad0d294c" }
+#   https://github.com/delta-io/delta-rs/compare/rust-v0.32.3...feldera:delta-rs:v0.32.3-feldera
+deltalake = { git = "https://github.com/feldera/delta-rs.git", rev = "5b35c0988b07ab921d5eee5b8da8da55e4d65945" }
+deltalake-catalog-unity = { git = "https://github.com/feldera/delta-rs.git", rev = "5b35c0988b07ab921d5eee5b8da8da55e4d65945" }
 
-delta_kernel = "0.19.0"
+delta_kernel = { package = "buoyant_kernel", version = "0.22" }
 derive_more = { version = "1.0.0" }
 directories = "6.0"
 dirs = "5.0"
@@ -159,11 +156,12 @@ hashbrown = "0.14.2"
 hdrhist = "0.5"
 hex = "0.4.3"
 home = "=0.5.9"
-iceberg = { version = "0.9.1" }
-iceberg-catalog-glue = "0.9.1"
-iceberg-catalog-rest = "0.9.1"
-iceberg-datafusion = "0.9.1"
-iceberg-storage-opendal = { version = "0.9.1", features = ["opendal-s3", "opendal-gcs", "opendal-fs", "opendal-memory"] }
+# TODO: Use iceberg v0.10.0 when released
+iceberg = { git = "https://github.com/feldera/iceberg-rust.git", rev = "28c4800f198686f306bd80d11d03f232670feec3" }
+iceberg-catalog-glue = { git = "https://github.com/feldera/iceberg-rust.git", rev = "28c4800f198686f306bd80d11d03f232670feec3" }
+iceberg-catalog-rest = { git = "https://github.com/feldera/iceberg-rust.git", rev = "28c4800f198686f306bd80d11d03f232670feec3" }
+iceberg-datafusion = { git = "https://github.com/feldera/iceberg-rust.git", rev = "28c4800f198686f306bd80d11d03f232670feec3" }
+iceberg-storage-opendal = { git = "https://github.com/feldera/iceberg-rust.git", rev = "28c4800f198686f306bd80d11d03f232670feec3", features = ["opendal-s3", "opendal-gcs", "opendal-fs", "opendal-memory"] }
 impl-trait-for-tuples = "0.2"
 indexmap = "2.7.1"
 indicatif = "0.17.0-rc.11"
@@ -172,7 +170,7 @@ inventory = "0.3"
 itertools = "0.14.0"
 jemalloc_pprof = "0.7.0"
 json_to_table = "0.9.0"
-jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
 lexical-core = "1.0.5"
 libc = "0.2.153"
 like = "0.3.1"
@@ -198,7 +196,7 @@ once_cell = "1.20.2"
 openssl = "0.10.80"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 ouroboros = "0.18.4"
-parquet = "57"
+parquet = "58"
 paste = "1.0.12"
 petgraph = "0.6.0"
 pg-client-config = "0.1.2"
@@ -244,7 +242,7 @@ ryu = "1.0.20"
 schema_registry_converter = "4.2.0"
 semver = "1.0.27"
 serde = "1.0.213"
-serde_arrow = { version = "0.13.7", features = ["arrow-57"] }
+serde_arrow = { version = "0.14.1", features = ["arrow-58"] }
 serde_bytes = "0.11.15"
 serde_json = { version = "1.0.132", features = ["arbitrary_precision"] }
 serde_json_path_to_error = "0.1.5"

--- a/crates/adapters/src/adhoc/table.rs
+++ b/crates/adapters/src/adhoc/table.rs
@@ -324,7 +324,7 @@ struct AdHocQueryExecution {
     projected_schema: Arc<Schema>,
     readers: Vec<Arc<dyn SerBatchReader>>,
     projection: Option<Vec<usize>>,
-    plan_properties: PlanProperties,
+    plan_properties: Arc<PlanProperties>,
     children: Vec<Arc<dyn ExecutionPlan>>,
 }
 
@@ -344,12 +344,12 @@ impl AdHocQueryExecution {
         let num_partitions = readers.as_ref().map(|r| r.len()).unwrap_or(1);
         let eq_props = EquivalenceProperties::new(projected_schema.clone());
         let partitioning = Partitioning::UnknownPartitioning(num_partitions);
-        let plan_properties = PlanProperties::new(
+        let plan_properties = Arc::new(PlanProperties::new(
             eq_props,
             partitioning,
             EmissionType::Both,
             Boundedness::Bounded,
-        );
+        ));
 
         Self {
             name,
@@ -393,7 +393,7 @@ impl ExecutionPlan for AdHocQueryExecution {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.plan_properties
     }
 

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1040,6 +1040,7 @@ impl DeltaTableInputEndpointInner {
                 },
             )
             .await?;
+        let latest = latest as i64;
         Ok(match self.config.end_version {
             Some(end_version) => min(latest, end_version),
             None => latest,
@@ -1220,7 +1221,7 @@ impl DeltaTableInputEndpointInner {
             .snapshot_records_total
             .fetch_add(record_count as u64, Ordering::Relaxed);
         self.metrics
-            .set_last_ingested_version(table.version().unwrap());
+            .set_last_ingested_version(table.version().unwrap() as i64);
 
         // Empty buffer to indicate checkpointable state.
         self.queue.push_entry(
@@ -1228,7 +1229,7 @@ impl DeltaTableInputEndpointInner {
                 timestamp,
                 QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(
                     // We verified that the table version is not None in the open_table method.
-                    table.version().unwrap(),
+                    table.version().unwrap() as i64,
                     !self.config.follow(),
                 ))),
             )
@@ -1242,7 +1243,7 @@ impl DeltaTableInputEndpointInner {
             "delta_table {}: snapshot load completed (records: {}, version: {})",
             &self.endpoint_name,
             record_count,
-            table.version().unwrap()
+            table.version().unwrap() as i64
         );
         Ok(record_count)
     }
@@ -1266,7 +1267,7 @@ impl DeltaTableInputEndpointInner {
             .read_ordered_snapshot_inner(table, input_stream, receiver)
             .await?;
         self.metrics
-            .set_last_ingested_version(table.version().unwrap());
+            .set_last_ingested_version(table.version().unwrap() as i64);
 
         // Empty buffer to indicate checkpointable state.
         self.queue.push_entry(
@@ -1274,7 +1275,7 @@ impl DeltaTableInputEndpointInner {
                 timestamp,
                 QueueEntry::ResumeInfo(Some(DeltaResumeInfo::follow_mode(
                     // We verified that the table version is not None in the open_table method.
-                    table.version().unwrap(),
+                    table.version().unwrap() as i64,
                     !self.config.follow(),
                 ))),
             )
@@ -1287,7 +1288,7 @@ impl DeltaTableInputEndpointInner {
             "delta_table {}: snapshot load completed (records: {}, version: {})",
             &self.endpoint_name,
             total_records,
-            table.version().unwrap()
+            table.version().unwrap() as i64
         );
         Ok(total_records)
     }
@@ -1428,7 +1429,7 @@ impl DeltaTableInputEndpointInner {
                     Utc::now(),
                     QueueEntry::ResumeInfo(Some(DeltaResumeInfo::snapshot_mode(
                         // We verified that the table version is not None in the open_table method.
-                        table.version().unwrap(),
+                        table.version().unwrap() as i64,
                         &start,
                     ))),
                 )
@@ -1437,7 +1438,7 @@ impl DeltaTableInputEndpointInner {
                 Vec::new(),
             );
             self.metrics
-                .set_last_ingested_version(table.version().unwrap());
+                .set_last_ingested_version(table.version().unwrap() as i64);
         }
 
         Ok(total_records)
@@ -1540,7 +1541,7 @@ impl DeltaTableInputEndpointInner {
         }
 
         // We verified that the table version is not None in the open_table method.
-        let mut version = table.version().unwrap();
+        let mut version = table.version().unwrap() as i64;
 
         // We haven't completed a snapshot before the checkpoint was taken if
         // - there is no checkpoint
@@ -1630,7 +1631,12 @@ impl DeltaTableInputEndpointInner {
                         Some("delta-next-log"),
                         move || {
                             let table = Arc::clone(&table_for_retry);
-                            async move { table.log_store().read_commit_entry(new_version).await }
+                            async move {
+                                table
+                                    .log_store()
+                                    .read_commit_entry(new_version as u64)
+                                    .await
+                            }
                         },
                     )
                     .await
@@ -1645,7 +1651,7 @@ impl DeltaTableInputEndpointInner {
                         if self.config.end_version.is_none()
                             || self.config.end_version.unwrap() >= new_version =>
                     {
-                        let actions = match logstore::get_actions(new_version, &bytes) {
+                        let actions = match logstore::get_actions(new_version as u64, &bytes) {
                             Ok(actions) => actions,
                             Err(e) => {
                                 self.consumer.error(
@@ -1814,7 +1820,7 @@ impl DeltaTableInputEndpointInner {
                 }) = self.last_resume_status.lock().unwrap().clone()
                 {
                     // If we are resuming from a checkpoint, use the version specified in the checkpoint.
-                    table_builder.with_version(version)
+                    table_builder.with_version(version as u64)
                 } else {
                     match &self.config {
                         DeltaTableReaderConfig {
@@ -1836,7 +1842,7 @@ impl DeltaTableInputEndpointInner {
                             version: Some(version),
                             datetime: None,
                             ..
-                        } => table_builder.with_version(*version),
+                        } => table_builder.with_version(*version as u64),
                         DeltaTableReaderConfig {
                             version: None,
                             datetime: Some(datetime),
@@ -1907,7 +1913,7 @@ impl DeltaTableInputEndpointInner {
                 &self.endpoint_name,
                 "internal error: table version is not available",
             )
-        })?;
+        })? as i64;
 
         // If we are about to follow the table, set resume state to the current table version, otherwise
         // the connector will remain in the barrier state until at least one transaction is added to the log.
@@ -1918,22 +1924,13 @@ impl DeltaTableInputEndpointInner {
                 DeltaResumeInfo::follow_mode(version, false);
         }
 
-        // Register object store & url pairs with datafusion.
-        //
-        // - Synthetic `delta-rs://...` URL + table-prefixed store: used when
-        //   we build parquet URIs from `Add.path` entries in the transaction
-        //   log (see `process_actions` and the listing-table path).
-        // - Table root URL + bucket-root store: used by the snapshot
-        //   `TableProvider` since delta-rs 0.31.x, which plans scans against
-        //   the root URL via datafusion's standard parquet `FileSource`.
-        //   Without this second registration, `select ... from snapshot` fails
-        //   with "No suitable object store found for <root>".
+        // Our snapshot scans and CDC listing tables both address files by the
+        // table's `root_url()`, so register that store with datafusion.
+        // Without it, `select ... from snapshot` fails with "No suitable object
+        // store found for <root>". (delta-rs 0.32.x no longer uses the old
+        // synthetic `delta-rs://` URL, so we don't register it anymore.)
         let log_store = delta_table.log_store();
         let runtime_env = self.datafusion.runtime_env();
-        runtime_env.register_object_store(
-            log_store.object_store_url().as_ref(),
-            log_store.object_store(None),
-        );
         runtime_env.register_object_store(log_store.root_url(), log_store.root_object_store(None));
 
         // if let Some(schema) = delta_table.schema() {
@@ -2652,7 +2649,18 @@ impl DeltaTableInputEndpointInner {
         // Collect Add and Remove file paths separately. The query below
         // subtracts Removes from Adds via `EXCEPT ALL` to cancel rewrites
         // that don't change logical data.
-        let url = table.log_store().object_store_url();
+        //
+        // We address files via the table's `root_url()` (e.g. `file:///...` or
+        // `s3://bucket/prefix/`) rather than the synthetic `delta-rs://...`
+        // URL returned by `object_store_url()`. The synthetic URL encodes the
+        // entire table filesystem path into the URL host (slashes become
+        // dashes), which works for DataFusion's `register_object_store`
+        // routing keyed by scheme+host but produces a malformed listing URL
+        // when concatenated with `Add.path`. Using `root_url()` keeps the
+        // listing path real, and `register_object_store(root_url, root_store)`
+        // (done in `start_input_endpoint`) provides the matching store.
+        let log_store = table.log_store();
+        let url = log_store.root_url();
         let path_of = |p: &str| format!("{}{}", url.as_str(), p);
         let adds: Vec<String> = actions
             .iter()
@@ -2732,7 +2740,7 @@ impl DeltaTableInputEndpointInner {
                 receiver,
                 start_transaction,
                 self.config.max_retries(),
-                table.version(),
+                table.version().map(|v| v as i64),
             )
             .await?;
 
@@ -2835,8 +2843,10 @@ impl DeltaTableInputEndpointInner {
     ) -> AnyResult<()> {
         let description = format!("file '{path}'");
 
-        // See comment about `object_store_url` above.
-        let full_path = format!("{}{}", table.log_store().object_store_url().as_str(), path);
+        // Address files via the table's real `root_url()` (e.g. `file:///...`
+        // or `s3://bucket/prefix/`). See `do_process_cdc_transaction` for the
+        // full reasoning on why we don't use `object_store_url()` here.
+        let full_path = format!("{}{}", table.log_store().root_url().as_str(), path);
 
         // Create a datafusion table backed by these files.
         let parquet_table = Arc::new(
@@ -2882,7 +2892,7 @@ impl DeltaTableInputEndpointInner {
                 receiver,
                 start_transaction,
                 self.config.max_retries(),
-                table.version(),
+                table.version().map(|v| v as i64),
             )
             .await?;
 

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -102,17 +102,6 @@ where
     json_file
 }
 
-/// Register the object stores required by delta-rs 0.31.x `TableProvider` scans.
-fn register_delta_table_object_stores(datafusion: &SessionContext, table: &DeltaTable) {
-    let log_store = table.log_store();
-    let runtime_env = datafusion.runtime_env();
-    runtime_env.register_object_store(
-        log_store.object_store_url().as_ref(),
-        log_store.object_store(None),
-    );
-    runtime_env.register_object_store(log_store.root_url(), log_store.root_object_store(None));
-}
-
 const DELTA_TEST_INPUT_ENDPOINT: &str = "test_input1";
 
 /// Completed Delta table version reported by the input connector waterline.
@@ -425,7 +414,7 @@ async fn run_catchup_lag_experiment(
         );
         assert_eq!(
             delta_last_ingested_version(&pipeline),
-            Some(table.version().unwrap()),
+            Some(table.version().unwrap() as i64),
             "last_ingested_version must reflect the snapshot version"
         );
         assert_eq!(
@@ -464,13 +453,13 @@ async fn run_catchup_lag_experiment(
         }
 
         let metric_at_round_start = delta_follow_transaction_starts(&pipeline);
-        let version_before_burst = table.version().unwrap();
+        let version_before_burst = table.version().unwrap() as i64;
 
         for _ in 0..num_versions {
             let record = delta_test_record(record_index * 2);
             record_index += 1;
             table = append_table_version(table, &arrow_schema, &record).await;
-            let new_version = table.version().unwrap();
+            let new_version = table.version().unwrap() as i64;
             if end_version.is_none() || new_version <= end_version.unwrap() {
                 let mut record = record;
                 record.unused = None;
@@ -478,7 +467,7 @@ async fn run_catchup_lag_experiment(
             }
         }
 
-        let version_after_burst = table.version().unwrap();
+        let version_after_burst = table.version().unwrap() as i64;
         assert_eq!(
             version_after_burst,
             version_before_burst + num_versions,
@@ -630,7 +619,12 @@ async fn wait_for_output_records<T>(
     T: for<'a> DeserializeWithContext<'a, SqlSerdeConfig, Variant> + DBData,
 {
     let start = Instant::now();
-    register_delta_table_object_stores(datafusion, table);
+    // Scans address files by the table's `root_url()`, so register that store
+    // before querying. Same as `register_snapshot_table` in input.rs.
+    let log_store = table.log_store();
+    datafusion
+        .runtime_env()
+        .register_object_store(log_store.root_url(), log_store.root_object_store(None));
     loop {
         // select count() output_table == len().
         Arc::get_mut(table)
@@ -1364,7 +1358,7 @@ async fn test_follow(
         serde_json::to_value(transaction_mode).unwrap(),
     );
 
-    let end_version = 5;
+    let end_version: i64 = 5;
     if test_end_version {
         input_config.insert("end_version".to_string(), end_version.into());
     }
@@ -1442,7 +1436,7 @@ async fn test_follow(
     wait(
         || {
             if let Some(version) = completed_version(&pipeline) {
-                let expected = input_table.version().unwrap();
+                let expected = input_table.version().unwrap() as i64;
                 debug!(
                     "pipeline completed version {version}, expected (initial version) {expected}, waterlines: {:?}",
                     pipeline
@@ -1469,7 +1463,7 @@ async fn test_follow(
         total_count += chunk.len();
         input_table = write_data_to_table(input_table, &arrow_schema, chunk).await;
 
-        if !test_end_version || input_table.version().unwrap() <= end_version {
+        if !test_end_version || input_table.version().unwrap() as i64 <= end_version {
             expected_output = data[0..total_count]
                 .iter()
                 .filter_map(|x| {
@@ -1556,9 +1550,9 @@ async fn test_follow(
                 || {
                     if let Some(version) = completed_version(&pipeline) {
                         let expected = if test_end_version {
-                            min(input_table.version().unwrap(), end_version)
+                            min(input_table.version().unwrap() as i64, end_version)
                         } else {
-                            input_table.version().unwrap()
+                            input_table.version().unwrap() as i64
                         };
                         debug!("pipeline completed version {version}, expected {expected}, waterlines: {:?}", pipeline.status().input_status().values().next().unwrap().completed_frontier.debug());
                         version == expected
@@ -1572,7 +1566,7 @@ async fn test_follow(
             .unwrap();
 
         // Wait a bit to make sure the pipeline doesn't process data beyond end_version.
-        if test_end_version && input_table.version().unwrap() > end_version {
+        if test_end_version && input_table.version().unwrap() as i64 > end_version {
             sleep(Duration::from_millis(1000)).await;
         }
 
@@ -1589,7 +1583,7 @@ async fn test_follow(
     }
 
     // If the table has reached the end_version, make sure the eoi status survives the suspend.
-    if test_end_version && suspend && input_table.version().unwrap() >= end_version {
+    if test_end_version && suspend && input_table.version().unwrap() as i64 >= end_version {
         suspend_pipeline(pipeline).await;
 
         pipeline = start_pipeline(

--- a/crates/adapters/src/server.rs
+++ b/crates/adapters/src/server.rs
@@ -1080,7 +1080,7 @@ fn get_env_filter(config: &PipelineConfig) -> EnvFilter {
     }
 
     // Otherwise, fall back to `INFO`
-    EnvFilter::try_new("object_store=warn,info").unwrap()
+    EnvFilter::try_new("object_store=warn,buoyant_kernel=warn,info").unwrap()
 }
 
 fn do_bootstrap(

--- a/crates/iceberg/src/input.rs
+++ b/crates/iceberg/src/input.rs
@@ -25,9 +25,8 @@ use feldera_types::{
 use futures_util::StreamExt;
 use iceberg::CatalogBuilder;
 use iceberg::{
-    io::{FileIOBuilder, StorageFactory},
-    spec::TableMetadata,
-    table::Table as IcebergTable,
+    io::{FileIO, FileIOBuilder, StorageFactory},
+    table::{StaticTable, Table as IcebergTable},
     Catalog, TableIdent,
 };
 use iceberg_catalog_glue::{
@@ -39,7 +38,7 @@ use iceberg_catalog_rest::{
     RestCatalogBuilder, REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
 };
 use iceberg_datafusion::IcebergStaticTableProvider;
-use iceberg_storage_opendal::OpenDalStorageFactory;
+use iceberg_storage_opendal::OpenDalResolvingStorageFactory;
 use log::{debug, info, trace};
 use std::{sync::Arc, thread};
 use tokio::{
@@ -49,62 +48,12 @@ use tokio::{
         watch::{channel, Receiver, Sender},
     },
 };
+use url::Url;
 
-/// Stable discriminant for the storage backend a location URL maps to.
-///
-/// Kept separate from `iceberg_storage_opendal::OpenDalStorageFactory` because
-/// that type is `#[non_exhaustive]` and erased behind `Arc<dyn StorageFactory>`
-/// at the call sites, so its variants are not a reliable assertion target. This
-/// enum is our own, internal contract: callers (and tests) can match on it
-/// without depending on the upstream Debug formatting or variant set.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StorageKind {
-    Fs,
-    Memory,
-    S3,
-    Gcs,
-}
-
-/// Map a location URL's scheme to a `StorageKind`.
-///
-/// Iceberg 0.9 removed scheme-aware FileIO construction from the core crate;
-/// callers must now inject a `StorageFactory` explicitly. Splitting "which
-/// backend" from "build the factory" lets tests assert on a stable discriminant
-/// while production code still gets the trait object.
-fn storage_kind_for_url(location: &str) -> AnyResult<StorageKind> {
-    // `url::Url::parse` returns a scheme that is already lowercased per RFC 3986,
-    // so no extra normalization is needed. A parse failure (e.g. a bare local
-    // path with no scheme) falls through to the local-filesystem default.
-    let scheme = url::Url::parse(location)
-        .map(|u| u.scheme().to_string())
-        .unwrap_or_else(|_| "file".to_string());
-    match scheme.as_str() {
-        "file" => Ok(StorageKind::Fs),
-        "memory" => Ok(StorageKind::Memory),
-        "s3" | "s3a" => Ok(StorageKind::S3),
-        "gs" | "gcs" => Ok(StorageKind::Gcs),
-        other => bail!("unsupported storage scheme '{other}' in location '{location}'"),
-    }
-}
-
-fn storage_factory_for_kind(kind: StorageKind, scheme: &str) -> Arc<dyn StorageFactory> {
-    match kind {
-        StorageKind::Fs => Arc::new(OpenDalStorageFactory::Fs),
-        StorageKind::Memory => Arc::new(OpenDalStorageFactory::Memory),
-        StorageKind::S3 => Arc::new(OpenDalStorageFactory::S3 {
-            configured_scheme: scheme.to_string(),
-            customized_credential_load: None,
-        }),
-        StorageKind::Gcs => Arc::new(OpenDalStorageFactory::Gcs),
-    }
-}
-
-fn storage_factory_for_url(location: &str) -> AnyResult<Arc<dyn StorageFactory>> {
-    let kind = storage_kind_for_url(location)?;
-    let scheme = url::Url::parse(location)
-        .map(|u| u.scheme().to_string())
-        .unwrap_or_else(|_| "file".to_string());
-    Ok(storage_factory_for_kind(kind, &scheme))
+/// Storage backend for object stores, picked per path from its scheme
+/// (`s3`/`s3a`/`gs`/`memory`/...). Used for catalogs and remote tables.
+fn storage_factory() -> Arc<dyn StorageFactory> {
+    Arc::new(OpenDalResolvingStorageFactory::new())
 }
 
 enum SnapshotDescr {
@@ -539,49 +488,32 @@ impl IcebergInputEndpointInner {
         // Safe due to checks in 'validate_catalog_config'.
         let metadata_location = self.config.metadata_location.as_ref().unwrap();
 
-        let factory = storage_factory_for_url(metadata_location).map_err(|e| {
-            ControllerError::invalid_transport_configuration(
-                &self.endpoint_name,
-                &format!("invalid 'metadata_location' value: {e}"),
-            )
-        })?;
-        let file_io = FileIOBuilder::new(factory)
-            .with_props(&self.config.fileio_config)
-            .build();
+        // Object stores (a URL with a non-`file` scheme) need the
+        // scheme-resolving factory and its props (credentials, region).
+        let file_io = match Url::parse(metadata_location) {
+            Ok(url) if url.scheme() != "file" => FileIOBuilder::new(storage_factory())
+                .with_props(&self.config.fileio_config)
+                .build(),
+            // Local table: a `file://` URL or a bare path. The factory can't
+            // read a bare path (it URL-parses every path, and e.g.
+            // `/tmp/t/metadata.json` has no scheme), so use the plain
+            // filesystem reader, which takes the string as a file path.
+            _ => FileIO::new_with_fs(),
+        };
 
-        let metadata_file = file_io.new_input(metadata_location).map_err(|e| {
-            ControllerError::invalid_transport_configuration(
-                &self.endpoint_name,
-                &format!("error opening metadata file at '{metadata_location}': {e}"),
-            )
-        })?;
-        let metadata_content = metadata_file.read().await.map_err(|e| {
-            ControllerError::invalid_transport_configuration(
-                &self.endpoint_name,
-                &format!("error reading metadatafile '{metadata_location}': {e}"),
-            )
-        })?;
-        let metadata = serde_json::from_slice::<TableMetadata>(&metadata_content).map_err(|e| {
-            ControllerError::invalid_transport_configuration(
-                &self.endpoint_name,
-                &format!("error parsing table metadata: {e}"),
-            )
-        })?;
-
+        // `StaticTable` loads the metadata read-only and wires up the current
+        // tokio runtime for us. (Glue/REST get their table from the catalog.)
         let table_ident = TableIdent::from_strs(["default", "table"]).unwrap();
-
-        IcebergTable::builder()
-            .file_io(file_io)
-            .metadata_location(metadata_location)
-            .metadata(metadata)
-            .identifier(table_ident)
-            .build()
+        let table = StaticTable::from_metadata_file(metadata_location, table_ident, file_io)
+            .await
             .map_err(|e| {
                 ControllerError::invalid_transport_configuration(
                     &self.endpoint_name,
-                    &format!("error configuring Iceberg table: {e}"),
+                    &format!("error opening Iceberg table at '{metadata_location}': {e}"),
                 )
-            })
+            })?;
+
+        Ok(table.into_table())
     }
 
     async fn open_table_glue(&self) -> Result<IcebergTable, ControllerError> {
@@ -644,25 +576,8 @@ impl IcebergInputEndpointInner {
             .as_ref()
             .map(|region_name| props.insert(AWS_REGION_NAME.to_string(), region_name.clone()));
 
-        // Override iceberg-catalog-glue 0.9's `s3a` FileIO default: Glue stores
-        // `metadata_location` as `s3://...` and opendal 0.9.1 rejects the
-        // mismatch. Match scheme from the warehouse URL.
-        let factory: Arc<dyn StorageFactory> =
-            match self.config.glue_catalog_config.warehouse.as_deref() {
-                Some(warehouse) => storage_factory_for_url(warehouse).map_err(|e| {
-                    ControllerError::invalid_transport_configuration(
-                        &self.endpoint_name,
-                        &format!("invalid 'warehouse' value: {e}"),
-                    )
-                })?,
-                None => Arc::new(OpenDalStorageFactory::S3 {
-                    configured_scheme: "s3".to_string(),
-                    customized_credential_load: None,
-                }),
-            };
-
         let catalog = GlueCatalogBuilder::default()
-            .with_storage_factory(factory)
+            .with_storage_factory(storage_factory())
             .load("glue".to_string(), props)
             .await
             .map_err(|e| {
@@ -751,25 +666,8 @@ impl IcebergInputEndpointInner {
             }
         };
 
-        // iceberg 0.9.x's REST catalog requires an explicit StorageFactory.
-        // Pick one from the configured warehouse URL when available; fall
-        // back to the same S3 default that iceberg-catalog-glue uses.
-        let factory: Arc<dyn StorageFactory> =
-            match self.config.rest_catalog_config.warehouse.as_deref() {
-                Some(warehouse) => storage_factory_for_url(warehouse).map_err(|e| {
-                    ControllerError::invalid_transport_configuration(
-                        &self.endpoint_name,
-                        &format!("invalid 'warehouse' value: {e}"),
-                    )
-                })?,
-                None => Arc::new(OpenDalStorageFactory::S3 {
-                    configured_scheme: "s3".to_string(),
-                    customized_credential_load: None,
-                }),
-            };
-
         let catalog = RestCatalogBuilder::default()
-            .with_storage_factory(factory)
+            .with_storage_factory(storage_factory())
             .load("rest".to_string(), props)
             .await
             .map_err(|e| {
@@ -1005,118 +903,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn storage_kind_for_url_picks_expected_backend() {
-        for (location, expected) in [
-            ("file:///tmp/warehouse/metadata.json", StorageKind::Fs),
-            ("memory://warehouse/metadata.json", StorageKind::Memory),
-            ("s3://bucket/path/metadata.json", StorageKind::S3),
-            ("s3a://bucket/path/metadata.json", StorageKind::S3),
-            ("gs://bucket/path/metadata.json", StorageKind::Gcs),
-            ("gcs://bucket/path/metadata.json", StorageKind::Gcs),
-        ] {
-            let kind = storage_kind_for_url(location)
-                .unwrap_or_else(|e| panic!("expected ok for {location}, got: {e}"));
-            assert_eq!(kind, expected, "wrong storage kind for {location}");
-        }
-    }
-
-    #[test]
-    fn storage_kind_for_url_falls_back_to_fs_when_url_is_unparseable() {
-        // No scheme — `url::Url::parse` fails, so we land on the local-fs default.
-        assert_eq!(
-            storage_kind_for_url("/tmp/warehouse/metadata.json").unwrap(),
-            StorageKind::Fs
-        );
-    }
-
-    #[test]
-    fn storage_kind_for_url_rejects_unsupported_scheme() {
-        let err = storage_kind_for_url("abfss://container/path").unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unsupported storage scheme") && msg.contains("abfss"),
-            "unexpected error message: {msg}"
-        );
-    }
-
-    #[test]
-    fn storage_factory_for_url_builds_a_factory_for_every_supported_scheme() {
-        // Smoke-test the trait-object path so a refactor that breaks
-        // kind -> factory mapping fails here rather than at runtime.
-        for location in [
-            "file:///tmp/warehouse/metadata.json",
-            "memory://warehouse/metadata.json",
-            "s3://bucket/path/metadata.json",
-            "gs://bucket/path/metadata.json",
-        ] {
-            storage_factory_for_url(location)
-                .unwrap_or_else(|e| panic!("expected factory for {location}, got: {e}"));
-        }
-    }
-
-    /// `s3://` must map to `configured_scheme="s3"`, `s3a://` to `"s3a"`.
-    /// Asserted via `Debug` since `Arc<dyn StorageFactory>` is opaque.
-    #[test]
-    fn storage_factory_for_url_preserves_s3_scheme_distinctly_from_s3a() {
-        let s3_factory = storage_factory_for_url("s3://bucket/path/metadata.json").unwrap();
-        let s3_debug = format!("{s3_factory:?}");
-        assert!(
-            s3_debug.contains("configured_scheme: \"s3\""),
-            "s3:// should map to configured_scheme=\"s3\", got: {s3_debug}"
-        );
-
-        let s3a_factory = storage_factory_for_url("s3a://bucket/path/metadata.json").unwrap();
-        let s3a_debug = format!("{s3a_factory:?}");
-        assert!(
-            s3a_debug.contains("configured_scheme: \"s3a\""),
-            "s3a:// should map to configured_scheme=\"s3a\", got: {s3a_debug}"
-        );
-    }
-
-    /// Reproduces the pre-fix Glue scenario: an `s3a`-configured factory
-    /// rejects `s3://` URLs at read time. A scheme-matched factory must clear
-    /// the same URL validation.
-    #[tokio::test]
-    async fn s3_scheme_mismatch_is_rejected_at_read_time() {
-        // Region required by opendal's s3 builder, else config validation
-        // fails before the scheme check.
-        let props = [("s3.region".to_string(), "us-east-1".to_string())];
-
-        let mismatched: Arc<dyn StorageFactory> = Arc::new(OpenDalStorageFactory::S3 {
-            configured_scheme: "s3a".to_string(),
-            customized_credential_load: None,
-        });
-        let file_io = FileIOBuilder::new(mismatched)
-            .with_props(props.clone())
-            .build();
-        let input = file_io
-            .new_input("s3://bucket/path/metadata.json")
-            .expect("new_input should construct lazily");
-        let err = input
-            .read()
-            .await
-            .expect_err("read with mismatched scheme must fail");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("Invalid s3 url") && msg.contains("s3a://"),
-            "expected scheme-mismatch error, got: {msg}"
-        );
-
-        // Scheme-matched factory must clear URL validation (later failures OK).
-        let matched: Arc<dyn StorageFactory> =
-            storage_factory_for_url("s3://bucket/path/metadata.json").unwrap();
-        let file_io = FileIOBuilder::new(matched)
-            .with_props(props.clone())
-            .build();
-        let input = file_io
-            .new_input("s3://bucket/path/metadata.json")
-            .expect("new_input should construct lazily");
-        if let Err(err) = input.read().await {
-            let msg = err.to_string();
-            assert!(
-                !msg.contains("Invalid s3 url"),
-                "scheme-matched factory must not produce a URL-validation error, got: {msg}"
-            );
-        }
+    fn storage_factory_constructs() {
+        // Smoke test; scheme dispatch is covered upstream in iceberg-rust.
+        let _factory = storage_factory();
     }
 }


### PR DESCRIPTION
jsonwebtoken < 10.3.0 has known CVE, this dependency was pulled in transitively by iceberg 0.9.1. Iceberg is yet to release 0.10.0 so till then we're using fork. Switch back to upstream iceberg-rust when they release 0.10.0

Cascading bumps required to align the dep graph:
- deltalake 0.31.1 -> 0.32.3 (feldera fork v0.32.3-feldera rebased onto rust-v0.32.3 and cherry picked required patches )
- datafusion 52.2 -> 53.1, arrow 57 -> 58, parquet 57 -> 58
- delta_kernel 0.19 -> buoyant_kernel 0.22 via `package =` alias
- serde_arrow 0.13.7 -> 0.14.1 (arrow-58)

Other required changes for it to compile and work properly

### Describe Manual Test Plan

Tested with various delta table read & write modes and configs.

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

updating dependencies should not be breaking change
