### PR TITLE
[samply] Fix broken build on MacOS.

### DIFF
--- a/crates/samply/src/lib.rs
+++ b/crates/samply/src/lib.rs
@@ -53,7 +53,7 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crossbeam::sync::{Parker, Unparker};
 use flate2::{


### PR DESCRIPTION
When merging the previous MaxOS PR, the pre-merge job deleted a dependency that was only used on MacOS, breaking MacOS build. This postfix brings it back behind `#cfg[target_os = "macos"]`.

