### PR TITLE
[web-console] Bring back the SQL editor context menu

### DIFF
--- a/js-packages/web-console/vite.config.ts
+++ b/js-packages/web-console/vite.config.ts
@@ -126,6 +126,7 @@ export default defineConfig(async () => {
           'browser',
           'clipboard',
           'comment',
+          'contextmenu',
           'find',
           'folding',
           'format',


### PR DESCRIPTION
Testing: manual

This feature was omitted by accident when migrating the implementation of SQL editor to a separate JS project to be re-usable in the standalone self-contained Profiler HTML app