### PR TITLE
adapters: handle deletion vector in delta input connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,6 +4149,7 @@ dependencies = [
  "rkyv",
  "rmp-serde",
  "rmpv",
+ "roaring",
  "rustls",
  "schema_registry_converter",
  "semver",

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -28,7 +28,15 @@ default = [
     "with-dynamodb",
 ]
 with-kafka = ["rdkafka"]
-with-deltalake = ["deltalake", "deltalake-catalog-unity"]
+# `parquet/async` + `parquet/object_store` serve only the deletion-vector
+# reader (`integrated/delta_table/deletion_vector.rs`).
+with-deltalake = [
+    "deltalake",
+    "deltalake-catalog-unity",
+    "roaring",
+    "parquet/async",
+    "parquet/object_store",
+]
 with-iceberg = ["feldera-iceberg"]
 with-pubsub = ["google-cloud-pubsub", "google-cloud-gax"]
 with-avro = [
@@ -210,6 +218,7 @@ sentry = { workspace = true }
 zip = { workspace = true }
 smallvec = { workspace = true }
 delta_kernel = { workspace = true }
+roaring = { workspace = true, optional = true }
 flate2 = { workspace = true }
 etl = { workspace = true, optional = true }
 etl-config = { workspace = true, optional = true }

--- a/crates/adapters/src/integrated/delta_table.rs
+++ b/crates/adapters/src/integrated/delta_table.rs
@@ -1,3 +1,4 @@
+mod deletion_vector;
 mod input;
 mod output;
 

--- a/crates/adapters/src/integrated/delta_table/deletion_vector.rs
+++ b/crates/adapters/src/integrated/delta_table/deletion_vector.rs
@@ -1,0 +1,519 @@
+//! Deletion-vector (DV) support for the Delta Lake input connector.
+//!
+//! A deletion vector marks deleted rows by their *physical position within an
+//! immutable Parquet file* — not by any key; the file's live rows are the rest.
+//! delta-rs applies DVs during
+//! snapshot reads, but the follow/cdc path reads each `Add`/`Remove` action's
+//! file directly and must apply the action's DV itself. We decode the DV with
+//! `delta_kernel`, which owns the on-disk format, and turn it into a Parquet
+//! [`RowSelection`] that drops the deleted rows during decode. The deletion is
+//! thus fully applied (deleted rows are never emitted), and memory stays bounded
+//! to one batch.
+
+use anyhow::{Result as AnyResult, anyhow};
+use arrow::array::{ArrayRef, new_null_array};
+use arrow::compute::cast;
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use async_stream::try_stream;
+use datafusion::catalog::TableProvider;
+use datafusion::catalog::streaming::StreamingTable;
+use datafusion::common::DataFusionError;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::streaming::PartitionStream;
+use delta_kernel::actions::deletion_vector::{
+    DeletionVectorDescriptor as KernelDvDescriptor, DeletionVectorStorageType,
+};
+use deltalake::kernel::{DeletionVectorDescriptor, StorageType};
+use deltalake::logstore::LogStore;
+use deltalake::{DeltaTable, ObjectStore, Path};
+use futures_util::StreamExt;
+use parquet::arrow::ProjectionMask;
+use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
+use roaring::RoaringTreemap;
+use std::fmt;
+use std::sync::Arc;
+
+/// Convert the delta-rs descriptor into its `delta_kernel` equivalent, which
+/// owns the decoding logic. The fields are identical; only the storage-type
+/// enum differs.
+fn to_kernel_descriptor(dv: &DeletionVectorDescriptor) -> KernelDvDescriptor {
+    KernelDvDescriptor {
+        storage_type: match dv.storage_type {
+            StorageType::UuidRelativePath => DeletionVectorStorageType::PersistedRelative,
+            StorageType::Inline => DeletionVectorStorageType::Inline,
+            StorageType::AbsolutePath => DeletionVectorStorageType::PersistedAbsolute,
+        },
+        path_or_inline_dv: dv.path_or_inline_dv.clone(),
+        offset: dv.offset,
+        size_in_bytes: dv.size_in_bytes,
+        cardinality: dv.cardinality,
+    }
+}
+
+/// Decode a deletion vector into the bitmap of deleted row positions.
+///
+/// `delta_kernel`'s `read` handles all three storage types ("i" inline,
+/// "u" relative sidecar, "p" absolute sidecar). It may block on I/O to fetch
+/// a sidecar file, so it runs on the blocking pool.
+pub(crate) async fn read_deletion_vector(
+    dv: &DeletionVectorDescriptor,
+    table: &DeltaTable,
+) -> AnyResult<RoaringTreemap> {
+    let log_store = table.log_store();
+    let storage = log_store.engine(None).storage_handler();
+
+    // Sidecar paths resolve via `Url::join`, which drops the last path
+    // segment unless the base URL ends with '/'.
+    let mut table_root = log_store.config().location().clone();
+    if !table_root.path().ends_with('/') {
+        table_root.set_path(&format!("{}/", table_root.path()));
+    }
+    let kernel_dv = to_kernel_descriptor(dv);
+    // Displays as the spec string: "u", "i", or "p".
+    let storage_str = dv.storage_type.to_string();
+    // An inline DV stores the whole bitmap here; truncate for error messages.
+    let path_or_inline = abbreviate(&dv.path_or_inline_dv);
+
+    tokio::task::spawn_blocking(move || kernel_dv.read(storage, &table_root))
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "deletion vector decode task failed (storageType='{storage_str}', \
+                 pathOrInlineDv='{path_or_inline}'): {e}"
+            )
+        })?
+        .map_err(|e| {
+            anyhow!(
+                "failed to decode deletion vector (storageType='{storage_str}', \
+                 pathOrInlineDv='{path_or_inline}'): {e}"
+            )
+        })
+}
+
+/// Shorten `value` to at most 64 characters for use in error messages.
+fn abbreviate(value: &str) -> String {
+    const MAX_CHARS: usize = 64;
+    match value.char_indices().nth(MAX_CHARS) {
+        None => value.to_string(),
+        Some((cut, _)) => format!("{}…", &value[..cut]),
+    }
+}
+
+/// Build a [`TableProvider`] over the Parquet file at `path` that skips the
+/// rows flagged by `bitmap`.
+///
+/// The bitmap indexes rows by physical position, so the file is read in
+/// order through a single-partition [`StreamingTable`] (a `ListingTable`
+/// could split and reorder it). The Parquet decoder skips deleted rows via a
+/// [`RowSelection`]; memory stays bounded to one batch.
+///
+/// `logical_schema` is the table's Arrow schema, restricted by the caller to
+/// the columns it wants read. Batches are projected to it by name (missing
+/// columns become NULL), and it doubles as the Parquet projection: columns it
+/// does not name are never decoded. The caller must restrict it itself, because
+/// [`StreamingTable`] does not push projections down.
+pub(crate) async fn masked_parquet_table(
+    store: Arc<dyn ObjectStore>,
+    path: Path,
+    bitmap: RoaringTreemap,
+    logical_schema: SchemaRef,
+) -> AnyResult<Arc<dyn TableProvider>> {
+    let partition = MaskedParquetPartition {
+        store,
+        path,
+        bitmap: Arc::new(bitmap),
+        schema: Arc::clone(&logical_schema),
+    };
+    let provider = StreamingTable::try_new(logical_schema, vec![Arc::new(partition)])
+        .map_err(|e| anyhow!("failed to build DV-masked streaming table: {e}"))?;
+    Ok(Arc::new(provider))
+}
+
+/// Single-partition [`PartitionStream`] that lazily opens a Parquet file and
+/// drops rows flagged by `bitmap` as batches flow through.
+struct MaskedParquetPartition {
+    store: Arc<dyn ObjectStore>,
+    path: Path,
+    /// Deleted row positions for this one file. A `RoaringTreemap` stays
+    /// compact even for dense deletes, and it is dropped once the partition
+    /// finishes streaming, so the footprint is bounded and short-lived.
+    bitmap: Arc<RoaringTreemap>,
+    /// The Delta logical schema; may differ from the file's own schema under
+    /// schema evolution.
+    schema: SchemaRef,
+}
+
+impl fmt::Debug for MaskedParquetPartition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MaskedParquetPartition")
+            .field("path", &self.path)
+            .field("deleted_rows", &self.bitmap.len())
+            .finish()
+    }
+}
+
+/// Project `batch` onto `logical_schema`: match columns by name, cast when the
+/// file and logical Arrow types differ, and null-fill columns the file lacks.
+/// The cast reconciles nested-field metadata/names (e.g. `List<Utf8>` vs
+/// `List<Utf8, field: 'element'>`) and safe widening (e.g. `Int32` to `Int64`);
+/// a genuinely incompatible pair makes `cast` fail and this returns an error.
+/// This mirrors DataFusion's default `SchemaAdapter`, which we cannot use
+/// here: DataFusion 53 deprecates it for an adapter that only works inside
+/// its own scan operators.
+///
+/// Partition columns also come out NULL (Delta stores them in
+/// `partitionValues`, not in the file). This is the same pre-existing
+/// limitation as the connector's `ListingTable` path.
+fn project_to_logical(
+    batch: &RecordBatch,
+    logical_schema: &SchemaRef,
+) -> Result<RecordBatch, DataFusionError> {
+    let num_rows = batch.num_rows();
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(logical_schema.fields().len());
+    for field in logical_schema.fields().iter() {
+        let col = match batch.schema().column_with_name(field.name()) {
+            Some((idx, file_field)) => {
+                if file_field.data_type() == field.data_type() {
+                    Arc::clone(batch.column(idx))
+                } else {
+                    cast(batch.column(idx), field.data_type()).map_err(|e| {
+                        DataFusionError::External(
+                            format!(
+                                "deletion-vector reader: cannot adapt file column '{}' \
+                                 ({:?}) to Delta logical type {:?}: {e}",
+                                field.name(),
+                                file_field.data_type(),
+                                field.data_type(),
+                            )
+                            .into(),
+                        )
+                    })?
+                }
+            }
+            None => new_null_array(field.data_type(), num_rows),
+        };
+        columns.push(col);
+    }
+    RecordBatch::try_new(Arc::clone(logical_schema), columns).map_err(|e| {
+        DataFusionError::External(
+            format!("deletion-vector reader: projected batch rejected by logical schema: {e}")
+                .into(),
+        )
+    })
+}
+
+/// Build the [`ProjectionMask`] selecting the root file columns that
+/// `logical_schema` names; the rest are never decoded.
+fn logical_projection_mask(
+    builder: &ParquetRecordBatchStreamBuilder<ParquetObjectReader>,
+    logical_schema: &SchemaRef,
+) -> ProjectionMask {
+    // Root Arrow fields map one-to-one, in order, to root Parquet columns, so
+    // this index mapping is infallible. A file column the logical schema does
+    // not name is pruned on purpose (not an error worth logging); a logical
+    // column the file lacks is null-filled later in `project_to_logical`.
+    let roots = builder
+        .schema()
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| logical_schema.column_with_name(field.name()).is_some())
+        .map(|(idx, _)| idx);
+    ProjectionMask::roots(builder.parquet_schema(), roots)
+}
+
+/// Build the [`RowSelection`] selecting every row in `0..total_rows` that is
+/// not in `bitmap`. Positions past `total_rows` are ignored.
+fn bitmap_to_row_selection(bitmap: &RoaringTreemap, total_rows: u64) -> RowSelection {
+    // One selector per *run* of selected/skipped rows, so the vector is small
+    // when deletes are clustered and grows to O(deletes) only when they alternate
+    // with live rows. It is built per file, consumed right away to build the
+    // Parquet stream, and dropped, so the footprint is bounded and short-lived.
+    let mut selectors: Vec<RowSelector> = Vec::new();
+    // First row not yet covered by a selector.
+    let mut cursor: u64 = 0;
+    for deleted in bitmap.iter().take_while(|&pos| pos < total_rows) {
+        if deleted > cursor {
+            selectors.push(RowSelector::select((deleted - cursor) as usize));
+        }
+        // Extend the previous skip when deletes are consecutive.
+        match selectors.last_mut() {
+            Some(last) if last.skip => last.row_count += 1,
+            _ => selectors.push(RowSelector::skip(1)),
+        }
+        cursor = deleted + 1;
+    }
+    if cursor < total_rows {
+        selectors.push(RowSelector::select((total_rows - cursor) as usize));
+    }
+    RowSelection::from(selectors)
+}
+
+/// `PartitionStream` is DataFusion's lazy single-partition row source;
+/// `StreamingTable` drives one per partition, calling `execute` to start the
+/// batch stream. Ours opens the Parquet file and masks deleted rows on the fly.
+impl PartitionStream for MaskedParquetPartition {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let store = Arc::clone(&self.store);
+        let path = self.path.clone();
+        let bitmap = Arc::clone(&self.bitmap);
+        let logical_schema = Arc::clone(&self.schema);
+
+        let stream = try_stream! {
+            let reader = ParquetObjectReader::new(store, path.clone());
+            let builder = ParquetRecordBatchStreamBuilder::new(reader)
+                .await
+                .map_err(|e| DataFusionError::External(
+                    format!("failed to open Parquet file '{path}': {e}").into()))?;
+            // `num_rows()` is `i64` because Parquet's metadata is signed
+            // throughout; it is non-negative for any file whose footer parsed
+            // (which it did, just above).
+            let total_rows = builder.metadata().file_metadata().num_rows() as u64;
+            // Decode only the columns the logical schema names.
+            let mask = logical_projection_mask(&builder, &logical_schema);
+            // Skip deleted rows inside the decoder.
+            let selection = bitmap_to_row_selection(&bitmap, total_rows);
+            let mut parquet_stream = builder
+                .with_projection(mask)
+                .with_row_selection(selection)
+                .build()
+                .map_err(|e| DataFusionError::External(
+                    format!("failed to build Parquet stream for '{path}': {e}").into()))?;
+
+            while let Some(batch) = parquet_stream.next().await {
+                let batch = batch.map_err(|e| DataFusionError::External(
+                    format!("error reading Parquet file '{path}': {e}").into()))?;
+                if batch.num_rows() > 0 {
+                    yield project_to_logical(&batch, &logical_schema)?;
+                }
+            }
+        };
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            stream,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, Int32Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+    use datafusion::prelude::SessionContext;
+    use deltalake::{DeltaTableBuilder, ensure_table_uri};
+    use proptest::prelude::*;
+    use tempfile::TempDir;
+
+    /// Expand a [`RowSelection`] into the row positions it selects.
+    fn selected_rows(selection: &RowSelection) -> Vec<u64> {
+        let mut rows = Vec::new();
+        let mut pos: u64 = 0;
+        for selector in selection.iter() {
+            if !selector.skip {
+                rows.extend(pos..pos + selector.row_count as u64);
+            }
+            pos += selector.row_count as u64;
+        }
+        rows
+    }
+
+    /// Rows in `0..total_rows` that are not in `deleted`.
+    fn expected_rows(deleted: &[u64], total_rows: u64) -> Vec<u64> {
+        (0..total_rows)
+            .filter(|row| !deleted.contains(row))
+            .collect()
+    }
+
+    fn check(deleted: &[u64], total_rows: u64) {
+        let bitmap = RoaringTreemap::from_iter(deleted.iter().copied());
+        let selection = bitmap_to_row_selection(&bitmap, total_rows);
+        assert_eq!(
+            selected_rows(&selection),
+            expected_rows(deleted, total_rows)
+        );
+    }
+
+    #[test]
+    fn empty_bitmap_selects_everything() {
+        check(&[], 0);
+        check(&[], 10);
+    }
+
+    #[test]
+    fn leading_and_trailing_deletes() {
+        check(&[0], 5);
+        check(&[4], 5);
+        check(&[0, 4], 5);
+    }
+
+    #[test]
+    fn contiguous_run_merges_into_one_skip() {
+        check(&[2, 3, 4], 10);
+        let bitmap = RoaringTreemap::from_iter([2u64, 3, 4]);
+        let selection = bitmap_to_row_selection(&bitmap, 10);
+        // select(2), skip(3), select(5)
+        assert_eq!(selection.iter().count(), 3);
+    }
+
+    #[test]
+    fn all_rows_deleted_selects_nothing() {
+        check(&[0, 1, 2], 3);
+    }
+
+    #[test]
+    fn positions_past_eof_are_ignored() {
+        check(&[1, 7, 100], 5);
+        check(&[5], 5);
+    }
+
+    proptest! {
+        /// The selection must pick exactly the complement of the bitmap.
+        #[test]
+        fn selection_is_complement_of_bitmap(
+            deleted in proptest::collection::btree_set(0u64..200, 0..50),
+            total_rows in 0u64..200,
+        ) {
+            let deleted: Vec<u64> = deleted.into_iter().collect();
+            check(&deleted, total_rows);
+        }
+    }
+
+    /// Every delta-rs storage type maps to its `delta_kernel` counterpart and
+    /// the remaining descriptor fields are copied verbatim. The decode itself
+    /// is `delta_kernel`'s, but this conversion is ours, so it is tested here:
+    /// the `"i"`/`"p"` arms are otherwise never hit by the Spark fixtures,
+    /// which only produce `"u"`.
+    #[test]
+    fn to_kernel_descriptor_maps_all_storage_types() {
+        use deltalake::kernel::{DeletionVectorDescriptor, StorageType};
+
+        let cases = [
+            (
+                StorageType::UuidRelativePath,
+                DeletionVectorStorageType::PersistedRelative,
+            ),
+            (StorageType::Inline, DeletionVectorStorageType::Inline),
+            (
+                StorageType::AbsolutePath,
+                DeletionVectorStorageType::PersistedAbsolute,
+            ),
+        ];
+
+        for (storage_type, expected) in cases {
+            let dv = DeletionVectorDescriptor {
+                storage_type,
+                path_or_inline_dv: "vBn[lQ{`".to_string(),
+                offset: Some(1),
+                size_in_bytes: 34,
+                cardinality: 2,
+            };
+            let kernel = to_kernel_descriptor(&dv);
+
+            assert_eq!(kernel.storage_type, expected);
+            assert_eq!(kernel.path_or_inline_dv, dv.path_or_inline_dv);
+            assert_eq!(kernel.offset, dv.offset);
+            assert_eq!(kernel.size_in_bytes, dv.size_in_bytes);
+            assert_eq!(kernel.cardinality, dv.cardinality);
+        }
+    }
+
+    // DV *decoding* is `delta_kernel`'s code and is tested upstream for all
+    // three storage types ("u"/"i"/"p"), so there are no decode tests here;
+    // [`read_deletion_vector`] adds only descriptor conversion and URL fixup,
+    // which the Spark-driven Python e2e tests exercise. What follows tests
+    // the masked Parquet reader, which is entirely ours.
+
+    /// A `DeltaTable` rooted at `dir`, built without loading a log: the test
+    /// needs only the table's local object store, so the directory does not
+    /// have to hold a Delta table at all.
+    fn unloaded_table(dir: &std::path::Path) -> DeltaTable {
+        DeltaTableBuilder::from_url(ensure_table_uri(dir.to_str().unwrap()).unwrap())
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    /// End-to-end check of [`masked_parquet_table`] against a real Parquet
+    /// file: DV-flagged rows are skipped inside the decoder, and the logical
+    /// schema drives the read. A file column it omits is pruned, a column it
+    /// widens is cast (`Int32` to `Int64`), and a column the file lacks comes
+    /// back NULL (schema evolution).
+    #[tokio::test]
+    async fn masked_reader_applies_dv_and_logical_schema() {
+        const TOTAL_ROWS: usize = 200;
+        let dir = TempDir::new().unwrap();
+
+        // File schema: `id` (narrower than the logical type) plus a `payload`
+        // column the logical schema omits.
+        let file_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int32, false),
+            ArrowField::new("payload", ArrowDataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..TOTAL_ROWS as i32);
+        let payloads = StringArray::from_iter_values((0..TOTAL_ROWS).map(|i| format!("row_{i}")));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&file_schema),
+            vec![Arc::new(ids), Arc::new(payloads)],
+        )
+        .unwrap();
+        let file = std::fs::File::create(dir.path().join("data.parquet")).unwrap();
+        let mut writer = parquet::arrow::ArrowWriter::try_new(file, file_schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let logical = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int64, true),
+            ArrowField::new("added_later", ArrowDataType::Utf8, true),
+        ]));
+        let deleted = RoaringTreemap::from_iter((0..TOTAL_ROWS as u64).filter(|i| i % 2 == 0));
+
+        let store = unloaded_table(dir.path()).log_store().object_store(None);
+        let provider = masked_parquet_table(
+            store,
+            Path::from("data.parquet"),
+            deleted,
+            Arc::clone(&logical),
+        )
+        .await
+        .unwrap();
+        let batches = SessionContext::new()
+            .read_table(provider)
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let mut got: Vec<i64> = Vec::new();
+        for batch in &batches {
+            assert_eq!(
+                batch.schema().as_ref(),
+                logical.as_ref(),
+                "batch schema must equal the declared logical schema"
+            );
+            let id = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            got.extend(id.iter().map(|v| v.unwrap()));
+            assert_eq!(
+                batch.column(1).null_count(),
+                batch.num_rows(),
+                "the column absent from the file must be all NULL"
+            );
+        }
+        got.sort();
+        let expected: Vec<i64> = (0..TOTAL_ROWS as i64).filter(|i| i % 2 != 0).collect();
+        assert_eq!(got, expected, "masked rows mismatch");
+    }
+}

--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -1,12 +1,15 @@
 use crate::catalog::{ArrowStream, InputCollectionHandle};
 use crate::format::InputBuffer;
+use crate::integrated::delta_table::deletion_vector::{masked_parquet_table, read_deletion_vector};
 use crate::integrated::delta_table::{delta_input_serde_config, register_storage_handlers};
 use crate::transport::{InputEndpoint, InputQueue, InputReaderCommand, IntegratedInputEndpoint};
 use crate::util::JobQueue;
 use crate::{ControllerError, InputConsumer, InputReader, PipelineState};
 use anyhow::{Error as AnyError, Result as AnyResult, anyhow, bail};
 use arrow::array::BooleanArray;
+use arrow::datatypes::Schema as ArrowSchema;
 use chrono::{DateTime, Utc};
+use datafusion::catalog::TableProvider;
 use datafusion::common::DataFusionError;
 use datafusion::common::arrow::array::RecordBatch;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
@@ -23,10 +26,12 @@ use deltalake::datafusion::prelude::SessionContext;
 use deltalake::datafusion::sql::sqlparser::dialect::GenericDialect;
 use deltalake::datafusion::sql::sqlparser::parser::Parser;
 use deltalake::datafusion::sql::sqlparser::tokenizer::Token;
-use deltalake::kernel::Action;
+use deltalake::kernel::{
+    Action, Add as AddAction, DeletionVectorDescriptor, Remove as RemoveAction,
+};
 use deltalake::logstore::{self, IORuntime};
 use deltalake::table::builder::ensure_table_uri;
-use deltalake::{DeltaTable, DeltaTableBuilder, datafusion};
+use deltalake::{DeltaTable, DeltaTableBuilder, Path, datafusion};
 use feldera_adapterlib::format::{ParseError, StagedInputBuffer};
 use feldera_adapterlib::metrics::{ConnectorMetrics, ValueType};
 use feldera_adapterlib::transport::{InputQueueEntry, Resume, Watermark, parse_resume_info};
@@ -46,7 +51,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::cmp::min;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Display;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -129,6 +134,11 @@ fn format_datafusion_error(prefix: &str, e: &DataFusionError) -> String {
     }
 }
 
+/// A deletion vector is only in effect when it flags at least one row.
+fn is_active_dv(dv: &DeletionVectorDescriptor) -> bool {
+    dv.cardinality > 0
+}
+
 /// Build the `DataFrame` that streams a CDC transaction to the circuit.
 ///
 /// Equivalent (in SQL) to:
@@ -157,10 +167,11 @@ fn format_datafusion_error(prefix: &str, e: &DataFusionError) -> String {
 /// `EXCEPT ALL`, which sorts both relations.
 ///
 /// The filter is parsed against each `DataFrame`'s own schema, so
-/// column references resolve to the correct table qualifier
-/// (`cdc_adds.col` vs `cdc_removes.col`). The two sides cannot share
-/// a single parsed `Expr` because column references would otherwise
-/// point at the wrong relation after `except`.
+/// column references resolve against the correct relation. The two
+/// sides cannot share a single parsed `Expr` because column
+/// references would otherwise point at the wrong relation after
+/// `except`. (`cdc_adds` and `cdc_removes` are labels for the two
+/// sides, not registered tables.)
 ///
 /// Caveat: `EXCEPT ALL` relies on `arrow_row::RowConverter`, which in
 /// the currently pinned `arrow-row` does not support `Map` columns.
@@ -1266,6 +1277,23 @@ impl DeltaTableInputEndpointInner {
                 .contains(&field.name.name())
     }
 
+    /// True if CDC keeps the column named `name`. When `skip_unused_columns`
+    /// is off, keep everything. When on, keep a column only if the circuit
+    /// reads it (`used_sql_columns`) or a connector expression names it
+    /// (`config_referenced_columns`, which also covers Delta metadata columns
+    /// like `__feldera_op` that the SQL schema omits).
+    ///
+    /// The plain and DV-masked CDC sides must apply this same rule, or their
+    /// columns differ and the `UNION ALL` no longer lines up by position. The
+    /// off case needs the explicit `!skip_unused_columns()`: `used_sql_columns`
+    /// holds only SQL columns, but the unprojected frame also carries Delta
+    /// physical columns the SQL table never maps.
+    fn keeps_cdc_column(&self, name: &str) -> bool {
+        !self.skip_unused_columns()
+            || self.used_sql_columns().contains(name)
+            || self.config_referenced_columns().contains(name)
+    }
+
     /// Project `df` to the columns the connector needs when `skip_unused_columns`
     /// is set, mirroring the snapshot path's `SELECT <used_columns>`: keep a
     /// column iff the circuit reads it (`used_sql_columns`) or a connector
@@ -1275,13 +1303,14 @@ impl DeltaTableInputEndpointInner {
     /// expressions can resolve. A Delta table may carry far more physical columns
     /// than the SQL table maps; this keeps the connector from reading the rest
     /// off disk.
+    ///
+    /// The plain `ListingTable` side and the DV-masked side of a CDC transaction
+    /// both project through [`keeps_cdc_column`](Self::keeps_cdc_column), so the
+    /// two relations expose the same columns and their `UNION ALL` lines up.
     fn project_cdc_columns(&self, df: DataFrame) -> AnyResult<DataFrame> {
         if !self.skip_unused_columns() {
             return Ok(df);
         }
-
-        let used = self.used_sql_columns();
-        let referenced = self.config_referenced_columns();
 
         // Filter `df`'s own field list (not the SQL schema) so the projection
         // tracks the read schema if column mapping ever varies it across
@@ -1294,7 +1323,7 @@ impl DeltaTableInputEndpointInner {
             .schema()
             .fields()
             .iter()
-            .filter(|f| used.contains(f.name()) || referenced.contains(f.name()))
+            .filter(|f| self.keeps_cdc_column(f.name()))
             .map(|f| f.name().to_string())
             .collect();
         let kept: Vec<&str> = kept.iter().map(String::as_str).collect();
@@ -2181,7 +2210,7 @@ impl DeltaTableInputEndpointInner {
 
         // The compiled `PhysicalExpr` binds columns by index, so it must see the
         // same schema as the batches it will evaluate. When `skip_unused_columns`
-        // is set, `do_process_cdc_transaction` projects those batches to the CDC
+        // is set, `process_cdc_transaction` projects those batches to the CDC
         // read set via `project_cdc_columns`, so project here through the same
         // helper. Both derive the read set from the same Delta snapshot (this
         // `snapshot` table is registered from it), so the column order matches.
@@ -2759,61 +2788,31 @@ impl DeltaTableInputEndpointInner {
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
     ) -> AnyResult<()> {
-        let result = self
-            .do_process_cdc_transaction(
-                actions,
-                table,
-                cdc_delete_filter,
-                input_stream,
-                receiver,
-                start_transaction,
-            )
-            .await;
-
-        // Deregister the tables registered by `do_process_cdc_transaction`.
-        // If a table does not exist, there's no harm.
-        let _ = self.datafusion.deregister_table("cdc_adds");
-        let _ = self.datafusion.deregister_table("cdc_removes");
-
-        result
-    }
-
-    async fn do_process_cdc_transaction(
-        &self,
-        actions: &[Action],
-        table: &DeltaTable,
-        cdc_delete_filter: Option<Arc<dyn PhysicalExpr>>,
-        input_stream: &mut dyn ArrowStream,
-        receiver: &mut Receiver<PipelineState>,
-        start_transaction: Option<Option<String>>,
-    ) -> AnyResult<()> {
-        // Collect Add and Remove file paths separately. The query below
-        // subtracts Removes from Adds via `EXCEPT ALL` to cancel rewrites
-        // that don't change logical data.
+        // CDC reads the table as an append-only log: added rows are events,
+        // deletions are ignored.
         //
-        // We address files via the table's `root_url()` (e.g. `file:///...` or
-        // `s3://bucket/prefix/`) rather than the synthetic `delta-rs://...`
-        // URL returned by `object_store_url()`. The synthetic URL encodes the
-        // entire table filesystem path into the URL host (slashes become
-        // dashes), which works for DataFusion's `register_object_store`
-        // routing keyed by scheme+host but produces a malformed listing URL
-        // when concatenated with `Add.path`. Using `root_url()` keeps the
-        // listing path real, and `register_object_store(root_url, root_store)`
-        // (done in `start_input_endpoint`) provides the matching store.
-        let log_store = table.log_store();
-        let url = log_store.root_url();
-        let path_of = |p: &str| format!("{}{}", url.as_str(), p);
-        let adds: Vec<String> = actions
+        // Delta files are immutable and addressed by path, so an Add and a Remove
+        // on the same path are the same bytes with a different deletion vector:
+        // a delete (with DVs, `DELETE` rewrites only the DV, not the file) or a
+        // restore — never new rows. Since CDC ignores deletes, we skip both
+        // without reading the file. We match on path alone; the DVs don't matter
+        // because we never act on the delete they describe.
+        //
+        // Unmatched actions feed the `EXCEPT ALL` in `build_cdc_dataframe`, each
+        // side masked by its DV so soft-deleted rows are neither emitted nor
+        // used to cancel live rows.
+        let adds: Vec<&AddAction> = actions
             .iter()
             .filter_map(|a| match a {
-                Action::Add(x) if x.data_change => Some(path_of(&x.path)),
+                Action::Add(x) if x.data_change => Some(x),
                 _ => None,
             })
             .collect();
-        let removes: Vec<String> = actions
+        // `BTreeMap` keeps log and processing order deterministic.
+        let mut removes_by_path: BTreeMap<&str, &RemoveAction> = actions
             .iter()
             .filter_map(|a| match a {
-                Action::Remove(x) if x.data_change => Some(path_of(&x.path)),
+                Action::Remove(x) if x.data_change => Some((x.path.as_str(), x)),
                 _ => None,
             })
             .collect();
@@ -2827,50 +2826,42 @@ impl DeltaTableInputEndpointInner {
         let description = format!(
             "CDC transaction with {} adds {:?} and {} removes {:?}",
             adds.len(),
-            &adds,
-            removes.len(),
-            &removes,
+            adds.iter().map(|a| &a.path).collect::<Vec<_>>(),
+            removes_by_path.len(),
+            removes_by_path.keys().collect::<Vec<_>>(),
         );
 
-        // `self.datafusion` is a per-endpoint `SessionContext` and
-        // `process_cdc_transaction` is invoked serially from the single
-        // dedicated `worker_task` loop, so the fixed table names
-        // `cdc_adds`/`cdc_removes` cannot collide across calls.
-        let adds_table = Arc::new(self.create_parquet_table(table, adds, &description).await?);
-        self.datafusion.register_table("cdc_adds", adds_table).map_err(|e| {
-            anyhow!("internal error processing {description}; {REPORT_ERROR}; error registering 'cdc_adds' table: {e}")
-        })?;
+        // Drop add/remove pairs on the same path (metadata-only rewrites).
+        // This loop must run before the removes side is built below: it
+        // drains `removes_by_path` of every matched path, leaving only the
+        // unpaired removes there.
+        let mut add_files: Vec<(&str, Option<&DeletionVectorDescriptor>)> = Vec::new();
+        for add in &adds {
+            if removes_by_path.remove(add.path.as_str()).is_some() {
+                continue;
+            }
+            add_files.push((add.path.as_str(), add.deletion_vector.as_ref()));
+        }
 
-        let adds_df = self.datafusion.table("cdc_adds").await.map_err(|e| {
-            anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading 'cdc_adds' table: {e}")
-        })?;
-
-        // Drop unused columns when `skip_unused_columns` is set, so DataFusion
-        // never reads them off disk. Both sides get the same column list so the
-        // `EXCEPT ALL` in `build_cdc_dataframe` still lines up, and metadata
-        // columns used by `cdc_order_by`/`cdc_delete_filter`/`filter` are kept.
-        let adds_df = self
-            .project_cdc_columns(adds_df)
-            .map_err(|e| anyhow!("internal error processing {description}; {REPORT_ERROR}; {e}"))?;
-
-        let removes_df = if removes.is_empty() {
-            None
-        } else {
-            let removes_table = Arc::new(
-                self.create_parquet_table(table, removes, &description)
-                    .await?,
-            );
-            self.datafusion.register_table("cdc_removes", removes_table).map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error registering 'cdc_removes' table: {e}")
-            })?;
-            let removes_df = self.datafusion.table("cdc_removes").await.map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading 'cdc_removes' table: {e}")
-            })?;
-            let removes_df = self.project_cdc_columns(removes_df).map_err(|e| {
-                anyhow!("internal error processing {description}; {REPORT_ERROR}; {e}")
-            })?;
-            Some(removes_df)
+        let Some(adds_df) = self
+            .cdc_side_dataframe(table, &add_files, &description)
+            .await?
+        else {
+            // Every add paired with a remove (a pure soft-delete commit):
+            // no new rows, nothing to emit.
+            return Ok(());
         };
+
+        // The removes left unpaired by the loop above feed the `EXCEPT ALL`;
+        // `cdc_side_dataframe` masks any with an active DV so only live rows
+        // subtract.
+        let remove_files: Vec<(&str, Option<&DeletionVectorDescriptor>)> = removes_by_path
+            .iter()
+            .map(|(path, remove)| (*path, remove.deletion_vector.as_ref()))
+            .collect();
+        let removes_df = self
+            .cdc_side_dataframe(table, &remove_files, &description)
+            .await?;
 
         // The `cdc_order_by` expression is mandatory in CDC mode (enforced
         // by `validate_cdc_config`), so the unwrap is safe.
@@ -2933,6 +2924,155 @@ impl DeltaTableInputEndpointInner {
         })
     }
 
+    /// Build a [`TableProvider`] over the data file at `path` (relative and
+    /// URL-encoded, as the Delta log stores it) with the rows flagged by
+    /// deletion vector `dv` masked out.
+    ///
+    /// `keep_column` picks the columns to read: the provider declares the
+    /// snapshot schema restricted to them, which doubles as the Parquet
+    /// projection (see [`masked_parquet_table`]). It must match the columns the
+    /// unmasked side keeps, so the two providers mix in one query. It is a
+    /// predicate rather than a fixed list because the callers differ: follow
+    /// keeps its `used_columns`, CDC keeps `keeps_cdc_column`.
+    async fn masked_file_provider(
+        &self,
+        table: &DeltaTable,
+        path: &str,
+        dv: &DeletionVectorDescriptor,
+        keep_column: impl Fn(&str) -> bool,
+        description: &str,
+    ) -> AnyResult<Arc<dyn TableProvider>> {
+        // Decode the DV into its bitmap of deleted row positions, retrying on
+        // transient object-store failures (the decode is idempotent).
+        let bitmap = self
+            .retry(
+                &format!(
+                    "decoding deletion vector for {description} at table version {:?}",
+                    table.version(),
+                ),
+                None,
+                || read_deletion_vector(dv, table),
+            )
+            .await?;
+
+        let snapshot_schema = table
+            .snapshot()
+            .map_err(|e| anyhow!("error accessing Delta table snapshot for {description}: {e}"))?
+            .snapshot()
+            .arrow_schema();
+
+        // Restrict the schema to the kept columns, preserving field order so
+        // unions with the unmasked side line up.
+        let fields: Vec<_> = snapshot_schema
+            .fields()
+            .iter()
+            .filter(|f| keep_column(f.name()))
+            .cloned()
+            .collect();
+        let logical_schema = if fields.len() == snapshot_schema.fields().len() {
+            snapshot_schema
+        } else {
+            Arc::new(ArrowSchema::new(fields))
+        };
+
+        // `Add.path` is URL-encoded per the Delta spec; decode it into a
+        // real object-store key.
+        let file_path = Path::from_url_path(path)
+            .map_err(|e| anyhow!("invalid file path '{path}' in Delta log action: {e}"))?;
+
+        masked_parquet_table(
+            table.log_store().object_store(None),
+            file_path,
+            bitmap,
+            logical_schema,
+        )
+        .await
+    }
+
+    /// Build the [`DataFrame`] for one side (adds or removes) of a CDC
+    /// transaction, or `None` when the side has no files.
+    ///
+    /// Each file is `(path, deletion_vector)`. Files with an active DV stream
+    /// through a [`masked_parquet_table`] that drops their deleted rows; the
+    /// rest are read together through one [`ListingTable`]. The pieces combine
+    /// with `UNION ALL`, each restricted to the same CDC read set (the columns
+    /// [`Self::project_cdc_columns`] keeps), so they line up by position for the
+    /// `EXCEPT ALL` in `build_cdc_dataframe` and never decode unused columns.
+    ///
+    /// Plain files use the table's `root_url()`, not the synthetic
+    /// `delta-rs://` URL from `object_store_url()`. The latter folds the table
+    /// path into the URL host (slashes become dashes), which routes DataFusion's
+    /// object store but is malformed once joined with `Add.path`.
+    /// `start_input_endpoint` registers the store under `root_url()`.
+    async fn cdc_side_dataframe(
+        &self,
+        table: &DeltaTable,
+        files: &[(&str, Option<&DeletionVectorDescriptor>)],
+        description: &str,
+    ) -> AnyResult<Option<DataFrame>> {
+        // Split by read strategy: files with an active DV are masked one by
+        // one; the rest are read together in one listing.
+        let mut plain: Vec<&str> = Vec::new();
+        let mut masked: Vec<(&str, &DeletionVectorDescriptor)> = Vec::new();
+        for &(path, dv) in files {
+            match dv.filter(|d| is_active_dv(d)) {
+                Some(dv) => masked.push((path, dv)),
+                None => plain.push(path),
+            }
+        }
+
+        let mut dfs: Vec<DataFrame> = Vec::new();
+
+        if !plain.is_empty() {
+            let log_store = table.log_store();
+            let root_url = log_store.root_url();
+            let files = plain
+                .iter()
+                .map(|p| format!("{}{}", root_url.as_str(), p))
+                .collect();
+            let listing_table =
+                Arc::new(self.create_parquet_table(table, files, description).await?);
+            let df = self.datafusion.read_table(listing_table).map_err(|e| {
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet files: {e}")
+            })?;
+            // Drop unused columns when `skip_unused_columns` is set, so
+            // DataFusion never reads them off disk.
+            dfs.push(self.project_cdc_columns(df).map_err(|e| {
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; {e}")
+            })?);
+        }
+
+        for (path, dv) in masked {
+            // Keep the same CDC read set as `project_cdc_columns` applies on the
+            // plain side (via `keeps_cdc_column`), so the two providers union
+            // cleanly.
+            let provider = self
+                .masked_file_provider(
+                    table,
+                    path,
+                    dv,
+                    |name| self.keeps_cdc_column(name),
+                    description,
+                )
+                .await?;
+            dfs.push(self.datafusion.read_table(provider).map_err(|e| {
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading masked file '{path}': {e}")
+            })?);
+        }
+
+        let mut dfs = dfs.into_iter();
+        let Some(first) = dfs.next() else {
+            return Ok(None);
+        };
+        // Every piece is already projected to the kept CDC columns.
+        let df = dfs.try_fold(first, |acc, df| {
+            acc.union(df).map_err(|e| {
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error combining files: {e}")
+            })
+        })?;
+        Ok(Some(df))
+    }
+
     async fn process_action(
         &self,
         action: &Action,
@@ -2942,11 +3082,12 @@ impl DeltaTableInputEndpointInner {
         receiver: &mut Receiver<PipelineState>,
         start_transaction: Option<Option<String>>,
     ) -> AnyResult<()> {
-        let result = match action {
+        match action {
             Action::Add(add) if add.data_change => {
                 self.add_with_polarity(
                     &add.path,
                     true,
+                    add.deletion_vector.as_ref(),
                     table,
                     used_columns,
                     input_stream,
@@ -2961,6 +3102,7 @@ impl DeltaTableInputEndpointInner {
                 self.add_with_polarity(
                     &remove.path,
                     false,
+                    remove.deletion_vector.as_ref(),
                     table,
                     used_columns,
                     input_stream,
@@ -2969,17 +3111,11 @@ impl DeltaTableInputEndpointInner {
                 )
                 .await
             }
-            _ => return Ok(()),
-        };
-
-        // Deregister the table registered by `add_with_polarity`.
-        // If the table does not exist, there's no harm.
-        let _ = self.datafusion.deregister_table("tmp_table");
-
-        result
+            _ => Ok(()),
+        }
     }
 
-    // NOTE: Column projection (follow mode here, CDC mode in `do_process_cdc_transaction`) projects
+    // NOTE: Column projection (follow mode here, CDC mode in `process_cdc_transaction`) projects
     // against the startup snapshot schema, which `create_parquet_table` forces onto every Parquet
     // file we read. This assumes a stable schema across the log versions we follow. DataFusion's
     // schema adapter handles additive evolution (new columns ignored, missing columns read as NULL);
@@ -2990,6 +3126,7 @@ impl DeltaTableInputEndpointInner {
         &self,
         path: &str,
         polarity: bool,
+        deletion_vector: Option<&DeletionVectorDescriptor>,
         table: &DeltaTable,
         used_columns: &[&str],
         input_stream: &mut dyn ArrowStream,
@@ -2998,31 +3135,40 @@ impl DeltaTableInputEndpointInner {
     ) -> AnyResult<()> {
         let description = format!("file '{path}'");
 
-        // Address files via the table's real `root_url()` (e.g. `file:///...`
-        // or `s3://bucket/prefix/`). See `do_process_cdc_transaction` for the
-        // full reasoning on why we don't use `object_store_url()` here.
-        let full_path = format!("{}{}", table.log_store().root_url().as_str(), path);
-
-        // Create a datafusion table backed by these files.
-        let parquet_table = Arc::new(
-            self.create_parquet_table(table, vec![full_path.clone()], &description)
-                .await?,
-        );
-
-        self.datafusion.register_table("tmp_table", parquet_table).map_err(|e| {
-            anyhow!("internal error processing file {full_path}; {REPORT_ERROR}; error registering Parquet table: {e}")
-        })?;
+        // An active deletion vector routes the file through a masked
+        // streaming provider, restricted to `used_columns` so unread columns
+        // are never decoded; otherwise the regular `ListingTable` path
+        // applies.
+        let provider: Arc<dyn TableProvider> =
+            if let Some(dv) = deletion_vector.filter(|d| is_active_dv(d)) {
+                self.masked_file_provider(
+                    table,
+                    path,
+                    dv,
+                    |name| used_columns.contains(&name),
+                    &description,
+                )
+                .await?
+            } else {
+                // Address files via the table's real `root_url()` (e.g. `file:///...`
+                // or `s3://bucket/prefix/`). See `cdc_side_dataframe` for why we
+                // don't use `object_store_url()` here.
+                let full_path = format!("{}{}", table.log_store().root_url().as_str(), path);
+                Arc::new(
+                    self.create_parquet_table(table, vec![full_path], &description)
+                        .await?,
+                )
+            };
 
         let df = self
             .datafusion
-            .table("tmp_table")
-            .await
+            .read_table(provider)
             .map_err(|e| {
-                anyhow!("internal error processing file {full_path}; {REPORT_ERROR}; error reading 'tmp_table': {e}")
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error reading Parquet file: {e}")
             })?
             .select_columns(used_columns)
             .map_err(|e| {
-                anyhow!("internal error processing file {full_path}; {REPORT_ERROR}; error selecting columns: {e}")
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error selecting columns: {e}")
             })?;
 
         let df = if let Some(filter) = &self.config.filter {
@@ -3030,7 +3176,7 @@ impl DeltaTableInputEndpointInner {
                 .parse_sql_expr(filter)
                 .map_err(|e| anyhow!("invalid 'filter' expression '{filter}': {e}"))?;
             df.filter(expr).map_err(|e| {
-                anyhow!("internal error processing file {full_path}; {REPORT_ERROR}; error applying 'filter': {e}")
+                anyhow!("internal error processing {description}; {REPORT_ERROR}; error applying 'filter': {e}")
             })?
         } else {
             df

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -3219,7 +3219,7 @@ async fn parse_cdc_order_by_defaults() {
 }
 
 /// Pin the exact set of arrow types that the `EXCEPT ALL` cancellation
-/// step in `do_process_cdc_transaction` cannot handle.
+/// step in `build_cdc_dataframe` cannot handle.
 ///
 /// `EXCEPT ALL` is planned via `RowConverter`, so any column type for
 /// which `RowConverter::supports_fields` returns `false` will make the
@@ -3322,7 +3322,7 @@ fn except_all_unsupported_types_are_only_map() {
     assert!(
         !supports(map_type),
         "Map is expected to be unsupported by RowConverter; if this \
-         changes, update the caveat in `do_process_cdc_transaction`",
+         changes, update the caveat in `build_cdc_dataframe`",
     );
 }
 

--- a/docs.feldera.com/docs/operations/guide.md
+++ b/docs.feldera.com/docs/operations/guide.md
@@ -81,7 +81,7 @@ The support bundle has the following content:
 
 **Error**: `Table metadata is invalid: Number of checkpoint files '0' is not equal to number of checkpoint metadata parts 'None'`
 
-**Solution**: This usually happens when the Delta Table uses features unsupported by `delta-rs` like liquid clustering or deletion vectors. Check the table properties and set the checkpoint policy to "classic":
+**Solution**: This usually happens when the Delta Table uses features unsupported by `delta-rs`, such as liquid clustering. Check the table properties and set the checkpoint policy to "classic":
 
 ```sql
 ALTER TABLE my_table SET TBLPROPERTIES (

--- a/python/tests/platform/fixtures/deletion_vectors.py
+++ b/python/tests/platform/fixtures/deletion_vectors.py
@@ -1,24 +1,124 @@
-"""Seed a Delta table with deletion vectors for the snapshot DV test.
+"""Seed Delta tables with deletion vectors for the DV input tests.
 
 Run this under ``delta-spark``, not bare ``pyspark``. The Delta write path and
 deletion-vector support live in the Delta Lake Spark *JARs* that Spark loads at
-runtime; ``delta-spark`` is the standard way to obtain them — it depends on a
+runtime; ``delta-spark`` is the standard way to obtain them. It depends on a
 compatible ``pyspark`` and ships ``configure_spark_with_delta_pip``, which
 auto-resolves the matching Delta JAR. Bare ``pyspark`` could write Delta too,
 but only by hardcoding the Delta Maven coordinate and Scala suffix and keeping
-them in lockstep with the pyspark version — fragile, and no cheaper (the JARs
-download at runtime either way). ``tests.utils.ensure_delta_spark_fixture``
+them in lockstep with the pyspark version, which is fragile and no cheaper (the
+JARs download at runtime either way). ``tests.utils.ensure_delta_spark_fixture``
 invokes this file with::
 
     uv run --with "delta-spark>=4.2,<5" python deletion_vectors.py \\
-        <dest> <total_rows> <expected_active>
+        <dest> <total_rows> <expected_active> [--cdc]
 
-It writes ``total_rows`` rows to ``dest`` with DVs enabled, runs a ``DELETE``
-on the even ``id`` rows that produces deletion vectors, then asserts that
-exactly ``expected_active`` rows remain readable.
+Without ``--cdc``, it writes a two-version table:
+
+* v0: ``total_rows`` rows (``id``, ``name``, ``value``) with DVs enabled.
+* v1: ``DELETE`` of the even ``id`` rows, which produces deletion vectors.
+
+With ``--cdc``, it writes a four-version table shaped like a CDC event log
+(``id``, ``__feldera_op``, ``__feldera_ts``, ``lsn``):
+
+* v0: ``total_rows`` insert events (``__feldera_op = 'i'``).
+* v1: ``DELETE`` of the even ``id`` events, producing deletion vectors.
+* v2: execute a ``RESTORE`` command to v0, shrinking the deletion vectors away again.
+* v3: one more insert event with ``id = total_rows + 1``.
+
+With ``--overwrite``, it writes a three-version CDC-shaped table that exercises
+the connector's ``removes_masked`` path:
+
+* v0: ``total_rows`` insert events.
+* v1: ``DELETE`` of the even ``id`` events, producing deletion vectors.
+* v2: ``INSERT OVERWRITE`` re-inserting exactly those even events. The overwrite
+  removes the DV-bearing file (a `remove` carrying the deletion vector, on a new
+  path) and adds the even events back.
+
+In every case the builder asserts that exactly ``expected_active`` rows remain
+readable, then exits.
 """
 
 import sys
+
+
+def _write_plain_fixture(spark, dest: str, total_rows: int) -> None:
+    """v0: `total_rows` rows; v1: DV `DELETE` of the even ids."""
+    (
+        spark.range(1, total_rows + 1)
+        .selectExpr(
+            "cast(id as int) as id",
+            "concat('user_', id) as name",
+            "cast(id * 1.5 as double) as value",
+        )
+        .write.format("delta")
+        .option("delta.enableDeletionVectors", "true")
+        .save(dest)
+    )
+    spark.sql("DELETE FROM delta.`" + dest + "` WHERE id % 2 = 0")
+
+
+def _cdc_events(spark, start_id: int, end_id: int):
+    """Build a DataFrame of CDC insert events with ids in [start_id, end_id]."""
+    return spark.range(start_id, end_id + 1).selectExpr(
+        "id",
+        "'i' as __feldera_op",
+        # Monotone event time derived from the id; `lsn` breaks ts ties.
+        "timestamp_micros(id * 1000000) as __feldera_ts",
+        "id as lsn",
+    )
+
+
+def _write_cdc_fixture(spark, dest: str, total_rows: int) -> None:
+    """v0: events; v1: DV `DELETE`; v2: `RESTORE` (DV shrink); v3: one event."""
+    (
+        _cdc_events(spark, 1, total_rows)
+        .write.format("delta")
+        .option("delta.enableDeletionVectors", "true")
+        .save(dest)
+    )
+    spark.sql("DELETE FROM delta.`" + dest + "` WHERE id % 2 = 0")
+    # Un-delete the soft-deleted events: the restore commit rewrites each
+    # file's deletion vector back to empty, a same-path `remove`/`add` pair
+    # the connector must skip, just like the delete in v1.
+    spark.sql("RESTORE TABLE delta.`" + dest + "` TO VERSION AS OF 0")
+    (
+        _cdc_events(spark, total_rows + 1, total_rows + 1)
+        .write.format("delta")
+        .mode("append")
+        .save(dest)
+    )
+
+
+def _write_cdc_overwrite_fixture(spark, dest: str, total_rows: int) -> None:
+    """v0: events; v1: DV `DELETE` of evens; v2: `INSERT OVERWRITE` re-inserting
+    exactly the deleted even events.
+
+    The overwrite removes the DV-bearing v1 file and adds a new file, so in CDC
+    mode the `remove` is *unmatched* (a different path) yet carries the delete's
+    deletion vector. This is the commit shape that drives the connector's
+    `removes_masked` path. The new file's rows equal the file's DV-*dead* rows,
+    so a correctly DV-masked `remove` cancels nothing (the even events are
+    emitted), whereas an unmasked `remove` would read the whole file and wrongly
+    cancel them.
+    """
+    (
+        _cdc_events(spark, 1, total_rows)
+        .write.format("delta")
+        .option("delta.enableDeletionVectors", "true")
+        .save(dest)
+    )
+    spark.sql("DELETE FROM delta.`" + dest + "` WHERE id % 2 = 0")
+    # Re-insert exactly the soft-deleted even events, with identical values. The
+    # removed file still physically holds these rows (the DV only masks them),
+    # so an unmasked `remove` would cancel the new copies by value.
+    (
+        _cdc_events(spark, 1, total_rows)
+        .where("id % 2 = 0")
+        .write.format("delta")
+        .mode("overwrite")
+        .save(dest)
+    )
 
 
 def main() -> None:
@@ -28,6 +128,8 @@ def main() -> None:
     dest = sys.argv[1]
     total_rows = int(sys.argv[2])
     expected_active = int(sys.argv[3])
+    cdc = "--cdc" in sys.argv[4:]
+    overwrite = "--overwrite" in sys.argv[4:]
 
     builder = (
         SparkSession.builder.appName("feldera_dv_fixture")
@@ -46,22 +148,16 @@ def main() -> None:
     spark = configure_spark_with_delta_pip(builder).getOrCreate()
     try:
         spark.sparkContext.setLogLevel("ERROR")
-        (
-            spark.range(1, total_rows + 1)
-            .selectExpr(
-                "cast(id as int) as id",
-                "concat('user_', id) as name",
-                "cast(id * 1.5 as double) as value",
-            )
-            .write.format("delta")
-            .option("delta.enableDeletionVectors", "true")
-            .save(dest)
-        )
-        spark.sql("DELETE FROM delta.`" + dest + "` WHERE id % 2 = 0")
+        if overwrite:
+            _write_cdc_overwrite_fixture(spark, dest, total_rows)
+        elif cdc:
+            _write_cdc_fixture(spark, dest, total_rows)
+        else:
+            _write_plain_fixture(spark, dest, total_rows)
         active = spark.read.format("delta").load(dest).count()
         assert active == expected_active, (
-            f"builder expected {expected_active} active rows after DV "
-            f"DELETE, got {active}"
+            f"builder expected {expected_active} active rows after the "
+            f"fixture commits, got {active}"
         )
     finally:
         spark.stop()

--- a/python/tests/platform/test_delta_input_deletion_vectors.py
+++ b/python/tests/platform/test_delta_input_deletion_vectors.py
@@ -1,6 +1,16 @@
-"""Snapshot read of a Delta table with deletion vectors.
+"""Delta input tests for tables with deletion vectors.
 
-PySpark seeds the fixture (delta-rs cannot write DVs). The builder lives in
+Covers the three ingest modes that interact with deletion vectors (DVs):
+
+* ``snapshot``: delta-rs applies DVs inside its table provider.
+* ``snapshot_and_follow``: the follow phase replays ``add``/``remove`` log
+  actions per file and must apply each action's DV itself.
+* ``cdc``: a DV rewrite commit re-references one immutable data file (identified
+  by its Parquet path) in both a ``remove`` and a new ``add``, only changing that
+  file's deletion vector. The connector recognizes this same-path pair as a
+  metadata-only rewrite and skips it; the test pins down that invariant.
+
+PySpark seeds the fixtures (delta-rs cannot write DVs). The builder lives in
 ``fixtures/deletion_vectors.py`` and runs via ``uv run --with delta-spark`` so
 the Spark/JVM wheels are only fetched on cache miss.
 """
@@ -24,6 +34,16 @@ TOTAL_ROWS = 200
 EXPECTED_ROWS_AFTER_DV = 100
 # Bump to invalidate cached MinIO copies when the fixture definition changes.
 FIXTURE_VERSION = "dv_snapshot_v1"
+# CDC-shaped fixture (see fixtures/deletion_vectors.py --cdc): v0 inserts
+# TOTAL_ROWS events, v1 DV-deletes the even ids, v2 restores them (shrinking
+# the DVs away), v3 appends one event.
+CDC_FIXTURE_VERSION = "dv_cdc_v1"
+CDC_EXPECTED_ACTIVE = TOTAL_ROWS + 1
+# Overwrite-shaped fixture (see fixtures/deletion_vectors.py --overwrite): v0
+# inserts TOTAL_ROWS events, v1 DV-deletes the even ids, v2 re-inserts exactly
+# those even events via INSERT OVERWRITE. After v2 only the EXPECTED_ROWS_AFTER_DV
+# even events remain.
+OVERWRITE_FIXTURE_VERSION = "dv_cdc_overwrite_v1"
 
 # Spark builder that writes the DV-enabled table. It runs in a subprocess
 # (see ensure_delta_spark_fixture) rather than being imported here.
@@ -35,7 +55,7 @@ def _log_has_dv_entries(loc: DeltaTestLocation) -> bool:
 
     The Spark builder validates the active row count itself before exiting,
     so on the Python side we only need to confirm that the fixture exists
-    and is DV-shaped — neither delta-rs nor the deltalake wheel reads DVs.
+    and is DV-shaped; neither delta-rs nor the deltalake wheel reads DVs.
     """
     try:
         log_paths = loc.log_json_paths()
@@ -54,61 +74,231 @@ def _log_has_dv_entries(loc: DeltaTestLocation) -> bool:
     return False
 
 
-def _build_sql(loc: DeltaTestLocation) -> str:
+def _build_sql(
+    loc: DeltaTestLocation,
+    *,
+    columns: str,
+    extra_config: dict | None = None,
+) -> str:
+    config = dict(loc.connector_config)
+    config.update(extra_config or {})
     connectors = json.dumps(
         [
             {
                 "name": CONNECTOR,
                 "transport": {
                     "name": "delta_table_input",
-                    "config": dict(loc.connector_config),
+                    "config": config,
                 },
             }
         ]
     ).replace("'", "''")
     return (
-        f"CREATE TABLE {TABLE} ("
-        "id INT NOT NULL,"
-        "name VARCHAR,"
-        "value DOUBLE"
-        f") WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
+        f"CREATE TABLE {TABLE} ({columns})"
+        f" WITH ('materialized' = 'true', 'connectors' = '{connectors}');"
     )
 
 
-def test_delta_input_snapshot_with_deletion_vectors(pipeline_name):
-    """Snapshot read of a DV-enabled table must skip soft-deleted rows."""
+def _run_to_completion(pipeline_name: str, sql: str) -> tuple[int, int]:
+    """Run the pipeline until end-of-input.
+
+    Returns ``(total_rows, even_id_rows)`` of TABLE. ``even_id_rows`` exists
+    because every fixture soft-deletes exactly the even ids: a correct ingest
+    leaves zero of them, and counting them catches an *inverted* deletion
+    vector (ingesting the deleted half), which COUNT(*) alone cannot, since
+    both halves have the same size.
+    """
+    pipeline = PipelineBuilder(
+        TEST_CLIENT,
+        pipeline_name,
+        sql=sql,
+        runtime_config=RuntimeConfig(
+            workers=FELDERA_TEST_NUM_WORKERS,
+            hosts=FELDERA_TEST_NUM_HOSTS,
+            logging="debug",
+        ),
+    ).create_or_replace()
+    pipeline.start()
+    pipeline.wait_for_completion(force_stop=False, timeout_s=600)
+
+    rows = list(
+        pipeline.query(
+            f"SELECT COUNT(*) AS total,"
+            f" COALESCE(SUM(CASE WHEN id % 2 = 0 THEN 1 ELSE 0 END), 0) AS even_id_rows"
+            f" FROM {TABLE}"
+        )
+    )
+    pipeline.stop(force=True)
+    return int(rows[0]["total"]), int(rows[0]["even_id_rows"])
+
+
+def _ingest_dv_fixture(
+    pipeline_name: str,
+    *,
+    mode: str,
+    fixture_version: str = FIXTURE_VERSION,
+    expected_active: int = EXPECTED_ROWS_AFTER_DV,
+    cdc: bool = False,
+    overwrite: bool = False,
+    columns: str = "id INT NOT NULL, name VARCHAR, value DOUBLE",
+    extra_config: dict | None = None,
+) -> tuple[int, int]:
+    """Ensure the fixture exists, ingest it in `mode`, return the row counts.
+
+    Owns the location's lifecycle (create/cleanup); the tests reduce to a
+    call plus their assertions. Returns ``_run_to_completion``'s
+    ``(total_rows, even_id_rows)`` pair.
+    """
+    builder_flags = (["--cdc"] if cdc else []) + (["--overwrite"] if overwrite else [])
     loc = DeltaTestLocation.create(
         pipeline_name,
-        mode="snapshot",
-        stable_subpath=FIXTURE_VERSION,
+        mode=mode,
+        stable_subpath=fixture_version,
     )
     try:
         ensure_delta_spark_fixture(
             loc,
             _FIXTURE_BUILDER,
-            [TOTAL_ROWS, EXPECTED_ROWS_AFTER_DV],
+            [TOTAL_ROWS, expected_active, *builder_flags],
             is_present=_log_has_dv_entries,
         )
-
-        pipeline = PipelineBuilder(
-            TEST_CLIENT,
+        return _run_to_completion(
             pipeline_name,
-            sql=_build_sql(loc),
-            runtime_config=RuntimeConfig(
-                workers=FELDERA_TEST_NUM_WORKERS,
-                hosts=FELDERA_TEST_NUM_HOSTS,
-                logging="debug",
-            ),
-        ).create_or_replace()
-        pipeline.start()
-        pipeline.wait_for_completion(force_stop=False, timeout_s=600)
-
-        rows = list(pipeline.query(f"SELECT COUNT(*) AS c FROM {TABLE}"))
-        assert int(rows[0]["c"]) == EXPECTED_ROWS_AFTER_DV, (
-            "snapshot ingest of a DV-enabled table must drop the soft-deleted "
-            f"rows ({TOTAL_ROWS - EXPECTED_ROWS_AFTER_DV} rows have id % 2 = 0)"
+            _build_sql(loc, columns=columns, extra_config=extra_config),
         )
-
-        pipeline.stop(force=True)
     finally:
         loc.cleanup()
+
+
+def test_delta_input_snapshot_with_deletion_vectors(pipeline_name):
+    """Snapshot read of a DV-enabled table must skip soft-deleted rows."""
+    total, even_id_rows = _ingest_dv_fixture(pipeline_name, mode="snapshot")
+    assert total == EXPECTED_ROWS_AFTER_DV, (
+        "snapshot ingest of a DV-enabled table must drop the soft-deleted "
+        f"rows ({TOTAL_ROWS - EXPECTED_ROWS_AFTER_DV} rows have id % 2 = 0)"
+    )
+    assert even_id_rows == 0, (
+        "the surviving rows must be the odd ids, not the deleted even ids"
+    )
+
+
+def test_delta_input_follow_with_deletion_vectors(pipeline_name):
+    """The follow path must apply the deletion vectors carried by log actions.
+
+    Replays the fixture's DV commit (v1) from version 0: the `remove`
+    retracts all rows of the rewritten file and the `add` re-inserts only
+    the DV survivors.
+    """
+    total, even_id_rows = _ingest_dv_fixture(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        extra_config={"version": 0, "end_version": 1},
+    )
+    assert total == EXPECTED_ROWS_AFTER_DV, (
+        "follow ingest of a DV commit must retract the soft-deleted rows; "
+        f"{TOTAL_ROWS} rows means the add action's deletion vector was ignored"
+    )
+    assert even_id_rows == 0, (
+        "the surviving rows must be the odd ids, not the deleted even ids"
+    )
+
+
+def test_delta_input_follow_restore_with_deletion_vectors(pipeline_name):
+    """Follow mode must apply a deletion vector carried by a `remove` action.
+
+    Reuses the CDC fixture and replays its restore commit (v2) in follow mode,
+    starting from the post-delete snapshot (v1). Unlike CDC mode, follow mode
+    does not skip the same-path `remove`/`add` pair; it processes each action
+    on its own. The restore's `remove` carries the delete's deletion vector, so
+    masking it retracts only the surviving odd ids; the `add` (DV-free again)
+    re-inserts the whole file, bringing the soft-deleted even ids back.
+
+    It drives the masked reader from a `remove` action whose deletion vector is
+    non-empty (the v0->v1 follow test's `remove` has no DV, as the file was
+    unmasked at v0).
+    """
+    total, even_id_rows = _ingest_dv_fixture(
+        pipeline_name,
+        mode="snapshot_and_follow",
+        fixture_version=CDC_FIXTURE_VERSION,
+        expected_active=CDC_EXPECTED_ACTIVE,
+        cdc=True,
+        columns="id BIGINT NOT NULL",
+        extra_config={"version": 1, "end_version": 2},
+    )
+    assert total == TOTAL_ROWS, (
+        "the restore's `add` must re-insert the whole file after its `remove` "
+        "(masked by the delete's deletion vector) retracts only the survivors; "
+        f"got {total} rows, expected {TOTAL_ROWS}"
+    )
+    assert even_id_rows == TOTAL_ROWS // 2, (
+        "the restored even ids must be present; their absence means the "
+        "`remove` action's deletion vector was applied to the wrong rows"
+    )
+
+
+def test_delta_input_cdc_overwrite_masks_removed_dv_rows(pipeline_name):
+    """CDC must mask a `remove` action's deletion vector before subtracting it.
+
+    The fixture's v2 overwrites the table by re-inserting exactly the even
+    events the v1 deletion vector soft-deleted. In CDC mode that overwrite's
+    `remove` is *unmatched* (a new file path) and carries the delete's deletion
+    vector: the only commit shape that drives the connector's `removes_masked`
+    path. Replaying only that commit (version 2): masking the `remove` to its
+    surviving (odd) rows means the re-inserted even events are not cancelled by
+    the `EXCEPT ALL` and are emitted. Without masking, the `remove` would read
+    the whole file (including its DV-dead even rows) and wrongly cancel the
+    new even events, leaving zero.
+    """
+    total, even_id_rows = _ingest_dv_fixture(
+        pipeline_name,
+        mode="cdc",
+        fixture_version=OVERWRITE_FIXTURE_VERSION,
+        expected_active=EXPECTED_ROWS_AFTER_DV,
+        overwrite=True,
+        columns="id BIGINT NOT NULL",
+        extra_config={
+            "version": 1,
+            "end_version": 2,
+            "cdc_delete_filter": "__feldera_op = 'd'",
+            "cdc_order_by": "__feldera_ts asc, lsn asc",
+        },
+    )
+    assert total == EXPECTED_ROWS_AFTER_DV, (
+        "the re-inserted even events must survive the `EXCEPT ALL`; a count of "
+        "0 means the `remove`'s deletion vector was ignored and its DV-dead "
+        "rows over-subtracted the new events"
+    )
+    assert even_id_rows == EXPECTED_ROWS_AFTER_DV, (
+        "every re-inserted event has an even id"
+    )
+
+
+def test_delta_input_cdc_with_deletion_vectors(pipeline_name):
+    """DV rewrite commits on a CDC source must not re-emit or drop events.
+
+    In CDC mode a commit that only rewrites deletion vectors (`remove` +
+    `add` of the same path) is metadata-only, and the connector skips it.
+    The fixture's v1 (DV delete) and v2 (restore, shrinking the DVs back)
+    are both such commits; replaying from version 0 must yield only the
+    single v3 insert.
+    """
+    total, _ = _ingest_dv_fixture(
+        pipeline_name,
+        mode="cdc",
+        fixture_version=CDC_FIXTURE_VERSION,
+        expected_active=CDC_EXPECTED_ACTIVE,
+        cdc=True,
+        columns="id BIGINT NOT NULL",
+        extra_config={
+            "version": 0,
+            "end_version": 3,
+            "cdc_delete_filter": "__feldera_op = 'd'",
+            "cdc_order_by": "__feldera_ts asc, lsn asc",
+        },
+    )
+    assert total == 1, (
+        "CDC replay of DV rewrite commits must net to zero events: "
+        "only the single v3 insert event may arrive; a higher count "
+        "means soft-deleted or restored events were re-ingested"
+    )


### PR DESCRIPTION
snapshot mode works fine with deletion vectors, but for follow mode we need parse and apply deletion vector ourselves to read parquet files, same with some cases in cdc mode

### Describe Manual Test Plan

<!-- Add a few sentences describing the steps you took to test this change. -->

## Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Not breaking change
