### PR TITLE
pipeline-manager: deprecate unstable feature `cluster_monitor_resources`

### DIFF
--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -1066,6 +1066,7 @@ mod test {
             https_tls_key_path: None,
             private_ca_cert_path: None,
             pipeline_monitor_events_retention: 720,
+            disable_cluster_monitor_resources: false,
         };
 
         let manager_config = ApiServerConfig {

--- a/crates/pipeline-manager/src/cluster_monitor.rs
+++ b/crates/pipeline-manager/src/cluster_monitor.rs
@@ -4,7 +4,6 @@ use crate::db::storage::Storage;
 use crate::db::storage_postgres::StoragePostgres;
 use crate::db::types::monitor::{MonitorStatus, NewClusterMonitorEvent};
 use crate::error::source_error;
-use crate::unstable_features;
 use async_trait::async_trait;
 use feldera_observability::ReqwestTracingExt;
 use std::{sync::Arc, time::Duration};
@@ -39,10 +38,8 @@ const RESOURCES_INFO_NOT_AVAILABLE: &str =
     "Resources information not available in Community edition.";
 
 /// Message when the resources information gathering is not enabled.
-const RESOURCES_INFO_NOT_ENABLED: &str = "Resources information is not enabled. \
-    Cluster monitoring resources is currently an unstable feature. It can be enabled by \
-    setting the control plane environment variable FELDERA_UNSTABLE_FEATURES and adding to it \
-    `cluster_monitor_resources` as one of the comma-separated entries.";
+const RESOURCES_INFO_DISABLED: &str =
+    "Cluster monitoring resources information is disabled in the configuration.";
 
 /// Target to poll resources of.
 pub enum PollResourcesTarget {
@@ -128,9 +125,16 @@ pub async fn cluster_monitor<P: ResourcesPoller>(
             api_resources_info,
             compiler_resources_info,
             runner_resources_info,
-        ) = if unstable_features().is_some_and(|activated_unstable_features| {
-            activated_unstable_features.contains("cluster_monitor_resources")
-        }) {
+        ) = if common_config.disable_cluster_monitor_resources {
+            (
+                true,
+                true,
+                true,
+                RESOURCES_INFO_DISABLED.to_string(),
+                RESOURCES_INFO_DISABLED.to_string(),
+                RESOURCES_INFO_DISABLED.to_string(),
+            )
+        } else {
             let (api_resources_ok, api_resources_info) = resources_poller
                 .poll_resources(PollResourcesTarget::Api)
                 .await;
@@ -147,15 +151,6 @@ pub async fn cluster_monitor<P: ResourcesPoller>(
                 truncate_info(api_resources_info),
                 truncate_info(compiler_resources_info),
                 truncate_info(runner_resources_info),
-            )
-        } else {
-            (
-                true,
-                true,
-                true,
-                RESOURCES_INFO_NOT_ENABLED.to_string(),
-                RESOURCES_INFO_NOT_ENABLED.to_string(),
-                RESOURCES_INFO_NOT_ENABLED.to_string(),
             )
         };
 

--- a/crates/pipeline-manager/src/compiler/test.rs
+++ b/crates/pipeline-manager/src/compiler/test.rs
@@ -49,6 +49,7 @@ impl CompilerTest {
             https_tls_key_path: None,
             private_ca_cert_path: None,
             pipeline_monitor_events_retention: 720,
+            disable_cluster_monitor_resources: false,
         };
         let compiler_config = CompilerConfig {
             sql_compiler_path:

--- a/crates/pipeline-manager/src/config.rs
+++ b/crates/pipeline-manager/src/config.rs
@@ -253,8 +253,6 @@ pub struct CommonConfig {
     /// Currently supported features:
     /// - `runtime_version`: Allows to override the runtime version of a pipeline on the platform.
     /// - `testing`
-    /// - `cluster_monitor_resources`: Cluster monitoring also monitors the resources backing the
-    ///   instance (i.e., the Kubernetes objects).
     /// - `rust_compiler_full_cleanup`: the Rust compiler fully cleans up the target directory if the
     ///   disk space usage is approaching its limit.
     #[arg(verbatim_doc_comment, long, env = "FELDERA_UNSTABLE_FEATURES")]
@@ -316,6 +314,14 @@ pub struct CommonConfig {
     /// Number of monitor events that are retained for each pipeline.
     #[arg(long, default_value_t = default_pipeline_monitor_events_retention(), env = "FELDERA_PIPELINE_MONITOR_EVENTS_RETENTION")]
     pub pipeline_monitor_events_retention: u32,
+
+    /// Whether to disable cluster monitoring of its own (Kubernetes) resources.
+    #[arg(
+        long,
+        default_value_t = false,
+        env = "FELDERA_DISABLE_CLUSTER_MONITOR_RESOURCES"
+    )]
+    pub disable_cluster_monitor_resources: bool,
 }
 
 impl CommonConfig {
@@ -588,6 +594,7 @@ impl CommonConfig {
             https_tls_key_path: None,
             private_ca_cert_path: None,
             pipeline_monitor_events_retention: 720,
+            disable_cluster_monitor_resources: false,
         }
     }
 }

--- a/crates/pipeline-manager/src/lib.rs
+++ b/crates/pipeline-manager/src/lib.rs
@@ -27,7 +27,6 @@ pub fn platform_enable_unstable(requested_features: &str) {
     let all_features: HashSet<&'static str> = HashSet::from_iter(vec![
         "runtime_version",
         "testing",
-        "cluster_monitor_resources",
         "rust_compiler_full_cleanup",
     ]);
     let mut enabled = HashSet::new();

--- a/crates/pipeline-manager/src/runner/pipeline_automata.rs
+++ b/crates/pipeline-manager/src/runner/pipeline_automata.rs
@@ -2155,6 +2155,7 @@ mod test {
                 https_tls_key_path: None,
                 private_ca_cert_path: None,
                 pipeline_monitor_events_retention: 720,
+                disable_cluster_monitor_resources: false,
             },
             pipeline_id,
             Some("test-pipeline".to_string()),

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,14 @@ import TabItem from '@theme/TabItem';
 
 	## Unreleased
 
+        - Cluster monitor events with information on the backing (Kubernetes) resources is
+          no longer gated behind unstable feature `cluster_monitor_resources` (deprecated).
+          It is now enabled by default. This change adds RBAC permissions to get the
+          deployments of the API server and the runner. The status of the backing Kubernetes
+          resources is shown in the Feldera Health page to every (authenticated) user.
+          The cluster monitoring of resources can still be disabled by setting in the Helm
+          chart `disableClusterMonitorResources` to `true`.
+
 	- A bug fix introduced a backward incompatible change to the replay journal format.
           This only affects pipelines configured with exactly-once fault tolerance. Such
           pipelines should not be upgraded to the new Feldera runtime if they are in a failed

--- a/docs.feldera.com/docs/get-started/enterprise/helm-chart-reference.md
+++ b/docs.feldera.com/docs/get-started/enterprise/helm-chart-reference.md
@@ -322,6 +322,7 @@ Configure HTTPS for all Feldera components. See the [HTTPS guide](./https) for c
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `unstableFeatures` | `[]` | List of unstable feature flags to enable. Possible values: `"testing"`, `"runtime_version"`, `"cluster_monitor_resources"`. Do not also set `FELDERA_UNSTABLE_FEATURES` in `controlPlane.env`. |
+| `unstableFeatures` | `[]` | List of unstable feature flags to enable. Possible values: `"testing"`, `"runtime_version"`, `"rust_compiler_full_cleanup"`. Do not also set `FELDERA_UNSTABLE_FEATURES` in `controlPlane.env`. |
 | `felderaSentryEnabled` | `false` | Send crash reports and logs to Feldera's Sentry installation. |
 | `cloudApiEndpoint` | `"https://cloud1.feldera.com"` | Feldera cloud API endpoint used for license verification and runner telemetry. |
+| `disableClusterMonitorResources` | `false` | Whether to disable cluster monitoring of its own (Kubernetes) resources. |

--- a/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
+++ b/docs.feldera.com/docs/tutorials/rest_api/cluster-monitoring.md
@@ -8,8 +8,8 @@ notably at most 1000 and with a time limit of 72 hours (whichever comes first).
 With this, it is possible to access both the latest health check of the cluster
 and its health in the recent past. The events are accessible through the API.
 
-The resources monitoring feature is not yet stabilized, but can already be activated by adding
-`cluster_monitor_resources` to the Helm chart `unstableFeatures` array value.
+The resources monitoring feature can be deactivated by setting
+in the Helm chart `disableClusterMonitorResources` to `true`.
 
 ## API usage
 


### PR DESCRIPTION
The backing (Kubernetes) resources information is now enabled by default for the cluster monitoring events. It can still be disabled by passing `--disable-cluster-monitor-resources` as argument.

**PR information**
- Backward compatible