### PR TITLE
python: fix long test names

### DIFF
--- a/python/feldera/testutils.py
+++ b/python/feldera/testutils.py
@@ -174,7 +174,14 @@ def unique_pipeline_name(base_name: str) -> str:
     of the commit SHA or 'local' if not in CI.
     """
     ci_tag = os.getenv("GITHUB_SHA", "local")[:5]
-    return f"{ci_tag}_{base_name}"
+    name = f"{ci_tag}_{base_name}"
+    # The pipeline name becomes a Kubernetes label value (max 63 chars). Fail here
+    # with a clear message rather than letting provisioning hit a cryptic 422.
+    assert len(name) <= 62, (
+        f"Generated pipeline name '{name}' is {len(name)} chars, exceeding the 62-char "
+        f"limit; shorten the test name '{base_name}' to at most {62 - len(ci_tag) - 1} chars."
+    )
+    return name
 
 
 def enterprise_only(fn):

--- a/python/tests/platform/test_connector_status.py
+++ b/python/tests/platform/test_connector_status.py
@@ -56,7 +56,7 @@ def _start_with_bootstrap_approval(pipeline: Pipeline) -> None:
 
 @enterprise_only
 @gen_pipeline_name
-def test_http_connector_status_across_restart_and_sql_changes(pipeline_name):
+def test_http_connector_status_across_restart_sql_changes(pipeline_name):
     """
     HTTP status lifecycle test. HTTP connectors are ephemeral and require special care
     to ensure they survive pipeline restarts.

--- a/python/tests/platform/test_pipeline_lifecycle.py
+++ b/python/tests/platform/test_pipeline_lifecycle.py
@@ -692,7 +692,7 @@ def test_refresh_version_due_to_status_changes(pipeline_name):
 
 
 @gen_pipeline_name
-def test_cannot_edit_runtime_config_resources_namespace_if_not_cleared(pipeline_name):
+def test_resources_namespace_edit_needs_cleared_storage(pipeline_name):
     pipeline = PipelineBuilder(TEST_CLIENT, pipeline_name, "").create_or_replace()
     pipeline.start()
     pipeline.stop(force=True)


### PR DESCRIPTION
This seems to be a problem for k8s which fails with

metadata.labels: Invalid value:
"bf920_test_cannot_edit_runtime_config_resources_namespace_if_not_cleared": must be no more than 63 characters

In the future we may need to restrict pipeline names directly rather than just making sure tests don't exceed it.

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
