### PR TITLE
pipeline-manager: limit pipeline name to 63 characters and pattern

### DIFF
--- a/crates/pipeline-manager/demos/README.md
+++ b/crates/pipeline-manager/demos/README.md
@@ -40,7 +40,7 @@ The format is as follows:
 ... with the following constraints:
 
 - `[title]` is non-empty and at most 100 characters.
-- `[pipeline-name]` adheres to the name constraints: at most 100 characters and follow pattern `[a-zA-Z0-9_-]+`.
+- `[pipeline-name]` adheres to the name constraints: at most 63 characters and follow pattern `([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]`.
 - There must be at least one `[description-line]`.
 - All `[description-line]` joined together as description is non-empty and at most 1000 characters.
 - The whitespace at the end of each preamble line is ignored.
@@ -49,15 +49,15 @@ The format is as follows:
 
 **How to validate: regular expression**
 ```regexp
-^-- (.+) \(([a-zA-Z0-9_-]+)\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n
+^-- (.+) \((([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n
 ```
 ... with afterward:
-- First group is title, second group is name, and third group is description lines.
+- First group is title, second group is name, and fourth group is description lines.
 - The description lines can then be parsed by finding in it all regex matches of `-- .+\r?\n`,
   of each removing the `-- ` prefix and trimming whitespace, finally join with
   a space character (` `), and trim whitespace.
 - Trim whitespace from the title, and check it is non-empty and at most 100 characters
-- Check name is at most 100 characters
+- Check name is at most 63 characters
 - Check description is at most 1000 characters
 
 ## Example

--- a/crates/pipeline-manager/demos/validate-preamble.py
+++ b/crates/pipeline-manager/demos/validate-preamble.py
@@ -9,7 +9,7 @@ import sys
 
 # Format the SQL must adhere to
 SQL_FORMAT_REGEX_PATTERN = re.compile(
-    "^-- (.+) \\(([a-zA-Z0-9_-]+)\\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n"
+    "^-- (.+) \\((([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9])\\)[ \t]*\r?\n--[ \t]*\r?\n((-- .+\r?\n)+)--[ \t]*\r?\n"
 )
 
 # Format of each description line
@@ -29,7 +29,7 @@ def main():
         # Extract from the SQL preamble the metadata
         title = result.group(1).strip()
         name = result.group(2)
-        description_lines = result.group(3)
+        description_lines = result.group(4)
 
         # Post-process description lines
         description_match = re.findall(SQL_FORMAT_DESCRIPTION_LINE, description_lines)
@@ -50,8 +50,8 @@ def main():
             print(f"FAIL: title '{title}' exceeds 100 characters")
             exit(1)
         # Name is already checked to be non-empty due to regex
-        if len(name) > 100:
-            print(f"FAIL: name '{name}' exceeds 100 characters")
+        if len(name) > 63:
+            print(f"FAIL: name '{name}' exceeds 63 characters")
             exit(1)
         if len(description) == 0:
             print("FAIL: description is empty")

--- a/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
+++ b/crates/pipeline-manager/src/api/endpoints/pipeline_management.rs
@@ -984,7 +984,7 @@ pub(crate) async fn get_pipeline(
         (status = BAD_REQUEST
             , body = ErrorResponse
             , examples(
-                ("Name does not match pattern" = (value = json!(examples::error_name_does_not_match_pattern())))
+                ("Name does not match pattern" = (value = json!(examples::error_pipeline_name_does_not_match_pattern())))
             )
         ),
         (status = INTERNAL_SERVER_ERROR, body = ErrorResponse),
@@ -1050,7 +1050,7 @@ pub(crate) async fn post_pipeline(
         (status = BAD_REQUEST
             , body = ErrorResponse
             , examples(
-                ("Name does not match pattern" = (value = json!(examples::error_name_does_not_match_pattern()))),
+                ("Name does not match pattern" = (value = json!(examples::error_pipeline_name_does_not_match_pattern()))),
                 ("Cannot update non-stopped pipeline" = (value = json!(examples::error_update_restricted_to_stopped())))
             )
         ),
@@ -1134,7 +1134,7 @@ pub(crate) async fn put_pipeline(
         (status = BAD_REQUEST
             , body = ErrorResponse
             , examples(
-                ("Name does not match pattern" = (value = json!(examples::error_name_does_not_match_pattern()))),
+                ("Name does not match pattern" = (value = json!(examples::error_pipeline_name_does_not_match_pattern()))),
                 ("Cannot update non-stopped pipeline" = (value = json!(examples::error_update_restricted_to_stopped())))
             )
         ),
@@ -1224,7 +1224,7 @@ pub(crate) async fn patch_pipeline(
         (status = BAD_REQUEST
             , body = ErrorResponse
             , examples(
-                ("Name does not match pattern" = (value = json!(examples::error_name_does_not_match_pattern()))),
+                ("Name does not match pattern" = (value = json!(examples::error_pipeline_name_does_not_match_pattern()))),
                 ("Cannot update non-stopped pipeline" = (value = json!(examples::error_update_restricted_to_stopped())))
             )
         ),

--- a/crates/pipeline-manager/src/api/examples.rs
+++ b/crates/pipeline-manager/src/api/examples.rs
@@ -13,6 +13,7 @@ use crate::db::types::resources_status::{ResourcesDesiredStatus, ResourcesStatus
 use crate::db::types::storage::StorageStatus;
 use crate::db::types::utils::{
     validate_program_config, validate_program_info, validate_runtime_config,
+    PATTERN_KUBERNETES_LABEL_VALUE, PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION,
 };
 use crate::db::types::version::Version;
 use crate::runner::error::RunnerError;
@@ -356,9 +357,11 @@ pub(crate) fn error_duplicate_name() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&DBError::DuplicateName)
 }
 
-pub(crate) fn error_name_does_not_match_pattern() -> ErrorResponse {
+pub(crate) fn error_pipeline_name_does_not_match_pattern() -> ErrorResponse {
     ErrorResponse::from_error_nolog(&DBError::NameDoesNotMatchPattern {
         name: "name-with-invalid-char-#".to_string(),
+        pattern: PATTERN_KUBERNETES_LABEL_VALUE.to_string(),
+        pattern_description: PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION.to_string(),
     })
 }
 

--- a/crates/pipeline-manager/src/db/error.rs
+++ b/crates/pipeline-manager/src/db/error.rs
@@ -123,6 +123,8 @@ pub enum DBError {
     },
     NameDoesNotMatchPattern {
         name: String,
+        pattern: String,
+        pattern_description: String,
     },
     // Tenant-related errors
     UnknownTenant {
@@ -526,8 +528,15 @@ impl Display for DBError {
                     "Name '{name}' is longer ({length}) than maximum allowed ({maximum})"
                 )
             }
-            DBError::NameDoesNotMatchPattern { name } => {
-                write!(f, "Name '{name}' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)")
+            DBError::NameDoesNotMatchPattern {
+                name,
+                pattern,
+                pattern_description,
+            } => {
+                write!(
+                    f,
+                    "Name '{name}' should {pattern_description} (pattern: '{pattern}')"
+                )
             }
             DBError::UnknownTenant { tenant_id } => {
                 write!(f, "Unknown tenant id '{tenant_id}'")

--- a/crates/pipeline-manager/src/db/operations/api_key.rs
+++ b/crates/pipeline-manager/src/db/operations/api_key.rs
@@ -6,7 +6,7 @@ use crate::db::types::api_key::{
     ApiKeyDescr, ApiKeyId, ApiPermission, API_PERMISSION_READ, API_PERMISSION_WRITE,
 };
 use crate::db::types::tenant::TenantId;
-use crate::db::types::utils::validate_name;
+use crate::db::types::utils::validate_api_key_name;
 use deadpool_postgres::Transaction;
 use openssl::sha;
 use std::str::FromStr;
@@ -86,7 +86,7 @@ pub async fn store_api_key_hash(
     key: &str,
     scopes: Vec<ApiPermission>,
 ) -> Result<(), DBError> {
-    validate_name(name)?;
+    validate_api_key_name(name)?;
     let mut hasher = sha::Sha256::new();
     hasher.update(key.as_bytes());
     let hash = openssl::base64::encode_block(&hasher.finish());

--- a/crates/pipeline-manager/src/db/operations/pipeline.rs
+++ b/crates/pipeline-manager/src/db/operations/pipeline.rs
@@ -25,8 +25,8 @@ use crate::db::types::resources_status::{
 use crate::db::types::storage::{validate_storage_status_transition, StorageStatus};
 use crate::db::types::tenant::TenantId;
 use crate::db::types::utils::{
-    validate_deployment_config, validate_name, validate_program_config, validate_program_info,
-    validate_runtime_config, validate_storage_status_details,
+    validate_deployment_config, validate_pipeline_name, validate_program_config,
+    validate_program_info, validate_runtime_config, validate_storage_status_details,
 };
 use crate::db::types::version::Version;
 use deadpool_postgres::Transaction;
@@ -176,7 +176,7 @@ pub(crate) async fn new_pipeline(
     platform_version: &str,
     pipeline: PipelineDescr,
 ) -> Result<(PipelineId, Version), DBError> {
-    validate_name(&pipeline.name)?;
+    validate_pipeline_name(&pipeline.name)?;
     // Validate runtime configuration JSON when deserializing it
     // and reserialize it to have it contain current default values
     let runtime_config =
@@ -297,7 +297,7 @@ pub(crate) async fn update_pipeline(
     program_config: &Option<serde_json::Value>,
 ) -> Result<Version, DBError> {
     if let Some(name) = name {
-        validate_name(name)?;
+        validate_pipeline_name(name)?;
     }
 
     // Validate runtime configuration JSON when deserializing it

--- a/crates/pipeline-manager/src/db/test.rs
+++ b/crates/pipeline-manager/src/db/test.rs
@@ -25,8 +25,9 @@ use crate::db::types::resources_status::{
 use crate::db::types::storage::{validate_storage_status_transition, StorageStatus};
 use crate::db::types::tenant::TenantId;
 use crate::db::types::utils::{
-    validate_deployment_config, validate_name, validate_program_config, validate_program_info,
-    validate_runtime_config, validate_storage_status_details,
+    validate_api_key_name, validate_deployment_config, validate_pipeline_name,
+    validate_program_config, validate_program_info, validate_runtime_config,
+    validate_storage_status_details,
 };
 use crate::db::types::version::Version;
 use async_trait::async_trait;
@@ -3855,7 +3856,7 @@ impl ModelHelpers for Mutex<DbModel> {
         program_config: &Option<serde_json::Value>,
     ) -> Result<ExtendedPipelineDescr, DBError> {
         if let Some(name) = name {
-            validate_name(name)?;
+            validate_pipeline_name(name)?;
         }
         if let Some(runtime_config) = runtime_config {
             validate_runtime_config(runtime_config, false).map_err(|e| {
@@ -4250,7 +4251,7 @@ impl Storage for Mutex<DbModel> {
         permissions: Vec<ApiPermission>,
     ) -> DBResult<()> {
         let mut s = self.lock().await;
-        validate_name(name)?;
+        validate_api_key_name(name)?;
         let mut hasher = sha::Sha256::new();
         hasher.update(key.as_bytes());
         let hash = openssl::base64::encode_block(&hasher.finish());
@@ -4411,7 +4412,7 @@ impl Storage for Mutex<DbModel> {
     ) -> Result<ExtendedPipelineDescr, DBError> {
         let mut state = self.lock().await;
 
-        validate_name(&pipeline.name)?;
+        validate_pipeline_name(&pipeline.name)?;
         validate_runtime_config(&pipeline.runtime_config, false).map_err(|e| {
             DBError::InvalidRuntimeConfig {
                 value: pipeline.runtime_config.clone(),

--- a/crates/pipeline-manager/src/db/types/program.rs
+++ b/crates/pipeline-manager/src/db/types/program.rs
@@ -1,7 +1,7 @@
 use crate::config::CompilerConfig;
 use crate::db::error::DBError;
 use crate::db::types::pipeline::PipelineId;
-use crate::db::types::utils::validate_name;
+use crate::db::types::utils::validate_connector_name;
 use crate::has_unstable_feature;
 use clap::Parser;
 use feldera_ir::Dataflow;
@@ -572,7 +572,7 @@ fn parse_named_connectors(
                 })?;
             for connector in &connectors {
                 if let Some(name) = &connector.name {
-                    validate_name(name).map_err(|e| {
+                    validate_connector_name(name).map_err(|e| {
                         ConnectorGenerationError::InvalidPropertyValue {
                             position: value.value_position,
                             relation: relation.sql_name(),

--- a/crates/pipeline-manager/src/db/types/utils.rs
+++ b/crates/pipeline-manager/src/db/types/utils.rs
@@ -11,34 +11,94 @@ use tracing::error;
 // Utility functions related to types which are stored in the database.
 // The functions center around serialization, deserialization and validation.
 
-/// Pattern that every name must adhere to.
-pub const PATTERN_VALID_NAME: &str = r"^[a-zA-Z0-9_-]+$";
+/// Pattern for non-empty string containing lowercase (a-z), uppercase (A-Z),
+/// number (0-9), underscore (_) or hyphen (-) characters.
+const PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN: &str = r"^[a-zA-Z0-9_-]+$";
 
-/// Maximum name length.
-pub const MAXIMUM_NAME_LENGTH: usize = 100;
+/// Description of the non-empty alphanumeric-underscore-hyphen pattern.
+const PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION: &str = "be non-empty and only \
+contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters";
+
+/// The pattern is almost the same as for Kubernetes label values but slightly stricter.
+/// Pattern for non-empty string containing lowercase (a-z), uppercase (A-Z),
+/// number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end
+/// with hyphen or underscore. In addition to Kubernetes label constraints, we do not
+/// allow dot characters or empty strings.
+pub const PATTERN_KUBERNETES_LABEL_VALUE: &str = r"^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$";
+
+/// Description of the Kubernetes label value pattern.
+pub const PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION: &str = "be non-empty and only contain \
+lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but \
+cannot start or end with hyphen or underscore";
+
+/// Maximum API key name length.
+pub(crate) const MAXIMUM_API_KEY_NAME_LENGTH: usize = 100;
+
+/// Maximum pipeline name length.
+/// It is limited to 63 to make it fit in a Kubernetes label value.
+pub(crate) const MAXIMUM_PIPELINE_NAME_LENGTH: usize = 63;
+
+/// Maximum connector name length.
+pub(crate) const MAXIMUM_CONNECTOR_NAME_LENGTH: usize = 100;
+
+/// Checks the provided API key name is valid.
+pub fn validate_api_key_name(name: &str) -> Result<(), DBError> {
+    validate_name(
+        name,
+        MAXIMUM_API_KEY_NAME_LENGTH,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION,
+    )
+}
+
+/// Checks the provided pipeline name is valid.
+pub fn validate_pipeline_name(name: &str) -> Result<(), DBError> {
+    validate_name(
+        name,
+        MAXIMUM_PIPELINE_NAME_LENGTH,
+        PATTERN_KUBERNETES_LABEL_VALUE,
+        PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION,
+    )
+}
+
+/// Checks the provided connector name is valid.
+pub fn validate_connector_name(name: &str) -> Result<(), DBError> {
+    validate_name(
+        name,
+        MAXIMUM_CONNECTOR_NAME_LENGTH,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION,
+    )
+}
 
 /// Checks whether the provided name is valid.
 /// The constraints are as follows:
 /// - It cannot be empty
-/// - It must be at most 100 characters long
-/// - It must contain only characters which are lowercase (a-z), uppercase (A-Z),
-//    numbers (0-9), underscores (_) or hyphens (-)
-pub fn validate_name(name: &str) -> Result<(), DBError> {
+/// - It must be at most `length_limit` characters long
+/// - It must contain characters that follow the `pattern`
+fn validate_name(
+    name: &str,
+    length_limit: usize,
+    pattern: &str,
+    pattern_description: &str,
+) -> Result<(), DBError> {
     if name.is_empty() {
         Err(DBError::EmptyName)
-    } else if name.len() > MAXIMUM_NAME_LENGTH {
+    } else if name.len() > length_limit {
         Err(DBError::TooLongName {
             name: name.to_string(),
             length: name.len(),
-            maximum: MAXIMUM_NAME_LENGTH,
+            maximum: length_limit,
         })
     } else {
-        let re = Regex::new(PATTERN_VALID_NAME).expect("Pattern for name must be valid");
+        let re = Regex::new(pattern).expect("Pattern for name must be valid");
         if re.is_match(name) {
             Ok(())
         } else {
             Err(DBError::NameDoesNotMatchPattern {
                 name: name.to_string(),
+                pattern: pattern.to_string(),
+                pattern_description: pattern_description.to_string(),
             })
         }
     }
@@ -158,8 +218,13 @@ pub(crate) fn validate_storage_status_details(
 #[cfg(test)]
 mod tests {
     use super::{
-        validate_deployment_config, validate_name, validate_program_config, validate_program_info,
-        validate_runtime_config, ValidationError,
+        validate_api_key_name, validate_connector_name, validate_deployment_config,
+        validate_pipeline_name, validate_program_config, validate_program_info,
+        validate_runtime_config, ValidationError, MAXIMUM_API_KEY_NAME_LENGTH,
+        MAXIMUM_CONNECTOR_NAME_LENGTH, MAXIMUM_PIPELINE_NAME_LENGTH,
+        PATTERN_KUBERNETES_LABEL_VALUE, PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN,
+        PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION,
     };
     use crate::db::error::DBError;
     use crate::db::types::program::{CompilationProfile, ProgramConfig, ProgramInfo};
@@ -169,6 +234,7 @@ mod tests {
 
     #[test]
     fn test_valid_names() {
+        // API key name
         let valid = vec![
             "a",
             "z",
@@ -176,8 +242,12 @@ mod tests {
             "Z",
             "0",
             "9",
+            "A-a",
+            "A_a",
             "-",
             "_",
+            "_-",
+            "_a-",
             "exampleExample",
             "example-1",
             "example-of-this",
@@ -187,24 +257,143 @@ mod tests {
             "EXAMPLE_example-example1234",
         ];
         for name in valid {
-            assert!(validate_name(name).is_ok());
+            assert!(validate_api_key_name(name).is_ok());
         }
+        assert!(validate_api_key_name(&"a".repeat(MAXIMUM_API_KEY_NAME_LENGTH)).is_ok());
+        assert!(validate_api_key_name(&"a".repeat(MAXIMUM_API_KEY_NAME_LENGTH - 1)).is_ok());
+
+        // Pipeline name
+        let valid = vec![
+            "a",
+            "z",
+            "A",
+            "Z",
+            "0",
+            "9",
+            "A-a",
+            "A_a",
+            "exampleExample",
+            "example-1",
+            "example-of-this",
+            "Aa0",
+            "example_2",
+            "Example",
+            "EXAMPLE_example-example1234",
+        ];
+        for name in valid {
+            assert!(validate_pipeline_name(name).is_ok());
+        }
+        assert!(validate_pipeline_name(&"a".repeat(MAXIMUM_PIPELINE_NAME_LENGTH)).is_ok());
+        assert!(validate_pipeline_name(&"a".repeat(MAXIMUM_PIPELINE_NAME_LENGTH - 1)).is_ok());
+
+        // Connector name
+        let valid = vec![
+            "a",
+            "z",
+            "A",
+            "Z",
+            "0",
+            "9",
+            "A-a",
+            "A_a",
+            "-",
+            "_",
+            "_-",
+            "_a-",
+            "exampleExample",
+            "example-1",
+            "example-of-this",
+            "Aa0_-",
+            "example_2",
+            "Example",
+            "EXAMPLE_example-example1234",
+        ];
+        for name in valid {
+            assert!(validate_connector_name(name).is_ok());
+        }
+        assert!(validate_connector_name(&"a".repeat(MAXIMUM_CONNECTOR_NAME_LENGTH)).is_ok());
+        assert!(validate_connector_name(&"a".repeat(MAXIMUM_CONNECTOR_NAME_LENGTH - 1)).is_ok());
     }
 
     #[test]
     fn test_invalid_names() {
-        assert!(matches!(validate_name(""), Err(DBError::EmptyName)));
+        // API key name
+        assert!(matches!(validate_api_key_name(""), Err(DBError::EmptyName)));
+        let just_exceeds_max_string = "a".repeat(MAXIMUM_API_KEY_NAME_LENGTH + 1);
         assert!(
-            matches!(validate_name("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), Err(DBError::TooLongName {
+            matches!(validate_api_key_name(&just_exceeds_max_string), Err(DBError::TooLongName {
             name, length, maximum
-        }) if name == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" && length == 101 && maximum == 100)
+        }) if name == just_exceeds_max_string && length == MAXIMUM_API_KEY_NAME_LENGTH + 1 && maximum == MAXIMUM_API_KEY_NAME_LENGTH)
         );
-        let invalid_due_to_pattern = vec!["%", "$", "abc@", "example example", " ", "%20"];
+        let invalid_due_to_pattern =
+            vec!["%", "$", "abc@", "example example", "a.b", ".", " ", "%20"];
         for invalid_name in invalid_due_to_pattern {
             assert!(
-                matches!(validate_name(invalid_name), Err(DBError::NameDoesNotMatchPattern {
-                name
-            }) if name == invalid_name)
+                matches!(validate_api_key_name(invalid_name), Err(DBError::NameDoesNotMatchPattern {
+                    name,
+                    pattern,
+                    pattern_description,
+                }) if name == invalid_name && pattern == PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN && pattern_description == PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION)
+            );
+        }
+
+        // Pipeline name
+        assert!(matches!(
+            validate_pipeline_name(""),
+            Err(DBError::EmptyName)
+        ));
+        let just_exceeds_max_string = "a".repeat(MAXIMUM_PIPELINE_NAME_LENGTH + 1);
+        assert!(
+            matches!(validate_pipeline_name(&just_exceeds_max_string), Err(DBError::TooLongName {
+            name, length, maximum
+        }) if name == just_exceeds_max_string && length == MAXIMUM_PIPELINE_NAME_LENGTH + 1 && maximum == MAXIMUM_PIPELINE_NAME_LENGTH)
+        );
+        let invalid_due_to_pattern = vec![
+            "%",
+            "$",
+            "abc@",
+            "example example",
+            " ",
+            "%20",
+            "-",
+            "_",
+            "_-",
+            "_a-",
+            "Aa0_-",
+            "_Aa0-",
+            "a.b",
+            ".",
+        ];
+        for invalid_name in invalid_due_to_pattern {
+            assert!(
+                matches!(validate_pipeline_name(invalid_name), Err(DBError::NameDoesNotMatchPattern {
+                    name,
+                    pattern,
+                    pattern_description,
+                }) if name == invalid_name && pattern == PATTERN_KUBERNETES_LABEL_VALUE && pattern_description == PATTERN_KUBERNETES_LABEL_VALUE_DESCRIPTION)
+            );
+        }
+
+        // Connector name
+        assert!(matches!(
+            validate_connector_name(""),
+            Err(DBError::EmptyName)
+        ));
+        let just_exceeds_max_string = "a".repeat(MAXIMUM_CONNECTOR_NAME_LENGTH + 1);
+        assert!(
+            matches!(validate_connector_name(&just_exceeds_max_string), Err(DBError::TooLongName {
+            name, length, maximum
+        }) if name == just_exceeds_max_string && length == MAXIMUM_CONNECTOR_NAME_LENGTH + 1 && maximum == MAXIMUM_CONNECTOR_NAME_LENGTH)
+        );
+        let invalid_due_to_pattern =
+            vec!["%", "$", "abc@", "example example", "a.b", ".", " ", "%20"];
+        for invalid_name in invalid_due_to_pattern {
+            assert!(
+                matches!(validate_connector_name(invalid_name), Err(DBError::NameDoesNotMatchPattern {
+                    name,
+                    pattern,
+                    pattern_description,
+                }) if name == invalid_name && pattern == PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN && pattern_description == PATTERN_NON_EMPTY_ALPHANUMERIC_UNDERSCORE_HYPHEN_DESCRIPTION)
             );
         }
     }

--- a/docs.feldera.com/docs/changelog.md
+++ b/docs.feldera.com/docs/changelog.md
@@ -14,6 +14,15 @@ import TabItem from '@theme/TabItem';
 
         ## Unreleased
 
+        - Pipeline name is now limited to 63 characters and must follow the Kubernetes
+          label pattern (and be non-empty and contain no dots as before). The check is only enforced
+          when the pipeline is being newly created, its `name` field is being PATCHed
+          or it is getting fully updated via PUT even if the name does not change.
+          Otherwise, existing pipelines with a now invalid name will continue to function.
+          This change is not backward compatible for scripts that create pipelines with names that are
+          no longer valid, in which case they will now receive an error instead of succeeding.
+          However, especially in the Kubernetes runner these pipelines would already not work.
+
         - Casts of strings to Boolean and floating point values will
         produce runtime errors instead of legal values for illegal string
         values.  The set of strings that can be legally converted to

--- a/openapi.json
+++ b/openapi.json
@@ -964,10 +964,12 @@
                 "examples": {
                   "Name does not match pattern": {
                     "value": {
-                      "message": "Name 'name-with-invalid-char-#' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)",
+                      "message": "Name 'name-with-invalid-char-#' should be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore (pattern: '^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$')",
                       "error_code": "NameDoesNotMatchPattern",
                       "details": {
-                        "name": "name-with-invalid-char-#"
+                        "name": "name-with-invalid-char-#",
+                        "pattern": "^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$",
+                        "pattern_description": "be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore"
                       }
                     }
                   }
@@ -1478,10 +1480,12 @@
                   },
                   "Name does not match pattern": {
                     "value": {
-                      "message": "Name 'name-with-invalid-char-#' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)",
+                      "message": "Name 'name-with-invalid-char-#' should be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore (pattern: '^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$')",
                       "error_code": "NameDoesNotMatchPattern",
                       "details": {
-                        "name": "name-with-invalid-char-#"
+                        "name": "name-with-invalid-char-#",
+                        "pattern": "^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$",
+                        "pattern_description": "be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore"
                       }
                     }
                   }
@@ -1748,10 +1752,12 @@
                   },
                   "Name does not match pattern": {
                     "value": {
-                      "message": "Name 'name-with-invalid-char-#' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)",
+                      "message": "Name 'name-with-invalid-char-#' should be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore (pattern: '^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$')",
                       "error_code": "NameDoesNotMatchPattern",
                       "details": {
-                        "name": "name-with-invalid-char-#"
+                        "name": "name-with-invalid-char-#",
+                        "pattern": "^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$",
+                        "pattern_description": "be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore"
                       }
                     }
                   }
@@ -6683,10 +6689,12 @@
                   },
                   "Name does not match pattern": {
                     "value": {
-                      "message": "Name 'name-with-invalid-char-#' contains characters which are not lowercase (a-z), uppercase (A-Z), numbers (0-9), underscores (_) or hyphens (-)",
+                      "message": "Name 'name-with-invalid-char-#' should be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore (pattern: '^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$')",
                       "error_code": "NameDoesNotMatchPattern",
                       "details": {
-                        "name": "name-with-invalid-char-#"
+                        "name": "name-with-invalid-char-#",
+                        "pattern": "^([A-Za-z0-9][-A-Za-z0-9_]*)?[A-Za-z0-9]$",
+                        "pattern_description": "be non-empty and only contain lowercase (a-z), uppercase (A-Z), number (0-9), underscore (_) or hyphen (-) characters, but cannot start or end with hyphen or underscore"
                       }
                     }
                   }

--- a/python/tests/platform/test_pipeline_configs.py
+++ b/python/tests/platform/test_pipeline_configs.py
@@ -1,5 +1,8 @@
 from http import HTTPStatus
 
+from feldera import PipelineBuilder
+from feldera.rest.errors import FelderaAPIError
+from tests import TEST_CLIENT
 from .helper import (
     API_PREFIX,
     cleanup_pipeline,
@@ -45,10 +48,12 @@ def test_pipeline_runtime_config(pipeline_name):
                     "storage_class": "normal",
                 },
             },
-            lambda rc: rc.get("workers") == 100
-            and rc.get("resources", {}).get("cpu_cores_min") == 5
-            and rc.get("resources", {}).get("storage_mb_max") == 2000
-            and rc.get("resources", {}).get("storage_class") == "normal",
+            lambda rc: (
+                rc.get("workers") == 100
+                and rc.get("resources", {}).get("cpu_cores_min") == 5
+                and rc.get("resources", {}).get("storage_mb_max") == 2000
+                and rc.get("resources", {}).get("storage_class") == "normal"
+            ),
         ),
         (
             {"env": {"TEST_ENV": "value"}},
@@ -193,3 +198,50 @@ def test_pipeline_program_config(pipeline_name):
     assert resp.status_code == HTTPStatus.OK
     pc_modified = resp.json()["program_config"]
     assert pc_modified.get("cache") is True
+
+
+@gen_pipeline_name
+def test_pipeline_field_name(pipeline_name):
+    def try_name(name, expected_error_code):
+        error = None
+        try:
+            pipeline = PipelineBuilder(TEST_CLIENT, name, "").create_or_replace(
+                wait=False
+            )
+            pipeline.delete()
+        except FelderaAPIError as e:
+            error = e
+
+        assert (error is None and expected_error_code is None) or (
+            error is not None
+            and expected_error_code is not None
+            and error.error_code == expected_error_code
+        ), (
+            f"Name: '{name}', expected error code: {expected_error_code}, actual error: {error}"
+        )
+
+    # Successful
+    try_name("a", None)
+    try_name("1", None)
+    try_name("A", None)
+    try_name("A-a", None)
+    try_name("A_a", None)
+    try_name("a1-_A", None)
+    try_name("a" * 62, None)
+    try_name("a" * 63, None)
+
+    # Not successful
+    # Does not work as it gives a 404: try_name("", "EmptyName")
+    try_name("a" * 64, "TooLongName")
+    try_name("@", "NameDoesNotMatchPattern")
+    # Does not work as it gives a 404: try_name(".", "NameDoesNotMatchPattern")
+    try_name("a.", "NameDoesNotMatchPattern")
+    try_name("a.b", "NameDoesNotMatchPattern")
+    try_name("-", "NameDoesNotMatchPattern")
+    try_name("_", "NameDoesNotMatchPattern")
+    try_name("a_", "NameDoesNotMatchPattern")
+    try_name("a-", "NameDoesNotMatchPattern")
+    try_name("-a", "NameDoesNotMatchPattern")
+    try_name("_a", "NameDoesNotMatchPattern")
+    try_name("_a-", "NameDoesNotMatchPattern")
+    try_name("-a_", "NameDoesNotMatchPattern")


### PR DESCRIPTION
The previous limit (100 characters) exceeded the maximum value length of a Kubernetes label, which is 63. This puts that (63) as the new limit. The pattern of a Kubernetes label is now also enforced, which means names can no longer end or start with hyphens or underscores. On top of that, it cannot be empty and cannot contain dots -- which was already the case before.

The check is only enforced when the pipeline is being newly created, its `name` field is being PATCHed or it is getting fully updated via PUT even if the name does not change. Otherwise, existing pipelines with a now invalid name will continue to function.

This change is not backward compatible for scripts that create pipelines with names that are no longer valid, in which case they will now receive an error instead of succeeding. However, especially in the Kubernetes runner these pipelines would already not work.

**PR information**
- Unit tests added
- Integration tests added
- Changelog updated
- Backward incompatible changes are noted above