### PR TITLE
[adapters] Expose pipeline process swap usage as a Prometheus metric

### DIFF
--- a/crates/adapters/src/server/metrics.rs
+++ b/crates/adapters/src/server/metrics.rs
@@ -476,12 +476,54 @@ where
                 threads,
             );
         }
+        if let Some(swap_bytes) = process_swap_bytes() {
+            self.gauge(
+                "process_swap_bytes",
+                "Amount of the process's memory that is swapped out, in bytes.  A nonzero value indicates that the process is swapping, which degrades performance.",
+                labels,
+                swap_bytes,
+            );
+        }
     }
 
     /// Consumes this metrics writer and returns the output.
     pub fn into_output(self) -> String {
         self.formatter.into_output()
     }
+}
+
+/// Returns the number of bytes of this process's memory that is currently
+/// swapped out, if it can be determined.
+///
+/// On Linux, this is read from the `VmSwap` field of `/proc/self/status`.  On
+/// other platforms, or if the field is unavailable, returns `None` so that the
+/// metric is simply omitted rather than reported as a misleading zero.
+#[cfg(target_os = "linux")]
+fn process_swap_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    parse_vm_swap_bytes(&status)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_swap_bytes() -> Option<u64> {
+    None
+}
+
+/// Parses the `VmSwap` field out of the contents of `/proc/self/status`,
+/// returning the swap usage in bytes.
+///
+/// The field looks like `VmSwap:\t    1234 kB`, where the value is in kibibytes.
+/// Returns `None` if the field is missing or cannot be parsed.
+#[cfg(any(target_os = "linux", test))]
+fn parse_vm_swap_bytes(status: &str) -> Option<u64> {
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmSwap:") {
+            // The value is in kB (kibibytes); convert to bytes.
+            let kib: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kib * 1024);
+        }
+    }
+    None
 }
 
 /// Transforms a label into the form used for formatting a Prometheus label.
@@ -818,8 +860,29 @@ impl Histogram for ExponentialHistogramSnapshot {
 mod tests {
     use crate::server::metrics::{
         Bucket, Histogram, JsonFormatter, LabelStack, MetricsFormatter, MetricsWriter,
-        PrometheusFormatter,
+        PrometheusFormatter, parse_vm_swap_bytes,
     };
+
+    #[test]
+    fn parse_vm_swap() {
+        let status = "\
+Name:\tpipeline
+VmPeak:\t  123456 kB
+VmSwap:\t    1024 kB
+Threads:\t8
+";
+        // 1024 kB == 1 MiB == 1048576 bytes.
+        assert_eq!(parse_vm_swap_bytes(status), Some(1024 * 1024));
+
+        // Missing field yields None.
+        assert_eq!(parse_vm_swap_bytes("VmPeak:\t  123456 kB\n"), None);
+
+        // Zero is a valid, distinct value (process not swapping).
+        assert_eq!(parse_vm_swap_bytes("VmSwap:\t       0 kB\n"), Some(0));
+
+        // Malformed value yields None rather than panicking.
+        assert_eq!(parse_vm_swap_bytes("VmSwap:\tnot-a-number kB\n"), None);
+    }
 
     #[test]
     fn prometheus_writer() {

--- a/docs.feldera.com/docs/operations/metrics.md
+++ b/docs.feldera.com/docs/operations/metrics.md
@@ -43,6 +43,7 @@ definitions].
 | <a name='process_panics_total'>`process_panics_total`</a> |counter | Number of times the process has panicked.  Panics do not necessarily indicate a bug or a crash but they can indicate that it is worth examining the log for details. |
 | <a name='process_resident_memory_bytes'>`process_resident_memory_bytes`</a> |gauge | Resident set size in bytes. |
 | <a name='process_start_time_seconds'>`process_start_time_seconds`</a> |counter | Start time of the process in seconds since the Unix epoch. |
+| <a name='process_swap_bytes'>`process_swap_bytes`</a> |gauge | Amount of the process's memory that is swapped out, in bytes.  A nonzero value indicates that the process is swapping, which degrades performance. |
 | <a name='process_threads'>`process_threads`</a> |gauge | Number of OS threads in the process. |
 | <a name='process_virtual_memory_bytes'>`process_virtual_memory_bytes`</a> |gauge | Virtual memory size in bytes. |
 | <a name='process_virtual_memory_max_bytes'>`process_virtual_memory_max_bytes`</a> |gauge | Maximum amount of virtual memory available in bytes. |


### PR DESCRIPTION
### Describe Manual Test Plan

Adds a `process_swap_bytes` gauge to the pipeline process metrics, reporting how many bytes of the process's memory are currently swapped out. A nonzero value tells operators the process is swapping, which degrades performance, as requested in #6382.

On Linux the value is read from the `VmSwap` field of `/proc/self/status` (reported in kB and converted to bytes). On non-Linux platforms (e.g. macOS), or when the field is unavailable, the metric is omitted rather than reported as a misleading zero — consistent with how the other `process_*` gauges in `process_metrics` are only emitted when present.

Verified locally:
- `cargo fmt --all --check` — clean
- `cargo clippy -p dbsp_adapters` — no new warnings
- `cargo build -p dbsp_adapters` — builds
- `cargo test -p dbsp_adapters --lib server::metrics` — 3 passed, incl. the new `parse_vm_swap` unit test (present / missing / zero / malformed `VmSwap`).

The Linux `/proc/self/status` read path itself was not exercised at runtime (developed on macOS), but the `VmSwap` parser is unit-tested cross-platform.

Closes #6382