### PR TITLE
[web-console] Add pipeline search feature to the pipeline list sidebar on the pipeline page

### DIFF
--- a/js-packages/web-console/src/lib/components/pipelines/List.svelte
+++ b/js-packages/web-console/src/lib/components/pipelines/List.svelte
@@ -5,6 +5,7 @@
 <script lang="ts">
   import PipelineStatus from '$lib/components/pipelines/list/PipelineStatusDot.svelte'
   import { resolve } from '$lib/functions/svelte'
+  import { matchesSubstring } from '$lib/functions/common/string'
   import { type PipelineThumb } from '$lib/services/pipelineManager'
 
   let {
@@ -18,6 +19,9 @@
     onclose?: () => void
     onaction?: () => void
   } = $props()
+
+  let nameSearch = $state('')
+  const visiblePipelines = $derived(pipelines?.filter((p) => matchesSubstring(p.name, nameSearch)))
   const bindScrollY = (node: HTMLElement, val: { scrollY: number }) => {
     $effect(() => {
       node.scrollTop = scrollY
@@ -37,13 +41,18 @@
   style="overflow-y: overlay;"
   use:bindScrollY={{ scrollY }}
 >
-  <div class="bg-white-dark sticky top-0 -mr-1 flex justify-between pb-2 pl-4">
-    <span class="content-center font-semibold">Pipelines</span>
+  <div class="bg-white-dark sticky top-0 -mr-1 flex items-center gap-2 pb-2">
+    <input
+      class="input h-8 min-w-0 flex-1"
+      type="search"
+      placeholder="Search pipelines..."
+      bind:value={nameSearch}
+    />
     <button onclick={onclose} class="fd fd-x btn-icon text-[24px]" aria-label="Close pipelines list"
     ></button>
   </div>
-  {#if pipelines}
-    {#each pipelines as pipeline}
+  {#if visiblePipelines}
+    {#each visiblePipelines as pipeline}
       <a
         class="flex h-9 flex-nowrap items-center justify-between gap-2 rounded py-2 pl-4 {pipelineName ===
         pipeline.name

--- a/js-packages/web-console/src/lib/components/pipelines/List.svelte.spec.ts
+++ b/js-packages/web-console/src/lib/components/pipelines/List.svelte.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-svelte'
+import type { PipelineThumb } from '$lib/services/pipelineManager'
+import List from './List.svelte'
+
+// List only reads `name` (for the label/filter) and `status` (for the status
+// dot) off each thumb, so a minimal stub is enough to exercise the search.
+const thumb = (name: string): PipelineThumb =>
+  ({ name, status: 'Stopped' }) as unknown as PipelineThumb
+
+const pipelines = [thumb('orders'), thumb('payments'), thumb('fraud-detection')]
+
+// Each rendered pipeline is an <a>; the only other interactive elements are the
+// search box and the close button, so counting links counts visible pipelines.
+const visibleNames = () => page.getByRole('link').elements().map((el) => el.textContent?.trim())
+
+describe('pipeline list search', () => {
+  it('lists every pipeline before any search term is entered', async () => {
+    render(List, { pipelineName: '', pipelines })
+
+    await expect.element(page.getByText('orders')).toBeInTheDocument()
+    await expect.element(page.getByText('payments')).toBeInTheDocument()
+    await expect.element(page.getByText('fraud-detection')).toBeInTheDocument()
+    expect(visibleNames()).toHaveLength(3)
+  })
+
+  it('filters to pipelines whose name contains the search term', async () => {
+    render(List, { pipelineName: '', pipelines })
+
+    await page.getByPlaceholder('Search pipelines...').fill('pay')
+
+    await expect.element(page.getByText('payments')).toBeInTheDocument()
+    await expect.element(page.getByText('orders')).not.toBeInTheDocument()
+    await expect.element(page.getByText('fraud-detection')).not.toBeInTheDocument()
+    expect(visibleNames()).toEqual(['payments'])
+  })
+
+  it('matches case-insensitively', async () => {
+    render(List, { pipelineName: '', pipelines })
+
+    await page.getByPlaceholder('Search pipelines...').fill('PAY')
+
+    expect(visibleNames()).toEqual(['payments'])
+  })
+
+  it('matches a substring anywhere in the name, not only a prefix', async () => {
+    render(List, { pipelineName: '', pipelines })
+
+    await page.getByPlaceholder('Search pipelines...').fill('detect')
+
+    expect(visibleNames()).toEqual(['fraud-detection'])
+  })
+
+  it('shows no pipelines when the term matches nothing', async () => {
+    render(List, { pipelineName: '', pipelines })
+
+    await page.getByPlaceholder('Search pipelines...').fill('no-such-pipeline')
+
+    expect(visibleNames()).toHaveLength(0)
+  })
+
+  it('restores the full list when the search term is cleared', async () => {
+    render(List, { pipelineName: '', pipelines })
+    const search = page.getByPlaceholder('Search pipelines...')
+
+    await search.fill('pay')
+    expect(visibleNames()).toEqual(['payments'])
+
+    await search.fill('')
+    expect(visibleNames()).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
This mirrors the search available on the home page

Testing: manual, added a UI unit test

<img width="1112" height="1199" alt="image" src="https://github.com/user-attachments/assets/178f7874-d508-4918-9828-35b21ea0cd95" />
