### PR TITLE
[dbsp] Use serde_json to serialize data for Broadcast operator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,7 +4014,6 @@ dependencies = [
  "rand_xoshiro",
  "reqwest 0.12.24",
  "rkyv",
- "rmp-serde",
  "roaring",
  "seq-macro",
  "serde",

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -95,7 +95,6 @@ feldera-ir = { workspace = true }
 smallvec = { workspace = true }
 async-stream = { workspace = true }
 futures-util = { workspace = true }
-rmp-serde = { workspace = true }
 feldera-buffer-cache = { workspace = true }
 memory-stats = { workspace = true }
 serde_json_path_to_error = { workspace = true }

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -1413,13 +1413,13 @@ where
                     exchange
                         .send_all_with_serializer(identifier, repeat(local.clone()), |local| {
                             let mut fbuf = FBuf::new();
-                            rmp_serde::encode::write(&mut fbuf, &local).unwrap();
+                            serde_json::to_writer(&mut fbuf, &local).unwrap();
                             fbuf
                         })
                         .await;
 
                     exchange
-                        .receive_all(|data| rmp_serde::from_slice(&data).unwrap())
+                        .receive_all(|data| serde_json::from_slice(&data).unwrap())
                         .await
                 })
                 .await


### PR DESCRIPTION
The Broadcast operator was using rmp_serde to serialize and deserialize data for exchange across hosts, for reasons that have been lost to the mists of time.  This serialization corrupted some of our data; for example, it caused an array of integers to become an array of array of stringified integers (!).

This commit fixes it by using serde_json instead of rmp_serde.  Since this was the only use of rmp_serde, it drops that dependency.

### Describe Manual Test Plan

I tested that a multihost pipeline that had adaptive joins enable didn't fail immediately on startup.
