### PR TITLE
Fix web-console not showing some adhoc errors

### DIFF
--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -10,8 +10,8 @@ use datafusion::prelude::*;
 use datafusion::sql::parser::{DFParserBuilder, Statement as DFStatement};
 use datafusion::sql::sqlparser::dialect::dialect_from_str;
 use executor::{
-    hash_query_result, infallible_from_bytestring, stream_arrow_query, stream_json_query,
-    stream_parquet_query, stream_text_query,
+    execute_adhoc_stream, hash_query_result, infallible_from_bytestring, stream_arrow_query,
+    stream_json_query, stream_parquet_query, stream_text_query,
 };
 use feldera_types::query::{AdHocResultFormat, AdhocQueryArgs, MAX_WS_FRAME_SIZE};
 use futures_util::StreamExt;
@@ -46,9 +46,24 @@ async fn adhoc_query_handler(
     mut ws_session: WsSession,
     args: AdhocQueryArgs,
 ) -> Result<(), Closed> {
+    // Set up execution before encoding. Planning and execute-time-setup
+    // errors (e.g. selecting from a non-materialized source) surface here;
+    // report them on the websocket and close, matching the per-format error
+    // handling below.
+    let (record_stream, schema) = match execute_adhoc_stream(df).await {
+        Ok(stream_and_schema) => stream_and_schema,
+        Err(e) => {
+            ws_session
+                .text(serde_json::to_string(&e).unwrap_or_else(|_| e.to_string()))
+                .await?;
+            ws_close(ws_session, CloseCode::Error).await;
+            return Ok(());
+        }
+    };
+
     match args.format {
         AdHocResultFormat::Text => {
-            let mut stream = Box::pin(stream_text_query(df));
+            let mut stream = Box::pin(stream_text_query(record_stream, schema));
             while let Some(res) = stream.next().await {
                 match res {
                     Ok(text) => {
@@ -63,7 +78,7 @@ async fn adhoc_query_handler(
             }
         }
         AdHocResultFormat::Json => {
-            let mut stream = Box::pin(stream_json_query(df));
+            let mut stream = Box::pin(stream_json_query(record_stream));
             while let Some(res) = stream.next().await {
                 match res {
                     Ok(byte_string) => {
@@ -80,7 +95,7 @@ async fn adhoc_query_handler(
             }
         }
         AdHocResultFormat::ArrowIpc => {
-            let mut stream = Box::pin(stream_arrow_query(df));
+            let mut stream = Box::pin(stream_arrow_query(record_stream, schema));
             while let Some(res) = stream.next().await {
                 match res {
                     Ok(bytes) => {
@@ -103,7 +118,7 @@ async fn adhoc_query_handler(
             }
         }
         AdHocResultFormat::Parquet => {
-            let mut stream = Box::pin(stream_parquet_query(df));
+            let mut stream = Box::pin(stream_parquet_query(record_stream, schema));
             while let Some(res) = stream.next().await {
                 match res {
                     Ok(bytes) => ws_session.binary(bytes).await?,
@@ -124,7 +139,7 @@ async fn adhoc_query_handler(
             }
         }
         AdHocResultFormat::Hash => {
-            let hash_result = hash_query_result(df).await;
+            let hash_result = hash_query_result(record_stream, schema).await;
             match hash_result {
                 Ok(hash) => {
                     ws_session.text(hash).await?;
@@ -445,28 +460,33 @@ pub(crate) async fn stream_adhoc_result(
 ) -> Result<HttpResponse, PipelineError> {
     let df = execute_sql(controller, &args.sql).await?;
 
-    // Note that once we are in the stream!{} macros any error that occurs will lead to the connection
-    // in the manager being terminated and a 500 error being returned to the client.
-    // We can't return an error in a stream that is already Response::Ok.
-    //
-    // Sometimes things do tend to fail inside the stream!{} macro, e.g., "select 1/0;" will cause a
-    // division by zero error during query execution. So we return errors according to the chosen
-    // format for text and json, and for parquet we return the 500 error.
+    // Set up execution before committing a response status. Planning and
+    // execute-time-setup errors — e,g, selecting from a non-materialized source —
+    // surface here and are returned as a regular `PipelineError` (HTTP 400),
+    // so the client sees the message rather than a truncated `200 OK` body.
+    let (record_stream, schema) = execute_adhoc_stream(df).await?;
+
+    // Once we hand a stream to `.streaming(...)` the `200 OK` status is
+    // already yielded, so an error raised *mid-stream* (e.g. "select
+    // 1/0;" failing on a later row) can no longer change the status. For
+    // text and json we fold such errors into the response body; for arrow
+    // and parquet the body is simply terminated (and the manager surfaces a 500).
     match args.format {
         AdHocResultFormat::Text => Ok(HttpResponse::Ok()
             .content_type(mime::TEXT_PLAIN)
-            .streaming::<_, Infallible>(infallible_from_bytestring(stream_text_query(df), |e| {
-                format!("ERROR: {}", e).into()
-            }))),
+            .streaming::<_, Infallible>(infallible_from_bytestring(
+                stream_text_query(record_stream, schema),
+                |e| format!("ERROR: {}", e).into(),
+            ))),
         AdHocResultFormat::Json => Ok(HttpResponse::Ok()
             .content_type(mime::APPLICATION_JSON)
             .streaming::<_, Infallible>(infallible_from_bytestring(
-            stream_json_query(df),
+            stream_json_query(record_stream),
             |e| serde_json::to_string(&e).unwrap().into(),
         ))),
         AdHocResultFormat::ArrowIpc => Ok(HttpResponse::Ok()
             .content_type(mime::APPLICATION_OCTET_STREAM)
-            .streaming(stream_arrow_query(df))),
+            .streaming(stream_arrow_query(record_stream, schema))),
         AdHocResultFormat::Parquet => {
             let file_name = format!(
                 "results_{}.parquet",
@@ -475,11 +495,11 @@ pub(crate) async fn stream_adhoc_result(
             Ok(HttpResponse::Ok()
                 .insert_header(header::ContentDisposition::attachment(file_name))
                 .content_type(mime::APPLICATION_OCTET_STREAM)
-                .streaming(stream_parquet_query(df)))
+                .streaming(stream_parquet_query(record_stream, schema)))
         }
         AdHocResultFormat::Hash => Ok(HttpResponse::Ok()
             .content_type(mime::TEXT_PLAIN)
-            .body(hash_query_result(df).await?)),
+            .body(hash_query_result(record_stream, schema).await?)),
     }
 }
 
@@ -683,5 +703,53 @@ mod tests {
         // that one row came back.
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 1);
+    }
+
+    /// Selecting from a non-materialized source fails during *execution
+    /// setup*, not planning. `execute_adhoc_stream` must surface that as an
+    /// `Err`, letting the HTTP handler return a non-2xx status before
+    /// committing a `200 OK` whose body would otherwise be silently
+    /// truncated. This is what gives the HTTP transport the same up-front
+    /// error visibility the WebSocket transport already has.
+    #[tokio::test]
+    async fn non_materialized_select_surfaces_error_before_streaming() {
+        use crate::adhoc::table::AdHocTable;
+        use datafusion::arrow::datatypes::{DataType, Field, Schema};
+        use feldera_types::program_schema::SqlIdentifier;
+        use std::collections::BTreeMap;
+        use std::sync::Weak;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+        let ctx = SessionContext::new_with_state(test_state());
+
+        // A view (no input handle) that is *not* materialized.
+        let table = Arc::new(AdHocTable::new(
+            false, // materialized
+            false, // indexed
+            Weak::new(),
+            None, // input_handle: view, not a base table
+            SqlIdentifier::new("v", false),
+            schema,
+        ));
+        ctx.register_table("v", table).unwrap();
+
+        // The scan reads a consistent snapshot from the session config; an
+        // empty one suffices because execution fails the materialization
+        // check before touching any data.
+        let mut state = ctx.state();
+        set_snapshot(&mut state, Arc::new(BTreeMap::new()));
+
+        // Planning succeeds: the materialization check lives in physical
+        // execution setup, not planning.
+        let df = execute_sql_with_state(state, "SELECT * FROM v")
+            .await
+            .expect("planning a select over a non-materialized view should succeed");
+
+        // The error must surface here, before any response status is set.
+        let msg = match execute_adhoc_stream(df).await {
+            Ok(_) => panic!("selecting from a non-materialized source must fail at setup"),
+            Err(e) => format!("{e}"),
+        };
+        assert!(msg.contains("non-materialized"), "unexpected error: {msg}");
     }
 }

--- a/crates/adapters/src/adhoc.rs
+++ b/crates/adapters/src/adhoc.rs
@@ -461,7 +461,7 @@ pub(crate) async fn stream_adhoc_result(
     let df = execute_sql(controller, &args.sql).await?;
 
     // Set up execution before committing a response status. Planning and
-    // execute-time-setup errors — e,g, selecting from a non-materialized source —
+    // execute-time-setup errors — e.g. selecting from a non-materialized source —
     // surface here and are returned as a regular `PipelineError` (HTTP 400),
     // so the client sees the message rather than a truncated `200 OK` body.
     let (record_stream, schema) = execute_adhoc_stream(df).await?;

--- a/crates/adapters/src/adhoc/executor.rs
+++ b/crates/adapters/src/adhoc/executor.rs
@@ -79,12 +79,10 @@ pub(crate) fn infallible_from_bytestring(
 }
 
 pub(crate) fn stream_text_query(
-    stream: SendableRecordBatchStream,
+    mut stream: SendableRecordBatchStream,
     schema: SchemaRef,
 ) -> impl Stream<Item = Result<ByteString, PipelineError>> {
     try_stream! {
-        let mut stream = stream;
-
         let mut headers_sent = false;
         let mut last_line: Option<String> = None;
         while let Some(batch) = stream.next().await {
@@ -184,11 +182,9 @@ impl BatchHasher {
 
 /// Computes an order-independent hash of a DataFrame's result set.
 pub(crate) async fn hash_query_result(
-    stream: SendableRecordBatchStream,
+    mut stream: SendableRecordBatchStream,
     schema: SchemaRef,
 ) -> Result<String, PipelineError> {
-    let mut stream = stream;
-
     let mut hasher = BatchHasher::new();
     while let Some(batch) = stream.next().await {
         let batch = batch.map_err(PipelineError::from)?;
@@ -198,10 +194,9 @@ pub(crate) async fn hash_query_result(
 }
 
 pub(crate) fn stream_json_query(
-    stream: SendableRecordBatchStream,
+    mut stream: SendableRecordBatchStream,
 ) -> impl Stream<Item = Result<ByteString, PipelineError>> {
     try_stream! {
-        let mut stream = stream;
         while let Some(batch) = stream.next().await {
             let batch = batch.map_err(PipelineError::from)?;
             let mut buf = Vec::with_capacity(4096);
@@ -261,12 +256,10 @@ impl AsyncFileWriter for ChannelWriter {
 /// <https://github.com/apache/arrow-rs/pull/9241>. Once that lands the
 /// per-batch buffering here can be replaced with a direct async sink.
 pub(crate) fn stream_arrow_query(
-    stream: SendableRecordBatchStream,
+    mut stream: SendableRecordBatchStream,
     schema: SchemaRef,
 ) -> impl Stream<Item = Result<Bytes, DataFusionError>> {
     try_stream! {
-        let mut stream = stream;
-
         // `try_new` writes the schema message to the inner buffer. The
         // `BytesMut` behind `BufMut::writer()` is a single allocation
         // that we slice off in O(1) chunks via `split()` after each
@@ -304,7 +297,7 @@ pub(crate) fn stream_arrow_query(
 }
 
 pub(crate) fn stream_parquet_query(
-    stream: SendableRecordBatchStream,
+    mut stream: SendableRecordBatchStream,
     schema: SchemaRef,
 ) -> impl Stream<Item = Result<Bytes, DataFusionError>> {
     // Should probably be smaller than `MAX_WS_FRAME_SIZE`.
@@ -315,8 +308,6 @@ pub(crate) fn stream_parquet_query(
 
     let mut stream_job = Box::pin(
         async move {
-            let mut stream = stream;
-
             let mut writer = AsyncArrowWriter::try_new(
                 ChannelWriter::new(tx),
                 schema,

--- a/crates/adapters/src/adhoc/executor.rs
+++ b/crates/adapters/src/adhoc/executor.rs
@@ -1,4 +1,5 @@
 use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
 use arrow::ipc::convert::IpcSchemaEncoder;
 use arrow::ipc::writer::StreamWriter;
 use arrow::util::pretty::pretty_format_batches;
@@ -40,6 +41,31 @@ fn execute_stream(df: DataFrame) -> Receiver<DFResult<SendableRecordBatchStream>
     rx
 }
 
+/// Drives physical planning and execution setup for `df`, returning the
+/// record-batch stream together with its schema.
+///
+/// Planning and execute-time-setup errors — e.g. selecting from a
+/// non-materialized table — surface here, before any result data is produced.
+/// Hoisting this step out of the per-format encoders lets the HTTP handler
+/// translate such an error into a proper 4xx response
+/// instead of a `200 OK` whose body is silently truncated.
+pub(crate) async fn execute_adhoc_stream(
+    df: DataFrame,
+) -> Result<(SendableRecordBatchStream, SchemaRef), PipelineError> {
+    let schema = df.schema().inner().clone();
+    let stream = execute_stream(df)
+        .await
+        .map_err(|e| PipelineError::AdHocQueryError {
+            error: e.to_string(),
+            df: None,
+        })?
+        .map_err(|e| PipelineError::AdHocQueryError {
+            error: e.to_string(),
+            df: Some(Box::new(e)),
+        })?;
+    Ok((stream, schema))
+}
+
 pub(crate) fn infallible_from_bytestring(
     fallible_stream: impl Stream<Item = Result<ByteString, PipelineError>>,
     map_err: impl Fn(PipelineError) -> Bytes + 'static,
@@ -53,13 +79,11 @@ pub(crate) fn infallible_from_bytestring(
 }
 
 pub(crate) fn stream_text_query(
-    df: DataFrame,
+    stream: SendableRecordBatchStream,
+    schema: SchemaRef,
 ) -> impl Stream<Item = Result<ByteString, PipelineError>> {
-    let schema = df.schema().inner().clone();
     try_stream! {
-        let stream_executor = execute_stream(df).await.map_err(|e| PipelineError::AdHocQueryError { error: e.to_string(), df: None })?;
-        let mut stream = stream_executor
-            .map_err(|e| PipelineError::AdHocQueryError { error: e.to_string(), df: Some(Box::new(e)) })?;
+        let mut stream = stream;
 
         let mut headers_sent = false;
         let mut last_line: Option<String> = None;
@@ -159,19 +183,11 @@ impl BatchHasher {
 }
 
 /// Computes an order-independent hash of a DataFrame's result set.
-pub(crate) async fn hash_query_result(df: DataFrame) -> Result<String, PipelineError> {
-    let schema = df.schema().inner().clone();
-
-    let stream_executor = execute_stream(df)
-        .await
-        .map_err(|e| PipelineError::AdHocQueryError {
-            error: e.to_string(),
-            df: None,
-        })?;
-    let mut stream = stream_executor.map_err(|e| PipelineError::AdHocQueryError {
-        error: e.to_string(),
-        df: Some(Box::new(e)),
-    })?;
+pub(crate) async fn hash_query_result(
+    stream: SendableRecordBatchStream,
+    schema: SchemaRef,
+) -> Result<String, PipelineError> {
+    let mut stream = stream;
 
     let mut hasher = BatchHasher::new();
     while let Some(batch) = stream.next().await {
@@ -182,12 +198,10 @@ pub(crate) async fn hash_query_result(df: DataFrame) -> Result<String, PipelineE
 }
 
 pub(crate) fn stream_json_query(
-    df: DataFrame,
+    stream: SendableRecordBatchStream,
 ) -> impl Stream<Item = Result<ByteString, PipelineError>> {
     try_stream! {
-        let stream_executor = execute_stream(df).await.map_err(|e| PipelineError::AdHocQueryError { error: e.to_string(), df: None })?;
-        let mut stream = stream_executor
-            .map_err(|e| PipelineError::AdHocQueryError { error: e.to_string(), df: Some(Box::new(e)) })?;
+        let mut stream = stream;
         while let Some(batch) = stream.next().await {
             let batch = batch.map_err(PipelineError::from)?;
             let mut buf = Vec::with_capacity(4096);
@@ -247,15 +261,11 @@ impl AsyncFileWriter for ChannelWriter {
 /// <https://github.com/apache/arrow-rs/pull/9241>. Once that lands the
 /// per-batch buffering here can be replaced with a direct async sink.
 pub(crate) fn stream_arrow_query(
-    df: DataFrame,
+    stream: SendableRecordBatchStream,
+    schema: SchemaRef,
 ) -> impl Stream<Item = Result<Bytes, DataFusionError>> {
     try_stream! {
-        let schema = df.schema().inner().clone();
-        let mut stream = execute_stream(df)
-            .await
-            .map_err(|e| DataFusionError::Execution(format!(
-                "ad-hoc query worker did not return a stream: {e}"
-            )))??;
+        let mut stream = stream;
 
         // `try_new` writes the schema message to the inner buffer. The
         // `BytesMut` behind `BufMut::writer()` is a single allocation
@@ -294,7 +304,8 @@ pub(crate) fn stream_arrow_query(
 }
 
 pub(crate) fn stream_parquet_query(
-    df: DataFrame,
+    stream: SendableRecordBatchStream,
+    schema: SchemaRef,
 ) -> impl Stream<Item = Result<Bytes, DataFusionError>> {
     // Should probably be smaller than `MAX_WS_FRAME_SIZE`.
     const PARQUET_CHUNK_SIZE: usize = MAX_WS_FRAME_SIZE / 2;
@@ -304,10 +315,7 @@ pub(crate) fn stream_parquet_query(
 
     let mut stream_job = Box::pin(
         async move {
-            let schema = df.schema().inner().clone();
-            let mut stream = execute_stream(df)
-                .await
-                .expect("unable to receive stream")?;
+            let mut stream = stream;
 
             let mut writer = AsyncArrowWriter::try_new(
                 ChannelWriter::new(tx),
@@ -528,8 +536,11 @@ mod tests {
         ctx.register_table("t", Arc::new(mem)).unwrap();
         let df = ctx.sql("SELECT * FROM t ORDER BY id").await.unwrap();
 
+        let (record_stream, schema) = execute_adhoc_stream(df)
+            .await
+            .expect("execute_adhoc_stream failed to set up the query");
         let mut buf = Vec::<u8>::new();
-        let mut stream = Box::pin(stream_arrow_query(df));
+        let mut stream = Box::pin(stream_arrow_query(record_stream, schema));
         while let Some(chunk) = stream.next().await {
             buf.extend_from_slice(&chunk.expect("stream_arrow_query yielded an error"));
         }
@@ -596,8 +607,11 @@ mod tests {
             ctx.register_table("t", Arc::new(mem)).unwrap();
             let df = ctx.sql("SELECT * FROM t").await.unwrap();
 
+            let (record_stream, schema) = execute_adhoc_stream(df)
+                .await
+                .expect("execute_adhoc_stream failed to set up the query");
             let mut buf = Vec::<u8>::new();
-            let mut stream = Box::pin(stream_arrow_query(df));
+            let mut stream = Box::pin(stream_arrow_query(record_stream, schema));
             while let Some(chunk) = stream.next().await {
                 buf.extend_from_slice(&chunk.expect("stream_arrow_query yielded an error"));
             }

--- a/crates/pipeline-manager/src/api/main.rs
+++ b/crates/pipeline-manager/src/api/main.rs
@@ -578,8 +578,18 @@ fn build_app(
     let app = match auth_configuration {
         Some(auth_configuration) => {
             let auth_middleware = HttpAuthentication::with_fn(crate::auth::auth_validator);
-            app.app_data(auth_configuration.clone())
-                .service(api_scope().wrap(auth_middleware).wrap(cors))
+            app.app_data(auth_configuration.clone()).service(
+                api_scope()
+                    .wrap(auth_middleware)
+                    // Runs ahead of `auth_middleware` (last wrap = outermost):
+                    // browsers can't set the `Authorization` header on a
+                    // WebSocket handshake, so promote a token carried in a
+                    // `feldera-bearer.*` subprotocol to that header first.
+                    .wrap(middleware::from_fn(
+                        crate::auth::promote_websocket_subprotocol_auth,
+                    ))
+                    .wrap(cors),
+            )
         }
         None => app.service(
             api_scope()

--- a/crates/pipeline-manager/src/auth.rs
+++ b/crates/pipeline-manager/src/auth.rs
@@ -46,13 +46,21 @@
 
 use std::{collections::HashMap, env};
 
+use actix_web::body::MessageBody;
+use actix_web::http::header::{self, HeaderMap, HeaderName, HeaderValue};
+use actix_web::middleware::Next;
 use actix_web::HttpMessage;
-use actix_web::{dev::ServiceRequest, error::ErrorUnauthorized, web::Data};
+use actix_web::{
+    dev::{ServiceRequest, ServiceResponse},
+    error::ErrorUnauthorized,
+    web::Data,
+};
 use actix_web_httpauth::extractors::{
     bearer::{BearerAuth, Config},
     AuthenticationError,
 };
 use awc::error::JsonPayloadError;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use cached::{Cached, TimedCache};
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, TokenData, Validation};
 use rand::rngs::ThreadRng;
@@ -80,6 +88,60 @@ pub(crate) fn tag_with_default_tenant_id(req: ServiceRequest) -> ServiceRequest 
     req.extensions_mut()
         .insert(vec![ApiPermission::Read, ApiPermission::Write]);
     req
+}
+
+/// WebSocket subprotocol prefixes carrying authentication, base64url-encoded
+/// (no padding). Browsers cannot set the `Authorization` or `Feldera-Tenant`
+/// headers on a WebSocket handshake — the `WebSocket` constructor only accepts
+/// a URL and a list of subprotocols — so the web console passes the bearer
+/// token and the selected tenant as subprotocols instead. See
+/// [`promote_websocket_subprotocol_auth`].
+const WS_BEARER_PROTOCOL_PREFIX: &str = "feldera-bearer.";
+const WS_TENANT_PROTOCOL_PREFIX: &str = "feldera-tenant.";
+
+/// Decode the first `Sec-WebSocket-Protocol` entry that begins with `prefix`,
+/// treating the remainder as a base64url (no-padding) string. Returns `None`
+/// if the header is absent, no entry matches, or decoding fails.
+fn decode_ws_subprotocol(headers: &HeaderMap, prefix: &str) -> Option<String> {
+    let raw = headers.get("Sec-WebSocket-Protocol")?.to_str().ok()?;
+    let encoded = raw
+        .split(',')
+        .map(str::trim)
+        .find_map(|protocol| protocol.strip_prefix(prefix))?;
+    let bytes = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Promote a bearer token (and optional tenant) carried in WebSocket
+/// subprotocols to the standard `Authorization` / `Feldera-Tenant` headers, so
+/// the regular bearer-auth path ([`auth_validator`]) handles WebSocket
+/// handshakes without modification.
+///
+/// This runs ahead of the bearer-auth middleware. It is a no-op when an
+/// `Authorization` header is already present (ordinary HTTP requests) or when
+/// no `feldera-bearer.` subprotocol is offered, so it cannot weaken auth: the
+/// promoted token still goes through full validation downstream.
+pub(crate) async fn promote_websocket_subprotocol_auth(
+    mut req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    if !req.headers().contains_key(header::AUTHORIZATION) {
+        if let Some(token) = decode_ws_subprotocol(req.headers(), WS_BEARER_PROTOCOL_PREFIX) {
+            if let Ok(authorization) = HeaderValue::from_str(&format!("Bearer {token}")) {
+                req.headers_mut()
+                    .insert(header::AUTHORIZATION, authorization);
+                if let Some(tenant) =
+                    decode_ws_subprotocol(req.headers(), WS_TENANT_PROTOCOL_PREFIX)
+                {
+                    if let Ok(tenant) = HeaderValue::from_str(&tenant) {
+                        req.headers_mut()
+                            .insert(HeaderName::from_static(TENANT_HEADER), tenant);
+                    }
+                }
+            }
+        }
+    }
+    next.call(req).await
 }
 
 /// Creates a JSON error response for authentication failures

--- a/js-packages/web-console/src/lib/components/adhoc/Query.svelte
+++ b/js-packages/web-console/src/lib/components/adhoc/Query.svelte
@@ -221,7 +221,9 @@
                 </tr>
               {:else if 'error' in row}
                 <tr {style} class={itemHeight} use:selectScope tabindex={-1}>
-                  <td colspan="99999999" class="preset-tonal-error px-2">{row.error}</td>
+                  <td colspan="99999999"
+                    ><div class="rounded bg-error-50-950/50 px-2">{row.error}</div></td
+                  >
                 </tr>
               {:else}
                 <tr {style} class={itemHeight} use:selectScope tabindex={-1}>

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte
@@ -111,16 +111,28 @@
         // `RecordBatchReader.from` returns before the stream header has been parsed
         // for the async variant — `schema` is only populated after `open()`.
         await arrowReader.open()
-        if (cancelled) return
-        if (adhocQueries[tenantName][pipelineName].queries[i]?.result) {
+        if (cancelled) {
+          return
+        }
+        // A query that fails before producing a schema yields no arrow schema;
+        // the actual error is reported out of band (see `adHocQuery`).
+        if (arrowReader.schema && adhocQueries[tenantName][pipelineName].queries[i]?.result) {
           adhocQueries[tenantName][pipelineName].queries[i].result.columns.push(
             ...arrowSchemaToFelderaFields(arrowReader.schema)
           )
         }
         for await (const batch of arrowReader) {
-          if (cancelled) return
+          if (cancelled) {
+            return
+          }
           const rows: Row[] = arrowIpcBatchToJS(batch).map(({ row }) => ({ cells: row }) as Row)
           appendRows(rows)
+        }
+        // The arrow stream is always closed cleanly; a query error (up front or
+        // mid-stream) surfaces here so the catch below renders it.
+        const queryError = result.error?.()
+        if (queryError) {
+          throw queryError
         }
       } catch (e) {
         if (!cancelled) {

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.spec.ts
@@ -43,7 +43,8 @@ const oneShotStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
 // --- Mock only the network: adHocQuery returns the fixture as a stream ---
 const adHocQueryMock = vi.fn(async () => ({
   stream: oneShotStream(base64ToBytes(ARROW_IPC_BASE64)),
-  cancel: () => {}
+  cancel: () => {},
+  error: (): Error | undefined => undefined
 }))
 
 vi.mock('$lib/compositions/usePipelineManager.svelte', () => ({
@@ -131,5 +132,28 @@ describe('TabAdHocQuery.svelte — arrow_ipc result rendering', () => {
       '{\n "a": 7,\n "b": "inner"\n}',
       '{\n "alpha": 1\n}'
     ])
+  })
+
+  it('renders a query error reported out of band instead of crashing on a missing schema', async () => {
+    // A query that fails before producing any rows (e.g. selecting from a
+    // non-materialized source) closes the stream cleanly with no arrow schema;
+    // the message arrives via `error()`. Regression test: the UI must show the
+    // message, not "can't access property fields, schema is undefined".
+    const message = 'Execution error: Tried to SELECT from a non-materialized source'
+    adHocQueryMock.mockResolvedValueOnce({
+      stream: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close()
+        }
+      }),
+      cancel: () => {},
+      error: () => new Error(message)
+    })
+
+    render(TabAdHocQuery, { pipeline: pipelineProp('p-adhoc-arrow-error') })
+    await page.getByRole('textbox').first().fill('SELECT * FROM not_materialized')
+    await page.getByRole('button', { name: 'Run query' }).first().click()
+
+    await expect.element(page.getByText(message)).toBeInTheDocument()
   })
 })

--- a/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.test.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/editor/TabAdHocQuery.svelte.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration UI test: ad-hoc query runtime-error propagation over WebSocket.
+ *
+ * Requires a running (open-source / no-auth) Feldera instance. Run with:
+ *   bun run test-integration
+ *
+ * Creates a real pipeline with a single non-materialized table, starts it, then
+ * drives the *real* `TabAdHocQuery` end to end — the query runs against the live
+ * pipeline over the WebSocket transport (`adHocQuery`), and the test asserts
+ * that an error raised at query *runtime* (not at planning) is rendered in the
+ * result, rather than swallowed or surfaced as an internal "schema is undefined"
+ * crash.
+ *
+ * Two runtime errors are exercised:
+ *   - `select * from t` against a non-materialized source — an error raised when
+ *     execution starts (before any schema), delivered as a WebSocket text frame.
+ *   - a divide-by-zero over an inline `VALUES` relation — an error raised
+ *     mid-stream, after the schema, while evaluating a row.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-svelte'
+
+// `adHocQuery` derives its WebSocket URL from `felderaEndpoint`, which in a
+// browser is computed from `window.location` — here the vitest dev-server
+// origin, not the Feldera manager. Point it at the same origin the API client
+// uses (configureTestClient) so the WebSocket reaches the running instance.
+vi.mock('$lib/functions/configs/felderaEndpoint', () => {
+  const env = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {}
+  const felderaEndpoint = (
+    env.FELDERA_TEST_API_ORIGIN ??
+    env.PLAYWRIGHT_API_ORIGIN ??
+    'http://localhost:8080'
+  ).replace(/\/$/, '')
+  return { felderaEndpoint }
+})
+
+// `TabAdHocQuery` pulls in editor components that read `$app/state`.
+vi.mock('$app/state', () => ({
+  page: {
+    data: {
+      feldera: { version: 'test-runtime', unstableFeatures: [], edition: 'Open Source' }
+    },
+    url: new URL('http://localhost/')
+  }
+}))
+
+import { getExtendedPipeline, putPipeline } from '$lib/services/pipelineManager'
+import {
+  cleanupPipeline,
+  configureTestClient,
+  startPipelineAndWaitForRunning,
+  waitForCompilation,
+  type ExtendedPipeline
+} from '$lib/services/testPipelineHelpers'
+import TabAdHocQuery from './TabAdHocQuery.svelte'
+
+const PIPELINE_NAME = 'test-adhoc-query-errors'
+
+let pipeline: ExtendedPipeline
+
+describe('TabAdHocQuery — runtime error propagation over WebSocket', () => {
+  beforeAll(async () => {
+    configureTestClient()
+    await cleanupPipeline(PIPELINE_NAME)
+    await putPipeline(PIPELINE_NAME, {
+      name: PIPELINE_NAME,
+      // `t` is non-materialized (no `materialized = 'true'`), so selecting from
+      // it directly is a runtime error.
+      program_code: 'create table t (x int);',
+      runtime_config: {}
+    })
+    await waitForCompilation(PIPELINE_NAME, 120_000)
+    await startPipelineAndWaitForRunning(PIPELINE_NAME, 60_000)
+    pipeline = await getExtendedPipeline(PIPELINE_NAME)
+  }, 180_000)
+
+  afterAll(async () => {
+    await cleanupPipeline(PIPELINE_NAME)
+  }, 60_000)
+
+  // Render the tab against the running pipeline, type `sql`, and run it.
+  const runQuery = async (sql: string) => {
+    const { unmount } = render(TabAdHocQuery, {
+      pipeline: { current: pipeline },
+      deleted: false
+    })
+    await page.getByRole('textbox').first().fill(sql)
+    await page.getByRole('button', { name: 'Run query' }).first().click()
+    return unmount
+  }
+
+  it('renders the execution error for a non-materialized SELECT', async () => {
+    const unmount = await runQuery('select * from t')
+    // e.g. "Execution error: Tried to SELECT from a non-materialized source. ..."
+    await expect
+      .element(page.getByText('Tried to SELECT from a non-materialized source', { exact: false }))
+      .toBeInTheDocument()
+    unmount()
+  }, 60_000)
+
+  it('renders the arrow runtime error for a divide-by-zero', async () => {
+    const unmount = await runQuery('SELECT 100 / d AS v FROM (VALUES (5), (2), (0), (1)) AS t(d)')
+    // e.g. "Arrow error: Divide by zero error"
+    await expect.element(page.getByText('Divide by zero', { exact: false })).toBeInTheDocument()
+    unmount()
+  }, 60_000)
+})

--- a/js-packages/web-console/src/lib/services/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/services/pipelineManager.ts
@@ -841,20 +841,25 @@ const getAuthenticatedFetch = (options?: FetchOptions): typeof globalThis.fetch 
 }
 
 function formatValue(details: unknown): string {
+  if (!details) {
+    return ''
+  }
   if (typeof details === 'string') {
     return details
   }
 
-  // Pretty‑print objects, arrays, numbers, booleans, etc.
+  // Pretty‑print objects, arrays, numbers, booleans, etc., dropping any
+  // `error` field that merely duplicates the message shown above it.
   try {
-    return JSON.stringify(details, null, 2)
+    const json = JSON.stringify(details, (key, value) => (key === 'error' ? undefined : value), 2)
+    return json === '{}' ? '' : json
   } catch {
     return String(details)
   }
 }
 
 const apiErrorText = (error: ErrorResponse) => {
-  return `${error.message}${error.details ? `\n${formatValue(error.details)}` : ''}`
+  return `${error.message}\n${formatValue(error.details)}`
 }
 
 const streamingFetch = (

--- a/js-packages/web-console/src/lib/services/pipelineManager.ts
+++ b/js-packages/web-console/src/lib/services/pipelineManager.ts
@@ -74,7 +74,7 @@ import JSONbig from 'true-json-bigint'
 import { singleton } from '$lib/functions/common/array'
 import { tuple } from '$lib/functions/common/tuple'
 import { felderaEndpoint } from '$lib/functions/configs/felderaEndpoint'
-import { applyAuthToRequest, handleAuthResponse } from '$lib/services/auth'
+import { applyAuthToRequest, getAuthorizationHeaders, handleAuthResponse } from '$lib/services/auth'
 import { createClient } from '$lib/services/manager/client'
 
 const unauthenticatedClient = createClient({
@@ -954,14 +954,118 @@ export const pipelineLogsStream = async (
   )
 }
 
-export const adHocQuery = async (pipelineName: string, query: string, options?: FetchOptions) => {
-  return streamResponse(
-    streamingFetch(
-      getAuthenticatedFetch(options),
-      `${felderaEndpoint}/v0/pipelines/${pipelineName}/query?sql=${encodeURIComponent(query)}&format=arrow_ipc`,
-      {}
-    )
-  )
+const httpToWs = (endpoint: string) => endpoint.replace(/^http(s?):\/\//, 'ws$1://')
+
+// base64url (no padding) — the only encoding whose alphabet is a valid
+// WebSocket subprotocol token, so it can carry the bearer token/tenant.
+const base64UrlEncode = (value: string): string =>
+  btoa(String.fromCharCode(...new TextEncoder().encode(value)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+
+// Extract a human-readable message from an ad-hoc error frame, which the
+// server sends as a serialized `PipelineError` (JSON) over the websocket.
+const adhocErrorText = (raw: string): string => {
+  try {
+    const body = JSON.parse(raw)
+    if (body && typeof body === 'object') {
+      if ('message' in body) {
+        return apiErrorText(body as ErrorResponse)
+      }
+      if ('error' in body && typeof body.error === 'string') {
+        return body.error
+      }
+    }
+  } catch {
+    // Not JSON — fall through to the raw text.
+  }
+  return raw
+}
+
+/**
+ * Runs an ad-hoc query over a WebSocket and returns its Arrow IPC result as a
+ * byte stream (or an `Error` if the socket cannot be created).
+ *
+ * The WebSocket transport carries the result as binary frames and reports a
+ * query error as a single text frame followed by an error close; that text
+ * frame surfaces as a stream error, so the caller's existing arrow-decode
+ * error handling reports it — without having to encode the error into the
+ * result stream itself.
+ *
+ * Browsers cannot set the `Authorization` header on a WebSocket handshake, so
+ * the bearer token and selected tenant are passed as `feldera-bearer.*` /
+ * `feldera-tenant.*` subprotocols; the manager promotes them back to headers
+ * (see `promote_websocket_subprotocol_auth` in the pipeline manager).
+ */
+export const adHocQuery = async (pipelineName: string, query: string) => {
+  const url = `${httpToWs(felderaEndpoint)}/v0/pipelines/${pipelineName}/query`
+
+  const authHeaders = await getAuthorizationHeaders()
+  const protocols: string[] = []
+  const token = authHeaders['Authorization']?.replace(/^Bearer /, '')
+  if (token) {
+    protocols.push(`feldera-bearer.${base64UrlEncode(token)}`)
+    const tenant = authHeaders['Feldera-Tenant']
+    if (tenant) {
+      protocols.push(`feldera-tenant.${base64UrlEncode(tenant)}`)
+    }
+  }
+
+  let ws: WebSocket
+  try {
+    ws = new WebSocket(url, protocols)
+  } catch (e) {
+    return e instanceof Error ? e : new Error(String(e))
+  }
+  ws.binaryType = 'arraybuffer'
+
+  // Errors are reported out of band rather than via `controller.error`:
+  // apache-arrow's ReadableStream adapter swallows a stream error (it cancels
+  // and ends the stream instead of rethrowing), so the byte stream is always
+  // closed cleanly and the caller inspects `error()` after draining it.
+  let streamError: Error | undefined
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let settled = false
+      const close = () => {
+        if (settled) {
+          return
+        }
+        settled = true
+        controller.close()
+      }
+      ws.onopen = () => ws.send(JSON.stringify({ sql: query, format: 'arrow_ipc' }))
+      ws.onmessage = (event) => {
+        if (typeof event.data === 'string') {
+          // Query error: a text frame carrying the message, then a close.
+          streamError ??= new Error(adhocErrorText(event.data))
+          close()
+          ws.close()
+          return
+        }
+        if (!settled) {
+          controller.enqueue(new Uint8Array(event.data as ArrayBuffer))
+        }
+      }
+      ws.onclose = (event) => {
+        // An abnormal close with no preceding error frame (e.g. a failed
+        // handshake or a dropped connection) still has to surface something.
+        if (streamError === undefined && event.code !== 1000 && event.code !== 1005) {
+          streamError = new Error(
+            event.reason || `Connection to the pipeline closed (code ${event.code})`
+          )
+        }
+        close()
+      }
+    },
+    cancel() {
+      ws.close()
+    }
+  })
+
+  return { stream, cancel: () => ws.close(), error: () => streamError }
 }
 
 export const pipelineTimeSeriesStream = async (pipelineName: string, options?: FetchOptions) => {

--- a/python/tests/runtime/test_adhoc_queries.py
+++ b/python/tests/runtime/test_adhoc_queries.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from pathlib import Path
 
+from feldera.rest.errors import FelderaAPIError
 from tests import TEST_CLIENT
 from tests.shared_test_pipeline import SharedTestPipeline, sql
 
@@ -216,9 +217,16 @@ class TestAdhocQueries(SharedTestPipeline):
         )
         assert "ERROR" in error_text.upper()
 
-        # Non-materialized table direct access should fail
-        res = list(self.pipeline.query("SELECT * FROM not_materialized"))
-        assert res and "error" in res[0]
+        # Non-materialized table direct access fails up front. The server
+        # reports this as an error response (HTTP 400) rather than a 200
+        # whose streamed body carries the error, so the query throws.
+        nonmat_ok = False
+        try:
+            list(self.pipeline.query("SELECT * FROM not_materialized"))
+        except FelderaAPIError as e:
+            nonmat_ok = True
+            assert "materialized" in str(e), f"unexpected error: {e}"
+        assert nonmat_ok, "Expected querying a non-materialized table to raise"
 
         # INSERT into materialized t1 using JSON query endpoint (to retrieve count row)
         insert_resp = list(
@@ -253,14 +261,22 @@ class TestAdhocQueries(SharedTestPipeline):
             self._count("SELECT COUNT(*) AS c FROM lateness_table3_materialized") == 3
         )
 
-        # FIXME: this should raise an exception, but it currently doesn't.
-        # https://github.com/feldera/feldera/issues/4973
-        result = list(
-            self.pipeline.query(
-                "SELECT COUNT(*) AS c FROM lateness_table1_not_materialized"
+        # This table is non-materialized because of the lateness attribute on
+        # its primary key. Querying it directly fails up front with an error
+        # response (HTTP 400), so the query throws.
+        lateness_nonmat_ok = False
+        try:
+            list(
+                self.pipeline.query(
+                    "SELECT COUNT(*) AS c FROM lateness_table1_not_materialized"
+                )
             )
+        except FelderaAPIError as e:
+            lateness_nonmat_ok = True
+            assert "materialized" in str(e), f"unexpected error: {e}"
+        assert lateness_nonmat_ok, (
+            "Expected querying a non-materialized lateness table to raise"
         )
-        assert len(result) == 1 and "Execution error" in str(result[0])
 
     @sql(
         """CREATE TABLE "TaBle1"(id bigint not null) WITH ('materialized' = 'true');"""


### PR DESCRIPTION
**[adapters] Hoist adhoc query processing to return errors early**
[web-console] Improve ad-hoc error rendering and formatting (remove message duplication)

The datafusion errors that occur during query setup did not get reported when querying over HTTP because the backend already yielded error status 200, and just interrupted the stream when the error was thrown.

This PR starts the query before deciding the HTTP status. If the query fails to start, the pipeline now returns the HTTP 400 error response with the error message, so the error shows up in the client. If the query starts cleanly, the pipeline responds with HTTP 200 OK and stream the results as before.

No significant delay is introduced - only extra milliseconds are spent waiting for query planning and SQL types header generation; the initial respone does not wait for the first data bytes to be generated.

Related issue: https://github.com/feldera/feldera/issues/4973

**[web-console] Run ad-hoc queries over a WebSocket**

Firstly, browsers can't directly set Authorization header on websocket handshake request (through the `new WebSocket` API), so pipeline-manager extended websocket request authorizaiton through a field in the `Sec-WebSocket-Protocol` header which is a convention to work around this problem. This allowed to switch web-console's ad-hoc queries to websocket even on authenticated connection

=========

Testing: manual both in unauthenticated and authenticated pipeline-manager, added unit test, added UI e2e test that checks for expected runtime adhoc errors to appear

Fix https://github.com/feldera/feldera/issues/6340

<img width="3336" height="658" alt="image" src="https://github.com/user-attachments/assets/35a29566-0bdd-4f54-9b02-3bc90246dff6" />
