### PR TITLE
[SQL] Never place two retain_value operators on the same input operator -- insert a noop on one side instead

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/circuit/operator/DBSPNoopOperator.java
@@ -61,10 +61,9 @@ public final class DBSPNoopOperator extends DBSPUnaryOperator implements ILinear
         }
     }
 
-    public DBSPNoopOperator(CalciteRelNode node, OutputPort source,
-                            @Nullable String comment) {
+    public DBSPNoopOperator(CalciteRelNode node, OutputPort source) {
         super(node, "noop", getClosure(source.outputType()),
-                source.outputType(), source.isMultiset(), source, comment);
+                source.outputType(), source.isMultiset(), source);
     }
 
     @Override
@@ -81,7 +80,7 @@ public final class DBSPNoopOperator extends DBSPUnaryOperator implements ILinear
             @Nullable DBSPExpression function, DBSPType outputType,
             List<OutputPort> newInputs, boolean force) {
         if (this.mustReplace(force, function, newInputs, outputType)) {
-            return new DBSPNoopOperator(this.getRelNode(), newInputs.get(0), this.comment)
+            return new DBSPNoopOperator(this.getRelNode(), newInputs.get(0))
                     .copyAnnotations(this);
         }
         return this;
@@ -92,7 +91,7 @@ public final class DBSPNoopOperator extends DBSPUnaryOperator implements ILinear
     @SuppressWarnings("unused")
     public static DBSPNoopOperator fromJson(JsonNode node, JsonDecoder decoder) {
         CommonInfo info = DBSPSimpleOperator.commonInfoFromJson(node, decoder);
-        return new DBSPNoopOperator(CalciteEmptyRel.INSTANCE, info.getInput(0), null)
+        return new DBSPNoopOperator(CalciteEmptyRel.INSTANCE, info.getInput(0))
                 .addAnnotations(info.annotations(), DBSPNoopOperator.class);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -133,6 +133,7 @@ public class RustFileWriter extends RustWriter {
                     // If it's a struct item, it is part of the list above
                     inner.accept(innerVisitor);
             } else {
+                this.materializations.clearRegions();
                 DBSPCircuit outer = node.to(DBSPCircuit.class);
                 ToRustVisitor visitor = new ToRustVisitor(
                         compiler, this.builder(), outer.metadata, declarationsDone, this.materializations);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -1504,7 +1504,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
             if (isLast) {
                 // Since we need to mark the node as final, insert a noop
                 this.addOperator(operator);
-                return new DBSPNoopOperator(node, operator.outputPort(), null);
+                return new DBSPNoopOperator(node, operator.outputPort());
             }
             return operator;
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/InsertLimiters.java
@@ -837,14 +837,19 @@ public class InsertLimiters extends CircuitCloneVisitor {
         this.map(operator, result, true);
     }
 
+    /** Represents a join and the two inputs.  onLeft is true if a retainKeys operator was inserted on the left input */
+    record JoinLimiters(DBSPSimpleOperator join, boolean onLeft, boolean onRight) {}
+
     @Nullable
-    DBSPSimpleOperator gcJoin(DBSPJoinBaseOperator join, CommonJoinDeltaExpansion expansion) {
+    JoinLimiters gcJoin(DBSPJoinBaseOperator join, CommonJoinDeltaExpansion expansion) {
         OutputPort leftLimiter = this.bound.get(join.left());
         OutputPort rightLimiter = this.bound.get(join.right());
         if (leftLimiter == null && rightLimiter == null) {
             return null;
         }
 
+        boolean onLeft = false;
+        boolean onRight = false;
         OutputPort left = this.mapped(join.left());
         OutputPort right = this.mapped(join.right());
         DBSPJoinBaseOperator result = join.withInputs(Linq.list(left, right), false)
@@ -857,6 +862,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
             // Check if the "key" field is monotone
             if (leftProjection.to(PartiallyMonotoneTuple.class).getField(0).mayBeMonotone()) {
                 this.createRetainKeys(join.getRelNode(), right, leftProjection, leftLimiter);
+                onRight = true;
             }
         }
 
@@ -868,9 +874,10 @@ public class InsertLimiters extends CircuitCloneVisitor {
             // Check if the "key" field is monotone
             if (rightProjection.to(PartiallyMonotoneTuple.class).getField(0).mayBeMonotone()) {
                 this.createRetainKeys(join.getRelNode(), left, rightProjection, rightLimiter);
+                onLeft = true;
             }
         }
-        return result;
+        return new JoinLimiters(result, onLeft, onRight);
     }
 
     @Override
@@ -884,7 +891,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         this.addJoinAnnotations(join);
         LeftJoinDeltaExpansion expansion = expanded.to(LeftJoinDeltaExpansion.class);
-        DBSPSimpleOperator result = this.gcJoin(join, expansion);
+        JoinLimiters result = this.gcJoin(join, expansion);
         if (result == null) {
             super.postorder(join);
             this.nonMonotone(join);
@@ -901,7 +908,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         OutputPort limiter = this.processSumOrDiff(expansion.sum);
         if (limiter != null)
             this.markBound(join.outputPort(), limiter);
-        this.map(join, result, true);
+        this.map(join, result.join, true);
     }
 
     @Override
@@ -915,7 +922,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         this.addJoinAnnotations(join);
         JoinDeltaExpansion expansion = expanded.to(JoinDeltaExpansion.class);
-        DBSPSimpleOperator result = this.gcJoin(join, expansion);
+        JoinLimiters result = this.gcJoin(join, expansion);
         if (result == null) {
             super.postorder(join);
             this.nonMonotone(join);
@@ -930,7 +937,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         OutputPort limiter = this.processSumOrDiff(expansion.sum);
         if (limiter != null)
             this.markBound(join.outputPort(), limiter);
-        this.map(join, result, true);
+        this.map(join, result.join, true);
     }
 
     public boolean processStarJoin(DBSPStarJoinBaseOperator join) {
@@ -1028,7 +1035,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
 
         this.addJoinAnnotations(join);
         JoinIndexDeltaExpansion expansion = expanded.to(JoinIndexDeltaExpansion.class);
-        DBSPSimpleOperator result = this.gcJoin(join, expansion);
+        JoinLimiters result = this.gcJoin(join, expansion);
         if (result == null) {
             super.postorder(join);
             this.nonMonotone(join);
@@ -1043,7 +1050,7 @@ public class InsertLimiters extends CircuitCloneVisitor {
         OutputPort limiter = this.processSumOrDiff(expansion.sum);
         if (limiter != null)
             this.markBound(join.outputPort(), limiter);
-        this.map(join, result, true);
+        this.map(join, result.join, true);
     }
 
     private void processIntegral(@Nullable DBSPDelayedIntegralOperator replacement) {
@@ -1206,13 +1213,14 @@ public class InsertLimiters extends CircuitCloneVisitor {
         JoinFilterMapExpansion expansion = expanded.to(JoinFilterMapExpansion.class);
 
         this.addJoinAnnotations(join);
-        DBSPSimpleOperator result = this.gcJoin(join, expansion);
+        final JoinLimiters result = this.gcJoin(join, expansion);
         if (result == null) {
             super.postorder(join);
             this.nonMonotone(join);
             return;
         }
 
+        DBSPSimpleOperator resultJoin = result.join;
         this.processIntegral(expansion.leftIntegrator);
         this.processIntegral(expansion.rightIntegrator);
         this.processJoin(expansion.leftDelta);
@@ -1245,8 +1253,10 @@ public class InsertLimiters extends CircuitCloneVisitor {
         // [2, 0]
         // [2, 1]
         // input# is 0 = key, 1 = left, 2 = right
-        int leftValueSize = join.left().getOutputIndexedZSetType().getElementTypeTuple().size();
-        int rightValueSize = join.right().getOutputIndexedZSetType().getElementTypeTuple().size();
+        DBSPTypeTuple leftValueType = join.left().getOutputIndexedZSetType().getElementTypeTuple();
+        DBSPTypeTuple rightValueType = join.right().getOutputIndexedZSetType().getElementTypeTuple();
+        int leftValueSize = leftValueType.size();
+        int rightValueSize = rightValueType.size();
 
         DBSPTypeTuple keyType = join.getKeyType().to(DBSPTypeTuple.class);
         PartiallyMonotoneTuple keyPart = PartiallyMonotoneTuple.noMonotoneFields(keyType);
@@ -1277,8 +1287,13 @@ public class InsertLimiters extends CircuitCloneVisitor {
                 List<DBSPExpression> monotoneFields = new ArrayList<>();
                 for (int varIndex = 0, field = 0; field < leftValueSize; field++) {
                     int firstOutputField = iomap.firstOutputField(1, field);
-                    if (firstOutputField < 0) continue;  // Field not used in the output
-                    IMaybeMonotoneType compareField = filterTuple.getField(firstOutputField);
+                    final IMaybeMonotoneType compareField;
+                    if (firstOutputField < 0) {
+                        // Field not used in the output
+                        compareField = new NonMonotoneType(leftValueType.getFieldType(field));
+                    } else {
+                        compareField = filterTuple.getField(firstOutputField);
+                    }
                     value.add(compareField);
                     if (compareField.mayBeMonotone()) {
                         monotoneFields.add(var.deref().field(varIndex++));
@@ -1326,8 +1341,13 @@ public class InsertLimiters extends CircuitCloneVisitor {
                 int varIndex = 0;
                 for (int field = 0; field < leftValueSize; field++) {
                     int firstOutputField = iomap.firstOutputField(1, field);
-                    if (firstOutputField < 0) continue; // field not used in the output
-                    IMaybeMonotoneType compareField = filterTuple.getField(firstOutputField);
+                    final IMaybeMonotoneType compareField;
+                    if (firstOutputField < 0) {
+                        // field not used in the output
+                        compareField = new NonMonotoneType(rightValueType.getFieldType(field));
+                    } else {
+                        compareField = filterTuple.getField(firstOutputField);
+                    }
                     if (compareField.mayBeMonotone()) {
                         varIndex++;
                     }
@@ -1349,16 +1369,31 @@ public class InsertLimiters extends CircuitCloneVisitor {
                 final DBSPExpression func = new DBSPTupleExpression(monotoneFields, false);
                 final OutputPort extractRight = this.createApply(rightLimiter, join, func.closure(var));
 
-                if (INSERT_RETAIN_VALUES) {
+                if (INSERT_RETAIN_VALUES && !result.onRight) {
+                    // If the two join inputs are actually the same operator, separate the inputs by inserting a noop
+                    // and insert limiters on the two inputs
+                    // TODO: it may be possible to actually combine the two retain values operators instead
+                    OutputPort left = this.mapped(join.left());
+                    OutputPort right = this.mapped(join.right());
+                    if (left == right) {
+                        var noop = new DBSPNoopOperator(right.operator.getRelNode(), right);
+                        this.addOperator(noop);
+                        right = noop.getOutput(0);
+                    }
+
                     DBSPSimpleOperator r = DBSPIntegrateTraceRetainValuesOperator.create(
-                            join.getRelNode(), this.mapped(join.right()), rightProjection,
+                            join.getRelNode(), right, rightProjection,
                             this.createDelay(extractRight));
                     this.addOperator(r);
+
+                    resultJoin = resultJoin.withInputs(Linq.list(resultJoin.inputs.get(0), right), true)
+                            .copyAnnotations(resultJoin)
+                            .to(DBSPSimpleOperator.class);
                 }
             }
         }
 
-        this.map(join, result, true);
+        this.map(join, resultJoin, true);
     }
 
     /** Given two expressions with the same type, compute the MAX expression pointwise,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MergeGC.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/MergeGC.java
@@ -114,13 +114,15 @@ public class MergeGC extends Passes {
         }
     }
 
+    /** Find multiple {@link DBSPIntegrateTraceRetainKeysOperator} that apply to the same
+     * operator (on their LHS input) and place them in a list. */
     static class FindMultipleRetainKeys extends CircuitWithGraphsVisitor {
-        final List<List<DBSPIntegrateTraceRetainKeysOperator>> toMerge;
+        final List<List<DBSPIntegrateTraceRetainKeysOperator>> shareLeftInput;
         final Set<DBSPIntegrateTraceRetainKeysOperator> visited;
 
         FindMultipleRetainKeys(DBSPCompiler compiler, CircuitGraphs graphs) {
             super(compiler, graphs);
-            this.toMerge = new ArrayList<>();
+            this.shareLeftInput = new ArrayList<>();
             this.visited = new HashSet<>();
         }
 
@@ -141,11 +143,12 @@ public class MergeGC extends Passes {
                 }
             }
             if (common.size() > 1) {
-                this.toMerge.add(common);
+                this.shareLeftInput.add(common);
             }
         }
     }
 
+    /** Merge multiple {@link DBSPIntegrateTraceRetainKeysOperator}s which share their left input */
     static class MergeRetain extends CircuitCloneVisitor {
         /** Keep a counter and a list; offer a method to decrement counter */
         static class ListCounter<T> {
@@ -194,7 +197,7 @@ public class MergeGC extends Passes {
 
         @Override
         public Token startVisit(IDBSPOuterNode circuit) {
-            for (var l: this.fmk.toMerge) {
+            for (var l: this.fmk.shareLeftInput) {
                 ListCounter<DBSPIntegrateTraceRetainKeysOperator> list = new ListCounter<>(l);
                 for (var e: l) {
                     Utilities.putNew(this.toMerge, e, list);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/outer/monotonicity/SeparateIntegrators.java
@@ -106,7 +106,7 @@ public class SeparateIntegrators extends CircuitCloneWithGraphsVisitor {
 
             OutputPort source = this.mapped(input);
             if (addBuffer) {
-                DBSPNoopOperator noop = new DBSPNoopOperator(operator.getRelNode(), source, null);
+                DBSPNoopOperator noop = new DBSPNoopOperator(operator.getRelNode(), source);
                 this.addOperator(noop);
                 sources.add(noop.outputPort());
             } else {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/IncrementalRegression2Tests.java
@@ -1,6 +1,7 @@
 package org.dbsp.sqlCompiler.compiler.sql.simple;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPFlatMapIndexOperator;
+import org.dbsp.sqlCompiler.circuit.operator.DBSPIntegrateTraceRetainValuesOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPMapIndexOperator;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.frontend.calciteObject.CalciteObject;
@@ -724,5 +725,81 @@ public class IncrementalRegression2Tests extends SqlIoTest {
                  id | bid | sum | weight
                 -------------------------
                  0  | 0   | 0 | -1""");
+    }
+
+
+    @Test
+    public void issue6350a() {
+        var ccs = this.getCCS("""
+                CREATE TABLE T (
+                   id UUID,
+                   ts TIMESTAMP NOT NULL LATENESS INTERVAL 3 DAYS,
+                   ea VARCHAR
+                );
+                
+                CREATE VIEW V AS
+                SELECT
+                  me.id,
+                  me.ts,
+                  ARRAY_TO_STRING(ARRAY_AGG(prev.ea), ' '),
+                  COUNT(prev.ea),
+                  MAX(prev.ts)
+                FROM T AS me
+                JOIN T AS prev
+                  ON prev.id = me.id
+                 AND prev.ts BETWEEN me.ts - INTERVAL '3' HOURS AND me.ts
+                GROUP BY me.id, me.ts;""");
+        // There should be two retain_values operators
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            int retains = 0;
+
+            @Override
+            public void postorder(DBSPIntegrateTraceRetainValuesOperator node) {
+                this.retains++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(2, this.retains);
+            }
+        });
+    }
+
+    @Test
+    public void issue6350b() {
+        // swap two fields in the table compared with issue6350a; this used to cause a crash in the compiler
+        var ccs = this.getCCS("""
+                CREATE TABLE T (
+                   id UUID,
+                   ea VARCHAR,
+                   ts TIMESTAMP NOT NULL LATENESS INTERVAL 3 DAYS
+                );
+                
+                CREATE VIEW V AS
+                SELECT
+                  me.id,
+                  me.ts,
+                  ARRAY_TO_STRING(ARRAY_AGG(prev.ea), ' '),
+                  COUNT(prev.ea),
+                  MAX(prev.ts)
+                FROM T AS me
+                JOIN T AS prev
+                  ON prev.id = me.id
+                 AND prev.ts BETWEEN me.ts - INTERVAL '3' HOURS AND me.ts
+                GROUP BY me.id, me.ts;""");
+        // There should be two retain_values operators
+        ccs.visit(new CircuitVisitor(ccs.compiler) {
+            int retains = 0;
+
+            @Override
+            public void postorder(DBSPIntegrateTraceRetainValuesOperator node) {
+                this.retains++;
+            }
+
+            @Override
+            public void endVisit() {
+                Assert.assertEquals(2, this.retains);
+            }
+        });
     }
 }


### PR DESCRIPTION
There may be a better way to resolve this, but for now we took a conservative approach and we create something like this:

<img width="699" height="292" alt="image" src="https://github.com/user-attachments/assets/33877c6d-c642-48cb-9ac0-0d3ed78c7ea9" />


### Describe Manual Test Plan

Ran all Java tests manually.

## Checklist

- [x] Unit tests added/updated
