### PR TITLE
[adapters] Delta transaction_mode:snapshot regression.

### DIFF
--- a/crates/adapters/src/integrated/delta_table/input.rs
+++ b/crates/adapters/src/integrated/delta_table/input.rs
@@ -742,7 +742,8 @@ struct DeltaTableMetrics {
     snapshot_records_total: AtomicU64,
     /// Number of Feldera follow transactions started (`follow-*` labels allocated).
     follow_transaction_starts: AtomicU64,
-    /// Number of Feldera snapshot transactions started (`snapshot-*` labels allocated).
+    /// Number of Feldera snapshot transactions actually started: incremented when a `snapshot-*`
+    /// label is propagated to a queue entry, not merely when the label is allocated.
     snapshot_transaction_starts: AtomicU64,
     /// Last ingested Delta table version; [`VERSION_METRIC_UNSET`] until the
     /// first successful ingest.
@@ -1028,14 +1029,30 @@ impl DeltaTableInputEndpointInner {
             // state to batch Delta log versions.
             DeltaTableTransactionMode::Catchup => {
                 if Self::is_snapshot_transaction_label(fallback) {
+                    self.count_snapshot_transaction_start();
                     fallback.clone()
                 } else {
                     self.catchup_follow_start_transaction()
                 }
             }
-            DeltaTableTransactionMode::Always => fallback.clone(),
-            _ => None,
+            DeltaTableTransactionMode::Always | DeltaTableTransactionMode::Snapshot => {
+                if Self::is_snapshot_transaction_label(fallback) {
+                    self.count_snapshot_transaction_start();
+                }
+                fallback.clone()
+            }
+            DeltaTableTransactionMode::None => None,
         }
+    }
+
+    /// Record that a `snapshot-*` Feldera transaction was actually started, i.e., its label was
+    /// propagated to a queue entry (and thence to the controller). Counted here rather than where
+    /// the label is allocated, so the metric reflects transactions the connector truly started, not
+    /// merely intended to start.
+    fn count_snapshot_transaction_start(&self) {
+        self.metrics
+            .snapshot_transaction_starts
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     fn skip_unused_columns(&self) -> bool {
@@ -1089,9 +1106,8 @@ impl DeltaTableInputEndpointInner {
                 | DeltaTableTransactionMode::Snapshot
                 | DeltaTableTransactionMode::Catchup
         ) {
-            self.metrics
-                .snapshot_transaction_starts
-                .fetch_add(1, Ordering::Relaxed);
+            // The metric is incremented in `follow_start_transaction` when the label is actually
+            // propagated, not here where it is merely allocated.
             Some(Some(format!(
                 "snapshot-{}",
                 self.transaction_index.fetch_add(1, Ordering::Release),

--- a/crates/adapters/src/integrated/delta_table/test.rs
+++ b/crates/adapters/src/integrated/delta_table/test.rs
@@ -3272,6 +3272,31 @@ async fn delta_table_snapshot_and_follow_catchup_snapshot_transaction_test() {
     );
 }
 
+/// Regression test for a bug where `snapshot` transaction mode ingested the initial snapshot
+/// without starting a Feldera transaction: `follow_start_transaction` dropped the `snapshot-*`
+/// label instead of propagating it. The `snapshot_transaction_starts` metric counts transactions
+/// actually started (the label reaching a queue entry), so it reads 0 when the bug is present.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delta_table_snapshot_mode_snapshot_transaction_test() {
+    const SNAPSHOT_ROWS: i64 = 10;
+    let result = run_catchup_lag_experiment(catchup_lag_options(
+        DeltaTableTransactionMode::Snapshot,
+        &[2],
+        None,
+        Some(SNAPSHOT_ROWS),
+    ))
+    .await;
+    assert_eq!(
+        result.snapshot_transaction_starts, 1,
+        "snapshot mode must ingest the initial snapshot in one Feldera transaction"
+    );
+    assert_eq!(
+        result.follow_transactions_per_round,
+        vec![0],
+        "snapshot mode must not start a Feldera transaction for follow commits"
+    );
+}
+
 #[tokio::test]
 async fn delta_table_snapshot_and_follow_file_catchup_test() {
     delta_table_follow_file_test_common(true, DeltaTableTransactionMode::Catchup, false, false)


### PR DESCRIPTION
When introducing catchup mode, I accidentally made a change that broke the `snapshot` mode, specifically, the connector didn't start a transaction to ingest a snapshot, as expected.

The commit fixes, the bug, adds a test that would have caught it and also fixes the implementation of the number-of-snapshot-transactions metric, which was introduced in the catchup PR.

### Describe Manual Test Plan

Tested on the medalion demo.

## Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Documentation updated
- [ ] Changelog updated

## Breaking Changes?

Mark if you think the answer is yes for any of these components:

- [ ] OpenAPI / REST HTTP API / feldera-types / manager ([What is a breaking change?](https://github.com/oasdiff/oasdiff/tree/main))
- [ ] Feldera SQL (Syntax, Semantics)
- [ ] feldera-sqllib (incl. dependencies fxp, etc.) ([What is a breaking change?](https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility))
- [ ] Python SDK  ([What is a breaking change?](https://peps.python.org/pep-0387/#backwards-compatibility-rules))
- [ ] fda (CLI arguments)
- [ ] Adapters (including configuration)
- [ ] Storage Format / Checkpoints
- [ ] Others (specify)

### Describe Incompatible Changes

<!-- Add a few sentences describing the incompatible changes if any. -->
