### PR TITLE
Bump major Node.js version in the build environment to 24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ## Install nodejs
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=20
+ENV NODE_MAJOR=24
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt update --fix-missing && apt install -y nodejs
 

--- a/deploy/build.Dockerfile
+++ b/deploy/build.Dockerfile
@@ -67,7 +67,7 @@ RUN  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmo
 ## Install nodejs
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=20
+ENV NODE_MAJOR=24
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update --fix-missing && apt-get install -y nodejs
 

--- a/js-packages/web-console/README.md
+++ b/js-packages/web-console/README.md
@@ -10,7 +10,7 @@ sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-NODE_MAJOR=20
+NODE_MAJOR=24
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 sudo apt-get update
 sudo apt-get install nodejs -y


### PR DESCRIPTION
After running `bun run clean` in the repo root for good measure (a custom script that cleans up all JS package, build cache and artifacts) and re-building pipeline-manager I did not observe any build issues, which is expected.