### PR TITLE
[SQL] Emit a warning if a view is not materialized and has no connectors

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/SqlToRelCompiler.java
@@ -2137,6 +2137,8 @@ public class SqlToRelCompiler implements IWritesLogs {
         @Nullable PropertyList viewProperties = this.createProperties(cv.viewProperties);
         int emitFinal = -1;
         Properties props = null;
+
+        boolean hasConnector = false;
         if (viewProperties != null) {
             viewProperties.checkDuplicates(this.errorReporter);
             SqlFragment materialized = viewProperties.getPropertyValue(CreateViewStatement.MATERIALIZED);
@@ -2178,12 +2180,22 @@ public class SqlToRelCompiler implements IWritesLogs {
             }
 
             for (var prop: viewProperties) {
+                String keyString = prop.getKey().getString();
+                if (keyString.equals("connectors"))
+                    hasConnector = true;
                 this.validateViewProperty(viewName, prop.getKey(), prop.getValue());
             }
+
             props = new Properties(viewProperties);
         }
 
-        // System.out.println(getPlan(relRoot.rel));
+        if (cv.viewKind == SqlCreateView.ViewKind.STANDARD && !hasConnector && !options.ioOptions.testing) {
+            this.errorReporter.reportWarning(new SourcePositionRange(node.statement().getParserPosition()),
+                    "View without connectors", viewName.singleQuote() +
+                    " is a non-materialized view without declared connectors.\n" +
+                            "Retrieving data reliably from such view is difficult; this may be an omission.");
+        }
+
         RewriteJoinAnnotations joinConverter = new RewriteJoinAnnotations(this.errorReporter);
         RelNode converted = joinConverter.visit(relRoot.rel);
         joinConverter.done();

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -691,6 +691,22 @@ public class MetadataTests extends BaseSQLTests {
     }
 
     @Test
+    public void issue6369() {
+        DBSPCompiler compiler = this.chattyCompiler();
+        // The warning is not produced when testing
+        compiler.options.ioOptions.testing = false;
+        compiler.submitStatementsForCompilation("""
+                CREATE TABLE T(x INT, y INT);
+                CREATE VIEW V as SELECT * FROM T;
+                """);
+        DBSPCircuit circuit = compiler.getFinalCircuit(false);
+        Assert.assertNotNull(circuit);
+        TestUtil.assertMessagesContain(compiler.messages, """
+                View without connectors: 'v' is a non-materialized view without declared connectors.
+                Retrieving data reliably from such view is difficult; this may be an omission.""");
+    }
+
+    @Test
     public void nullKey() {
         String ddl = """
                CREATE TABLE T (


### PR DESCRIPTION
Fixes #6369 

If a view has no connectors and is not materialized retrieving data from the view is not a reliable process. 
This commit adds a warning for such cases.

There may be some danger that this will produce spurious warnings if there is a legitimate use case for such views, and in this case we should not merge this. But @wilmaontherun suggested that this would be actually useful.

- [x] Unit tests added/updated
