### PR TITLE
[SQL] Emit a compiler warning on suspicious casts from constant strings to Booleans

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/Simplify.java
@@ -243,7 +243,21 @@ public class Simplify extends ExpressionTranslator {
                 // This is mostly useful for testing code, to fold various literals.
                 DBSPStringLiteral str = lit.to(DBSPStringLiteral.class);
                 Objects.requireNonNull(str.value);
-                if (type.is(DBSPTypeDate.class)) {
+                if (type.is(DBSPTypeBool.class)) {
+                    String normalized = str.value.trim().toLowerCase(Locale.ENGLISH);
+                    Boolean value = null;
+                    if (normalized.equals("false"))
+                        value = false;
+                    else if (normalized.equals("true"))
+                        value = true;
+                    if (value == null) {
+                        this.compiler.reportWarning(expression.getSourcePosition(), "Suspicious argument",
+                                "String " + Utilities.singleQuote(str.value) +
+                                        " cannot be interpreted as a BOOLEAN");
+                    } else {
+                        result = new DBSPBoolLiteral(lit.getNode(), type, value);
+                    }
+                } if (type.is(DBSPTypeDate.class)) {
                     // We have to validate the date, it may be invalid, and in this case
                     // the result is 'null'.  This pattern is hardwired in Calcite.
                     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd", Locale.US)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/MetadataTests.java
@@ -201,13 +201,6 @@ public class MetadataTests extends BaseSQLTests {
         Assert.assertTrue(found);
     }
 
-    DBSPCompiler chattyCompiler() {
-        DBSPCompiler compiler = this.testCompiler();
-        compiler.options.languageOptions.throwOnError = false;
-        compiler.options.ioOptions.quiet = false;
-        return compiler;
-    }
-
     @Test
     public void issue3341() {
         String sql = """

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/simple/Regression3Tests.java
@@ -2,6 +2,8 @@ package org.dbsp.sqlCompiler.compiler.sql.simple;
 
 import org.dbsp.sqlCompiler.circuit.operator.DBSPStreamJoinOperator;
 import org.dbsp.sqlCompiler.circuit.operator.DBSPWaterlineOperator;
+import org.dbsp.sqlCompiler.compiler.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.TestUtil;
 import org.dbsp.sqlCompiler.compiler.sql.tools.SqlIoTest;
 import org.dbsp.sqlCompiler.compiler.visitors.outer.CircuitVisitor;
 import org.junit.Assert;
@@ -12,6 +14,20 @@ public class Regression3Tests extends SqlIoTest {
     public void withSuggestion() {
         this.statementsFailingInCompilation("WITH V AS (SELECT 1) SELECT * FROM V;",
                 "Raw 'SELECT' statements are not supported; did you forget to CREATE VIEW?");
+    }
+
+    @Test
+    public void issue6400() {
+        String sql = """
+                CREATE TABLE t(b BOOLEAN);
+                CREATE VIEW V AS SELECT b = 't' FROM T;""";
+        DBSPCompiler compiler = this.chattyCompiler();
+        compiler.submitStatementsForCompilation(sql);
+        TestUtil.assertMessagesContain(compiler, """
+                Suspicious argument: String 't' cannot be interpreted as a BOOLEAN
+                    1|CREATE TABLE t(b BOOLEAN);
+                    2|CREATE VIEW V AS SELECT b = 't' FROM T;
+                                                  ^^^""");
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/sql/tools/BaseSQLTests.java
@@ -100,6 +100,13 @@ public class BaseSQLTests {
         return new CompilerCircuitStream(compiler, this);
     }
 
+    public DBSPCompiler chattyCompiler() {
+        DBSPCompiler compiler = this.testCompiler();
+        compiler.options.languageOptions.throwOnError = false;
+        compiler.options.ioOptions.quiet = false;
+        return compiler;
+    }
+
     public CompilerCircuit getCC(String sql) {
         DBSPCompiler compiler = this.testCompiler();
         this.prepareInputs(compiler);


### PR DESCRIPTION
Fixes #6400 (for some definition of "fixes")

A comparison such as `boolean = 't'` will be now flagged at compile-time as a possible error.
Unfortunately this does not really fix broken programs, but at least may help detecting errors early.

## Checklist

- [x] Unit tests added/updated
